### PR TITLE
fix: re-enqueue Linear tasks when issue moves into Rework

### DIFF
--- a/cmd/linear-poller/main.go
+++ b/cmd/linear-poller/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -13,6 +14,19 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+// reworkStateName is the Linear state that should re-enqueue a task each
+// time the issue moves into it. The poller treats this state specially when
+// composing source_event_id so re-runs are not deduped against the original
+// task.
+const reworkStateName = "Rework"
+
+// enqueuer is the subset of queue.Store used by the poller. Defined as an
+// interface so the poll loop can be exercised in unit tests without a real
+// Postgres pool.
+type enqueuer interface {
+	Enqueue(ctx context.Context, t task.Task) (task.Task, bool, error)
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -43,32 +57,72 @@ func main() {
 			time.Sleep(interval)
 			continue
 		}
-		for _, issue := range issues {
-			if wf.Config.Repo.CloneURL == "" {
-				log.Printf("skip %s: repo.clone_url missing in WORKFLOW.md", issue.Identifier)
-				continue
-			}
-			out, deduped, err := store.Enqueue(ctx, task.Task{
-				SourceType:    "linear_issue",
-				SourceEventID: issue.ID,
-				RepoOwner:     wf.Config.Repo.Owner,
-				RepoName:      wf.Config.Repo.Name,
-				CloneURL:      wf.Config.Repo.CloneURL,
-				BaseBranch:    wf.Config.Repo.DefaultBranch,
-				Title:         fmt.Sprintf("%s %s", issue.Identifier, issue.Title),
-				Description:   issue.Description + "\n\nLinear: " + issue.URL,
-				Actor:         "linear",
-				Model:         wf.Config.Agent.Default,
-				Priority:      50,
-			})
-			if err != nil {
-				log.Printf("enqueue %s error: %v", issue.Identifier, err)
-				continue
-			}
-			log.Printf("issue %s -> task %s deduped=%v", issue.Identifier, out.ID, deduped)
-		}
+		processIssues(ctx, store, &wf.Config, issues)
 		time.Sleep(interval)
 	}
