### PR TITLE
feat: verifier phase honors timeout and allow_failure (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ If none of the three exist, the worker proceeds with built-in defaults:
 
 A `WORKFLOW.md` with no YAML front matter (just a prompt body) is supported: the body becomes the prompt template, all other settings fall through to the defaults above. The `workflow_resolved` event records this as `source: prompt_only` so an operator can tell apart "ran with full Symphony config" from "ran with body-only template".
 
+### `verify.timeout` and `verify.allow_failure`
+
+`verify.timeout` (Go duration string, e.g. `5m`) caps the entire verify phase.
+The default `0` means unbounded, preserving the previous behavior. When the
+deadline elapses, the in-flight command is killed via context cancellation and
+the remaining commands are skipped; the task fails through the normal verify
+path unless `verify.allow_failure` is set.
+
+`verify.allow_failure: true` opts the worker into "investigation mode": when
+verify fails the worker still opens a draft PR (regardless of `pr.draft`),
+emits a `verify_end` event with `status: failed_allowed`, and prepends a
+warning banner to the PR body pointing to `.aiops/VERIFICATION.txt`. Use this
+when you want to inspect what the agent produced even though the checks
+flagged it. Default is `false`; failed verification blocks PR creation.
+
 To inspect the effective configuration for a workdir without consuming a task:
 
 ```bash

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -177,24 +177,10 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 		return cfg, err
 	}
 
-	emit(ctx, ev, t.ID, task.EventVerifyStart, "verify started", map[string]any{"commands": cfg.Verify.Commands})
-	verifyStart := time.Now()
-	verifyResults, verifyErr := workspace.RunVerify(ctx, workdir, cfg)
-	verifyDur := time.Since(verifyStart)
-	if writeErr := workspace.WriteVerification(workdir, verifyResults); writeErr != nil {
-		log.Printf("task %s: write verification artifact: %v", t.ID, writeErr)
+	verifyDegraded, err := runVerifyPhase(ctx, ev, t.ID, workdir, cfg)
+	if err != nil {
+		return cfg, err
 	}
-	verifyPayload := map[string]any{
-		"duration_ms": verifyDur.Milliseconds(),
-		"commands":    summarizeVerifyResults(verifyResults),
-	}
-	if verifyErr != nil {
-		verifyPayload["error"] = errSummary(verifyErr)
-		emit(ctx, ev, t.ID, task.EventVerifyEnd, "verify failed", verifyPayload)
-		writeFailureArtifacts(ctx, workdir, verifyResults, "verify failed: "+errSummary(verifyErr))
-		return cfg, verifyErr
-	}
-	emit(ctx, ev, t.ID, task.EventVerifyEnd, "verify completed", verifyPayload)
 
 	// Gate: the runner is required to write .aiops/RUN_SUMMARY.md describing
 	// the change. If it is missing/empty/a placeholder we refuse to open a PR
@@ -218,7 +204,7 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 			"reason": "summary_unreadable",
 			"path":   workspace.SummaryPath,
 		})
-		writeFailureArtifacts(ctx, workdir, verifyResults, "RUN_SUMMARY.md unreadable: "+errSummary(checkErr))
+		writeFailureArtifacts(ctx, workdir, nil, "RUN_SUMMARY.md unreadable: "+errSummary(checkErr))
 		return cfg, fmt.Errorf("read %s: %w", workspace.SummaryPath, checkErr)
 	}
 	if status != workspace.SummaryOK {
@@ -230,7 +216,7 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 			"reason": "summary_" + string(status),
 			"path":   workspace.SummaryPath,
 		})
-		writeFailureArtifacts(ctx, workdir, verifyResults, fmt.Sprintf("RUN_SUMMARY.md %s; runner must write %s before exiting.", status, workspace.SummaryPath))
+		writeFailureArtifacts(ctx, workdir, nil, fmt.Sprintf("RUN_SUMMARY.md %s; runner must write %s before exiting.", status, workspace.SummaryPath))
 		return cfg, fmt.Errorf("missing required artifact %s (%s)", workspace.SummaryPath, status)
 	}
 
@@ -239,7 +225,7 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 	// Failures flow through writeFailureArtifacts + the existing
 	// failed_attempt path so operators can inspect what the scanner saw.
 	if err := runSecretScan(ctx, ev, t.ID, workdir, wf.Config); err != nil {
-		writeFailureArtifacts(ctx, workdir, verifyResults, "secret scan blocked push: "+errSummary(err))
+		writeFailureArtifacts(ctx, workdir, nil, "secret scan blocked push: "+errSummary(err))
 		return cfg, err
 	}
 
@@ -273,7 +259,10 @@ func runTask(ctx context.Context, ev eventEmitter, t task.Task) (workflow.Config
 		"sample_changes": sampleSlice(changed, 10),
 	})
 
-	return cfg, createPR(ctx, ev, t, cfg, summary)
+	if verifyDegraded {
+		cfg.PR.Draft = true
+	}
+	return cfg, createPR(ctx, ev, t, cfg, summary, verifyDegraded)
 }
 
 // runRunnerWithTimeout invokes the runner under a per-task timeout derived
@@ -329,6 +318,61 @@ func runRunnerWithTimeout(ctx context.Context, ev eventEmitter, r runner.Runner,
 	}
 	emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner completed", endPayload)
 	return res, nil
+}
+
+// runVerifyPhase runs the configured verify commands, persists the
+// VERIFICATION.txt artifact, emits the verify_start/verify_end events,
+// and returns whether the run is in degraded mode. Degraded mode means
+// at least one command failed (or the phase deadline elapsed) AND the
+// operator has opted into verify.allow_failure: the caller continues
+// to PR creation but must mark the PR draft and annotate the body.
+//
+// Returns (degraded, err). When err is non-nil, verify failed AND
+// allow_failure was off; the caller propagates the error and skips PR
+// creation. When degraded=true, err is nil but downstream stages must
+// signal the verify failure to the human.
+func runVerifyPhase(ctx context.Context, ev eventEmitter, taskID, workdir string, cfg workflow.Config) (bool, error) {
+	emit(ctx, ev, taskID, task.EventVerifyStart, "verify started", map[string]any{
+		"commands":      cfg.Verify.Commands,
+		"timeout_ms":    cfg.Verify.Timeout.Milliseconds(),
+		"allow_failure": cfg.Verify.AllowFailure,
+	})
+	start := time.Now()
+	results, verifyErr := workspace.RunVerify(ctx, workdir, cfg)
+	if writeErr := workspace.WriteVerification(workdir, results); writeErr != nil {
+		log.Printf("task %s: write verification artifact: %v", taskID, writeErr)
+	}
+	payload := map[string]any{
+		"duration_ms":   time.Since(start).Milliseconds(),
+		"commands":      summarizeVerifyResults(results),
+		"failed_count":  countVerifyFailures(results),
+		"allow_failure": cfg.Verify.AllowFailure,
+	}
+	if verifyErr == nil {
+		payload["status"] = "ok"
+		emit(ctx, ev, taskID, task.EventVerifyEnd, "verify completed", payload)
+		return false, nil
+	}
+	payload["error"] = errSummary(verifyErr)
+	if cfg.Verify.AllowFailure {
+		payload["status"] = "failed_allowed"
+		emit(ctx, ev, taskID, task.EventVerifyEnd, "verify failed (investigation mode)", payload)
+		return true, nil
+	}
+	payload["status"] = "failed"
+	emit(ctx, ev, taskID, task.EventVerifyEnd, "verify failed", payload)
+	writeFailureArtifacts(ctx, workdir, results, "verify failed: "+errSummary(verifyErr))
+	return false, verifyErr
+}
+
+func countVerifyFailures(results []workspace.VerifyResult) int {
+	n := 0
+	for _, r := range results {
+		if r.Err != nil || r.ExitCode != 0 {
+			n++
+		}
+	}
+	return n
 }
 
 // secretScanFn is the indirection used to swap the real workspace scanner
@@ -424,9 +468,9 @@ type prClient interface {
 	CreatePullRequest(ctx context.Context, in gitea.CreatePullRequestInput) (*gitea.PullRequest, error)
 }
 
-func createPR(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config, summary string) error {
+func createPR(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config, summary string, verifyDegraded bool) error {
 	client := gitea.Client{BaseURL: os.Getenv("GITEA_BASE_URL"), Token: os.Getenv("GITEA_TOKEN")}
-	return createPRWith(ctx, ev, t, cfg, summary, client)
+	return createPRWith(ctx, ev, t, cfg, summary, verifyDegraded, client)
 }
 
 // createPRWith performs the PR handoff using the supplied client. It first
@@ -436,7 +480,7 @@ func createPR(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Co
 // logged and falls through to the create path so a transient Gitea hiccup
 // during the lookup does not block the task; the create call itself remains
 // the source of truth for surfacing real failures.
-func createPRWith(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config, summary string, client prClient) error {
+func createPRWith(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config, summary string, verifyDegraded bool, client prClient) error {
 	if existing, err := client.FindOpenPullRequest(ctx, gitea.FindOpenPullRequestInput{
 		Owner: t.RepoOwner, Repo: t.RepoName, Head: t.WorkBranch,
 	}); err != nil {
@@ -450,7 +494,7 @@ func createPRWith(ctx context.Context, ev eventEmitter, t task.Task, cfg workflo
 		log.Printf("task %s reused PR #%d %s", t.ID, existing.Number, existing.HTMLURL)
 		return nil
 	}
-	body := buildPRBody(t, summary)
+	body := buildPRBody(t, summary, verifyDegraded)
 	pr, err := client.CreatePullRequest(ctx, gitea.CreatePullRequestInput{Owner: t.RepoOwner, Repo: t.RepoName, Title: "chore(ai): " + t.Title, Body: body, Head: t.WorkBranch, Base: t.BaseBranch, Draft: cfg.PR.Draft})
 	if err != nil {
 		emit(ctx, ev, t.ID, task.EventPRCreated, "pr creation failed", map[string]any{"error": errSummary(err)})
@@ -529,8 +573,11 @@ const prBodySummaryCap = 8 << 10 // 8 KiB
 // buildPRBody renders the pull request body with the runner-produced
 // RUN_SUMMARY.md content inlined (truncated to prBodySummaryCap) and a link
 // to the full artifact path on the work branch. Callers must pass a summary
-// that has already been validated by workspace.CheckSummary.
-func buildPRBody(t task.Task, summary string) string {
+// that has already been validated by workspace.CheckSummary. verifyDegraded
+// indicates the verify phase failed with allow_failure=true; Task 4 will use
+// this flag to render the investigation-mode banner.
+func buildPRBody(t task.Task, summary string, verifyDegraded bool) string {
+	_ = verifyDegraded // banner rendering deferred to Task 4
 	excerpt, truncated := truncateForPR(summary, prBodySummaryCap)
 	var b strings.Builder
 	fmt.Fprintf(&b, "## AI Task\n\nTask ID: `%s`\n\n", t.ID)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -573,9 +573,10 @@ const prBodySummaryCap = 8 << 10 // 8 KiB
 // buildPRBody renders the pull request body with the runner-produced
 // RUN_SUMMARY.md content inlined (truncated to prBodySummaryCap) and a link
 // to the full artifact path on the work branch. Callers must pass a summary
-// that has already been validated by workspace.CheckSummary. verifyDegraded
-// indicates the verify phase failed with allow_failure=true; Task 4 will use
-// this flag to render the investigation-mode banner.
+// that has already been validated by workspace.CheckSummary. When
+// verifyDegraded is true (verify failed under verify.allow_failure), the
+// body is prepended with a blockquote banner pointing reviewers at
+// .aiops/VERIFICATION.txt.
 func buildPRBody(t task.Task, summary string, verifyDegraded bool) string {
 	excerpt, truncated := truncateForPR(summary, prBodySummaryCap)
 	var b strings.Builder

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -577,9 +577,14 @@ const prBodySummaryCap = 8 << 10 // 8 KiB
 // indicates the verify phase failed with allow_failure=true; Task 4 will use
 // this flag to render the investigation-mode banner.
 func buildPRBody(t task.Task, summary string, verifyDegraded bool) string {
-	_ = verifyDegraded // banner rendering deferred to Task 4
 	excerpt, truncated := truncateForPR(summary, prBodySummaryCap)
 	var b strings.Builder
+	if verifyDegraded {
+		b.WriteString("> ⚠️ **Verification failed (investigation mode).** ")
+		b.WriteString("This PR was opened despite a failing verify phase because ")
+		b.WriteString("`verify.allow_failure` is enabled. Inspect ")
+		b.WriteString("`.aiops/VERIFICATION.txt` before merging.\n\n")
+	}
 	fmt.Fprintf(&b, "## AI Task\n\nTask ID: `%s`\n\n", t.ID)
 	fmt.Fprintf(&b, "## Source\n\n%s / %s\n\n", t.SourceType, t.SourceEventID)
 	b.WriteString("## Run summary\n\n")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -354,6 +354,16 @@ func runVerifyPhase(ctx context.Context, ev eventEmitter, taskID, workdir string
 		return false, nil
 	}
 	payload["error"] = errSummary(verifyErr)
+	// Parent context cancellation (worker shutdown, task abort) must always
+	// propagate, even when allow_failure is on. allow_failure only downgrades
+	// real verification failures — a canceled task is not an "investigation"
+	// case and must not result in a degraded PR being opened. RunVerify
+	// returns ctx.Err() directly on parent-cancel, so errors.Is matches.
+	if errors.Is(verifyErr, context.Canceled) || errors.Is(verifyErr, context.DeadlineExceeded) {
+		payload["status"] = "canceled"
+		emit(ctx, ev, taskID, task.EventVerifyEnd, "verify canceled", payload)
+		return false, verifyErr
+	}
 	if cfg.Verify.AllowFailure {
 		payload["status"] = "failed_allowed"
 		emit(ctx, ev, taskID, task.EventVerifyEnd, "verify failed (investigation mode)", payload)

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -731,7 +731,7 @@ func TestVerifyAllowFailure_OpensDegradedDraftPR(t *testing.T) {
 
 	cfg := workflow.Config{
 		Verify: workflow.VerifyConfig{
-			Commands:     []string{"sh", "-c", "exit 1"},
+			Commands:     []string{"sh -c 'exit 1'"},
 			AllowFailure: true,
 		},
 		PR: workflow.PRConfig{Draft: false}, // prove override forces draft
@@ -782,7 +782,7 @@ func TestVerifyFails_BlocksPRWhenAllowFailureOff(t *testing.T) {
 
 	cfg := workflow.Config{
 		Verify: workflow.VerifyConfig{
-			Commands:     []string{"sh", "-c", "exit 1"},
+			Commands:     []string{"sh -c 'exit 1'"},
 			AllowFailure: false,
 		},
 	}

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -805,3 +805,51 @@ func TestVerifyFails_BlocksPRWhenAllowFailureOff(t *testing.T) {
 		t.Fatalf("verify_end status: got=%q want=%q", status, "failed")
 	}
 }
+
+// TestVerifyAllowFailure_DoesNotMaskParentCancel pins that allow_failure
+// only downgrades real verification failures, not context cancellation.
+// Codex review on PR #55 caught that the original runVerifyPhase swallowed
+// every non-nil verifyErr under allow_failure, including context.Canceled
+// from a parent ctx, turning worker shutdown into a "failed_allowed" PR.
+// The cancellation must still abort the task.
+func TestVerifyAllowFailure_DoesNotMaskParentCancel(t *testing.T) {
+	ev := &fakeEmitter{}
+	dir := t.TempDir()
+
+	cfg := workflow.Config{
+		Verify: workflow.VerifyConfig{
+			Commands:     []string{"sleep 5"},
+			AllowFailure: true, // would otherwise downgrade
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	degraded, err := runVerifyPhase(ctx, ev, "tsk_cancel", dir, cfg)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("runVerifyPhase did not honor parent cancel; took %v", elapsed)
+	}
+	if degraded {
+		t.Fatalf("degraded must be false on parent cancel even when allow_failure=true")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want errors.Is(err, context.Canceled)", err)
+	}
+
+	// Event should report status=canceled, not failed_allowed.
+	ends := ev.byKind(task.EventVerifyEnd)
+	if len(ends) != 1 {
+		t.Fatalf("verify_end event count: got=%d want=1", len(ends))
+	}
+	status, _ := payloadField(t, ends[0].Payload, "status").(string)
+	if status != "canceled" {
+		t.Fatalf("verify_end status: got=%q want=%q", status, "canceled")
+	}
+}

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -138,7 +138,7 @@ func TestBuildPRBodyEmbedsRunSummary(t *testing.T) {
 		WorkBranch:    "ai/tsk_42",
 	}
 	summary := "# Run summary\n\nFixed the off-by-one in foo().\nVerified with `go test ./...`.\n"
-	body := buildPRBody(t1, summary)
+	body := buildPRBody(t1, summary, false)
 	for _, want := range []string{
 		"tsk_42",
 		"github_issue / issue#7",
@@ -166,7 +166,7 @@ func TestBuildPRBodyTruncatesLongSummary(t *testing.T) {
 	// it into the rendered body.
 	const sentinel = "Z"
 	long := strings.Repeat(sentinel, prBodySummaryCap+1024)
-	body := buildPRBody(t1, long)
+	body := buildPRBody(t1, long, false)
 	if !strings.Contains(body, "_Summary truncated at") {
 		t.Fatalf("expected truncation marker in PR body for oversized summary")
 	}
@@ -528,7 +528,7 @@ func TestCreatePRWith_ReusesExistingPR(t *testing.T) {
 		findResult: &gitea.PullRequest{Number: 17, HTMLURL: "http://gitea.local/o/r/pulls/17", Title: "chore(ai): fix bug"},
 	}
 
-	if err := createPRWith(context.Background(), ev, tk, cfg, "summary", client); err != nil {
+	if err := createPRWith(context.Background(), ev, tk, cfg, "summary", false, client); err != nil {
 		t.Fatalf("createPRWith: %v", err)
 	}
 
@@ -562,7 +562,7 @@ func TestCreatePRWith_CreatesWhenNoneExists(t *testing.T) {
 		createPR:   &gitea.PullRequest{Number: 99, HTMLURL: "http://gitea.local/o/r/pulls/99", Title: "chore(ai): fix bug"},
 	}
 
-	if err := createPRWith(context.Background(), ev, tk, workflow.Config{}, "summary", client); err != nil {
+	if err := createPRWith(context.Background(), ev, tk, workflow.Config{}, "summary", false, client); err != nil {
 		t.Fatalf("createPRWith: %v", err)
 	}
 
@@ -596,7 +596,7 @@ func TestCreatePRWith_ListErrorFallsThroughToCreate(t *testing.T) {
 		findErr: errors.New("list pull requests failed: 500"),
 	}
 
-	if err := createPRWith(context.Background(), ev, tk, workflow.Config{}, "summary", client); err != nil {
+	if err := createPRWith(context.Background(), ev, tk, workflow.Config{}, "summary", false, client); err != nil {
 		t.Fatalf("createPRWith: %v", err)
 	}
 	if len(client.createCalls) != 1 {
@@ -694,5 +694,91 @@ func TestRunRunnerWithTimeout_StampsWorkflowSource(t *testing.T) {
 	payload, _ := got[0].Payload.(map[string]any)
 	if payload["workflow_source"] != "prompt_only" {
 		t.Fatalf("workflow_source = %v, want %q", payload["workflow_source"], "prompt_only")
+	}
+}
+
+// TestVerifyAllowFailure_OpensDegradedDraftPR pins the investigation-override
+// contract: when verify fails AND verify.allow_failure=true, runVerifyPhase
+// returns (true, nil), the caller forces cfg.PR.Draft=true, and the eventual
+// createPRWith call opens a draft PR. A verify_end event with
+// status="failed_allowed" must be emitted.
+func TestVerifyAllowFailure_OpensDegradedDraftPR(t *testing.T) {
+	ev := &fakeEmitter{}
+	dir := t.TempDir()
+
+	cfg := workflow.Config{
+		Verify: workflow.VerifyConfig{
+			Commands:     []string{"sh", "-c", "exit 1"},
+			AllowFailure: true,
+		},
+		PR: workflow.PRConfig{Draft: false}, // prove override forces draft
+	}
+
+	degraded, err := runVerifyPhase(context.Background(), ev, "tsk_af", dir, cfg)
+	if err != nil {
+		t.Fatalf("runVerifyPhase with allow_failure=true must not return error, got: %v", err)
+	}
+	if !degraded {
+		t.Fatal("runVerifyPhase must return degraded=true when verify fails with allow_failure=true")
+	}
+
+	// Confirm verify_end event with status=failed_allowed.
+	ends := ev.byKind(task.EventVerifyEnd)
+	if len(ends) != 1 {
+		t.Fatalf("verify_end event count: got=%d want=1", len(ends))
+	}
+	status, _ := payloadField(t, ends[0].Payload, "status").(string)
+	if status != "failed_allowed" {
+		t.Fatalf("verify_end status: got=%q want=%q", status, "failed_allowed")
+	}
+
+	// Now exercise createPRWith with verifyDegraded=true and Draft forced to true.
+	if degraded {
+		cfg.PR.Draft = true
+	}
+	tk := samplePRTask()
+	client := &fakePRClient{}
+	if err := createPRWith(context.Background(), ev, tk, cfg, "summary", true, client); err != nil {
+		t.Fatalf("createPRWith: %v", err)
+	}
+	if len(client.createCalls) != 1 {
+		t.Fatalf("expected one CreatePullRequest call, got %d", len(client.createCalls))
+	}
+	if !client.createCalls[0].Draft {
+		t.Fatal("PR must be created as draft when verifyDegraded=true")
+	}
+}
+
+// TestVerifyFails_BlocksPRWhenAllowFailureOff pins the default behavior:
+// a failing verify command without allow_failure prevents PR creation.
+// This locks the contract that the new collect-all semantics did not
+// weaken safety.
+func TestVerifyFails_BlocksPRWhenAllowFailureOff(t *testing.T) {
+	ev := &fakeEmitter{}
+	dir := t.TempDir()
+
+	cfg := workflow.Config{
+		Verify: workflow.VerifyConfig{
+			Commands:     []string{"sh", "-c", "exit 1"},
+			AllowFailure: false,
+		},
+	}
+
+	degraded, err := runVerifyPhase(context.Background(), ev, "tsk_naf", dir, cfg)
+	if err == nil {
+		t.Fatal("runVerifyPhase must return error when verify fails and allow_failure=false")
+	}
+	if degraded {
+		t.Fatal("runVerifyPhase must return degraded=false when allow_failure=false")
+	}
+
+	// Confirm verify_end event with status=failed.
+	ends := ev.byKind(task.EventVerifyEnd)
+	if len(ends) != 1 {
+		t.Fatalf("verify_end event count: got=%d want=1", len(ends))
+	}
+	status, _ := payloadField(t, ends[0].Payload, "status").(string)
+	if status != "failed" {
+		t.Fatalf("verify_end status: got=%q want=%q", status, "failed")
 	}
 }

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -175,6 +175,29 @@ func TestBuildPRBodyTruncatesLongSummary(t *testing.T) {
 	}
 }
 
+// TestBuildPRBody_VerifyDegradedBanner pins the contract that a
+// degraded run (verify.allow_failure took effect) prepends a clear
+// warning banner to the PR body so a human reviewer cannot miss it.
+func TestBuildPRBody_VerifyDegradedBanner(t *testing.T) {
+	tk := task.Task{ID: "tsk_demo", SourceType: "linear", SourceEventID: "ABC-1", WorkBranch: "ai/tsk_demo"}
+	body := buildPRBody(tk, "Did the thing.", true)
+
+	if !strings.Contains(body, "Verification failed (investigation mode)") {
+		t.Fatalf("expected investigation-mode banner; body:\n%s", body)
+	}
+	bannerIdx := strings.Index(body, "Verification failed (investigation mode)")
+	taskHeaderIdx := strings.Index(body, "## AI Task")
+	if bannerIdx < 0 || taskHeaderIdx < 0 || bannerIdx > taskHeaderIdx {
+		t.Fatalf("banner must precede the AI Task heading; banner=%d task=%d body:\n%s", bannerIdx, taskHeaderIdx, body)
+	}
+
+	// And: a non-degraded body must not carry the banner.
+	clean := buildPRBody(tk, "Did the thing.", false)
+	if strings.Contains(clean, "Verification failed") {
+		t.Fatalf("clean body should not mention verification failure; body:\n%s", clean)
+	}
+}
+
 // TestAppendRunSummaryDirectiveAppendsOnce verifies the runner contract is
 // only appended when the rendered prompt does not already mention it. This
 // keeps workflow templates free to embed their own (more detailed) version

--- a/docs/superpowers/plans/2026-05-09-verifier-phase.md
+++ b/docs/superpowers/plans/2026-05-09-verifier-phase.md
@@ -1,0 +1,777 @@
+# Verifier Phase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the verifier phase (issue #18) so it runs all configured commands and collects their results, supports a phase-level timeout, and offers an opt-in "investigation" override that opens a degraded draft PR when verification fails.
+
+**Architecture:** The verify phase already exists in `cmd/worker/main.go` between policy enforcement and the RUN_SUMMARY gate. This plan does not relocate the phase; it changes the semantics of `workspace.RunVerify` (collect-all instead of short-circuit, plus phase-level deadline) and threads a new `verify.allow_failure` configuration through `runTask` so a failing verify with the override opens a draft PR with a banner annotation. The schema gains two new fields (`verify.timeout`, `verify.allow_failure`); existing `verify.commands` and `verify.secret_scan` are unchanged.
+
+**Tech Stack:** Go 1.22, gopkg.in/yaml.v3, existing internal packages (`internal/workflow`, `internal/workspace`, `internal/task`, `internal/gitea`).
+
+---
+
+## Context
+
+The current state (read before starting):
+- `internal/workflow/config.go` — `VerifyConfig{Commands, SecretScan}`. No timeout, no allow-failure flag.
+- `internal/workspace/manager.go:151` — `RunVerify` short-circuits on first failing command. Returns `(results, error)` where error is the first failure.
+- `cmd/worker/main.go:180` — `runTask` emits `verify_start`/`verify_end`, calls `WriteVerification`, and returns the verify error immediately on any failure (preventing PR creation).
+- `cmd/worker/main.go:533` — `buildPRBody` builds the PR body. No verify-state input today.
+- `internal/gitea/client.go:18` — `CreatePullRequestInput` has `Draft bool`. No `Labels` field. Adding labels would need a separate Gitea endpoint call; **out of scope**.
+
+## Design decisions locked
+
+(Confirmed by user; see conversation transcript 2026-05-09.)
+
+1. **Collect-all** — `RunVerify` runs every non-empty command and returns one result per command, even after failures. Surfacing all failures at once shortens the AI agent's rework loop.
+2. **Phase-level timeout** — A single `verify.timeout` caps the entire phase, not per-command. Default `0` = unbounded so existing repos see no behavior change.
+3. **Global investigation override only** — Issue AC requires "Optional config allows PR creation with failed verification for investigation." A single boolean `verify.allow_failure` covers this. Per-command `continue_on_error` was discussed in brainstorming (Q2) but is **deferred**: it requires schema polymorphism (`commands` becoming string-or-object) and is not required by the issue AC. Add it in a separate PR if real demand emerges.
+4. **Events are the source of truth** — `VERIFICATION.txt` already serves as the human-readable artifact derived from the same `[]VerifyResult` slice the events summarize. No new artifact file. The PR body gains a banner when running in degraded mode.
+5. **Degraded PR semantics** — When verify fails AND `allow_failure: true`, the worker:
+   - Emits `verify_end` with `status: failed_allowed` (distinct from `failed`).
+   - Forces the PR to draft regardless of `pr.draft`.
+   - Prepends a `> ⚠ Verification failed (investigation mode)` banner to the PR body.
+   - Continues through the secret scan, summary gate, push, and PR creation.
+
+## Out of scope
+
+- Per-command `continue_on_error` (see decision 3).
+- Adding labels to the Gitea PR (`internal/gitea` would need a separate /labels call).
+- Parallel command execution (sequential is fine; verify commands are typically fast).
+- Cancelling the runner phase early when verify is known to be required (orthogonal).
+
+## File structure
+
+| File | Change |
+|------|--------|
+| `internal/workflow/config.go` | Add `Timeout` and `AllowFailure` to `VerifyConfig`. |
+| `internal/workflow/loader.go` | No change needed — `expandConfig` doesn't seed verify defaults; `0` timeout is intentional. |
+| `internal/workflow/loader_test.go` | Add round-trip test for new fields. |
+| `internal/workspace/manager.go` | Rewrite `RunVerify` for collect-all + phase deadline; result errors stay on individual `VerifyResult.Err`; aggregate error returned only when ≥1 command failed (or deadline hit before completion). |
+| `internal/workspace/manager_test.go` | Update existing `TestRunVerifyCapturesOutputAndStopsOnFailure` → `TestRunVerifyCollectsAllFailures`. Add `TestRunVerify_PhaseTimeout`. |
+| `cmd/worker/main.go` | In `runTask`: branch verify-failed-but-allowed path; force PR draft; pass new flag to `createPR` → `buildPRBody`. Update `summarizeVerifyResults` to include a `failed` boolean per command. |
+| `cmd/worker/main_test.go` | Add `TestRunTask_VerifyFailedAllowsDegradedPR` and `TestRunTask_VerifyFailedBlocksPRWhenAllowFailureOff`. |
+| `README.md` | Add a paragraph under the workflow config section documenting `verify.timeout` and `verify.allow_failure`. |
+
+---
+
+## Task 1: Schema additions for `verify.timeout` and `verify.allow_failure`
+
+**Files:**
+- Modify: `internal/workflow/config.go`
+- Test: `internal/workflow/loader_test.go`
+
+- [ ] **Step 1: Add the failing round-trip test**
+
+Append to `internal/workflow/loader_test.go`:
+
+```go
+func TestLoad_VerifyTimeoutAndAllowFailureRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\n" +
+		"repo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n" +
+		"verify:\n  timeout: 5m\n  allow_failure: true\n  commands:\n    - go test ./...\n" +
+		"---\nprompt\n"
+	p := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wf, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := wf.Config.Verify.Timeout, 5*time.Minute; got != want {
+		t.Fatalf("Verify.Timeout = %v, want %v", got, want)
+	}
+	if !wf.Config.Verify.AllowFailure {
+		t.Fatalf("Verify.AllowFailure = false, want true")
+	}
+}
+```
+
+If `time` is not yet imported in this test file, add `"time"` to the import block. Check before editing:
+
+```bash
+grep -n '"time"' internal/workflow/loader_test.go
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/workflow/... -run TestLoad_VerifyTimeoutAndAllowFailureRoundTrip -count=1 -v`
+Expected: FAIL — compile error referencing `Timeout` / `AllowFailure` not defined on `VerifyConfig`.
+
+- [ ] **Step 3: Add the schema fields**
+
+In `internal/workflow/config.go`, modify `VerifyConfig`:
+
+```go
+type VerifyConfig struct {
+	Commands   []string         `yaml:"commands" json:"commands"`
+	SecretScan SecretScanConfig `yaml:"secret_scan" json:"secret_scan"`
+	// Timeout caps the entire verify phase. Zero (the default) means
+	// unbounded so repos that have not opted in keep their previous
+	// behavior. When exceeded, the in-flight command is killed via
+	// context cancellation and remaining commands are skipped; the
+	// task fails through the normal verify path unless AllowFailure
+	// is set.
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
+	// AllowFailure, when true, lets the worker open a draft PR even
+	// after verify reports failures, so the human can inspect what
+	// the agent produced and what the verifier saw. The PR body is
+	// annotated with a "verification failed (investigation mode)"
+	// banner. Default false: failed verification blocks PR creation.
+	AllowFailure bool `yaml:"allow_failure" json:"allow_failure"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/workflow/... -count=1`
+Expected: PASS (all tests, including the new round-trip).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/workflow/config.go internal/workflow/loader_test.go
+git commit -m "feat: add verify.timeout and verify.allow_failure schema fields
+
+Refs #18. Adds two opt-in VerifyConfig fields:
+- Timeout caps the entire verify phase (0 = unbounded, preserving
+  current behavior for existing repos).
+- AllowFailure lets the worker open a degraded draft PR when verify
+  fails, so a human can investigate what the agent produced.
+
+Wiring in RunVerify and the worker pipeline lands in the next commits."
+```
+
+---
+
+## Task 2: `RunVerify` collects all results + applies phase timeout
+
+**Files:**
+- Modify: `internal/workspace/manager.go:151-184`
+- Test: `internal/workspace/manager_test.go:417-448` (rewrite) and append a new test
+
+- [ ] **Step 1: Rewrite the failing test (collect-all)**
+
+Replace the body of `TestRunVerifyCapturesOutputAndStopsOnFailure` with a new test that asserts collect-all. Rename it for clarity:
+
+```go
+// TestRunVerifyCollectsAllFailures pins the post-#18 contract: RunVerify
+// runs every non-empty command and records a result for each, even after
+// a non-zero exit. The aggregate error is non-nil iff at least one
+// command failed; per-command failure detail lives on VerifyResult.Err.
+func TestRunVerifyCollectsAllFailures(t *testing.T) {
+	dir := t.TempDir()
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{Commands: []string{
+		"echo hello-world",
+		"   ", // empty command should be skipped without recording a result
+		"sh -c 'echo to-stderr 1>&2; exit 7'",
+		"sh -c 'echo still-running; exit 0'",
+		"sh -c 'exit 3'",
+	}}}
+
+	results, err := RunVerify(context.Background(), dir, cfg)
+	if err == nil {
+		t.Fatalf("RunVerify should report an aggregate error when any command fails")
+	}
+	if got, want := len(results), 4; got != want {
+		t.Fatalf("expected %d verify results (skipping the empty entry), got %d", want, got)
+	}
+	if results[0].ExitCode != 0 || results[0].Err != nil {
+		t.Fatalf("result[0] should be success: %+v", results[0])
+	}
+	if !strings.Contains(results[0].Output, "hello-world") {
+		t.Fatalf("result[0] missing stdout: %q", results[0].Output)
+	}
+	if results[1].ExitCode != 7 || results[1].Err == nil {
+		t.Fatalf("result[1] should record exit=7 and Err: %+v", results[1])
+	}
+	if !strings.Contains(results[1].Output, "to-stderr") {
+		t.Fatalf("result[1] should capture stderr: %q", results[1].Output)
+	}
+	if results[2].ExitCode != 0 || results[2].Err != nil {
+		t.Fatalf("result[2] should be success despite earlier failure: %+v", results[2])
+	}
+	if !strings.Contains(results[2].Output, "still-running") {
+		t.Fatalf("result[2] missing stdout: %q", results[2].Output)
+	}
+	if results[3].ExitCode != 3 || results[3].Err == nil {
+		t.Fatalf("result[3] should record exit=3 and Err: %+v", results[3])
+	}
+}
+```
+
+- [ ] **Step 2: Add the failing phase-timeout test**
+
+Append to `internal/workspace/manager_test.go`:
+
+```go
+// TestRunVerify_PhaseTimeout pins the verify-phase deadline behavior:
+// when Verify.Timeout elapses, the in-flight command is killed via
+// context cancellation, remaining commands are not started, and the
+// aggregate error is non-nil. Already-completed results are preserved.
+func TestRunVerify_PhaseTimeout(t *testing.T) {
+	dir := t.TempDir()
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{
+		Timeout: 200 * time.Millisecond,
+		Commands: []string{
+			"echo first-finished",
+			"sleep 5",         // killed by phase deadline
+			"echo unreachable", // skipped
+		},
+	}}
+	start := time.Now()
+	results, err := RunVerify(context.Background(), dir, cfg)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("RunVerify should report an aggregate error on timeout")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("phase took %v, expected ~200ms (timeout not enforced)", elapsed)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results (first finished + sleep killed), got %d", len(results))
+	}
+	if results[0].ExitCode != 0 || results[0].Err != nil {
+		t.Fatalf("result[0] should be success: %+v", results[0])
+	}
+	if results[1].Err == nil {
+		t.Fatalf("result[1] (sleep) should record an error from context cancel")
+	}
+	for _, r := range results[2:] {
+		if r.Command == "echo unreachable" {
+			t.Fatalf("third command must not have been executed after deadline")
+		}
+	}
+}
+```
+
+If `time` is not yet imported in this test file, add it.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./internal/workspace/... -run 'TestRunVerifyCollectsAllFailures|TestRunVerify_PhaseTimeout' -count=1 -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Rewrite `RunVerify`**
+
+In `internal/workspace/manager.go`, replace the existing `RunVerify` (lines 151-184) with:
+
+```go
+// RunVerify executes the workflow verify commands in order and returns
+// one VerifyResult per non-empty command. Unlike the original
+// short-circuit semantics, it does not stop on the first failing
+// command: the AI workflow is more efficient when a single rework cycle
+// can address every reported failure. Per-command failure detail stays
+// on VerifyResult.Err and ExitCode.
+//
+// When wf.Verify.Timeout > 0 the entire phase runs under a derived
+// deadline. If the deadline elapses, the in-flight command is killed
+// via context cancellation and remaining commands are skipped (no
+// result is recorded for the skipped tail). The returned aggregate
+// error is non-nil iff at least one command failed or the phase
+// deadline was exceeded; callers inspect individual results to see
+// which.
+func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]VerifyResult, error) {
+	runCtx := ctx
+	if wf.Verify.Timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, wf.Verify.Timeout)
+		defer cancel()
+	}
+
+	var (
+		results  []VerifyResult
+		failures int
+	)
+	for _, command := range wf.Verify.Commands {
+		if strings.TrimSpace(command) == "" {
+			continue
+		}
+		// Stop launching new commands once the phase deadline has
+		// elapsed; the in-flight command (if any) was already killed
+		// by runCtx.Done().
+		if runCtx.Err() != nil {
+			break
+		}
+		start := time.Now()
+		buf := &cappedBuffer{Cap: VerifyOutputCap}
+		cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
+		cmd.Dir = workdir
+		cmd.Stdout = buf
+		cmd.Stderr = buf
+		runErr := cmd.Run()
+		res := VerifyResult{
+			Command:   command,
+			Output:    buf.String(),
+			Truncated: buf.Truncated(),
+			Duration:  time.Since(start),
+			ExitCode:  cmd.ProcessState.ExitCode(),
+		}
+		if runErr != nil {
+			res.Err = runErr
+			failures++
+		}
+		results = append(results, res)
+	}
+
+	if runCtx.Err() == context.DeadlineExceeded {
+		return results, fmt.Errorf("verify phase exceeded timeout %s after %d command(s)", wf.Verify.Timeout, len(results))
+	}
+	if failures > 0 {
+		return results, fmt.Errorf("verify: %d of %d command(s) failed", failures, len(results))
+	}
+	return results, nil
+}
+```
+
+- [ ] **Step 5: Run all workspace tests**
+
+Run: `go test ./internal/workspace/... -count=1`
+Expected: PASS. The existing `TestRunVerifyCapsLargeOutputAndMarksTruncated` and other artifact tests should remain green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/workspace/manager.go internal/workspace/manager_test.go
+git commit -m "feat: collect all verify results and honor phase timeout
+
+Refs #18. RunVerify no longer short-circuits on the first failing
+command — it runs every non-empty command and records a result per
+command. The aggregate error stays non-nil iff at least one command
+failed, but callers now have full diagnostic detail in one cycle
+instead of fix-retry-fix-retry.
+
+When verify.timeout > 0 the phase runs under a derived deadline.
+The in-flight command is killed via context cancellation and the
+remaining commands are skipped. Default 0 (unbounded) preserves
+backward compatibility.
+
+The existing stop-on-failure test is replaced with a collect-all
+assertion plus a phase-timeout test."
+```
+
+---
+
+## Task 3: Worker `runTask` honors `allow_failure` and emits a distinct event
+
+**Files:**
+- Modify: `cmd/worker/main.go:180-197` (verify block) and `cmd/worker/main.go:507-521` (`summarizeVerifyResults`)
+- Modify: `cmd/worker/main.go:276` (`runTask`'s tail-call to `createPR`) and `cmd/worker/main.go:427-466` (`createPR`/`createPRWith`)
+- Test: `cmd/worker/main_test.go`
+
+- [ ] **Step 1: Locate the worker test scaffolding**
+
+Read `cmd/worker/main_test.go` to find the existing fake PR client and event recorder used by current tests:
+
+```bash
+grep -n "func Test\|fakePR\|recordingEmitter\|runTask" cmd/worker/main_test.go | head -40
+```
+
+If a usable fake (with `CreatePullRequest` capturing `Draft` and `Body`) already exists, reuse it. Otherwise, the new test below defines one inline.
+
+- [ ] **Step 2: Add the failing tests**
+
+Append to `cmd/worker/main_test.go`. The two tests pin the contract independently. The exact harness is determined by what already exists in the file — adapt names and helper signatures to match. The shape below assumes a helper that drives `runTask` against an in-process fake; if no such helper exists, reach into the worker through its constituent functions (`runVerifyPhase` and `createPRWith`) and exercise them directly.
+
+```go
+// TestVerifyAllowFailure_OpensDegradedDraftPR pins the investigation
+// override: when verify fails AND verify.allow_failure is true, the
+// worker forces a draft PR, the body carries the failure banner, and
+// a verify_end event with status="failed_allowed" is emitted.
+func TestVerifyAllowFailure_OpensDegradedDraftPR(t *testing.T) {
+	// Arrange: workflow with a deliberately failing verify command and
+	//          allow_failure=true. pr.draft=false to prove the override
+	//          forces draft regardless.
+	cfg := workflow.Config{
+		Verify: workflow.VerifyConfig{
+			Commands:     []string{"sh -c 'exit 1'"},
+			AllowFailure: true,
+		},
+		PR: workflow.PRConfig{Draft: false},
+	}
+
+	// Run only the post-runner verify+PR slice — see helper.
+	got := runWorkerVerifyAndPR(t, cfg /* helper-supplied task, fake client, recorder */)
+
+	if !got.PRCreated {
+		t.Fatalf("expected PR to be created in allow_failure path")
+	}
+	if !got.PRDraftRequested {
+		t.Fatalf("PR must be draft when verify failed under allow_failure (got Draft=false)")
+	}
+	if !strings.Contains(got.PRBody, "Verification failed (investigation mode)") {
+		t.Fatalf("PR body missing degraded banner; body:\n%s", got.PRBody)
+	}
+	if !got.HasEventOfStatus("verify_end", "failed_allowed") {
+		t.Fatalf("expected verify_end event with status=failed_allowed; events: %v", got.Events)
+	}
+}
+
+// TestVerifyFails_BlocksPRWhenAllowFailureOff pins the default
+// behavior: a failing verify command without allow_failure prevents
+// PR creation. This locks the contract that the new collect-all
+// semantics did not weaken safety.
+func TestVerifyFails_BlocksPRWhenAllowFailureOff(t *testing.T) {
+	cfg := workflow.Config{
+		Verify: workflow.VerifyConfig{
+			Commands:     []string{"sh -c 'exit 1'"},
+			AllowFailure: false,
+		},
+	}
+	got := runWorkerVerifyAndPR(t, cfg)
+	if got.PRCreated {
+		t.Fatalf("PR must not be created when verify fails and allow_failure is off")
+	}
+	if !got.HasEventOfStatus("verify_end", "failed") {
+		t.Fatalf("expected verify_end event with status=failed; events: %v", got.Events)
+	}
+}
+```
+
+If the worker test file has no existing helper for this slice, write a minimal one in the same test file. The helper should:
+- Create a temp dir as the workdir.
+- Call the verify section directly (extracting helper if needed; see Step 4).
+- Stub `prClient` with a fake that records the `CreatePullRequestInput`.
+- Capture emitted events via the existing emitter test double.
+
+If extracting a helper makes the change cleaner, do it as part of Step 4.
+
+- [ ] **Step 3: Run new tests to verify they fail**
+
+Run: `go test ./cmd/worker/... -run 'TestVerifyAllowFailure_OpensDegradedDraftPR|TestVerifyFails_BlocksPRWhenAllowFailureOff' -count=1 -v`
+Expected: FAIL — either compile errors (helper not yet defined) or assertion failures (status=failed_allowed not emitted).
+
+- [ ] **Step 4: Refactor `runTask`'s verify block + thread the degraded flag**
+
+Extract the verify section into a helper to keep `runTask` tight. In `cmd/worker/main.go`, after Task 1's import additions are in place, replace lines 180-197 with:
+
+```go
+verifyDegraded, err := runVerifyPhase(ctx, ev, t.ID, workdir, cfg)
+if err != nil {
+	return cfg, err
+}
+```
+
+…and define `runVerifyPhase` near the other phase helpers (e.g., just below `runRunnerWithTimeout`):
+
+```go
+// runVerifyPhase runs the configured verify commands, persists the
+// VERIFICATION.txt artifact, emits the verify_start/verify_end events,
+// and returns whether the run is in degraded mode. Degraded mode means
+// at least one command failed (or the phase deadline elapsed) and the
+// operator has opted into verify.allow_failure: the caller continues
+// to PR creation but must mark the PR draft and annotate the body.
+//
+// Returns (degraded, err). When err is non-nil, verify failed AND
+// allow_failure was off; the caller propagates the error and skips PR
+// creation. When degraded=true, err is nil but downstream stages must
+// signal the verify failure to the human.
+func runVerifyPhase(ctx context.Context, ev eventEmitter, taskID, workdir string, cfg workflow.Config) (bool, error) {
+	emit(ctx, ev, taskID, task.EventVerifyStart, "verify started", map[string]any{
+		"commands":      cfg.Verify.Commands,
+		"timeout_ms":    cfg.Verify.Timeout.Milliseconds(),
+		"allow_failure": cfg.Verify.AllowFailure,
+	})
+	start := time.Now()
+	results, verifyErr := workspace.RunVerify(ctx, workdir, cfg)
+	if writeErr := workspace.WriteVerification(workdir, results); writeErr != nil {
+		log.Printf("task %s: write verification artifact: %v", taskID, writeErr)
+	}
+	payload := map[string]any{
+		"duration_ms":   time.Since(start).Milliseconds(),
+		"commands":      summarizeVerifyResults(results),
+		"failed_count":  countVerifyFailures(results),
+		"allow_failure": cfg.Verify.AllowFailure,
+	}
+	if verifyErr == nil {
+		payload["status"] = "ok"
+		emit(ctx, ev, taskID, task.EventVerifyEnd, "verify completed", payload)
+		return false, nil
+	}
+	payload["error"] = errSummary(verifyErr)
+	if cfg.Verify.AllowFailure {
+		payload["status"] = "failed_allowed"
+		emit(ctx, ev, taskID, task.EventVerifyEnd, "verify failed (investigation mode)", payload)
+		return true, nil
+	}
+	payload["status"] = "failed"
+	emit(ctx, ev, taskID, task.EventVerifyEnd, "verify failed", payload)
+	writeFailureArtifacts(ctx, workdir, results, "verify failed: "+errSummary(verifyErr))
+	return false, verifyErr
+}
+
+func countVerifyFailures(results []workspace.VerifyResult) int {
+	n := 0
+	for _, r := range results {
+		if r.Err != nil || r.ExitCode != 0 {
+			n++
+		}
+	}
+	return n
+}
+```
+
+Then thread the degraded flag from `runTask` through to the PR creation site:
+
+In `runTask`, replace the existing tail call
+
+```go
+return cfg, createPR(ctx, ev, t, cfg, summary)
+```
+
+with
+
+```go
+if verifyDegraded {
+	cfg.PR.Draft = true
+}
+return cfg, createPR(ctx, ev, t, cfg, summary, verifyDegraded)
+```
+
+Update `createPR` and `createPRWith` signatures to accept the new flag and pass it to `buildPRBody` (Task 4 implements the body change). Until Task 4 lands, `buildPRBody` can ignore the parameter — keep it on the signature so this commit compiles.
+
+```go
+func createPR(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config, summary string, verifyDegraded bool) error {
+	client := gitea.Client{BaseURL: os.Getenv("GITEA_BASE_URL"), Token: os.Getenv("GITEA_TOKEN")}
+	return createPRWith(ctx, ev, t, cfg, summary, verifyDegraded, client)
+}
+
+func createPRWith(ctx context.Context, ev eventEmitter, t task.Task, cfg workflow.Config, summary string, verifyDegraded bool, client prClient) error {
+	// ... existing body ...
+	body := buildPRBody(t, summary, verifyDegraded)
+	// ... existing CreatePullRequest call (keep Draft: cfg.PR.Draft) ...
+}
+```
+
+Update `buildPRBody`'s signature to take the new `verifyDegraded bool` argument; for this task leave the body unchanged (just accept and ignore the flag). Task 4 implements the banner.
+
+```go
+func buildPRBody(t task.Task, summary string, verifyDegraded bool) string {
+	_ = verifyDegraded // wired up in Task 4
+	// existing body unchanged
+}
+```
+
+- [ ] **Step 4b: Update existing test call sites for the new signatures**
+
+Adding `verifyDegraded` to `createPRWith` and `buildPRBody` breaks compilation of existing tests. Update each call site to pass `false`:
+
+In `cmd/worker/main_test.go`:
+- `TestBuildPRBodyEmbedsRunSummary` (~line 132): `buildPRBody(tk, summary)` → `buildPRBody(tk, summary, false)`.
+- `TestBuildPRBodyTruncatesLongSummary` (~line 162): same change.
+- `TestCreatePRWith_ReusesExistingPR` (~line 523): `createPRWith(ctx, ev, tk, cfg, "summary", client)` → `createPRWith(ctx, ev, tk, cfg, "summary", false, client)`.
+- `TestCreatePRWith_CreatesWhenNoneExists` (~line 557): same change.
+- `TestCreatePRWith_ListErrorFallsThroughToCreate` (~line 592): same change.
+
+If any other call sites in non-test code reference `createPR` or `buildPRBody`, update those too. Verify with:
+
+```bash
+grep -n "createPR(\|createPRWith(\|buildPRBody(" cmd/worker/*.go
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./cmd/worker/... -count=1`
+Expected: PASS — including the two new tests. The banner-body assertion from `TestVerifyAllowFailure_OpensDegradedDraftPR` should be deferred to Task 4 (mark it with `// banner asserted in Task 4` and skip that single check here). The cleanest split:
+- This task asserts: PRCreated, PRDraftRequested, status=failed_allowed event.
+- Task 4 asserts: PR body contains the banner.
+
+Verify all other worker tests (PR reuse, secret scan, summary gate, build PR body) still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/worker/main.go cmd/worker/main_test.go
+git commit -m "feat: thread verify.allow_failure through the worker pipeline
+
+Refs #18. Extract the verify section of runTask into runVerifyPhase
+and add the investigation-override path: when verify fails AND
+verify.allow_failure is true, the worker emits verify_end with
+status=failed_allowed, forces the PR to draft regardless of the
+configured pr.draft, and continues through summary/scan/push/PR.
+
+The PR body banner is added in the next commit; this commit threads
+the verifyDegraded flag through createPR / createPRWith / buildPRBody
+so Task 4 only has to render."
+```
+
+---
+
+## Task 4: PR body annotates verify-degraded state
+
+**Files:**
+- Modify: `cmd/worker/main.go:533-556` (`buildPRBody`)
+- Test: `cmd/worker/main_test.go`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `cmd/worker/main_test.go`:
+
+```go
+// TestBuildPRBody_VerifyDegradedBanner pins the contract that a
+// degraded run (verify.allow_failure took effect) prepends a clear
+// warning banner to the PR body so a human reviewer cannot miss it.
+func TestBuildPRBody_VerifyDegradedBanner(t *testing.T) {
+	tk := task.Task{ID: "tsk_demo", SourceType: "linear", SourceEventID: "ABC-1", WorkBranch: "ai/tsk_demo"}
+	body := buildPRBody(tk, "Did the thing.", true)
+
+	if !strings.Contains(body, "Verification failed (investigation mode)") {
+		t.Fatalf("expected investigation-mode banner; body:\n%s", body)
+	}
+	bannerIdx := strings.Index(body, "Verification failed (investigation mode)")
+	taskHeaderIdx := strings.Index(body, "## AI Task")
+	if bannerIdx < 0 || taskHeaderIdx < 0 || bannerIdx > taskHeaderIdx {
+		t.Fatalf("banner must precede the AI Task heading; banner=%d task=%d body:\n%s", bannerIdx, taskHeaderIdx, body)
+	}
+
+	// And: a non-degraded body must not carry the banner.
+	clean := buildPRBody(tk, "Did the thing.", false)
+	if strings.Contains(clean, "Verification failed") {
+		t.Fatalf("clean body should not mention verification failure; body:\n%s", clean)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/worker/... -run TestBuildPRBody_VerifyDegradedBanner -count=1 -v`
+Expected: FAIL — banner not yet rendered.
+
+- [ ] **Step 3: Render the banner**
+
+In `cmd/worker/main.go`, modify `buildPRBody`:
+
+```go
+func buildPRBody(t task.Task, summary string, verifyDegraded bool) string {
+	excerpt, truncated := truncateForPR(summary, prBodySummaryCap)
+	var b strings.Builder
+	if verifyDegraded {
+		b.WriteString("> ⚠️ **Verification failed (investigation mode).** ")
+		b.WriteString("This PR was opened despite a failing verify phase because ")
+		b.WriteString("`verify.allow_failure` is enabled. Inspect ")
+		b.WriteString("`.aiops/VERIFICATION.txt` before merging.\n\n")
+	}
+	fmt.Fprintf(&b, "## AI Task\n\nTask ID: `%s`\n\n", t.ID)
+	// ... rest of the existing body unchanged ...
+}
+```
+
+(Preserve the existing `## Source`, `## Run summary`, `## Verification`, `## Risk` sections after the banner.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/worker/... -count=1`
+Expected: PASS for all worker tests including the new banner test and the previously deferred banner assertion in `TestVerifyAllowFailure_OpensDegradedDraftPR` (re-enable any banner assertion you commented out in Task 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/worker/main.go cmd/worker/main_test.go
+git commit -m "feat: annotate degraded PR body when verify failed under allow_failure
+
+Refs #18. Prepends a blockquote banner to the PR body when verify
+ran in investigation mode. The banner sits above the existing AI
+Task / Source / Run summary sections so a human reviewer cannot
+miss it, and points to .aiops/VERIFICATION.txt for the failure
+detail."
+```
+
+---
+
+## Task 5: Document the new fields
+
+**Files:**
+- Modify: `README.md` (workflow config section)
+
+- [ ] **Step 1: Locate the workflow config section**
+
+Run: `grep -n "verify\|VerifyConfig\|WORKFLOW.md" README.md | head -20`. Identify the section that documents `verify.commands` (or the section listing top-level workflow keys). If no such section exists, document under the "Configuration" or "Workflow" heading — the goal is one paragraph any operator can find.
+
+- [ ] **Step 2: Add documentation**
+
+Add this paragraph (adapt heading depth to match the existing README structure):
+
+```markdown
+### `verify.timeout` and `verify.allow_failure`
+
+`verify.timeout` (Go duration string, e.g. `5m`) caps the entire verify phase.
+The default `0` means unbounded, preserving the previous behavior. When the
+deadline elapses, the in-flight command is killed via context cancellation and
+the remaining commands are skipped; the task fails through the normal verify
+path unless `verify.allow_failure` is set.
+
+`verify.allow_failure: true` opts the worker into "investigation mode": when
+verify fails the worker still opens a draft PR (regardless of `pr.draft`),
+emits a `verify_end` event with `status: failed_allowed`, and prepends a
+warning banner to the PR body pointing to `.aiops/VERIFICATION.txt`. Use this
+when you want to inspect what the agent produced even though the checks
+flagged it. Default is `false`; failed verification blocks PR creation.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document verify.timeout and verify.allow_failure
+
+Refs #18. Adds a short README section pointing operators at the two
+new VerifyConfig fields and the investigation-mode behavior."
+```
+
+---
+
+## Final verification
+
+- [ ] **Run full test suite**
+
+```bash
+go build ./...
+go vet ./...
+go test ./... -count=1
+```
+
+Expected: all green.
+
+- [ ] **Smoke-check `--print-config` output**
+
+```bash
+go run ./cmd/worker --print-config /tmp 2>&1 | grep -A2 '"verify"'
+```
+
+Expected: the JSON shape includes `"timeout"` and `"allow_failure"` under `"verify"` (alongside `"commands"` and `"secret_scan"`).
+
+- [ ] **Open PR**
+
+```bash
+git push -u origin feat/verifier-phase
+gh pr create --title "feat: verifier phase honors timeout and allow_failure (#18)" --body "$(cat <<'EOF'
+## Summary
+- Closes #18. RunVerify now collects all results instead of short-circuiting; surfacing every failure in one cycle is more efficient for the AI rework loop.
+- New `verify.timeout` caps the phase (default 0 = unbounded, backward-compatible).
+- New `verify.allow_failure` opts the worker into investigation mode: failed verify still opens a draft PR with a banner annotation; emits `verify_end` with `status=failed_allowed` so observers can distinguish the bypass.
+
+## Out of scope
+- Per-command `continue_on_error` (would need schema polymorphism; not required by issue AC).
+- Adding labels to the Gitea PR (would need a new client endpoint).
+
+## Test plan
+- [x] `go test ./... -count=1`
+- [x] `go vet ./...`
+- [x] New unit tests cover collect-all, phase timeout, allow_failure path, default block-on-failure, and PR body banner.
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage:
+  - "Worker runs configured verify commands after runner" ✓ (already true, preserved).
+  - "Verification output is captured" ✓ (VERIFICATION.txt unchanged + collect-all gives more output).
+  - "Failure prevents PR creation by default" ✓ (Task 3 default path).
+  - "Optional config allows PR creation with failed verification for investigation" ✓ (Task 3 + Task 4).
+- Type consistency: `verifyDegraded bool` is the single threaded flag. `cfg.Verify.AllowFailure` is the schema source. `cfg.PR.Draft` mutated locally in `runTask` only.
+- Placeholders: none (all code blocks are concrete; the `runWorkerVerifyAndPR` helper in Task 3 Step 2 is the one piece that requires inspecting the existing test file before locking the exact form — that is intentional, not a TBD).

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -98,6 +98,19 @@ func (p PolicyConfig) LineLimit() int {
 type VerifyConfig struct {
 	Commands   []string         `yaml:"commands" json:"commands"`
 	SecretScan SecretScanConfig `yaml:"secret_scan" json:"secret_scan"`
+	// Timeout caps the entire verify phase. Zero (the default) means
+	// unbounded so repos that have not opted in keep their previous
+	// behavior. When exceeded, the in-flight command is killed via
+	// context cancellation and remaining commands are skipped; the
+	// task fails through the normal verify path unless AllowFailure
+	// is set.
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
+	// AllowFailure, when true, lets the worker open a draft PR even
+	// after verify reports failures, so the human can inspect what
+	// the agent produced and what the verifier saw. The PR body is
+	// annotated with a "verification failed (investigation mode)"
+	// banner. Default false: failed verification blocks PR creation.
+	AllowFailure bool `yaml:"allow_failure" json:"allow_failure"`
 }
 
 // SecretScanConfig describes an optional pre-push secret scanner that runs

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -397,3 +397,25 @@ func TestLoadOptionalHonorsExplicitZeroMaxTimeoutRetries(t *testing.T) {
 		t.Fatalf("explicit zero Agent.MaxTimeoutRetriesValue: got %d want 0", got)
 	}
 }
+
+func TestLoad_VerifyTimeoutAndAllowFailureRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\n" +
+		"repo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\n" +
+		"verify:\n  timeout: 5m\n  allow_failure: true\n  commands:\n    - go test ./...\n" +
+		"---\nprompt\n"
+	p := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wf, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := wf.Config.Verify.Timeout, 5*time.Minute; got != want {
+		t.Fatalf("Verify.Timeout = %v, want %v", got, want)
+	}
+	if !wf.Config.Verify.AllowFailure {
+		t.Fatalf("Verify.AllowFailure = false, want true")
+	}
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -148,20 +148,45 @@ func WritePrompt(workdir string, prompt string) error {
 	return os.WriteFile(filepath.Join(dir, "PROMPT.md"), []byte(prompt), 0o644)
 }
 
-// RunVerify executes the workflow verify commands in order. It returns one
-// VerifyResult per non-empty command (even when one fails) so callers can
-// persist the combined output as a run artifact for post-mortem inspection.
-// On the first failing command the slice is returned together with the
-// underlying error and remaining commands are skipped.
+// RunVerify executes the workflow verify commands in order and returns
+// one VerifyResult per non-empty command. Unlike the original
+// short-circuit semantics, it does not stop on the first failing
+// command: the AI workflow is more efficient when a single rework cycle
+// can address every reported failure. Per-command failure detail stays
+// on VerifyResult.Err and ExitCode.
+//
+// When wf.Verify.Timeout > 0 the entire phase runs under a derived
+// deadline. If the deadline elapses, the in-flight command is killed
+// via context cancellation and remaining commands are skipped (no
+// result is recorded for the skipped tail). The returned aggregate
+// error is non-nil iff at least one command failed or the phase
+// deadline was exceeded; callers inspect individual results to see
+// which.
 func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]VerifyResult, error) {
-	var results []VerifyResult
+	runCtx := ctx
+	if wf.Verify.Timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, wf.Verify.Timeout)
+		defer cancel()
+	}
+
+	var (
+		results  []VerifyResult
+		failures int
+	)
 	for _, command := range wf.Verify.Commands {
 		if strings.TrimSpace(command) == "" {
 			continue
 		}
+		// Stop launching new commands once the phase deadline has
+		// elapsed; the in-flight command (if any) was already killed
+		// by runCtx.Done().
+		if runCtx.Err() != nil {
+			break
+		}
 		start := time.Now()
 		buf := &cappedBuffer{Cap: VerifyOutputCap}
-		cmd := exec.CommandContext(ctx, "sh", "-lc", command)
+		cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
 		cmd.Dir = workdir
 		cmd.Stdout = buf
 		cmd.Stderr = buf
@@ -175,10 +200,16 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		}
 		if runErr != nil {
 			res.Err = runErr
-			results = append(results, res)
-			return results, fmt.Errorf("verify command failed %q: %w", command, runErr)
+			failures++
 		}
 		results = append(results, res)
+	}
+
+	if runCtx.Err() == context.DeadlineExceeded {
+		return results, fmt.Errorf("verify phase exceeded timeout %s after %d command(s)", wf.Verify.Timeout, len(results))
+	}
+	if failures > 0 {
+		return results, fmt.Errorf("verify: %d of %d command(s) failed", failures, len(results))
 	}
 	return results, nil
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -178,9 +178,10 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		if strings.TrimSpace(command) == "" {
 			continue
 		}
