### PR TITLE
feat: add optional pre-push secret scan hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This repository implements the second track.
 - [CI/CD runbook](docs/runbooks/ci.md)
 - [Task debugging API](docs/runbooks/task-api.md)
 - [Workspace cache and cleanup](docs/runbooks/workspace-cache.md)
+- [Pre-push secret scanning](docs/runbooks/secret-scanning.md)
 
 ## Continuous integration
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -134,6 +134,15 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 	}
 	emit(ctx, ev, t.ID, task.EventVerifyEnd, "verify completed", verifyPayload)
 
+	// Run the optional pre-push secret scanner between verify and push so a
+	// branch carrying credential leaks never reaches the remote. Failures
+	// flow through writeFailureArtifacts + the existing failed_attempt path
+	// so operators can inspect what the scanner saw.
+	if err := runSecretScan(ctx, ev, t.ID, workdir, wf.Config); err != nil {
+		writeFailureArtifacts(ctx, workdir, verifyResults, "secret scan blocked push: "+errSummary(err))
+		return err
+	}
+
 	// Snapshot the changed files AFTER all run artifacts have been written so
 	// that CHANGED_FILES.txt, RUN_SUMMARY.md, and the success-path event
 	// payload reflect what is actually about to be committed (artifacts
@@ -171,6 +180,75 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 	})
 
 	return createPR(ctx, ev, t, wf.Config)
+}
+
+// secretScanFn is the indirection used to swap the real workspace scanner
+// for a stub in tests. It mirrors workspace.RunSecretScan's signature.
+type secretScanFn func(ctx context.Context, workdir string, cfg workflow.SecretScanConfig) workspace.SecretScanResult
+
+// runSecretScan executes the configured pre-push secret scanner and
+// records structured task events for the start, clean exit, finding, or
+// execution error cases. It returns a non-nil error only when the push
+// should be aborted, so the caller can simply propagate the error and let
+// the existing failed_attempt path take over.
+//
+// Event kinds emitted (mirroring the existing event vocabulary):
+//
+//   - secret_scan_start:     scanner is about to run
+//   - secret_scan_clean:     scanner exited zero, no findings
+//   - secret_scan_violation: scanner exited non-zero (potential secrets)
+//   - secret_scan_error:     scanner failed to run (binary missing, etc.)
+//
+// When the scan is disabled or unconfigured, no events are emitted; this
+// preserves the worker's previous behavior for repos that have not opted
+// in.
+func runSecretScan(ctx context.Context, ev eventEmitter, taskID string, workdir string, cfg workflow.Config) error {
+	return runSecretScanWith(ctx, ev, taskID, workdir, cfg, workspace.RunSecretScan)
+}
+
+func runSecretScanWith(ctx context.Context, ev eventEmitter, taskID string, workdir string, cfg workflow.Config, scan secretScanFn) error {
+	scfg := cfg.Verify.SecretScan
+	if !scfg.Enabled || len(scfg.Command) == 0 {
+		return nil
+	}
+
+	_ = ev.AddEventWithPayload(ctx, taskID, "secret_scan_start", "running pre-push secret scan", map[string]any{
+		"command": scfg.Command,
+	})
+
+	res := scan(ctx, workdir, scfg)
+	payload := map[string]any{
+		"command":     res.Command,
+		"exit_code":   res.ExitCode,
+		"duration_ms": res.DurationMs,
+		"stdout":      res.Stdout,
+		"stderr":      res.Stderr,
+	}
+
+	switch res.Status {
+	case workspace.SecretScanClean:
+		_ = ev.AddEventWithPayload(ctx, taskID, "secret_scan_clean", "secret scan reported no findings", payload)
+		return nil
+	case workspace.SecretScanViolation:
+		msg := fmt.Sprintf("secret scan reported findings (exit %d)", res.ExitCode)
+		_ = ev.AddEventWithPayload(ctx, taskID, "secret_scan_violation", msg, payload)
+		if res.ShouldBlockPush(scfg) {
+			return errors.New(msg)
+		}
+		return nil
+	case workspace.SecretScanError:
+		msg := fmt.Sprintf("secret scan failed to execute: %v", res.Err)
+		_ = ev.AddEventWithPayload(ctx, taskID, "secret_scan_error", msg, payload)
+		// Execution errors always block: an operator-misconfigured scanner
+		// must not silently allow pushes.
+		return errors.New(msg)
+	default:
+		// Defensive: an unexpected status should not leak through. Treat
+		// like a violation so pushes are blocked rather than waved through.
+		msg := fmt.Sprintf("secret scan returned unexpected status %q", res.Status)
+		_ = ev.AddEventWithPayload(ctx, taskID, "secret_scan_error", msg, payload)
+		return errors.New(msg)
+	}
 }
 
 // recordPolicyViolation writes a structured `policy_violation` task event