+}
+
+// processIssues enqueues each polled Linear issue once. It is split out from
+// main so unit tests can drive the dedupe and Rework re-enqueue behavior
+// without standing up Postgres or the Linear API.
+func processIssues(ctx context.Context, store enqueuer, cfg *workflow.Config, issues []tracker.Issue) {
+	for _, issue := range issues {
+		if cfg.Repo.CloneURL == "" {
+			log.Printf("skip %s: repo.clone_url missing in WORKFLOW.md", issue.Identifier)
+			continue
+		}
+		out, deduped, err := store.Enqueue(ctx, task.Task{
+			SourceType:    "linear_issue",
+			SourceEventID: sourceEventID(issue),
+			RepoOwner:     cfg.Repo.Owner,
+			RepoName:      cfg.Repo.Name,
+			CloneURL:      cfg.Repo.CloneURL,
+			BaseBranch:    cfg.Repo.DefaultBranch,
+			Title:         fmt.Sprintf("%s %s", issue.Identifier, issue.Title),
+			Description:   issue.Description + "\n\nLinear: " + issue.URL,
+			Actor:         "linear",
+			Model:         cfg.Agent.Default,
+			Priority:      50,
+		})
+		if err != nil {
+			log.Printf("enqueue %s error: %v", issue.Identifier, err)
+			continue
+		}
+		log.Printf("issue %s -> task %s deduped=%v", issue.Identifier, out.ID, deduped)
+	}
+}
+
+// sourceEventID builds the dedupe key the poller hands to queue.Store.Enqueue.
+//
+// For non-Rework states (e.g. AI Ready, In Progress) the key is just the
+// Linear issue.ID. queue.Enqueue uses ON CONFLICT (source_type,
+// source_event_id) DO UPDATE, so repeated polls of the same issue collapse
+// into the original task row, which is what we want while a task is in
+// flight or being iterated on.
+//
+// For Rework, we want each transition into Rework to produce a fresh task
+// even though earlier polls of the same issue.ID already created a row.
+// Linear's GraphQL exposes issue.updatedAt, which advances whenever the
+// issue's state (or fields) change. Composing the key as
+//
+//	<issue.ID>|rework|<updatedAt>
+//
+// makes the first poll after the issue lands in Rework a brand-new
+// source_event_id (so Postgres INSERTs a new task), while subsequent polls
+// during the same Rework dwell stay deduped because updatedAt does not
+// change. A later move into Rework (e.g. Human Review -> Rework after the
+// agent retried) advances updatedAt again, producing the next fresh task.
+//
+// This deliberately uses issue.UpdatedAt as a fallback for Linear's
+// state-transition history: the GraphQL ListIssues query in
+// internal/tracker/linear.go does not currently fetch issue history nodes,
+// and updatedAt is sufficient because state changes are the dominant
+// trigger for re-polling a Rework issue.
+func sourceEventID(issue tracker.Issue) string {
+	if strings.EqualFold(issue.State, reworkStateName) && issue.UpdatedAt != "" {
+		return issue.ID + "|rework|" + issue.UpdatedAt
+	}
+	return issue.ID
 }
 
 func env(k, d string) string {

--- a/cmd/linear-poller/main_test.go
+++ b/cmd/linear-poller/main_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// fakeStore mimics queue.Store.Enqueue with the same dedupe semantics as the
+// Postgres ON CONFLICT (source_type, source_event_id) DO UPDATE clause: the
+// first call for a given key INSERTs and returns deduped=false, repeats
+// return the original row with deduped=true.
+type fakeStore struct {
+	calls    []task.Task
+	bySource map[string]task.Task
+	nextID   int
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{bySource: map[string]task.Task{}}
+}
+
+func (f *fakeStore) Enqueue(_ context.Context, t task.Task) (task.Task, bool, error) {
+	f.calls = append(f.calls, t)
+	key := t.SourceType + "|" + t.SourceEventID
+	if existing, ok := f.bySource[key]; ok {
+		return existing, true, nil
+	}
+	f.nextID++
+	t.ID = fmt.Sprintf("tsk_%d", f.nextID)
+	t.Status = task.StatusQueued
+	f.bySource[key] = t
+	return t, false, nil
+}
+
+func (f *fakeStore) inserts() int {
+	return len(f.bySource)
+}
+
+func baseConfig() *workflow.Config {
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "linear"
+	cfg.Repo.Owner = "octo"
+	cfg.Repo.Name = "demo"
+	cfg.Repo.CloneURL = "git@example.com:octo/demo.git"
+	cfg.Repo.DefaultBranch = "main"
+	cfg.Agent.Default = "mock"
+	return &cfg
+}
+
+func TestSourceEventIDNonReworkUsesIssueID(t *testing.T) {
+	for _, state := range []string{"AI Ready", "In Progress"} {
+		issue := tracker.Issue{ID: "abc-123", State: state, UpdatedAt: "2026-05-08T10:00:00Z"}
+		got := sourceEventID(issue)
+		if got != "abc-123" {
+			t.Fatalf("state=%q sourceEventID = %q, want %q", state, got, "abc-123")
+		}
+	}
+}
+
+func TestSourceEventIDReworkComposesUpdatedAt(t *testing.T) {
+	issue := tracker.Issue{ID: "abc-123", State: "Rework", UpdatedAt: "2026-05-08T10:00:00Z"}
+	got := sourceEventID(issue)
+	want := "abc-123|rework|2026-05-08T10:00:00Z"
+	if got != want {
+		t.Fatalf("sourceEventID = %q, want %q", got, want)
+	}
+}
+
+func TestProcessIssuesDedupesSameStateRepoll(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	issue := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "do thing",
+		State: "AI Ready", UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+
+	// First poll inserts.
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issue})
+	if store.inserts() != 1 {
+		t.Fatalf("inserts after first poll = %d, want 1", store.inserts())
+	}
+
+	// Second poll of same AI Ready issue dedupes — no new task row.
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issue})
+	if store.inserts() != 1 {
+		t.Fatalf("inserts after repeat poll = %d, want 1 (deduped)", store.inserts())
+	}
+	if len(store.calls) != 2 {
+		t.Fatalf("Enqueue calls = %d, want 2", len(store.calls))
+	}
+}
+
+func TestProcessIssuesReEnqueuesOnReworkTransition(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+
+	// Issue starts in AI Ready, gets enqueued, then moves to Rework with
+	// a new updatedAt. The Rework transition must produce a fresh task.
+	aiReady := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "do thing",
+		State: "AI Ready", UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+	rework := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "do thing",
+		State: "Rework", UpdatedAt: "2026-05-08T11:30:00Z",
+	}
+
+	processIssues(context.Background(), store, cfg, []tracker.Issue{aiReady})
+	processIssues(context.Background(), store, cfg, []tracker.Issue{rework})
+
+	if store.inserts() != 2 {
+		t.Fatalf("inserts = %d, want 2 (one for AI Ready, one for Rework)", store.inserts())
+	}
+
+	// Confirm the two source_event_ids actually differ — the Rework one is
+	// composed with the rework marker and updatedAt.
+	if _, ok := store.bySource["linear_issue|abc-123"]; !ok {
+		t.Fatalf("missing AI Ready task keyed by issue.ID")
+	}
+	reworkKey := "linear_issue|abc-123|rework|2026-05-08T11:30:00Z"
+	if _, ok := store.bySource[reworkKey]; !ok {
+		t.Fatalf("missing Rework task keyed by %q; got keys=%v", reworkKey, mapKeys(store.bySource))
+	}
+}
+
+func TestProcessIssuesDoesNotLoopWhileStuckInRework(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+
+	// Issue is parked in Rework. Multiple polls happen before the user
+	// touches the issue, so updatedAt does not advance. We must not create
+	// a fresh task on every poll.
+	rework := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "do thing",
+		State: "Rework", UpdatedAt: "2026-05-08T11:30:00Z",
+	}
+
+	for i := 0; i < 5; i++ {
+		processIssues(context.Background(), store, cfg, []tracker.Issue{rework})
+	}
+
+	if store.inserts() != 1 {
+		t.Fatalf("inserts after 5 Rework polls with same updatedAt = %d, want 1", store.inserts())
+	}
+}
+
+func TestProcessIssuesSkipsWhenCloneURLMissing(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Repo.CloneURL = ""
+
+	issue := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", State: "AI Ready",
+		UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issue})
+
+	if len(store.calls) != 0 {
+		t.Fatalf("Enqueue called %d times, want 0 when clone_url missing", len(store.calls))
+	}
+}
+
+func mapKeys(m map[string]task.Task) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -19,7 +19,7 @@ Per-state rules:
 - `AI Ready`: refined and small enough that an agent can attempt it. The poller picks these up.
 - `In Progress`: the worker has claimed an issue or you are iterating on it. Stays in `active_states` so re-runs after a push are allowed.
 - `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself.
-- `Rework`: review found issues and you want another attempt. The state is in `active_states`, but moving the Linear issue to `Rework` does not by itself re-enqueue: the poller uses `issue.ID` as `source_event_id` and `Enqueue` dedupes via `ON CONFLICT (source_type, source_event_id)` (see `cmd/linear-poller/main.go` and `internal/queue/postgres.go`). Use `/ai-run` on Gitea or `POST /v1/tasks` to actually trigger a fresh run; see "Re-running a failed task" below.
+- `Rework`: review found issues and you want another attempt. Moving the Linear issue into `Rework` re-enqueues a fresh task automatically. The poller composes `source_event_id` as `<issue.ID>|rework|<issue.updatedAt>` whenever the state is `Rework`, so each transition into Rework is a brand-new dedupe key and Postgres INSERTs a new task row. While the issue stays parked in Rework, repeated polls reuse the same `updatedAt` and dedupe (no enqueue loop). Non-Rework states still use plain `issue.ID`, so `AI Ready` -> `In Progress` iteration on a single task is unchanged. See `cmd/linear-poller/main.go` (`sourceEventID`) and `internal/queue/postgres.go` (`Enqueue`).
 - `Done` / `Canceled`: terminal. Listed under `tracker.terminal_states`.
 
 Default `active_states` in code:
@@ -158,14 +158,15 @@ curl 'http://localhost:8080/v1/tasks/<task-id>/events'
 - Verification command failed (`go test ./...` non-zero): read `.aiops/RUN_SUMMARY.md` in the work branch if the runner produced one. Reproduce locally on the same branch.
 - Policy violation (deny path or size cap): re-scope the task into a smaller issue, or do it manually.
 - Runner command not found: confirm `codex.command` or `claude.command` resolves on the worker host. The shell runner uses `sh -lc`, so PATH must be set in the worker's login shell.
-- Empty diff: agent decided nothing to do. Tighten the issue body, move it to `Rework`, then re-trigger via `/ai-run` on Gitea or `POST /v1/tasks` (the Linear state change alone will not re-enqueue — see below).
+- Empty diff: agent decided nothing to do. Tighten the issue body, then move it to `Rework`. The state change alone re-enqueues a fresh task (the poller keys Rework by `issue.ID|rework|updatedAt`). `/ai-run` on Gitea and `POST /v1/tasks` are still available as fallbacks if the poller is paused.
 
 ### Re-running a failed task
 
-Two options, in order of preference (moving the Linear issue alone is not enough — the poller dedupes on `source_event_id = issue.ID` via `ON CONFLICT (source_type, source_event_id) DO UPDATE SET updated_at`, so re-polling just touches the existing task instead of creating a fresh queued one):
+Three options, in order of preference:
 
-1. Re-trigger from Gitea by commenting `/ai-run` on the issue. The trigger API uses the Gitea delivery ID (or `comment-<id>`) as `source_event_id`, so each comment produces a new queued task.
-2. Manual enqueue against the trigger API (each call defaults `source_event_id` to `manual-<unix-nanos>`, so it is always fresh):
+1. Move the Linear issue to `Rework`. The poller composes `source_event_id` as `<issue.ID>|rework|<updatedAt>` for the Rework state, so the transition INSERTs a new task row instead of deduping against the original. Subsequent polls while the issue stays in Rework reuse the same `updatedAt` and stay deduped, so you do not get an enqueue loop.
+2. Re-trigger from Gitea by commenting `/ai-run` on the issue. The trigger API uses the Gitea delivery ID (or `comment-<id>`) as `source_event_id`, so each comment produces a new queued task. Useful when you want to retry without changing Linear state.
+3. Manual enqueue against the trigger API (each call defaults `source_event_id` to `manual-<unix-nanos>`, so it is always fresh):
 
    ```bash
    curl -X POST http://localhost:8080/v1/tasks \


