### PR TITLE
feat: make PR handoff idempotent on retry

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -382,9 +382,40 @@ func recordPolicyViolation(ctx context.Context, ev eventEmitter, taskID string, 
 	_ = ev.AddEvent(ctx, taskID, "policy_violation", err.Error())
 }
 
+// prClient is the subset of gitea.Client the worker needs for PR handoff.
+// Defined as an interface so tests can inject a fake implementation without
+// standing up a real Gitea HTTP server.
+type prClient interface {
+	FindOpenPullRequest(ctx context.Context, in gitea.FindOpenPullRequestInput) (*gitea.PullRequest, error)
+	CreatePullRequest(ctx context.Context, in gitea.CreatePullRequestInput) (*gitea.PullRequest, error)
+}
+
 func createPR(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config, summary string) error {
-	_ = cfg
 	client := gitea.Client{BaseURL: os.Getenv("GITEA_BASE_URL"), Token: os.Getenv("GITEA_TOKEN")}
+	return createPRWith(ctx, ev, t, cfg, summary, client)
+}
+
+// createPRWith performs the PR handoff using the supplied client. It first
+// looks for an existing open PR for the work branch and reuses it instead of
+// asking Gitea to create a duplicate — this is what makes retries safe to
+// re-enter after a previous attempt already produced a PR. A list error is
+// logged and falls through to the create path so a transient Gitea hiccup
+// during the lookup does not block the task; the create call itself remains
+// the source of truth for surfacing real failures.
+func createPRWith(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config, summary string, client prClient) error {
+	if existing, err := client.FindOpenPullRequest(ctx, gitea.FindOpenPullRequestInput{
+		Owner: t.RepoOwner, Repo: t.RepoName, Head: t.WorkBranch,
+	}); err != nil {
+		log.Printf("task %s: list open PRs failed: %v", t.ID, err)
+	} else if existing != nil {
+		emit(ctx, ev, t.ID, task.EventPRReused, "pr reused", map[string]any{
+			"number":   existing.Number,
+			"html_url": existing.HTMLURL,
+			"title":    existing.Title,
+		})
+		log.Printf("task %s reused PR #%d %s", t.ID, existing.Number, existing.HTMLURL)
+		return nil
+	}
 	body := buildPRBody(t, summary)
 	pr, err := client.CreatePullRequest(ctx, gitea.CreatePullRequestInput{Owner: t.RepoOwner, Repo: t.RepoName, Title: "chore(ai): " + t.Title, Body: body, Head: t.WorkBranch, Base: t.BaseBranch, Draft: cfg.PR.Draft})
 	if err != nil {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -298,6 +299,7 @@ func TestEventKindConstantsAreSnakeCase(t *testing.T) {
 		task.EventVerifyEnd,
 		task.EventPush,
 		task.EventPRCreated,
+		task.EventPRReused,
 	}
 	for _, kind := range required {
 		if kind == "" {
@@ -462,5 +464,142 @@ func TestRunRunnerWithTimeoutZeroBudgetUsesDefault(t *testing.T) {
 	want := float64((30 * time.Minute).Milliseconds())
 	if got != want {
 		t.Fatalf("expected default timeout %v ms, got %v", want, got)
+	}
+}
+
+// fakePRClient lets PR-handoff tests script the responses from the gitea
+// client without going through HTTP. It also records every call so tests can
+// assert on whether CreatePullRequest was even attempted on the reuse path.
+type fakePRClient struct {
+	findResult *gitea.PullRequest
+	findErr    error
+	createPR   *gitea.PullRequest
+	createErr  error
+
+	mu          sync.Mutex
+	findCalls   []gitea.FindOpenPullRequestInput
+	createCalls []gitea.CreatePullRequestInput
+}
+
+func (f *fakePRClient) FindOpenPullRequest(_ context.Context, in gitea.FindOpenPullRequestInput) (*gitea.PullRequest, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.findCalls = append(f.findCalls, in)
+	return f.findResult, f.findErr
+}
+
+func (f *fakePRClient) CreatePullRequest(_ context.Context, in gitea.CreatePullRequestInput) (*gitea.PullRequest, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createCalls = append(f.createCalls, in)
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	if f.createPR != nil {
+		return f.createPR, nil
+	}
+	return &gitea.PullRequest{Number: 1, HTMLURL: "http://gitea.local/o/r/pulls/1", Title: in.Title}, nil
+}
+
+func samplePRTask() task.Task {
+	return task.Task{
+		ID:            "tsk_42",
+		Title:         "fix bug",
+		SourceType:    "gitea_issue",
+		SourceEventID: "evt-1",
+		RepoOwner:     "o",
+		RepoName:      "r",
+		BaseBranch:    "main",
+		WorkBranch:    "ai/tsk_42",
+	}
+}
+
+// TestCreatePRWith_ReusesExistingPR is the core of issue #7: when a previous
+// attempt already opened a PR for the work branch, the retry must reuse it
+// rather than asking Gitea to create a duplicate (which would fail with 422
+// and surface as a task failure). The test asserts both that CreatePullRequest
+// is NOT called and that a pr_reused event is emitted with the existing PR's
+// metadata so observers can attribute the handoff.
+func TestCreatePRWith_ReusesExistingPR(t *testing.T) {
+	ev := &fakeEmitter{}
+	tk := samplePRTask()
+	cfg := workflow.Config{}
+	client := &fakePRClient{
+		findResult: &gitea.PullRequest{Number: 17, HTMLURL: "http://gitea.local/o/r/pulls/17", Title: "chore(ai): fix bug"},
+	}
+
+	if err := createPRWith(context.Background(), ev, tk, cfg, "summary", client); err != nil {
+		t.Fatalf("createPRWith: %v", err)
+	}
+
+	if len(client.createCalls) != 0 {
+		t.Fatalf("expected zero CreatePullRequest calls when reusing, got %d", len(client.createCalls))
+	}
+	if len(client.findCalls) != 1 || client.findCalls[0].Head != tk.WorkBranch {
+		t.Fatalf("expected single FindOpenPullRequest with head=%q, got %#v", tk.WorkBranch, client.findCalls)
+	}
+	reused := ev.byKind(task.EventPRReused)
+	if len(reused) != 1 {
+		t.Fatalf("expected one pr_reused event, got %d (events=%#v)", len(reused), ev.events)
+	}
+	number, _ := payloadField(t, reused[0].Payload, "number").(float64)
+	if int(number) != 17 {
+		t.Fatalf("pr_reused number: got %v want 17", number)
+	}
+	if got := len(ev.byKind(task.EventPRCreated)); got != 0 {
+		t.Fatalf("pr_created must not fire on reuse, got %d", got)
+	}
+}
+
+// TestCreatePRWith_CreatesWhenNoneExists confirms the unchanged happy path:
+// when the lookup returns no match, the worker still calls CreatePullRequest
+// exactly once and emits pr_created with the new PR metadata.
+func TestCreatePRWith_CreatesWhenNoneExists(t *testing.T) {
+	ev := &fakeEmitter{}
+	tk := samplePRTask()
+	client := &fakePRClient{
+		findResult: nil,
+		createPR:   &gitea.PullRequest{Number: 99, HTMLURL: "http://gitea.local/o/r/pulls/99", Title: "chore(ai): fix bug"},
+	}
+
+	if err := createPRWith(context.Background(), ev, tk, workflow.Config{}, "summary", client); err != nil {
+		t.Fatalf("createPRWith: %v", err)
+	}
+
+	if len(client.createCalls) != 1 {
+		t.Fatalf("expected exactly one CreatePullRequest call, got %d", len(client.createCalls))
+	}
+	if got := len(ev.byKind(task.EventPRReused)); got != 0 {
+		t.Fatalf("pr_reused must not fire on create path, got %d", got)
+	}
+	created := ev.byKind(task.EventPRCreated)
+	if len(created) != 1 {
+		t.Fatalf("expected one pr_created event, got %d", len(created))
+	}
+	number, _ := payloadField(t, created[0].Payload, "number").(float64)
+	if int(number) != 99 {
+		t.Fatalf("pr_created number: got %v want 99", number)
+	}
+}
+
+// TestCreatePRWith_ListErrorFallsThroughToCreate ensures that a transient
+// failure in the list step does not block the worker: we still attempt to
+// create. This is the safer fallback because if a PR really does already
+// exist, Gitea will surface a 422 from CreatePullRequest, which then flows
+// through the existing failure-attribution path; meanwhile a real
+// "no PR exists yet" lookup that just happened to fail (network hiccup,
+// 5xx) still completes the handoff.
+func TestCreatePRWith_ListErrorFallsThroughToCreate(t *testing.T) {
+	ev := &fakeEmitter{}
+	tk := samplePRTask()
+	client := &fakePRClient{
+		findErr: errors.New("list pull requests failed: 500"),
+	}
+
+	if err := createPRWith(context.Background(), ev, tk, workflow.Config{}, "summary", client); err != nil {
+		t.Fatalf("createPRWith: %v", err)
+	}
+	if len(client.createCalls) != 1 {
+		t.Fatalf("expected fallback CreatePullRequest call, got %d", len(client.createCalls))
 	}
 }

--- a/docs/runbooks/task-api.md
+++ b/docs/runbooks/task-api.md
@@ -35,8 +35,13 @@ failed run can be reconstructed from the event timeline alone:
 - `enqueued`, `claimed` — queue lifecycle
 - `runner_start`, `runner_end` — agent runner timing and summary
 - `verify_start`, `verify_end` — workflow verify command results
-- `push` — git push outcome and changed file count
+- `push` — git push outcome and changed file count. Retries push the work
+  branch with `--force-with-lease` so an earlier attempt's tip is overwritten
+  cleanly instead of failing as non-fast-forward.
 - `pr_created` — pull request creation (number, html_url) or failure
+- `pr_reused` — emitted instead of `pr_created` when the work branch already
+  has an open PR from a previous attempt; the worker reuses it (number,
+  html_url, title) and skips the create call so retries do not duplicate PRs
 - `succeeded`, `failed_attempt` — terminal outcomes
 
 The worker also writes the following artifacts under `.aiops/` in the

--- a/internal/gitea/client.go
+++ b/internal/gitea/client.go
@@ -35,6 +35,79 @@ type PullRequest struct {
 	Title   string `json:"title"`
 }
 
+type FindOpenPullRequestInput struct {
+	Owner string
+	Repo  string
+	// Head is the source branch ref (e.g. "ai/tsk_42") to match against the
+	// `head.ref` of each open pull request. Gitea's list endpoint does not
+	// reliably support filtering by head across versions, so we filter
+	// client-side after pulling each page.
+	Head string
+}
+
+// listPullsPageSize is the page size we ask Gitea for when scanning open PRs
+// looking for one whose head ref matches a given work branch. Gitea's default
+// page size is 50; we cap pagination at listPullsMaxPages so a misconfigured
+// server cannot make us walk forever.
+const (
+	listPullsPageSize = 50
+	listPullsMaxPages = 10
+)
+
+// FindOpenPullRequest returns the first open pull request whose head ref
+// equals in.Head, or (nil, nil) when no open PR exists for that branch. It is
+// used by the worker to make PR handoff idempotent: if a previous attempt for
+// the same task has already opened a PR for the work branch, retries reuse it
+// instead of asking Gitea to create a duplicate.
+func (c Client) FindOpenPullRequest(ctx context.Context, in FindOpenPullRequestInput) (*PullRequest, error) {
+	if c.BaseURL == "" || c.Token == "" {
+		return nil, fmt.Errorf("GITEA_BASE_URL and GITEA_TOKEN are required")
+	}
+	client := c.HTTP
+	if client == nil {
+		client = http.DefaultClient
+	}
+	base := strings.TrimRight(c.BaseURL, "/") + fmt.Sprintf("/api/v1/repos/%s/%s/pulls", in.Owner, in.Repo)
+	for page := 1; page <= listPullsMaxPages; page++ {
+		u := fmt.Sprintf("%s?state=open&page=%d&limit=%d", base, page, listPullsPageSize)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "token "+c.Token)
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		var batch []struct {
+			Number  int    `json:"number"`
+			HTMLURL string `json:"html_url"`
+			Title   string `json:"title"`
+			Head    struct {
+				Ref string `json:"ref"`
+			} `json:"head"`
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resp.Body.Close()
+			return nil, fmt.Errorf("list pull requests failed: %s", resp.Status)
+		}
+		err = json.NewDecoder(resp.Body).Decode(&batch)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range batch {
+			if p.Head.Ref == in.Head {
+				return &PullRequest{Number: p.Number, HTMLURL: p.HTMLURL, Title: p.Title}, nil
+			}
+		}
+		if len(batch) < listPullsPageSize {
+			return nil, nil
+		}
+	}
+	return nil, nil
+}
+
 func (c Client) CreatePullRequest(ctx context.Context, in CreatePullRequestInput) (*PullRequest, error) {
 	if c.BaseURL == "" || c.Token == "" {
 		return nil, fmt.Errorf("GITEA_BASE_URL and GITEA_TOKEN are required")

--- a/internal/gitea/client_test.go
+++ b/internal/gitea/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -77,5 +78,121 @@ func TestCreatePullRequest_DraftFalseOmitsDraftField(t *testing.T) {
 		if _, present := got[k]; !present {
 			t.Fatalf("payload missing %q: %#v", k, got)
 		}
+	}
+}
+
+func TestFindOpenPullRequest_ReturnsMatchByHeadRef(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		if r.URL.Path != "/api/v1/repos/o/r/pulls" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{"number": 11, "html_url": "http://gitea.local/o/r/pulls/11", "title": "other", "head": {"ref": "ai/tsk_other"}},
+			{"number": 12, "html_url": "http://gitea.local/o/r/pulls/12", "title": "match", "head": {"ref": "ai/tsk_42"}}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := Client{BaseURL: srv.URL, Token: "fake"}
+	pr, err := c.FindOpenPullRequest(context.Background(), FindOpenPullRequestInput{
+		Owner: "o", Repo: "r", Head: "ai/tsk_42",
+	})
+	if err != nil {
+		t.Fatalf("FindOpenPullRequest: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("expected match, got nil")
+	}
+	if pr.Number != 12 {
+		t.Fatalf("pr number: got %d want 12", pr.Number)
+	}
+	q, _ := url.ParseQuery(gotQuery)
+	if got := q.Get("state"); got != "open" {
+		t.Fatalf("query state: got %q want open", got)
+	}
+}
+
+func TestFindOpenPullRequest_NoMatchReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{"number": 11, "html_url": "http://gitea.local/o/r/pulls/11", "title": "other", "head": {"ref": "ai/tsk_other"}}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := Client{BaseURL: srv.URL, Token: "fake"}
+	pr, err := c.FindOpenPullRequest(context.Background(), FindOpenPullRequestInput{
+		Owner: "o", Repo: "r", Head: "ai/tsk_42",
+	})
+	if err != nil {
+		t.Fatalf("FindOpenPullRequest: %v", err)
+	}
+	if pr != nil {
+		t.Fatalf("expected nil, got %#v", pr)
+	}
+}
+
+func TestFindOpenPullRequest_PaginatesUntilMatch(t *testing.T) {
+	var pages int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch page {
+		case "1":
+			// First page: 50 unrelated PRs, signalling more results follow.
+			out := make([]map[string]any, 0, 50)
+			for i := 0; i < 50; i++ {
+				out = append(out, map[string]any{
+					"number":   i + 100,
+					"html_url": "http://gitea.local/x",
+					"title":    "x",
+					"head":     map[string]any{"ref": "ai/tsk_other"},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(out)
+		case "2":
+			_, _ = w.Write([]byte(`[
+				{"number": 200, "html_url": "http://gitea.local/o/r/pulls/200", "title": "match", "head": {"ref": "ai/tsk_42"}}
+			]`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	defer srv.Close()
+
+	c := Client{BaseURL: srv.URL, Token: "fake"}
+	pr, err := c.FindOpenPullRequest(context.Background(), FindOpenPullRequestInput{
+		Owner: "o", Repo: "r", Head: "ai/tsk_42",
+	})
+	if err != nil {
+		t.Fatalf("FindOpenPullRequest: %v", err)
+	}
+	if pr == nil || pr.Number != 200 {
+		t.Fatalf("expected match #200, got %#v", pr)
+	}
+	if pages < 2 {
+		t.Fatalf("expected at least 2 pages requested, got %d", pages)
+	}
+}
+
+func TestFindOpenPullRequest_NonSuccessReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := Client{BaseURL: srv.URL, Token: "fake"}
+	if _, err := c.FindOpenPullRequest(context.Background(), FindOpenPullRequestInput{
+		Owner: "o", Repo: "r", Head: "ai/tsk_42",
+	}); err == nil {
+		t.Fatal("expected error on 500, got nil")
 	}
 }

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -29,6 +29,7 @@ const (
 	EventVerifyEnd     = "verify_end"
 	EventPush          = "push"
 	EventPRCreated     = "pr_created"
+	EventPRReused      = "pr_reused"
 	EventSucceeded     = "succeeded"
 	EventFailedAttempt = "failed_attempt"
 )

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -478,6 +478,15 @@ func EnforcePolicy(ctx context.Context, workdir string, cfg workflow.Config) err
 	return nil
 }
 
+// CommitAndPush stages the workdir, commits with a Title-derived message,
+// and pushes to origin/<branch>. Retries for the same task ID reuse the same
+// work branch (see queue.Postgres.Enqueue), so on the second attempt origin
+// already holds the rejected commit from the previous run. We push with
+// --force-with-lease so retries cleanly overwrite that stale tip without
+// silently clobbering anything else: the lease is computed from the
+// remote-tracking ref we refresh just before the push. The pre-fetch is
+// best-effort because the very first push has no upstream branch to fetch;
+// in that case --force-with-lease degrades to a normal create-and-push.
 func CommitAndPush(ctx context.Context, workdir string, title string, branch string) error {
 	if err := run(ctx, workdir, "git", "add", "."); err != nil {
 		return err
@@ -488,7 +497,8 @@ func CommitAndPush(ctx context.Context, workdir string, title string, branch str
 	if err := run(ctx, workdir, "git", "commit", "-m", "chore(ai): "+title); err != nil {
 		return err
 	}
-	return run(ctx, workdir, "git", "push", "origin", branch)
+	_ = runQuiet(ctx, workdir, "git", "fetch", "origin", branch)
+	return run(ctx, workdir, "git", "push", "--force-with-lease", "origin", branch)
 }
 
 func run(ctx context.Context, dir string, name string, args ...string) error {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -480,13 +480,17 @@ func EnforcePolicy(ctx context.Context, workdir string, cfg workflow.Config) err
 
 // CommitAndPush stages the workdir, commits with a Title-derived message,
 // and pushes to origin/<branch>. Retries for the same task ID reuse the same
-// work branch (see queue.Postgres.Enqueue), so on the second attempt origin
-// already holds the rejected commit from the previous run. We push with
-// --force-with-lease so retries cleanly overwrite that stale tip without
-// silently clobbering anything else: the lease is computed from the
-// remote-tracking ref we refresh just before the push. The pre-fetch is
-// best-effort because the very first push has no upstream branch to fetch;
-// in that case --force-with-lease degrades to a normal create-and-push.
+// work branch (see queue.Postgres.Enqueue), so on retry origin may already
+// hold a commit from the previous attempt. To make that case safe we probe
+// the upstream first and choose the push mode explicitly:
+//
+//   - Remote branch exists: refresh the local tracking ref via `git fetch`
+//     and push with `--force-with-lease`, so the retry overwrites the stale
+//     tip without silently clobbering anything else.
+//   - Remote branch is absent (first attempt, or an operator cleaned up the
+//     branch between retries): delete any stale `refs/remotes/origin/<branch>`
+//     so a leftover tracking ref cannot block a fresh create with `stale info`,
+//     then plain-push to (re)create the branch upstream.
 func CommitAndPush(ctx context.Context, workdir string, title string, branch string) error {
 	if err := run(ctx, workdir, "git", "add", "."); err != nil {
 		return err
@@ -497,8 +501,35 @@ func CommitAndPush(ctx context.Context, workdir string, title string, branch str
 	if err := run(ctx, workdir, "git", "commit", "-m", "chore(ai): "+title); err != nil {
 		return err
 	}
-	_ = runQuiet(ctx, workdir, "git", "fetch", "origin", branch)
-	return run(ctx, workdir, "git", "push", "--force-with-lease", "origin", branch)
+	exists, err := remoteBranchExists(ctx, workdir, branch)
+	if err != nil {
+		return fmt.Errorf("probe remote branch %q: %w", branch, err)
+	}
+	if exists {
+		if err := run(ctx, workdir, "git", "fetch", "origin", branch); err != nil {
+			return fmt.Errorf("fetch origin/%s: %w", branch, err)
+		}
+		return run(ctx, workdir, "git", "push", "--force-with-lease", "origin", branch)
+	}
+	_ = runQuiet(ctx, workdir, "git", "update-ref", "-d", "refs/remotes/origin/"+branch)
+	return run(ctx, workdir, "git", "push", "origin", branch)
+}
+
+// remoteBranchExists reports whether `origin/<branch>` exists upstream by
+// asking `git ls-remote --heads`. It is intentionally separate from
+// `git fetch` so we can distinguish "branch absent upstream" (a normal,
+// non-error state for first push or after manual cleanup) from "fetch
+// failed" (a real connectivity / auth problem we should surface).
+func remoteBranchExists(ctx context.Context, workdir, branch string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--heads", "origin", branch)
+	cmd.Dir = workdir
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(stdout.String()) != "", nil
 }
 
 func run(ctx context.Context, dir string, name string, args ...string) error {

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -251,6 +251,78 @@ func TestCommitAndPush_RetryOverwritesRemoteBranch(t *testing.T) {
 	}
 }
 
+// TestCommitAndPush_RemoteBranchDeletedRecreates covers the regression
+// flagged in PR #51 review: when a previous attempt pushed origin/<branch>
+// and then an operator (or a separate cleanup workflow) deleted that branch
+// upstream, the retry must not get wedged on a stale local tracking ref. The
+// push is expected to recreate the branch on the remote rather than fail
+// with `stale info` from --force-with-lease.
+func TestCommitAndPush_RemoteBranchDeletedRecreates(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+	tk := makeTask("deleted-task", upstream)
+
+	// First attempt: create the branch upstream.
+	dir, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("first prepare: %v", err)
+	}
+	if err := configureGitIdentity(dir); err != nil {
+		t.Fatalf("configure identity: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "first.txt"), []byte("first\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CommitAndPush(ctx, dir, "first", tk.WorkBranch); err != nil {
+		t.Fatalf("first CommitAndPush: %v", err)
+	}
+
+	// Operator cleanup: delete the work branch from the bare upstream.
+	bare := strings.TrimPrefix(upstream, "file://")
+	if out, err := exec.Command("git", "--git-dir", bare, "update-ref", "-d", "refs/heads/"+tk.WorkBranch).CombinedOutput(); err != nil {
+		t.Fatalf("delete remote branch: %v\n%s", err, out)
+	}
+
+	// Seed a stale local tracking ref so the retry's git push has something
+	// to (mis)compute a lease against — the exact condition the review
+	// flagged as breaking the previous unconditional --force-with-lease path.
+	if out, err := exec.Command("git", "-C", dir, "fetch", "origin", "main").CombinedOutput(); err != nil {
+		t.Fatalf("seed: fetch main: %v\n%s", err, out)
+	}
+	mainSHA, err := exec.Command("git", "-C", dir, "rev-parse", "origin/main").Output()
+	if err != nil {
+		t.Fatalf("seed: rev-parse: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", dir, "update-ref", "refs/remotes/origin/"+tk.WorkBranch, strings.TrimSpace(string(mainSHA))).CombinedOutput(); err != nil {
+		t.Fatalf("seed stale tracking ref: %v\n%s", err, out)
+	}
+
+	// Retry: same task ID, fresh worktree, new content. Must succeed and
+	// recreate the branch on the bare upstream.
+	dir2, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("second prepare: %v", err)
+	}
+	if err := configureGitIdentity(dir2); err != nil {
+		t.Fatalf("configure identity: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir2, "retry.txt"), []byte("retry\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CommitAndPush(ctx, dir2, "retry", tk.WorkBranch); err != nil {
+		t.Fatalf("retry CommitAndPush after upstream branch deletion: %v", err)
+	}
+
+	out, err := exec.Command("git", "--git-dir", bare, "ls-tree", "-r", "--name-only", tk.WorkBranch).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ls-tree: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "retry.txt") {
+		t.Fatalf("expected branch to be recreated with retry.txt; tree=%q", out)
+	}
+}
+
 // configureGitIdentity sets a deterministic committer for the per-test
 // worktree. PrepareGitWorkspace inherits config from the bare mirror, but the
 // mirror is created without an identity (we never commit inside it), so a

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -191,6 +191,97 @@ func TestPrepareGitWorkspace_RerunReusesPathIdempotently(t *testing.T) {
 	}
 }
 
+// TestCommitAndPush_RetryOverwritesRemoteBranch covers the issue #7 scenario:
+// a previous attempt for the same task ID already pushed a commit to
+// origin/ai/<id>, then the worker retried and produced a different commit on
+// the same work branch. The second push must succeed (using --force-with-lease
+// internally) so the existing PR points at the latest run, instead of failing
+// with a non-fast-forward error and leaving the task stuck.
+func TestCommitAndPush_RetryOverwritesRemoteBranch(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+	tk := makeTask("retry-task", upstream)
+
+	dir, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("first prepare: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "first.txt"), []byte("first attempt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := configureGitIdentity(dir); err != nil {
+		t.Fatalf("configure identity: %v", err)
+	}
+	if err := CommitAndPush(ctx, dir, "first attempt", tk.WorkBranch); err != nil {
+		t.Fatalf("first CommitAndPush: %v", err)
+	}
+
+	// Simulate the worker re-claiming the same task: PrepareGitWorkspace
+	// resets the worktree to a fresh checkout off main, so the retry's local
+	// branch tip diverges from the remote one we just pushed.
+	dir2, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("second prepare: %v", err)
+	}
+	if err := configureGitIdentity(dir2); err != nil {
+		t.Fatalf("configure identity: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir2, "second.txt"), []byte("retry\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CommitAndPush(ctx, dir2, "retry attempt", tk.WorkBranch); err != nil {
+		t.Fatalf("retry CommitAndPush: %v", err)
+	}
+
+	// Confirm the remote tip is the retry commit (contains second.txt and
+	// not first.txt) — i.e. the retry overwrote the previous push instead
+	// of being silently merged into it.
+	bare := strings.TrimPrefix(upstream, "file://")
+	out, err := exec.Command("git", "--git-dir", bare, "ls-tree", "-r", "--name-only", tk.WorkBranch).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ls-tree: %v\n%s", err, out)
+	}
+	tree := string(out)
+	if !strings.Contains(tree, "second.txt") {
+		t.Fatalf("expected retry commit on remote, missing second.txt; tree=%q", tree)
+	}
+	if strings.Contains(tree, "first.txt") {
+		t.Fatalf("expected retry to overwrite remote, but first.txt still present; tree=%q", tree)
+	}
+}
+
+// configureGitIdentity sets a deterministic committer for the per-test
+// worktree. PrepareGitWorkspace inherits config from the bare mirror, but the
+// mirror is created without an identity (we never commit inside it), so a
+// commit issued from the worktree would otherwise fail in CI environments
+// without a global git identity.
+func configureGitIdentity(dir string) error {
+	for _, args := range [][]string{
+		{"git", "-C", dir, "config", "user.email", "u@example.com"},
+		{"git", "-C", dir, "config", "user.name", "u"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			return errFromOut(args, err, out)
+		}
+	}
+	return nil
+}
+
+func errFromOut(args []string, err error, out []byte) error {
+	return &gitCmdError{Args: args, Err: err, Out: string(out)}
+}
+
+type gitCmdError struct {
+	Args []string
+	Err  error
+	Out  string
+}
+
+func (e *gitCmdError) Error() string {
+	return strings.Join(e.Args, " ") + ": " + e.Err.Error() + "\n" + e.Out
+}
+
 func TestCleanup_RemovesOldWorktreesKeepsRecent(t *testing.T) {
 	upstream := initBareUpstream(t)
 	mgr := newTestManager(t)


### PR DESCRIPTION
## Summary

- Worker now looks up an existing open PR for the work branch and reuses it instead of asking Gitea to create a duplicate (which previously failed with 422 and surfaced as a task failure).
- `CommitAndPush` switches to `git push --force-with-lease` (with a best-effort pre-fetch to seed the lease) so a retry's commit cleanly overwrites the previous attempt's tip without non-fast-forward rejection.
- New `pr_reused` task event records the existing PR (number / html_url / title) so observers can attribute the reuse path; runbook documents the event and the new push semantics.

Closes #7.

## Test plan

- [x] `gofmt -l .` (clean)
- [x] `go vet ./...`
- [x] `go mod tidy` (no changes)
- [x] `go test -race -covermode=atomic ./...`
- New tests:
  - `internal/gitea`: `FindOpenPullRequest` happy path, no-match, pagination, 5xx error
  - `internal/workspace`: `CommitAndPush` retry overwrites remote work branch (force-with-lease verified by remote tree)
  - `cmd/worker`: `createPRWith` reuses existing PR (no create call, emits `pr_reused`); creates when none exists; falls through to create on list error