### PR TITLE
feat: harden WORKFLOW.md schema validation

### DIFF
--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -16,6 +16,7 @@ func TestLoad_PRDraftFromFrontMatter(t *testing.T) {
 repo:
   owner: o
   name: r
+  clone_url: git@example.com:o/r.git
 pr:
   draft: true
 ---
@@ -57,6 +58,7 @@ func TestLoad_PRDraftDefaultsAndExplicitFalse(t *testing.T) {
 repo:
   owner: o
   name: r
+  clone_url: git@example.com:o/r.git
 pr:
   draft: false
 ---
@@ -69,6 +71,7 @@ body
 repo:
   owner: o
   name: r
+  clone_url: git@example.com:o/r.git
 ---
 body
 `,
@@ -114,7 +117,7 @@ func TestDefaultConfigAgentTimeout(t *testing.T) {
 func TestLoadOptionalAppliesAgentTimeoutDefaults(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
-	body := "---\nrepo:\n  owner: o\n  name: n\n  default_branch: main\n---\nhello\n"
+	body := "---\nrepo:\n  owner: o\n  name: n\n  clone_url: git@example.com:o/n.git\n  default_branch: main\n---\nhello\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +138,7 @@ func TestLoadOptionalAppliesAgentTimeoutDefaults(t *testing.T) {
 func TestLoadOptionalHonorsExplicitAgentTimeout(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
-	body := "---\nagent:\n  timeout: 5m\n  max_timeout_retries: 3\n---\nhello\n"
+	body := "---\nrepo:\n  owner: o\n  name: n\n  clone_url: git@example.com:o/n.git\nagent:\n  timeout: 5m\n  max_timeout_retries: 3\n---\nhello\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -166,6 +169,7 @@ func TestLoad_RejectsRemovedAgentFallback(t *testing.T) {
 repo:
   owner: o
   name: r
+  clone_url: git@example.com:o/r.git
 agent:
   default: mock
   fallback: claude
@@ -187,6 +191,168 @@ prompt body
 	}
 }
 
+// TestLoad_RejectsMissingCloneURL verifies that a workflow front matter
+// that omits `repo.clone_url` (or sets it to an empty string after env
+// expansion) fails Load with an error that names the file path and the
+// missing field. Without this check, the worker only discovered the
+// missing URL deep inside `git clone`, producing a confusing "repository
+// not found" failure (issue #9).
+func TestLoad_RejectsMissingCloneURL(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+tracker:
+  kind: gitea
+---
+prompt
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	_, err := Load(p)
+	if err == nil {
+		t.Fatalf("Load: expected error for missing repo.clone_url, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"repo.clone_url", p} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("Load error %q: want substring %q", msg, want)
+		}
+	}
+}
+
+// TestLoad_RejectsUnsupportedTrackerKind ensures Load fails fast when
+// tracker.kind is set to a value the platform does not implement. The
+// legal set is {"gitea", "linear"} — anything else would silently fall
+// through to a runtime no-op in the poller. The error must point at the
+// field, the file, and the offending value so the operator can fix it.
+func TestLoad_RejectsUnsupportedTrackerKind(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  kind: jira
+---
+prompt
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	_, err := Load(p)
+	if err == nil {
+		t.Fatalf("Load: expected error for unsupported tracker.kind, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"tracker.kind", "jira", p} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("Load error %q: want substring %q", msg, want)
+		}
+	}
+}
+
+// TestLoad_RejectsUnsupportedAgentDefault matches the runner registry in
+// internal/runner: only mock/codex/claude are wired up. Catching a typo
+// like `agent.default: codexx` at Load time prevents the worker from
+// claiming a task and then dying with "unknown runner" partway through.
+func TestLoad_RejectsUnsupportedAgentDefault(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+agent:
+  default: codexx
+---
+prompt
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	_, err := Load(p)
+	if err == nil {
+		t.Fatalf("Load: expected error for unsupported agent.default, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"agent.default", "codexx", p} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("Load error %q: want substring %q", msg, want)
+		}
+	}
+}
+
+// TestLoad_AcceptsMinimalValidFrontMatter pins the positive case: a
+// workflow that supplies the required repo.clone_url with default
+// tracker/agent kinds parses cleanly. This guards against the new
+// validator over-rejecting legitimate minimal workflows.
+func TestLoad_AcceptsMinimalValidFrontMatter(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+---
+prompt
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	if _, err := Load(p); err != nil {
+		t.Fatalf("Load: unexpected error %v", err)
+	}
+}
+
+// TestLoad_CloneURLViaEnvExpansion confirms that a clone_url provided as
+// an env var reference (e.g. `$REPO_URL`) is considered set as long as
+// the variable resolves to a non-empty value. The validator must run
+// after expandConfig so this works.
+func TestLoad_CloneURLViaEnvExpansion(t *testing.T) {
+	t.Setenv("AIOPS_TEST_REPO_URL", "git@example.com:o/r.git")
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: $AIOPS_TEST_REPO_URL
+---
+prompt
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	if _, err := Load(p); err != nil {
+		t.Fatalf("Load: unexpected error %v", err)
+	}
+}
+
+// TestLoadOptional_MissingFileSkipsValidation guards the operational
+// contract that a repo without a WORKFLOW.md still loads cleanly with
+// schema defaults. The validator must only run when an actual file was
+// parsed; otherwise the worker would refuse to act on any repo that has
+// not yet adopted Symphony.
+func TestLoadOptional_MissingFileSkipsValidation(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	wf, err := LoadOptional(p)
+	if err != nil {
+		t.Fatalf("LoadOptional: unexpected error %v", err)
+	}
+	if wf.Config.Repo.CloneURL != "" {
+		t.Fatalf("default Config.Repo.CloneURL: got %q want empty", wf.Config.Repo.CloneURL)
+	}
+}
+
 // TestLoadOptionalHonorsExplicitZeroMaxTimeoutRetries verifies that an
 // operator who deliberately sets max_timeout_retries: 0 in YAML can
 // disable the runner-timeout retry budget entirely. Previously the
@@ -194,7 +360,7 @@ prompt body
 func TestLoadOptionalHonorsExplicitZeroMaxTimeoutRetries(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
-	body := "---\nagent:\n  max_timeout_retries: 0\n---\nhello\n"
+	body := "---\nrepo:\n  owner: o\n  name: n\n  clone_url: git@example.com:o/n.git\nagent:\n  max_timeout_retries: 0\n---\nhello\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -312,6 +312,31 @@ prompt
 	}
 }
 
+// TestLoad_AcceptsPromptOnlyFile guards backward compatibility for
+// WORKFLOW.md files that contain only a prompt template with no `---`
+// front matter. These rely on the same built-in defaults that
+// LoadOptional supplies when the file is absent, so Load must not
+// invoke schema validation against an empty config (issue #9 review
+// from chatgpt-codex-connector).
+func TestLoad_AcceptsPromptOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := "just a prompt template, no front matter\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	wf, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: unexpected error %v", err)
+	}
+	if wf.PromptTemplate != "just a prompt template, no front matter" {
+		t.Fatalf("PromptTemplate: got %q", wf.PromptTemplate)
+	}
+	if wf.Config.Repo.CloneURL != "" {
+		t.Fatalf("Config.Repo.CloneURL: got %q want empty (defaults)", wf.Config.Repo.CloneURL)
+	}
+}
+
 // TestLoad_CloneURLViaEnvExpansion confirms that a clone_url provided as
 // an env var reference (e.g. `$REPO_URL`) is considered set as long as
 // the variable resolves to a non-empty value. The validator must run

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -23,7 +23,8 @@ func Load(path string) (*Workflow, error) {
 	}
 	front, body := splitFrontMatter(string(b))
 	cfg := DefaultConfig()
-	if strings.TrimSpace(front) != "" {
+	hasFrontMatter := strings.TrimSpace(front) != ""
+	if hasFrontMatter {
 		if err := rejectRemovedFields([]byte(front)); err != nil {
 			return nil, err
 		}
@@ -32,8 +33,16 @@ func Load(path string) (*Workflow, error) {
 		}
 	}
 	expandConfig(&cfg)
-	if err := validateConfig(path, cfg); err != nil {
-		return nil, err
+	// Only validate when the file actually carries a front-matter block.
+	// Prompt-only WORKFLOW.md files are a supported pattern for repos that
+	// rely on the worker's built-in defaults (same semantic as
+	// LoadOptional's no-file fallback). Forcing schema validation on those
+	// would regress every repo that has not yet adopted the explicit
+	// Symphony front matter.
+	if hasFrontMatter {
+		if err := validateConfig(path, cfg); err != nil {
+			return nil, err
+		}
 	}
 	return &Workflow{Path: path, Config: cfg, PromptTemplate: strings.TrimSpace(body)}, nil
 }

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -32,7 +32,49 @@ func Load(path string) (*Workflow, error) {
 		}
 	}
 	expandConfig(&cfg)
+	if err := validateConfig(path, cfg); err != nil {
+		return nil, err
+	}
 	return &Workflow{Path: path, Config: cfg, PromptTemplate: strings.TrimSpace(body)}, nil
+}
+
+// supportedTrackerKinds enumerates the tracker integrations the platform
+// actually wires up today (see cmd/linear-poller and the Gitea webhook
+// path in cmd/api). Anything outside this set would parse as a typed
+// string but go nowhere at runtime, so reject it at Load.
+var supportedTrackerKinds = map[string]struct{}{
+	"gitea":  {},
+	"linear": {},
+}
+
+// supportedAgentDefaults mirrors the runner registry in
+// internal/runner.New. Keeping the two lists in sync at the schema layer
+// turns "unknown runner: X" — which today only surfaces after a task is
+// claimed and the workspace prepared — into a load-time configuration
+// error with the workflow file path attached.
+var supportedAgentDefaults = map[string]struct{}{
+	"mock":   {},
+	"codex":  {},
+	"claude": {},
+}
+
+// validateConfig enforces the required-field and enum constraints that
+// the typed YAML decoder cannot express on its own. It runs after
+// expandConfig so env-var indirections (e.g. `clone_url: $REPO_URL`)
+// are evaluated before non-empty checks. Errors include the workflow
+// file path and the offending field/value so operators can fix the
+// source rather than chasing runtime symptoms (issue #9).
+func validateConfig(path string, cfg Config) error {
+	if strings.TrimSpace(cfg.Repo.CloneURL) == "" {
+		return fmt.Errorf("%s: repo.clone_url is required", path)
+	}
+	if _, ok := supportedTrackerKinds[cfg.Tracker.Kind]; !ok {
+		return fmt.Errorf("%s: tracker.kind %q is not supported (allowed: gitea, linear)", path, cfg.Tracker.Kind)
+	}
+	if _, ok := supportedAgentDefaults[cfg.Agent.Default]; !ok {
+		return fmt.Errorf("%s: agent.default %q is not supported (allowed: mock, codex, claude)", path, cfg.Agent.Default)
+	}
+	return nil
 }
 
 // rejectRemovedFields surfaces a clear error for keys that were once part


### PR DESCRIPTION
## Summary

Closes #9. Surface bad workflow config as a clear `Load`-time error instead of a confusing runtime symptom.

- `repo.clone_url` is required (after env expansion, so `$REPO_URL` indirections still work).
- `tracker.kind` must be in `{gitea, linear}`.
- `agent.default` must be in `{mock, codex, claude}`, mirroring the runner registry in `internal/runner.New`.

All errors include the workflow file path and the offending field/value, e.g.:

```
/path/to/WORKFLOW.md: tracker.kind "jira" is not supported (allowed: gitea, linear)
```

`LoadOptional` still falls back to schema defaults when the file is absent; validation only runs against parsed front matter, so repos that have not yet adopted Symphony are unaffected.

## Test plan

- [x] `go test ./...` passes.
- [x] New negative tests cover missing `clone_url`, unsupported `tracker.kind`, unsupported `agent.default`.
- [x] New positive tests cover minimal valid front matter and `clone_url` via env expansion.
- [x] `LoadOptional` no-file path still skips validation.
- [x] `examples/WORKFLOW.md` and `docs/workflows/company-cautious-WORKFLOW.md` validate cleanly under the new rules (verified locally with a temporary test).