### PR TITLE
feat: enforce runner timeout with cancellation and dedicated retry

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -70,7 +70,7 @@ func main() {
 // purely concerned with retry routing.
 func handleTaskFailure(ctx context.Context, store *queue.Store, t task.Task, cfg workflow.Config, err error) {
 	if runner.IsTimeout(err) {
-		budget := cfg.Agent.MaxTimeoutRetries
+		budget := cfg.Agent.MaxTimeoutRetriesValue()
 		if _, ferr := store.FailTimeout(ctx, t.ID, err.Error(), budget); ferr != nil {
 			log.Printf("task %s FailTimeout error: %v", t.ID, ferr)
 		}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -20,7 +20,9 @@ import (
 
 // eventEmitter is the subset of the queue store the worker needs to record
 // per-stage events. Defined here so unit tests can verify the worker emits
-// the right kinds without standing up a database.
+// the right kinds without standing up a database. The payload parameter is
+// `any` so callers can pass either structured maps (Marshal'd by the store)
+// or pre-serialized JSON []byte.
 type eventEmitter interface {
 	AddEvent(ctx context.Context, taskID, typ, msg string) error
 	AddEventWithPayload(ctx context.Context, taskID, typ, msg string, payload any) error
@@ -47,29 +49,56 @@ func main() {
 			time.Sleep(3 * time.Second)
 			continue
 		}
-		if err := runTask(ctx, store, *t); err != nil {
+		cfg, err := runTask(ctx, store, *t)
+		if err != nil {
 			log.Printf("task %s failed: %v", t.ID, err)
-			_ = store.Fail(ctx, t.ID, err.Error())
+			handleTaskFailure(ctx, store, *t, cfg, err)
 			continue
 		}
 		_ = store.Complete(ctx, t.ID)
 	}
 }
 
-func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
+// handleTaskFailure routes a task error to the right retry bucket.
+//
+// Runner timeouts use a dedicated budget (agent.max_timeout_retries) so a
+// hung agent cannot consume the generic max_attempts reserved for
+// verify/policy/transient infra failures. Non-timeout failures fall through
+// to the legacy Fail path which is still gated by max_attempts. Failure
+// artifacts (CHANGED_FILES.txt / RUN_SUMMARY.md / VERIFICATION.json) are
+// written by the runTask code path on the way out, so this function is
+// purely concerned with retry routing.
+func handleTaskFailure(ctx context.Context, store *queue.Store, t task.Task, cfg workflow.Config, err error) {
+	if runner.IsTimeout(err) {
+		budget := cfg.Agent.MaxTimeoutRetries
+		if _, ferr := store.FailTimeout(ctx, t.ID, err.Error(), budget); ferr != nil {
+			log.Printf("task %s FailTimeout error: %v", t.ID, ferr)
+		}
+		return
+	}
+	_ = store.Fail(ctx, t.ID, err.Error())
+}
+
+// runTask executes a single task end-to-end and returns the resolved
+// workflow config alongside any error so callers can route retries by
+// failure class. The returned config carries the per-agent timeout and
+// retry budgets so handleTaskFailure does not need to re-prepare the
+// workspace just to read agent settings.
+func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config, error) {
 	mgr := workspace.New(env("WORKSPACE_ROOT", "/tmp/aiops-workspaces"))
 	mgr.MirrorRoot = os.Getenv("AIOPS_MIRROR_ROOT")
 	workdir, err := mgr.PrepareGitWorkspace(ctx, t)
 	if err != nil {
-		return err
+		return workflow.Config{}, err
 	}
 
 	wf, err := workflow.LoadOptional(workdir + "/WORKFLOW.md")
 	if err != nil {
-		return err
+		return workflow.Config{}, err
 	}
+	cfg := wf.Config
 	if t.Model == "" || t.Model == "mock" {
-		t.Model = wf.Config.Agent.Default
+		t.Model = cfg.Agent.Default
 		if t.Model == "" {
 			t.Model = "mock"
 		}
@@ -85,39 +114,29 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 		"repo.branch":      t.BaseBranch,
 	})
 	if err := writeTaskFiles(workdir, t, prompt); err != nil {
-		return err
+		return cfg, err
 	}
 
 	r, err := runner.New(t.Model)
 	if err != nil {
-		return err
+		return cfg, err
 	}
 
-	emit(ctx, ev, t.ID, task.EventRunnerStart, "runner started", map[string]any{"model": t.Model})
-	runnerStart := time.Now()
-	res, runErr := r.Run(ctx, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, Prompt: prompt})
-	runnerDur := time.Since(runnerStart)
-	runnerPayload := map[string]any{"model": t.Model, "duration_ms": runnerDur.Milliseconds()}
+	res, runErr := runRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, Prompt: prompt}, cfg.Agent.Timeout)
 	if runErr != nil {
-		runnerPayload["error"] = errSummary(runErr)
-		emit(ctx, ev, t.ID, task.EventRunnerEnd, "runner failed", runnerPayload)
 		writeFailureArtifacts(ctx, workdir, nil, "runner failed: "+errSummary(runErr))
-		return runErr
+		return cfg, runErr
 	}
-	if res.Summary != "" {
-		runnerPayload["summary"] = res.Summary
-	}
-	emit(ctx, ev, t.ID, task.EventRunnerEnd, "runner completed", runnerPayload)
 
