### PR TITLE
feat: workflow discovery and fallback (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,42 @@ This repository implements the second track.
 - `internal/queue`: PostgreSQL-backed task queue using `FOR UPDATE SKIP LOCKED`.
 - `internal/gitea`: webhook parser, signature verification, and PR client.
 
+## WORKFLOW.md discovery
+
+The worker looks for `WORKFLOW.md` in three locations and uses the first one it finds:
+
+1. `<repo>/WORKFLOW.md`
+2. `<repo>/.aiops/WORKFLOW.md`
+3. `<repo>/.github/WORKFLOW.md`
+
+When multiple files exist, lower-priority files are recorded as `shadowed_by` on the `workflow_resolved` event but are otherwise ignored. The worker does not warn or fail.
+
+If none of the three exist, the worker proceeds with built-in defaults:
+
+| Setting | Default |
+|---------|---------|
+| `agent.default` | `mock` |
+| `agent.timeout` | `30m` |
+| `agent.max_concurrent_agents` | `1` |
+| `pr.draft` | `false` |
+| `pr.labels` | `[ai-generated, needs-review]` |
+| `policy.mode` | `draft_pr` |
+| `policy.max_changed_files` | `12` |
+| `policy.max_changed_loc` | `300` |
+| `verify.commands` | none |
+
+A `WORKFLOW.md` with no YAML front matter (just a prompt body) is supported: the body becomes the prompt template, all other settings fall through to the defaults above. The `workflow_resolved` event records this as `source: prompt_only` so an operator can tell apart "ran with full Symphony config" from "ran with body-only template".
+
+To inspect the effective configuration for a workdir without consuming a task:
+
+```bash
+worker --print-config /path/to/repo/clone
+```
+
+The output is JSON. `tracker.api_key` is masked as `***`; the prompt template is summarized (length + first line) rather than printed verbatim — `cat <resolution.path>` to see the full body.
+
+For post-hoc inspection, the `workflow_resolved` task event records the source, path, and shadowed list of every run.
+
 ## Architecture notes
 
 - [Symphony integration guide](docs/symphony-integration.md)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -118,7 +118,7 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 		return workflow.Config{}, err
 	}
 
-	wf, _, err := resolveWorkflow(ctx, ev, t.ID, workdir)
+	wf, workflowSource, err := resolveWorkflow(ctx, ev, t.ID, workdir)
 	if err != nil {
 		return workflow.Config{}, err
 	}
@@ -159,7 +159,7 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 		return cfg, fmt.Errorf("reset run summary: %w", err)
 	}
 
-	if _, runErr := runRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, Prompt: prompt}, cfg.Agent.Timeout); runErr != nil {
+	if _, runErr := runRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, Prompt: prompt}, cfg.Agent.Timeout, workflowSource); runErr != nil {
 		writeFailureArtifacts(ctx, workdir, nil, "runner failed: "+errSummary(runErr))
 		return cfg, runErr
 	}
@@ -275,14 +275,15 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 // can distinguish a clean exit from a kill due to deadline. The returned
 // runner.Result is what runTask passes to runSummary on the success path;
 // on failure it is zero-valued.
-func runRunnerWithTimeout(ctx context.Context, ev eventEmitter, r runner.Runner, in runner.RunInput, timeout time.Duration) (runner.Result, error) {
+func runRunnerWithTimeout(ctx context.Context, ev eventEmitter, r runner.Runner, in runner.RunInput, timeout time.Duration, workflowSource string) (runner.Result, error) {
 	if timeout <= 0 {
 		timeout = 30 * time.Minute
 	}
 
 	emit(ctx, ev, in.Task.ID, task.EventRunnerStart, "runner started", map[string]any{
-		"model":      in.Task.Model,
-		"timeout_ms": timeout.Milliseconds(),
+		"model":           in.Task.Model,
+		"timeout_ms":      timeout.Milliseconds(),
+		"workflow_source": workflowSource,
 	})
 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -55,7 +55,11 @@ func resolveWorkflow(ctx context.Context, ev eventEmitter, taskID, workdir strin
 }
 
 func main() {
-	if len(os.Args) >= 3 && os.Args[1] == "--print-config" {
+	if len(os.Args) >= 2 && os.Args[1] == "--print-config" {
+		if len(os.Args) < 3 {
+			fmt.Fprintln(os.Stderr, "usage: worker --print-config <workdir>")
+			os.Exit(2)
+		}
 		os.Exit(printConfig(os.Args[2], os.Stdout, os.Stderr))
 	}
 	ctx := context.Background()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -28,6 +28,32 @@ type eventEmitter interface {
 	AddEventWithPayload(ctx context.Context, taskID, typ, msg string, payload any) error
 }
 
+// resolveWorkflow performs WORKFLOW.md discovery for a prepared workdir
+// and emits the workflow_resolved event before any runner work begins.
+// Returning the workflow_source string lets callers stamp it onto the
+// runner_start payload as a quick-look field; the full provenance lives
+// on the workflow_resolved event itself.
+func resolveWorkflow(ctx context.Context, ev eventEmitter, taskID, workdir string) (*workflow.Workflow, string, error) {
+	wf, res, err := workflow.Resolve(workdir)
+	if err != nil {
+		return nil, "", err
+	}
+	payload := map[string]any{
+		"source":        string(res.Source),
+		"agent_default": wf.Config.Agent.Default,
+		"policy_mode":   wf.Config.Policy.Mode,
+		"tracker_kind":  wf.Config.Tracker.Kind,
+	}
+	if res.Path != "" {
+		payload["path"] = res.Path
+	}
+	if len(res.ShadowedBy) > 0 {
+		payload["shadowed_by"] = res.ShadowedBy
+	}
+	emit(ctx, ev, taskID, task.EventWorkflowResolved, "workflow resolved", payload)
+	return wf, string(res.Source), nil
+}
+
 func main() {
 	ctx := context.Background()
 	dsn := env("DATABASE_URL", "postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable")
@@ -92,7 +118,7 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 		return workflow.Config{}, err
 	}
 
-	wf, err := workflow.LoadOptional(workdir + "/WORKFLOW.md")
+	wf, _, err := resolveWorkflow(ctx, ev, t.ID, workdir)
 	if err != nil {
 		return workflow.Config{}, err
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -55,6 +55,9 @@ func resolveWorkflow(ctx context.Context, ev eventEmitter, taskID, workdir strin
 }
 
 func main() {
+	if len(os.Args) >= 3 && os.Args[1] == "--print-config" {
+		os.Exit(printConfig(os.Args[2], os.Stdout, os.Stderr))
+	}
 	ctx := context.Background()
 	dsn := env("DATABASE_URL", "postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable")
 	pool, err := pgxpool.New(ctx, dsn)

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -365,7 +365,7 @@ func TestRunRunnerWithTimeoutEmitsTimeoutEvent(t *testing.T) {
 		Workflow: workflow.Workflow{},
 		Workdir:  t.TempDir(),
 	}
-	_, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{sleep: 5 * time.Second}, in, 30*time.Millisecond)
+	_, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{sleep: 5 * time.Second}, in, 30*time.Millisecond, "file")
 	if !runner.IsTimeout(err) {
 		t.Fatalf("expected TimeoutError from runRunnerWithTimeout, got %v", err)
 	}
@@ -399,7 +399,7 @@ func TestRunRunnerWithTimeoutHappyPath(t *testing.T) {
 		Workflow: workflow.Workflow{},
 		Workdir:  t.TempDir(),
 	}
-	if _, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{}, in, time.Second); err != nil {
+	if _, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{}, in, time.Second, "file"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := len(ev.byKind(task.EventRunnerStart)); got != 1 {
@@ -430,7 +430,7 @@ func TestRunRunnerWithTimeoutNonTimeoutError(t *testing.T) {
 		Workflow: workflow.Workflow{},
 		Workdir:  t.TempDir(),
 	}
-	_, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{err: wantErr}, in, time.Second)
+	_, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{err: wantErr}, in, time.Second, "file")
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("err propagation broken: got %v want %v", err, wantErr)
 	}
@@ -456,7 +456,7 @@ func TestRunRunnerWithTimeoutZeroBudgetUsesDefault(t *testing.T) {
 		Workflow: workflow.Workflow{},
 		Workdir:  t.TempDir(),
 	}
-	if _, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{sleep: 10 * time.Millisecond}, in, 0); err != nil {
+	if _, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{sleep: 10 * time.Millisecond}, in, 0, "default"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	pe := ev.byKind(task.EventRunnerStart)[0]
@@ -673,5 +673,26 @@ func TestResolveWorkflow_DefaultSourceOmitsPath(t *testing.T) {
 	}
 	if _, present := payload["shadowed_by"]; present {
 		t.Fatalf("payload should omit shadowed_by when empty: %#v", payload)
+	}
+}
+
+// TestRunRunnerWithTimeout_StampsWorkflowSource verifies the
+// runner_start payload carries workflow_source as a quick-look field.
+// The full provenance is on workflow_resolved; this stamp lets a
+// timeline viewer color the runner stage by source without joining
+// against the earlier event.
+func TestRunRunnerWithTimeout_StampsWorkflowSource(t *testing.T) {
+	ev := &fakeEmitter{}
+	in := runner.RunInput{Task: task.Task{ID: "tsk_1", Model: "mock"}}
+	if _, err := runRunnerWithTimeout(context.Background(), ev, stubRunner{}, in, time.Second, "prompt_only"); err != nil {
+		t.Fatalf("runRunnerWithTimeout: %v", err)
+	}
+	got := ev.byKind(task.EventRunnerStart)
+	if len(got) != 1 {
+		t.Fatalf("runner_start events = %d, want 1", len(got))
+	}
+	payload, _ := got[0].Payload.(map[string]any)
+	if payload["workflow_source"] != "prompt_only" {
+		t.Fatalf("workflow_source = %v, want %q", payload["workflow_source"], "prompt_only")
 	}
 }

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -603,3 +603,75 @@ func TestCreatePRWith_ListErrorFallsThroughToCreate(t *testing.T) {
 		t.Fatalf("expected fallback CreatePullRequest call, got %d", len(client.createCalls))
 	}
 }
+
+// TestResolveWorkflow_EmitsResolvedEvent verifies the worker emits a
+// workflow_resolved event whose payload carries Source, Path, and the
+// effective config quick-look fields (agent_default, policy_mode,
+// tracker_kind). These four fields are what the spec promises for the
+// post-hoc inspection contract.
+func TestResolveWorkflow_EmitsResolvedEvent(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  default: codex\npolicy:\n  mode: draft_pr\ntracker:\n  kind: linear\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	ev := &fakeEmitter{}
+	wf, src, err := resolveWorkflow(context.Background(), ev, "tsk_1", dir)
+	if err != nil {
+		t.Fatalf("resolveWorkflow: %v", err)
+	}
+	if src != "file" {
+		t.Fatalf("workflow_source = %q, want %q", src, "file")
+	}
+	if wf.Config.Agent.Default != "codex" {
+		t.Fatalf("agent.default not loaded: %q", wf.Config.Agent.Default)
+	}
+	got := ev.byKind(task.EventWorkflowResolved)
+	if len(got) != 1 {
+		t.Fatalf("workflow_resolved events = %d, want 1", len(got))
+	}
+	payload, _ := got[0].Payload.(map[string]any)
+	for _, key := range []string{"source", "path", "agent_default", "policy_mode", "tracker_kind"} {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("payload missing key %q: %#v", key, payload)
+		}
+	}
+	if payload["source"] != "file" {
+		t.Fatalf("payload.source = %v, want \"file\"", payload["source"])
+	}
+	if payload["path"] != "WORKFLOW.md" {
+		t.Fatalf("payload.path = %v, want \"WORKFLOW.md\"", payload["path"])
+	}
+	if payload["agent_default"] != "codex" {
+		t.Fatalf("payload.agent_default = %v, want \"codex\"", payload["agent_default"])
+	}
+	if _, present := payload["shadowed_by"]; present {
+		t.Fatalf("payload should omit shadowed_by when empty: %#v", payload)
+	}
+}
+
+// TestResolveWorkflow_DefaultSourceOmitsPath checks that when no
+// WORKFLOW.md exists, the resolved event records source=default and
+// does not emit an empty path key.
+func TestResolveWorkflow_DefaultSourceOmitsPath(t *testing.T) {
+	dir := t.TempDir()
+	ev := &fakeEmitter{}
+	_, src, err := resolveWorkflow(context.Background(), ev, "tsk_2", dir)
+	if err != nil {
+		t.Fatalf("resolveWorkflow: %v", err)
+	}
+	if src != "default" {
+		t.Fatalf("workflow_source = %q, want %q", src, "default")
+	}
+	got := ev.byKind(task.EventWorkflowResolved)
+	if len(got) != 1 {
+		t.Fatalf("workflow_resolved events = %d, want 1", len(got))
+	}
+	payload, _ := got[0].Payload.(map[string]any)
+	if _, present := payload["path"]; present {
+		t.Fatalf("payload should omit path when source=default: %#v", payload)
+	}
+	if _, present := payload["shadowed_by"]; present {
+		t.Fatalf("payload should omit shadowed_by when empty: %#v", payload)
+	}
+}

--- a/cmd/worker/print_config.go
+++ b/cmd/worker/print_config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -29,6 +30,28 @@ type promptSummary struct {
 	FirstLine string `json:"first_line"`
 }
 
+const promptFirstLineMaxBytes = 200
+
+// summarizePrompt produces the bounded prompt summary published by
+// --print-config. Length is the byte length of the trimmed body so a
+// reader can sanity-check completeness; FirstLine is truncated to keep
+// debug output cheap to paste even when an author writes a long single
+// line. The full body is never echoed (see spec safety contract).
+func summarizePrompt(body string) promptSummary {
+	trimmed := strings.TrimSpace(body)
+	first := trimmed
+	if i := strings.IndexByte(first, '\n'); i >= 0 {
+		first = first[:i]
+	}
+	if len(first) > promptFirstLineMaxBytes {
+		first = first[:promptFirstLineMaxBytes]
+	}
+	return promptSummary{
+		Length:    len(trimmed),
+		FirstLine: first,
+	}
+}
+
 // printConfig writes the effective workflow for workdir as JSON to
 // stdout. Returns the process exit code (0 on success, 1 on schema
 // validation error). Used both by main()'s --print-config dispatch and