--- a/cmd/worker/secretscan_test.go
+++ b/cmd/worker/secretscan_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
+)
+
+// secretScanKinds extracts the ordered list of event kinds the fake
+// emitter has recorded so far. Hoisted out of each subtest to keep
+// individual cases focused on their assertions.
+func secretScanKinds(ev *fakeEmitter) []string {
+	out := make([]string, 0, len(ev.events))
+	for _, e := range ev.events {
+		out = append(out, e.Kind)
+	}
+	return out
+}
+
+// payloadString JSON-marshals a recorded payload so substring assertions
+// (e.g. "leak found in foo.go" or a command argument) remain stable
+// regardless of whether the helper passes a map[string]any, a []byte, or
+// any other shape into AddEventWithPayload.
+func payloadString(t *testing.T, payload any) string {
+	t.Helper()
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("payload marshal: %v", err)
+	}
+	return string(b)
+}
+
+func enabledSecretScanCfg() workflow.Config {
+	return workflow.Config{Verify: workflow.VerifyConfig{
+		SecretScan: workflow.SecretScanConfig{
+			Enabled: true,
+			Command: []string{"gitleaks", "detect", "--source", "."},
+		},
+	}}
+}
+
+func TestRunSecretScanWith_DisabledIsNoop(t *testing.T) {
+	ev := &fakeEmitter{}
+	called := false
+	stub := func(_ context.Context, _ string, _ workflow.SecretScanConfig) workspace.SecretScanResult {
+		called = true
+		return workspace.SecretScanResult{}
+	}
+	cfg := workflow.Config{} // SecretScan zero value: disabled
+	if err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", cfg, stub); err != nil {
+		t.Fatalf("disabled scan must not error, got %v", err)
+	}
+	if called {
+		t.Fatal("scanner must not run when disabled")
+	}
+	if len(ev.events) != 0 {
+		t.Fatalf("disabled scan must emit no events, got %v", secretScanKinds(ev))
+	}
+}
+
+func TestRunSecretScanWith_CleanEmitsStartAndClean(t *testing.T) {
+	ev := &fakeEmitter{}
+	stub := func(_ context.Context, _ string, _ workflow.SecretScanConfig) workspace.SecretScanResult {
+		return workspace.SecretScanResult{Status: workspace.SecretScanClean, ExitCode: 0, DurationMs: 12}
+	}
+	if err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", enabledSecretScanCfg(), stub); err != nil {
+		t.Fatalf("clean scan must not error, got %v", err)
+	}
+	got := secretScanKinds(ev)
+	want := []string{"secret_scan_start", "secret_scan_clean"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("event kinds: got=%v want=%v", got, want)
+	}
+}
+
+func TestRunSecretScanWith_ViolationBlocksPushAndEmitsViolationEvent(t *testing.T) {
+	ev := &fakeEmitter{}
+	stub := func(_ context.Context, _ string, _ workflow.SecretScanConfig) workspace.SecretScanResult {
+		return workspace.SecretScanResult{
+			Status:     workspace.SecretScanViolation,
+			ExitCode:   1,
+			DurationMs: 99,
+			Stdout:     "leak found in file foo.go\n",
+		}
+	}
+	err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", enabledSecretScanCfg(), stub)
+	if err == nil {
+		t.Fatal("violation with default fail_on_finding must abort push")
+	}
+	if !strings.Contains(err.Error(), "secret scan reported findings") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+	kinds := secretScanKinds(ev)
+	if len(kinds) != 2 || kinds[0] != "secret_scan_start" || kinds[1] != "secret_scan_violation" {
+		t.Fatalf("expected start+violation events, got %v", kinds)
+	}
+	// Sanity: the violation event payload includes the captured stdout so
+	// operators can see what the scanner reported without re-running it.
+	if payload := payloadString(t, ev.events[1].Payload); !strings.Contains(payload, "leak found in file foo.go") {
+		t.Fatalf("violation payload should include scanner stdout: %s", payload)
+	}
+}
+
+func TestRunSecretScanWith_ViolationWarnOnlyAllowsPush(t *testing.T) {
+	ev := &fakeEmitter{}
+	cfg := enabledSecretScanCfg()
+	off := false
+	cfg.Verify.SecretScan.FailOnFinding = &off
+	stub := func(_ context.Context, _ string, _ workflow.SecretScanConfig) workspace.SecretScanResult {
+		return workspace.SecretScanResult{Status: workspace.SecretScanViolation, ExitCode: 1}
+	}
+	if err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", cfg, stub); err != nil {
+		t.Fatalf("warn-only must not block push, got %v", err)
+	}
+	kinds := secretScanKinds(ev)
+	if len(kinds) != 2 || kinds[1] != "secret_scan_violation" {
+		t.Fatalf("expected violation event in warn-only mode, got %v", kinds)
+	}
+}
+
+func TestRunSecretScanWith_ExecErrorBlocksAndEmitsErrorEvent(t *testing.T) {
+	ev := &fakeEmitter{}
+	stub := func(_ context.Context, _ string, _ workflow.SecretScanConfig) workspace.SecretScanResult {
+		return workspace.SecretScanResult{
+			Status: workspace.SecretScanError,
+			Err:    errors.New("exec: gitleaks: not found"),
+		}
+	}
+	err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", enabledSecretScanCfg(), stub)
+	if err == nil {
+		t.Fatal("exec error must block push")
+	}
+	if !strings.Contains(err.Error(), "secret scan failed to execute") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+	kinds := secretScanKinds(ev)
+	if len(kinds) != 2 || kinds[1] != "secret_scan_error" {
+		t.Fatalf("expected secret_scan_error event, got %v", kinds)
+	}
+}
+
+func TestRunSecretScanWith_StartPayloadCarriesCommand(t *testing.T) {
+	ev := &fakeEmitter{}
+	stub := func(_ context.Context, _ string, _ workflow.SecretScanConfig) workspace.SecretScanResult {
+		return workspace.SecretScanResult{Status: workspace.SecretScanClean}
+	}
+	cfg := enabledSecretScanCfg()
+	if err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", cfg, stub); err != nil {
+		t.Fatalf("clean scan must not error, got %v", err)
+	}
+	if len(ev.events) < 1 {
+		t.Fatal("expected at least one event")
+	}
+	startPayload := payloadString(t, ev.events[0].Payload)
+	for _, want := range cfg.Verify.SecretScan.Command {
+		if !strings.Contains(startPayload, want) {
+			t.Fatalf("start payload missing arg %q: %s", want, startPayload)
+		}
+	}
+}