-	if err := workspace.EnforcePolicy(ctx, workdir, wf.Config); err != nil {
+	if err := workspace.EnforcePolicy(ctx, workdir, cfg); err != nil {
 		recordPolicyViolation(ctx, ev, t.ID, err)
 		writeFailureArtifacts(ctx, workdir, nil, "policy check failed: "+errSummary(err))
-		return err
+		return cfg, err
 	}
 
-	emit(ctx, ev, t.ID, task.EventVerifyStart, "verify started", map[string]any{"commands": wf.Config.Verify.Commands})
+	emit(ctx, ev, t.ID, task.EventVerifyStart, "verify started", map[string]any{"commands": cfg.Verify.Commands})
 	verifyStart := time.Now()
-	verifyResults, verifyErr := workspace.RunVerify(ctx, workdir, wf.Config)
+	verifyResults, verifyErr := workspace.RunVerify(ctx, workdir, cfg)
 	verifyDur := time.Since(verifyStart)
 	if writeErr := workspace.WriteVerification(workdir, verifyResults); writeErr != nil {
 		log.Printf("task %s: write verification artifact: %v", t.ID, writeErr)
@@ -130,7 +149,7 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 		verifyPayload["error"] = errSummary(verifyErr)
 		emit(ctx, ev, t.ID, task.EventVerifyEnd, "verify failed", verifyPayload)
 		writeFailureArtifacts(ctx, workdir, verifyResults, "verify failed: "+errSummary(verifyErr))
-		return verifyErr
+		return cfg, verifyErr
 	}
 	emit(ctx, ev, t.ID, task.EventVerifyEnd, "verify completed", verifyPayload)
 
@@ -161,7 +180,7 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 			"duration_ms": time.Since(pushStart).Milliseconds(),
 			"error":       errSummary(err),
 		})
-		return err
+		return cfg, err
 	}
 	emit(ctx, ev, t.ID, task.EventPush, "push completed", map[string]any{
 		"branch":         t.WorkBranch,
@@ -170,7 +189,61 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) error {
 		"sample_changes": sampleSlice(changed, 10),
 	})
 
-	return createPR(ctx, ev, t, wf.Config)
+	return cfg, createPR(ctx, ev, t, cfg)
+}
+
+// runRunnerWithTimeout invokes the runner under a per-task timeout derived
+// from agent.timeout. It emits structured task events
+// (runner_start, runner_end, runner_timeout) so retry policy and observers
+// can distinguish a clean exit from a kill due to deadline. The returned
+// runner.Result is what runTask passes to runSummary on the success path;
+// on failure it is zero-valued.
+func runRunnerWithTimeout(ctx context.Context, ev eventEmitter, r runner.Runner, in runner.RunInput, timeout time.Duration) (runner.Result, error) {
+	if timeout <= 0 {
+		timeout = 30 * time.Minute
+	}
+
+	emit(ctx, ev, in.Task.ID, task.EventRunnerStart, "runner started", map[string]any{
+		"model":      in.Task.Model,
+		"timeout_ms": timeout.Milliseconds(),
+	})
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+	res, runErr := r.Run(runCtx, in)
+	elapsed := time.Since(start)
+
+	if runErr != nil {
+		var te *runner.TimeoutError
+		if errors.As(runErr, &te) {
+			emit(ctx, ev, in.Task.ID, task.EventRunnerTimeout, te.Error(), map[string]any{
+				"model":      in.Task.Model,
+				"timeout_ms": te.Timeout.Milliseconds(),
+				"elapsed_ms": te.Elapsed.Milliseconds(),
+			})
+			return runner.Result{}, runErr
+		}
+		emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner failed", map[string]any{
+			"model":       in.Task.Model,
+			"duration_ms": elapsed.Milliseconds(),
+			"error":       errSummary(runErr),
+			"ok":          false,
+		})
+		return runner.Result{}, runErr
+	}
+
+	endPayload := map[string]any{
+		"model":       in.Task.Model,
+		"duration_ms": elapsed.Milliseconds(),
+		"ok":          true,
+	}
+	if res.Summary != "" {
+		endPayload["summary"] = res.Summary
+	}
+	emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner completed", endPayload)
+	return res, nil
 }
 
 // recordPolicyViolation writes a structured `policy_violation` task event

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
 )
 