@@ -47,7 +70,7 @@ func printConfig(workdir string, stdout, stderr io.Writer) int {
 			ShadowedBy: res.ShadowedBy,
 		},
 		Config:         wf.Config,
-		PromptTemplate: promptSummary{}, // populated in Task 12
+		PromptTemplate: summarizePrompt(wf.PromptTemplate),
 	}
 	enc := json.NewEncoder(stdout)
 	enc.SetIndent("", "  ")

--- a/cmd/worker/print_config.go
+++ b/cmd/worker/print_config.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// printConfigOutput is the JSON shape of `worker --print-config <dir>`.
+// Stable: external tooling may consume it.
+type printConfigOutput struct {
+	Resolution     printConfigResolution `json:"resolution"`
+	Config         workflow.Config       `json:"config"`
+	PromptTemplate promptSummary         `json:"prompt_template"`
+}
+
+type printConfigResolution struct {
+	Source     string   `json:"source"`
+	Path       string   `json:"path,omitempty"`
+	ShadowedBy []string `json:"shadowed_by,omitempty"`
+}
+
+// promptSummary is intentionally not the full prompt body. See spec
+// section "Why prompt body is summarized, not printed" for the rationale.
+type promptSummary struct {
+	Length    int    `json:"length"`
+	FirstLine string `json:"first_line"`
+}
+
+// printConfig writes the effective workflow for workdir as JSON to
+// stdout. Returns the process exit code (0 on success, 1 on schema
+// validation error). Used both by main()'s --print-config dispatch and
+// by tests; stdout/stderr are explicit io.Writer parameters so tests
+// can capture the output without subprocessing.
+func printConfig(workdir string, stdout, stderr io.Writer) int {
+	wf, res, err := workflow.Resolve(workdir)
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return 1
+	}
+	out := printConfigOutput{
+		Resolution: printConfigResolution{
+			Source:     string(res.Source),
+			Path:       res.Path,
+			ShadowedBy: res.ShadowedBy,
+		},
+		Config:         wf.Config,
+		PromptTemplate: promptSummary{}, // populated in Task 12
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return 1
+	}
+	return 0
+}

--- a/cmd/worker/print_config.go
+++ b/cmd/worker/print_config.go
@@ -52,6 +52,20 @@ func summarizePrompt(body string) promptSummary {
 	}
 }
 
+const maskedSecret = "***"
+
+// maskSecrets rewrites secret-bearing fields on a Config to a fixed
+// placeholder before serialization. The function takes its argument by
+// value; the workflow.Config used by the running worker is never
+// touched. Currently only Tracker.APIKey is masked — extend this list
+// when new secret-bearing fields are added to the schema.
+func maskSecrets(cfg workflow.Config) workflow.Config {
+	if cfg.Tracker.APIKey != "" {
+		cfg.Tracker.APIKey = maskedSecret
+	}
+	return cfg
+}
+
 // printConfig writes the effective workflow for workdir as JSON to
 // stdout. Returns the process exit code (0 on success, 1 on schema
 // validation error). Used both by main()'s --print-config dispatch and
@@ -69,7 +83,7 @@ func printConfig(workdir string, stdout, stderr io.Writer) int {
 			Path:       res.Path,
 			ShadowedBy: res.ShadowedBy,
 		},
-		Config:         wf.Config,
+		Config:         maskSecrets(wf.Config),
 		PromptTemplate: summarizePrompt(wf.PromptTemplate),
 	}
 	enc := json.NewEncoder(stdout)

--- a/cmd/worker/print_config_test.go
+++ b/cmd/worker/print_config_test.go
@@ -9,6 +9,31 @@ import (
 	"testing"
 )
 
+// TestPrintConfig_MasksTrackerAPIKey verifies the secret-masking
+// contract from the spec. Even when --print-config is used legitimately
+// for debugging, the API key must never reach stdout. We test with the
+// env-var indirection style that examples/WORKFLOW.md uses, since that
+// is the realistic source of a non-empty key.
+func TestPrintConfig_MasksTrackerAPIKey(t *testing.T) {
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin_super_secret_value")
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  api_key: $AIOPS_TEST_LINEAR_KEY\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	got := stdout.String()
+	if strings.Contains(got, "lin_super_secret_value") {
+		t.Fatalf("api_key value leaked into stdout:\n%s", got)
+	}
+	if !strings.Contains(got, `"api_key": "***"`) {
+		t.Fatalf("api_key not masked; stdout:\n%s", got)
+	}
+}
+
 // TestPrintConfig_DefaultSource verifies the simplest case: an empty
 // workdir resolves to source=default, and the JSON output reports it
 // without a path or shadowed_by field.

--- a/cmd/worker/print_config_test.go
+++ b/cmd/worker/print_config_test.go
@@ -116,3 +116,26 @@ func TestPrintConfig_FileSourceWithPromptCanary(t *testing.T) {
 		t.Fatalf("length = %d, want > 0", out.PromptTemplate.Length)
 	}
 }
+
+// TestPrintConfig_SchemaErrorReturnsExitOne pins the contract that
+// schema validation failures produce a non-zero exit and route the
+// human-readable error to stderr. Stdout must remain empty so a script
+// piping the JSON elsewhere does not feed it a malformed document.
+func TestPrintConfig_SchemaErrorReturnsExitOne(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n---\nprompt\n" // no clone_url
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := printConfig(dir, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout not empty on error: %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "repo.clone_url") {
+		t.Fatalf("stderr missing field name: %s", stderr.String())
+	}
+}

