### PR TITLE
docs: add personal daily workflow runbook

### DIFF
--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -19,7 +19,7 @@ Per-state rules:
 - `AI Ready`: refined and small enough that an agent can attempt it. The poller picks these up.
 - `In Progress`: the worker has claimed an issue or you are iterating on it. Stays in `active_states` so re-runs after a push are allowed.
 - `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself.
-- `Rework`: review found issues and you want the agent to retry. Move it back here to re-enqueue.
+- `Rework`: review found issues and you want another attempt. The state is in `active_states`, but moving the Linear issue to `Rework` does not by itself re-enqueue: the poller uses `issue.ID` as `source_event_id` and `Enqueue` dedupes via `ON CONFLICT (source_type, source_event_id)` (see `cmd/linear-poller/main.go` and `internal/queue/postgres.go`). Use `/ai-run` on Gitea or `POST /v1/tasks` to actually trigger a fresh run; see "Re-running a failed task" below.
 - `Done` / `Canceled`: terminal. Listed under `tracker.terminal_states`.
 
 Default `active_states` in code:
@@ -109,12 +109,11 @@ Use when:
 
 - the task touches several files or needs more reasoning across a package.
 - you want richer tool use during the run.
-- Codex produced a thin or wrong patch and you want a second opinion. Set `agent.fallback: claude` in `WORKFLOW.md` to make this the retry runner.
+- Codex produced a thin or wrong patch and you want a second opinion. To switch runner you set `agent.default` in `WORKFLOW.md`, or pass `model` per task via `POST /v1/tasks`. Note: `agent.fallback` exists as a config field (`internal/workflow/config.go`) but no runtime path reads it today — `cmd/worker/main.go` selects the runner from `t.Model`/`agent.default`, and `internal/runner/runner.go` has no fallback handling. Setting `agent.fallback` will not change retry behavior.
 
 ```yaml
 agent:
   default: claude
