### PR TITLE
feat: harden path policy and diffstat checks

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -37,7 +39,7 @@ func main() {
 			time.Sleep(3 * time.Second)
 			continue
 		}
-		if err := runTask(ctx, *t); err != nil {
+		if err := runTask(ctx, store, *t); err != nil {
 			log.Printf("task %s failed: %v", t.ID, err)
 			_ = store.Fail(ctx, t.ID, err.Error())
 			continue
@@ -46,7 +48,7 @@ func main() {
 	}
 }
 
-func runTask(ctx context.Context, t task.Task) error {
+func runTask(ctx context.Context, store *queue.Store, t task.Task) error {
 	mgr := workspace.New(env("WORKSPACE_ROOT", "/tmp/aiops-workspaces"))
 	workdir, err := mgr.PrepareGitWorkspace(ctx, t)
 	if err != nil {
@@ -85,6 +87,7 @@ func runTask(ctx context.Context, t task.Task) error {
 		return err
 	}
 	if err := workspace.EnforcePolicy(ctx, workdir, wf.Config); err != nil {
+		recordPolicyViolation(ctx, store, t.ID, err)
 		return err
 	}
 	if err := workspace.RunVerify(ctx, workdir, wf.Config); err != nil {
@@ -94,6 +97,21 @@ func runTask(ctx context.Context, t task.Task) error {
 		return err
 	}
 	return createPR(ctx, t, wf.Config)
+}
+
+// recordPolicyViolation writes a structured `policy_violation` task event
+// before the worker fails the task. The push/PR step is skipped because the
+// caller returns the error immediately after this call.
+func recordPolicyViolation(ctx context.Context, store *queue.Store, taskID string, err error) {
+	var perr *workspace.PolicyError
+	if errors.As(err, &perr) {
+		payload, mErr := json.Marshal(map[string]any{"violations": perr.Violations})
+		if mErr == nil {
+			_ = store.AddEventWithPayload(ctx, taskID, "policy_violation", perr.Error(), payload)
+			return
+		}
+	}
+	_ = store.AddEvent(ctx, taskID, "policy_violation", err.Error())
 }
 
 func createPR(ctx context.Context, t task.Task, cfg workflow.Config) error {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,219 @@
+// Package policy implements path and diffstat policy checks used by the
+// worker before pushing AI-generated commits. It is intentionally
+// dependency-free so it can be unit tested without git or a database.
+package policy
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Config mirrors the relevant fields of workflow.PolicyConfig. It is
+// duplicated as a small struct so this package does not import workflow
+// (which would create a cycle once workflow uses this package).
+type Config struct {
+	AllowPaths      []string
+	DenyPaths       []string
+	MaxChangedFiles int
+	MaxChangedLines int
+}
+
+// ViolationKind enumerates the structured policy failure categories.
+type ViolationKind string
+
+const (
+	KindDenyPath        ViolationKind = "deny_path"
+	KindNotAllowed      ViolationKind = "not_allowed"
+	KindMaxChangedFiles ViolationKind = "max_changed_files"
+	KindMaxChangedLines ViolationKind = "max_changed_lines"
+)
+
+// Violation describes a single policy failure with enough structure for
+// task event payloads and human-readable error messages.
+type Violation struct {
+	Kind    ViolationKind `json:"kind"`
+	Path    string        `json:"path,omitempty"`
+	Pattern string        `json:"pattern,omitempty"`
+	Limit   int           `json:"limit,omitempty"`
+	Actual  int           `json:"actual,omitempty"`
+	Message string        `json:"message"`
+}
+
+func (v Violation) Error() string { return v.Message }
+
+// Diffstat is the per-run measurement used to evaluate policy.
+type Diffstat struct {
+	Files []string
+	Lines int
+}
+
+// Evaluate returns every policy violation observed for the given diffstat
+// and config. An empty slice means the change is acceptable.
+//
+// Rules:
+//   - If AllowPaths is non-empty, every changed file must match at least one
+//     allow pattern, otherwise a not_allowed violation is recorded.
+//   - Any file matching DenyPaths produces a deny_path violation, even if it
+//     also matches AllowPaths (deny wins).
+//   - MaxChangedFiles / MaxChangedLines (when > 0) are enforced as upper
+//     bounds on len(Files) and Lines respectively.
+func Evaluate(d Diffstat, cfg Config) []Violation {
+	var out []Violation
+
+	for _, f := range d.Files {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		if pat, ok := matchAny(cfg.DenyPaths, f); ok {
+			out = append(out, Violation{
+				Kind:    KindDenyPath,
+				Path:    f,
+				Pattern: pat,
+				Message: fmt.Sprintf("path %q matches deny pattern %q", f, pat),
+			})
+			continue
+		}
+		if len(cfg.AllowPaths) > 0 {
+			if _, ok := matchAny(cfg.AllowPaths, f); !ok {
+				out = append(out, Violation{
+					Kind:    KindNotAllowed,
+					Path:    f,
+					Message: fmt.Sprintf("path %q does not match any allow pattern", f),
+				})
+			}
+		}
+	}
+
+	if cfg.MaxChangedFiles > 0 && len(d.Files) > cfg.MaxChangedFiles {
+		out = append(out, Violation{
+			Kind:    KindMaxChangedFiles,
+			Limit:   cfg.MaxChangedFiles,
+			Actual:  len(d.Files),
+			Message: fmt.Sprintf("changed files %d exceeds max %d", len(d.Files), cfg.MaxChangedFiles),
+		})
+	}
+
+	if cfg.MaxChangedLines > 0 && d.Lines > cfg.MaxChangedLines {
+		out = append(out, Violation{
+			Kind:    KindMaxChangedLines,
+			Limit:   cfg.MaxChangedLines,
+			Actual:  d.Lines,
+			Message: fmt.Sprintf("changed lines %d exceeds max %d", d.Lines, cfg.MaxChangedLines),
+		})
+	}
+
+	return out
+}
+
+// Summarize returns a single-line summary of all violations, suitable for a
+// task event message field.
+func Summarize(vs []Violation) string {
+	if len(vs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(vs))
+	for _, v := range vs {
+		parts = append(parts, v.Message)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func matchAny(patterns []string, path string) (string, bool) {
+	for _, p := range patterns {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if Match(p, path) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// Match reports whether path matches the glob pattern. Supported syntax:
+//
+//   - "?"  matches any single character except "/"
+//   - "*"  matches any sequence of characters except "/"
+//   - "**" matches any sequence of characters, including "/"
+//   - "/**" as a trailing component matches the empty string or "/<anything>"
+//   - "**/" as a leading component matches the empty string or "<anything>/"
+//
+// Patterns are matched against the full path (no implicit prefix). A pattern
+// with no wildcards must equal path exactly. Pattern matching is anchored at
+// both ends.
+func Match(pattern, path string) bool {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return false
+	}
+	// Convenience: "foo/" is treated as "foo/**" (directory match).
+	if strings.HasSuffix(pattern, "/") {
+		pattern += "**"
+	}
+	return globMatch(pattern, path)
+}
+
+// globMatch is the recursive glob matcher. It walks both pattern and path
+// with explicit handling for "**" so that double-star spans path separators
+// while single "*" and "?" do not.
+func globMatch(pattern, path string) bool {
+	for len(pattern) > 0 {
+		switch {
+		case strings.HasPrefix(pattern, "**"):
+			rest := strings.TrimPrefix(pattern, "**")
+			// Allow leading "/" after "**" to consume an arbitrary number of
+			// path segments, including zero.
+			if strings.HasPrefix(rest, "/") {
+				inner := rest[1:]
+				// "**/" matches zero segments.
+				if globMatch(inner, path) {
+					return true
+				}
+				for i := 0; i < len(path); i++ {
+					if path[i] == '/' && globMatch(inner, path[i+1:]) {
+						return true
+					}
+				}
+				return false
+			}
+			// Trailing "**" matches the rest of path.
+			if rest == "" {
+				return true
+			}
+			// "**" followed by non-slash: try every suffix.
+			for i := 0; i <= len(path); i++ {
+				if globMatch(rest, path[i:]) {
+					return true
+				}
+			}
+			return false
+		case pattern[0] == '*':
+			rest := pattern[1:]
+			// Match any run of non-"/" characters, including empty.
+			for i := 0; i <= len(path); i++ {
+				if i > 0 && path[i-1] == '/' {
+					return false
+				}
+				if globMatch(rest, path[i:]) {
+					return true
+				}
+			}
+			return false
+		case pattern[0] == '?':
+			if len(path) == 0 || path[0] == '/' {
+				return false
+			}
+			pattern = pattern[1:]
+			path = path[1:]
+		default:
+			if len(path) == 0 || pattern[0] != path[0] {
+				return false
+			}
+			pattern = pattern[1:]
+			path = path[1:]
+		}
+	}
+	return len(path) == 0
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,0 +1,168 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	cases := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		// exact
+		{"README.md", "README.md", true},
+		{"README.md", "docs/README.md", false},
+
+		// single star: bounded by "/"
+		{"*.go", "main.go", true},
+		{"*.go", "cmd/main.go", false},
+		{"cmd/*.go", "cmd/main.go", true},
+		{"cmd/*.go", "cmd/sub/main.go", false},
+		{"foo*bar", "foozzbar", true},
+		{"foo*bar", "foo/bar", false},
+
+		// question mark
+		{"?.md", "a.md", true},
+		{"?.md", "ab.md", false},
+		{"?.md", "/x.md", false},
+
+		// double star: spans separators
+		{"**", "anything/at/all.go", true},
+		{"infra/**", "infra/", true},
+		{"infra/**", "infra/db/migrate.sql", true},
+		{"infra/**", "infrastructure/x.go", false},
+		{"deploy/**", "deploy/k8s/values.yaml", true},
+		{"db/migrations/**", "db/migrations/0001_init.sql", true},
+		{"**/secrets.yaml", "config/prod/secrets.yaml", true},
+		{"**/secrets.yaml", "secrets.yaml", true},
+		{"a/**/b.go", "a/b.go", true},
+		{"a/**/b.go", "a/x/b.go", true},
+		{"a/**/b.go", "a/x/y/b.go", true},
+		{"a/**/b.go", "a/b.go.bak", false},
+
+		// trailing slash convenience: "foo/" == "foo/**"
+		{"vendor/", "vendor/lib/x.go", true},
+		{"vendor/", "vendor/", true},
+		{"vendor/", "vendor", false},
+
+		// edge cases
+		{"", "anything", false},
+		{"   ", "anything", false},
+	}
+	for _, tc := range cases {
+		got := Match(tc.pattern, tc.path)
+		if got != tc.want {
+			t.Errorf("Match(%q, %q) = %v, want %v", tc.pattern, tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestEvaluateDenyPaths(t *testing.T) {
+	cfg := Config{
+		DenyPaths: []string{"infra/**", "deploy/**", "**/secrets.yaml", "db/migrations/**"},
+	}
+	d := Diffstat{Files: []string{
+		"cmd/worker/main.go",
+		"infra/terraform/main.tf",
+		"src/app/secrets.yaml",
+		"db/migrations/0002_add.sql",
+		"docs/readme.md",
+	}}
+	vs := Evaluate(d, cfg)
+	if len(vs) != 3 {
+		t.Fatalf("expected 3 deny violations, got %d: %v", len(vs), vs)
+	}
+	for _, v := range vs {
+		if v.Kind != KindDenyPath {
+			t.Errorf("expected KindDenyPath, got %s for %s", v.Kind, v.Path)
+		}
+		if v.Pattern == "" || v.Path == "" {
+			t.Errorf("violation missing path/pattern: %+v", v)
+		}
+	}
+}
+
+func TestEvaluateAllowPathsRequiresMatch(t *testing.T) {
+	cfg := Config{AllowPaths: []string{"src/**", "docs/**"}}
+	d := Diffstat{Files: []string{"src/a.go", "docs/x.md", "Makefile"}}
+	vs := Evaluate(d, cfg)
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 not_allowed violation, got %d: %v", len(vs), vs)
+	}
+	if vs[0].Kind != KindNotAllowed || vs[0].Path != "Makefile" {
+		t.Errorf("unexpected violation: %+v", vs[0])
+	}
+}
+
+func TestEvaluateDenyTrumpsAllow(t *testing.T) {
+	cfg := Config{
+		AllowPaths: []string{"**"},
+		DenyPaths:  []string{"infra/**"},
+	}
+	d := Diffstat{Files: []string{"infra/main.tf", "src/a.go"}}
+	vs := Evaluate(d, cfg)
+	if len(vs) != 1 || vs[0].Kind != KindDenyPath {
+		t.Fatalf("expected single deny violation, got %v", vs)
+	}
+}
+
+func TestEvaluateMaxChangedFiles(t *testing.T) {
+	cfg := Config{MaxChangedFiles: 2}
+	d := Diffstat{Files: []string{"a.go", "b.go", "c.go"}}
+	vs := Evaluate(d, cfg)
+	if len(vs) != 1 || vs[0].Kind != KindMaxChangedFiles {
+		t.Fatalf("expected max_changed_files violation, got %v", vs)
+	}
+	if vs[0].Limit != 2 || vs[0].Actual != 3 {
+		t.Errorf("violation limits wrong: %+v", vs[0])
+	}
+}
+
+func TestEvaluateMaxChangedLines(t *testing.T) {
+	cfg := Config{MaxChangedLines: 100}
+	d := Diffstat{Files: []string{"a.go"}, Lines: 250}
+	vs := Evaluate(d, cfg)
+	if len(vs) != 1 || vs[0].Kind != KindMaxChangedLines {
+		t.Fatalf("expected max_changed_lines violation, got %v", vs)
+	}
+	if vs[0].Limit != 100 || vs[0].Actual != 250 {
+		t.Errorf("violation limits wrong: %+v", vs[0])
+	}
+}
+
+func TestEvaluateZeroLimitsDisabled(t *testing.T) {
+	cfg := Config{} // no limits, no deny, no allow
+	d := Diffstat{Files: []string{"a.go", "b.go"}, Lines: 10000}
+	if vs := Evaluate(d, cfg); len(vs) != 0 {
+		t.Fatalf("expected no violations, got %v", vs)
+	}
+}
+
+func TestEvaluateMultipleViolationsAccumulate(t *testing.T) {
+	cfg := Config{
+		DenyPaths:       []string{"secrets/**"},
+		MaxChangedFiles: 1,
+		MaxChangedLines: 5,
+	}
+	d := Diffstat{Files: []string{"secrets/key.pem", "src/a.go"}, Lines: 50}
+	vs := Evaluate(d, cfg)
+	if len(vs) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %v", len(vs), vs)
+	}
+	summary := Summarize(vs)
+	for _, want := range []string{"deny pattern", "exceeds max"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary %q missing %q", summary, want)
+		}
+	}
+}
+
+func TestEvaluateSkipsBlankFiles(t *testing.T) {
+	cfg := Config{DenyPaths: []string{"infra/**"}}
+	d := Diffstat{Files: []string{"", "  ", "src/a.go"}}
+	if vs := Evaluate(d, cfg); len(vs) != 0 {
+		t.Fatalf("expected no violations for blank entries, got %v", vs)
+	}
+}

--- a/internal/queue/postgres.go
+++ b/internal/queue/postgres.go
@@ -149,6 +149,17 @@ func (s *Store) AddEvent(ctx context.Context, taskID, typ, msg string) error {
 	return err
 }
 
+// AddEventWithPayload writes a task event with a JSON payload. It is used
+// for structured events such as policy_violation where callers want to
+// attach the full violation list for later inspection.
+func (s *Store) AddEventWithPayload(ctx context.Context, taskID, typ, msg string, payload []byte) error {
+	if len(payload) == 0 {
+		return s.AddEvent(ctx, taskID, typ, msg)
+	}
+	_, err := s.db.Exec(ctx, "INSERT INTO task_events(task_id,event_type,message,payload) VALUES($1,$2,$3,$4)", taskID, typ, msg, payload)
+	return err
+}
+
 type taskScanner interface {
 	Scan(dest ...any) error
 }

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -49,7 +49,20 @@ type PolicyConfig struct {
 	AllowPaths      []string `yaml:"allow_paths"`
 	DenyPaths       []string `yaml:"deny_paths"`
 	MaxChangedFiles int      `yaml:"max_changed_files"`
-	MaxChangedLOC   int      `yaml:"max_changed_loc"`
+	// MaxChangedLines bounds the total added+deleted lines reported by
+	// `git diff --numstat`. The legacy YAML key `max_changed_loc` is still
+	// honored via MaxChangedLOC below for back-compat.
+	MaxChangedLines int `yaml:"max_changed_lines"`
+	MaxChangedLOC   int `yaml:"max_changed_loc"`
+}
+
+// LineLimit returns the effective maximum changed lines, preferring the
+// new MaxChangedLines field but falling back to the legacy MaxChangedLOC.
+func (p PolicyConfig) LineLimit() int {
+	if p.MaxChangedLines > 0 {
+		return p.MaxChangedLines
+	}
+	return p.MaxChangedLOC
 }
 
 type VerifyConfig struct {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -74,7 +74,12 @@ func ChangedFiles(ctx context.Context, workdir string) ([]string, error) {
 // Diffstat returns the set of changed files and the total added+deleted
 // lines for the working tree at workdir. It uses `git add --intent-to-add
 // --all` so newly created (untracked) files show up, then runs
-// `git diff --numstat HEAD` to capture both modified and added paths.
+// `git diff --numstat -z HEAD` to capture both modified and added paths.
+// The `-z` flag is required for correct policy matching: without it, git
+// emits rename entries as `old => new` or `{a => b}/c` strings that no
+// glob will match, silently bypassing deny/allow rules. With `-z`, rename
+// entries are emitted as `added\tdeleted\t\0old\0new\0` (three NUL fields
+// instead of one), letting us pull the destination path verbatim.
 // Binary files (which numstat reports as "-\t-") contribute 0 lines but
 // are still counted as changed files.
 func Diffstat(ctx context.Context, workdir string) (policy.Diffstat, error) {
@@ -84,27 +89,55 @@ func Diffstat(ctx context.Context, workdir string) (policy.Diffstat, error) {
 	if err := run(ctx, workdir, "git", "add", "--intent-to-add", "--all"); err != nil {
 		return policy.Diffstat{}, fmt.Errorf("git add --intent-to-add: %w", err)
 	}
-	cmd := exec.CommandContext(ctx, "git", "diff", "--numstat", "HEAD")
+	cmd := exec.CommandContext(ctx, "git", "diff", "--numstat", "-z", "HEAD")
 	cmd.Dir = workdir
 	out, err := cmd.Output()
 	if err != nil {
 		return policy.Diffstat{}, err
 	}
+	return parseNumstatZ(out)
+}
+
+// parseNumstatZ parses the NUL-delimited output of `git diff --numstat -z`.
+// Each record is one of:
+//
+//	"<added>\t<deleted>\t<path>\0"               (normal)
+//	"<added>\t<deleted>\t\0<old_path>\0<new_path>\0" (rename/copy)
+//
+// For renames we record only the destination path so that policy globs
+// match the file as it will live in the tree.
+func parseNumstatZ(out []byte) (policy.Diffstat, error) {
 	var d policy.Diffstat
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	// Split on NUL; the trailing terminator yields a final empty token we skip.
+	tokens := strings.Split(string(out), "\x00")
+	i := 0
+	for i < len(tokens) {
+		tok := tokens[i]
+		if tok == "" {
+			i++
 			continue
 		}
-		// numstat format: "<added>\t<deleted>\t<path>" (path may include rename "old => new")
-		parts := strings.SplitN(line, "\t", 3)
+		// Each numstat record begins with "<added>\t<deleted>\t<rest>".
+		parts := strings.SplitN(tok, "\t", 3)
 		if len(parts) != 3 {
+			i++
 			continue
 		}
 		added, _ := strconv.Atoi(parts[0])
 		deleted, _ := strconv.Atoi(parts[1])
 		d.Lines += added + deleted
+		if parts[2] == "" {
+			// Rename/copy: next two NUL-delimited tokens are old, then new.
+			if i+2 >= len(tokens) {
+				return d, fmt.Errorf("malformed numstat -z rename record: %q", tok)
+			}
+			newPath := tokens[i+2]
+			d.Files = append(d.Files, newPath)
+			i += 3
+			continue
+		}
 		d.Files = append(d.Files, parts[2])
+		i++
 	}
 	return d, nil
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/policy"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -62,36 +64,78 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) error {
 }
 
 func ChangedFiles(ctx context.Context, workdir string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only")
-	cmd.Dir = workdir
-	out, err := cmd.Output()
+	d, err := Diffstat(ctx, workdir)
 	if err != nil {
 		return nil, err
 	}
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	files := make([]string, 0, len(lines))
-	for _, l := range lines {
-		if strings.TrimSpace(l) != "" {
-			files = append(files, strings.TrimSpace(l))
-		}
-	}
-	return files, nil
+	return d.Files, nil
 }
 
+// Diffstat returns the set of changed files and the total added+deleted
+// lines for the working tree at workdir. It uses `git add --intent-to-add
+// --all` so newly created (untracked) files show up, then runs
+// `git diff --numstat HEAD` to capture both modified and added paths.
+// Binary files (which numstat reports as "-\t-") contribute 0 lines but
+// are still counted as changed files.
+func Diffstat(ctx context.Context, workdir string) (policy.Diffstat, error) {
+	// Mark untracked files so they appear in `git diff` without actually
+	// staging their content. This is reversible and idempotent; the
+	// subsequent `git add .` in CommitAndPush will fully stage them.
+	if err := run(ctx, workdir, "git", "add", "--intent-to-add", "--all"); err != nil {
+		return policy.Diffstat{}, fmt.Errorf("git add --intent-to-add: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, "git", "diff", "--numstat", "HEAD")
+	cmd.Dir = workdir
+	out, err := cmd.Output()
+	if err != nil {
+		return policy.Diffstat{}, err
+	}
+	var d policy.Diffstat
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// numstat format: "<added>\t<deleted>\t<path>" (path may include rename "old => new")
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		added, _ := strconv.Atoi(parts[0])
+		deleted, _ := strconv.Atoi(parts[1])
+		d.Lines += added + deleted
+		d.Files = append(d.Files, parts[2])
+	}
+	return d, nil
+}
+
+// PolicyError is returned by EnforcePolicy when one or more policy checks
+// fail. It carries the structured violations so callers (the worker) can
+// emit a precise task event.
+type PolicyError struct {
+	Violations []policy.Violation
+}
+
+func (e *PolicyError) Error() string {
+	return "policy violation: " + policy.Summarize(e.Violations)
+}
+
+// EnforcePolicy gathers a diffstat for workdir and evaluates it against the
+// workflow PolicyConfig. On any violation it returns *PolicyError so that
+// the worker can both block the push and write a structured task event.
 func EnforcePolicy(ctx context.Context, workdir string, cfg workflow.Config) error {
-	files, err := ChangedFiles(ctx, workdir)
+	d, err := Diffstat(ctx, workdir)
 	if err != nil {
 		return err
 	}
-	if cfg.Policy.MaxChangedFiles > 0 && len(files) > cfg.Policy.MaxChangedFiles {
-		return fmt.Errorf("changed files %d exceeds max %d", len(files), cfg.Policy.MaxChangedFiles)
+	pcfg := policy.Config{
+		AllowPaths:      cfg.Policy.AllowPaths,
+		DenyPaths:       cfg.Policy.DenyPaths,
+		MaxChangedFiles: cfg.Policy.MaxChangedFiles,
+		MaxChangedLines: cfg.Policy.LineLimit(),
 	}
-	for _, f := range files {
-		for _, p := range cfg.Policy.DenyPaths {
-			if matchesPath(p, f) {
-				return fmt.Errorf("changed denied path %s matches %s", f, p)
-			}
-		}
+	if vs := policy.Evaluate(d, pcfg); len(vs) > 0 {
+		return &PolicyError{Violations: vs}
 	}
 	return nil
 }
@@ -121,19 +165,4 @@ func sanitize(s string) string {
 	s = strings.ReplaceAll(s, "/", "_")
 	s = strings.ReplaceAll(s, " ", "_")
 	return s
-}
-
-func matchesPath(pattern, file string) bool {
-	pattern = strings.TrimSpace(pattern)
-	if pattern == "" {
-		return false
-	}
-	if strings.HasSuffix(pattern, "/**") {
-		return strings.HasPrefix(file, strings.TrimSuffix(pattern, "**"))
-	}
-	if strings.HasSuffix(pattern, "*") {
-		return strings.HasPrefix(file, strings.TrimSuffix(pattern, "*"))
-	}
-	ok, _ := filepath.Match(pattern, file)
-	return ok || pattern == file
 }

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1,0 +1,136 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/policy"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// initRepo creates a temp git repo seeded with a single committed file so
+// `git diff HEAD` has a valid base.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "init", "-q", "-b", "main"},
+		{"git", "config", "user.email", "test@example.com"},
+		{"git", "config", "user.name", "test"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-q", "-m", "seed"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+func TestDiffstatCountsModifiedAndUntracked(t *testing.T) {
+	dir := initRepo(t)
+	// modify seed
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\nmore\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// add untracked deny-pathish file
+	if err := os.MkdirAll(filepath.Join(dir, "infra"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "infra", "main.tf"), []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := Diffstat(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Diffstat error: %v", err)
+	}
+	if len(d.Files) != 2 {
+		t.Fatalf("expected 2 files, got %v", d.Files)
+	}
+	if d.Lines < 4 { // 1 added line on seed + 3 added lines on infra/main.tf
+		t.Fatalf("expected >=4 lines, got %d", d.Lines)
+	}
+}
+
+func TestEnforcePolicyDenyBlocksAndReturnsStructuredError(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.MkdirAll(filepath.Join(dir, "infra"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "infra", "main.tf"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := workflow.Config{Policy: workflow.PolicyConfig{
+		DenyPaths:       []string{"infra/**"},
+		MaxChangedFiles: 100,
+		MaxChangedLines: 100,
+	}}
+	err := EnforcePolicy(context.Background(), dir, cfg)
+	if err == nil {
+		t.Fatal("expected policy error")
+	}
+	var pe *PolicyError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *PolicyError, got %T: %v", err, err)
+	}
+	if len(pe.Violations) != 1 || pe.Violations[0].Kind != policy.KindDenyPath {
+		t.Fatalf("unexpected violations: %+v", pe.Violations)
+	}
+}
+
+func TestEnforcePolicyMaxLinesUsesLegacyLOC(t *testing.T) {
+	dir := initRepo(t)
+	// 10 added lines
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := workflow.Config{Policy: workflow.PolicyConfig{MaxChangedLOC: 3}}
+	err := EnforcePolicy(context.Background(), dir, cfg)
+	var pe *PolicyError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected PolicyError, got %v", err)
+	}
+	found := false
+	for _, v := range pe.Violations {
+		if v.Kind == policy.KindMaxChangedLines {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected max_changed_lines violation, got %+v", pe.Violations)
+	}
+}
+
+func TestEnforcePolicyCleanWorkdir(t *testing.T) {
+	dir := initRepo(t)
+	cfg := workflow.Config{Policy: workflow.PolicyConfig{
+		DenyPaths:       []string{"infra/**"},
+		MaxChangedFiles: 5,
+		MaxChangedLines: 50,
+	}}
+	if err := EnforcePolicy(context.Background(), dir, cfg); err != nil {
+		t.Fatalf("expected no policy error on clean workdir, got %v", err)
+	}
+}

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/policy"
@@ -120,6 +121,143 @@ func TestEnforcePolicyMaxLinesUsesLegacyLOC(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected max_changed_lines violation, got %+v", pe.Violations)
+	}
+}
+
+// TestParseNumstatZ_VanillaRenameAndBrace covers the three numstat -z
+// shapes we care about for path-policy enforcement:
+//
+//  1. Normal modify/add: "added\tdeleted\tpath\0"
+//  2. Cross-directory rename (would render as "old => new" without -z):
+//     "added\tdeleted\t\0old\0new\0"
+//  3. Brace rename with shared prefix (would render as "{a => b}/c" without -z):
+//     "added\tdeleted\t\0src/sub/file.go\0infra/sub/file.go\0"
+//
+// In all rename cases we must report the *new* path so that policy globs
+// like "infra/**" match.
+func TestParseNumstatZ_VanillaRenameAndBrace(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		wantFiles []string
+		wantLines int
+	}{
+		{
+			name:      "vanilla modify",
+			raw:       "1\t0\tseed.txt\x00",
+			wantFiles: []string{"seed.txt"},
+			wantLines: 1,
+		},
+		{
+			name:      "cross-directory rename (=> form)",
+			raw:       "0\t0\t\x00src/old.go\x00infra/new.go\x00",
+			wantFiles: []string{"infra/new.go"},
+			wantLines: 0,
+		},
+		{
+			name:      "brace rename (shared prefix/suffix)",
+			raw:       "0\t0\t\x00src/sub/file.go\x00infra/sub/file.go\x00",
+			wantFiles: []string{"infra/sub/file.go"},
+			wantLines: 0,
+		},
+		{
+			name:      "mixed: modify + rename + add",
+			raw:       "2\t1\tseed.txt\x000\t0\t\x00src/a.go\x00infra/a.go\x003\t0\tnew.md\x00",
+			wantFiles: []string{"seed.txt", "infra/a.go", "new.md"},
+			wantLines: 6,
+		},
+		{
+			name:      "binary file (numstat reports - -)",
+			raw:       "-\t-\timg.png\x00",
+			wantFiles: []string{"img.png"},
+			wantLines: 0,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseNumstatZ([]byte(tc.raw))
+			if err != nil {
+				t.Fatalf("parseNumstatZ error: %v", err)
+			}
+			if !reflect.DeepEqual(got.Files, tc.wantFiles) {
+				t.Fatalf("files mismatch:\n got=%q\nwant=%q", got.Files, tc.wantFiles)
+			}
+			if got.Lines != tc.wantLines {
+				t.Fatalf("lines mismatch: got=%d want=%d", got.Lines, tc.wantLines)
+			}
+		})
+	}
+}
+
+// TestEnforcePolicyDeniesCrossDirectoryRename is the regression test for
+// the P1 review thread: before normalizing rename paths, a `git mv
+// src/foo.go infra/foo.tf` would emit `src/foo.go => infra/foo.tf` in
+// numstat output, which does not match the `infra/**` glob, so the deny
+// rule was silently bypassed. With -z parsing the destination path is
+// matched directly.
+func TestEnforcePolicyDeniesCrossDirectoryRename(t *testing.T) {
+	dir := initRepo(t)
+	// Seed a file inside src/ and commit it so we have something to rename.
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "src", "main.tf"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-q", "-m", "add src/main.tf"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	// Rename across directories into a denied path.
+	if err := os.MkdirAll(filepath.Join(dir, "infra"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "mv", "src/main.tf", "infra/main.tf")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git mv: %v\n%s", err, out)
+	}
+
+	cfg := workflow.Config{Policy: workflow.PolicyConfig{
+		DenyPaths:       []string{"infra/**"},
+		MaxChangedFiles: 100,
+		MaxChangedLines: 100,
+	}}
+	err := EnforcePolicy(context.Background(), dir, cfg)
+	if err == nil {
+		t.Fatal("expected policy error for cross-directory rename into infra/")
+	}
+	var pe *PolicyError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *PolicyError, got %T: %v", err, err)
+	}
+	foundDeny := false
+	for _, v := range pe.Violations {
+		if v.Kind == policy.KindDenyPath {
+			foundDeny = true
+		}
+	}
+	if !foundDeny {
+		t.Fatalf("expected deny_path violation, got %+v", pe.Violations)
+	}
+
+	// Sanity: ChangedFiles should report the destination path, not the
+	// `src/main.tf => infra/main.tf` rename form.
+	files, err := ChangedFiles(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("ChangedFiles: %v", err)
+	}
+	for _, f := range files {
+		if f != "infra/main.tf" {
+			t.Fatalf("expected normalized destination path infra/main.tf, got %q (full=%v)", f, files)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #21

## Summary
- Adds a dependency-free `internal/policy` package with a robust glob matcher (`**`, `*`, `?`) and structured `Violation` values for `deny_path`, `not_allowed`, `max_changed_files`, `max_changed_lines`.
- `workspace.Diffstat` now uses `git add --intent-to-add --all` + `git diff --numstat HEAD` so untracked files and total added+deleted lines are observable, not just modified file names.
- `workspace.EnforcePolicy` returns a typed `*PolicyError` carrying every violation. The worker writes a structured `policy_violation` task event (with JSON payload listing each violation) and returns the error before push/PR, so policy failures reliably block remote changes.
- `workflow.PolicyConfig` adds `max_changed_lines` while preserving the legacy `max_changed_loc` via `PolicyConfig.LineLimit()`. Existing WORKFLOW.md files keep working.
- Adds `queue.Store.AddEventWithPayload` so structured events can attach JSON details.

## Acceptance criteria
- [x] Deny paths support glob patterns reliably (covers `**`, `*`, `?`, `path/`, `**/file`, etc.)
- [x] Max changed files enforced (`max_changed_files`).
- [x] Max changed lines enforced (`max_changed_lines`, with `max_changed_loc` fallback).
- [x] Policy failure blocks push/PR (returns before `CommitAndPush` / `createPR`).
- [x] Policy failure writes a clear task event (`policy_violation` with JSON payload).

## Tests
- `internal/policy/policy_test.go` covers glob edge cases, deny/allow precedence, file/line limits, blank entries, and accumulated violations.
- `internal/workspace/manager_test.go` exercises `Diffstat` and `EnforcePolicy` end-to-end against a real temp git repo (skips if `git` is unavailable).
- `gofmt -l cmd internal`, `go vet ./...`, `go build ./...`, `go test ./...` all pass locally.

## Dependencies
- No new dependencies. Glob matching is implemented with stdlib only (no `doublestar` or similar).