### PR TITLE
fix: remove unread agent.fallback from WORKFLOW schema

### DIFF
--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -109,7 +109,7 @@ Use when:
 
 - the task touches several files or needs more reasoning across a package.
 - you want richer tool use during the run.
-- Codex produced a thin or wrong patch and you want a second opinion. To switch runner you set `agent.default` in `WORKFLOW.md`, or pass `model` per task via `POST /v1/tasks`. Note: `agent.fallback` exists as a config field (`internal/workflow/config.go`) but no runtime path reads it today — `cmd/worker/main.go` selects the runner from `t.Model`/`agent.default`, and `internal/runner/runner.go` has no fallback handling. Setting `agent.fallback` will not change retry behavior.
+- Codex produced a thin or wrong patch and you want a second opinion. To switch runner you set `agent.default` in `WORKFLOW.md`, or pass `model` per task via `POST /v1/tasks`. Note: `agent.fallback` was removed in issue #40 — workflows that still carry the key now fail validation at load time.
 
 ```yaml
 agent:

--- a/docs/workflows/company-cautious-WORKFLOW.md
+++ b/docs/workflows/company-cautious-WORKFLOW.md
@@ -29,7 +29,6 @@ agent:
   # any other name fails the task with `unknown runner`. Switch to
   # `codex` (or `claude`) only after auditing several mock runs.
   default: mock
-  fallback: mock
   max_concurrent_agents: 1
   max_turns: 6
 

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -22,7 +22,6 @@ workspace:
 
 agent:
   default: mock
-  fallback: claude
   max_concurrent_agents: 1
   max_turns: 8
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -37,7 +37,6 @@ type WorkspaceConfig struct {
 
 type AgentConfig struct {
 	Default             string `yaml:"default"`
-	Fallback            string `yaml:"fallback"`
 	MaxConcurrentAgents int    `yaml:"max_concurrent_agents"`
 	MaxTurns            int    `yaml:"max_turns"`
 	// Timeout caps a single runner invocation. When exceeded, the runner
@@ -157,7 +156,6 @@ func DefaultConfig() Config {
 		// MaxTimeoutRetriesValue().
 		Agent: AgentConfig{
 			Default:             "mock",
-			Fallback:            "claude",
 			MaxConcurrentAgents: 1,
 			MaxTurns:            8,
 			Timeout:             30 * time.Minute,

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -147,6 +148,42 @@ func TestLoadOptionalHonorsExplicitAgentTimeout(t *testing.T) {
 	}
 	if got := wf.Config.Agent.MaxTimeoutRetriesValue(); got != 3 {
 		t.Fatalf("explicit Agent.MaxTimeoutRetriesValue: got %d want 3", got)
+	}
+}
+
+// TestLoad_RejectsRemovedAgentFallback verifies that workflows still
+// carrying the removed `agent.fallback` key fail Load with an error that
+// points the operator at the supported alternative (`agent.default`).
+//
+// `agent.fallback` was historically declared on AgentConfig but never
+// read by the worker (issue #40). Silently dropping the key would let
+// authors keep believing it controlled retry behavior, so Load must
+// surface a clear validation error instead.
+func TestLoad_RejectsRemovedAgentFallback(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+agent:
+  default: mock
+  fallback: claude
+---
+prompt body
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	_, err := Load(p)
+	if err == nil {
+		t.Fatalf("Load: expected error for removed agent.fallback, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"agent.fallback", "agent.default"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("Load error %q: want substring %q", msg, want)
+		}
 	}
 }
 

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -24,12 +24,35 @@ func Load(path string) (*Workflow, error) {
 	front, body := splitFrontMatter(string(b))
 	cfg := DefaultConfig()
 	if strings.TrimSpace(front) != "" {
+		if err := rejectRemovedFields([]byte(front)); err != nil {
+			return nil, err
+		}
 		if err := yaml.Unmarshal([]byte(front), &cfg); err != nil {
 			return nil, fmt.Errorf("parse workflow front matter: %w", err)
 		}
 	}
 	expandConfig(&cfg)
 	return &Workflow{Path: path, Config: cfg, PromptTemplate: strings.TrimSpace(body)}, nil
+}
+
+// rejectRemovedFields surfaces a clear error for keys that were once part
+// of the schema but have been removed. The typed Unmarshal above silently
+// drops unknown fields, which would let workflow authors keep believing
+// the key still controls behavior. Targeted detection keeps existing
+// benign extras working while flagging known footguns.
+func rejectRemovedFields(front []byte) error {
+	var raw map[string]any
+	if err := yaml.Unmarshal(front, &raw); err != nil {
+		return nil
+	}
+	agent, ok := raw["agent"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if _, present := agent["fallback"]; present {
+		return fmt.Errorf("agent.fallback is no longer supported (issue #40); the worker never read this field. Remove it and set agent.default to a more reliable runner if you need a different default")
+	}
+	return nil
 }
 
 func LoadOptional(path string) (*Workflow, error) {


### PR DESCRIPTION
## Summary

- `Agent.Fallback` was declared on `AgentConfig` and documented in WORKFLOW templates, but no runtime path ever read it. PR #36 already corrected the daily runbook to stop claiming it controlled retries; this change finishes the cleanup.
- Picked Option B from the issue: drop the field rather than wire up a half-built fallback. Fewer lines of code, no new retry semantics to debug, and operators get an explicit validation error instead of silent dead config.
- Workflows that still carry `agent.fallback` now fail `Load` with an error pointing at `agent.default` as the supported knob.

## Changes

- `internal/workflow/config.go`: drop `Fallback` from `AgentConfig` and from `DefaultConfig()`.
- `internal/workflow/loader.go`: new `rejectRemovedFields` pre-pass; targeted detection so other unknown YAML keys are still tolerated.
- `internal/workflow/config_test.go`: `TestLoad_RejectsRemovedAgentFallback` covers the validation path.
- `examples/WORKFLOW.md`, `docs/workflows/company-cautious-WORKFLOW.md`: remove the misleading `fallback:` line.
- `docs/runbooks/personal-daily-workflow.md`: replace the "exists but unread" caveat with a one-line note that the key was removed.

## Test plan

- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`
- [x] `gofmt -l` clean
- [x] `go mod tidy` no diff
- [ ] CI green on this PR

Closes #40