### PR TITLE
feat: use bare mirror cache and per-task worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This repository implements the second track.
 - [Local development runbook](docs/runbooks/local-dev.md)
 - [CI/CD runbook](docs/runbooks/ci.md)
 - [Task debugging API](docs/runbooks/task-api.md)
+- [Workspace cache and cleanup](docs/runbooks/workspace-cache.md)
 
 ## Continuous integration
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -58,6 +58,7 @@ func main() {
 
 func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 	mgr := workspace.New(env("WORKSPACE_ROOT", "/tmp/aiops-workspaces"))
+	mgr.MirrorRoot = os.Getenv("AIOPS_MIRROR_ROOT")
 	workdir, err := mgr.PrepareGitWorkspace(ctx, t)
 	if err != nil {
 		return err

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -231,3 +231,15 @@ Stop the conflicting local service or change the published port in `deploy/docke
 ### `go: module lookup disabled` or `go.sum` mismatch
 
 Run `go mod tidy`, then re-run the failing command. CI will reject changes that leave `go.mod` or `go.sum` dirty; see [CI/CD runbook](ci.md) for the local pre-push check list.
+
+## Workspace cache and cleanup
+
+After M2, the worker keeps a per-repo bare mirror under
+`AIOPS_MIRROR_ROOT` (default `os.UserCacheDir()/aiops-platform/mirrors`)
+and creates a per-task worktree under `WORKSPACE_ROOT` for every claimed
+task. This avoids re-cloning on every retry and lets two tasks run
+concurrently without sharing a working tree. See the dedicated
+[workspace cache runbook](workspace-cache.md) for the on-disk layout,
+configuration knobs, and recommended cleanup cadence (the
+`(*workspace.Manager).Cleanup` API or `rm -rf $WORKSPACE_ROOT/*` once
+old tasks no longer matter).

--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -1,0 +1,92 @@
+# Workspace cache and cleanup
+
+The worker (`cmd/worker`) prepares a Git workspace for every claimed task.
+Until M2 each task ran a fresh `git clone`, which paid the full network
+cost on every retry and on every concurrent task. This runbook describes
+the post-#11 layout: a per-repo bare cache plus per-task worktrees, and
+how to prune the cache on a long-running host.
+
+## Layout
+
+```text
+$AIOPS_MIRROR_ROOT/                 # bare mirror cache (one per repo)
+  <host>/<owner>/<repo>.git/        # populated by `git clone --bare`
+$WORKSPACE_ROOT/                    # per-task worktrees
+  <owner>_<repo>/<task-id>/         # populated by `git worktree add`
+```
+
+- The first task targeting a given clone URL pays the network cost of
+  `git clone --bare`. The fetch refspec is normalised to
+  `+refs/heads/*:refs/remotes/origin/*` so future fetches keep upstream
+  branches under `refs/remotes/origin/*` and never disturb the
+  per-task work branches we create under `refs/heads/<work>`.
+- Subsequent tasks (same repo, different task IDs) skip the clone and
+  run `git fetch --prune --tags origin` against the cached mirror, then
+  `git worktree add -B <work-branch> <task-dir> origin/<base-branch>`.
+  The worktree shares objects with the mirror via `gitdir` linkage, so
+  disk usage is roughly `O(repo)` rather than `O(repo) * O(tasks)`.
+- Each task gets its own directory under `WORKSPACE_ROOT`, so two
+  concurrent workers never share a working tree.
+
+## Configuration
+
+| Env var               | Default                                                                 | Purpose                                                  |
+| --------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------- |
+| `WORKSPACE_ROOT`      | `/tmp/aiops-workspaces`                                                 | Where per-task worktrees live.                           |
+| `AIOPS_MIRROR_ROOT`   | `os.UserCacheDir()/aiops-platform/mirrors` (fallback `$TMPDIR/...`)     | Where bare mirror clones are cached.                     |
+
+On Linux containers `os.UserCacheDir()` resolves to `$XDG_CACHE_HOME` or
+`$HOME/.cache`. On macOS dev boxes it resolves to
+`~/Library/Caches/aiops-platform/mirrors`. Override `AIOPS_MIRROR_ROOT`
+when you want the cache on a dedicated volume — for example the
+`workspace-cache` named volume in `deploy/docker-compose.yml`.
+
+## Cleanup policy
+
+The worker does **not** automatically delete old worktrees. The
+recommended strategy is age-based pruning, gated on operator preference:
+
+- **Per-task worktrees** (`$WORKSPACE_ROOT/...`): safe to delete once
+  the corresponding task is `succeeded` or `failed`. Use a 24h-72h
+  window for personal use; pick something larger if you frequently
+  inspect old runs.
+- **Bare mirrors** (`$AIOPS_MIRROR_ROOT/...`): treat as a long-lived
+  cache. They survive worktree cleanup intentionally, because deleting
+  them costs you a fresh `git clone` on the next task. Only purge a
+  mirror when you change its upstream URL or the cache disk fills up.
+
+The Go API for cleanup is `(*workspace.Manager).Cleanup(ctx, maxAge)`.
+It walks `$WORKSPACE_ROOT`, deletes each task directory whose mtime
+predates `now - maxAge`, and returns a `CleanupReport` with counts of
+removed/skipped/failed entries. It never touches the mirror cache.
+
+### How to trigger cleanup
+
+There is no built-in scheduler. Pick one of the following based on how
+the worker is deployed:
+
+1. **Cron / launchd**: schedule a tiny wrapper binary that calls
+   `workspace.New(root).Cleanup(ctx, 48*time.Hour)`. Suitable for the
+   personal daily workflow described in
+   [personal-daily-workflow.md](personal-daily-workflow.md).
+2. **Manual**: `rm -rf $WORKSPACE_ROOT/*` between long pauses works in
+   a pinch. The next task simply re-creates its worktree from the bare
+   mirror, which is fast.
+3. **Future hook**: a follow-up issue may wire `Cleanup` into the
+   worker's main loop (e.g. once per N completed tasks). Until that
+   lands, treat cleanup as an out-of-band concern.
+
+## Troubleshooting
+
+- `fatal: '<dir>' is not a working tree` printed during task setup is
+  expected on the first prepare for a brand-new task ID and is
+  swallowed. If it shows up repeatedly for the same task ID, check
+  whether `$WORKSPACE_ROOT` is on a shared filesystem with a different
+  worker writing to the same path.
+- If you see `error: cannot lock ref 'refs/heads/<work>'` during
+  `worktree add`, run `git -C $AIOPS_MIRROR_ROOT/<host>/<repo>.git
+  worktree prune` and retry. The worker does this automatically before
+  every prepare; manual intervention is only needed if you ran
+  out-of-band git commands against the mirror.
+- To inspect what mirrors exist:
+  `find $AIOPS_MIRROR_ROOT -maxdepth 4 -name HEAD -printf '%h\n'`.

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -72,8 +72,17 @@ func (c *cappedBuffer) Dropped() int64  { return c.dropped }
 // Compile-time check that cappedBuffer satisfies io.Writer.
 var _ io.Writer = (*cappedBuffer)(nil)
 
+// Manager owns per-task workspace creation, layered on top of a process-wide
+// bare mirror cache. Each task gets its own detached worktree under Root so
+// concurrent workers cannot stomp on each other, while the heavy network IO
+// (object download) happens once per repo in the mirror cache and is
+// reused on every subsequent task.
 type Manager struct {
+	// Root is the per-task worktree root, typically WORKSPACE_ROOT.
 	Root string
+	// MirrorRoot overrides the bare mirror cache location. When empty,
+	// MirrorRoot() resolves it from os.UserCacheDir or os.TempDir.
+	MirrorRoot string
 }
 
 func New(root string) *Manager { return &Manager{Root: root} }
@@ -83,21 +92,51 @@ func (m *Manager) PathFor(t task.Task) string {
 	return filepath.Join(m.Root, repo, t.ID)
 }
 
+// PrepareGitWorkspace materialises a per-task workspace by adding a fresh
+// worktree off the cached bare mirror for t.CloneURL. The worktree is
+// created at PathFor(t) on the work branch, with origin set back to the
+// upstream URL so `git push origin <branch>` works without further setup.
+//
+// On every call we refresh the mirror first so the worktree starts from
+// up-to-date refs; this replaces the previous behaviour of running a fresh
+// `git clone` per task, which was both slow and wasteful for large repos.
 func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string, error) {
 	workdir := m.PathFor(t)
-	_ = os.RemoveAll(workdir)
 	if err := os.MkdirAll(filepath.Dir(workdir), 0o755); err != nil {
 		return "", err
 	}
-	if err := run(ctx, filepath.Dir(workdir), "git", "clone", t.CloneURL, workdir); err != nil {
+	mirror, err := m.EnsureMirror(ctx, t.CloneURL)
+	if err != nil {
 		return "", err
 	}
-	if err := run(ctx, workdir, "git", "checkout", t.BaseBranch); err != nil {
-		return "", err
+	// Drop any leftover worktree from a previous run *before* asking git to
+	// add a new one at the same path. We deliberately ignore failures and
+	// silence stderr because the common case ("no such worktree") prints a
+	// scary fatal line that obscures real worker logs.
+	_ = runQuiet(ctx, mirror, "git", "worktree", "remove", "--force", workdir)
+	_ = os.RemoveAll(workdir)
+	if err := runQuiet(ctx, mirror, "git", "worktree", "prune"); err != nil {
+		return "", fmt.Errorf("worktree prune: %w", err)
 	}
-	if err := run(ctx, workdir, "git", "checkout", "-b", t.WorkBranch); err != nil {
-		return "", err
+	// Create the worktree on the work branch, branched from the requested
+	// base ref. We resolve the base via `origin/<base>` because the bare
+	// cache stores upstream branches as remote-tracking refs (see
+	// EnsureMirror); falling back to the bare name covers `file://` test
+	// fixtures where the upstream is the same on-disk repo. Using -B makes
+	// the operation idempotent if a previous attempt left an in-mirror
+	// branch behind.
+	startRef := "origin/" + t.BaseBranch
+	if err := runQuiet(ctx, mirror, "git", "rev-parse", "--verify", startRef); err != nil {
+		startRef = t.BaseBranch
 	}
+	if err := run(ctx, mirror, "git", "worktree", "add", "-B", t.WorkBranch, workdir, startRef); err != nil {
+		return "", fmt.Errorf("worktree add: %w", err)
+	}
+	// The mirror's "origin" remote points at the upstream URL, but inside
+	// the worktree git resolves remotes via the linked repo, so push works
+	// out of the box. We still set the URL explicitly for clarity in case
+	// downstream tooling inspects `git remote -v` from within the worktree.
+	_ = run(ctx, workdir, "git", "remote", "set-url", "origin", t.CloneURL)
 	return workdir, nil
 }
 
@@ -359,6 +398,15 @@ func run(ctx context.Context, dir string, name string, args ...string) error {
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// runQuiet runs a command without forwarding stdout/stderr. We use it for
+// probe operations like `git rev-parse --verify` whose stderr is expected
+// noise on the unhappy path.
+func runQuiet(ctx context.Context, dir string, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
 	return cmd.Run()
 }
 

--- a/internal/workspace/mirror.go
+++ b/internal/workspace/mirror.go
@@ -1,0 +1,210 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// MirrorRoot returns the directory where bare mirror clones are cached.
+//
+// Resolution order:
+//  1. explicit override (typically the AIOPS_MIRROR_ROOT env var) when non-empty
+//  2. <user-cache-dir>/aiops-platform/mirrors (best effort)
+//  3. <os.TempDir>/aiops-platform/mirrors as a last-resort fallback
+//
+// The directory is created on demand by callers; this function only resolves
+// the path so it can be reused by Cleanup callers and tests.
+func MirrorRoot(override string) string {
+	if strings.TrimSpace(override) != "" {
+		return override
+	}
+	if dir, err := os.UserCacheDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "aiops-platform", "mirrors")
+	}
+	return filepath.Join(os.TempDir(), "aiops-platform", "mirrors")
+}
+
+// mirrorPathFor maps a clone URL to a stable on-disk location under root.
+// We do not need cryptographic uniqueness, just a deterministic, filesystem-
+// safe path keyed by host + path so two repos never collide. The trailing
+// ".git" is preserved to keep the layout recognisable when inspected by hand.
+func mirrorPathFor(root, cloneURL string) string {
+	host, repoPath := splitCloneURL(cloneURL)
+	host = sanitize(host)
+	repoPath = strings.TrimSuffix(repoPath, ".git")
+	// Preserve owner/name structure so multiple repos under the same owner
+	// share a parent directory, which makes manual cleanup easier.
+	parts := strings.Split(repoPath, "/")
+	for i, p := range parts {
+		parts[i] = sanitize(p)
+	}
+	repoPath = strings.Join(parts, string(filepath.Separator))
+	if repoPath == "" {
+		repoPath = "repo"
+	}
+	return filepath.Join(root, host, repoPath+".git")
+}
+
+// splitCloneURL extracts a host and path component from either an https://
+// URL or an scp-style ssh URL (git@host:owner/repo.git). Errors are
+// swallowed; the worst case is we end up with a sanitized fallback path,
+// which is still safe and deterministic.
+func splitCloneURL(cloneURL string) (host, path string) {
+	cloneURL = strings.TrimSpace(cloneURL)
+	if cloneURL == "" {
+		return "unknown", "repo"
+	}
+	if strings.Contains(cloneURL, "://") {
+		if u, err := url.Parse(cloneURL); err == nil {
+			host = u.Host
+			path = strings.TrimPrefix(u.Path, "/")
+			if host == "" {
+				host = "unknown"
+			}
+			return host, path
+		}
+	}
+	// scp-style: git@host:owner/repo.git
+	if at := strings.Index(cloneURL, "@"); at >= 0 {
+		rest := cloneURL[at+1:]
+		if colon := strings.Index(rest, ":"); colon >= 0 {
+			return rest[:colon], rest[colon+1:]
+		}
+	}
+	return "unknown", sanitize(cloneURL)
+}
+
+// EnsureMirror returns the local path to a bare mirror clone of cloneURL,
+// creating it on first use and refreshing it on subsequent calls.
+//
+// We deliberately do not use `git clone --mirror`: the mirror refspec
+// `+refs/*:refs/*` plus a periodic `--prune` would silently delete the
+// per-task work branches that worktrees depend on. Instead we use a plain
+// `git clone --bare` with the default `+refs/heads/*:refs/remotes/origin/*`
+// fetch refspec, which keeps remote-tracking refs neatly under
+// `refs/remotes/origin/*` so our `refs/heads/<work>` branches are never
+// touched by fetch --prune.
+//
+// First call: `git clone --bare <url> <mirror>` populates the cache.
+// Subsequent calls run `git fetch --prune origin` to bring remote-tracking
+// refs up to date without disturbing local work branches.
+//
+// The mirror parent directory is created lazily so callers do not need to
+// pre-create AIOPS_MIRROR_ROOT.
+func (m *Manager) EnsureMirror(ctx context.Context, cloneURL string) (string, error) {
+	root := MirrorRoot(m.MirrorRoot)
+	mirror := mirrorPathFor(root, cloneURL)
+	if err := os.MkdirAll(filepath.Dir(mirror), 0o755); err != nil {
+		return "", fmt.Errorf("mkdir mirror parent: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err == nil {
+		// Existing mirror: refresh remote-tracking refs only.
+		if err := run(ctx, mirror, "git", "fetch", "--prune", "--tags", "origin"); err != nil {
+			return "", fmt.Errorf("refresh mirror %s: %w", mirror, err)
+		}
+		return mirror, nil
+	}
+	// First-time clone. Remove any partial directory left over from a prior
+	// failed attempt so `git clone` does not refuse to overwrite it.
+	_ = os.RemoveAll(mirror)
+	if err := run(ctx, filepath.Dir(mirror), "git", "clone", "--bare", cloneURL, mirror); err != nil {
+		return "", fmt.Errorf("clone mirror %s: %w", cloneURL, err)
+	}
+	// `git clone --bare` defaults to a "do nothing" fetch refspec; rewrite
+	// it to the standard remote-tracking layout so subsequent fetches and
+	// `origin/<branch>` lookups behave like a regular clone.
+	if err := run(ctx, mirror, "git", "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+		return "", fmt.Errorf("configure fetch refspec: %w", err)
+	}
+	if err := run(ctx, mirror, "git", "fetch", "--prune", "--tags", "origin"); err != nil {
+		return "", fmt.Errorf("initial fetch: %w", err)
+	}
+	return mirror, nil
+}
+
+// Cleanup removes per-task worktrees whose directory mtime is older than
+// maxAge. For each stale worktree we first try `git worktree remove --force`
+// against the owning mirror so the bare repo's administrative state is
+// cleaned up, then fall back to plain os.RemoveAll if git refuses (for
+// example when the mirror has been deleted out from under us).
+//
+// The function never returns an error for a single failed entry; it logs
+// the count of removed and failed entries via the returned CleanupReport so
+// callers can decide whether to surface a warning. Errors are only returned
+// for catastrophic conditions (root unreadable).
+//
+// maxAge <= 0 is treated as "remove everything", which is occasionally
+// useful from an operator CLI; callers that want a no-op should skip the
+// call entirely.
+func (m *Manager) Cleanup(ctx context.Context, maxAge time.Duration) (CleanupReport, error) {
+	report := CleanupReport{Threshold: maxAge}
+	cutoff := time.Now().Add(-maxAge)
+	entries, err := os.ReadDir(m.Root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return report, nil
+		}
+		return report, fmt.Errorf("read workspace root: %w", err)
+	}
+	for _, repoEntry := range entries {
+		if !repoEntry.IsDir() {
+			continue
+		}
+		repoDir := filepath.Join(m.Root, repoEntry.Name())
+		taskEntries, err := os.ReadDir(repoDir)
+		if err != nil {
+			report.Failed++
+			continue
+		}
+		for _, te := range taskEntries {
+			if !te.IsDir() {
+				continue
+			}
+			taskDir := filepath.Join(repoDir, te.Name())
+			info, err := os.Stat(taskDir)
+			if err != nil {
+				report.Failed++
+				continue
+			}
+			if maxAge > 0 && info.ModTime().After(cutoff) {
+				report.Skipped++
+				continue
+			}
+			if removeWorktree(ctx, taskDir) {
+				report.Removed++
+			} else {
+				report.Failed++
+			}
+		}
+	}
+	return report, nil
+}
+
+// removeWorktree best-effort detaches a task directory from its owning bare
+// mirror and deletes the on-disk path. It returns true when the directory
+// is gone after the call.
+func removeWorktree(ctx context.Context, taskDir string) bool {
+	// The worktree's gitdir file points at <mirror>/worktrees/<id>; we ask
+	// git itself to clean both sides via the worktree itself.
+	_ = run(ctx, taskDir, "git", "worktree", "remove", "--force", ".")
+	if _, err := os.Stat(taskDir); err == nil {
+		if err := os.RemoveAll(taskDir); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// CleanupReport summarises a Cleanup pass. It is intentionally tiny and
+// JSON-friendly so it can be logged or surfaced in a future ops CLI.
+type CleanupReport struct {
+	Threshold time.Duration `json:"threshold"`
+	Removed   int           `json:"removed"`
+	Skipped   int           `json:"skipped"`
+	Failed    int           `json:"failed"`
+}

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -1,0 +1,274 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+)
+
+// initBareUpstream creates a tiny upstream repo with one commit on `main`
+// and returns a `file://` clone URL pointing at it. The repo is bare so
+// `git push` can target it without the receiving branch checkout error.
+func initBareUpstream(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	work := filepath.Join(root, "work")
+	bare := filepath.Join(root, "upstream.git")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "init", "-q", "-b", "main", work},
+		{"git", "-C", work, "config", "user.email", "u@example.com"},
+		{"git", "-C", work, "config", "user.name", "u"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", work, "add", "."},
+		{"git", "-C", work, "commit", "-q", "-m", "seed"},
+		{"git", "init", "--bare", "-q", "-b", "main", bare},
+		{"git", "-C", work, "remote", "add", "origin", bare},
+		{"git", "-C", work, "push", "-q", "origin", "main"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	return "file://" + bare
+}
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return &Manager{
+		Root:       t.TempDir(),
+		MirrorRoot: t.TempDir(),
+	}
+}
+
+func makeTask(id, cloneURL string) task.Task {
+	return task.Task{
+		ID:         id,
+		RepoOwner:  "acme",
+		RepoName:   "demo",
+		CloneURL:   cloneURL,
+		BaseBranch: "main",
+		WorkBranch: "ai/" + id,
+	}
+}
+
+func TestEnsureMirror_FirstCallClonesSecondCallReuses(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	mirror, err := mgr.EnsureMirror(ctx, upstream)
+	if err != nil {
+		t.Fatalf("first EnsureMirror: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err != nil {
+		t.Fatalf("expected bare repo HEAD at %s: %v", mirror, err)
+	}
+	// A bare clone has no working tree; assert that absence to confirm
+	// we used --mirror rather than a regular clone.
+	if _, err := os.Stat(filepath.Join(mirror, ".git")); err == nil {
+		t.Fatalf("expected bare repo (no .git/), found one at %s", mirror)
+	}
+
+	// Stamp a sentinel file so we can detect whether the second call
+	// nuked the cache directory (it must not).
+	sentinel := filepath.Join(mirror, "aiops-sentinel")
+	if err := os.WriteFile(sentinel, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mirror2, err := mgr.EnsureMirror(ctx, upstream)
+	if err != nil {
+		t.Fatalf("second EnsureMirror: %v", err)
+	}
+	if mirror2 != mirror {
+		t.Fatalf("mirror path drifted: %s != %s", mirror2, mirror)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("mirror was recreated; sentinel gone: %v", err)
+	}
+}
+
+func TestPrepareGitWorkspace_IsolatedWorktreesShareMirror(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	t1 := makeTask("task-a", upstream)
+	t2 := makeTask("task-b", upstream)
+
+	dir1, err := mgr.PrepareGitWorkspace(ctx, t1)
+	if err != nil {
+		t.Fatalf("prepare t1: %v", err)
+	}
+	dir2, err := mgr.PrepareGitWorkspace(ctx, t2)
+	if err != nil {
+		t.Fatalf("prepare t2: %v", err)
+	}
+	if dir1 == dir2 {
+		t.Fatalf("expected isolated worktrees, both at %s", dir1)
+	}
+
+	// Each worktree must contain the seed file from upstream.
+	for _, d := range []string{dir1, dir2} {
+		if _, err := os.Stat(filepath.Join(d, "README.md")); err != nil {
+			t.Fatalf("expected README.md inside %s: %v", d, err)
+		}
+	}
+
+	// Writing in t1 must not affect t2.
+	marker1 := filepath.Join(dir1, "only-in-1.txt")
+	if err := os.WriteFile(marker1, []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir2, "only-in-1.txt")); !os.IsNotExist(err) {
+		t.Fatalf("worktrees not isolated: file leaked into %s (err=%v)", dir2, err)
+	}
+
+	// Both worktrees should be on their respective work branches.
+	for _, tc := range []struct {
+		dir, want string
+	}{{dir1, t1.WorkBranch}, {dir2, t2.WorkBranch}} {
+		out, err := exec.Command("git", "-C", tc.dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
+		if err != nil {
+			t.Fatalf("rev-parse %s: %v", tc.dir, err)
+		}
+		if got := strings.TrimSpace(string(out)); got != tc.want {
+			t.Fatalf("worktree %s on branch %q, want %q", tc.dir, got, tc.want)
+		}
+	}
+
+	// The mirror cache must contain exactly one bare repo for the
+	// upstream URL — that's the whole point of the cache.
+	mirror := mirrorPathFor(MirrorRoot(mgr.MirrorRoot), upstream)
+	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err != nil {
+		t.Fatalf("expected shared mirror at %s: %v", mirror, err)
+	}
+}
+
+func TestPrepareGitWorkspace_RerunReusesPathIdempotently(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+	tk := makeTask("task-x", upstream)
+
+	dir, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("first prepare: %v", err)
+	}
+	// Simulate a partial run leaving an extra file behind. The next
+	// PrepareGitWorkspace must give us a clean checkout.
+	if err := os.WriteFile(filepath.Join(dir, "stale.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir2, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("second prepare: %v", err)
+	}
+	if dir != dir2 {
+		t.Fatalf("path changed across runs: %s vs %s", dir, dir2)
+	}
+	if _, err := os.Stat(filepath.Join(dir2, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale file survived re-prepare: %v", err)
+	}
+}
+
+func TestCleanup_RemovesOldWorktreesKeepsRecent(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	old := makeTask("old", upstream)
+	recent := makeTask("recent", upstream)
+
+	oldDir, err := mgr.PrepareGitWorkspace(ctx, old)
+	if err != nil {
+		t.Fatalf("prepare old: %v", err)
+	}
+	recentDir, err := mgr.PrepareGitWorkspace(ctx, recent)
+	if err != nil {
+		t.Fatalf("prepare recent: %v", err)
+	}
+
+	// Backdate the "old" worktree so it sits well outside the cleanup
+	// threshold while "recent" stays inside it.
+	past := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(oldDir, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := mgr.Cleanup(ctx, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if report.Removed != 1 {
+		t.Fatalf("expected 1 removal, got %+v", report)
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("old worktree still present at %s", oldDir)
+	}
+	if _, err := os.Stat(recentDir); err != nil {
+		t.Fatalf("recent worktree should still exist: %v", err)
+	}
+
+	// The mirror itself must survive cleanup so subsequent tasks reuse it.
+	mirror := mirrorPathFor(MirrorRoot(mgr.MirrorRoot), upstream)
+	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err != nil {
+		t.Fatalf("mirror lost during cleanup: %v", err)
+	}
+}
+
+func TestCleanup_MissingRootIsNotAnError(t *testing.T) {
+	mgr := &Manager{Root: filepath.Join(t.TempDir(), "does-not-exist")}
+	report, err := mgr.Cleanup(context.Background(), time.Hour)
+	if err != nil {
+		t.Fatalf("expected nil error for missing root, got %v", err)
+	}
+	if report.Removed != 0 || report.Failed != 0 {
+		t.Fatalf("expected empty report, got %+v", report)
+	}
+}
+
+func TestMirrorRoot_OverrideWins(t *testing.T) {
+	if got := MirrorRoot("/tmp/explicit"); got != "/tmp/explicit" {
+		t.Fatalf("override ignored: %s", got)
+	}
+	if got := MirrorRoot(""); got == "" {
+		t.Fatal("default mirror root must not be empty")
+	}
+}
+
+func TestMirrorPathFor_StableAcrossSchemes(t *testing.T) {
+	root := "/cache"
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://gitea.example.com/acme/demo.git", "/cache/gitea.example.com/acme/demo.git"},
+		{"https://gitea.example.com/acme/demo", "/cache/gitea.example.com/acme/demo.git"},
+		{"git@gitea.example.com:acme/demo.git", "/cache/gitea.example.com/acme/demo.git"},
+	}
+	for _, tc := range cases {
+		if got := mirrorPathFor(root, tc.in); got != tc.want {
+			t.Errorf("mirrorPathFor(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Replace per-task `git clone` with a per-repo bare mirror cache plus `git worktree add` per task. Mirrors live under `AIOPS_MIRROR_ROOT` (default `os.UserCacheDir()/aiops-platform/mirrors`); worktrees keep living under `WORKSPACE_ROOT`. First task pays the network cost; subsequent tasks reuse the mirror via `git fetch --prune`.
- Add `(*workspace.Manager).Cleanup(ctx, maxAge)` for age-based pruning of stale per-task worktrees. Mirrors are intentionally preserved; cleanup only walks `WORKSPACE_ROOT`.
- Document the layout, env knobs, and cleanup cadence in `docs/runbooks/workspace-cache.md`, linked from `README.md` and `docs/runbooks/local-dev.md`.

Implementation notes:
- We use `git clone --bare` (not `--mirror`) and rewrite `remote.origin.fetch` to `+refs/heads/*:refs/remotes/origin/*` so future `git fetch --prune` cannot delete the per-task `refs/heads/<work>` branches.
- `PrepareGitWorkspace` is idempotent: repeated calls drop the prior worktree, prune stale admin state, and re-add at `origin/<base>` (falling back to the bare base name for `file://` test fixtures).
- No new dependencies. Public API of `Manager` is unchanged; only `MirrorRoot` field and `Cleanup`/`EnsureMirror` methods are added.

## Acceptance criteria

- [x] Maintain a local bare mirror cache per repo (`EnsureMirror`).
- [x] Create isolated worktrees per task (`PrepareGitWorkspace` via `git worktree add`).
- [x] Support cleanup of old workspaces (`Manager.Cleanup` with `CleanupReport`).
- [x] Document cache path and cleanup policy (`docs/runbooks/workspace-cache.md`).

## Test plan

- [x] `gofmt -l cmd internal`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./... -count=1` (new tests cover mirror reuse, worktree isolation, idempotent re-prepare, age-based cleanup, missing-root cleanup, `MirrorRoot` override, and clone-URL parsing)

Closes #11