-		// Stop launching new commands once the phase deadline has
-		// elapsed; the in-flight command (if any) was already killed
-		// by runCtx.Done().
+		// Stop launching new commands once the phase deadline (or the
+		// parent context) has elapsed. The previous command's cmd.Run
+		// already returned with a context-related error; we don't need
+		// to wait for anything.
 		if runCtx.Err() != nil {
 			break
 		}
@@ -191,12 +192,22 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		cmd.Stdout = buf
 		cmd.Stderr = buf
 		runErr := cmd.Run()
+		// Nil-guard ProcessState: when the context expires between the
+		// pre-loop check and exec.Cmd.Start(), Go returns an error without
+		// starting the process, leaving ProcessState nil. Calling ExitCode()
+		// on a nil pointer would panic; -1 is Go's documented "no exit code"
+		// sentinel and matches the behaviour callers already expect for
+		// context-cancelled commands.
+		exitCode := -1
+		if cmd.ProcessState != nil {
+			exitCode = cmd.ProcessState.ExitCode()
+		}
 		res := VerifyResult{
 			Command:   command,
 			Output:    buf.String(),
 			Truncated: buf.Truncated(),
 			Duration:  time.Since(start),
-			ExitCode:  cmd.ProcessState.ExitCode(),
+			ExitCode:  exitCode,
 		}
 		if runErr != nil {
 			res.Err = runErr
@@ -205,6 +216,9 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		results = append(results, res)
 	}
 