@@ -38,6 +39,19 @@ func (f *fakeEmitter) AddEventWithPayload(_ context.Context, _ string, kind, msg
 	defer f.mu.Unlock()
 	f.events = append(f.events, recordedEvent{Kind: kind, Message: msg, Payload: payload})
 	return f.err
+}
+
+// byKind returns the recorded events whose Kind matches.
+func (f *fakeEmitter) byKind(kind string) []recordedEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []recordedEvent
+	for _, e := range f.events {
+		if e.Kind == kind {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 func TestEmitRecordsEventOnFakeEmitter(t *testing.T) {
@@ -125,6 +139,7 @@ func TestEventKindConstantsAreSnakeCase(t *testing.T) {
 	required := []string{
 		task.EventRunnerStart,
 		task.EventRunnerEnd,
+		task.EventRunnerTimeout,
 		task.EventVerifyStart,
 		task.EventVerifyEnd,
 		task.EventPush,
@@ -137,5 +152,161 @@ func TestEventKindConstantsAreSnakeCase(t *testing.T) {
 		if strings.ToLower(kind) != kind {
 			t.Fatalf("event kind %q must be lowercase snake_case", kind)
 		}
+	}
+}
+
+// stubRunner lets tests control the runner's outcome (sleep + final
+// error) without invoking a subprocess.
+type stubRunner struct {
+	sleep time.Duration
+	err   error
+}
+
+func (s stubRunner) Run(ctx context.Context, _ runner.RunInput) (runner.Result, error) {
+	if s.sleep > 0 {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return runner.Result{}, &runner.TimeoutError{
+					Timeout: 25 * time.Millisecond,
+					Elapsed: 25 * time.Millisecond,
+					Cause:   ctx.Err(),
+				}
+			}
+			return runner.Result{}, ctx.Err()
+		case <-time.After(s.sleep):
+		}
+	}
+	return runner.Result{Summary: "ok"}, s.err
+}
+
+// payloadField round-trips a recorded event payload through JSON and
+// returns the value at key. Centralising this here keeps the
+// runRunnerWithTimeout assertions resilient to the eventEmitter accepting
+// `any` payload (map[string]any in this code path).
+func payloadField(t *testing.T, p any, key string) any {
+	t.Helper()
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return m[key]
+}
+
+// TestRunRunnerWithTimeoutEmitsTimeoutEvent confirms that a runner
+// killed by the per-task timeout produces exactly one runner_start +
+// one runner_timeout event (and no runner_end), with payload fields the
+// debug API can rely on.
+func TestRunRunnerWithTimeoutEmitsTimeoutEvent(t *testing.T) {
+	t.Parallel()
+	ev := &fakeEmitter{}
+	in := runner.RunInput{
+		Task:     task.Task{ID: "tsk_to", Model: "mock"},
+		Workflow: workflow.Workflow{},
+		Workdir:  t.TempDir(),
+	}
+	_, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{sleep: 5 * time.Second}, in, 30*time.Millisecond)
+	if !runner.IsTimeout(err) {
+		t.Fatalf("expected TimeoutError from runRunnerWithTimeout, got %v", err)
+	}
+	if got := len(ev.byKind(task.EventRunnerStart)); got != 1 {
+		t.Fatalf("runner_start count: got=%d want=1", got)
+	}
+	if got := len(ev.byKind(task.EventRunnerTimeout)); got != 1 {
+		t.Fatalf("runner_timeout count: got=%d want=1", got)
+	}
+	if got := len(ev.byKind(task.EventRunnerEnd)); got != 0 {
+		t.Fatalf("runner_end must not fire on timeout, got=%d", got)
+	}
+
+	// Payload sanity: timeout_ms and elapsed_ms must be present.
+	pe := ev.byKind(task.EventRunnerTimeout)[0]
+	if got := payloadField(t, pe.Payload, "timeout_ms"); got == nil {
+		t.Fatal("runner_timeout payload missing timeout_ms")
+	}
+	if got := payloadField(t, pe.Payload, "elapsed_ms"); got == nil {
+		t.Fatal("runner_timeout payload missing elapsed_ms")
+	}
+}
+
+// TestRunRunnerWithTimeoutHappyPath emits runner_start + runner_end
+// (with ok=true) when the runner completes within budget.
+func TestRunRunnerWithTimeoutHappyPath(t *testing.T) {
+	t.Parallel()
+	ev := &fakeEmitter{}
+	in := runner.RunInput{
+		Task:     task.Task{ID: "tsk_ok", Model: "mock"},
+		Workflow: workflow.Workflow{},
+		Workdir:  t.TempDir(),
+	}
+	if _, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{}, in, time.Second); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(ev.byKind(task.EventRunnerStart)); got != 1 {
+		t.Fatalf("runner_start count: got=%d want=1", got)
+	}
+	if got := len(ev.byKind(task.EventRunnerEnd)); got != 1 {
+		t.Fatalf("runner_end count: got=%d want=1", got)
+	}
+	if got := len(ev.byKind(task.EventRunnerTimeout)); got != 0 {
+		t.Fatalf("runner_timeout must not fire on success, got=%d", got)
+	}
+	pe := ev.byKind(task.EventRunnerEnd)[0]
+	ok, _ := payloadField(t, pe.Payload, "ok").(bool)
+	if !ok {
+		t.Fatalf("runner_end payload ok=true expected, got %v", payloadField(t, pe.Payload, "ok"))
+	}
+}
+
+// TestRunRunnerWithTimeoutNonTimeoutError keeps verify-vs-timeout
+// retry buckets disjoint: a generic runner error must surface as
+// runner_end with ok=false (not runner_timeout).
+func TestRunRunnerWithTimeoutNonTimeoutError(t *testing.T) {
+	t.Parallel()
+	ev := &fakeEmitter{}
+	wantErr := errors.New("agent crashed")
+	in := runner.RunInput{
+		Task:     task.Task{ID: "tsk_err", Model: "mock"},
+		Workflow: workflow.Workflow{},
+		Workdir:  t.TempDir(),
+	}
+	_, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{err: wantErr}, in, time.Second)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err propagation broken: got %v want %v", err, wantErr)
+	}
+	if runner.IsTimeout(err) {
+		t.Fatal("non-timeout error must not be classified as timeout")
+	}
+	if got := len(ev.byKind(task.EventRunnerTimeout)); got != 0 {
+		t.Fatalf("runner_timeout must not fire on plain error, got=%d", got)
+	}
+	if got := len(ev.byKind(task.EventRunnerEnd)); got != 1 {
+		t.Fatalf("runner_end count: got=%d want=1", got)
+	}
+}
+
+// TestRunRunnerWithTimeoutZeroBudgetUsesDefault ensures we never call
+// context.WithTimeout(0), which would fire instantly. A zero budget
+// should fall back to the schema default (30m).
+func TestRunRunnerWithTimeoutZeroBudgetUsesDefault(t *testing.T) {
+	t.Parallel()
+	ev := &fakeEmitter{}
+	in := runner.RunInput{
+		Task:     task.Task{ID: "tsk_zero", Model: "mock"},
+		Workflow: workflow.Workflow{},
+		Workdir:  t.TempDir(),
+	}
+	if _, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{sleep: 10 * time.Millisecond}, in, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pe := ev.byKind(task.EventRunnerStart)[0]
+	got, _ := payloadField(t, pe.Payload, "timeout_ms").(float64)
+	want := float64((30 * time.Minute).Milliseconds())
+	if got != want {
+		t.Fatalf("expected default timeout %v ms, got %v", want, got)
 	}
 }