--- a/docs/runbooks/secret-scanning.md
+++ b/docs/runbooks/secret-scanning.md
@@ -1,0 +1,223 @@
+# Secret scanning runbook
+
+This runbook covers the optional pre-push secret scan hook the worker runs
+between the `verify` phase and `git push`. Its goal is to catch obvious
+credential leaks before an AI-generated branch reaches the remote.
+
+The hook is **off by default** so existing workflows are unchanged.
+Operators opt in by adding a `verify.secret_scan` block to `WORKFLOW.md`.
+
+## How it fits in the worker flow
+
+```
+runner -> policy enforce -> verify commands -> secret scan -> git push -> PR
+                                               ^^^^^^^^^^^
+                                               this runbook
+```
+
+When the scan reports findings, the worker:
+
+1. Emits a `secret_scan_violation` task event with the captured stdout,
+   stderr, exit code, and duration in the payload.
+2. Returns an error from `runTask`, which the queue records via the
+   existing `failed_attempt` path.
+3. **Skips `git push` and PR creation entirely.** No remote artifact is
+   created until the leak is removed and the task is retried.
+
+When the scanner cannot be executed at all (binary missing, permission
+denied), the worker emits `secret_scan_error` and also blocks the push,
+regardless of `fail_on_finding`. This is intentional: a misconfigured
+scanner should fail closed, not silently allow pushes.
+
+## Configuration schema
+
+```yaml
+verify:
+  commands:
+    - go test ./...
+  secret_scan:
+    enabled: true
+    command:
+      - gitleaks
+      - detect
+      - --source
+      - .
+      - --no-banner
+    fail_on_finding: true   # optional, defaults to true
+```
+
+Fields:
+
+- `enabled` (bool): toggles the hook. When false or omitted, the worker
+  skips the scan and emits no events.
+- `command` ([]string): argv to exec inside the workspace directory. The
+  first element is the binary; remaining elements are passed verbatim.
+  No shell is involved, so quoting/expansion does not happen — pass each
+  flag as its own list item.
+- `fail_on_finding` (bool, default `true`): when false, the worker still
+  emits `secret_scan_violation` events but does **not** block the push.
+  Useful while tuning rules to avoid false-positive churn. Operators
+  should treat this as a temporary state, not a steady-state setting.
+
+The scanner runs with the workspace directory as its working directory,
+so relative paths like `--source .` resolve to the AI-modified tree.
+
+## Recommended tools
+
+The worker does not bundle a scanner; install one of the following on the
+worker host (or in the worker container image) and reference its binary
+in `verify.secret_scan.command`.
+
+### gitleaks
+
+[gitleaks](https://github.com/gitleaks/gitleaks) is fast, has good
+defaults, and ships as a static binary.
+
+Install:
+
+```bash
+# macOS
+brew install gitleaks
+
+# Linux (binary release)
+curl -sSL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_linux_x64.tar.gz \
+  | tar -xz -C /usr/local/bin gitleaks
+
+# Verify
+gitleaks version
+```
+
+Recommended `WORKFLOW.md` snippet:
+
+```yaml
+verify:
+  secret_scan:
+    enabled: true
+    command:
+      - gitleaks
+      - detect
+      - --source
+      - .
+      - --no-banner
+      - --redact
+```
+
+Notes:
+
+- `--no-banner` keeps stdout machine-readable; the worker captures up to
+  1 MiB of output into the task event payload.
+- `--redact` masks the matched secret in the report. Recommended so the
+  task event payload itself does not become a secondary leak.
+- A custom `gitleaks.toml` checked into the repo is honored automatically.
+
+### trufflehog
+
+[trufflehog](https://github.com/trufflesecurity/trufflehog) has a
+verifier mode that calls real APIs to confirm a secret is live. The
+filesystem subcommand is the one to use here:
+
+```yaml
+verify:
+  secret_scan:
+    enabled: true
+    command:
+      - trufflehog
+      - filesystem
+      - --no-update
+      - --fail
+      - .
+```
+
+Notes:
+
+- `--no-update` prevents the binary from contacting the network for
+  self-updates, which keeps the scan deterministic.
+- `--fail` makes trufflehog exit non-zero on any verified finding. The
+  worker treats any non-zero exit as a violation.
+
+### detect-secrets
+
+[detect-secrets](https://github.com/Yelp/detect-secrets) is the right
+choice if your team already curates a baseline file:
+
+```yaml
+verify:
+  secret_scan:
+    enabled: true
+    command:
+      - detect-secrets-hook
+      - --baseline
+      - .secrets.baseline
+```
+
+The hook exits non-zero when new secrets appear that are not in the
+baseline. Combine with periodic `detect-secrets scan --update` runs done
+by humans, not the AI worker.
+
+## CI integration
+
+Run the same scanner in CI so that secrets which somehow slipped past
+the worker (or were added to the base branch by humans) still fail
+visibly. A minimal GitHub Actions step:
+
+```yaml
+- name: Secret scan
+  run: |
+    gitleaks detect --source . --no-banner --redact
+```
+
+Run this in the same job that runs `go test`, before any deploy steps.
+The worker's pre-push hook is a fast feedback loop; CI is the safety
+net.
+
+## Handling false positives
+
+False positives are inevitable. Resolve them in this order:
+
+1. **Prefer rule-level allowlists in the scanner config.** Both gitleaks
+   and trufflehog support per-repo allowlists checked into the repo
+   (e.g. `gitleaks.toml`). This keeps the suppression next to the code
+   and reviewable in PRs.
+2. **For detect-secrets, update the baseline.** Run
+   `detect-secrets scan --update .secrets.baseline` locally, review the
+   diff, and commit it. Never let the worker commit baseline updates.
+3. **Use `fail_on_finding: false` only as a stopgap.** It is fine for
+   the first day or two while you tune rules, but a permanent
+   `fail_on_finding: false` defeats the purpose of the hook. Track it as
+   technical debt.
+4. **Do not silence findings by editing the AI-generated branch.** If
+   the scanner flags a real secret, rotate it, then remove it from the
+   working tree. Re-running the task should produce a clean scan.
+
+## Task events
+
+Operators can inspect scan outcomes via the task events API
+(`docs/runbooks/task-api.md`). Event kinds emitted by this hook:
+
+| Event kind              | Meaning                                                   |
+| ----------------------- | --------------------------------------------------------- |
+| `secret_scan_start`     | Scanner is about to run; payload includes the argv.       |
+| `secret_scan_clean`     | Scanner exited zero. No findings.                         |
+| `secret_scan_violation` | Scanner exited non-zero. Push was blocked unless          |
+|                         | `fail_on_finding: false`. Payload has stdout/stderr.      |
+| `secret_scan_error`     | Scanner could not be executed (binary missing, etc).     |
+|                         | Push is always blocked. Fix the worker host configuration.|
+
+All payloads include `command`, `exit_code`, `duration_ms`, and the
+captured `stdout`/`stderr` truncated to 1 MiB to bound event size.
+
+## Operational tips
+
+- **Pin the scanner version** in your worker image so behavior does not
+  drift between deploys. A new gitleaks rule release can change which
+  branches pass overnight.
+- **Watch event durations.** A scan that spikes from 2s to 60s usually
+  means the workspace is accumulating untracked artifacts (caches, build
+  outputs). Add them to `.gitignore` rather than tuning the scanner.
+- **Do not point the scanner at `.git/`.** Some scanners walk it by
+  default and surface historical findings unrelated to the AI change.
+  Use `--source .` (gitleaks) or scan only the diff if your scanner
+  supports it.
+- **Treat `secret_scan_error` as a paging-level event.** Unlike
+  `secret_scan_violation` (real finding, AI branch is the problem),
+  `secret_scan_error` means the worker host itself is broken.

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -66,7 +66,43 @@ func (p PolicyConfig) LineLimit() int {
 }
 
 type VerifyConfig struct {
-	Commands []string `yaml:"commands"`
+	Commands   []string         `yaml:"commands"`
+	SecretScan SecretScanConfig `yaml:"secret_scan"`
+}
+
+// SecretScanConfig describes an optional pre-push secret scanner that runs
+// after verify commands and policy enforcement but before `git push`. The
+// scanner is invoked in the workspace directory; a non-zero exit code is
+// treated as a finding by default and blocks the push.
+//
+// Recommended tools (installed by the operator, not bundled here):
+//
+//   - gitleaks:   ["gitleaks", "detect", "--source", ".", "--no-banner"]
+//   - trufflehog: ["trufflehog", "filesystem", "--no-update", "."]
+//
+// Leave Enabled=false (or omit the section) to keep the previous behavior.
+type SecretScanConfig struct {
+	// Enabled toggles the hook. When false, the worker skips the scan and
+	// proceeds to push, preserving backward compatibility.
+	Enabled bool `yaml:"enabled"`
+	// Command is argv to exec inside the workspace. The first element is
+	// the binary; remaining elements are passed verbatim. No shell is used,
+	// so quoting/expansion is not performed.
+	Command []string `yaml:"command"`
+	// FailOnFinding controls whether a non-zero exit code blocks the push.
+	// Defaults to true. Set to false to surface findings as a warning event
+	// without aborting (useful while tuning false positives).
+	FailOnFinding *bool `yaml:"fail_on_finding,omitempty"`
+}
+
+// ShouldFailOnFinding reports whether a non-zero exit from the scanner
+// should block the push. The default is true; callers should pass through
+// this method rather than reading FailOnFinding directly.
+func (s SecretScanConfig) ShouldFailOnFinding() bool {
+	if s.FailOnFinding == nil {
+		return true
+	}
+	return *s.FailOnFinding
 }
 
 type PRConfig struct {

--- a/internal/workspace/secretscan.go
+++ b/internal/workspace/secretscan.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"syscall"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -102,11 +103,31 @@ func runSecretScanWith(ctx context.Context, workdir string, cfg workflow.SecretS
 		Stderr:     truncate(stderr, secretScanOutputCap),
 	}
 	if err != nil {
+		// If the parent context was canceled or its deadline elapsed, the
+		// scan never had a chance to complete. We must not treat that as a
+		// finding: report it as an execution error so the push is blocked
+		// regardless of fail_on_finding (we simply do not know whether the
+		// repo contains secrets).
+		if ctxErr := ctx.Err(); errors.Is(ctxErr, context.Canceled) || errors.Is(ctxErr, context.DeadlineExceeded) {
+			res.Status = SecretScanError
+			res.Err = fmt.Errorf("secret scan aborted: %w", ctxErr)
+			return res
+		}
 		// Distinguish "ran and exited non-zero" (ExitError) from "could
-		// not start at all" (e.g. binary missing). The former is a finding
-		// to surface; the latter is an operator error.
+		// not start at all" (e.g. binary missing) and from "process was
+		// killed by a signal" (OOM kill, external SIGTERM, etc.).
+		//
+		// A normal non-zero exit is a finding to surface (SecretScanViolation).
+		// A failure to start or a signal-killed process is an operator/exec
+		// error: the scan never produced a trustworthy result, so we map
+		// it to SecretScanError, which always blocks the push.
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
+			if isSignaled(ee) {
+				res.Status = SecretScanError
+				res.Err = fmt.Errorf("secret scan terminated by signal: %w", err)
+				return res
+			}
 			res.Status = SecretScanViolation
 			return res
 		}
@@ -116,6 +137,34 @@ func runSecretScanWith(ctx context.Context, workdir string, cfg workflow.SecretS
 	}
 	res.Status = SecretScanClean
 	return res
+}
+
+// isSignaled reports whether the process exited because it received a
+// signal (SIGKILL/SIGTERM/etc.) rather than calling exit(2) on its own.
+// Such terminations are not trustworthy scanner results: an OOM kill or
+// timeout-driven SIGKILL leaves the scan incomplete and must not be
+// classified as "found a secret".
+//
+// On Unix, the underlying ProcessState's WaitStatus exposes Signaled().
+// As a portable fallback, a -1 exit code (or any negative code) also
+// indicates the OS reported no normal exit code, which Go uses for
+// signal-terminated processes.
+func isSignaled(ee *exec.ExitError) bool {
+	if ee == nil || ee.ProcessState == nil {
+		return false
+	}
+	if ws, ok := ee.ProcessState.Sys().(syscall.WaitStatus); ok {
+		if ws.Signaled() {
+			return true
+		}
+	}
+	// Defensive fallback: ExitCode() returns -1 when the process did not
+	// exit normally (e.g. killed by signal, or platforms without
+	// WaitStatus). Treat any negative code as "not a real exit".
+	if ee.ProcessState.ExitCode() < 0 {
+		return true
+	}
+	return false
 }
 
 // runSecretScanCommand is the default command runner. It captures stdout

--- a/internal/workspace/secretscan.go
+++ b/internal/workspace/secretscan.go
@@ -1,0 +1,154 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// secretScanOutputCap bounds captured stdout/stderr to keep task event
+// payloads small. Mirrors the cap used elsewhere when summarizing long
+// command output.
+const secretScanOutputCap = 1 << 20 // 1 MiB
+
+// SecretScanStatus categorizes the outcome of a secret scan run.
+type SecretScanStatus string
+
+const (
+	// SecretScanSkipped indicates the scanner was disabled or unconfigured.
+	SecretScanSkipped SecretScanStatus = "skipped"
+	// SecretScanClean indicates the scanner exited zero (no findings).
+	SecretScanClean SecretScanStatus = "clean"
+	// SecretScanViolation indicates the scanner exited non-zero (findings).
+	SecretScanViolation SecretScanStatus = "violation"
+	// SecretScanError indicates the scanner could not be executed at all
+	// (binary not found, etc.). This is distinct from a finding because it
+	// is typically an operator misconfiguration.
+	SecretScanError SecretScanStatus = "error"
+)
+
+// SecretScanResult is the structured outcome of a single scan invocation.
+// It is suitable for direct JSON serialization into a task event payload.
+type SecretScanResult struct {
+	Status     SecretScanStatus `json:"status"`
+	Command    []string         `json:"command,omitempty"`
+	ExitCode   int              `json:"exit_code"`
+	DurationMs int64            `json:"duration_ms"`
+	Stdout     string           `json:"stdout,omitempty"`
+	Stderr     string           `json:"stderr,omitempty"`
+	// Err captures execution failures (e.g. binary not found). It is not
+	// serialized as JSON; callers convert it to an event message instead.
+	Err error `json:"-"`
+}
+
+// ShouldBlockPush reports whether this result should prevent the push,
+// honoring the workflow's FailOnFinding setting. Execution errors always
+// block; a clean or skipped result never blocks.
+func (r SecretScanResult) ShouldBlockPush(cfg workflow.SecretScanConfig) bool {
+	switch r.Status {
+	case SecretScanError:
+		return true
+	case SecretScanViolation:
+		return cfg.ShouldFailOnFinding()
+	default:
+		return false
+	}
+}
+
+// secretScanCommandRunner is an indirection seam used by the unit tests to
+// stub command execution without touching the real PATH. Production code
+// uses runSecretScanCommand below.
+type secretScanCommandRunner func(ctx context.Context, dir string, argv []string) (stdout, stderr []byte, exitCode int, err error)
+
+var defaultSecretScanRunner secretScanCommandRunner = runSecretScanCommand
+
+// RunSecretScan executes the configured pre-push secret scanner inside
+// workdir. It returns a structured SecretScanResult; callers decide
+// whether to block the push based on ShouldBlockPush.
+//
+// Behavior:
+//   - If the section is disabled or no command is configured, the result
+//     status is SecretScanSkipped and the caller proceeds with push.
+//   - If the scanner exits zero, status is SecretScanClean.
+//   - If the scanner exits non-zero, status is SecretScanViolation. Whether
+//     this blocks the push depends on cfg.ShouldFailOnFinding().
+//   - If the scanner cannot be executed (e.g. binary missing), status is
+//     SecretScanError and Err is populated; this always blocks the push.
+//
+// Captured stdout/stderr are truncated to 1 MiB to bound event payload
+// size, matching the behavior of other long-running command captures.
+func RunSecretScan(ctx context.Context, workdir string, cfg workflow.SecretScanConfig) SecretScanResult {
+	if !cfg.Enabled || len(cfg.Command) == 0 {
+		return SecretScanResult{Status: SecretScanSkipped}
+	}
+	return runSecretScanWith(ctx, workdir, cfg, defaultSecretScanRunner)
+}
+
+func runSecretScanWith(ctx context.Context, workdir string, cfg workflow.SecretScanConfig, runner secretScanCommandRunner) SecretScanResult {
+	argv := append([]string(nil), cfg.Command...)
+	start := time.Now()
+	stdout, stderr, code, err := runner(ctx, workdir, argv)
+	dur := time.Since(start).Milliseconds()
+
+	res := SecretScanResult{
+		Command:    argv,
+		ExitCode:   code,
+		DurationMs: dur,
+		Stdout:     truncate(stdout, secretScanOutputCap),
+		Stderr:     truncate(stderr, secretScanOutputCap),
+	}
+	if err != nil {
+		// Distinguish "ran and exited non-zero" (ExitError) from "could
+		// not start at all" (e.g. binary missing). The former is a finding
+		// to surface; the latter is an operator error.
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			res.Status = SecretScanViolation
+			return res
+		}
+		res.Status = SecretScanError
+		res.Err = fmt.Errorf("secret scan exec: %w", err)
+		return res
+	}
+	res.Status = SecretScanClean
+	return res
+}
+
+// runSecretScanCommand is the default command runner. It captures stdout
+// and stderr separately, which lets callers log them independently and
+// surface scanner findings (typically on stdout) cleanly in events. The
+// in-memory buffers reuse cappedBuffer (defined in manager.go) so a
+// runaway scanner cannot exhaust worker memory.
+func runSecretScanCommand(ctx context.Context, dir string, argv []string) ([]byte, []byte, int, error) {
+	if len(argv) == 0 {
+		return nil, nil, 0, fmt.Errorf("secret scan: empty command")
+	}
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Dir = dir
+	stdout := &cappedBuffer{Cap: secretScanOutputCap}
+	stderr := &cappedBuffer{Cap: secretScanOutputCap}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+		}
+	} else if cmd.ProcessState != nil {
+		code = cmd.ProcessState.ExitCode()
+	}
+	return []byte(stdout.String()), []byte(stderr.String()), code, err
+}
+
+func truncate(b []byte, max int) string {
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max])
+}