--- a/cmd/worker/print_config_test.go
+++ b/cmd/worker/print_config_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestPrintConfig_DefaultSource verifies the simplest case: an empty
+// workdir resolves to source=default, and the JSON output reports it
+// without a path or shadowed_by field.
+func TestPrintConfig_DefaultSource(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := printConfig(dir, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	var out struct {
+		Resolution struct {
+			Source     string   `json:"source"`
+			Path       string   `json:"path,omitempty"`
+			ShadowedBy []string `json:"shadowed_by,omitempty"`
+		} `json:"resolution"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout: %s", err, stdout.String())
+	}
+	if out.Resolution.Source != "default" {
+		t.Fatalf("resolution.source = %q, want %q", out.Resolution.Source, "default")
+	}
+	if out.Resolution.Path != "" {
+		t.Fatalf("resolution.path = %q, want empty", out.Resolution.Path)
+	}
+}

--- a/cmd/worker/print_config_test.go
+++ b/cmd/worker/print_config_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -31,5 +34,60 @@ func TestPrintConfig_DefaultSource(t *testing.T) {
 	}
 	if out.Resolution.Path != "" {
 		t.Fatalf("resolution.path = %q, want empty", out.Resolution.Path)
+	}
+}
+
+// TestPrintConfig_FileSourceWithPromptCanary covers two contracts at once:
+//
+//  1. Source=file populates config from the front matter (here: a
+//     non-default agent.default and tracker.kind).
+//  2. The prompt body is summarized rather than echoed. We embed a
+//     recognizable canary string in the body and assert it never reaches
+//     stdout. This is the spec's safety contract — see "Why prompt body
+//     is summarized, not printed".
+func TestPrintConfig_FileSourceWithPromptCanary(t *testing.T) {
+	dir := t.TempDir()
+	canary := "SHOULD_NOT_LEAK_xyz"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  default: codex\ntracker:\n  kind: linear\n---\nFirst line of prompt template.\nSecond line includes canary " + canary + " in the middle.\nMore body...\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+
+	if strings.Contains(stdout.String(), canary) {
+		t.Fatalf("canary %q leaked into stdout:\n%s", canary, stdout.String())
+	}
+
+	var out struct {
+		Resolution struct {
+			Source string `json:"source"`
+		} `json:"resolution"`
+		Config struct {
+			Agent struct {
+				Default string `json:"default"`
+			} `json:"agent"`
+		} `json:"config"`
+		PromptTemplate struct {
+			Length    int    `json:"length"`
+			FirstLine string `json:"first_line"`
+		} `json:"prompt_template"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout: %s", err, stdout.String())
+	}
+	if out.Resolution.Source != "file" {
+		t.Fatalf("source = %q, want %q", out.Resolution.Source, "file")
+	}
+	if out.Config.Agent.Default != "codex" {
+		t.Fatalf("agent.default = %q, want %q", out.Config.Agent.Default, "codex")
+	}
+	if out.PromptTemplate.FirstLine != "First line of prompt template." {
+		t.Fatalf("first_line = %q", out.PromptTemplate.FirstLine)
+	}
+	if out.PromptTemplate.Length <= 0 {
+		t.Fatalf("length = %d, want > 0", out.PromptTemplate.Length)
 	}
 }

--- a/docs/superpowers/plans/2026-05-09-workflow-discovery-fallback.md
+++ b/docs/superpowers/plans/2026-05-09-workflow-discovery-fallback.md
@@ -1,0 +1,1429 @@
+# Workflow Discovery and Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make worker behavior deterministic about WHERE `WORKFLOW.md` is loaded from and WHAT was used on a given run, by introducing a `Resolve(workdir)` function with documented precedence (root → `.aiops/` → `.github/`), a new `workflow_resolved` task event, and a `worker --print-config <workdir>` debug subcommand.
+
+**Architecture:** New `internal/workflow/resolver.go` carries `Source` enum, `Resolution` value type, and `Resolve()`. The worker swaps `LoadOptional` for `Resolve` and emits `workflow_resolved` before `runner_start`. A new `cmd/worker/print_config.go` adds a `--print-config` subcommand that masks `tracker.api_key` and summarizes (not prints) the prompt body.
+
+**Tech Stack:** Go 1.22 (standard library only — `os`, `path/filepath`, `strings`, `encoding/json`, `testing`); existing `gopkg.in/yaml.v3` used transitively through `workflow.Load`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-09-workflow-discovery-fallback-design.md`](../specs/2026-05-09-workflow-discovery-fallback-design.md)
+
+---
+
+## File Structure
+
+**Create:**
+- `internal/workflow/resolver.go` — `Source` constants, `Resolution` struct, `Resolve()` function, `hasFrontMatterAt` helper
+- `internal/workflow/resolver_test.go` — discovery test matrix
+- `cmd/worker/print_config.go` — `printConfig` entry, `maskSecrets` helper, `summarizePrompt` helper
+- `cmd/worker/print_config_test.go` — print-config tests including secret masking and prompt-body canary
+
+**Modify:**
+- `internal/workflow/loader.go` — add deprecation comment on `LoadOptional`
+- `internal/task/task.go` — add `EventWorkflowResolved` constant
+- `cmd/worker/main.go` — `runTask` switches to `Resolve`, emits `workflow_resolved`; `runRunnerWithTimeout` accepts and emits `workflow_source`; `main()` dispatches `--print-config`
+- `cmd/worker/main_test.go` — add `resolveWorkflow` helper test, `runner_start` payload assertion
+- `README.md` — new "WORKFLOW.md discovery" subsection
+
+**Touch nothing:** `cmd/linear-poller/main.go` (still uses `Load(path)` with explicit path), `cmd/api/*`, `internal/runner/*`, `internal/queue/*`.
+
+---
+
+## Task 1: `Resolve()` returns defaults when no WORKFLOW.md exists
+
+**Files:**
+- Create: `internal/workflow/resolver.go`
+- Test: `internal/workflow/resolver_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/workflow/resolver_test.go`:
+
+```go
+package workflow
+
+import (
+	"testing"
+)
+
+// TestResolve_NoFileReturnsDefaults pins the contract from spec section
+// "Discovery Contract": when no WORKFLOW.md exists in any of the search
+// locations, Resolve must succeed with Source=default and the schema
+// defaults applied (so a fresh repo can run with the mock runner).
+func TestResolve_NoFileReturnsDefaults(t *testing.T) {
+	dir := t.TempDir()
+	wf, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: unexpected error: %v", err)
+	}
+	if res.Source != SourceDefault {
+		t.Fatalf("Source = %q, want %q", res.Source, SourceDefault)
+	}
+	if res.Path != "" {
+		t.Fatalf("Path = %q, want empty (no file)", res.Path)
+	}
+	if len(res.ShadowedBy) != 0 {
+		t.Fatalf("ShadowedBy = %v, want empty", res.ShadowedBy)
+	}
+	if wf == nil || wf.Config.Agent.Default != "mock" {
+		t.Fatalf("default Agent.Default = %q, want %q", wf.Config.Agent.Default, "mock")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/workflow/ -run TestResolve_NoFileReturnsDefaults`
+
+Expected: FAIL with "undefined: Resolve" / "undefined: SourceDefault".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/workflow/resolver.go`:
+
+```go
+package workflow
+
+// Source describes where the effective workflow came from on a given
+// load. SourceFile means a WORKFLOW.md with valid YAML front matter was
+// found and parsed; SourcePromptOnly means a file existed but had no
+// front matter (the body became the prompt template, config came from
+// schema defaults); SourceDefault means no file was found at all.
+type Source string
+
+const (
+	SourceFile       Source = "file"
+	SourcePromptOnly Source = "prompt_only"
+	SourceDefault    Source = "default"
+)
+
+// Resolution carries the runtime fact of how a workflow was loaded for
+// a single task. It is intentionally separate from Workflow because
+// "where did this come from on this invocation" is not a property of
+// the configuration itself; it is per-load metadata that the worker
+// uses to populate the workflow_resolved event.
+type Resolution struct {
+	Source     Source
+	Path       string   // repo-relative; "" when Source == SourceDefault
+	ShadowedBy []string // other repo-relative paths that exist but lost precedence
+}
+
+// Resolve discovers WORKFLOW.md inside workdir, applying the documented
+// precedence (root > .aiops/ > .github/), and returns the loaded
+// Workflow alongside a Resolution describing the source. When no file
+// is found, the schema defaults are returned with Source=default.
+func Resolve(workdir string) (*Workflow, *Resolution, error) {
+	cfg := DefaultConfig()
+	expandConfig(&cfg)
+	wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt()}
+	return wf, &Resolution{Source: SourceDefault}, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/workflow/ -run TestResolve_NoFileReturnsDefaults`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/workflow/resolver.go internal/workflow/resolver_test.go
+git commit -m "feat(workflow): add Resolve scaffold returning defaults when no file (#10)"
+```
+
+---
+
+## Task 2: `Resolve()` finds root `WORKFLOW.md` and classifies as `file`
+
+**Files:**
+- Modify: `internal/workflow/resolver.go`
+- Test: `internal/workflow/resolver_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/workflow/resolver_test.go`:
+
+```go
+import (
+	"os"
+	"path/filepath"
+)
+
+// TestResolve_FindsRootWorkflowFile covers the most common case: a
+// WORKFLOW.md at the repo root with valid YAML front matter resolves
+// as Source=file with the relative path "WORKFLOW.md".
+func TestResolve_FindsRootWorkflowFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n---\nprompt body\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wf, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != SourceFile {
+		t.Fatalf("Source = %q, want %q", res.Source, SourceFile)
+	}
+	if res.Path != "WORKFLOW.md" {
+		t.Fatalf("Path = %q, want %q", res.Path, "WORKFLOW.md")
+	}
+	if wf.Config.Repo.CloneURL != "git@example.com:o/r.git" {
+		t.Fatalf("CloneURL = %q, not loaded from front matter", wf.Config.Repo.CloneURL)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/workflow/ -run TestResolve_FindsRootWorkflowFile`
+
+Expected: FAIL — "Source = \"default\", want \"file\"".
+
+- [ ] **Step 3: Replace `Resolve` with discovery logic**
+
+Edit `internal/workflow/resolver.go` — replace the body of `Resolve` (keep imports/types):
+
+```go
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var resolveCandidates = []string{
+	"WORKFLOW.md",
+	".aiops/WORKFLOW.md",
+	".github/WORKFLOW.md",
+}
+
+func Resolve(workdir string) (*Workflow, *Resolution, error) {
+	var found string
+	for _, rel := range resolveCandidates {
+		abs := filepath.Join(workdir, rel)
+		info, err := os.Stat(abs)
+		if err == nil && !info.IsDir() {
+			if found == "" {
+				found = rel
+			}
+			continue
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return nil, nil, err
+		}
+	}
+	if found == "" {
+		cfg := DefaultConfig()
+		expandConfig(&cfg)
+		wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt()}
+		return wf, &Resolution{Source: SourceDefault}, nil
+	}
+	abs := filepath.Join(workdir, found)
+	wf, err := Load(abs)
+	if err != nil {
+		return nil, nil, err
+	}
+	return wf, &Resolution{Source: SourceFile, Path: found}, nil
+}
+
+// hasFrontMatterAt returns true when path begins with a YAML front
+// matter fence (`---\n` or `---\r\n`) followed somewhere by a closing
+// fence. Used by Resolve to distinguish prompt-only files from full
+// workflow files without threading a flag out of Load.
+func hasFrontMatterAt(path string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	s := string(b)
+	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
+		return false
+	}
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
+	return strings.Contains(trimmed, "\n---")
+}
+```
+
+`hasFrontMatterAt` is unused in this task but added now so Task 3's diff stays small. The body mirrors the un-exported `splitFrontMatter` in `loader.go` deliberately — duplicating ~5 lines is cheaper than exporting an internal helper that promises a stable contract.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/workflow/`
+
+Expected: all `TestResolve_*` pass; pre-existing `TestLoad_*` and `TestLoadOptional*` continue to pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/workflow/resolver.go internal/workflow/resolver_test.go
+git commit -m "feat(workflow): Resolve discovers root WORKFLOW.md (#10)"
+```
+
+---
+
+## Task 3: `Resolve()` classifies prompt-only files as `prompt_only`
+
+**Files:**
+- Modify: `internal/workflow/resolver.go`
+- Test: `internal/workflow/resolver_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/workflow/resolver_test.go`:
+
+```go
+// TestResolve_PromptOnlyFile pins the spec contract that a WORKFLOW.md
+// without a YAML front matter block resolves as Source=prompt_only:
+// the body becomes the prompt template, but config falls through to
+// schema defaults. This is consistent with TestLoad_AcceptsPromptOnlyFile.
+func TestResolve_PromptOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "just a prompt template, no front matter\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wf, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != SourcePromptOnly {
+		t.Fatalf("Source = %q, want %q", res.Source, SourcePromptOnly)
+	}
+	if res.Path != "WORKFLOW.md" {
+		t.Fatalf("Path = %q, want %q", res.Path, "WORKFLOW.md")
+	}
+	if wf.PromptTemplate != "just a prompt template, no front matter" {
+		t.Fatalf("PromptTemplate = %q", wf.PromptTemplate)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/workflow/ -run TestResolve_PromptOnlyFile`
+
+Expected: FAIL — "Source = \"file\", want \"prompt_only\"".
+
+- [ ] **Step 3: Branch on front-matter presence**
+
+Edit `internal/workflow/resolver.go`. Replace the final `return` in `Resolve` (the one producing `SourceFile`) with:
+
+```go
+src := SourceFile
+if !hasFrontMatterAt(abs) {
+	src = SourcePromptOnly
+}
+return wf, &Resolution{Source: src, Path: found}, nil
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/workflow/`
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/workflow/resolver.go internal/workflow/resolver_test.go
+git commit -m "feat(workflow): classify prompt-only files in Resolve (#10)"
+```
+
+---
+
+## Task 4: `Resolve()` searches `.aiops/` and `.github/` in priority order
+
+**Files:**
+- Test: `internal/workflow/resolver_test.go`
+
+This task is test-only — Task 2 already wired the candidate list in priority order. We pin the precedence with explicit cases.
+
+- [ ] **Step 1: Add the table-driven test**
+
+Append to `internal/workflow/resolver_test.go`:
+
+```go
+// TestResolve_AlternateLocations covers the .aiops/ and .github/
+// fallback locations declared in the discovery contract. Each case
+// puts WORKFLOW.md in exactly one place; precedence (when multiple
+// exist) is covered by TestResolve_ShadowedBy.
+func TestResolve_AlternateLocations(t *testing.T) {
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n---\nprompt\n"
+	cases := []struct {
+		name string
+		rel  string
+	}{
+		{"aiops_dir", ".aiops/WORKFLOW.md"},
+		{"github_dir", ".github/WORKFLOW.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			abs := filepath.Join(dir, tc.rel)
+			if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			_, res, err := Resolve(dir)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if res.Source != SourceFile {
+				t.Fatalf("Source = %q, want %q", res.Source, SourceFile)
+			}
+			if res.Path != tc.rel {
+				t.Fatalf("Path = %q, want %q", res.Path, tc.rel)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes immediately**
+
+Run: `go test ./internal/workflow/ -run TestResolve_AlternateLocations`
+
+Expected: PASS — Task 2's `resolveCandidates` list already covers these.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/workflow/resolver_test.go
+git commit -m "test(workflow): pin .aiops/ and .github/ discovery (#10)"
+```
+
+---
+
+## Task 5: `Resolve()` reports `ShadowedBy` for lower-priority files
+
+**Files:**
+- Modify: `internal/workflow/resolver.go`
+- Test: `internal/workflow/resolver_test.go`
+
+Task 2's discovery loop selects the first hit but does not track the others. This task adds shadow tracking.
+
+- [ ] **Step 1: Add shadow tracking to `Resolve`**
+
+Edit `internal/workflow/resolver.go`. In `Resolve`, declare `shadows` alongside `found` and append to it on subsequent hits:
+
+```go
+var found string
+var shadows []string
+for _, rel := range resolveCandidates {
+	abs := filepath.Join(workdir, rel)
+	info, err := os.Stat(abs)
+	if err == nil && !info.IsDir() {
+		if found == "" {
+			found = rel
+		} else {
+			shadows = append(shadows, rel)
+		}
+		continue
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
+	}
+}
+```
+
+Update the file-found return to thread `shadows`:
+
+```go
+// in the "file found" branch (Source set above):
+return wf, &Resolution{Source: src, Path: found, ShadowedBy: shadows}, nil
+```
+
+The `SourceDefault` branch is unchanged — when no file is found, there is nothing to shadow.
+
+- [ ] **Step 2: Write the test**
+
+Append to `internal/workflow/resolver_test.go`:
+
+```go
+// TestResolve_ShadowedBy covers the precedence contract: when multiple
+// WORKFLOW.md files exist, the first in declaration order wins and the
+// remaining ones are recorded in ShadowedBy in declaration order. The
+// shadow list is data only — Resolve does not warn or error.
+func TestResolve_ShadowedBy(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n---\nprompt\n"
+	for _, rel := range []string{"WORKFLOW.md", ".aiops/WORKFLOW.md", ".github/WORKFLOW.md"} {
+		abs := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	_, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Path != "WORKFLOW.md" {
+		t.Fatalf("Path = %q, want root", res.Path)
+	}
+	want := []string{".aiops/WORKFLOW.md", ".github/WORKFLOW.md"}
+	if len(res.ShadowedBy) != len(want) {
+		t.Fatalf("ShadowedBy = %v, want %v", res.ShadowedBy, want)
+	}
+	for i := range want {
+		if res.ShadowedBy[i] != want[i] {
+			t.Fatalf("ShadowedBy[%d] = %q, want %q", i, res.ShadowedBy[i], want[i])
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test ./internal/workflow/`
+
+Expected: all pass. If `TestResolve_ShadowedBy` fails, recheck Step 1's `else` branch.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/workflow/resolver.go internal/workflow/resolver_test.go
+git commit -m "feat(workflow): record shadowed_by in Resolve (#10)"
+```
+
+---
+
+## Task 6: `Resolve()` propagates schema validation errors
+
+**Files:**
+- Test: `internal/workflow/resolver_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Append to `internal/workflow/resolver_test.go`:
+
+```go
+// TestResolve_PropagatesSchemaErrors guards the contract that Resolve
+// does NOT silently fall back to defaults when a file is found but
+// fails schema validation. Falling back would mask real configuration
+// mistakes and reduce the entire validation effort from #48/#49 to
+// theatre. The error must name the offending field and the file path.
+func TestResolve_PropagatesSchemaErrors(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n---\nprompt\n" // no clone_url
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err := Resolve(dir)
+	if err == nil {
+		t.Fatalf("Resolve: expected error for missing clone_url, got nil")
+	}
+	for _, want := range []string{"repo.clone_url", "WORKFLOW.md"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q: want substring %q", err.Error(), want)
+		}
+	}
+}
+```
+
+Add `"strings"` to the test file's imports if not already present.
+
+- [ ] **Step 2: Run test**
+
+Run: `go test ./internal/workflow/ -run TestResolve_PropagatesSchemaErrors`
+
+Expected: PASS — Task 2 calls `Load(abs)` which already validates; the error propagates through `Resolve` unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/workflow/resolver_test.go
+git commit -m "test(workflow): pin Resolve does not mask schema errors (#10)"
+```
+
+---
+
+## Task 7: Mark `LoadOptional` deprecated
+
+**Files:**
+- Modify: `internal/workflow/loader.go`
+
+- [ ] **Step 1: Add deprecation comment**
+
+Edit `internal/workflow/loader.go`. Above the existing `func LoadOptional(path string) (*Workflow, error) {` line, replace any current comment with:
+
+```go
+// LoadOptional loads a workflow from an explicit path, returning schema
+// defaults when the file does not exist. New worker code should use
+// Resolve(workdir), which handles repo-relative discovery and returns
+// resolution metadata.
+//
+// Deprecated: use Resolve(workdir) for repo-relative discovery. Retained
+// for callers that pass an explicit path (e.g. cmd/linear-poller has a
+// related but separate loader contract).
+func LoadOptional(path string) (*Workflow, error) {
+```
+
+- [ ] **Step 2: Verify the package still builds**
+
+Run: `go build ./...`
+
+Expected: clean build. The `// Deprecated:` line is a Go doc convention; `go vet` / staticcheck may surface it but `go build` accepts it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/workflow/loader.go
+git commit -m "docs(workflow): deprecate LoadOptional in favor of Resolve (#10)"
+```
+
+---
+
+## Task 8: Add `EventWorkflowResolved` constant
+
+**Files:**
+- Modify: `internal/task/task.go`
+
+- [ ] **Step 1: Add the constant**
+
+Edit `internal/task/task.go`. The existing `const` block lives around lines 22-34 (between `EventEnqueued` and `EventFailedAttempt`). Add `EventWorkflowResolved` between `EventClaimed` and `EventRunnerStart`:
+
+```go
+const (
+	EventEnqueued         = "enqueued"
+	EventClaimed          = "claimed"
+	EventWorkflowResolved = "workflow_resolved"
+	EventRunnerStart      = "runner_start"
+	EventRunnerEnd        = "runner_end"
+	// ... rest unchanged ...
+)
+```
+
+The position before `EventRunnerStart` reflects the actual emit order in `runTask`: workflow resolution happens after claim and before any runner work.
+
+- [ ] **Step 2: Verify**
+
+Run: `go build ./...`
+
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/task/task.go
+git commit -m "feat(task): add EventWorkflowResolved constant (#10)"
+```
+
+---
+
+## Task 9: Worker uses `Resolve` and emits `workflow_resolved`
+
+**Files:**
+- Modify: `cmd/worker/main.go`
+- Modify: `cmd/worker/main_test.go`
+
+This task introduces a small `resolveWorkflow` helper inside the worker package so the emit logic can be unit-tested without `workspace.PrepareGitWorkspace` (which would clone real repositories). The helper takes an already-prepared workdir.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/worker/main_test.go`:
+
+```go
+// TestResolveWorkflow_EmitsResolvedEvent verifies the worker emits a
+// workflow_resolved event whose payload carries Source, Path, and the
+// effective config quick-look fields (agent_default, policy_mode,
+// tracker_kind). These four fields are what the spec promises for the
+// post-hoc inspection contract.
+func TestResolveWorkflow_EmitsResolvedEvent(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  default: codex\npolicy:\n  mode: draft_pr\ntracker:\n  kind: linear\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	ev := &fakeEmitter{}
+	wf, src, err := resolveWorkflow(context.Background(), ev, "tsk_1", dir)
+	if err != nil {
+		t.Fatalf("resolveWorkflow: %v", err)
+	}
+	if src != "file" {
+		t.Fatalf("workflow_source = %q, want %q", src, "file")
+	}
+	if wf.Config.Agent.Default != "codex" {
+		t.Fatalf("agent.default not loaded: %q", wf.Config.Agent.Default)
+	}
+	got := ev.byKind(task.EventWorkflowResolved)
+	if len(got) != 1 {
+		t.Fatalf("workflow_resolved events = %d, want 1", len(got))
+	}
+	payload, _ := got[0].Payload.(map[string]any)
+	for _, key := range []string{"source", "path", "agent_default", "policy_mode", "tracker_kind"} {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("payload missing key %q: %#v", key, payload)
+		}
+	}
+	if payload["source"] != "file" {
+		t.Fatalf("payload.source = %v, want \"file\"", payload["source"])
+	}
+	if payload["path"] != "WORKFLOW.md" {
+		t.Fatalf("payload.path = %v, want \"WORKFLOW.md\"", payload["path"])
+	}
+	if payload["agent_default"] != "codex" {
+		t.Fatalf("payload.agent_default = %v, want \"codex\"", payload["agent_default"])
+	}
+	if _, present := payload["shadowed_by"]; present {
+		t.Fatalf("payload should omit shadowed_by when empty: %#v", payload)
+	}
+}
+
+// TestResolveWorkflow_DefaultSourceOmitsPath checks that when no
+// WORKFLOW.md exists, the resolved event records source=default and
+// does not emit an empty path key.
+func TestResolveWorkflow_DefaultSourceOmitsPath(t *testing.T) {
+	dir := t.TempDir()
+	ev := &fakeEmitter{}
+	_, src, err := resolveWorkflow(context.Background(), ev, "tsk_2", dir)
+	if err != nil {
+		t.Fatalf("resolveWorkflow: %v", err)
+	}
+	if src != "default" {
+		t.Fatalf("workflow_source = %q, want %q", src, "default")
+	}
+	got := ev.byKind(task.EventWorkflowResolved)
+	if len(got) != 1 {
+		t.Fatalf("workflow_resolved events = %d, want 1", len(got))
+	}
+	payload, _ := got[0].Payload.(map[string]any)
+	if _, present := payload["path"]; present {
+		t.Fatalf("payload should omit path when source=default: %#v", payload)
+	}
+	if _, present := payload["shadowed_by"]; present {
+		t.Fatalf("payload should omit shadowed_by when empty: %#v", payload)
+	}
+}
+```
+
+Imports already in `main_test.go` cover `context`, `os`, `path/filepath`, `testing`, `task`. If `path/filepath` is missing, add it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/worker/ -run TestResolveWorkflow`
+
+Expected: FAIL with "undefined: resolveWorkflow".
+
+- [ ] **Step 3: Add the helper**
+
+Edit `cmd/worker/main.go`. Add a new function near the top of the file (just below `eventEmitter` interface, before `func main()`):
+
+```go
+// resolveWorkflow performs WORKFLOW.md discovery for a prepared workdir
+// and emits the workflow_resolved event before any runner work begins.
+// Returning the workflow_source string lets callers stamp it onto the
+// runner_start payload as a quick-look field; the full provenance lives
+// on the workflow_resolved event itself.
+func resolveWorkflow(ctx context.Context, ev eventEmitter, taskID, workdir string) (*workflow.Workflow, string, error) {
+	wf, res, err := workflow.Resolve(workdir)
+	if err != nil {
+		return nil, "", err
+	}
+	payload := map[string]any{
+		"source":        string(res.Source),
+		"agent_default": wf.Config.Agent.Default,
+		"policy_mode":   wf.Config.Policy.Mode,
+		"tracker_kind":  wf.Config.Tracker.Kind,
+	}
+	if res.Path != "" {
+		payload["path"] = res.Path
+	}
+	if len(res.ShadowedBy) > 0 {
+		payload["shadowed_by"] = res.ShadowedBy
+	}
+	emit(ctx, ev, taskID, task.EventWorkflowResolved, "workflow resolved", payload)
+	return wf, string(res.Source), nil
+}
+```
+
+- [ ] **Step 4: Wire the helper into `runTask`**
+
+In `cmd/worker/main.go`, replace the existing block at line 95 (current `wf, err := workflow.LoadOptional(workdir + "/WORKFLOW.md")`):
+
+```go
+wf, _, err := resolveWorkflow(ctx, ev, t.ID, workdir)
+if err != nil {
+	return workflow.Config{}, err
+}
+```
+
+The discarded return is the workflow_source string — Task 10 wires it through to `runRunnerWithTimeout`. For now `runTask` keeps compiling.
+
+- [ ] **Step 5: Run all worker tests**
+
+Run: `go test ./cmd/worker/`
+
+Expected: all `TestResolveWorkflow_*` pass; pre-existing tests continue to pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/worker/main.go cmd/worker/main_test.go
+git commit -m "feat(worker): emit workflow_resolved via Resolve helper (#10)"
+```
+
+---
+
+## Task 10: `runner_start` payload includes `workflow_source`
+
+**Files:**
+- Modify: `cmd/worker/main.go`
+- Modify: `cmd/worker/main_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/worker/main_test.go`:
+
+```go
+// TestRunRunnerWithTimeout_StampsWorkflowSource verifies the
+// runner_start payload carries workflow_source as a quick-look field.
+// The full provenance is on workflow_resolved; this stamp lets a
+// timeline viewer color the runner stage by source without joining
+// against the earlier event.
+func TestRunRunnerWithTimeout_StampsWorkflowSource(t *testing.T) {
+	ev := &fakeEmitter{}
+	stub := stubRunner{}
+	in := runner.RunInput{Task: task.Task{ID: "tsk_1", Model: "mock"}}
+	if _, err := runRunnerWithTimeout(context.Background(), ev, stub, in, time.Second, "prompt_only"); err != nil {
+		t.Fatalf("runRunnerWithTimeout: %v", err)
+	}
+	got := ev.byKind(task.EventRunnerStart)
+	if len(got) != 1 {
+		t.Fatalf("runner_start events = %d, want 1", len(got))
+	}
+	payload, _ := got[0].Payload.(map[string]any)
+	if payload["workflow_source"] != "prompt_only" {
+		t.Fatalf("workflow_source = %v, want %q", payload["workflow_source"], "prompt_only")
+	}
+}
+
+type stubRunner struct{}
+
+func (stubRunner) Run(_ context.Context, _ runner.RunInput) (runner.Result, error) {
+	return runner.Result{Summary: "ok"}, nil
+}
+```
+
+If `time` is not yet imported in `main_test.go`, add it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/worker/ -run TestRunRunnerWithTimeout_StampsWorkflowSource`
+
+Expected: FAIL — `runRunnerWithTimeout` currently takes 5 args, test passes 6.
+
+- [ ] **Step 3: Extend `runRunnerWithTimeout` signature**
+
+Edit `cmd/worker/main.go`. Change the function signature (currently at line 252):
+
+```go
+func runRunnerWithTimeout(ctx context.Context, ev eventEmitter, r runner.Runner, in runner.RunInput, timeout time.Duration, workflowSource string) (runner.Result, error) {
+```
+
+Inside the function, modify the runner_start emit (currently around line 257):
+
+```go
+emit(ctx, ev, in.Task.ID, task.EventRunnerStart, "runner started", map[string]any{
+	"model":           in.Task.Model,
+	"timeout_ms":      timeout.Milliseconds(),
+	"workflow_source": workflowSource,
+})
+```
+
+- [ ] **Step 4: Update the caller in `runTask`**
+
+In `runTask`, two changes:
+
+1. Capture the `workflow_source` from the `resolveWorkflow` helper introduced in Task 9 — replace `wf, _, err := resolveWorkflow(...)` with:
+
+```go
+wf, workflowSource, err := resolveWorkflow(ctx, ev, t.ID, workdir)
+if err != nil {
+	return workflow.Config{}, err
+}
+```
+
+2. Pass it through to `runRunnerWithTimeout` (around line 136):
+
+```go
+if _, runErr := runRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, Prompt: prompt}, cfg.Agent.Timeout, workflowSource); runErr != nil {
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `go test ./cmd/worker/`
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/worker/main.go cmd/worker/main_test.go
+git commit -m "feat(worker): stamp workflow_source on runner_start payload (#10)"
+```
+
+---
+
+## Task 11: `--print-config` skeleton (default source case)
+
+**Files:**
+- Create: `cmd/worker/print_config.go`
+- Create: `cmd/worker/print_config_test.go`
+- Modify: `cmd/worker/main.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/worker/print_config_test.go`:
+
+```go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestPrintConfig_DefaultSource verifies the simplest case: an empty
+// workdir resolves to source=default, and the JSON output reports it
+// without a path or shadowed_by field.
+func TestPrintConfig_DefaultSource(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := printConfig(dir, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	var out struct {
+		Resolution struct {
+			Source     string   `json:"source"`
+			Path       string   `json:"path,omitempty"`
+			ShadowedBy []string `json:"shadowed_by,omitempty"`
+		} `json:"resolution"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout: %s", err, stdout.String())
+	}
+	if out.Resolution.Source != "default" {
+		t.Fatalf("resolution.source = %q, want %q", out.Resolution.Source, "default")
+	}
+	if out.Resolution.Path != "" {
+		t.Fatalf("resolution.path = %q, want empty", out.Resolution.Path)
+	}
+}
+```
+
+`t.TempDir()` is part of `testing` — already imported transitively.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/worker/ -run TestPrintConfig_DefaultSource`
+
+Expected: FAIL — "undefined: printConfig".
+
+- [ ] **Step 3: Create `cmd/worker/print_config.go`**
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// printConfigOutput is the JSON shape of `worker --print-config <dir>`.
+// Stable: external tooling may consume it.
+type printConfigOutput struct {
+	Resolution     printConfigResolution `json:"resolution"`
+	Config         workflow.Config       `json:"config"`
+	PromptTemplate promptSummary         `json:"prompt_template"`
+}
+
+type printConfigResolution struct {
+	Source     string   `json:"source"`
+	Path       string   `json:"path,omitempty"`
+	ShadowedBy []string `json:"shadowed_by,omitempty"`
+}
+
+// promptSummary is intentionally not the full prompt body. See spec
+// section "Why prompt body is summarized, not printed" for the rationale.
+type promptSummary struct {
+	Length    int    `json:"length"`
+	FirstLine string `json:"first_line"`
+}
+
+// printConfig writes the effective workflow for workdir as JSON to
+// stdout. Returns the process exit code (0 on success, 1 on schema
+// validation error). Used both by main()'s --print-config dispatch and
+// by tests; stdout/stderr are explicit io.Writer parameters so tests
+// can capture the output without subprocessing.
+func printConfig(workdir string, stdout, stderr io.Writer) int {
+	wf, res, err := workflow.Resolve(workdir)
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return 1
+	}
+	out := printConfigOutput{
+		Resolution: printConfigResolution{
+			Source:     string(res.Source),
+			Path:       res.Path,
+			ShadowedBy: res.ShadowedBy,
+		},
+		Config:         wf.Config,
+		PromptTemplate: promptSummary{}, // populated in Task 12
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return 1
+	}
+	return 0
+}
+```
+
+- [ ] **Step 4: Wire `main()` dispatch**
+
+In `cmd/worker/main.go`, at the top of `func main()` (before `ctx := context.Background()`):
+
+```go
+func main() {
+	if len(os.Args) >= 3 && os.Args[1] == "--print-config" {
+		os.Exit(printConfig(os.Args[2], os.Stdout, os.Stderr))
+	}
+	ctx := context.Background()
+	// ... rest unchanged
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./cmd/worker/ -run TestPrintConfig_DefaultSource`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/worker/print_config.go cmd/worker/print_config_test.go cmd/worker/main.go
+git commit -m "feat(worker): add --print-config subcommand skeleton (#10)"
+```
+
+---
+
+## Task 12: `--print-config` populates config and summarizes prompt body
+
+**Files:**
+- Modify: `cmd/worker/print_config.go`
+- Modify: `cmd/worker/print_config_test.go`
+
+- [ ] **Step 1: Write the failing test (canary included)**
+
+Append to `cmd/worker/print_config_test.go`. Merge `os`, `path/filepath`, `strings` into the existing `import` block (do **not** add a second `import (…)` group — Go's tooling complains):
+
+```go
+// TestPrintConfig_FileSourceWithPromptCanary covers two contracts at once:
+//
+//  1. Source=file populates config from the front matter (here: a
+//     non-default agent.default and tracker.kind).
+//  2. The prompt body is summarized rather than echoed. We embed a
+//     recognizable canary string in the body and assert it never reaches
+//     stdout. This is the spec's safety contract — see "Why prompt body
+//     is summarized, not printed".
+func TestPrintConfig_FileSourceWithPromptCanary(t *testing.T) {
+	dir := t.TempDir()
+	canary := "SHOULD_NOT_LEAK_xyz"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  default: codex\ntracker:\n  kind: linear\n---\nFirst line of prompt template.\nSecond line includes canary " + canary + " in the middle.\nMore body...\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+
+	if strings.Contains(stdout.String(), canary) {
+		t.Fatalf("canary %q leaked into stdout:\n%s", canary, stdout.String())
+	}
+
+	var out struct {
+		Resolution struct {
+			Source string `json:"source"`
+		} `json:"resolution"`
+		Config struct {
+			Agent struct {
+				Default string `json:"default"`
+			} `json:"agent"`
+		} `json:"config"`
+		PromptTemplate struct {
+			Length    int    `json:"length"`
+			FirstLine string `json:"first_line"`
+		} `json:"prompt_template"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout: %s", err, stdout.String())
+	}
+	if out.Resolution.Source != "file" {
+		t.Fatalf("source = %q, want %q", out.Resolution.Source, "file")
+	}
+	if out.Config.Agent.Default != "codex" {
+		t.Fatalf("agent.default = %q, want %q", out.Config.Agent.Default, "codex")
+	}
+	if out.PromptTemplate.FirstLine != "First line of prompt template." {
+		t.Fatalf("first_line = %q", out.PromptTemplate.FirstLine)
+	}
+	if out.PromptTemplate.Length <= 0 {
+		t.Fatalf("length = %d, want > 0", out.PromptTemplate.Length)
+	}
+}
+```
+
+After this edit the import block at the top of `cmd/worker/print_config_test.go` should be:
+
+```go
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/worker/ -run TestPrintConfig_FileSourceWithPromptCanary`
+
+Expected: FAIL — `first_line` is empty (Task 11's stub).
+
+- [ ] **Step 3: Implement `summarizePrompt`**
+
+Edit `cmd/worker/print_config.go`. Add a helper function:
+
+```go
+const promptFirstLineMaxBytes = 200
+
+// summarizePrompt produces the bounded prompt summary published by
+// --print-config. Length is the byte length of the trimmed body so a
+// reader can sanity-check completeness; FirstLine is truncated to keep
+// debug output cheap to paste even when an author writes a long single
+// line. The full body is never echoed (see spec safety contract).
+func summarizePrompt(body string) promptSummary {
+	trimmed := strings.TrimSpace(body)
+	first := trimmed
+	if i := strings.IndexByte(first, '\n'); i >= 0 {
+		first = first[:i]
+	}
+	if len(first) > promptFirstLineMaxBytes {
+		first = first[:promptFirstLineMaxBytes]
+	}
+	return promptSummary{
+		Length:    len(trimmed),
+		FirstLine: first,
+	}
+}
+```
+
+Add `"strings"` to the imports.
+
+Then in `printConfig`, populate `out.PromptTemplate`:
+
+```go
+out := printConfigOutput{
+	Resolution: printConfigResolution{
+		Source:     string(res.Source),
+		Path:       res.Path,
+		ShadowedBy: res.ShadowedBy,
+	},
+	Config:         wf.Config,
+	PromptTemplate: summarizePrompt(wf.PromptTemplate),
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./cmd/worker/`
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/worker/print_config.go cmd/worker/print_config_test.go
+git commit -m "feat(worker): summarize prompt body in --print-config (#10)"
+```
+
+---
+
+## Task 13: `--print-config` masks `tracker.api_key`
+
+**Files:**
+- Modify: `cmd/worker/print_config.go`
+- Modify: `cmd/worker/print_config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/worker/print_config_test.go`:
+
+```go
+// TestPrintConfig_MasksTrackerAPIKey verifies the secret-masking
+// contract from the spec. Even when --print-config is used legitimately
+// for debugging, the API key must never reach stdout. We test with the
+// env-var indirection style that examples/WORKFLOW.md uses, since that
+// is the realistic source of a non-empty key.
+func TestPrintConfig_MasksTrackerAPIKey(t *testing.T) {
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin_super_secret_value")
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  api_key: $AIOPS_TEST_LINEAR_KEY\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	got := stdout.String()
+	if strings.Contains(got, "lin_super_secret_value") {
+		t.Fatalf("api_key value leaked into stdout:\n%s", got)
+	}
+	if !strings.Contains(got, `"api_key": "***"`) {
+		t.Fatalf("api_key not masked; stdout:\n%s", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/worker/ -run TestPrintConfig_MasksTrackerAPIKey`
+
+Expected: FAIL — `api_key` value appears in stdout because `wf.Config` is encoded as-is.
+
+- [ ] **Step 3: Add masking helper**
+
+Edit `cmd/worker/print_config.go`. Add:
+
+```go
+const maskedSecret = "***"
+
+// maskSecrets rewrites secret-bearing fields on a Config to a fixed
+// placeholder before serialization. The function takes its argument by
+// value; the workflow.Config used by the running worker is never
+// touched. Currently only Tracker.APIKey is masked — extend this list
+// when new secret-bearing fields are added to the schema.
+func maskSecrets(cfg workflow.Config) workflow.Config {
+	if cfg.Tracker.APIKey != "" {
+		cfg.Tracker.APIKey = maskedSecret
+	}
+	return cfg
+}
+```
+
+In `printConfig`, replace `Config: wf.Config` with:
+
+```go
+Config: maskSecrets(wf.Config),
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./cmd/worker/`
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/worker/print_config.go cmd/worker/print_config_test.go
+git commit -m "feat(worker): mask tracker.api_key in --print-config output (#10)"
+```
+
+---
+
+## Task 14: `--print-config` schema errors → stderr, exit 1
+
+**Files:**
+- Modify: `cmd/worker/print_config_test.go`
+
+The `printConfig` function from Task 11 already returns 1 and writes to stderr when `Resolve` fails. Pin the contract.
+
+- [ ] **Step 1: Write the test**
+
+Append to `cmd/worker/print_config_test.go`:
+
+```go
+// TestPrintConfig_SchemaErrorReturnsExitOne pins the contract that
+// schema validation failures produce a non-zero exit and route the
+// human-readable error to stderr. Stdout must remain empty so a script
+// piping the JSON elsewhere does not feed it a malformed document.
+func TestPrintConfig_SchemaErrorReturnsExitOne(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n---\nprompt\n" // no clone_url
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := printConfig(dir, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout not empty on error: %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "repo.clone_url") {
+		t.Fatalf("stderr missing field name: %s", stderr.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `go test ./cmd/worker/ -run TestPrintConfig_SchemaErrorReturnsExitOne`
+
+Expected: PASS — Task 11's implementation already exits 1 and writes to stderr.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/worker/print_config_test.go
+git commit -m "test(worker): pin --print-config error semantics (#10)"
+```
+
+---
+
+## Task 15: README discovery section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Locate the insertion point**
+
+Run: `grep -n "internal/workflow" /Users/yvan/developer/aiops-platform/README.md`
+
+Expected line: `internal/workflow: loads repo-owned WORKFLOW.md configuration and prompt body.`
+
+This is around line 31, inside the project layout list. The new section goes immediately after the layout list ends (the README has a blank line before the next H2; insert there).
+
+- [ ] **Step 2: Write the section**
+
+Add this content to `README.md`, placed before the existing `## Two-track workflow` heading or wherever the project layout block ends:
+
+```markdown
+## WORKFLOW.md discovery
+
+The worker looks for `WORKFLOW.md` in three locations and uses the first one it finds:
+
+1. `<repo>/WORKFLOW.md`
+2. `<repo>/.aiops/WORKFLOW.md`
+3. `<repo>/.github/WORKFLOW.md`
+
+When multiple files exist, lower-priority files are recorded as `shadowed_by` on the `workflow_resolved` event but are otherwise ignored. The worker does not warn or fail.
+
+If none of the three exist, the worker proceeds with built-in defaults:
+
+| Setting | Default |
+|---------|---------|
+| `agent.default` | `mock` |
+| `agent.timeout` | `30m` |
+| `agent.max_concurrent_agents` | `1` |
+| `pr.draft` | `false` |
+| `pr.labels` | `[ai-generated, needs-review]` |
+| `policy.mode` | `draft_pr` |
+| `policy.max_changed_files` | `12` |
+| `policy.max_changed_loc` | `300` |
+| `verify.commands` | none |
+
+A `WORKFLOW.md` with no YAML front matter (just a prompt body) is supported: the body becomes the prompt template, all other settings fall through to the defaults above. The `workflow_resolved` event records this as `source: prompt_only` so an operator can tell apart "ran with full Symphony config" from "ran with body-only template".
+
+To inspect the effective configuration for a workdir without consuming a task:
+
+```bash
+worker --print-config /path/to/repo/clone
+```
+
+The output is JSON. `tracker.api_key` is masked as `***`; the prompt template is summarized (length + first line) rather than printed verbatim — `cat <resolution.path>` to see the full body.
+
+For post-hoc inspection, the `workflow_resolved` task event records the source, path, and shadowed list of every run.
+```
+
+- [ ] **Step 3: Verify the README still reads coherently**
+
+Run: `grep -n "## " /Users/yvan/developer/aiops-platform/README.md`
+
+Expected: section ordering still flows naturally (project layout → WORKFLOW.md discovery → Two-track workflow / etc.).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document WORKFLOW.md discovery contract (#10)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `go test ./...`
+
+Expected: all packages pass.
+
+- [ ] **Step 2: Run `go vet`**
+
+Run: `go vet ./...`
+
+Expected: clean.
+
+- [ ] **Step 3: Smoke-test `--print-config` against the in-tree example**
+
+Run:
+```bash
+go build -o /tmp/aiops-worker ./cmd/worker
+mkdir -p /tmp/aiops-pc-smoke
+cp examples/WORKFLOW.md /tmp/aiops-pc-smoke/WORKFLOW.md
+/tmp/aiops-worker --print-config /tmp/aiops-pc-smoke
+```
+
+Expected: JSON document with `resolution.source = "file"`, `resolution.path = "WORKFLOW.md"`, no leakage of any value matching the contents of `$LINEAR_API_KEY`.
+
+- [ ] **Step 4: Confirm acceptance criteria from issue #10**
+
+Walk the four lines of issue #10 against the merged code:
+- [ ] Worker loads repo `WORKFLOW.md` when present — Tasks 2, 4
+- [ ] Worker uses safe defaults when absent — Task 1
+- [ ] Task event records which workflow file/default was used — Tasks 8, 9, 10
+- [ ] README documents where `WORKFLOW.md` should live — Task 15
+
+- [ ] **Step 5: Open PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "feat: workflow discovery and fallback (#10)" --body "$(cat <<'EOF'
+## Summary
+- Adds workflow.Resolve(workdir) with documented precedence (root > .aiops/ > .github/) and source classification (file / prompt_only / default).
+- New workflow_resolved task event captures source, path, shadowed_by, and key effective config fields.
+- New worker --print-config <workdir> debug subcommand; masks tracker.api_key and summarizes the prompt body to avoid leaks via shell history / support bundles.
+- README documents the discovery contract and the default values an absent WORKFLOW.md falls back to.
+
+Closes #10. Spec at docs/superpowers/specs/2026-05-09-workflow-discovery-fallback-design.md.
+
+## Test plan
+- [ ] go test ./... passes
+- [ ] worker --print-config against examples/WORKFLOW.md does not leak tracker.api_key value
+- [ ] worker --print-config against an empty workdir reports source=default
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-09-workflow-discovery-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-09-workflow-discovery-fallback-design.md
@@ -204,17 +204,35 @@ Emitted exactly once per task, after `Resolve` succeeds, before `runner.New`. If
     "tracker": { "api_key": "***", "...": "..." },
     "agent": { "default": "codex", "...": "..." }
   },
-  "prompt_template": "<full prompt body>"
+  "prompt_template": {
+    "length": 1234,
+    "first_line": "You are working on a personal AI coding task."
+  }
 }
 ```
 
 ### Secret masking
 
-Before serialization, walk the `Config` and replace these fields with `"***"` if non-empty:
+Before serialization, replace `Tracker.APIKey` with `"***"` if non-empty.
 
-- `Tracker.APIKey`
+This is the only secret-bearing field today. The list lives next to `printConfig` so a future schema addition has an obvious place to land.
 
-(This is the only secret-bearing field today. The list lives next to `printConfig` so a future schema addition has an obvious place to land.)
+### Why prompt body is summarized, not printed
+
+The prompt template is treated as opaque text by the worker, and `prompt_only` `WORKFLOW.md` files allow the body to be anything an author chooses to put there. `--print-config` output gets pasted into shell history, support bundles, gists, and CI logs — venues with broader visibility than the repo. Echoing the entire prompt verbatim would create an asymmetric safety contract (we mask `api_key` but dump unbounded body bytes next to it).
+
+Instead the debug command emits a small, deterministic summary:
+
+```go
+type promptSummary struct {
+    Length    int    `json:"length"`     // utf-8 byte length of the trimmed body
+    FirstLine string `json:"first_line"` // first non-empty line, truncated at 200 bytes
+}
+```
+
+A reader who needs the full prompt can `cat <resolution.path>` directly — the file is right there. We deliberately do **not** add an `--include-prompt` flag: extra knobs invite misuse, and the local file is the canonical source.
+
+This is a usability/safety contract decision, not a redaction policy: we make no claim that the summary scrubs secrets a determined operator embeds in a prompt. The contract is "this debug command does not enlarge the leak surface beyond the config fields whose schema we own."
 
 ### Wiring
 
@@ -250,6 +268,7 @@ A bare `os.Args` check, not the `flag` package: one sub-command, one positional.
 - Assert `runner_start` payload contains `workflow_source`.
 - `--print-config` against a temp workdir for each of the three layouts (root / `.aiops/` / `.github/`); decode JSON; assert `resolution.source` and `resolution.path`.
 - `--print-config` with `Tracker.APIKey` set in front matter; assert output contains `"api_key":"***"`, never the original value.
+- `--print-config` with a long prompt body (e.g. 5 KB containing a recognizable canary string `SHOULD_NOT_LEAK_xyz`); decode JSON; assert `prompt_template.length` equals the trimmed byte count, `prompt_template.first_line` is truncated at 200 bytes, and the canary string does NOT appear anywhere in stdout.
 
 ## Documentation
 

--- a/docs/superpowers/specs/2026-05-09-workflow-discovery-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-09-workflow-discovery-fallback-design.md
@@ -1,0 +1,280 @@
+# Workflow Discovery and Fallback Behavior
+
+**Issue:** [#10](../../../) — [M2][P0] Define workflow discovery and fallback behavior
+**Date:** 2026-05-09
+**Status:** Approved (pending implementation plan)
+
+## Problem
+
+The worker is non-deterministic about *where* `WORKFLOW.md` lives and *what was used* on a given run. Today:
+
+- Discovery is hardcoded to `<workdir>/WORKFLOW.md` (`cmd/worker/main.go:95`).
+- `workflow.LoadOptional` silently substitutes built-in defaults when the file is absent — but no task event records that this happened, so an operator inspecting the event stream cannot tell apart "ran with the repo's WORKFLOW.md", "ran with a prompt-only file", and "ran with zero repo configuration".
+- README mentions `WORKFLOW.md` in passing but does not define a discovery contract.
+
+This is the central contract for Symphony-style operation; downstream M3 work (Linear status transitions) and M4 work (verifier independence) both assume it is settled.
+
+## Goals
+
+1. Worker loads repo `WORKFLOW.md` from a documented set of locations, with a documented precedence.
+2. Worker uses safe built-in defaults when no `WORKFLOW.md` is found.
+3. Every task event stream records which workflow source was used and where it was found.
+4. README documents the contract so a repo author can predict worker behavior without reading Go.
+5. A `worker --print-config <workdir>` debug entry-point lets a human inspect the effective config without consuming a task or touching the database.
+
+## Non-Goals
+
+- Changing `cmd/linear-poller`. The poller takes an explicit path argument; discovery is a worker-side concern.
+- Deleting `workflow.LoadOptional`. It is marked deprecated; existing callers (notably any future `cmd/api` use) keep working until they migrate.
+- A `--diff-against-defaults` mode, multiple output formats, or YAML output for `--print-config`.
+- Replacing the worker's `os.Args` handling with the `flag` package. One positional sub-command does not justify it.
+- Emitting a separate `workflow_shadowed` warning event. The shadow list is carried inside `workflow_resolved`.
+
+## Discovery Contract
+
+Worker searches the workdir in declared order. **First hit wins.**
+
+| Priority | Path |
+|----------|------|
+| 1 | `<workdir>/WORKFLOW.md` |
+| 2 | `<workdir>/.aiops/WORKFLOW.md` |
+| 3 | `<workdir>/.github/WORKFLOW.md` |
+
+If multiple files exist, the lower-priority ones are recorded as shadowed (data only — no warning event, no error).
+
+If none of the three exist, the worker proceeds with built-in defaults. This preserves the current `LoadOptional` behavior of "every repo can run, even pre-Symphony adoption."
+
+### Source classification
+
+The `Resolution.Source` field is one of:
+
+- `file` — a `WORKFLOW.md` was found and contains a YAML front-matter block.
+- `prompt_only` — a `WORKFLOW.md` was found but has no front matter; the worker uses the file's body as the prompt template and built-in defaults for everything else. Backward-compatible with the contract pinned by `TestLoad_AcceptsPromptOnlyFile`.
+- `default` — no file found; both config and prompt come from `DefaultConfig()` / `DefaultPrompt()`.
+
+### Error semantics
+
+- Schema validation errors from a found file (missing `repo.clone_url`, unsupported `tracker.kind`, etc.) propagate. The worker does **not** silently fall back to defaults — that would mask a real configuration mistake.
+- `os.Stat` errors other than `IsNotExist` (e.g., permission denied) propagate, matching `LoadOptional`'s current semantics.
+
+## API Surface
+
+New, in `internal/workflow`:
+
+```go
+type Source string
+
+const (
+    SourceFile       Source = "file"
+    SourcePromptOnly Source = "prompt_only"
+    SourceDefault    Source = "default"
+)
+
+type Resolution struct {
+    Source     Source
+    Path       string   // repo-relative, "" when Source=default
+    ShadowedBy []string // repo-relative, declaration order, omitempty
+}
+
+func Resolve(workdir string) (*Workflow, *Resolution, error)
+```
+
+Rationale for `Resolution` as a separate type rather than fields on `Workflow`:
+
+- `Workflow` is a description of *what* the configuration is. `Resolution` is a runtime fact about *where it came from* on this particular invocation. Mixing them muddles two lifetimes (config can be cached/serialized; resolution cannot).
+- The shadow list has no meaning outside discovery. Putting it on `Workflow` would force every other `Workflow` constructor (tests, future cached loads) to think about it.
+
+### Implementation sketch
+
+```go
+func Resolve(workdir string) (*Workflow, *Resolution, error) {
+    candidates := []string{
+        "WORKFLOW.md",
+        ".aiops/WORKFLOW.md",
+        ".github/WORKFLOW.md",
+    }
+    var found string
+    var shadows []string
+    for _, rel := range candidates {
+        abs := filepath.Join(workdir, rel)
+        if _, err := os.Stat(abs); err == nil {
+            if found == "" {
+                found = rel
+            } else {
+                shadows = append(shadows, rel)
+            }
+        } else if !os.IsNotExist(err) {
+            return nil, nil, err
+        }
+    }
+    if found == "" {
+        cfg := DefaultConfig()
+        expandConfig(&cfg)
+        return &Workflow{Config: cfg, PromptTemplate: DefaultPrompt()},
+            &Resolution{Source: SourceDefault},
+            nil
+    }
+    wf, err := Load(filepath.Join(workdir, found))
+    if err != nil {
+        return nil, nil, err
+    }
+    src := SourceFile
+    if !hasFrontMatterAt(filepath.Join(workdir, found)) {
+        src = SourcePromptOnly
+    }
+    return wf, &Resolution{Source: src, Path: found, ShadowedBy: shadows}, nil
+}
+```
+
+`hasFrontMatterAt` is a small helper that re-runs `splitFrontMatter` on the bytes (`Load` already does this internally; rather than threading a flag out of `Workflow`, classify here). The double parse is cheap relative to `git clone` / runner invocation and keeps `Workflow` unchanged.
+
+### Deprecation
+
+`LoadOptional` gets a doc comment:
+
+```
+// Deprecated: use Resolve(workdir) for repo-relative discovery and
+// resolution metadata. Retained for callers that pass an explicit path.
+```
+
+`Load(path)` is unchanged.
+
+## Worker Integration
+
+`cmd/worker/main.go runTask`:
+
+```go
+wf, res, err := workflow.Resolve(workdir)
+if err != nil {
+    return workflow.Config{}, err
+}
+payload := map[string]any{
+    "source":        string(res.Source),
+    "agent_default": wf.Config.Agent.Default,
+    "policy_mode":   wf.Config.Policy.Mode,
+    "tracker_kind":  wf.Config.Tracker.Kind,
+}
+if res.Path != "" {
+    payload["path"] = res.Path
+}
+if len(res.ShadowedBy) > 0 {
+    payload["shadowed_by"] = res.ShadowedBy
+}
+emit(ctx, ev, t.ID, task.EventWorkflowResolved, "workflow resolved", payload)
+```
+
+`path` and `shadowed_by` are added conditionally so that the `default` source case does not emit an empty `path: ""` or `shadowed_by: []`. `map[string]any` has no `omitempty` mechanism — the conditional inserts make the contract explicit.
+
+The existing `runner_start` payload gets one additional key:
+
+```go
+"workflow_source": string(res.Source)
+```
+
+`res` is threaded through `runTask` as a local; no changes to existing function signatures other than the worker's own.
+
+## New Event
+
+`internal/task/task.go`:
+
+```go
+EventWorkflowResolved = "workflow_resolved"
+```
+
+Emitted exactly once per task, after `Resolve` succeeds, before `runner.New`. If `Resolve` returns an error (schema validation), no `workflow_resolved` event is emitted — there was nothing to resolve. The task fails through the existing error path.
+
+## `worker --print-config <workdir>` Subcommand
+
+### Behavior
+
+- `worker --print-config <workdir>` runs `workflow.Resolve(workdir)` and writes JSON to stdout.
+- Schema validation errors go to stderr, exit code 1.
+- Does **not** open a database connection or read `DATABASE_URL`.
+- Output shape:
+
+```json
+{
+  "resolution": {
+    "source": "file",
+    "path": ".aiops/WORKFLOW.md",
+    "shadowed_by": ["WORKFLOW.md"]
+  },
+  "config": {
+    "repo": { "...": "..." },
+    "tracker": { "api_key": "***", "...": "..." },
+    "agent": { "default": "codex", "...": "..." }
+  },
+  "prompt_template": "<full prompt body>"
+}
+```
+
+### Secret masking
+
+Before serialization, walk the `Config` and replace these fields with `"***"` if non-empty:
+
+- `Tracker.APIKey`
+
+(This is the only secret-bearing field today. The list lives next to `printConfig` so a future schema addition has an obvious place to land.)
+
+### Wiring
+
+```go
+func main() {
+    if len(os.Args) >= 3 && os.Args[1] == "--print-config" {
+        os.Exit(printConfig(os.Args[2]))
+    }
+    // existing main loop
+}
+```
+
+A bare `os.Args` check, not the `flag` package: one sub-command, one positional.
+
+## Testing
+
+### `internal/workflow/loader_test.go`
+
+| Case | Expected |
+|------|----------|
+| All three locations empty | `Source=default, Path="", ShadowedBy=nil` |
+| Only root, with front matter | `Source=file, Path="WORKFLOW.md"` |
+| Only `.aiops/` | `Source=file, Path=".aiops/WORKFLOW.md"` |
+| Only `.github/` | `Source=file, Path=".github/WORKFLOW.md"` |
+| Root + `.aiops/` | `Path="WORKFLOW.md"`, `ShadowedBy=[".aiops/WORKFLOW.md"]` |
+| Root + `.aiops/` + `.github/` | `ShadowedBy=[".aiops/WORKFLOW.md", ".github/WORKFLOW.md"]` (declared order) |
+| Only root, prompt-only body | `Source=prompt_only, Path="WORKFLOW.md"` |
+| Only root, front matter missing `clone_url` | error mentions `repo.clone_url` and the path |
+
+### `cmd/worker/main_test.go`
+
+- Fake `eventEmitter` captures emitted events; assert `workflow_resolved` is present with `source` and `agent_default` keys on the success path.
+- Assert `runner_start` payload contains `workflow_source`.
+- `--print-config` against a temp workdir for each of the three layouts (root / `.aiops/` / `.github/`); decode JSON; assert `resolution.source` and `resolution.path`.
+- `--print-config` with `Tracker.APIKey` set in front matter; assert output contains `"api_key":"***"`, never the original value.
+
+## Documentation
+
+`README.md` gains a "WORKFLOW.md discovery" section near line 31 (the existing `internal/workflow` mention). Contents:
+
+- Three search locations, in priority order.
+- What "absent" means: built-in defaults, with the operationally interesting ones spelled out (`agent.default: mock`, `agent.timeout: 30m`, `pr.draft: false`, `pr.labels: [ai-generated, needs-review]`, no verify commands, no policy deny-paths). Reader should not need to open Go to predict behavior.
+- Prompt-only files are supported and produce `Source=prompt_only`.
+- Pointer to `worker --print-config <workdir>` for debugging.
+- Pointer to the `workflow_resolved` event for post-hoc inspection.
+
+## Files Changed
+
+1. `internal/workflow/loader.go` — `Source` constants, `Resolution` type, `Resolve` function, `LoadOptional` deprecation comment, `hasFrontMatterAt` helper.
+2. `internal/workflow/loader_test.go` — discovery test matrix above.
+3. `internal/task/task.go` — `EventWorkflowResolved` constant.
+4. `cmd/worker/main.go` — `runTask` switches to `Resolve`; emits `workflow_resolved`; `runner_start` payload gains `workflow_source`; `main()` entry handles `--print-config`; new `printConfig` and secret-masking helpers.
+5. `cmd/worker/main_test.go` — emit assertions and `--print-config` tests.
+6. `README.md` — discovery section.
+
+## Acceptance Criteria Mapping
+
+| Issue #10 criterion | Where addressed |
+|---------------------|-----------------|
+| Worker loads repo `WORKFLOW.md` when present | `Resolve` discovery (root → `.aiops/` → `.github/`) |
+| Worker uses safe defaults when absent | `Source=default` branch in `Resolve` |
+| Task event records which workflow file/default was used | `EventWorkflowResolved` + `workflow_source` on `runner_start` |
+| README documents where `WORKFLOW.md` should live | New discovery section |

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -20,18 +20,19 @@ const (
 // Event kinds emitted by the queue store and the worker. Keep these in sync
 // with the docs in docs/runbooks/task-api.md and the cmd/worker stage helpers.
 const (
-	EventEnqueued      = "enqueued"
-	EventClaimed       = "claimed"
-	EventRunnerStart   = "runner_start"
-	EventRunnerEnd     = "runner_end"
-	EventRunnerTimeout = "runner_timeout"
-	EventVerifyStart   = "verify_start"
-	EventVerifyEnd     = "verify_end"
-	EventPush          = "push"
-	EventPRCreated     = "pr_created"
-	EventPRReused      = "pr_reused"
-	EventSucceeded     = "succeeded"
-	EventFailedAttempt = "failed_attempt"
+	EventEnqueued         = "enqueued"
+	EventClaimed          = "claimed"
+	EventWorkflowResolved = "workflow_resolved"
+	EventRunnerStart      = "runner_start"
+	EventRunnerEnd        = "runner_end"
+	EventRunnerTimeout    = "runner_timeout"
+	EventVerifyStart      = "verify_start"
+	EventVerifyEnd        = "verify_end"
+	EventPush             = "push"
+	EventPRCreated        = "pr_created"
+	EventPRReused         = "pr_reused"
+	EventSucceeded        = "succeeded"
+	EventFailedAttempt    = "failed_attempt"
 )
 
 type Task struct {

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -3,47 +3,47 @@ package workflow
 import "time"
 
 type Config struct {
-	Repo      RepoConfig      `yaml:"repo"`
-	Tracker   TrackerConfig   `yaml:"tracker"`
-	Workspace WorkspaceConfig `yaml:"workspace"`
-	Agent     AgentConfig     `yaml:"agent"`
-	Codex     CommandConfig   `yaml:"codex"`
-	Claude    CommandConfig   `yaml:"claude"`
-	Policy    PolicyConfig    `yaml:"policy"`
-	Verify    VerifyConfig    `yaml:"verify"`
-	PR        PRConfig        `yaml:"pr"`
+	Repo      RepoConfig      `yaml:"repo" json:"repo"`
+	Tracker   TrackerConfig   `yaml:"tracker" json:"tracker"`
+	Workspace WorkspaceConfig `yaml:"workspace" json:"workspace"`
+	Agent     AgentConfig     `yaml:"agent" json:"agent"`
+	Codex     CommandConfig   `yaml:"codex" json:"codex"`
+	Claude    CommandConfig   `yaml:"claude" json:"claude"`
+	Policy    PolicyConfig    `yaml:"policy" json:"policy"`
+	Verify    VerifyConfig    `yaml:"verify" json:"verify"`
+	PR        PRConfig        `yaml:"pr" json:"pr"`
 }
 
 type RepoConfig struct {
-	Owner         string `yaml:"owner"`
-	Name          string `yaml:"name"`
-	CloneURL      string `yaml:"clone_url"`
-	DefaultBranch string `yaml:"default_branch"`
+	Owner         string `yaml:"owner" json:"owner"`
+	Name          string `yaml:"name" json:"name"`
+	CloneURL      string `yaml:"clone_url" json:"clone_url"`
+	DefaultBranch string `yaml:"default_branch" json:"default_branch"`
 }
 
 type TrackerConfig struct {
-	Kind           string   `yaml:"kind"`
+	Kind           string   `yaml:"kind" json:"kind"`
 	APIKey         string   `yaml:"api_key" json:"api_key"`
-	TeamKey        string   `yaml:"team_key"`
-	ProjectSlug    string   `yaml:"project_slug"`
-	ActiveStates   []string `yaml:"active_states"`
-	TerminalStates []string `yaml:"terminal_states"`
-	PollIntervalMs int      `yaml:"poll_interval_ms"`
+	TeamKey        string   `yaml:"team_key" json:"team_key"`
+	ProjectSlug    string   `yaml:"project_slug" json:"project_slug"`
+	ActiveStates   []string `yaml:"active_states" json:"active_states"`
+	TerminalStates []string `yaml:"terminal_states" json:"terminal_states"`
+	PollIntervalMs int      `yaml:"poll_interval_ms" json:"poll_interval_ms"`
 }
 
 type WorkspaceConfig struct {
-	Root string `yaml:"root"`
+	Root string `yaml:"root" json:"root"`
 }
 
 type AgentConfig struct {
-	Default             string `yaml:"default"`
-	MaxConcurrentAgents int    `yaml:"max_concurrent_agents"`
-	MaxTurns            int    `yaml:"max_turns"`
+	Default             string `yaml:"default" json:"default"`
+	MaxConcurrentAgents int    `yaml:"max_concurrent_agents" json:"max_concurrent_agents"`
+	MaxTurns            int    `yaml:"max_turns" json:"max_turns"`
 	// Timeout caps a single runner invocation. When exceeded, the runner
 	// subprocess is killed and the task records a `runner_timeout` event.
 	// Configured via YAML as `agent.timeout: 10m`. Zero means use the
 	// schema default of 30m.
-	Timeout time.Duration `yaml:"timeout"`
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
 	// MaxTimeoutRetries bounds how many times a task may be re-queued
 	// after a runner timeout. This is intentionally separate from the
 	// generic max_attempts (which covers verify/policy/other failures)
@@ -52,7 +52,7 @@ type AgentConfig struct {
 	// Pointer-typed so we can distinguish "absent" (nil → schema default
 	// of 1) from "explicitly set to 0" (no retry). Read via
 	// MaxTimeoutRetriesValue() rather than dereferencing directly.
-	MaxTimeoutRetries *int `yaml:"max_timeout_retries"`
+	MaxTimeoutRetries *int `yaml:"max_timeout_retries" json:"max_timeout_retries"`
 }
 
 // MaxTimeoutRetriesValue returns the effective runner-timeout retry
@@ -71,19 +71,19 @@ func (a AgentConfig) MaxTimeoutRetriesValue() int {
 }
 
 type CommandConfig struct {
-	Command string `yaml:"command"`
+	Command string `yaml:"command" json:"command"`
 }
 
 type PolicyConfig struct {
-	Mode            string   `yaml:"mode"`
-	AllowPaths      []string `yaml:"allow_paths"`
-	DenyPaths       []string `yaml:"deny_paths"`
-	MaxChangedFiles int      `yaml:"max_changed_files"`
+	Mode            string   `yaml:"mode" json:"mode"`
+	AllowPaths      []string `yaml:"allow_paths" json:"allow_paths"`
+	DenyPaths       []string `yaml:"deny_paths" json:"deny_paths"`
+	MaxChangedFiles int      `yaml:"max_changed_files" json:"max_changed_files"`
 	// MaxChangedLines bounds the total added+deleted lines reported by
 	// `git diff --numstat`. The legacy YAML key `max_changed_loc` is still
 	// honored via MaxChangedLOC below for back-compat.
-	MaxChangedLines int `yaml:"max_changed_lines"`
-	MaxChangedLOC   int `yaml:"max_changed_loc"`
+	MaxChangedLines int `yaml:"max_changed_lines" json:"max_changed_lines"`
+	MaxChangedLOC   int `yaml:"max_changed_loc" json:"max_changed_loc"`
 }
 
 // LineLimit returns the effective maximum changed lines, preferring the
@@ -96,8 +96,8 @@ func (p PolicyConfig) LineLimit() int {
 }
 
 type VerifyConfig struct {
-	Commands   []string         `yaml:"commands"`
-	SecretScan SecretScanConfig `yaml:"secret_scan"`
+	Commands   []string         `yaml:"commands" json:"commands"`
+	SecretScan SecretScanConfig `yaml:"secret_scan" json:"secret_scan"`
 }
 
 // SecretScanConfig describes an optional pre-push secret scanner that runs
@@ -114,15 +114,15 @@ type VerifyConfig struct {
 type SecretScanConfig struct {
 	// Enabled toggles the hook. When false, the worker skips the scan and
 	// proceeds to push, preserving backward compatibility.
-	Enabled bool `yaml:"enabled"`
+	Enabled bool `yaml:"enabled" json:"enabled"`
 	// Command is argv to exec inside the workspace. The first element is
 	// the binary; remaining elements are passed verbatim. No shell is used,
 	// so quoting/expansion is not performed.
-	Command []string `yaml:"command"`
+	Command []string `yaml:"command" json:"command"`
 	// FailOnFinding controls whether a non-zero exit code blocks the push.
 	// Defaults to true. Set to false to surface findings as a warning event
 	// without aborting (useful while tuning false positives).
-	FailOnFinding *bool `yaml:"fail_on_finding,omitempty"`
+	FailOnFinding *bool `yaml:"fail_on_finding,omitempty" json:"fail_on_finding,omitempty"`
 }
 
 // ShouldFailOnFinding reports whether a non-zero exit from the scanner
@@ -136,9 +136,9 @@ func (s SecretScanConfig) ShouldFailOnFinding() bool {
 }
 
 type PRConfig struct {
-	Draft     bool     `yaml:"draft"`
-	Labels    []string `yaml:"labels"`
-	Reviewers []string `yaml:"reviewers"`
+	Draft     bool     `yaml:"draft" json:"draft"`
+	Labels    []string `yaml:"labels" json:"labels"`
+	Reviewers []string `yaml:"reviewers" json:"reviewers"`
 }
 
 func DefaultConfig() Config {

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -23,7 +23,7 @@ type RepoConfig struct {
 
 type TrackerConfig struct {
 	Kind           string   `yaml:"kind"`
-	APIKey         string   `yaml:"api_key"`
+	APIKey         string   `yaml:"api_key" json:"api_key"`
 	TeamKey        string   `yaml:"team_key"`
 	ProjectSlug    string   `yaml:"project_slug"`
 	ActiveStates   []string `yaml:"active_states"`

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -106,6 +106,14 @@ func rejectRemovedFields(front []byte) error {
 	return nil
 }
 
+// LoadOptional loads a workflow from an explicit path, returning schema
+// defaults when the file does not exist. New worker code should use
+// Resolve(workdir), which handles repo-relative discovery and returns
+// resolution metadata.
+//
+// Deprecated: use Resolve(workdir) for repo-relative discovery. Retained
+// for callers that pass an explicit path (e.g. cmd/linear-poller has a
+// related but separate loader contract).
 func LoadOptional(path string) (*Workflow, error) {
 	wf, err := Load(path)
 	if err == nil {

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,6 +43,14 @@ var resolveCandidates = []string{
 // source. When no file is found, the schema defaults are returned with
 // Source=default.
 func Resolve(workdir string) (*Workflow, *Resolution, error) {
+	info, err := os.Stat(workdir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("workdir %q: %w", workdir, err)
+	}
+	if !info.IsDir() {
+		return nil, nil, fmt.Errorf("workdir %q is not a directory", workdir)
+	}
+
 	var found string
 	var shadows []string
 	for _, rel := range resolveCandidates {

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -1,5 +1,11 @@
 package workflow
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
 // Source describes where the effective workflow came from on a given
 // load. SourceFile means a WORKFLOW.md with valid YAML front matter was
 // found and parsed; SourcePromptOnly means a file existed but had no
@@ -24,13 +30,59 @@ type Resolution struct {
 	ShadowedBy []string // other repo-relative paths that exist but lost precedence
 }
 
-// Resolve discovers WORKFLOW.md inside workdir, applying the documented
-// precedence (root > .aiops/ > .github/), and returns the loaded
-// Workflow alongside a Resolution describing the source. When no file
-// is found, the schema defaults are returned with Source=default.
+var resolveCandidates = []string{
+	"WORKFLOW.md",
+	".aiops/WORKFLOW.md",
+	".github/WORKFLOW.md",
+}
+
+// Resolve discovers WORKFLOW.md inside workdir (expected to be an absolute
+// path), applying the documented precedence (root > .aiops/ > .github/),
+// and returns the loaded Workflow alongside a Resolution describing the
+// source. When no file is found, the schema defaults are returned with
+// Source=default.
 func Resolve(workdir string) (*Workflow, *Resolution, error) {
-	cfg := DefaultConfig()
-	expandConfig(&cfg)
-	wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt()}
-	return wf, &Resolution{Source: SourceDefault}, nil
+	var found string
+	for _, rel := range resolveCandidates {
+		abs := filepath.Join(workdir, rel)
+		info, err := os.Stat(abs)
+		if err == nil && !info.IsDir() {
+			if found == "" {
+				found = rel
+			}
+			continue
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return nil, nil, err
+		}
+	}
+	if found == "" {
+		cfg := DefaultConfig()
+		expandConfig(&cfg)
+		wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt()}
+		return wf, &Resolution{Source: SourceDefault}, nil
+	}
+	abs := filepath.Join(workdir, found)
+	wf, err := Load(abs)
+	if err != nil {
+		return nil, nil, err
+	}
+	return wf, &Resolution{Source: SourceFile, Path: found}, nil
+}
+
+// hasFrontMatterAt returns true when path begins with a YAML front
+// matter fence (`---\n` or `---\r\n`) followed somewhere by a closing
+// fence. Used by Resolve to distinguish prompt-only files from full
+// workflow files without threading a flag out of Load.
+func hasFrontMatterAt(path string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	s := string(b)
+	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
+		return false
+	}
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
+	return strings.Contains(trimmed, "\n---")
 }

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -1,0 +1,36 @@
+package workflow
+
+// Source describes where the effective workflow came from on a given
+// load. SourceFile means a WORKFLOW.md with valid YAML front matter was
+// found and parsed; SourcePromptOnly means a file existed but had no
+// front matter (the body became the prompt template, config came from
+// schema defaults); SourceDefault means no file was found at all.
+type Source string
+
+const (
+	SourceFile       Source = "file"
+	SourcePromptOnly Source = "prompt_only"
+	SourceDefault    Source = "default"
+)
+
+// Resolution carries the runtime fact of how a workflow was loaded for
+// a single task. It is intentionally separate from Workflow because
+// "where did this come from on this invocation" is not a property of
+// the configuration itself; it is per-load metadata that the worker
+// uses to populate the workflow_resolved event.
+type Resolution struct {
+	Source     Source
+	Path       string   // repo-relative; "" when Source == SourceDefault
+	ShadowedBy []string // other repo-relative paths that exist but lost precedence
+}
+
+// Resolve discovers WORKFLOW.md inside workdir, applying the documented
+// precedence (root > .aiops/ > .github/), and returns the loaded
+// Workflow alongside a Resolution describing the source. When no file
+// is found, the schema defaults are returned with Source=default.
+func Resolve(workdir string) (*Workflow, *Resolution, error) {
+	cfg := DefaultConfig()
+	expandConfig(&cfg)
+	wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt()}
+	return wf, &Resolution{Source: SourceDefault}, nil
+}

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -50,10 +50,13 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 			if found == "" {
 				found = rel
 			}
-			continue
-		}
-		if err != nil && !os.IsNotExist(err) {
-			return nil, nil, err
+		} else if err != nil && !os.IsNotExist(err) {
+			// Hard stat errors (permission denied, I/O) on a lower-priority
+			// candidate must not invalidate a winner already found. Only
+			// propagate when no winner has been picked yet.
+			if found == "" {
+				return nil, nil, err
+			}
 		}
 	}
 	if found == "" {
@@ -73,7 +76,9 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 // hasFrontMatterAt returns true when path begins with a YAML front
 // matter fence (`---\n` or `---\r\n`) followed somewhere by a closing
 // fence. Used by Resolve to distinguish prompt-only files from full
-// workflow files without threading a flag out of Load.
+// workflow files without threading a flag out of Load. Mirrors the
+// detection logic in splitFrontMatter (loader.go) — keep the two in
+// sync if the front-matter syntax ever changes.
 func hasFrontMatterAt(path string) bool {
 	b, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -70,7 +70,11 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	return wf, &Resolution{Source: SourceFile, Path: found}, nil
+	src := SourceFile
+	if !hasFrontMatterAt(abs) {
+		src = SourcePromptOnly
+	}
+	return wf, &Resolution{Source: src, Path: found}, nil
 }
 
 // hasFrontMatterAt returns true when path begins with a YAML front

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -43,12 +43,15 @@ var resolveCandidates = []string{
 // Source=default.
 func Resolve(workdir string) (*Workflow, *Resolution, error) {
 	var found string
+	var shadows []string
 	for _, rel := range resolveCandidates {
 		abs := filepath.Join(workdir, rel)
 		info, err := os.Stat(abs)
 		if err == nil && !info.IsDir() {
 			if found == "" {
 				found = rel
+			} else {
+				shadows = append(shadows, rel)
 			}
 		} else if err != nil && !os.IsNotExist(err) {
 			// Hard stat errors (permission denied, I/O) on a lower-priority
@@ -78,7 +81,7 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 	if !hasFront {
 		src = SourcePromptOnly
 	}
-	return wf, &Resolution{Source: src, Path: found}, nil
+	return wf, &Resolution{Source: src, Path: found, ShadowedBy: shadows}, nil
 }
 
 // hasFrontMatterAt returns true when path begins with a YAML front

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -70,8 +70,12 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	hasFront, err := hasFrontMatterAt(abs)
+	if err != nil {
+		return nil, nil, err
+	}
 	src := SourceFile
-	if !hasFrontMatterAt(abs) {
+	if !hasFront {
 		src = SourcePromptOnly
 	}
 	return wf, &Resolution{Source: src, Path: found}, nil
@@ -83,15 +87,22 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 // workflow files without threading a flag out of Load. Mirrors the
 // detection logic in splitFrontMatter (loader.go) — keep the two in
 // sync if the front-matter syntax ever changes.
-func hasFrontMatterAt(path string) bool {
+//
+// Returns the read error rather than silently classifying as false:
+// after Load(path) has succeeded, a read failure here means the file
+// disappeared or became unreadable mid-resolution (TOCTOU race on
+// network filesystems). Misclassifying that as prompt_only would put
+// a wrong Source value on the workflow_resolved event for a file
+// whose contents we successfully parsed moments earlier.
+func hasFrontMatterAt(path string) (bool, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return false
+		return false, err
 	}
 	s := string(b)
 	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
-		return false
+		return false, nil
 	}
 	trimmed := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
-	return strings.Contains(trimmed, "\n---")
+	return strings.Contains(trimmed, "\n---"), nil
 }

--- a/internal/workflow/resolver_test.go
+++ b/internal/workflow/resolver_test.go
@@ -53,3 +53,51 @@ func TestResolve_FindsRootWorkflowFile(t *testing.T) {
 		t.Fatalf("CloneURL = %q, not loaded from front matter", wf.Config.Repo.CloneURL)
 	}
 }
+
+// TestResolve_LowerPriorityStatErrorIgnored guards against a regression
+// where a permission error on .aiops/WORKFLOW.md (or any non-winning
+// candidate) caused Resolve to fail even though the root WORKFLOW.md
+// had already been picked. We can't portably create a "permission
+// denied" error on macOS without changing process privileges, so we
+// instead trigger an EACCES-equivalent by making the parent directory
+// unreadable and confirming Resolve still succeeds via the root file.
+//
+// The platform-portable angle: turn the candidate path into something
+// os.Stat can't classify cleanly. The simplest cross-platform option is
+// to put a directory at the candidate path; os.Stat then returns
+// info.IsDir()=true, the loop's success branch rejects it, and the
+// error branch never fires — so this isn't really the bug we want to
+// pin. Instead skip the symlink dance and write a test that depends on
+// chmod, which is reliable on Linux/macOS and irrelevant on Windows
+// (the CI matrix is Unix-only).
+func TestResolve_LowerPriorityStatErrorIgnored(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: chmod-based permission test does not apply")
+	}
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write root: %v", err)
+	}
+	aiopsDir := filepath.Join(dir, ".aiops")
+	if err := os.Mkdir(aiopsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(aiopsDir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write aiops: %v", err)
+	}
+	// Strip read+execute on the .aiops directory so os.Stat on the file
+	// inside it returns a permission error instead of NotExist.
+	if err := os.Chmod(aiopsDir, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(aiopsDir, 0o755) })
+
+	_, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve must not fail when winner already found; got: %v", err)
+	}
+	if res.Source != SourceFile || res.Path != "WORKFLOW.md" {
+		t.Fatalf("got Source=%q Path=%q; want file/WORKFLOW.md", res.Source, res.Path)
+	}
+}

--- a/internal/workflow/resolver_test.go
+++ b/internal/workflow/resolver_test.go
@@ -184,6 +184,40 @@ func TestResolve_PropagatesSchemaErrors(t *testing.T) {
 	}
 }
 
+// TestResolve_NonExistentWorkdirErrors guards against the silent
+// success that Codex review flagged on PR #52: previously a typo'd
+// path returned SourceDefault, hiding the operator's mistake. Resolve
+// now refuses to proceed when workdir does not exist.
+func TestResolve_NonExistentWorkdirErrors(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "definitely-does-not-exist")
+	_, _, err := Resolve(dir)
+	if err == nil {
+		t.Fatalf("Resolve: expected error for non-existent workdir")
+	}
+	if !strings.Contains(err.Error(), "definitely-does-not-exist") {
+		t.Fatalf("error %q should name the missing path", err.Error())
+	}
+}
+
+// TestResolve_FileWorkdirErrors guards the second precondition: the
+// workdir must be a directory, not a regular file. Without this check
+// Resolve would fall through to "no candidates found" and return
+// defaults, which is the same misleading silent success.
+func TestResolve_FileWorkdirErrors(t *testing.T) {
+	dir := t.TempDir()
+	notDir := filepath.Join(dir, "i-am-a-file")
+	if err := os.WriteFile(notDir, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err := Resolve(notDir)
+	if err == nil {
+		t.Fatalf("Resolve: expected error when workdir is a file")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("error %q should mention 'not a directory'", err.Error())
+	}
+}
+
 // TestResolve_AlternateLocations covers the .aiops/ and .github/
 // fallback locations declared in the discovery contract. Each case
 // puts WORKFLOW.md in exactly one place; precedence (when multiple

--- a/internal/workflow/resolver_test.go
+++ b/internal/workflow/resolver_test.go
@@ -126,3 +126,40 @@ func TestResolve_PromptOnlyFile(t *testing.T) {
 		t.Fatalf("PromptTemplate = %q", wf.PromptTemplate)
 	}
 }
+
+// TestResolve_AlternateLocations covers the .aiops/ and .github/
+// fallback locations declared in the discovery contract. Each case
+// puts WORKFLOW.md in exactly one place; precedence (when multiple
+// exist) is covered by TestResolve_ShadowedBy.
+func TestResolve_AlternateLocations(t *testing.T) {
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n---\nprompt\n"
+	cases := []struct {
+		name string
+		rel  string
+	}{
+		{"aiops_dir", ".aiops/WORKFLOW.md"},
+		{"github_dir", ".github/WORKFLOW.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			abs := filepath.Join(dir, tc.rel)
+			if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			_, res, err := Resolve(dir)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if res.Source != SourceFile {
+				t.Fatalf("Source = %q, want %q", res.Source, SourceFile)
+			}
+			if res.Path != tc.rel {
+				t.Fatalf("Path = %q, want %q", res.Path, tc.rel)
+			}
+		})
+	}
+}

--- a/internal/workflow/resolver_test.go
+++ b/internal/workflow/resolver_test.go
@@ -1,0 +1,29 @@
+package workflow
+
+import (
+	"testing"
+)
+
+// TestResolve_NoFileReturnsDefaults pins the contract from spec section
+// "Discovery Contract": when no WORKFLOW.md exists in any of the search
+// locations, Resolve must succeed with Source=default and the schema
+// defaults applied (so a fresh repo can run with the mock runner).
+func TestResolve_NoFileReturnsDefaults(t *testing.T) {
+	dir := t.TempDir()
+	wf, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: unexpected error: %v", err)
+	}
+	if res.Source != SourceDefault {
+		t.Fatalf("Source = %q, want %q", res.Source, SourceDefault)
+	}
+	if res.Path != "" {
+		t.Fatalf("Path = %q, want empty (no file)", res.Path)
+	}
+	if len(res.ShadowedBy) != 0 {
+		t.Fatalf("ShadowedBy = %v, want empty", res.ShadowedBy)
+	}
+	if wf == nil || wf.Config.Agent.Default != "mock" {
+		t.Fatalf("default Agent.Default = %q, want %q", wf.Config.Agent.Default, "mock")
+	}
+}

--- a/internal/workflow/resolver_test.go
+++ b/internal/workflow/resolver_test.go
@@ -127,6 +127,40 @@ func TestResolve_PromptOnlyFile(t *testing.T) {
 	}
 }
 
+// TestResolve_ShadowedBy covers the precedence contract: when multiple
+// WORKFLOW.md files exist, the first in declaration order wins and the
+// remaining ones are recorded in ShadowedBy in declaration order. The
+// shadow list is data only — Resolve does not warn or error.
+func TestResolve_ShadowedBy(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n---\nprompt\n"
+	for _, rel := range []string{"WORKFLOW.md", ".aiops/WORKFLOW.md", ".github/WORKFLOW.md"} {
+		abs := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	_, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Path != "WORKFLOW.md" {
+		t.Fatalf("Path = %q, want root", res.Path)
+	}
+	want := []string{".aiops/WORKFLOW.md", ".github/WORKFLOW.md"}
+	if len(res.ShadowedBy) != len(want) {
+		t.Fatalf("ShadowedBy = %v, want %v", res.ShadowedBy, want)
+	}
+	for i := range want {
+		if res.ShadowedBy[i] != want[i] {
+			t.Fatalf("ShadowedBy[%d] = %q, want %q", i, res.ShadowedBy[i], want[i])
+		}
+	}
+}
+
 // TestResolve_AlternateLocations covers the .aiops/ and .github/
 // fallback locations declared in the discovery contract. Each case
 // puts WORKFLOW.md in exactly one place; precedence (when multiple

--- a/internal/workflow/resolver_test.go
+++ b/internal/workflow/resolver_test.go
@@ -101,3 +101,28 @@ func TestResolve_LowerPriorityStatErrorIgnored(t *testing.T) {
 		t.Fatalf("got Source=%q Path=%q; want file/WORKFLOW.md", res.Source, res.Path)
 	}
 }
+
+// TestResolve_PromptOnlyFile pins the spec contract that a WORKFLOW.md
+// without a YAML front matter block resolves as Source=prompt_only:
+// the body becomes the prompt template, but config falls through to
+// schema defaults. This is consistent with TestLoad_AcceptsPromptOnlyFile.
+func TestResolve_PromptOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "just a prompt template, no front matter\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wf, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != SourcePromptOnly {
+		t.Fatalf("Source = %q, want %q", res.Source, SourcePromptOnly)
+	}
+	if res.Path != "WORKFLOW.md" {
+		t.Fatalf("Path = %q, want %q", res.Path, "WORKFLOW.md")
+	}
+	if wf.PromptTemplate != "just a prompt template, no front matter" {
+		t.Fatalf("PromptTemplate = %q", wf.PromptTemplate)
+	}
+}

--- a/internal/workflow/resolver_test.go
+++ b/internal/workflow/resolver_test.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -25,5 +27,29 @@ func TestResolve_NoFileReturnsDefaults(t *testing.T) {
 	}
 	if wf == nil || wf.Config.Agent.Default != "mock" {
 		t.Fatalf("default Agent.Default = %q, want %q", wf.Config.Agent.Default, "mock")
+	}
+}
+
+// TestResolve_FindsRootWorkflowFile covers the most common case: a
+// WORKFLOW.md at the repo root with valid YAML front matter resolves
+// as Source=file with the relative path "WORKFLOW.md".
+func TestResolve_FindsRootWorkflowFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n---\nprompt body\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wf, res, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != SourceFile {
+		t.Fatalf("Source = %q, want %q", res.Source, SourceFile)
+	}
+	if res.Path != "WORKFLOW.md" {
+		t.Fatalf("Path = %q, want %q", res.Path, "WORKFLOW.md")
+	}
+	if wf.Config.Repo.CloneURL != "git@example.com:o/r.git" {
+		t.Fatalf("CloneURL = %q, not loaded from front matter", wf.Config.Repo.CloneURL)
 	}
 }

--- a/internal/workflow/resolver_test.go
+++ b/internal/workflow/resolver_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -157,6 +158,28 @@ func TestResolve_ShadowedBy(t *testing.T) {
 	for i := range want {
 		if res.ShadowedBy[i] != want[i] {
 			t.Fatalf("ShadowedBy[%d] = %q, want %q", i, res.ShadowedBy[i], want[i])
+		}
+	}
+}
+
+// TestResolve_PropagatesSchemaErrors guards the contract that Resolve
+// does NOT silently fall back to defaults when a file is found but
+// fails schema validation. Falling back would mask real configuration
+// mistakes and reduce the entire validation effort from #48/#49 to
+// theatre. The error must name the offending field and the file path.
+func TestResolve_PropagatesSchemaErrors(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n---\nprompt\n" // no clone_url
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err := Resolve(dir)
+	if err == nil {
+		t.Fatalf("Resolve: expected error for missing clone_url, got nil")
+	}
+	for _, want := range []string{"repo.clone_url", "WORKFLOW.md"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q: want substring %q", err.Error(), want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #10 (M2 P0). Resolves "where does WORKFLOW.md live and what was actually used on this run" so M3 (Linear status transitions) and M4 (verifier independence) can build on a settled contract.

- **`workflow.Resolve(workdir)`** — searches root → `.aiops/` → `.github/`, first hit wins; lower-priority hits recorded as `shadowed_by` (data only, no warn). Returns `{Source, Path, ShadowedBy}` describing the load. Source is one of `file` / `prompt_only` / `default`.
- **`task.EventWorkflowResolved`** — new event emitted before `runner_start`. Payload always carries `source`, `agent_default`, `policy_mode`, `tracker_kind`; `path` and `shadowed_by` included only when meaningful (no empty keys for the default branch). `runner_start` payload also gains `workflow_source` as a quick-look field.
- **`worker --print-config <workdir>`** — debug subcommand. Resolves the workdir without touching the database, emits JSON. `tracker.api_key` masked as `***`. Prompt body is summarized (`length`, `first_line ≤ 200B`) rather than echoed — see spec section "Why prompt body is summarized, not printed". Schema validation errors → stderr, exit 1.
- **`workflow.Config` json tags** — added across all sub-types (snake_case, matching existing yaml tags) so `--print-config` output is stable and consistent. Previously only `TrackerConfig.APIKey` had a json tag, producing mixed PascalCase/snake_case output.
- **README** — new "WORKFLOW.md discovery" section documents precedence, defaults table, and pointers to `--print-config` / `workflow_resolved`.
- **`workflow.LoadOptional`** marked `// Deprecated:` pointing at `Resolve`. `cmd/linear-poller` continues to use `Load(path)` directly (it has an explicit path argument).

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-09-workflow-discovery-fallback-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-workflow-discovery-fallback.md`

The spec went through one Codex adversarial review round (flagged `--print-config` leaking the prompt body — addressed before implementation by switching to length+first_line summary). Implementation went through two-stage subagent review per task; two mid-implementation fix commits (`fix(workflow): keep Resolve winner when lower-priority stat fails` and `fix(workflow): propagate read errors from hasFrontMatterAt`) address review-flagged edge cases.

## Acceptance criteria (#10)

- ✅ Worker loads repo `WORKFLOW.md` when present — `internal/workflow/resolver.go` `Resolve()`
- ✅ Worker uses safe defaults when absent — `SourceDefault` branch + `cmd/worker/main.go` `resolveWorkflow`
- ✅ Task event records which workflow file/default was used — `task.EventWorkflowResolved` payload + `runner_start.workflow_source`
- ✅ README documents where `WORKFLOW.md` should live

## Test plan

- [x] `go test ./...` — all packages pass under `-race`
- [x] `go vet ./...` — clean
- [x] Smoke `worker --print-config` against `examples/WORKFLOW.md` with a canary `LINEAR_API_KEY=lin_canary_DO_NOT_LEAK` — canary does NOT appear in output, `"api_key": "***"` is present
- [x] All keys in `--print-config` output are lowercase snake_case

## Notes for review

- This PR also brings the spec + plan commits forward (they were authored on local main pre-branch and are inseparable from the implementation history). They land on origin/main when this PR merges.
- `workflow.Config` JSON tags are a behavior change for anything that may JSON-encode Config in the future. Audit found no current callers besides `--print-config`.