--- a/internal/queue/postgres.go
+++ b/internal/queue/postgres.go
@@ -145,6 +145,48 @@ func (s *Store) Fail(ctx context.Context, id string, msg string) error {
 	return err
 }
 
+// FailTimeout records a runner timeout failure for task id and re-queues
+// the task only if it has not yet reached its dedicated timeout retry
+// budget. The budget is intentionally separate from the generic
+// max_attempts (covering verify/policy/other failures) so a flaky
+// runner cannot exhaust the global retry pool. Returns true when the
+// task was re-queued, false when it was permanently failed.
+func (s *Store) FailTimeout(ctx context.Context, id string, msg string, maxTimeoutRetries int) (bool, error) {
+	prior, err := s.CountEvents(ctx, id, "runner_timeout")
+	if err != nil {
+		return false, err
+	}
+	// `prior` already includes the timeout event for the current attempt
+	// (callers should have emitted runner_timeout before invoking us).
+	// Re-queue while we still have unused budget.
+	if prior <= maxTimeoutRetries {
+		_, err := s.db.Exec(ctx, `UPDATE tasks SET status='queued', available_at=now()+interval '60 seconds', updated_at=now() WHERE id=$1`, id)
+		if err != nil {
+			return false, err
+		}
+		_ = s.AddEvent(ctx, id, "failed_attempt", msg)
+		return true, nil
+	}
+	_, err = s.db.Exec(ctx, "UPDATE tasks SET status='failed', updated_at=now() WHERE id=$1", id)
+	if err != nil {
+		return false, err
+	}
+	_ = s.AddEvent(ctx, id, "failed_attempt", msg)
+	return false, nil
+}
+
+// CountEvents returns the number of task_events of the given event_type
+// associated with taskID. It is used by retry policy to differentiate
+// timeout failures from verify/policy failures.
+func (s *Store) CountEvents(ctx context.Context, taskID, eventType string) (int, error) {
+	var n int
+	row := s.db.QueryRow(ctx, "SELECT count(*) FROM task_events WHERE task_id=$1 AND event_type=$2", taskID, eventType)
+	if err := row.Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
 func (s *Store) AddEvent(ctx context.Context, taskID, typ, msg string) error {
 	_, err := s.db.Exec(ctx, "INSERT INTO task_events(task_id,event_type,message) VALUES($1,$2,$3)", taskID, typ, msg)
 	return err

--- a/internal/runner/mock.go
+++ b/internal/runner/mock.go
@@ -2,15 +2,41 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 )
 
-type MockRunner struct{}
+// MockRunner is the Symphony-style Day-1 runner used in tests and the
+// `mock` agent path. Sleep, when > 0, makes the runner block until either
+// it elapses or the context is cancelled — this is how tests drive the
+// timeout path without spawning a real subprocess.
+type MockRunner struct {
+	Sleep time.Duration
+}
 
-func (MockRunner) Run(ctx context.Context, in RunInput) (Result, error) {
+func (m MockRunner) Run(ctx context.Context, in RunInput) (Result, error) {
+	if m.Sleep > 0 {
+		start := time.Now()
+		t := time.NewTimer(m.Sleep)
+		defer t.Stop()
+		select {
+		case <-ctx.Done():
+			elapsed := time.Since(start)
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return Result{}, &TimeoutError{
+					Timeout: deadlineBudget(ctx, start),
+					Elapsed: elapsed,
+					Cause:   ctx.Err(),
+				}
+			}
+			return Result{}, ctx.Err()
+		case <-t.C:
+		}
+	}
+
 	dir := filepath.Join(in.Workdir, ".aiops")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return Result{}, err

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -34,4 +36,30 @@ func New(name string) (Runner, error) {
 	default:
 		return nil, fmt.Errorf("unknown runner: %s", name)
 	}
+}
+
+// TimeoutError is returned by Runner implementations when the parent
+// context's deadline elapsed before the runner subprocess finished.
+// Callers should treat this distinctly from a generic non-zero exit so
+// retry policy can differentiate transient hangs from real failures.
+type TimeoutError struct {
+	// Timeout is the configured per-task budget.
+	Timeout time.Duration
+	// Elapsed is how long the runner actually ran before being killed.
+	Elapsed time.Duration
+	// Cause is the wrapped underlying error (typically a context
+	// DeadlineExceeded or os/exec error from the killed subprocess).
+	Cause error
+}
+
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("runner timed out after %s (budget %s): %v", e.Elapsed, e.Timeout, e.Cause)
+}
+
+func (e *TimeoutError) Unwrap() error { return e.Cause }
+
+// IsTimeout reports whether err is (or wraps) a *TimeoutError.
+func IsTimeout(err error) bool {
+	var te *TimeoutError
+	return errors.As(err, &te)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,0 +1,171 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// shellTestWorkdir creates a temp workdir with a stub .aiops/PROMPT.md
+// so the ShellRunner's `< .aiops/PROMPT.md` redirection does not fail
+// before the actual command runs (we care about the kill path, not
+// the prompt plumbing).
+func shellTestWorkdir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".aiops"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".aiops", "PROMPT.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestMockRunnerTimeoutReturnsTimeoutError verifies that when the mock
+// runner is asked to sleep longer than the parent context's deadline,
+// it returns *TimeoutError (not a generic ctx.Err()) so worker retry
+// policy can route it to the timeout-specific bucket.
+func TestMockRunnerTimeoutReturnsTimeoutError(t *testing.T) {
+	t.Parallel()
+	r := MockRunner{Sleep: 5 * time.Second}
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := r.Run(ctx, RunInput{
+		Task:     task.Task{ID: "tsk_test", Model: "mock"},
+		Workflow: workflow.Workflow{},
+		Workdir:  t.TempDir(),
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from timed-out runner, got nil")
+	}
+	if !IsTimeout(err) {
+		t.Fatalf("expected TimeoutError, got %T: %v", err, err)
+	}
+	var te *TimeoutError
+	if !errors.As(err, &te) {
+		t.Fatalf("errors.As to *TimeoutError failed: %v", err)
+	}
+	if te.Elapsed <= 0 {
+		t.Fatalf("expected non-zero elapsed, got %v", te.Elapsed)
+	}
+	// We should have returned promptly when ctx fired, well before the
+	// 5s sleep would have completed naturally.
+	if elapsed >= 2*time.Second {
+		t.Fatalf("runner did not honor ctx cancellation; elapsed=%v", elapsed)
+	}
+}
+
+// TestMockRunnerNoTimeoutWhenSleepShort confirms the happy path: with
+// adequate budget the mock runner returns Result without a TimeoutError.
+func TestMockRunnerNoTimeoutWhenSleepShort(t *testing.T) {
+	t.Parallel()
+	r := MockRunner{Sleep: 5 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	res, err := r.Run(ctx, RunInput{
+		Task:     task.Task{ID: "tsk_ok", Model: "mock"},
+		Workflow: workflow.Workflow{},
+		Workdir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Summary == "" {
+		t.Fatal("expected non-empty Result.Summary on success")
+	}
+	if IsTimeout(err) {
+		t.Fatal("IsTimeout should be false for nil error")
+	}
+}
+
+// TestShellRunnerKillsRunawayProcess wires the real ShellRunner against
+// a `sleep 30` command and asserts that a 50ms timeout actually kills
+// the subprocess (i.e. ctx-driven SIGTERM/SIGKILL works end-to-end). The
+// guard `time.Since(start) < 5s` would fail loudly if the kill path
+// regressed and we waited the full sleep budget.
+func TestShellRunnerKillsRunawayProcess(t *testing.T) {
+	t.Parallel()
+	wf := workflow.Workflow{Config: workflow.Config{
+		Codex: workflow.CommandConfig{Command: "sleep 30"},
+	}}
+	r := ShellRunner{Name: "codex"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := r.Run(ctx, RunInput{
+		Task:     task.Task{ID: "tsk_shell"},
+		Workflow: wf,
+		Workdir:  shellTestWorkdir(t),
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from killed sh subprocess")
+	}
+	if !IsTimeout(err) {
+		t.Fatalf("expected TimeoutError from shell runner, got %T: %v", err, err)
+	}
+	// Even with the SIGTERM->SIGKILL grace (5s) the wait must complete
+	// well before sleep 30s would have. Allow generous slack for CI.
+	if elapsed > 10*time.Second {
+		t.Fatalf("shell runner did not kill subprocess promptly; elapsed=%v", elapsed)
+	}
+}
+
+// TestShellRunnerNonTimeoutErrorNotMisclassified guarantees a runner
+// that exits non-zero quickly (no ctx expiry) is *not* tagged as a
+// TimeoutError — verify-vs-timeout retry routing depends on this.
+func TestShellRunnerNonTimeoutErrorNotMisclassified(t *testing.T) {
+	t.Parallel()
+	wf := workflow.Workflow{Config: workflow.Config{
+		Codex: workflow.CommandConfig{Command: "exit 3"},
+	}}
+	r := ShellRunner{Name: "codex"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := r.Run(ctx, RunInput{
+		Task:     task.Task{ID: "tsk_nonzero"},
+		Workflow: wf,
+		Workdir:  shellTestWorkdir(t),
+	})
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+	if IsTimeout(err) {
+		t.Fatalf("non-zero exit must not be classified as timeout: %v", err)
+	}
+}
+
+func TestIsTimeoutNilAndOther(t *testing.T) {
+	t.Parallel()
+	if IsTimeout(nil) {
+		t.Fatal("IsTimeout(nil) should be false")
+	}
+	if IsTimeout(errors.New("boom")) {
+		t.Fatal("IsTimeout on plain error should be false")
+	}
+	te := &TimeoutError{Timeout: time.Second, Elapsed: time.Second, Cause: errors.New("x")}
+	if !IsTimeout(te) {
+		t.Fatal("IsTimeout on *TimeoutError should be true")
+	}
+	wrapped := errors.Join(errors.New("ctx"), te)
+	if !IsTimeout(wrapped) {
+		t.Fatal("IsTimeout should unwrap joined errors")
+	}
+}

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -2,14 +2,22 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 )
 
 type ShellRunner struct {
 	Name string
 }
+
+// killGrace is how long the runner waits between SIGTERM and SIGKILL when
+// the parent context is cancelled or its deadline elapses. We prefer a
+// graceful shutdown so codex/claude can flush output, then fall back to
+// SIGKILL to guarantee the worker does not block forever.
+const killGrace = 5 * time.Second
 
 func (r ShellRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 	command := ""
@@ -22,12 +30,47 @@ func (r ShellRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 	if command == "" {
 		return Result{}, fmt.Errorf("empty command for runner %s", r.Name)
 	}
+
+	start := time.Now()
 	cmd := exec.CommandContext(ctx, "sh", "-lc", command+" < .aiops/PROMPT.md")
 	cmd.Dir = in.Workdir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	// Wire platform-specific group-kill semantics. On Unix we put the
+	// shell in its own process group so SIGTERM/SIGKILL reach
+	// grandchildren too; on Windows this is a no-op and exec defaults
+	// apply.
+	configurePlatformKill(cmd)
+	cmd.WaitDelay = killGrace
+
+	err := cmd.Run()
+	elapsed := time.Since(start)
+	if err != nil {
+		// Distinguish ctx-driven termination (timeout/cancel) from a
+		// regular non-zero exit. A killed subprocess often surfaces as
+		// `signal: terminated` or `signal: killed`; the authoritative
+		// signal is ctx.Err().
+		if cerr := ctx.Err(); errors.Is(cerr, context.DeadlineExceeded) {
+			return Result{}, &TimeoutError{
+				Timeout: deadlineBudget(ctx, start),
+				Elapsed: elapsed,
+				Cause:   err,
+			}
+		}
 		return Result{}, err
 	}
 	return Result{Summary: r.Name + " completed"}, nil
+}
+
+// deadlineBudget reports the originally-configured timeout window. When
+// the parent context has a deadline we report the gap between start and
+// that deadline; otherwise we fall back to the elapsed runtime so the
+// emitted event still carries a useful number.
+func deadlineBudget(ctx context.Context, start time.Time) time.Duration {
+	if d, ok := ctx.Deadline(); ok {
+		if budget := d.Sub(start); budget > 0 {
+			return budget
+		}
+	}
+	return time.Since(start)
 }

--- a/internal/runner/shell_unix.go
+++ b/internal/runner/shell_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package runner
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// configurePlatformKill makes the shell runner survive SIGTERM-resistant
+// children (e.g. `sleep` under `sh -lc`). The runner runs in its own
+// process group so we can deliver signals to the entire group on
+// context cancel; otherwise WaitDelay would only kill `sh` and leave
+// grandchildren orphaned, blocking workspace cleanup.
+func configurePlatformKill(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Negative pid targets the process group leader created above.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		// Backstop: if the group is still alive after killGrace, send
+		// SIGKILL to the whole group. cmd.WaitDelay only handles the
+		// direct child; grandchildren can survive otherwise.
+		go func(pid int) {
+			time.Sleep(killGrace)
+			_ = syscall.Kill(-pid, syscall.SIGKILL)
+		}(cmd.Process.Pid)
+		return nil
+	}
+}

--- a/internal/runner/shell_windows.go
+++ b/internal/runner/shell_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package runner
+
+import "os/exec"
+
+// configurePlatformKill is a no-op on Windows; exec.CommandContext's
+// default Cancel (SIGKILL on the direct child) plus cmd.WaitDelay are
+// the strongest guarantees the os/exec stdlib offers cross-platform.
+// Job-object based group kill could be added later if Windows worker
+// hosting becomes a real target.
+func configurePlatformKill(_ *exec.Cmd) {}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -24,6 +24,7 @@ const (
 	EventClaimed       = "claimed"
 	EventRunnerStart   = "runner_start"
 	EventRunnerEnd     = "runner_end"
+	EventRunnerTimeout = "runner_timeout"
 	EventVerifyStart   = "verify_start"
 	EventVerifyEnd     = "verify_end"
 	EventPush          = "push"

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -1,5 +1,7 @@
 package workflow
 
+import "time"
+
 type Config struct {
 	Repo      RepoConfig      `yaml:"repo"`
 	Tracker   TrackerConfig   `yaml:"tracker"`
@@ -38,6 +40,16 @@ type AgentConfig struct {
 	Fallback            string `yaml:"fallback"`
 	MaxConcurrentAgents int    `yaml:"max_concurrent_agents"`
 	MaxTurns            int    `yaml:"max_turns"`
+	// Timeout caps a single runner invocation. When exceeded, the runner
+	// subprocess is killed and the task records a `runner_timeout` event.
+	// Configured via YAML as `agent.timeout: 10m`. Zero means use the
+	// schema default of 30m.
+	Timeout time.Duration `yaml:"timeout"`
+	// MaxTimeoutRetries bounds how many times a task may be re-queued
+	// after a runner timeout. This is intentionally separate from the
+	// generic max_attempts (which covers verify/policy/other failures)
+	// so a flaky runner cannot exhaust the global retry budget.
+	MaxTimeoutRetries int `yaml:"max_timeout_retries"`
 }
 
 type CommandConfig struct {
@@ -84,11 +96,18 @@ func DefaultConfig() Config {
 			PollIntervalMs: 30000,
 		},
 		Workspace: WorkspaceConfig{Root: "~/aiops-workspaces"},
-		Agent:     AgentConfig{Default: "mock", Fallback: "claude", MaxConcurrentAgents: 1, MaxTurns: 8},
-		Codex:     CommandConfig{Command: "codex exec"},
-		Claude:    CommandConfig{Command: "claude"},
-		Policy:    PolicyConfig{Mode: "draft_pr", MaxChangedFiles: 12, MaxChangedLOC: 300},
-		Verify:    VerifyConfig{Commands: []string{}},
+		Agent: AgentConfig{
+			Default:             "mock",
+			Fallback:            "claude",
+			MaxConcurrentAgents: 1,
+			MaxTurns:            8,
+			Timeout:             30 * time.Minute,
+			MaxTimeoutRetries:   1,
+		},
+		Codex:  CommandConfig{Command: "codex exec"},
+		Claude: CommandConfig{Command: "claude"},
+		Policy: PolicyConfig{Mode: "draft_pr", MaxChangedFiles: 12, MaxChangedLOC: 300},
+		Verify: VerifyConfig{Commands: []string{}},
 		// PR.Draft defaults to false so workflows that omit `pr.draft` keep
 		// the historical worker behavior of opening ready-for-review PRs.
 		// Profiles that want draft PRs (e.g. company-cautious) opt in by

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -49,7 +49,26 @@ type AgentConfig struct {
 	// after a runner timeout. This is intentionally separate from the
 	// generic max_attempts (which covers verify/policy/other failures)
 	// so a flaky runner cannot exhaust the global retry budget.
-	MaxTimeoutRetries int `yaml:"max_timeout_retries"`
+	//
+	// Pointer-typed so we can distinguish "absent" (nil → schema default
+	// of 1) from "explicitly set to 0" (no retry). Read via
+	// MaxTimeoutRetriesValue() rather than dereferencing directly.
+	MaxTimeoutRetries *int `yaml:"max_timeout_retries"`
+}
+
+// MaxTimeoutRetriesValue returns the effective runner-timeout retry
+// budget. A nil pointer (field omitted from YAML) yields the schema
+// default of 1 bonus retry; an explicit value—including 0—is honored
+// as configured. Negative values are clamped to 0 since a negative
+// retry budget is meaningless.
+func (a AgentConfig) MaxTimeoutRetriesValue() int {
+	if a.MaxTimeoutRetries == nil {
+		return 1
+	}
+	if *a.MaxTimeoutRetries < 0 {
+		return 0
+	}
+	return *a.MaxTimeoutRetries
 }
 
 type CommandConfig struct {
@@ -96,13 +115,16 @@ func DefaultConfig() Config {
 			PollIntervalMs: 30000,
 		},
 		Workspace: WorkspaceConfig{Root: "~/aiops-workspaces"},
+		// Agent.MaxTimeoutRetries is intentionally left nil here so the
+		// "absent" signal survives a YAML unmarshal that overlays this
+		// default. The effective default of 1 retry is supplied by
+		// MaxTimeoutRetriesValue().
 		Agent: AgentConfig{
 			Default:             "mock",
 			Fallback:            "claude",
 			MaxConcurrentAgents: 1,
 			MaxTurns:            8,
 			Timeout:             30 * time.Minute,
-			MaxTimeoutRetries:   1,
 		},
 		Codex:  CommandConfig{Command: "codex exec"},
 		Claude: CommandConfig{Command: "claude"},

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestLoad_PRDraftFromFrontMatter verifies the YAML key `pr.draft` is parsed
@@ -90,5 +91,61 @@ body
 				t.Fatalf("PR.Draft: got %v want %v", wf.Config.PR.Draft, tc.want)
 			}
 		})
+	}
+}
+
+// TestDefaultConfigAgentTimeout pins the schema-level defaults the
+// platform contract advertises: a 30-minute per-task timeout and one
+// dedicated retry slot for runner timeouts.
+func TestDefaultConfigAgentTimeout(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Agent.Timeout != 30*time.Minute {
+		t.Fatalf("default Agent.Timeout: got %v want 30m", cfg.Agent.Timeout)
+	}
+	if cfg.Agent.MaxTimeoutRetries != 1 {
+		t.Fatalf("default Agent.MaxTimeoutRetries: got %d want 1", cfg.Agent.MaxTimeoutRetries)
+	}
+}
+
+// TestLoadOptionalAppliesAgentTimeoutDefaults verifies that a workflow
+// missing agent.timeout in its front matter still ends up with the
+// schema default after expandConfig runs.
+func TestLoadOptionalAppliesAgentTimeoutDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := "---\nrepo:\n  owner: o\n  name: n\n  default_branch: main\n---\nhello\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wf, err := LoadOptional(path)
+	if err != nil {
+		t.Fatalf("LoadOptional: %v", err)
+	}
+	if wf.Config.Agent.Timeout != 30*time.Minute {
+		t.Fatalf("expanded Agent.Timeout: got %v want 30m", wf.Config.Agent.Timeout)
+	}
+	if wf.Config.Agent.MaxTimeoutRetries != 1 {
+		t.Fatalf("expanded Agent.MaxTimeoutRetries: got %d want 1", wf.Config.Agent.MaxTimeoutRetries)
+	}
+}
+
+// TestLoadOptionalHonorsExplicitAgentTimeout confirms a user-specified
+// agent.timeout / max_timeout_retries override the schema defaults.
+func TestLoadOptionalHonorsExplicitAgentTimeout(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := "---\nagent:\n  timeout: 5m\n  max_timeout_retries: 3\n---\nhello\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wf, err := LoadOptional(path)
+	if err != nil {
+		t.Fatalf("LoadOptional: %v", err)
+	}
+	if wf.Config.Agent.Timeout != 5*time.Minute {
+		t.Fatalf("explicit Agent.Timeout: got %v want 5m", wf.Config.Agent.Timeout)
+	}
+	if wf.Config.Agent.MaxTimeoutRetries != 3 {
+		t.Fatalf("explicit Agent.MaxTimeoutRetries: got %d want 3", wf.Config.Agent.MaxTimeoutRetries)
 	}
 }

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -102,8 +102,8 @@ func TestDefaultConfigAgentTimeout(t *testing.T) {
 	if cfg.Agent.Timeout != 30*time.Minute {
 		t.Fatalf("default Agent.Timeout: got %v want 30m", cfg.Agent.Timeout)
 	}
-	if cfg.Agent.MaxTimeoutRetries != 1 {
-		t.Fatalf("default Agent.MaxTimeoutRetries: got %d want 1", cfg.Agent.MaxTimeoutRetries)
+	if got := cfg.Agent.MaxTimeoutRetriesValue(); got != 1 {
+		t.Fatalf("default Agent.MaxTimeoutRetriesValue: got %d want 1", got)
 	}
 }
 
@@ -124,8 +124,8 @@ func TestLoadOptionalAppliesAgentTimeoutDefaults(t *testing.T) {
 	if wf.Config.Agent.Timeout != 30*time.Minute {
 		t.Fatalf("expanded Agent.Timeout: got %v want 30m", wf.Config.Agent.Timeout)
 	}
-	if wf.Config.Agent.MaxTimeoutRetries != 1 {
-		t.Fatalf("expanded Agent.MaxTimeoutRetries: got %d want 1", wf.Config.Agent.MaxTimeoutRetries)
+	if got := wf.Config.Agent.MaxTimeoutRetriesValue(); got != 1 {
+		t.Fatalf("expanded Agent.MaxTimeoutRetriesValue: got %d want 1", got)
 	}
 }
 
@@ -145,7 +145,27 @@ func TestLoadOptionalHonorsExplicitAgentTimeout(t *testing.T) {
 	if wf.Config.Agent.Timeout != 5*time.Minute {
 		t.Fatalf("explicit Agent.Timeout: got %v want 5m", wf.Config.Agent.Timeout)
 	}
-	if wf.Config.Agent.MaxTimeoutRetries != 3 {
-		t.Fatalf("explicit Agent.MaxTimeoutRetries: got %d want 3", wf.Config.Agent.MaxTimeoutRetries)
+	if got := wf.Config.Agent.MaxTimeoutRetriesValue(); got != 3 {
+		t.Fatalf("explicit Agent.MaxTimeoutRetriesValue: got %d want 3", got)
+	}
+}
+
+// TestLoadOptionalHonorsExplicitZeroMaxTimeoutRetries verifies that an
+// operator who deliberately sets max_timeout_retries: 0 in YAML can
+// disable the runner-timeout retry budget entirely. Previously the
+// loader coerced 0 back to 1, silently undoing this override.
+func TestLoadOptionalHonorsExplicitZeroMaxTimeoutRetries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := "---\nagent:\n  max_timeout_retries: 0\n---\nhello\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wf, err := LoadOptional(path)
+	if err != nil {
+		t.Fatalf("LoadOptional: %v", err)
+	}
+	if got := wf.Config.Agent.MaxTimeoutRetriesValue(); got != 0 {
+		t.Fatalf("explicit zero Agent.MaxTimeoutRetriesValue: got %d want 0", got)
 	}
 }

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -74,6 +75,16 @@ func expandConfig(cfg *Config) {
 	}
 	if cfg.Agent.MaxConcurrentAgents <= 0 {
 		cfg.Agent.MaxConcurrentAgents = 1
+	}
+	if cfg.Agent.Timeout <= 0 {
+		cfg.Agent.Timeout = 30 * time.Minute
+	}
+	// MaxTimeoutRetries defaults to 1 when unspecified or negative so
+	// callers do not silently lose their one bonus retry budget on a
+	// transient agent hang. Set explicitly to 0 in YAML (or any other
+	// concrete non-negative value) to override.
+	if cfg.Agent.MaxTimeoutRetries == 0 || cfg.Agent.MaxTimeoutRetries < 0 {
+		cfg.Agent.MaxTimeoutRetries = 1
 	}
 	if cfg.Tracker.PollIntervalMs <= 0 {
 		cfg.Tracker.PollIntervalMs = 30000

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -79,13 +79,11 @@ func expandConfig(cfg *Config) {
 	if cfg.Agent.Timeout <= 0 {
 		cfg.Agent.Timeout = 30 * time.Minute
 	}
-	// MaxTimeoutRetries defaults to 1 when unspecified or negative so
-	// callers do not silently lose their one bonus retry budget on a
-	// transient agent hang. Set explicitly to 0 in YAML (or any other
-	// concrete non-negative value) to override.
-	if cfg.Agent.MaxTimeoutRetries == 0 || cfg.Agent.MaxTimeoutRetries < 0 {
-		cfg.Agent.MaxTimeoutRetries = 1
-	}
+	// MaxTimeoutRetries is *int so callers can distinguish "absent"
+	// (nil → MaxTimeoutRetriesValue() returns the schema default of 1)
+	// from "explicitly 0" (zero retries). We deliberately do not coerce
+	// here: forcing 0 → 1 stripped users of the ability to disable the
+	// runner-timeout retry budget entirely.
 	if cfg.Tracker.PollIntervalMs <= 0 {
 		cfg.Tracker.PollIntervalMs = 30000
 	}


### PR DESCRIPTION
## Summary

- Adds a per-task runner timeout (`agent.timeout`, default 30m) with `context.WithTimeout`; the runner subprocess and its process group (Unix) get SIGTERM then SIGKILL via `cmd.WaitDelay` so hung agents cannot block the worker.
- Emits `runner_start` / `runner_end` / `runner_timeout` task events with structured payload (timeout_ms, elapsed_ms, runner) so the debug API and operators can distinguish a clean exit from a deadline kill.
- Splits retry policy: `agent.max_timeout_retries` (default 1) bounds re-queue on timeout independently of the generic `max_attempts` reserved for verify/policy/transient failures. Implemented via `queue.FailTimeout` + `CountEvents("runner_timeout")`.

Closes #20.

## Files

- `internal/workflow/{config.go,loader.go}` — new `Agent.Timeout`, `Agent.MaxTimeoutRetries`; defaults wired through `DefaultConfig` and `expandConfig`.
- `internal/runner/runner.go` — `TimeoutError` sentinel + `IsTimeout` helper.
- `internal/runner/shell.go` + `shell_unix.go` / `shell_windows.go` — process-group SIGTERM->SIGKILL on Unix; stdlib default on Windows; ctx.Err() drives timeout classification.
- `internal/runner/mock.go` — `Sleep` field so tests drive ctx cancel without subprocesses.
- `internal/queue/postgres.go` — `FailTimeout`, `CountEvents`.
- `cmd/worker/main.go` — `runRunnerWithTimeout`, `handleTaskFailure` routing, returns resolved `workflow.Config` so retry policy reads the right budget without re-loading.
- Tests: `internal/runner/runner_test.go`, `cmd/worker/main_test.go`, `internal/workflow/config_test.go`.

## Test plan

- [x] `gofmt -l cmd internal` (clean)
- [x] `go vet ./...`
- [x] `go build ./...` on darwin, linux, windows
- [x] `go test ./...` (all green; covers MockRunner timeout, ShellRunner kill-on-deadline + group teardown, non-timeout misclassification guard, worker event emission for start/end/timeout/error, zero-budget fallback, config defaults + YAML overrides)