### PR TITLE
docs: document CI expectations in README (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ This repository implements the second track.
 - [CI/CD runbook](docs/runbooks/ci.md)
 - [Task debugging API](docs/runbooks/task-api.md)
 
+## Continuous integration
+
+Every push to `main` and every pull request targeting `main` runs
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml). The CI job is the
+safety net for all changes; PRs should not merge while it is red.
+
+CI expectations on each run:
+
+- `gofmt` check on all tracked Go files (no diff).
+- `go mod tidy` check (`go.mod` and `go.sum` clean).
+- `go test -race -covermode=atomic ./...`.
+- `go build` of `cmd/trigger-api`, `cmd/worker`, and `cmd/linear-poller`.
+- Docker image build of the repository `Dockerfile`.
+
+See the [CI/CD runbook](docs/runbooks/ci.md) for triggers, security posture,
+release flow, and local pre-push checks.
+
 ## Quick start: Gitea webhook path
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #2.

The CI workflow `.github/workflows/ci.yml` already exists (added in
commit `a4ab327`) and runs `gofmt`, `go mod tidy`, `go test ./...`, and
builds `cmd/trigger-api`, `cmd/worker`, and `cmd/linear-poller`. The
only remaining acceptance-criterion gap from issue #2 was that the
README did not explicitly call out CI expectations.

This PR adds a dedicated "Continuous integration" section to the
README that:

- Links to `.github/workflows/ci.yml` directly.
- Lists every check CI performs on each push to `main` and PR.
- Cross-links the existing [CI/CD runbook](docs/runbooks/ci.md).

## Acceptance criteria

- [x] `.github/workflows/ci.yml` exists (pre-existing).
- [x] CI runs `go mod tidy` check, `gofmt` check, and `go test ./...` (pre-existing).
- [x] CI builds `cmd/trigger-api`, `cmd/worker`, and `cmd/linear-poller` (pre-existing).
- [x] README links to CI expectations (this PR).

## Why no workflow changes?

The pre-existing `ci.yml` already meets the build/test/lint AC verbatim,
so touching it would only churn the file. Per the issue notes ("safety
net for future changes"), the value-add here is making CI expectations
discoverable from the README so contributors know what must stay green.

## Test plan

- [x] `gofmt -l cmd internal` clean locally.
- [x] `go build ./...` succeeds locally.
- [x] `go test ./...` passes locally.
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` parses cleanly.
- [ ] CI run on this PR is green.