### PR TITLE
chore: ignore local .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ coverage.out
 
 # macOS
 .DS_Store
+
+# Local Claude Code state (worktrees, plugin cache, transcripts)
+.claude/


### PR DESCRIPTION
## Summary

The Claude Code CLI writes per-session worktrees, plugin caches, and transcripts under `.claude/` in the working repo. These are local agent artifacts that point at the developer's filesystem and should never land in git history. Add a single ignore rule.

Independent of #49 — this is purely a hygiene fix.

## Test plan

- [x] `git status` no longer lists `.claude/` as untracked.