### PR DESCRIPTION
## Summary

- Compose Linear poller `source_event_id` as `<issue.ID>|rework|<issue.updatedAt>` when the issue is in `Rework`, while non-Rework states keep using the plain `issue.ID`. Each transition into Rework advances `updatedAt`, producing a fresh dedupe key so Postgres INSERTs a new task; polls while the issue is parked in Rework reuse the same key and stay deduped, so there is no enqueue loop.
- Refactor the inline poll loop in `cmd/linear-poller/main.go` into `processIssues(...)` against an `enqueuer` interface so the dedupe semantics can be exercised without a real Postgres pool.
- Add unit tests for: AI Ready repeat-poll dedupe, Rework re-enqueue on transition (separate `source_event_id` from the original AI Ready task), no-loop while parked in Rework with unchanged `updatedAt`, and the missing `clone_url` skip path.
- Update `docs/runbooks/personal-daily-workflow.md` so the Rework / "Re-running a failed task" / "Empty diff" sections describe the new behavior; Linear `Rework` is now a first-class re-trigger, with `/ai-run` and `POST /v1/tasks` listed as fallbacks.

Closes #39.

## Test plan

- [x] `gofmt -l cmd internal` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` passes (new `cmd/linear-poller` tests included)
- [ ] Manual: drag a real Linear issue from `Human Review` to `Rework` against a running poller and confirm a new task row is created