### PR TITLE
feat: enrich task events and run artifacts

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -17,6 +17,14 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
 )
+
+// eventEmitter is the subset of the queue store the worker needs to record
+// per-stage events. Defined here so unit tests can verify the worker emits
+// the right kinds without standing up a database.
+type eventEmitter interface {
+	AddEvent(ctx context.Context, taskID, typ, msg string) error
+	AddEventWithPayload(ctx context.Context, taskID, typ, msg string, payload any) error
+}
 
 func main() {
 	ctx := context.Background()
@@ -48,7 +56,7 @@ func main() {
 	}
 }
 
-func runTask(ctx context.Context, store *queue.Store, t task.Task) error {
+func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 	mgr := workspace.New(env("WORKSPACE_ROOT", "/tmp/aiops-workspaces"))
 	workdir, err := mgr.PrepareGitWorkspace(ctx, t)
 	if err != nil {
@@ -83,44 +91,105 @@ func runTask(ctx context.Context, store *queue.Store, t task.Task) error {
 	if err != nil {
 		return err
 	}
-	if _, err := r.Run(ctx, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, Prompt: prompt}); err != nil {
-		return err
+
+	emit(ctx, ev, t.ID, task.EventRunnerStart, "runner started", map[string]any{"model": t.Model})
+	runnerStart := time.Now()
+	res, runErr := r.Run(ctx, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, Prompt: prompt})
+	runnerDur := time.Since(runnerStart)
+	runnerPayload := map[string]any{"model": t.Model, "duration_ms": runnerDur.Milliseconds()}
+	if runErr != nil {
+		runnerPayload["error"] = errSummary(runErr)
+		emit(ctx, ev, t.ID, task.EventRunnerEnd, "runner failed", runnerPayload)
+		writeFailureArtifacts(ctx, workdir, nil, "runner failed: "+errSummary(runErr))
+		return runErr
 	}
+	if res.Summary != "" {
+		runnerPayload["summary"] = res.Summary
+	}
+	emit(ctx, ev, t.ID, task.EventRunnerEnd, "runner completed", runnerPayload)
+
 	if err := workspace.EnforcePolicy(ctx, workdir, wf.Config); err != nil {
-		recordPolicyViolation(ctx, store, t.ID, err)
+		recordPolicyViolation(ctx, ev, t.ID, err)
+		writeFailureArtifacts(ctx, workdir, nil, "policy check failed: "+errSummary(err))
 		return err
 	}
-	if err := workspace.RunVerify(ctx, workdir, wf.Config); err != nil {
-		return err
+
+	emit(ctx, ev, t.ID, task.EventVerifyStart, "verify started", map[string]any{"commands": wf.Config.Verify.Commands})
+	verifyStart := time.Now()
+	verifyResults, verifyErr := workspace.RunVerify(ctx, workdir, wf.Config)
+	verifyDur := time.Since(verifyStart)
+	if writeErr := workspace.WriteVerification(workdir, verifyResults); writeErr != nil {
+		log.Printf("task %s: write verification artifact: %v", t.ID, writeErr)
 	}
+	verifyPayload := map[string]any{
+		"duration_ms": verifyDur.Milliseconds(),
+		"commands":    summarizeVerifyResults(verifyResults),
+	}
+	if verifyErr != nil {
+		verifyPayload["error"] = errSummary(verifyErr)
+		emit(ctx, ev, t.ID, task.EventVerifyEnd, "verify failed", verifyPayload)
+		writeFailureArtifacts(ctx, workdir, verifyResults, "verify failed: "+errSummary(verifyErr))
+		return verifyErr
+	}
+	emit(ctx, ev, t.ID, task.EventVerifyEnd, "verify completed", verifyPayload)
+
+	changed, _ := workspace.AllChangedFiles(ctx, workdir)
+	if err := workspace.WriteChangedFiles(workdir, changed); err != nil {
+		log.Printf("task %s: write changed files artifact: %v", t.ID, err)
+	}
+	if err := workspace.WriteSummary(workdir, runSummary(t, res, changed, verifyResults)); err != nil {
+		log.Printf("task %s: write run summary artifact: %v", t.ID, err)
+	}
+
+	pushStart := time.Now()
 	if err := workspace.CommitAndPush(ctx, workdir, t.Title, t.WorkBranch); err != nil {
+		emit(ctx, ev, t.ID, task.EventPush, "push failed", map[string]any{
+			"branch":      t.WorkBranch,
+			"duration_ms": time.Since(pushStart).Milliseconds(),
+			"error":       errSummary(err),
+		})
 		return err
 	}
-	return createPR(ctx, t, wf.Config)
+	emit(ctx, ev, t.ID, task.EventPush, "push completed", map[string]any{
+		"branch":         t.WorkBranch,
+		"duration_ms":    time.Since(pushStart).Milliseconds(),
+		"changed_files":  len(changed),
+		"sample_changes": sampleSlice(changed, 10),
+	})
+
+	return createPR(ctx, ev, t, wf.Config)
 }
 
 // recordPolicyViolation writes a structured `policy_violation` task event
 // before the worker fails the task. The push/PR step is skipped because the
 // caller returns the error immediately after this call.
-func recordPolicyViolation(ctx context.Context, store *queue.Store, taskID string, err error) {
+func recordPolicyViolation(ctx context.Context, ev eventEmitter, taskID string, err error) {
+	if ev == nil {
+		return
+	}
 	var perr *workspace.PolicyError
 	if errors.As(err, &perr) {
-		payload, mErr := json.Marshal(map[string]any{"violations": perr.Violations})
-		if mErr == nil {
-			_ = store.AddEventWithPayload(ctx, taskID, "policy_violation", perr.Error(), payload)
+		if emitErr := ev.AddEventWithPayload(ctx, taskID, "policy_violation", perr.Error(), map[string]any{"violations": perr.Violations}); emitErr == nil {
 			return
 		}
 	}
-	_ = store.AddEvent(ctx, taskID, "policy_violation", err.Error())
+	_ = ev.AddEvent(ctx, taskID, "policy_violation", err.Error())
 }
 
-func createPR(ctx context.Context, t task.Task, cfg workflow.Config) error {
+func createPR(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config) error {
+	_ = cfg
 	client := gitea.Client{BaseURL: os.Getenv("GITEA_BASE_URL"), Token: os.Getenv("GITEA_TOKEN")}
 	body := fmt.Sprintf("## AI Task\n\nTask ID: `%s`\n\n## Source\n\n%s / %s\n\n## Changes\n\nGenerated by aiops-platform Symphony-style worker.\n\n## Verification\n\nSee workflow verify commands and worker logs.\n\n## Risk\n\nHuman review required.\n", t.ID, t.SourceType, t.SourceEventID)
 	pr, err := client.CreatePullRequest(ctx, gitea.CreatePullRequestInput{Owner: t.RepoOwner, Repo: t.RepoName, Title: "chore(ai): " + t.Title, Body: body, Head: t.WorkBranch, Base: t.BaseBranch})
 	if err != nil {
+		emit(ctx, ev, t.ID, task.EventPRCreated, "pr creation failed", map[string]any{"error": errSummary(err)})
 		return err
 	}
+	emit(ctx, ev, t.ID, task.EventPRCreated, "pr created", map[string]any{
+		"number":   pr.Number,
+		"html_url": pr.HTMLURL,
+		"title":    pr.Title,
+	})
 	log.Printf("task %s created PR #%d %s", t.ID, pr.Number, pr.HTMLURL)
 	return nil
 }
@@ -130,6 +199,91 @@ func writeTaskFiles(workdir string, t task.Task, prompt string) error {
 		return err
 	}
 	return os.WriteFile(workdir+"/.aiops/TASK.md", []byte(fmt.Sprintf("# Task %s\n\n%s\n", t.ID, t.Description)), 0o644)
+}
+
+// writeFailureArtifacts persists what we know on the failure path so failed
+// tasks can be inspected after the fact via the workspace tree.
+func writeFailureArtifacts(ctx context.Context, workdir string, verifyResults []workspace.VerifyResult, summary string) {
+	if changed, err := workspace.AllChangedFiles(ctx, workdir); err == nil {
+		_ = workspace.WriteChangedFiles(workdir, changed)
+	}
+	if len(verifyResults) > 0 {
+		_ = workspace.WriteVerification(workdir, verifyResults)
+	}
+	_ = workspace.WriteSummary(workdir, summary+"\n")
+}
+
+func emit(ctx context.Context, ev eventEmitter, taskID, kind, msg string, payload any) {
+	if ev == nil {
+		return
+	}
+	if err := ev.AddEventWithPayload(ctx, taskID, kind, msg, payload); err != nil {
+		log.Printf("task %s: emit %s event: %v", taskID, kind, err)
+	}
+}
+
+func errSummary(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if len(msg) > 500 {
+		msg = msg[:500] + "..."
+	}
+	return msg
+}
+
+func summarizeVerifyResults(results []workspace.VerifyResult) []map[string]any {
+	out := make([]map[string]any, 0, len(results))
+	for _, r := range results {
+		entry := map[string]any{
+			"command":     r.Command,
+			"exit_code":   r.ExitCode,
+			"duration_ms": r.Duration.Milliseconds(),
+		}
+		if r.Err != nil {
+			entry["error"] = errSummary(r.Err)
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func runSummary(t task.Task, res runner.Result, changed []string, verifyResults []workspace.VerifyResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Run summary for %s\n\n", t.ID)
+	fmt.Fprintf(&b, "- Title: %s\n", t.Title)
+	fmt.Fprintf(&b, "- Actor: %s\n", t.Actor)
+	fmt.Fprintf(&b, "- Model: %s\n", t.Model)
+	if res.Summary != "" {
+		fmt.Fprintf(&b, "- Runner: %s\n", res.Summary)
+	}
+	fmt.Fprintf(&b, "- Branch: %s -> %s\n", t.BaseBranch, t.WorkBranch)
+	fmt.Fprintf(&b, "- Changed files: %d\n", len(changed))
+	if len(changed) > 0 {
+		b.WriteString("\n## Changed files\n\n")
+		for _, f := range changed {
+			fmt.Fprintf(&b, "- %s\n", f)
+		}
+	}
+	if len(verifyResults) > 0 {
+		b.WriteString("\n## Verification\n\n")
+		for _, r := range verifyResults {
+			status := "ok"
+			if r.Err != nil {
+				status = "failed"
+			}
+			fmt.Fprintf(&b, "- `%s` (%s, %dms)\n", r.Command, status, r.Duration.Milliseconds())
+		}
+	}
+	return b.String()
+}
+
+func sampleSlice(items []string, max int) []string {
+	if len(items) <= max {
+		return items
+	}
+	return items[:max]
 }
 
 func env(k, d string) string {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -133,6 +133,18 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 	}
 	emit(ctx, ev, t.ID, task.EventVerifyEnd, "verify completed", verifyPayload)
 
+	// Snapshot the changed files AFTER all run artifacts have been written so
+	// that CHANGED_FILES.txt, RUN_SUMMARY.md, and the success-path event
+	// payload reflect what is actually about to be committed (artifacts
+	// included). We seed the artifacts with empty stubs so they are present in
+	// the working tree when `git status --porcelain` runs, then rewrite them
+	// with the final snapshot contents.
+	if err := workspace.WriteChangedFiles(workdir, nil); err != nil {
+		log.Printf("task %s: seed changed files artifact: %v", t.ID, err)
+	}
+	if err := workspace.WriteSummary(workdir, ""); err != nil {
+		log.Printf("task %s: seed run summary artifact: %v", t.ID, err)
+	}
 	changed, _ := workspace.AllChangedFiles(ctx, workdir)
 	if err := workspace.WriteChangedFiles(workdir, changed); err != nil {
 		log.Printf("task %s: write changed files artifact: %v", t.ID, err)

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
+)
+
+type recordedEvent struct {
+	Kind    string
+	Message string
+	Payload any
+}
+
+type fakeEmitter struct {
+	mu     sync.Mutex
+	events []recordedEvent
+	err    error
+}
+
+func (f *fakeEmitter) AddEvent(_ context.Context, _ string, kind, msg string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, recordedEvent{Kind: kind, Message: msg})
+	return f.err
+}
+
+func (f *fakeEmitter) AddEventWithPayload(_ context.Context, _ string, kind, msg string, payload any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, recordedEvent{Kind: kind, Message: msg, Payload: payload})
+	return f.err
+}
+
+func TestEmitRecordsEventOnFakeEmitter(t *testing.T) {
+	ev := &fakeEmitter{}
+	emit(context.Background(), ev, "tsk_1", task.EventRunnerStart, "runner started", map[string]any{"model": "mock"})
+	if len(ev.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(ev.events))
+	}
+	got := ev.events[0]
+	if got.Kind != task.EventRunnerStart {
+		t.Fatalf("kind = %q, want %q", got.Kind, task.EventRunnerStart)
+	}
+	// Payload must round-trip through JSON since the queue store stores it as jsonb.
+	b, err := json.Marshal(got.Payload)
+	if err != nil {
+		t.Fatalf("payload marshal error: %v", err)
+	}
+	if !strings.Contains(string(b), `"model":"mock"`) {
+		t.Fatalf("payload JSON = %s, want model=mock", b)
+	}
+}
+
+func TestEmitNilEmitterIsNoop(t *testing.T) {
+	// Should not panic when worker is started without an emitter (e.g. tests).
+	emit(context.Background(), nil, "tsk_1", task.EventRunnerStart, "ignored", nil)
+}
+
+func TestEmitLogsEmitterError(t *testing.T) {
+	ev := &fakeEmitter{err: errors.New("db down")}
+	emit(context.Background(), ev, "tsk_1", task.EventPush, "push", nil)
+	if len(ev.events) != 1 {
+		t.Fatalf("event should still be recorded by fake even when error returned")
+	}
+}
+
+func TestErrSummaryTruncatesLongMessages(t *testing.T) {
+	if errSummary(nil) != "" {
+		t.Fatalf("nil error should map to empty string")
+	}
+	long := strings.Repeat("x", 600)
+	got := errSummary(errors.New(long))
+	if len(got) > 600 {
+		t.Fatalf("errSummary did not truncate: len=%d", len(got))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("truncated message should end with ellipsis, got %q", got[len(got)-10:])
+	}
+}
+
+func TestSummarizeVerifyResultsIncludesError(t *testing.T) {
+	results := []workspace.VerifyResult{
+		{Command: "go test", ExitCode: 0, Duration: 10 * time.Millisecond},
+		{Command: "make lint", ExitCode: 2, Err: errors.New("lint failed"), Duration: 5 * time.Millisecond},
+	}
+	got := summarizeVerifyResults(results)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	if got[0]["command"] != "go test" || got[0]["exit_code"] != 0 {
+		t.Fatalf("entry 0 = %+v", got[0])
+	}
+	if got[1]["error"] != "lint failed" {
+		t.Fatalf("entry 1 should propagate error, got %+v", got[1])
+	}
+	// Round-trip JSON to ensure it is a valid jsonb payload.
+	if _, err := json.Marshal(got); err != nil {
+		t.Fatalf("verify summary JSON: %v", err)
+	}
+}
+
+func TestRunSummaryContainsKeyFields(t *testing.T) {
+	t1 := task.Task{ID: "tsk_99", Title: "fix bug", Actor: "octo", Model: "claude", BaseBranch: "main", WorkBranch: "ai/tsk_99"}
+	res := runner.Result{Summary: "claude completed"}
+	changed := []string{"a.go", "b.go"}
+	verify := []workspace.VerifyResult{{Command: "go test", ExitCode: 0, Duration: time.Millisecond}}
+	out := runSummary(t1, res, changed, verify)
+	for _, want := range []string{"tsk_99", "fix bug", "claude completed", "main -> ai/tsk_99", "Changed files: 2", "a.go", "go test"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("run summary missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestEventKindConstantsAreSnakeCase(t *testing.T) {
+	required := []string{
+		task.EventRunnerStart,
+		task.EventRunnerEnd,
+		task.EventVerifyStart,
+		task.EventVerifyEnd,
+		task.EventPush,
+		task.EventPRCreated,
+	}
+	for _, kind := range required {
+		if kind == "" {
+			t.Fatalf("event kind constant is empty")
+		}
+		if strings.ToLower(kind) != kind {
+			t.Fatalf("event kind %q must be lowercase snake_case", kind)
+		}
+	}
+}

--- a/docs/runbooks/task-api.md
+++ b/docs/runbooks/task-api.md
@@ -27,3 +27,23 @@ curl 'http://localhost:8080/v1/tasks/tsk_example/events'
 ```
 
 Returns task events in creation order. Use this after a manual enqueue or webhook run to inspect enqueue, claim, retry, and completion progress.
+
+The worker emits the following per-stage events with structured `payload`
+context (durations in `duration_ms`, command summaries, error excerpts) so a
+failed run can be reconstructed from the event timeline alone:
+
+- `enqueued`, `claimed` — queue lifecycle
+- `runner_start`, `runner_end` — agent runner timing and summary
+- `verify_start`, `verify_end` — workflow verify command results
+- `push` — git push outcome and changed file count
+- `pr_created` — pull request creation (number, html_url) or failure
+- `succeeded`, `failed_attempt` — terminal outcomes
+
+The worker also writes the following artifacts under `.aiops/` in the
+workspace so failed tasks can be inspected on disk:
+
+- `PROMPT.md` — rendered prompt sent to the runner
+- `TASK.md` — task description
+- `RUN_SUMMARY.md` — high-level summary of the run, including changed files and verify status
+- `CHANGED_FILES.txt` — newline-separated list of files the worker is committing
+- `VERIFICATION.txt` — combined stdout+stderr of every verify command, with exit codes and durations

--- a/internal/queue/postgres.go
+++ b/internal/queue/postgres.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -42,7 +43,7 @@ RETURNING id,status,source_type,source_event_id,repo_owner,repo_name,clone_url,b
 	if err != nil {
 		return task.Task{}, false, err
 	}
-	_ = s.AddEvent(ctx, out.ID, "enqueued", "task accepted")
+	_ = s.AddEvent(ctx, out.ID, task.EventEnqueued, "task accepted")
 	return out, deduped, nil
 }
 
@@ -65,7 +66,7 @@ RETURNING t.id,t.status,t.source_type,t.source_event_id,t.repo_owner,t.repo_name
 	if err != nil {
 		return nil, err
 	}
-	_ = s.AddEvent(ctx, out.ID, "claimed", "worker claimed task")
+	_ = s.AddEvent(ctx, out.ID, task.EventClaimed, "worker claimed task")
 	return &out, nil
 }
 
@@ -131,7 +132,7 @@ func (s *Store) TaskEvents(ctx context.Context, taskID string) ([]task.Event, er
 func (s *Store) Complete(ctx context.Context, id string) error {
 	_, err := s.db.Exec(ctx, "UPDATE tasks SET status='succeeded', updated_at=now() WHERE id=$1", id)
 	if err == nil {
-		_ = s.AddEvent(ctx, id, "succeeded", "task completed")
+		_ = s.AddEvent(ctx, id, task.EventSucceeded, "task completed")
 	}
 	return err
 }
@@ -139,7 +140,7 @@ func (s *Store) Complete(ctx context.Context, id string) error {
 func (s *Store) Fail(ctx context.Context, id string, msg string) error {
 	_, err := s.db.Exec(ctx, `UPDATE tasks SET status=CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'queued' END, available_at=now()+interval '60 seconds', updated_at=now() WHERE id=$1`, id)
 	if err == nil {
-		_ = s.AddEvent(ctx, id, "failed_attempt", msg)
+		_ = s.AddEvent(ctx, id, task.EventFailedAttempt, msg)
 	}
 	return err
 }
@@ -149,14 +150,27 @@ func (s *Store) AddEvent(ctx context.Context, taskID, typ, msg string) error {
 	return err
 }
 
-// AddEventWithPayload writes a task event with a JSON payload. It is used
-// for structured events such as policy_violation where callers want to
-// attach the full violation list for later inspection.
-func (s *Store) AddEventWithPayload(ctx context.Context, taskID, typ, msg string, payload []byte) error {
-	if len(payload) == 0 {
+// AddEventWithPayload writes a task event with a structured JSON payload. It
+// is used for events such as policy_violation, runner_start, verify_end, etc.
+// where callers want to attach extra context for later inspection. Pass nil
+// (or an empty []byte) to keep the payload column NULL. The payload column is
+// jsonb; raw []byte is sent as-is, anything else is json.Marshal'd first.
+func (s *Store) AddEventWithPayload(ctx context.Context, taskID, typ, msg string, payload any) error {
+	if payload == nil {
 		return s.AddEvent(ctx, taskID, typ, msg)
 	}
-	_, err := s.db.Exec(ctx, "INSERT INTO task_events(task_id,event_type,message,payload) VALUES($1,$2,$3,$4)", taskID, typ, msg, payload)
+	if raw, ok := payload.([]byte); ok {
+		if len(raw) == 0 {
+			return s.AddEvent(ctx, taskID, typ, msg)
+		}
+		_, err := s.db.Exec(ctx, "INSERT INTO task_events(task_id,event_type,message,payload) VALUES($1,$2,$3,$4)", taskID, typ, msg, raw)
+		return err
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal task event payload: %w", err)
+	}
+	_, err = s.db.Exec(ctx, "INSERT INTO task_events(task_id,event_type,message,payload) VALUES($1,$2,$3,$4::jsonb)", taskID, typ, msg, string(b))
 	return err
 }
 

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -17,6 +17,21 @@ const (
 	StatusFailed    Status = "failed"
 )
 
+// Event kinds emitted by the queue store and the worker. Keep these in sync
+// with the docs in docs/runbooks/task-api.md and the cmd/worker stage helpers.
+const (
+	EventEnqueued      = "enqueued"
+	EventClaimed       = "claimed"
+	EventRunnerStart   = "runner_start"
+	EventRunnerEnd     = "runner_end"
+	EventVerifyStart   = "verify_start"
+	EventVerifyEnd     = "verify_end"
+	EventPush          = "push"
+	EventPRCreated     = "pr_created"
+	EventSucceeded     = "succeeded"
+	EventFailedAttempt = "failed_attempt"
+)
+
 type Task struct {
 	ID            string    `json:"id"`
 	Status        Status    `json:"status"`

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -8,11 +9,23 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/policy"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+// VerifyResult captures the outcome of running a workflow verify command.
+// Output contains the combined stdout+stderr so it can be persisted as a
+// run artifact even when the command fails.
+type VerifyResult struct {
+	Command  string
+	ExitCode int
+	Output   string
+	Duration time.Duration
+	Err      error
+}
 
 type Manager struct {
 	Root string
@@ -51,16 +64,84 @@ func WritePrompt(workdir string, prompt string) error {
 	return os.WriteFile(filepath.Join(dir, "PROMPT.md"), []byte(prompt), 0o644)
 }
 
-func RunVerify(ctx context.Context, workdir string, wf workflow.Config) error {
+// RunVerify executes the workflow verify commands in order. It returns one
+// VerifyResult per non-empty command (even when one fails) so callers can
+// persist the combined output as a run artifact for post-mortem inspection.
+// On the first failing command the slice is returned together with the
+// underlying error and remaining commands are skipped.
+func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]VerifyResult, error) {
+	var results []VerifyResult
 	for _, command := range wf.Verify.Commands {
 		if strings.TrimSpace(command) == "" {
 			continue
 		}
-		if err := run(ctx, workdir, "sh", "-lc", command); err != nil {
-			return fmt.Errorf("verify command failed %q: %w", command, err)
+		start := time.Now()
+		var buf bytes.Buffer
+		cmd := exec.CommandContext(ctx, "sh", "-lc", command)
+		cmd.Dir = workdir
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		runErr := cmd.Run()
+		res := VerifyResult{
+			Command:  command,
+			Output:   buf.String(),
+			Duration: time.Since(start),
+			ExitCode: cmd.ProcessState.ExitCode(),
+		}
+		if runErr != nil {
+			res.Err = runErr
+			results = append(results, res)
+			return results, fmt.Errorf("verify command failed %q: %w", command, runErr)
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
+
+// WriteSummary writes the per-run summary to .aiops/RUN_SUMMARY.md so it can
+// be committed alongside the change and inspected on failure paths.
+func WriteSummary(workdir, summary string) error {
+	return writeAiopsFile(workdir, "RUN_SUMMARY.md", summary)
+}
+
+// WriteChangedFiles writes one path per line to .aiops/CHANGED_FILES.txt.
+func WriteChangedFiles(workdir string, files []string) error {
+	body := strings.Join(files, "\n")
+	if body != "" {
+		body += "\n"
+	}
+	return writeAiopsFile(workdir, "CHANGED_FILES.txt", body)
+}
+
+// WriteVerification serializes verify command results to
+// .aiops/VERIFICATION.txt so failed runs preserve the diagnostic output.
+func WriteVerification(workdir string, results []VerifyResult) error {
+	var buf bytes.Buffer
+	for i, r := range results {
+		if i > 0 {
+			buf.WriteString("\n")
+		}
+		fmt.Fprintf(&buf, "$ %s\n", r.Command)
+		fmt.Fprintf(&buf, "exit_code=%d duration_ms=%d\n", r.ExitCode, r.Duration.Milliseconds())
+		if r.Err != nil {
+			fmt.Fprintf(&buf, "error: %s\n", r.Err.Error())
+		}
+		if r.Output != "" {
+			buf.WriteString(r.Output)
+			if !strings.HasSuffix(r.Output, "\n") {
+				buf.WriteString("\n")
+			}
 		}
 	}
-	return nil
+	return writeAiopsFile(workdir, "VERIFICATION.txt", buf.String())
+}
+
+func writeAiopsFile(workdir, name, body string) error {
+	dir := filepath.Join(workdir, ".aiops")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644)
 }
 
 func ChangedFiles(ctx context.Context, workdir string) ([]string, error) {
@@ -140,6 +221,42 @@ func parseNumstatZ(out []byte) (policy.Diffstat, error) {
 		i++
 	}
 	return d, nil
+}
+
+// AllChangedFiles returns every path the worker is about to commit: tracked
+// modifications plus untracked files reported by `git status --porcelain`.
+// This is what we want to persist as a run artifact since the runner often
+// creates new files (for example .aiops/RUN_SUMMARY.md) that `git diff`
+// alone does not surface.
+func AllChangedFiles(ctx context.Context, workdir string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
+	cmd.Dir = workdir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	files := []string{}
+	for _, line := range strings.Split(string(out), "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		path := strings.TrimSpace(line[3:])
+		if path == "" {
+			continue
+		}
+		// Rename entries look like "old -> new"; keep the new path.
+		if idx := strings.Index(path, " -> "); idx >= 0 {
+			path = strings.TrimSpace(path[idx+4:])
+		}
+		path = strings.Trim(path, "\"")
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		files = append(files, path)
+	}
+	return files, nil
 }
 
 // PolicyError is returned by EnforcePolicy when one or more policy checks

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,16 +17,60 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+// VerifyOutputCap bounds how many bytes of combined stdout+stderr we keep in
+// memory per verify command. Verbose verify steps (e.g. `go test -v ./...`)
+// can emit tens of MiB; capping prevents unbounded RAM use and the duplicate
+// allocation that happens when the output is later written as an artifact.
+const VerifyOutputCap = 1 << 20 // 1 MiB
+
 // VerifyResult captures the outcome of running a workflow verify command.
 // Output contains the combined stdout+stderr so it can be persisted as a
-// run artifact even when the command fails.
+// run artifact even when the command fails. When the captured output exceeds
+// VerifyOutputCap, Output is truncated to the cap and Truncated is set so
+// callers can surface the fact in artifacts and event payloads.
 type VerifyResult struct {
-	Command  string
-	ExitCode int
-	Output   string
-	Duration time.Duration
-	Err      error
+	Command   string
+	ExitCode  int
+	Output    string
+	Truncated bool
+	Duration  time.Duration
+	Err       error
 }
+
+// cappedBuffer is an io.Writer that buffers up to Cap bytes and silently
+// drops the rest while remembering how many bytes were dropped. It avoids
+// holding the entire output of a verbose verify command in memory.
+type cappedBuffer struct {
+	Cap     int
+	buf     bytes.Buffer
+	dropped int64
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	remaining := c.Cap - c.buf.Len()
+	if remaining > 0 {
+		take := len(p)
+		if take > remaining {
+			take = remaining
+		}
+		c.buf.Write(p[:take])
+		if take < len(p) {
+			c.dropped += int64(len(p) - take)
+		}
+	} else {
+		c.dropped += int64(len(p))
+	}
+	// Always report the full length so the producer treats the write as
+	// successful and does not block trying to drain io.ErrShortWrite.
+	return len(p), nil
+}
+
+func (c *cappedBuffer) String() string  { return c.buf.String() }
+func (c *cappedBuffer) Truncated() bool { return c.dropped > 0 }
+func (c *cappedBuffer) Dropped() int64  { return c.dropped }
+
+// Compile-time check that cappedBuffer satisfies io.Writer.
+var _ io.Writer = (*cappedBuffer)(nil)
 
 type Manager struct {
 	Root string
@@ -76,17 +121,18 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 			continue
 		}
 		start := time.Now()
-		var buf bytes.Buffer
+		buf := &cappedBuffer{Cap: VerifyOutputCap}
 		cmd := exec.CommandContext(ctx, "sh", "-lc", command)
 		cmd.Dir = workdir
-		cmd.Stdout = &buf
-		cmd.Stderr = &buf
+		cmd.Stdout = buf
+		cmd.Stderr = buf
 		runErr := cmd.Run()
 		res := VerifyResult{
-			Command:  command,
-			Output:   buf.String(),
-			Duration: time.Since(start),
-			ExitCode: cmd.ProcessState.ExitCode(),
+			Command:   command,
+			Output:    buf.String(),
+			Truncated: buf.Truncated(),
+			Duration:  time.Since(start),
+			ExitCode:  cmd.ProcessState.ExitCode(),
 		}
 		if runErr != nil {
 			res.Err = runErr
@@ -131,6 +177,9 @@ func WriteVerification(workdir string, results []VerifyResult) error {
 			if !strings.HasSuffix(r.Output, "\n") {
 				buf.WriteString("\n")
 			}
+		}
+		if r.Truncated {
+			fmt.Fprintf(&buf, "...output truncated at %d bytes\n", VerifyOutputCap)
 		}
 	}
 	return writeAiopsFile(workdir, "VERIFICATION.txt", buf.String())
@@ -227,9 +276,11 @@ func parseNumstatZ(out []byte) (policy.Diffstat, error) {
 // modifications plus untracked files reported by `git status --porcelain`.
 // This is what we want to persist as a run artifact since the runner often
 // creates new files (for example .aiops/RUN_SUMMARY.md) that `git diff`
-// alone does not surface.
+// alone does not surface. We pass `-uall` so newly created directories like
+// `.aiops/` are expanded to their individual files instead of collapsed to a
+// single `.aiops/` entry.
 func AllChangedFiles(ctx context.Context, workdir string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
+	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain", "-uall")
 	cmd.Dir = workdir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -336,5 +337,107 @@ func TestWriteArtifacts(t *testing.T) {
 		if !strings.Contains(string(got), want) {
 			t.Fatalf("%s = %q, want substring %q", name, got, want)
 		}
+	}
+}
+
+func TestRunVerifyCapsLargeOutputAndMarksTruncated(t *testing.T) {
+	dir := t.TempDir()
+	// Emit ~2 MiB so we exceed VerifyOutputCap (1 MiB) and trigger truncation.
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{Commands: []string{
+		"yes 0123456789abcdef0123456789abcdef | head -c 2097152",
+	}}}
+
+	results, err := RunVerify(context.Background(), dir, cfg)
+	if err != nil {
+		t.Fatalf("RunVerify error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 verify result, got %d", len(results))
+	}
+	r := results[0]
+	if !r.Truncated {
+		t.Fatalf("expected Truncated=true for 2 MiB output, got false")
+	}
+	if got := len(r.Output); got > VerifyOutputCap {
+		t.Fatalf("captured output should be <= cap, got %d > %d", got, VerifyOutputCap)
+	}
+	if got := len(r.Output); got < VerifyOutputCap-1024 {
+		t.Fatalf("captured output unexpectedly small: %d bytes", got)
+	}
+
+	// Persist + ensure the artifact mentions the truncation.
+	if err := WriteVerification(dir, results); err != nil {
+		t.Fatalf("WriteVerification: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, ".aiops", "VERIFICATION.txt"))
+	if err != nil {
+		t.Fatalf("read VERIFICATION.txt: %v", err)
+	}
+	wantMarker := fmt.Sprintf("...output truncated at %d bytes", VerifyOutputCap)
+	if !strings.Contains(string(body), wantMarker) {
+		t.Fatalf("VERIFICATION.txt missing truncation marker %q", wantMarker)
+	}
+}
+
+func TestCappedBufferDropsBeyondCap(t *testing.T) {
+	buf := &cappedBuffer{Cap: 10}
+	n, err := buf.Write([]byte("hello "))
+	if err != nil || n != 6 {
+		t.Fatalf("first write n=%d err=%v", n, err)
+	}
+	n, err = buf.Write([]byte("world!!"))
+	if err != nil || n != 7 {
+		t.Fatalf("second write should report full length, n=%d err=%v", n, err)
+	}
+	if got := buf.String(); got != "hello worl" {
+		t.Fatalf("buffered content = %q, want %q", got, "hello worl")
+	}
+	if !buf.Truncated() {
+		t.Fatalf("buffer should report Truncated=true after exceeding cap")
+	}
+	if buf.Dropped() != 3 {
+		t.Fatalf("dropped bytes = %d, want 3", buf.Dropped())
+	}
+}
+
+func TestAllChangedFilesIncludesArtifactsWhenSnapshotAfterWrite(t *testing.T) {
+	// Regression: success-path metadata under-reported pushed contents because
+	// AllChangedFiles ran before .aiops artifacts were written. Ordering the
+	// snapshot after WriteChangedFiles/WriteSummary should make those files
+	// appear in the result.
+	dir := t.TempDir()
+	mustGit(t, dir, "init", "-q")
+	mustGit(t, dir, "config", "user.email", "test@example.com")
+	mustGit(t, dir, "config", "user.name", "test")
+	mustGit(t, dir, "commit", "--allow-empty", "-q", "-m", "init")
+
+	if err := os.WriteFile(filepath.Join(dir, "src.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write src.go: %v", err)
+	}
+	if err := WriteChangedFiles(dir, nil); err != nil {
+		t.Fatalf("seed CHANGED_FILES.txt: %v", err)
+	}
+	if err := WriteSummary(dir, ""); err != nil {
+		t.Fatalf("seed RUN_SUMMARY.md: %v", err)
+	}
+
+	files, err := AllChangedFiles(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("AllChangedFiles: %v", err)
+	}
+	got := strings.Join(files, ",")
+	for _, want := range []string{"src.go", ".aiops/CHANGED_FILES.txt", ".aiops/RUN_SUMMARY.md"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("AllChangedFiles missing %q in %q", want, got)
+		}
+	}
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
 }

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/policy"
@@ -270,5 +271,70 @@ func TestEnforcePolicyCleanWorkdir(t *testing.T) {
 	}}
 	if err := EnforcePolicy(context.Background(), dir, cfg); err != nil {
 		t.Fatalf("expected no policy error on clean workdir, got %v", err)
+	}
+}
+
+func TestRunVerifyCapturesOutputAndStopsOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{Commands: []string{
+		"echo hello-world",
+		"   ", // empty command should be skipped without recording a result
+		"sh -c 'echo to-stderr 1>&2; exit 7'",
+		"echo unreachable",
+	}}}
+
+	results, err := RunVerify(context.Background(), dir, cfg)
+	if err == nil {
+		t.Fatalf("RunVerify should report failure when a command exits non-zero")
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 verify results (skip empty + stop after failure), got %d", len(results))
+	}
+	if !strings.Contains(results[0].Output, "hello-world") {
+		t.Fatalf("first result missing stdout: %q", results[0].Output)
+	}
+	if results[0].ExitCode != 0 || results[0].Err != nil {
+		t.Fatalf("first result should be success, got %+v", results[0])
+	}
+	if results[1].ExitCode != 7 {
+		t.Fatalf("second result exit code = %d, want 7", results[1].ExitCode)
+	}
+	if !strings.Contains(results[1].Output, "to-stderr") {
+		t.Fatalf("second result should capture stderr: %q", results[1].Output)
+	}
+	if results[1].Err == nil {
+		t.Fatalf("failed verify result should retain underlying error")
+	}
+}
+
+func TestWriteArtifacts(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteSummary(dir, "summary body"); err != nil {
+		t.Fatalf("WriteSummary error: %v", err)
+	}
+	if err := WriteChangedFiles(dir, []string{"a.go", "b.go"}); err != nil {
+		t.Fatalf("WriteChangedFiles error: %v", err)
+	}
+	if err := WriteVerification(dir, []VerifyResult{{
+		Command:  "go test ./...",
+		ExitCode: 0,
+		Output:   "ok\n",
+	}}); err != nil {
+		t.Fatalf("WriteVerification error: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"RUN_SUMMARY.md":    "summary body",
+		"CHANGED_FILES.txt": "a.go\nb.go\n",
+		"VERIFICATION.txt":  "go test ./...",
+	} {
+		got, err := os.ReadFile(filepath.Join(dir, ".aiops", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("%s = %q, want substring %q", name, got, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Emit structured per-stage task events (`runner_start`, `runner_end`, `verify_start`, `verify_end`, `push`, `pr_created`) with `duration_ms`, command summaries, and error excerpts in the existing `task_events.payload` jsonb column so a failed run can be reconstructed from the event timeline alone.
- Capture each workflow verify command's combined stdout+stderr, exit code, and duration; write run artifacts under `.aiops/` (`RUN_SUMMARY.md`, `CHANGED_FILES.txt`, `VERIFICATION.txt`) on both success and failure paths.
- Reuse the existing `task_events`/`AddEvent` and `.aiops/` artifact conventions; no schema migration required (payload column was already jsonb).

## Acceptance criteria

- [x] Task events include runner start/end, verify start/end, push, and PR creation
- [x] Artifacts include prompt, summary, changed files, and verification output
- [x] Failed tasks write the same artifacts and emit the matching `*_end`/`push`/`pr_created` failure events for inspection

## Test plan

- [x] `gofmt -l cmd internal`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...` (new tests in `internal/workspace` and `cmd/worker`)
- [ ] Manual smoke: run worker against a fake task, inspect `/v1/tasks/{id}/events` payloads and `.aiops/` artifacts

Closes #25