+	if ctx.Err() != nil {
+		return results, ctx.Err()
+	}
 	if runCtx.Err() == context.DeadlineExceeded {
 		return results, fmt.Errorf("verify phase exceeded timeout %s after %d command(s)", wf.Verify.Timeout, len(results))
 	}

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -623,6 +623,34 @@ func TestRunVerify_PhaseTimeout(t *testing.T) {
 	}
 }
 
+// TestRunVerify_ParentContextCancelPropagates pins the contract that
+// when the parent context is canceled (not the inner verify.timeout),
+// RunVerify returns the cancellation error rather than misattributing
+// the killed commands as plain verify failures.
+func TestRunVerify_ParentContextCancelPropagates(t *testing.T) {
+	dir := t.TempDir()
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{Commands: []string{
+		"sleep 5",
+	}}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := RunVerify(ctx, dir, cfg)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("RunVerify did not honor parent cancel; took %v", elapsed)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want errors.Is(err, context.Canceled)", err)
+	}
+}
+
 func mustGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/policy"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -414,36 +415,47 @@ func TestWriteAndReadSummaryRoundTrip(t *testing.T) {
 	}
 }
 
-func TestRunVerifyCapturesOutputAndStopsOnFailure(t *testing.T) {
+// TestRunVerifyCollectsAllFailures pins the post-#18 contract: RunVerify
+// runs every non-empty command and records a result for each, even after
+// a non-zero exit. The aggregate error is non-nil iff at least one
+// command failed; per-command failure detail lives on VerifyResult.Err.
+func TestRunVerifyCollectsAllFailures(t *testing.T) {
 	dir := t.TempDir()
 	cfg := workflow.Config{Verify: workflow.VerifyConfig{Commands: []string{
 		"echo hello-world",
 		"   ", // empty command should be skipped without recording a result
 		"sh -c 'echo to-stderr 1>&2; exit 7'",
-		"echo unreachable",
+		"sh -c 'echo still-running; exit 0'",
+		"sh -c 'exit 3'",
 	}}}
 
 	results, err := RunVerify(context.Background(), dir, cfg)
 	if err == nil {
-		t.Fatalf("RunVerify should report failure when a command exits non-zero")
+		t.Fatalf("RunVerify should report an aggregate error when any command fails")
 	}
-	if len(results) != 2 {
-		t.Fatalf("expected 2 verify results (skip empty + stop after failure), got %d", len(results))
-	}
-	if !strings.Contains(results[0].Output, "hello-world") {
-		t.Fatalf("first result missing stdout: %q", results[0].Output)
+	if got, want := len(results), 4; got != want {
+		t.Fatalf("expected %d verify results (skipping the empty entry), got %d", want, got)
 	}
 	if results[0].ExitCode != 0 || results[0].Err != nil {
-		t.Fatalf("first result should be success, got %+v", results[0])
+		t.Fatalf("result[0] should be success: %+v", results[0])
 	}
-	if results[1].ExitCode != 7 {
-		t.Fatalf("second result exit code = %d, want 7", results[1].ExitCode)
+	if !strings.Contains(results[0].Output, "hello-world") {
+		t.Fatalf("result[0] missing stdout: %q", results[0].Output)
+	}
+	if results[1].ExitCode != 7 || results[1].Err == nil {
+		t.Fatalf("result[1] should record exit=7 and Err: %+v", results[1])
 	}
 	if !strings.Contains(results[1].Output, "to-stderr") {
-		t.Fatalf("second result should capture stderr: %q", results[1].Output)
+		t.Fatalf("result[1] should capture stderr: %q", results[1].Output)
 	}
-	if results[1].Err == nil {
-		t.Fatalf("failed verify result should retain underlying error")
+	if results[2].ExitCode != 0 || results[2].Err != nil {
+		t.Fatalf("result[2] should be success despite earlier failure: %+v", results[2])
+	}
+	if !strings.Contains(results[2].Output, "still-running") {
+		t.Fatalf("result[2] missing stdout: %q", results[2].Output)
+	}
+	if results[3].ExitCode != 3 || results[3].Err == nil {
+		t.Fatalf("result[3] should record exit=3 and Err: %+v", results[3])
 	}
 }
 
@@ -568,6 +580,45 @@ func TestAllChangedFilesIncludesArtifactsWhenSnapshotAfterWrite(t *testing.T) {
 	for _, want := range []string{"src.go", ".aiops/CHANGED_FILES.txt", ".aiops/RUN_SUMMARY.md"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("AllChangedFiles missing %q in %q", want, got)
+		}
+	}
+}
+
+// TestRunVerify_PhaseTimeout pins the verify-phase deadline behavior:
+// when Verify.Timeout elapses, the in-flight command is killed via
+// context cancellation, remaining commands are not started, and the
+// aggregate error is non-nil. Already-completed results are preserved.
+func TestRunVerify_PhaseTimeout(t *testing.T) {
+	dir := t.TempDir()
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{
+		Timeout: 200 * time.Millisecond,
+		Commands: []string{
+			"echo first-finished",
+			"sleep 5",          // killed by phase deadline
+			"echo unreachable", // skipped
+		},
+	}}
+	start := time.Now()
+	results, err := RunVerify(context.Background(), dir, cfg)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("RunVerify should report an aggregate error on timeout")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("phase took %v, expected ~200ms (timeout not enforced)", elapsed)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results (first finished + sleep killed), got %d", len(results))
+	}
+	if results[0].ExitCode != 0 || results[0].Err != nil {
+		t.Fatalf("result[0] should be success: %+v", results[0])
+	}
+	if results[1].Err == nil {
+		t.Fatalf("result[1] (sleep) should record an error from context cancel")
+	}
+	for _, r := range results[2:] {
+		if r.Command == "echo unreachable" {
+			t.Fatalf("third command must not have been executed after deadline")
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #18. Hardens the verifier phase with three behavior changes plus operator-facing config:

- **Collect-all semantics** — `RunVerify` no longer short-circuits on the first failing command. Every non-empty command runs, every result is recorded. Surfacing all failures in one cycle shortens the AI rework loop.
- **`verify.timeout`** — phase-level deadline. Default `0` is unbounded (backward compatible). When the deadline elapses the in-flight command is killed via context cancellation; remaining commands are skipped (no zero-value placeholders).
- **`verify.allow_failure`** — investigation-mode override. When `true` and verify fails, the worker emits `verify_end` with `status: failed_allowed`, forces the PR to draft regardless of `pr.draft`, and prepends a `> ⚠️ Verification failed (investigation mode)` blockquote pointing reviewers at `.aiops/VERIFICATION.txt`. Default `false`: failed verification still blocks PR creation.

Hardening flushed out by code review:

- Nil-guard `cmd.ProcessState.ExitCode()` for the case where Go returns an error from `Cmd.Start` without starting the process (race window between the pre-loop `runCtx.Err()` check and `Start`).
- Distinguish parent `ctx` cancellation from inner `verify.timeout` deadline so worker-shutdown is propagated as `context.Canceled` rather than misattributed as "verify failures."

## Out of scope

- Per-command `continue_on_error` (would need `Commands` to become string-or-object polymorphic; not required by issue AC).
- Adding labels to the Gitea PR (would need a new `internal/gitea` endpoint).
- Loaded-WORKFLOW.md → RunVerify integration test (covered piecewise; full seam test is a follow-up).

## Commits

```
80d1c22 chore: refresh buildPRBody doc and tighten verify-test fixtures
663a883 docs: document verify.timeout and verify.allow_failure
c0d8b5c feat: annotate degraded PR body when verify failed under allow_failure
14e0f81 feat: thread verify.allow_failure through the worker pipeline
59c6830 fix: harden RunVerify against ctx race and parent cancel
6a82329 feat: collect all verify results and honor phase timeout
f44873c feat: add verify.timeout and verify.allow_failure schema fields
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — 11 packages green
- [x] New unit tests cover: collect-all (`TestRunVerifyCollectsAllFailures`), phase timeout (`TestRunVerify_PhaseTimeout`), parent-cancel propagation (`TestRunVerify_ParentContextCancelPropagates`), schema round-trip (`TestLoad_VerifyTimeoutAndAllowFailureRoundTrip`), allow_failure path (`TestVerifyAllowFailure_OpensDegradedDraftPR`), default block-on-failure (`TestVerifyFails_BlocksPRWhenAllowFailureOff`), PR body banner (`TestBuildPRBody_VerifyDegradedBanner`).
- [x] Existing PR-handoff/secret-scan/summary-gate tests still pass.

Plan: `docs/superpowers/plans/2026-05-09-verifier-phase.md`