### PR TITLE
feat: render agent.timeout as duration string in --print-config

### DIFF
--- a/cmd/worker/print_config.go
+++ b/cmd/worker/print_config.go
@@ -13,8 +13,61 @@ import (
 // Stable: external tooling may consume it.
 type printConfigOutput struct {
 	Resolution     printConfigResolution `json:"resolution"`
-	Config         workflow.Config       `json:"config"`
+	Config         configView            `json:"config"`
 	PromptTemplate promptSummary         `json:"prompt_template"`
+}
+
+// configView mirrors workflow.Config for --print-config output, but
+// substitutes typed-nanosecond fields with human-readable forms. It is
+// deliberately local to this debug command: keeping the conversion here
+// preserves the in-process workflow.Config representation (a typed
+// time.Duration) while ensuring the published JSON contract carries the
+// duration as a string that round-trips through time.ParseDuration.
+//
+// See issue #53 for the rationale and the rejected alternative
+// (a wrapper Duration type with custom MarshalJSON).
+type configView struct {
+	Repo      workflow.RepoConfig      `json:"repo"`
+	Tracker   workflow.TrackerConfig   `json:"tracker"`
+	Workspace workflow.WorkspaceConfig `json:"workspace"`
+	Agent     agentConfigView          `json:"agent"`
+	Codex     workflow.CommandConfig   `json:"codex"`
+	Claude    workflow.CommandConfig   `json:"claude"`
+	Policy    workflow.PolicyConfig    `json:"policy"`
+	Verify    workflow.VerifyConfig    `json:"verify"`
+	PR        workflow.PRConfig        `json:"pr"`
+}
+
+// agentConfigView mirrors workflow.AgentConfig but renders Timeout as a
+// duration string (e.g. "30m0s") rather than a raw nanosecond integer.
+// The remaining fields keep their original JSON tags so external
+// consumers see the same shape.
+type agentConfigView struct {
+	Default             string `json:"default"`
+	MaxConcurrentAgents int    `json:"max_concurrent_agents"`
+	MaxTurns            int    `json:"max_turns"`
+	Timeout             string `json:"timeout"`
+	MaxTimeoutRetries   *int   `json:"max_timeout_retries"`
+}
+
+func newConfigView(cfg workflow.Config) configView {
+	return configView{
+		Repo:      cfg.Repo,
+		Tracker:   cfg.Tracker,
+		Workspace: cfg.Workspace,
+		Agent: agentConfigView{
+			Default:             cfg.Agent.Default,
+			MaxConcurrentAgents: cfg.Agent.MaxConcurrentAgents,
+			MaxTurns:            cfg.Agent.MaxTurns,
+			Timeout:             cfg.Agent.Timeout.String(),
+			MaxTimeoutRetries:   cfg.Agent.MaxTimeoutRetries,
+		},
+		Codex:  cfg.Codex,
+		Claude: cfg.Claude,
+		Policy: cfg.Policy,
+		Verify: cfg.Verify,
+		PR:     cfg.PR,
+	}
 }
 
 type printConfigResolution struct {
@@ -83,7 +136,7 @@ func printConfig(workdir string, stdout, stderr io.Writer) int {
 			Path:       res.Path,
 			ShadowedBy: res.ShadowedBy,
 		},
-		Config:         maskSecrets(wf.Config),
+		Config:         newConfigView(maskSecrets(wf.Config)),
 		PromptTemplate: summarizePrompt(wf.PromptTemplate),
 	}
 	enc := json.NewEncoder(stdout)

--- a/cmd/worker/print_config_test.go
+++ b/cmd/worker/print_config_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestPrintConfig_MasksTrackerAPIKey verifies the secret-masking
@@ -114,6 +115,57 @@ func TestPrintConfig_FileSourceWithPromptCanary(t *testing.T) {
 	}
 	if out.PromptTemplate.Length <= 0 {
 		t.Fatalf("length = %d, want > 0", out.PromptTemplate.Length)
+	}
+}
+
+// TestPrintConfig_RendersAgentTimeoutAsDurationString pins the contract
+// from issue #53: agent.timeout in --print-config output must be a
+// human-readable duration string (e.g. "30m0s") rather than a raw
+// nanosecond integer. The default schema timeout is 30 minutes.
+func TestPrintConfig_RendersAgentTimeoutAsDurationString(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	var out struct {
+		Config struct {
+			Agent struct {
+				Timeout string `json:"timeout"`
+			} `json:"agent"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout: %s", err, stdout.String())
+	}
+	if got, want := out.Config.Agent.Timeout, "30m0s"; got != want {
+		t.Fatalf("agent.timeout = %q, want %q\nstdout:\n%s", got, want, stdout.String())
+	}
+	d, err := time.ParseDuration(out.Config.Agent.Timeout)
+	if err != nil {
+		t.Fatalf("ParseDuration(%q): %v", out.Config.Agent.Timeout, err)
+	}
+	if d != 30*time.Minute {
+		t.Fatalf("round-trip duration = %v, want 30m", d)
+	}
+}
+
+// TestPrintConfig_AgentTimeoutFromYAMLOverride covers the round-trip
+// requirement: a YAML config supplying `timeout: 10m` must surface as
+// "10m0s" in the print-config output, and that string must parse back
+// to the same duration.
+func TestPrintConfig_AgentTimeoutFromYAMLOverride(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  timeout: 10m\ntracker:\n  kind: linear\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"timeout": "10m0s"`) {
+		t.Fatalf("expected timeout=\"10m0s\" in output, got:\n%s", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Closes #53. `worker --print-config` now serializes `agent.timeout` as `"30m0s"` rather than `1800000000000`.
- Implementation uses a print-config-local view struct (`configView` / `agentConfigView`) per issue Option 2 — keeps `workflow.Config` typed as `time.Duration` and confines the marshal change to the debug command.
- `tracker.poll_interval_ms` left as `int` per the issue note (the `_ms` suffix already telegraphs the unit, and changing it would touch the YAML schema).

## Test plan
- [x] `go test ./cmd/worker/... -count=1` — new tests pass:
  - `TestPrintConfig_RendersAgentTimeoutAsDurationString` — default config (30m) round-trips through `time.ParseDuration`.
  - `TestPrintConfig_AgentTimeoutFromYAMLOverride` — YAML `timeout: 10m` surfaces as `"10m0s"`.
- [x] `go test ./... -count=1` — full module green.
- [x] `go vet ./...` — clean.