--- a/internal/workspace/secretscan_test.go
+++ b/internal/workspace/secretscan_test.go
@@ -1,0 +1,202 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// fakeExitError satisfies errors.As(*exec.ExitError) by using a real
+// exec.ExitError obtained from running `false`. Building one by hand is
+// awkward because os.ProcessState is unexported; running the binary is
+// the cleanest cross-platform way.
+func fakeExitError(t *testing.T) *exec.ExitError {
+	t.Helper()
+	cmd := exec.Command("false")
+	err := cmd.Run()
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("could not synthesize *exec.ExitError, got %T: %v", err, err)
+	}
+	return ee
+}
+
+func TestRunSecretScan_DisabledIsSkipped(t *testing.T) {
+	res := RunSecretScan(context.Background(), t.TempDir(), workflow.SecretScanConfig{
+		Enabled: false,
+		Command: []string{"echo", "hi"},
+	})
+	if res.Status != SecretScanSkipped {
+		t.Fatalf("expected skipped, got %q", res.Status)
+	}
+	if res.ShouldBlockPush(workflow.SecretScanConfig{}) {
+		t.Fatal("skipped result must not block push")
+	}
+}
+
+func TestRunSecretScan_EnabledNoCommandIsSkipped(t *testing.T) {
+	res := RunSecretScan(context.Background(), t.TempDir(), workflow.SecretScanConfig{
+		Enabled: true,
+		Command: nil,
+	})
+	if res.Status != SecretScanSkipped {
+		t.Fatalf("expected skipped when command empty, got %q", res.Status)
+	}
+}
+
+func TestRunSecretScan_CleanExit(t *testing.T) {
+	cfg := workflow.SecretScanConfig{Enabled: true, Command: []string{"my-scanner", "detect"}}
+	called := false
+	stub := func(ctx context.Context, dir string, argv []string) ([]byte, []byte, int, error) {
+		called = true
+		if !reflect.DeepEqual(argv, cfg.Command) {
+			t.Fatalf("argv passthrough mismatch: got=%v want=%v", argv, cfg.Command)
+		}
+		return []byte("no leaks\n"), nil, 0, nil
+	}
+	res := runSecretScanWith(context.Background(), t.TempDir(), cfg, stub)
+	if !called {
+		t.Fatal("runner was not invoked")
+	}
+	if res.Status != SecretScanClean {
+		t.Fatalf("expected clean, got %q", res.Status)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", res.ExitCode)
+	}
+	if res.Stdout != "no leaks\n" {
+		t.Fatalf("expected stdout passthrough, got %q", res.Stdout)
+	}
+	if res.ShouldBlockPush(cfg) {
+		t.Fatal("clean scan must not block push")
+	}
+}
+
+func TestRunSecretScan_NonZeroIsViolation(t *testing.T) {
+	cfg := workflow.SecretScanConfig{Enabled: true, Command: []string{"gitleaks", "detect"}}
+	stub := func(ctx context.Context, dir string, argv []string) ([]byte, []byte, int, error) {
+		return []byte("leak found in foo.go\n"), []byte("WRN ...\n"), 1, fakeExitError(t)
+	}
+	res := runSecretScanWith(context.Background(), t.TempDir(), cfg, stub)
+	if res.Status != SecretScanViolation {
+		t.Fatalf("expected violation, got %q", res.Status)
+	}
+	if res.ExitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", res.ExitCode)
+	}
+	if !strings.Contains(res.Stdout, "leak found") {
+		t.Fatalf("stdout not preserved: %q", res.Stdout)
+	}
+	if !res.ShouldBlockPush(cfg) {
+		t.Fatal("violation with default fail_on_finding must block push")
+	}
+}
+
+func TestRunSecretScan_ViolationWarnOnlyDoesNotBlock(t *testing.T) {
+	warn := false
+	cfg := workflow.SecretScanConfig{
+		Enabled:       true,
+		Command:       []string{"gitleaks"},
+		FailOnFinding: &warn,
+	}
+	stub := func(ctx context.Context, dir string, argv []string) ([]byte, []byte, int, error) {
+		return nil, nil, 1, fakeExitError(t)
+	}
+	res := runSecretScanWith(context.Background(), t.TempDir(), cfg, stub)
+	if res.Status != SecretScanViolation {
+		t.Fatalf("expected violation, got %q", res.Status)
+	}
+	if res.ShouldBlockPush(cfg) {
+		t.Fatal("warn-only mode must not block push on violation")
+	}
+}
+
+func TestRunSecretScan_ExecErrorBlocksPush(t *testing.T) {
+	cfg := workflow.SecretScanConfig{Enabled: true, Command: []string{"gitleaks-not-installed"}}
+	stub := func(ctx context.Context, dir string, argv []string) ([]byte, []byte, int, error) {
+		return nil, nil, 0, errors.New(`exec: "gitleaks-not-installed": executable file not found in $PATH`)
+	}
+	res := runSecretScanWith(context.Background(), t.TempDir(), cfg, stub)
+	if res.Status != SecretScanError {
+		t.Fatalf("expected error status, got %q", res.Status)
+	}
+	if res.Err == nil {
+		t.Fatal("expected Err populated for exec error")
+	}
+	// Error status always blocks regardless of FailOnFinding.
+	off := false
+	cfg.FailOnFinding = &off
+	if !res.ShouldBlockPush(cfg) {
+		t.Fatal("exec error must block push even when fail_on_finding=false")
+	}
+}
+
+func TestRunSecretScan_RealBinaryCleanAndDirty(t *testing.T) {
+	// Use built-in shell utilities so this works on any CI box without
+	// installing gitleaks. `true` exits 0 (clean); `false` exits 1 (finding).
+	if _, err := exec.LookPath("true"); err != nil {
+		t.Skip("/usr/bin/true not available")
+	}
+	clean := RunSecretScan(context.Background(), t.TempDir(), workflow.SecretScanConfig{
+		Enabled: true,
+		Command: []string{"true"},
+	})
+	if clean.Status != SecretScanClean {
+		t.Fatalf("expected clean from `true`, got %+v", clean)
+	}
+
+	if _, err := exec.LookPath("false"); err != nil {
+		t.Skip("/usr/bin/false not available")
+	}
+	dirty := RunSecretScan(context.Background(), t.TempDir(), workflow.SecretScanConfig{
+		Enabled: true,
+		Command: []string{"false"},
+	})
+	if dirty.Status != SecretScanViolation {
+		t.Fatalf("expected violation from `false`, got %+v", dirty)
+	}
+	if dirty.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit from `false`, got %d", dirty.ExitCode)
+	}
+}
+
+func TestRunSecretScan_RealBinaryMissingIsExecError(t *testing.T) {
+	res := RunSecretScan(context.Background(), t.TempDir(), workflow.SecretScanConfig{
+		Enabled: true,
+		Command: []string{"definitely-not-a-real-binary-aiops-platform"},
+	})
+	if res.Status != SecretScanError {
+		t.Fatalf("expected error status, got %+v", res)
+	}
+}
+
+func TestSecretScanConfig_ShouldFailOnFindingDefaultsTrue(t *testing.T) {
+	cfg := workflow.SecretScanConfig{}
+	if !cfg.ShouldFailOnFinding() {
+		t.Fatal("default should be true (block on finding)")
+	}
+	off := false
+	cfg.FailOnFinding = &off
+	if cfg.ShouldFailOnFinding() {
+		t.Fatal("explicit false must be honored")
+	}
+	on := true
+	cfg.FailOnFinding = &on
+	if !cfg.ShouldFailOnFinding() {
+		t.Fatal("explicit true must be honored")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if truncate([]byte("hello"), 10) != "hello" {
+		t.Fatal("under-cap should be unchanged")
+	}
+	if truncate([]byte("hello"), 3) != "hel" {
+		t.Fatal("over-cap should be truncated")
+	}
+}

--- a/internal/workspace/secretscan_test.go
+++ b/internal/workspace/secretscan_test.go
@@ -6,7 +6,9 @@ import (
 	"os/exec"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -189,6 +191,124 @@ func TestSecretScanConfig_ShouldFailOnFindingDefaultsTrue(t *testing.T) {
 	cfg.FailOnFinding = &on
 	if !cfg.ShouldFailOnFinding() {
 		t.Fatal("explicit true must be honored")
+	}
+}
+
+// killedExitError starts a long-running subprocess, kills it with SIGKILL,
+// and returns the resulting *exec.ExitError. This is the cleanest way to
+// produce a real signal-terminated ProcessState across Unix platforms.
+func killedExitError(t *testing.T) *exec.ExitError {
+	t.Helper()
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep(1) not available")
+	}
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("kill sleep: %v", err)
+	}
+	err := cmd.Wait()
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *exec.ExitError after SIGKILL, got %T: %v", err, err)
+	}
+	if ws, ok := ee.ProcessState.Sys().(syscall.WaitStatus); ok && !ws.Signaled() {
+		t.Fatalf("expected WaitStatus.Signaled()==true; ws=%#v", ws)
+	}
+	return ee
+}
+
+func TestRunSecretScan_SignalKilledIsExecError(t *testing.T) {
+	cfg := workflow.SecretScanConfig{Enabled: true, Command: []string{"gitleaks"}}
+	ee := killedExitError(t)
+	stub := func(ctx context.Context, dir string, argv []string) ([]byte, []byte, int, error) {
+		return nil, nil, ee.ProcessState.ExitCode(), ee
+	}
+	res := runSecretScanWith(context.Background(), t.TempDir(), cfg, stub)
+	if res.Status != SecretScanError {
+		t.Fatalf("SIGKILL should map to SecretScanError, got %q (err=%v)", res.Status, res.Err)
+	}
+	if res.Err == nil {
+		t.Fatal("expected Err populated when scanner is signal-killed")
+	}
+	// Always block, including warn-only mode: we never know if there's a secret.
+	off := false
+	cfg.FailOnFinding = &off
+	if !res.ShouldBlockPush(cfg) {
+		t.Fatal("signal-killed scanner must block push even with fail_on_finding=false")
+	}
+}
+
+func TestRunSecretScan_ContextCanceledIsExecError(t *testing.T) {
+	cfg := workflow.SecretScanConfig{Enabled: true, Command: []string{"gitleaks"}}
+	// Stub returns an ExitError to mimic exec.CommandContext killing the
+	// process when the parent ctx is canceled. The classifier should look
+	// at ctx.Err() first and route this to SecretScanError, not Violation.
+	ee := killedExitError(t)
+	stub := func(ctx context.Context, dir string, argv []string) ([]byte, []byte, int, error) {
+		return nil, nil, ee.ProcessState.ExitCode(), ee
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled
+	res := runSecretScanWith(ctx, t.TempDir(), cfg, stub)
+	if res.Status != SecretScanError {
+		t.Fatalf("canceled ctx should yield SecretScanError, got %q", res.Status)
+	}
+	if !errors.Is(res.Err, context.Canceled) {
+		t.Fatalf("expected wrapped context.Canceled, got %v", res.Err)
+	}
+	off := false
+	cfg.FailOnFinding = &off
+	if !res.ShouldBlockPush(cfg) {
+		t.Fatal("ctx-canceled scan must block push even in warn-only mode")
+	}
+}
+
+func TestRunSecretScan_ContextDeadlineExceededIsExecError(t *testing.T) {
+	cfg := workflow.SecretScanConfig{Enabled: true, Command: []string{"gitleaks"}}
+	ee := killedExitError(t)
+	stub := func(ctx context.Context, dir string, argv []string) ([]byte, []byte, int, error) {
+		// Simulate the deadline elapsing during the run.
+		<-ctx.Done()
+		return nil, nil, ee.ProcessState.ExitCode(), ee
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	res := runSecretScanWith(ctx, t.TempDir(), cfg, stub)
+	if res.Status != SecretScanError {
+		t.Fatalf("deadline exceeded should yield SecretScanError, got %q", res.Status)
+	}
+	if !errors.Is(res.Err, context.DeadlineExceeded) {
+		t.Fatalf("expected wrapped context.DeadlineExceeded, got %v", res.Err)
+	}
+	off := false
+	cfg.FailOnFinding = &off
+	if !res.ShouldBlockPush(cfg) {
+		t.Fatal("deadline-exceeded scan must block push even in warn-only mode")
+	}
+}
+
+func TestIsSignaled(t *testing.T) {
+	// Normal non-zero exit: not signaled.
+	cmd := exec.Command("false")
+	err := cmd.Run()
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *exec.ExitError from false, got %T", err)
+	}
+	if isSignaled(ee) {
+		t.Fatal("`false` exits normally; isSignaled must return false")
+	}
+	// SIGKILL: signaled.
+	killed := killedExitError(t)
+	if !isSignaled(killed) {
+		t.Fatal("SIGKILL'd process must be reported as signaled")
+	}
+	// Nil-safety.
+	if isSignaled(nil) {
+		t.Fatal("nil ExitError must not panic and must return false")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an optional pre-push secret scan hook between the workflow `verify`
phase and `git push`, so AI-generated branches with credential leaks
never reach the remote. Disabled by default; opt-in via the new
`verify.secret_scan` block in `WORKFLOW.md`.

- Configurable via `verify.secret_scan` (`enabled`, `command []string`, `fail_on_finding` defaulting to true).
- Findings emit a structured `secret_scan_violation` task event with command, exit code, duration, and 1 MiB-capped stdout/stderr in the payload, then block both `git push` and PR creation via the existing `failed_attempt` path.
- Execution errors (binary missing, etc.) emit `secret_scan_error` and always block — a misconfigured scanner fails closed.
- New runbook `docs/runbooks/secret-scanning.md` documents recommended tools (gitleaks, trufflehog, detect-secrets), CI integration, and false-positive handling. README links it.
- Zero new Go dependencies; the scanner is an external binary the operator installs.

## Event vocabulary

| Kind                    | When                              |
| ----------------------- | --------------------------------- |
| `secret_scan_start`     | scanner about to run              |
| `secret_scan_clean`     | exit 0                            |
| `secret_scan_violation` | non-zero exit (potential secrets) |
| `secret_scan_error`     | failed to execute (always blocks) |

## Test plan

- [x] `gofmt -l cmd internal` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green, including new `internal/workspace` and `cmd/worker` suites)
- [x] `go test -race ./internal/workspace/... ./cmd/worker/...`
- [x] `go mod tidy` produces no diff (no new dependencies)
- [x] Unit tests cover: disabled noop, clean exit, violation blocks push, warn-only mode does not block, exec error blocks, real-binary smoke (`true`/`false`), event-emission ordering, payload contents

Closes #23