-  fallback: claude
 claude:
   command: claude
 ```
@@ -159,15 +158,14 @@ curl 'http://localhost:8080/v1/tasks/<task-id>/events'
 - Verification command failed (`go test ./...` non-zero): read `.aiops/RUN_SUMMARY.md` in the work branch if the runner produced one. Reproduce locally on the same branch.
 - Policy violation (deny path or size cap): re-scope the task into a smaller issue, or do it manually.
 - Runner command not found: confirm `codex.command` or `claude.command` resolves on the worker host. The shell runner uses `sh -lc`, so PATH must be set in the worker's login shell.
-- Empty diff: agent decided nothing to do. Tighten the issue body and move it to `Rework`.
+- Empty diff: agent decided nothing to do. Tighten the issue body, move it to `Rework`, then re-trigger via `/ai-run` on Gitea or `POST /v1/tasks` (the Linear state change alone will not re-enqueue — see below).
 
 ### Re-running a failed task
 
-Three options, in order of preference:
+Two options, in order of preference (moving the Linear issue alone is not enough — the poller dedupes on `source_event_id = issue.ID` via `ON CONFLICT (source_type, source_event_id) DO UPDATE SET updated_at`, so re-polling just touches the existing task instead of creating a fresh queued one):
 
-1. Move the Linear issue to `Rework`. The poller will re-enqueue under the same `source_event_id` (idempotent via dedupe).
-2. Re-trigger from Gitea by commenting `/ai-run` on the issue.
-3. Manual enqueue against the trigger API:
+1. Re-trigger from Gitea by commenting `/ai-run` on the issue. The trigger API uses the Gitea delivery ID (or `comment-<id>`) as `source_event_id`, so each comment produces a new queued task.
+2. Manual enqueue against the trigger API (each call defaults `source_event_id` to `manual-<unix-nanos>`, so it is always fresh):
 
    ```bash
    curl -X POST http://localhost:8080/v1/tasks \

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -1,0 +1,197 @@
+# Personal daily workflow
+
+This runbook describes how to use `aiops-platform` day to day so it stays a useful tool instead of another system to babysit.
+
+The defaults below match `examples/WORKFLOW.md` and the active state list hardcoded in `internal/workflow/config.go`.
+
+## Linear states
+
+The Linear poller in `cmd/linear-poller` only enqueues issues whose state name appears in `tracker.active_states` of your `WORKFLOW.md`. Use a simple lifecycle:
+
+```text
+Backlog -> AI Ready -> In Progress -> Human Review -> Rework -> Done
+                                                  \-> Canceled
+```
+
+Per-state rules:
+
+- `Backlog`: not picked up. Use this for anything you have not refined yet.
+- `AI Ready`: refined and small enough that an agent can attempt it. The poller picks these up.
+- `In Progress`: the worker has claimed an issue or you are iterating on it. Stays in `active_states` so re-runs after a push are allowed.
+- `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself.
+- `Rework`: review found issues and you want the agent to retry. Move it back here to re-enqueue.
+- `Done` / `Canceled`: terminal. Listed under `tracker.terminal_states`.
+
+Default `active_states` in code:
+
+```yaml
+tracker:
+  active_states:
+    - AI Ready
+    - In Progress
+    - Rework
+```
+
+Rule of thumb: if you do not feel comfortable letting an agent open a draft PR for an issue right now, do not move it to `AI Ready`.
+
+## Writing good issues
+
+The issue title and description are passed to the runner via the `PROMPT.md` template (see `examples/WORKFLOW.md`). Vague issues produce vague diffs.
+
+Checklist before moving an issue to `AI Ready`:
+
+- One clear outcome. Not "improve logging" but "log request id in `cmd/trigger-api` access log".
+- Concrete file or package hints. Mention paths like `internal/runner/shell.go` so the agent does not wander.
+- Acceptance criteria as a bullet list. The verification section in `WORKFLOW.md` runs `go test ./...`, but tests do not catch design intent.
+- Out-of-scope notes. Call out things you do not want touched, especially anything under `policy.deny_paths` (`infra/**`, `deploy/**`, `db/migrations/**`, `secrets/**`).
+- Size budget that fits `policy.max_changed_files: 12` and `policy.max_changed_loc: 300`. If a task realistically needs more, split it.
+- Link to the relevant ADR or research doc when the task involves architecture decisions.
+
+Issue template that works well:
+
+```markdown
+## Goal
+<one sentence>
+
+## Acceptance criteria
+- ...
+- ...
+
+## Scope hints
+- touch: <paths>
+- do not touch: <paths>
+
+## Notes
+<anything an agent could not infer from the codebase>
+```
+
+## Choosing a runner
+
+Runners are selected by the `agent.default` field in `WORKFLOW.md` and resolved in `internal/runner/runner.go`. Valid values: `mock`, `codex`, `claude`. Per-task overrides can be sent via the `model` field on the manual task API.
+
+### `mock`
+
+What it does: writes a stub file under `.aiops/<task-id>.md` and returns success. No model call. See `internal/runner/mock.go`.
+
+Use when:
+
+- you just changed `WORKFLOW.md`, queue plumbing, or PR handoff and want to confirm the loop end-to-end.
+- you are onboarding a new repository and want a safe first PR before pointing a real model at it.
+- the model API is rate-limited or down and you still want to verify queue and worker behavior.
+
+```yaml
+agent:
+  default: mock
+```
+
+### `codex`
+
+Shell runner that pipes `.aiops/PROMPT.md` into `codex.command` (default `codex exec`). See `internal/runner/shell.go`.
+
+Use when:
+
+- the task is a focused change inside one or two files.
+- you have a Codex CLI session already authenticated locally.
+- you want to compare a Codex result against a Claude result for the same issue.
+
+```yaml
+agent:
+  default: codex
+codex:
+  command: codex exec
+```
+
+### `claude`
+
+Same shell runner, invokes `claude.command` (default `claude`).
+
+Use when:
+
+- the task touches several files or needs more reasoning across a package.
+- you want richer tool use during the run.
+- Codex produced a thin or wrong patch and you want a second opinion. Set `agent.fallback: claude` in `WORKFLOW.md` to make this the retry runner.
+
+```yaml
+agent:
+  default: claude
+  fallback: claude
+claude:
+  command: claude
+```
+
+### Manual review (no runner)
+
+Skip automation entirely when:
+
+- the task touches `policy.deny_paths` (infra, deploy, migrations, secrets).
+- it is a security-sensitive change or a data migration.
+- requirements are still ambiguous. Use a planning issue instead and only move to `AI Ready` once the design is settled.
+- the change is large enough that a draft PR would exceed `max_changed_files` or `max_changed_loc`.
+
+Decision shortcut:
+
+```text
+unsure or risky                  -> manual review, keep issue out of AI Ready
+plumbing or smoke test           -> mock
+small, well-scoped code change   -> codex
+multi-file or reasoning-heavy    -> claude
+```
+
+## Handling failed tasks
+
+A task is `failed` only after `attempts` reaches `max_attempts`. Until then, a failing attempt sets the status back to `queued` with a 60s backoff (`internal/queue/postgres.go`). Status values are defined in `internal/task/task.go`: `queued`, `running`, `succeeded`, `failed`.
+
+### Triage with the debugging API
+
+See `docs/runbooks/task-api.md` for full details. Quick commands:
+
+```bash
+curl 'http://localhost:8080/v1/tasks?status=failed'
+curl 'http://localhost:8080/v1/tasks/<task-id>'
+curl 'http://localhost:8080/v1/tasks/<task-id>/events'
+```
+
+`/events` is the most useful endpoint. Look for `enqueued`, `claimed`, `failed_attempt`, `succeeded`, `failed` in order, and read the messages.
+
+### Common causes and fixes
+
+- `repo.clone_url missing in WORKFLOW.md`: poller log line. Fix `WORKFLOW.md`, restart the poller.
+- Verification command failed (`go test ./...` non-zero): read `.aiops/RUN_SUMMARY.md` in the work branch if the runner produced one. Reproduce locally on the same branch.
+- Policy violation (deny path or size cap): re-scope the task into a smaller issue, or do it manually.
+- Runner command not found: confirm `codex.command` or `claude.command` resolves on the worker host. The shell runner uses `sh -lc`, so PATH must be set in the worker's login shell.
+- Empty diff: agent decided nothing to do. Tighten the issue body and move it to `Rework`.
+
+### Re-running a failed task
+
+Three options, in order of preference:
+
+1. Move the Linear issue to `Rework`. The poller will re-enqueue under the same `source_event_id` (idempotent via dedupe).
+2. Re-trigger from Gitea by commenting `/ai-run` on the issue.
+3. Manual enqueue against the trigger API:
+
+   ```bash
+   curl -X POST http://localhost:8080/v1/tasks \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "repo_owner": "your-user",
+       "repo_name": "your-repo",
+       "clone_url": "git@gitea.local:your-user/your-repo.git",
+       "base_branch": "main",
+       "title": "retry: <original title>",
+       "description": "...",
+       "model": "claude",
+       "priority": 50
+     }'
+   ```
+
+   Set `model` to switch runner for this attempt only.
+
+### When to give up on automation
+
+Mark the issue back to `Backlog` or `Human Review` and finish it by hand if any of these are true:
+
+- two runner attempts produced wrong or empty diffs.
+- the failure mode is unclear after reading `/v1/tasks/<id>/events`.
+- the work has crossed into a `deny_paths` area or grown past the size caps.
+
+The platform is meant to save time on small, well-scoped tasks. When it stops doing that for a given issue, do not fight it.


### PR DESCRIPTION
## Summary

- Adds `docs/runbooks/personal-daily-workflow.md` covering Linear states, how to write good issues, runner choice (mock / codex / claude / manual), and triage for failed tasks.
- State names, runner names, default `active_states`, policy fields, and task statuses are taken from `examples/WORKFLOW.md`, `internal/workflow/config.go`, `internal/runner/runner.go`, `internal/queue/postgres.go`, and `internal/task/task.go`.
- Cross-links `docs/runbooks/task-api.md` for failure triage commands.

## Test plan

- [x] File renders as Markdown.
- [x] Names referenced (`AI Ready`, `In Progress`, `Rework`, `Human Review`, `Done`, `Canceled`, `mock`, `codex`, `claude`, `queued`, `running`, `succeeded`, `failed`, `deny_paths`, `max_changed_files`, `max_changed_loc`) match code and example workflow.

Closes #27