### PR TITLE
feat: drive Linear status transitions on task lifecycle (#14)

### DIFF
--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -16,6 +16,17 @@ tracker:
     - Done
     - Canceled
   poll_interval_ms: 30000
+  # statuses configures the Linear workflow state names the worker drives
+  # the issue through as a task progresses:
+  #   - claim          -> in_progress
+  #   - PR opened      -> human_review
+  #   - failure        -> rework (or a comment if the move fails)
+  # Defaults match Linear's stock template; uncomment and edit only if
+  # your board uses different labels.
+  # statuses:
+  #   in_progress: "In Progress"
+  #   human_review: "Human Review"
+  #   rework: "Rework"
 
 workspace:
   root: ~/aiops-workspaces/personal

--- a/internal/queue/postgres.go
+++ b/internal/queue/postgres.go
@@ -137,12 +137,20 @@ func (s *Store) Complete(ctx context.Context, id string) error {
 	return err
 }
 
-func (s *Store) Fail(ctx context.Context, id string, msg string) error {
-	_, err := s.db.Exec(ctx, `UPDATE tasks SET status=CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'queued' END, available_at=now()+interval '60 seconds', updated_at=now() WHERE id=$1`, id)
-	if err == nil {
-		_ = s.AddEvent(ctx, id, task.EventFailedAttempt, msg)
+// Fail records a failed attempt. The task is re-queued (status='queued')
+// until attempts >= max_attempts, after which it transitions to the
+// terminal 'failed' status. Returns terminal=true exactly when the row
+// reached 'failed' so callers can branch on whether the task will be
+// retried — e.g. the worker's tracker hooks announce a final failure
+// to Linear only when the queue agrees the task is done.
+func (s *Store) Fail(ctx context.Context, id string, msg string) (bool, error) {
+	row := s.db.QueryRow(ctx, `UPDATE tasks SET status=CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'queued' END, available_at=now()+interval '60 seconds', updated_at=now() WHERE id=$1 RETURNING status`, id)
+	var status string
+	if err := row.Scan(&status); err != nil {
+		return false, err
 	}
-	return err
+	_ = s.AddEvent(ctx, id, task.EventFailedAttempt, msg)
+	return status == string(task.StatusFailed), nil
 }
 
 // FailTimeout records a runner timeout failure for task id and re-queues

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -31,22 +31,6 @@ func (c *LinearClient) ListActiveIssues(ctx context.Context) ([]Issue, error) {
     nodes { id identifier title description url updatedAt state { name } }
   }
 }`
-	payload := map[string]any{"query": query, "variables": map[string]any{"states": c.Config.ActiveStates}}
-	b, _ := json.Marshal(payload)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL, bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("linear query failed: %s", resp.Status)
-	}
 	var out struct {
 		Data struct {
 			Issues struct {
@@ -65,7 +49,7 @@ func (c *LinearClient) ListActiveIssues(ctx context.Context) ([]Issue, error) {
 		} `json:"data"`
 		Errors []map[string]any `json:"errors"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := c.graphql(ctx, query, map[string]any{"states": c.Config.ActiveStates}, &out); err != nil {
 		return nil, err
 	}
 	if len(out.Errors) > 0 {
@@ -76,4 +60,160 @@ func (c *LinearClient) ListActiveIssues(ctx context.Context) ([]Issue, error) {
 		issues = append(issues, Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, UpdatedAt: n.UpdatedAt, State: n.State.Name})
 	}
 	return issues, nil
+}
+
+// MoveIssueToState updates the named Linear issue so its workflowState
+// matches stateName. Linear's GraphQL requires a state ID rather than a
+// name, so this performs a workflowStates lookup first (scoped to the
+// configured TeamKey when present so identically-named states from
+// other teams cannot match by accident). A non-nil error here is
+// surfaced as a tracker_transition_error event by the worker; it never
+// aborts the underlying task.
+func (c *LinearClient) MoveIssueToState(ctx context.Context, issueID, stateName string) error {
+	if c.APIKey == "" {
+		return fmt.Errorf("Linear API key is required")
+	}
+	if issueID == "" {
+		return fmt.Errorf("issue id is required")
+	}
+	if stateName == "" {
+		return fmt.Errorf("state name is required")
+	}
+	stateID, err := c.lookupStateID(ctx, stateName)
+	if err != nil {
+		return fmt.Errorf("lookup state %q: %w", stateName, err)
+	}
+	mutation := `mutation IssueUpdate($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) { success }
+}`
+	var out struct {
+		Data struct {
+			IssueUpdate struct {
+				Success bool `json:"success"`
+			} `json:"issueUpdate"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := c.graphql(ctx, mutation, map[string]any{"id": issueID, "stateId": stateID}, &out); err != nil {
+		return err
+	}
+	if len(out.Errors) > 0 {
+		return fmt.Errorf("linear errors: %v", out.Errors)
+	}
+	if !out.Data.IssueUpdate.Success {
+		return fmt.Errorf("linear: issueUpdate did not report success")
+	}
+	return nil
+}
+
+// AddComment posts a comment on the named Linear issue. Used as the
+// failure fallback when MoveIssueToState fails so a failure is still
+// visible on the issue even if the workflow state could not be moved.
+func (c *LinearClient) AddComment(ctx context.Context, issueID, body string) error {
+	if c.APIKey == "" {
+		return fmt.Errorf("Linear API key is required")
+	}
+	if issueID == "" {
+		return fmt.Errorf("issue id is required")
+	}
+	mutation := `mutation CommentCreate($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) { success }
+}`
+	var out struct {
+		Data struct {
+			CommentCreate struct {
+				Success bool `json:"success"`
+			} `json:"commentCreate"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := c.graphql(ctx, mutation, map[string]any{"issueId": issueID, "body": body}, &out); err != nil {
+		return err
+	}
+	if len(out.Errors) > 0 {
+		return fmt.Errorf("linear errors: %v", out.Errors)
+	}
+	if !out.Data.CommentCreate.Success {
+		return fmt.Errorf("linear: commentCreate did not report success")
+	}
+	return nil
+}
+
+// lookupStateID resolves a workflowState name to its UUID. When TeamKey
+// is configured the filter pins the lookup to that team so a state with
+// the same label in another team cannot be picked. When TeamKey is empty
+// (operators that have not set it) the first matching state is used,
+// which is acceptable for personal/single-team boards.
+func (c *LinearClient) lookupStateID(ctx context.Context, stateName string) (string, error) {
+	var query string
+	vars := map[string]any{"name": stateName}
+	if c.Config.TeamKey != "" {
+		query = `query StateByName($name: String!, $teamKey: String!) {
+  workflowStates(filter: { name: { eq: $name }, team: { key: { eq: $teamKey } } }, first: 5) {
+    nodes { id name }
+  }
+}`
+		vars["teamKey"] = c.Config.TeamKey
+	} else {
+		query = `query StateByName($name: String!) {
+  workflowStates(filter: { name: { eq: $name } }, first: 5) {
+    nodes { id name }
+  }
+}`
+	}
+	var out struct {
+		Data struct {
+			WorkflowStates struct {
+				Nodes []struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"nodes"`
+			} `json:"workflowStates"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := c.graphql(ctx, query, vars, &out); err != nil {
+		return "", err
+	}
+	if len(out.Errors) > 0 {
+		return "", fmt.Errorf("linear errors: %v", out.Errors)
+	}
+	if len(out.Data.WorkflowStates.Nodes) == 0 {
+		return "", fmt.Errorf("no workflow state matches %q", stateName)
+	}
+	return out.Data.WorkflowStates.Nodes[0].ID, nil
+}
+
+// graphql issues a single GraphQL POST against c.BaseURL and decodes the
+// response into out. It is unexported because callers should go through
+// one of the typed methods (ListActiveIssues / MoveIssueToState /
+// AddComment) so the request shape and error semantics are consistent.
+func (c *LinearClient) graphql(ctx context.Context, query string, variables map[string]any, out any) error {
+	payload := map[string]any{"query": query, "variables": variables}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("linear request failed: %s", resp.Status)
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
 }

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -1,0 +1,276 @@
+package tracker
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// fakeLinearServer is a single-handler GraphQL fake. Tests script its
+// responses by name (the GraphQL operationName, derived from the first
+// `query|mutation NAME(` token in the body) so a single test can answer
+// both the workflowStates lookup and the issueUpdate mutation that
+// MoveIssueToState issues. Recorded requests are exposed for
+// assertions on payload shape and Authorization headers.
+type fakeLinearServer struct {
+	mu        sync.Mutex
+	requests  []fakeLinearRequest
+	responses map[string]string // op name -> JSON body to return
+}
+
+type fakeLinearRequest struct {
+	OpName    string
+	Variables map[string]any
+	AuthHeader string
+}
+
+func newFakeLinearServer() *fakeLinearServer {
+	return &fakeLinearServer{responses: map[string]string{}}
+}
+
+func (f *fakeLinearServer) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		op := opNameFromQuery(payload.Query)
+		f.mu.Lock()
+		f.requests = append(f.requests, fakeLinearRequest{
+			OpName:     op,
+			Variables:  payload.Variables,
+			AuthHeader: r.Header.Get("Authorization"),
+		})
+		resp, ok := f.responses[op]
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if !ok {
+			// Default: succeed-shaped response so tests that don't pre-script
+			// every op (e.g. lookup-only) don't have to.
+			http.Error(w, `{"errors":[{"message":"unscripted op `+op+`"}]}`, http.StatusOK)
+			return
+		}
+		_, _ = io.WriteString(w, resp)
+	})
+}
+
+// opNameFromQuery extracts the GraphQL operation name from a query
+// string. The Linear client formats queries as `query NAME(...)` or
+// `mutation NAME(...)`, so a small token scan is enough; we avoid
+// pulling in a real GraphQL parser to keep the test dependency-free.
+func opNameFromQuery(q string) string {
+	q = strings.TrimSpace(q)
+	for _, prefix := range []string{"query ", "mutation "} {
+		if strings.HasPrefix(q, prefix) {
+			rest := q[len(prefix):]
+			end := strings.IndexAny(rest, "( {")
+			if end < 0 {
+				return strings.TrimSpace(rest)
+			}
+			return strings.TrimSpace(rest[:end])
+		}
+	}
+	return ""
+}
+
+func newTestClient(t *testing.T, srv *httptest.Server, cfg workflow.TrackerConfig) *LinearClient {
+	t.Helper()
+	if cfg.APIKey == "" {
+		cfg.APIKey = "test-key"
+	}
+	c := NewLinearClient(cfg)
+	c.BaseURL = srv.URL
+	c.HTTP = srv.Client()
+	return c
+}
+
+// TestMoveIssueToState_LooksUpStateThenMutates verifies the two-step
+// flow: a workflowStates lookup (scoped to TeamKey when present)
+// resolves the human-readable state name to its UUID, then issueUpdate
+// mutates the issue. Both calls must carry the bearer token.
+func TestMoveIssueToState_LooksUpStateThenMutates(t *testing.T) {
+	srv := newFakeLinearServer()
+	srv.responses["StateByName"] = `{"data":{"workflowStates":{"nodes":[{"id":"state-uuid-1","name":"In Progress"}]}}}`
+	srv.responses["IssueUpdate"] = `{"data":{"issueUpdate":{"success":true}}}`
+
+	httpSrv := httptest.NewServer(srv.handler())
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{TeamKey: "ENG"})
+
+	if err := client.MoveIssueToState(context.Background(), "issue-1", "In Progress"); err != nil {
+		t.Fatalf("MoveIssueToState: %v", err)
+	}
+
+	if got := len(srv.requests); got != 2 {
+		t.Fatalf("requests = %d, want 2 (lookup + mutate)", got)
+	}
+	lookup := srv.requests[0]
+	if lookup.OpName != "StateByName" {
+		t.Fatalf("first op = %q, want StateByName", lookup.OpName)
+	}
+	if lookup.Variables["name"] != "In Progress" {
+		t.Fatalf("lookup name = %v, want \"In Progress\"", lookup.Variables["name"])
+	}
+	if lookup.Variables["teamKey"] != "ENG" {
+		t.Fatalf("lookup teamKey = %v, want \"ENG\"", lookup.Variables["teamKey"])
+	}
+	if lookup.AuthHeader != "Bearer test-key" {
+		t.Fatalf("lookup Authorization = %q, want \"Bearer test-key\"", lookup.AuthHeader)
+	}
+
+	mutate := srv.requests[1]
+	if mutate.OpName != "IssueUpdate" {
+		t.Fatalf("second op = %q, want IssueUpdate", mutate.OpName)
+	}
+	if mutate.Variables["id"] != "issue-1" {
+		t.Fatalf("mutate id = %v, want \"issue-1\"", mutate.Variables["id"])
+	}
+	if mutate.Variables["stateId"] != "state-uuid-1" {
+		t.Fatalf("mutate stateId = %v, want \"state-uuid-1\"", mutate.Variables["stateId"])
+	}
+}
+
+// TestMoveIssueToState_OmitsTeamKeyFilterWhenUnset confirms the lookup
+// query drops the team filter when TeamKey is empty so single-team
+// boards (the personal profile) work without operators having to fill
+// in a teamKey they don't otherwise need.
+func TestMoveIssueToState_OmitsTeamKeyFilterWhenUnset(t *testing.T) {
+	srv := newFakeLinearServer()
+	srv.responses["StateByName"] = `{"data":{"workflowStates":{"nodes":[{"id":"state-uuid","name":"Rework"}]}}}`
+	srv.responses["IssueUpdate"] = `{"data":{"issueUpdate":{"success":true}}}`
+
+	httpSrv := httptest.NewServer(srv.handler())
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{}) // no TeamKey
+
+	if err := client.MoveIssueToState(context.Background(), "issue-1", "Rework"); err != nil {
+		t.Fatalf("MoveIssueToState: %v", err)
+	}
+	if got := len(srv.requests); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+	if _, present := srv.requests[0].Variables["teamKey"]; present {
+		t.Fatalf("lookup variables should omit teamKey when unset, got %#v", srv.requests[0].Variables)
+	}
+}
+
+// TestMoveIssueToState_NoMatchingStateReturnsError pins that a
+// configured status name with no Linear workflow state behind it
+// surfaces a clear error rather than silently no-op'ing. This is the
+// signal OnFailure relies on to fall back to the comment path.
+func TestMoveIssueToState_NoMatchingStateReturnsError(t *testing.T) {
+	srv := newFakeLinearServer()
+	srv.responses["StateByName"] = `{"data":{"workflowStates":{"nodes":[]}}}`
+
+	httpSrv := httptest.NewServer(srv.handler())
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{})
+
+	err := client.MoveIssueToState(context.Background(), "issue-1", "Mystery")
+	if err == nil {
+		t.Fatalf("expected error when no state matches, got nil")
+	}
+	if !strings.Contains(err.Error(), "Mystery") {
+		t.Fatalf("error should name the missing state, got %q", err.Error())
+	}
+	// Lookup happens; mutation must not.
+	if got := len(srv.requests); got != 1 {
+		t.Fatalf("requests = %d, want 1 (lookup only)", got)
+	}
+}
+
+// TestMoveIssueToState_GraphQLErrorBubblesUp pins that a Linear-side
+// `errors` field is treated as a hard failure rather than absorbed.
+// Without this assertion, a misconfigured TeamKey or revoked API key
+// could leak through as a silent no-op.
+func TestMoveIssueToState_GraphQLErrorBubblesUp(t *testing.T) {
+	srv := newFakeLinearServer()
+	srv.responses["StateByName"] = `{"data":null,"errors":[{"message":"unauthenticated"}]}`
+
+	httpSrv := httptest.NewServer(srv.handler())
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{})
+
+	if err := client.MoveIssueToState(context.Background(), "issue-1", "In Progress"); err == nil {
+		t.Fatalf("expected error on GraphQL errors field, got nil")
+	}
+}
+
+// TestMoveIssueToState_RejectsEmptyArgs guards the small input contract
+// so callers (the worker hooks) get a deterministic error rather than a
+// confusing 400 from Linear when invariants are missed.
+func TestMoveIssueToState_RejectsEmptyArgs(t *testing.T) {
+	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k"})
+	if err := client.MoveIssueToState(context.Background(), "", "In Progress"); err == nil {
+		t.Fatal("empty issue id should error")
+	}
+	if err := client.MoveIssueToState(context.Background(), "issue-1", ""); err == nil {
+		t.Fatal("empty state name should error")
+	}
+
+	noKey := NewLinearClient(workflow.TrackerConfig{})
+	if err := noKey.MoveIssueToState(context.Background(), "issue-1", "In Progress"); err == nil {
+		t.Fatal("missing API key should error")
+	}
+}
+
+// TestAddComment_SendsCommentCreateMutation locks the GraphQL shape
+// the worker's failure-fallback path depends on.
+func TestAddComment_SendsCommentCreateMutation(t *testing.T) {
+	srv := newFakeLinearServer()
+	srv.responses["CommentCreate"] = `{"data":{"commentCreate":{"success":true}}}`
+
+	httpSrv := httptest.NewServer(srv.handler())
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{})
+
+	if err := client.AddComment(context.Background(), "issue-1", "AI run failed"); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	if got := len(srv.requests); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+	req := srv.requests[0]
+	if req.OpName != "CommentCreate" {
+		t.Fatalf("op = %q, want CommentCreate", req.OpName)
+	}
+	if req.Variables["issueId"] != "issue-1" {
+		t.Fatalf("variables.issueId = %v, want \"issue-1\"", req.Variables["issueId"])
+	}
+	if req.Variables["body"] != "AI run failed" {
+		t.Fatalf("variables.body = %v, want \"AI run failed\"", req.Variables["body"])
+	}
+}
+
+// TestAddComment_FailureSurfacesError pins the failure path so the
+// worker's OnFailure can record a tracker_transition_error event when
+// even the comment fallback can't be delivered.
+func TestAddComment_FailureSurfacesError(t *testing.T) {
+	srv := newFakeLinearServer()
+	srv.responses["CommentCreate"] = `{"data":{"commentCreate":{"success":false}}}`
+
+	httpSrv := httptest.NewServer(srv.handler())
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{})
+
+	if err := client.AddComment(context.Background(), "issue-1", "msg"); err == nil {
+		t.Fatal("AddComment with success=false should error")
+	}
+}
+
+// TestLinearClient_SatisfiesTransitioner is a compile-time check that
+// *LinearClient implements tracker.Transitioner. Worker.NewTransitioner
+// returns the interface; this assertion catches a future signature
+// drift before it manifests as a runtime nil interface assignment.
+func TestLinearClient_SatisfiesTransitioner(t *testing.T) {
+	var _ Transitioner = (*LinearClient)(nil)
+}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -15,3 +15,22 @@ type Issue struct {
 type Client interface {
 	ListActiveIssues(ctx context.Context) ([]Issue, error)
 }
+
+// Transitioner is the subset of a tracker client used by the worker to
+// drive the linked issue through its lifecycle. The worker calls these
+// methods at task claim, PR handoff, and failure so the tracker view
+// stays in sync with the queue. Implementations must be safe to call
+// from a single goroutine (the worker loop) and should use the supplied
+// context for both deadlines and cancellation.
+type Transitioner interface {
+	// MoveIssueToState updates the issue identified by issueID so its
+	// workflow state matches stateName. The state name is matched as
+	// the human-readable label visible in the tracker UI; resolution
+	// from name to internal ID is the implementation's responsibility.
+	MoveIssueToState(ctx context.Context, issueID, stateName string) error
+	// AddComment attaches a comment to the issue identified by issueID.
+	// Used as the fallback when the worker cannot move the issue to a
+	// configured failure state but still wants the human to see the
+	// failure on the issue.
+	AddComment(ctx context.Context, issueID, body string) error
+}

--- a/internal/worker/handletaskfailure_test.go
+++ b/internal/worker/handletaskfailure_test.go
@@ -1,0 +1,144 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// fakeFailingStore mocks the queue.Store subset handleTaskFailure
+// uses. Tests script Fail/FailTimeout return values to drive the
+// terminality decision the worker hands to OnFailure.
+type fakeFailingStore struct {
+	failResult      bool
+	failErr         error
+	failTimeoutReq  bool
+	failTimeoutErr  error
+	failCalls       []failCall
+	failTimoutCalls []failTimeoutCall
+}
+
+type failCall struct {
+	ID, Msg string
+}
+
+type failTimeoutCall struct {
+	ID, Msg            string
+	MaxTimeoutRetries  int
+}
+
+func (f *fakeFailingStore) Fail(_ context.Context, id, msg string) (bool, error) {
+	f.failCalls = append(f.failCalls, failCall{ID: id, Msg: msg})
+	return f.failResult, f.failErr
+}
+
+func (f *fakeFailingStore) FailTimeout(_ context.Context, id, msg string, max int) (bool, error) {
+	f.failTimoutCalls = append(f.failTimoutCalls, failTimeoutCall{ID: id, Msg: msg, MaxTimeoutRetries: max})
+	return f.failTimeoutReq, f.failTimeoutErr
+}
+
+func sampleTask() task.Task {
+	return task.Task{ID: "tsk_failtest"}
+}
+
+// TestHandleTaskFailure_NonTimeoutTerminalReportsTrue locks the
+// contract that the queue's Fail returning terminal=true propagates
+// back to the caller, which is what gates the OnFailure tracker move.
+func TestHandleTaskFailure_NonTimeoutTerminalReportsTrue(t *testing.T) {
+	store := &fakeFailingStore{failResult: true}
+	got := handleTaskFailure(context.Background(), store, sampleTask(), workflow.Config{}, errors.New("policy violation"))
+	if !got {
+		t.Fatalf("terminal = false, want true when Fail reports terminal")
+	}
+	if len(store.failCalls) != 1 {
+		t.Fatalf("Fail calls = %d, want 1", len(store.failCalls))
+	}
+	if len(store.failTimoutCalls) != 0 {
+		t.Fatalf("FailTimeout must not run on a non-timeout error; got %d calls", len(store.failTimoutCalls))
+	}
+}
+
+// TestHandleTaskFailure_NonTimeoutRequeueReportsFalse pins the
+// behaviour the spec criterion 3 hinges on: when the queue re-queues
+// the task for another attempt, the worker must not announce a
+// terminal failure (otherwise OnFailure would move the Linear issue to
+// Rework, the poller would re-enqueue, and the original re-queued task
+// plus the new poller task would race on the same issue).
+func TestHandleTaskFailure_NonTimeoutRequeueReportsFalse(t *testing.T) {
+	store := &fakeFailingStore{failResult: false}
+	got := handleTaskFailure(context.Background(), store, sampleTask(), workflow.Config{}, errors.New("verify failed"))
+	if got {
+		t.Fatalf("terminal = true, want false when Fail re-queues the task")
+	}
+}
+
+// TestHandleTaskFailure_NonTimeoutErrorIsConservative covers the rare
+// path where the queue write itself fails. We can't tell whether the
+// task is terminal, so we report false and skip the tracker mutation
+// — better to leave the Linear issue stale than to falsely announce a
+// final failure based on indeterminate queue state.
+func TestHandleTaskFailure_NonTimeoutErrorIsConservative(t *testing.T) {
+	store := &fakeFailingStore{failErr: errors.New("db down")}
+	got := handleTaskFailure(context.Background(), store, sampleTask(), workflow.Config{}, errors.New("boom"))
+	if got {
+		t.Fatalf("terminal = true, want false on Fail error")
+	}
+}
+
+// TestHandleTaskFailure_TimeoutRequeueReportsFalse mirrors the
+// non-timeout case for the dedicated timeout retry budget. A re-queued
+// timeout (within budget) is not terminal; the next attempt reuses the
+// same Linear issue without status churn.
+func TestHandleTaskFailure_TimeoutRequeueReportsFalse(t *testing.T) {
+	store := &fakeFailingStore{failTimeoutReq: true}
+	cfg := workflow.Config{}
+	terr := &runner.TimeoutError{Timeout: time.Second, Elapsed: 2 * time.Second}
+	got := handleTaskFailure(context.Background(), store, sampleTask(), cfg, terr)
+	if got {
+		t.Fatalf("terminal = true, want false when FailTimeout re-queues")
+	}
+	if len(store.failCalls) != 0 {
+		t.Fatalf("Fail must not run on a timeout error; got %d calls", len(store.failCalls))
+	}
+	if len(store.failTimoutCalls) != 1 {
+		t.Fatalf("FailTimeout calls = %d, want 1", len(store.failTimoutCalls))
+	}
+}
+
+// TestHandleTaskFailure_TimeoutBudgetExhaustedReportsTrue confirms
+// timeouts that exhaust the dedicated retry budget do reach Linear:
+// the operator needs the issue surfaced so they can intervene
+// (raise the budget, switch runners, etc.) rather than have the
+// worker silently drop the failure.
+func TestHandleTaskFailure_TimeoutBudgetExhaustedReportsTrue(t *testing.T) {
+	store := &fakeFailingStore{failTimeoutReq: false} // permanently failed
+	cfg := workflow.Config{}
+	terr := &runner.TimeoutError{Timeout: time.Second, Elapsed: 2 * time.Second}
+	got := handleTaskFailure(context.Background(), store, sampleTask(), cfg, terr)
+	if !got {
+		t.Fatalf("terminal = false, want true when FailTimeout exhausts the budget")
+	}
+}
+
+// TestHandleTaskFailure_TimeoutHonorsConfiguredBudget makes sure the
+// configured agent.max_timeout_retries is the value passed to the
+// queue, not a hard-coded constant. Regression guard for cases where
+// the routing logic could accidentally short-circuit the config plumb.
+func TestHandleTaskFailure_TimeoutHonorsConfiguredBudget(t *testing.T) {
+	store := &fakeFailingStore{}
+	budget := 7
+	cfg := workflow.Config{Agent: workflow.AgentConfig{MaxTimeoutRetries: &budget}}
+	terr := &runner.TimeoutError{Timeout: time.Second, Elapsed: 2 * time.Second}
+	_ = handleTaskFailure(context.Background(), store, sampleTask(), cfg, terr)
+	if len(store.failTimoutCalls) != 1 {
+		t.Fatalf("FailTimeout calls = %d, want 1", len(store.failTimoutCalls))
+	}
+	if got := store.failTimoutCalls[0].MaxTimeoutRetries; got != budget {
+		t.Fatalf("FailTimeout budget = %d, want %d", got, budget)
+	}
+}

--- a/internal/worker/run.go
+++ b/internal/worker/run.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/queue"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 // Config holds the runtime parameters for the worker process. Fields that were
@@ -22,6 +24,13 @@ type Config struct {
 	GiteaToken      string
 	IdleSleep       time.Duration
 	ClaimErrorSleep time.Duration
+	// NewTransitioner builds the per-task tracker.Transitioner used by
+	// the Linear status-transition hooks (OnClaim / OnPRCreated /
+	// OnFailure). Resolved per-task because each repo carries its own
+	// tracker credentials in WORKFLOW.md, not from worker env. Returning
+	// nil disables the hooks (e.g. for non-Linear trackers, empty
+	// API keys, or tests that do not exercise this path).
+	NewTransitioner func(workflow.TrackerConfig) Transitioner
 }
 
 // LoadConfigFromEnv reads the worker configuration from the environment using
@@ -35,7 +44,22 @@ func LoadConfigFromEnv() Config {
 		GiteaToken:      os.Getenv("GITEA_TOKEN"),
 		IdleSleep:       3 * time.Second,
 		ClaimErrorSleep: 5 * time.Second,
+		NewTransitioner: defaultNewTransitioner,
 	}
+}
+
+// defaultNewTransitioner is the production factory for Transitioner.
+// Linear is the only tracker today that exposes mutation APIs we wired
+// up; gitea webhooks do not need outbound state writes (the state is
+// the issue itself in Gitea), so we return nil for non-Linear kinds and
+// for Linear configs without an API key (e.g. while a workflow is being
+// authored locally without secrets exported). nil is a documented
+// no-op signal, not an error.
+func defaultNewTransitioner(tcfg workflow.TrackerConfig) Transitioner {
+	if tcfg.Kind != "linear" || tcfg.APIKey == "" {
+		return nil
+	}
+	return tracker.NewLinearClient(tcfg)
 }
 
 // PrintConfig dispatches the `worker --print-config <workdir>` subcommand.
@@ -68,6 +92,17 @@ func Run(ctx context.Context, store *queue.Store, cfg Config) {
 			log.Printf("task %s failed: %v", t.ID, rterr.Err)
 			cleanupCtx, cancel := terminalUpdateContext(ctx)
 			handleTaskFailure(cleanupCtx, store, *t, rterr.Cfg, rterr.Err)
+			// Fire the tracker-side failure transition under the same
+			// terminal-update context so a parent cancel (SIGTERM) does
+			// not leave the Linear issue stuck in "In Progress" while
+			// the task itself has been moved to failed/queued. The hook
+			// is a no-op when no transitioner factory is configured or
+			// the task did not come from Linear.
+			var tr Transitioner
+			if cfg.NewTransitioner != nil {
+				tr = cfg.NewTransitioner(rterr.Cfg.Tracker)
+			}
+			OnFailure(cleanupCtx, store, tr, *t, rterr.Cfg, rterr.Err)
 			cancel()
 			if ctx.Err() != nil {
 				return

--- a/internal/worker/run.go
+++ b/internal/worker/run.go
@@ -91,18 +91,21 @@ func Run(ctx context.Context, store *queue.Store, cfg Config) {
 		if rterr := runTask(ctx, store, *t, cfg); rterr != nil {
 			log.Printf("task %s failed: %v", t.ID, rterr.Err)
 			cleanupCtx, cancel := terminalUpdateContext(ctx)
-			handleTaskFailure(cleanupCtx, store, *t, rterr.Cfg, rterr.Err)
-			// Fire the tracker-side failure transition under the same
-			// terminal-update context so a parent cancel (SIGTERM) does
-			// not leave the Linear issue stuck in "In Progress" while
-			// the task itself has been moved to failed/queued. The hook
-			// is a no-op when no transitioner factory is configured or
-			// the task did not come from Linear.
-			var tr Transitioner
-			if cfg.NewTransitioner != nil {
-				tr = cfg.NewTransitioner(rterr.Cfg.Tracker)
+			terminal := handleTaskFailure(cleanupCtx, store, *t, rterr.Cfg, rterr.Err)
+			// Only announce the failure to Linear once the queue agrees
+			// the task is done — i.e. attempts >= max_attempts (or the
+			// timeout retry budget exhausted). Firing on every transient
+			// re-queue would flicker the issue between In Progress and
+			// Rework, and the Rework move would trip cmd/linear-poller's
+			// re-enqueue path (#43), creating a duplicate task each time
+			// while the original is still being retried internally.
+			if terminal {
+				var tr Transitioner
+				if cfg.NewTransitioner != nil {
+					tr = cfg.NewTransitioner(rterr.Cfg.Tracker)
+				}
+				OnFailure(cleanupCtx, store, tr, *t, rterr.Cfg, rterr.Err)
 			}
-			OnFailure(cleanupCtx, store, tr, *t, rterr.Cfg, rterr.Err)
 			cancel()
 			if ctx.Err() != nil {
 				return

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
-	"github.com/xrf9268-hue/aiops-platform/internal/queue"
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -72,7 +71,16 @@ func ResolveWorkflow(ctx context.Context, ev EventEmitter, taskID, workdir strin
 	return wf, string(res.Source), nil
 }
 
-// handleTaskFailure routes a task error to the right retry bucket.
+// failingStore is the subset of queue.Store handleTaskFailure needs.
+// Defined as an interface so the terminality-routing logic can be
+// unit-tested with a fake; *queue.Store satisfies it implicitly.
+type failingStore interface {
+	Fail(ctx context.Context, id, msg string) (bool, error)
+	FailTimeout(ctx context.Context, id, msg string, maxTimeoutRetries int) (bool, error)
+}
+
+// handleTaskFailure routes a task error to the right retry bucket and
+// reports whether the task reached its terminal failed state.
 //
 // Runner timeouts use a dedicated budget (agent.max_timeout_retries) so a
 // hung agent cannot consume the generic max_attempts reserved for
@@ -81,15 +89,30 @@ func ResolveWorkflow(ctx context.Context, ev EventEmitter, taskID, workdir strin
 // artifacts (CHANGED_FILES.txt / RUN_SUMMARY.md / VERIFICATION.json) are
 // written by the runTask code path on the way out, so this function is
 // purely concerned with retry routing.
-func handleTaskFailure(ctx context.Context, store *queue.Store, t task.Task, cfg workflow.Config, err error) {
+//
+// terminal=true means the queue actually transitioned the row to
+// 'failed'; the worker's tracker hooks use this to skip status
+// mutations during transient retries (which would otherwise flicker
+// the linked Linear issue between In Progress and Rework, and trigger
+// the poller's Rework re-enqueue path so the same issue accumulates
+// duplicate tasks). A queue-side error propagates as terminal=false so
+// we keep the conservative (no Linear write) behavior on uncertainty.
+func handleTaskFailure(ctx context.Context, store failingStore, t task.Task, cfg workflow.Config, err error) bool {
 	if runner.IsTimeout(err) {
 		budget := cfg.Agent.MaxTimeoutRetriesValue()
-		if _, ferr := store.FailTimeout(ctx, t.ID, err.Error(), budget); ferr != nil {
+		requeued, ferr := store.FailTimeout(ctx, t.ID, err.Error(), budget)
+		if ferr != nil {
 			log.Printf("task %s FailTimeout error: %v", t.ID, ferr)
+			return false
 		}
-		return
+		return !requeued
 	}
-	_ = store.Fail(ctx, t.ID, err.Error())
+	terminal, ferr := store.Fail(ctx, t.ID, err.Error())
+	if ferr != nil {
+		log.Printf("task %s Fail error: %v", t.ID, ferr)
+		return false
+	}
+	return terminal
 }
 
 // runTask executes a single task end-to-end and returns a *RunTaskError when

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -115,6 +115,17 @@ func runTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 		}
 	}
 
+	// The tracker transitioner is resolved from the workflow's tracker
+	// config (per-task, not per-worker) because each repo carries its
+	// own credentials. Constructed here so OnClaim sees the freshly
+	// loaded config; the same instance is reused for OnPRCreated below
+	// to amortize any future client-internal caching.
+	var tr Transitioner
+	if cfg.NewTransitioner != nil {
+		tr = cfg.NewTransitioner(wcfg.Tracker)
+	}
+	OnClaim(ctx, ev, tr, t, wcfg)
+
 	prompt := workflow.Render(wf.PromptTemplate, map[string]string{
 		"task.id":          t.ID,
 		"task.title":       t.Title,
@@ -240,7 +251,15 @@ func runTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 	if verifyDegraded {
 		wcfg.PR.Draft = true
 	}
-	return wrapErr(wcfg, CreatePR(ctx, ev, t, wcfg, cfg, summary, verifyDegraded))
+	prErr := CreatePR(ctx, ev, t, wcfg, cfg, summary, verifyDegraded)
+	if prErr == nil {
+		// Fired on both create-new and reuse-existing paths so a retry
+		// that lands on an already-open PR still flips the Linear issue
+		// to "Human Review" — the human's signal that hands have been
+		// handed off, regardless of which gitea code path produced the PR.
+		OnPRCreated(ctx, ev, tr, t, wcfg)
+	}
+	return wrapErr(wcfg, prErr)
 }
 
 // wrapErr returns nil if err is nil, otherwise wraps it in a RunTaskError.

--- a/internal/worker/transitions.go
+++ b/internal/worker/transitions.go
@@ -62,9 +62,9 @@ func OnPRCreated(ctx context.Context, ev EventEmitter, tr Transitioner, t task.T
 // preferred path is moving the issue to the configured "rework" state
 // because the poller's Rework re-enqueue logic (cmd/linear-poller's
 // sourceEventID) depends on that transition to retry. When the move
-// itself fails (state name typo, API error, missing permission) we
-// fall back to attaching a comment so the human still has visibility
-// into what happened — better than silent tracker drift.
+// fails (state name typo, missing state, revoked permission, API
+// error) we fall back to attaching a comment so the human still has
+// visibility into what happened — better than silent tracker drift.
 func OnFailure(ctx context.Context, ev EventEmitter, tr Transitioner, t task.Task, cfg workflow.Config, runErr error) {
 	if tr == nil || cfg.Tracker.Kind != "linear" {
 		return
@@ -73,24 +73,23 @@ func OnFailure(ctx context.Context, ev EventEmitter, tr Transitioner, t task.Tas
 	if !ok {
 		return
 	}
-	if state := cfg.Tracker.Statuses.Rework; state != "" {
-		err := tr.MoveIssueToState(ctx, issueID, state)
-		if err == nil {
-			Emit(ctx, ev, t.ID, "tracker_transition", "issue moved to rework", map[string]any{
-				"issue_id":     issueID,
-				"target_state": state,
-				"reason":       "failure",
-			})
-			return
-		}
-		// Record the move failure, then fall through to the comment path so
-		// the human still sees the failure on the issue.
-		Emit(ctx, ev, t.ID, "tracker_transition_error", "move to rework failed", map[string]any{
+	state := cfg.Tracker.Statuses.Rework
+	moveErr := tr.MoveIssueToState(ctx, issueID, state)
+	if moveErr == nil {
+		Emit(ctx, ev, t.ID, "tracker_transition", "issue moved to rework", map[string]any{
 			"issue_id":     issueID,
 			"target_state": state,
-			"error":        ErrSummary(err),
+			"reason":       "failure",
 		})
+		return
 	}
+	// Record the move failure, then fall through to the comment path so
+	// the human still sees the failure on the issue.
+	Emit(ctx, ev, t.ID, "tracker_transition_error", "move to rework failed", map[string]any{
+		"issue_id":     issueID,
+		"target_state": state,
+		"error":        ErrSummary(moveErr),
+	})
 	body := fmt.Sprintf("AI run failed for task `%s`: %s", t.ID, ErrSummary(runErr))
 	if err := tr.AddComment(ctx, issueID, body); err != nil {
 		Emit(ctx, ev, t.ID, "tracker_transition_error", "failure comment failed", map[string]any{

--- a/internal/worker/transitions.go
+++ b/internal/worker/transitions.go
@@ -1,0 +1,131 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// Transitioner is the worker-facing alias for tracker.Transitioner. The
+// alias keeps internal/worker depending on the abstraction (which is
+// trivially fakeable in tests) without forcing every call site to import
+// internal/tracker just to type a parameter.
+type Transitioner = tracker.Transitioner
+
+// LinearIssueID returns the Linear issue.ID a task originated from,
+// stripping the `|rework|<updatedAt>` suffix the poller adds when it
+// re-enqueues a task on a Rework transition (cmd/linear-poller). The
+// suffix exists for the queue-side dedupe key only; the API mutations
+// always need the bare issue.ID.
+//
+// Returns ok=false when the task did not come from Linear or the source
+// ID is empty, so callers can no-op cleanly without scattering source
+// checks across each lifecycle hook.
+func LinearIssueID(t task.Task) (string, bool) {
+	if t.SourceType != "linear_issue" || t.SourceEventID == "" {
+		return "", false
+	}
+	id := t.SourceEventID
+	if i := strings.Index(id, "|"); i >= 0 {
+		id = id[:i]
+	}
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// OnClaim moves the linked Linear issue to the configured "in progress"
+// state. No-op when the task did not come from Linear, when the worker
+// was started without a transitioner factory, or when the configured
+// status name is empty. Errors are recorded as a tracker_transition_error
+// event and swallowed: a tracker hiccup must not abort the actual code
+// work.
+func OnClaim(ctx context.Context, ev EventEmitter, tr Transitioner, t task.Task, cfg workflow.Config) {
+	transitionTo(ctx, ev, tr, t, cfg, cfg.Tracker.Statuses.InProgress, "claimed")
+}
+
+// OnPRCreated moves the linked Linear issue to the configured
+// "human review" state. The worker calls this whenever CreatePR returns
+// nil, which covers both the create-new and reuse-existing paths so a
+// retried task that lands on an existing PR still flips the issue
+// forward.
+func OnPRCreated(ctx context.Context, ev EventEmitter, tr Transitioner, t task.Task, cfg workflow.Config) {
+	transitionTo(ctx, ev, tr, t, cfg, cfg.Tracker.Statuses.HumanReview, "pr_created")
+}
+
+// OnFailure routes a task failure to the linked Linear issue. The
+// preferred path is moving the issue to the configured "rework" state
+// because the poller's Rework re-enqueue logic (cmd/linear-poller's
+// sourceEventID) depends on that transition to retry. When the move
+// itself fails (state name typo, API error, missing permission) we
+// fall back to attaching a comment so the human still has visibility
+// into what happened — better than silent tracker drift.
+func OnFailure(ctx context.Context, ev EventEmitter, tr Transitioner, t task.Task, cfg workflow.Config, runErr error) {
+	if tr == nil || cfg.Tracker.Kind != "linear" {
+		return
+	}
+	issueID, ok := LinearIssueID(t)
+	if !ok {
+		return
+	}
+	if state := cfg.Tracker.Statuses.Rework; state != "" {
+		err := tr.MoveIssueToState(ctx, issueID, state)
+		if err == nil {
+			Emit(ctx, ev, t.ID, "tracker_transition", "issue moved to rework", map[string]any{
+				"issue_id":     issueID,
+				"target_state": state,
+				"reason":       "failure",
+			})
+			return
+		}
+		// Record the move failure, then fall through to the comment path so
+		// the human still sees the failure on the issue.
+		Emit(ctx, ev, t.ID, "tracker_transition_error", "move to rework failed", map[string]any{
+			"issue_id":     issueID,
+			"target_state": state,
+			"error":        ErrSummary(err),
+		})
+	}
+	body := fmt.Sprintf("AI run failed for task `%s`: %s", t.ID, ErrSummary(runErr))
+	if err := tr.AddComment(ctx, issueID, body); err != nil {
+		Emit(ctx, ev, t.ID, "tracker_transition_error", "failure comment failed", map[string]any{
+			"issue_id": issueID,
+			"error":    ErrSummary(err),
+		})
+		return
+	}
+	Emit(ctx, ev, t.ID, "tracker_comment", "failure comment posted", map[string]any{
+		"issue_id": issueID,
+	})
+}
+
+// transitionTo is the shared body of OnClaim and OnPRCreated. It guards
+// the no-op cases (no transitioner, non-Linear tracker, empty target,
+// non-Linear task) and emits a single tracker_transition or
+// tracker_transition_error event with a uniform payload shape so the
+// debug API can surface the lifecycle without cross-event reconciliation.
+func transitionTo(ctx context.Context, ev EventEmitter, tr Transitioner, t task.Task, cfg workflow.Config, target, reason string) {
+	if tr == nil || cfg.Tracker.Kind != "linear" || target == "" {
+		return
+	}
+	issueID, ok := LinearIssueID(t)
+	if !ok {
+		return
+	}
+	payload := map[string]any{
+		"issue_id":     issueID,
+		"target_state": target,
+		"reason":       reason,
+	}
+	if err := tr.MoveIssueToState(ctx, issueID, target); err != nil {
+		payload["error"] = ErrSummary(err)
+		Emit(ctx, ev, t.ID, "tracker_transition_error", "issue transition failed", payload)
+		return
+	}
+	Emit(ctx, ev, t.ID, "tracker_transition", "issue transitioned", payload)
+}

--- a/internal/worker/transitions_test.go
+++ b/internal/worker/transitions_test.go
@@ -1,0 +1,334 @@
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	worker "github.com/xrf9268-hue/aiops-platform/internal/worker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// fakeTransitioner records every call so tests can assert the worker
+// hooks fired with the right issue ID and target state. Errors can be
+// scripted per-method to drive the comment-fallback and event-emission
+// branches.
+type fakeTransitioner struct {
+	mu sync.Mutex
+
+	moveErr    error
+	commentErr error
+
+	moves    []moveCall
+	comments []commentCall
+}
+
+type moveCall struct {
+	IssueID, State string
+}
+
+type commentCall struct {
+	IssueID, Body string
+}
+
+func (f *fakeTransitioner) MoveIssueToState(_ context.Context, issueID, state string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.moves = append(f.moves, moveCall{IssueID: issueID, State: state})
+	return f.moveErr
+}
+
+func (f *fakeTransitioner) AddComment(_ context.Context, issueID, body string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.comments = append(f.comments, commentCall{IssueID: issueID, Body: body})
+	return f.commentErr
+}
+
+// linearTask is a small constructor for the source_type=linear_issue
+// shape the hooks key off of. The default ID maps to a bare issue UUID
+// (no rework suffix).
+func linearTask(eventID string) task.Task {
+	return task.Task{
+		ID:            "tsk_lin",
+		SourceType:    "linear_issue",
+		SourceEventID: eventID,
+	}
+}
+
+// linearCfg returns a workflow.Config wired for Linear with the
+// stock status names. Tests that need to vary the names override the
+// fields after this returns.
+func linearCfg() workflow.Config {
+	return workflow.Config{
+		Tracker: workflow.TrackerConfig{
+			Kind: "linear",
+			Statuses: workflow.TrackerStatusConfig{
+				InProgress:  "In Progress",
+				HumanReview: "Human Review",
+				Rework:      "Rework",
+			},
+		},
+	}
+}
+
+// TestLinearIssueID_StripsReworkSuffix pins the parser the hooks rely
+// on to recover the bare Linear issue.ID even after the poller's
+// rework re-enqueue has rewritten source_event_id.
+func TestLinearIssueID_StripsReworkSuffix(t *testing.T) {
+	cases := []struct {
+		name string
+		t    task.Task
+		want string
+		ok   bool
+	}{
+		{"plain", task.Task{SourceType: "linear_issue", SourceEventID: "abc"}, "abc", true},
+		{"rework suffix", task.Task{SourceType: "linear_issue", SourceEventID: "abc|rework|2026-05-08T10:00:00Z"}, "abc", true},
+		{"non-linear", task.Task{SourceType: "gitea_issue", SourceEventID: "abc"}, "", false},
+		{"empty source id", task.Task{SourceType: "linear_issue", SourceEventID: ""}, "", false},
+	}
+	for _, tc := range cases {
+		got, ok := worker.LinearIssueID(tc.t)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("%s: LinearIssueID = (%q, %v), want (%q, %v)", tc.name, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestOnClaim_MovesIssueToInProgress is the core happy-path: a Linear
+// task triggers a single MoveIssueToState call and one tracker_transition
+// event with reason=claimed.
+func TestOnClaim_MovesIssueToInProgress(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{}
+	worker.OnClaim(context.Background(), ev, tr, linearTask("issue-uuid"), linearCfg())
+
+	if len(tr.moves) != 1 {
+		t.Fatalf("MoveIssueToState calls = %d, want 1", len(tr.moves))
+	}
+	if tr.moves[0].IssueID != "issue-uuid" || tr.moves[0].State != "In Progress" {
+		t.Fatalf("move call = %#v, want issue-uuid -> In Progress", tr.moves[0])
+	}
+	transitions := ev.byKind("tracker_transition")
+	if len(transitions) != 1 {
+		t.Fatalf("tracker_transition events = %d, want 1", len(transitions))
+	}
+	payload := transitions[0].Payload.(map[string]any)
+	if payload["target_state"] != "In Progress" {
+		t.Fatalf("payload.target_state = %v", payload["target_state"])
+	}
+	if payload["reason"] != "claimed" {
+		t.Fatalf("payload.reason = %v", payload["reason"])
+	}
+}
+
+// TestOnClaim_NoOpWhenTrackerNil locks the documented "missing
+// transitioner = no-op" contract. The factory returns nil for
+// non-Linear or unkeyed tracker configs, and the hook must tolerate
+// that without panicking or emitting events.
+func TestOnClaim_NoOpWhenTrackerNil(t *testing.T) {
+	ev := &fakeEmitter{}
+	worker.OnClaim(context.Background(), ev, nil, linearTask("issue-uuid"), linearCfg())
+	if len(ev.events) != 0 {
+		t.Fatalf("expected zero events with nil transitioner, got %d", len(ev.events))
+	}
+}
+
+// TestOnClaim_NoOpForNonLinearTask covers the gitea-only path. Even
+// with a configured transitioner, a task originating from gitea must
+// not trigger Linear mutations.
+func TestOnClaim_NoOpForNonLinearTask(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{}
+	t1 := task.Task{SourceType: "gitea_issue", SourceEventID: "evt-1"}
+	worker.OnClaim(context.Background(), ev, tr, t1, linearCfg())
+
+	if len(tr.moves) != 0 {
+		t.Fatalf("non-linear task must not call MoveIssueToState; got %d", len(tr.moves))
+	}
+	if len(ev.events) != 0 {
+		t.Fatalf("expected zero events for non-linear task, got %d", len(ev.events))
+	}
+}
+
+// TestOnClaim_RecordsErrorEventOnMutationFailure pins the safety
+// contract: the hook never aborts the task, but it must surface the
+// API failure so an operator can investigate after the fact.
+func TestOnClaim_RecordsErrorEventOnMutationFailure(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{moveErr: errors.New("403 Forbidden")}
+	worker.OnClaim(context.Background(), ev, tr, linearTask("issue-uuid"), linearCfg())
+
+	errEvents := ev.byKind("tracker_transition_error")
+	if len(errEvents) != 1 {
+		t.Fatalf("tracker_transition_error events = %d, want 1; events=%#v", len(errEvents), ev.events)
+	}
+	if got := ev.byKind("tracker_transition"); len(got) != 0 {
+		t.Fatalf("success event must not fire on error path, got %d", len(got))
+	}
+	payload := errEvents[0].Payload.(map[string]any)
+	if !strings.Contains(payload["error"].(string), "403 Forbidden") {
+		t.Fatalf("error payload should include underlying error: %v", payload["error"])
+	}
+}
+
+// TestOnClaim_StripsReworkSuffixBeforeAPI mirrors the integration the
+// poller depends on: tasks created on a Rework re-enqueue have
+// source_event_id="<id>|rework|<updatedAt>", but the API call must
+// target the bare issue.ID.
+func TestOnClaim_StripsReworkSuffixBeforeAPI(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{}
+	worker.OnClaim(context.Background(), ev, tr, linearTask("issue-uuid|rework|2026-05-08T10:00:00Z"), linearCfg())
+
+	if len(tr.moves) != 1 {
+		t.Fatalf("MoveIssueToState calls = %d, want 1", len(tr.moves))
+	}
+	if tr.moves[0].IssueID != "issue-uuid" {
+		t.Fatalf("issue id = %q, want \"issue-uuid\" (suffix should be stripped)", tr.moves[0].IssueID)
+	}
+}
+
+// TestOnPRCreated_MovesToHumanReview is the sister test of
+// TestOnClaim_MovesIssueToInProgress, just for the PR handoff stage.
+func TestOnPRCreated_MovesToHumanReview(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{}
+	worker.OnPRCreated(context.Background(), ev, tr, linearTask("issue-uuid"), linearCfg())
+
+	if len(tr.moves) != 1 {
+		t.Fatalf("MoveIssueToState calls = %d, want 1", len(tr.moves))
+	}
+	if tr.moves[0].State != "Human Review" {
+		t.Fatalf("target state = %q, want \"Human Review\"", tr.moves[0].State)
+	}
+	transitions := ev.byKind("tracker_transition")
+	if len(transitions) != 1 {
+		t.Fatalf("tracker_transition events = %d, want 1", len(transitions))
+	}
+	payload := transitions[0].Payload.(map[string]any)
+	if payload["reason"] != "pr_created" {
+		t.Fatalf("payload.reason = %v, want \"pr_created\"", payload["reason"])
+	}
+}
+
+// TestOnFailure_MovesToReworkOnSuccess covers the preferred failure
+// path: a single MoveIssueToState call with reason=failure and no
+// fallback comment.
+func TestOnFailure_MovesToReworkOnSuccess(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{}
+	worker.OnFailure(context.Background(), ev, tr, linearTask("issue-uuid"), linearCfg(), errors.New("verify failed"))
+
+	if len(tr.moves) != 1 || tr.moves[0].State != "Rework" {
+		t.Fatalf("expected one move to Rework, got %#v", tr.moves)
+	}
+	if len(tr.comments) != 0 {
+		t.Fatalf("expected zero comments on successful state move, got %d", len(tr.comments))
+	}
+	transitions := ev.byKind("tracker_transition")
+	if len(transitions) != 1 {
+		t.Fatalf("tracker_transition events = %d, want 1", len(transitions))
+	}
+	payload := transitions[0].Payload.(map[string]any)
+	if payload["reason"] != "failure" {
+		t.Fatalf("payload.reason = %v, want \"failure\"", payload["reason"])
+	}
+}
+
+// TestOnFailure_FallsBackToCommentWhenMoveFails pins the spec language
+// "move issue to Rework or comment with failure": when the state mutation
+// errors (e.g. wrong status name, revoked permission), the hook attaches
+// a comment so the human still sees the failure on the issue.
+func TestOnFailure_FallsBackToCommentWhenMoveFails(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{moveErr: errors.New("no matching state")}
+	cfg := linearCfg()
+	worker.OnFailure(context.Background(), ev, tr, linearTask("issue-uuid"), cfg, errors.New("policy violation"))
+
+	if len(tr.moves) != 1 {
+		t.Fatalf("expected the move to be attempted, got %d", len(tr.moves))
+	}
+	if len(tr.comments) != 1 {
+		t.Fatalf("expected fallback comment, got %d", len(tr.comments))
+	}
+	if !strings.Contains(tr.comments[0].Body, "policy violation") {
+		t.Fatalf("comment body should include the run error; got %q", tr.comments[0].Body)
+	}
+	if !strings.Contains(tr.comments[0].Body, "tsk_lin") {
+		t.Fatalf("comment body should mention the task ID; got %q", tr.comments[0].Body)
+	}
+
+	// The error event for the move and the success event for the comment
+	// should both be recorded, in that order.
+	errEvents := ev.byKind("tracker_transition_error")
+	if len(errEvents) != 1 {
+		t.Fatalf("tracker_transition_error count = %d, want 1", len(errEvents))
+	}
+	commentEvents := ev.byKind("tracker_comment")
+	if len(commentEvents) != 1 {
+		t.Fatalf("tracker_comment count = %d, want 1", len(commentEvents))
+	}
+}
+
+// TestOnFailure_CommentOnlyWhenReworkUnconfigured covers the
+// configuration where the operator opts out of state mutation by
+// leaving the rework name empty (post-load): the hook skips the move
+// entirely and goes straight to the comment.
+func TestOnFailure_CommentOnlyWhenReworkUnconfigured(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{}
+	cfg := linearCfg()
+	cfg.Tracker.Statuses.Rework = ""
+
+	worker.OnFailure(context.Background(), ev, tr, linearTask("issue-uuid"), cfg, errors.New("boom"))
+
+	if len(tr.moves) != 0 {
+		t.Fatalf("expected zero moves when rework name is empty, got %d", len(tr.moves))
+	}
+	if len(tr.comments) != 1 {
+		t.Fatalf("expected single comment, got %d", len(tr.comments))
+	}
+}
+
+// TestOnFailure_RecordsErrorWhenCommentFails locks the worst-case
+// path: both mutations fail. The hook must not panic, must not loop,
+// and must leave a tracker_transition_error event behind.
+func TestOnFailure_RecordsErrorWhenCommentFails(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{
+		moveErr:    errors.New("403"),
+		commentErr: errors.New("500"),
+	}
+	worker.OnFailure(context.Background(), ev, tr, linearTask("issue-uuid"), linearCfg(), errors.New("verify failed"))
+
+	if got := len(tr.moves); got != 1 {
+		t.Fatalf("moves = %d, want 1", got)
+	}
+	if got := len(tr.comments); got != 1 {
+		t.Fatalf("comments = %d, want 1", got)
+	}
+	// Both error events should be recorded — one for the move, one for the comment.
+	errEvents := ev.byKind("tracker_transition_error")
+	if len(errEvents) != 2 {
+		t.Fatalf("tracker_transition_error events = %d, want 2", len(errEvents))
+	}
+}
+
+// TestOnClaim_HonoursCustomStatusName confirms acceptance criterion 4
+// end-to-end: a workflow.Config with a non-default in_progress label
+// flows through to the API call.
+func TestOnClaim_HonoursCustomStatusName(t *testing.T) {
+	ev := &fakeEmitter{}
+	tr := &fakeTransitioner{}
+	cfg := linearCfg()
+	cfg.Tracker.Statuses.InProgress = "Coding"
+	worker.OnClaim(context.Background(), ev, tr, linearTask("issue-uuid"), cfg)
+
+	if len(tr.moves) != 1 || tr.moves[0].State != "Coding" {
+		t.Fatalf("expected single move to \"Coding\", got %#v", tr.moves)
+	}
+}

--- a/internal/worker/transitions_test.go
+++ b/internal/worker/transitions_test.go
@@ -274,23 +274,26 @@ func TestOnFailure_FallsBackToCommentWhenMoveFails(t *testing.T) {
 	}
 }
 
-// TestOnFailure_CommentOnlyWhenReworkUnconfigured covers the
-// configuration where the operator opts out of state mutation by
-// leaving the rework name empty (post-load): the hook skips the move
-// entirely and goes straight to the comment.
-func TestOnFailure_CommentOnlyWhenReworkUnconfigured(t *testing.T) {
+// TestOnFailure_EmptyReworkStateAttemptsMoveThenComments locks the
+// behavior when a caller hands OnFailure a Config whose Rework name is
+// blank (which workflow.Load always populates with the default, but
+// a direct caller could miss). The hook attempts the move — the
+// Linear client surfaces a "state name is required" error — and then
+// falls back to the comment path. This guards against the failure
+// path silently swallowing such configs.
+func TestOnFailure_EmptyReworkStateAttemptsMoveThenComments(t *testing.T) {
 	ev := &fakeEmitter{}
-	tr := &fakeTransitioner{}
+	tr := &fakeTransitioner{moveErr: errors.New("state name is required")}
 	cfg := linearCfg()
 	cfg.Tracker.Statuses.Rework = ""
 
 	worker.OnFailure(context.Background(), ev, tr, linearTask("issue-uuid"), cfg, errors.New("boom"))
 
-	if len(tr.moves) != 0 {
-		t.Fatalf("expected zero moves when rework name is empty, got %d", len(tr.moves))
+	if len(tr.moves) != 1 {
+		t.Fatalf("expected one move attempt, got %d", len(tr.moves))
 	}
 	if len(tr.comments) != 1 {
-		t.Fatalf("expected single comment, got %d", len(tr.comments))
+		t.Fatalf("expected single comment fallback, got %d", len(tr.comments))
 	}
 }
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -38,9 +38,10 @@ type TrackerConfig struct {
 // used by the personal profile; teams that customize their workflow
 // states override the names without touching code.
 //
-// An empty Rework name is meaningful: it switches the failure path from
-// "move to Rework" to "post a failure comment" so the operator can opt
-// out of state mutation while still surfacing the failure on the issue.
+// An unrecognized state name (typo, missing permission, deleted state)
+// surfaces from the Linear API as a MoveIssueToState error; the worker
+// then falls back to attaching a failure comment so the human still
+// has visibility on the issue.
 type TrackerStatusConfig struct {
 	InProgress  string `yaml:"in_progress" json:"in_progress"`
 	HumanReview string `yaml:"human_review" json:"human_review"`

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -22,13 +22,29 @@ type RepoConfig struct {
 }
 
 type TrackerConfig struct {
-	Kind           string   `yaml:"kind" json:"kind"`
-	APIKey         string   `yaml:"api_key" json:"api_key"`
-	TeamKey        string   `yaml:"team_key" json:"team_key"`
-	ProjectSlug    string   `yaml:"project_slug" json:"project_slug"`
-	ActiveStates   []string `yaml:"active_states" json:"active_states"`
-	TerminalStates []string `yaml:"terminal_states" json:"terminal_states"`
-	PollIntervalMs int      `yaml:"poll_interval_ms" json:"poll_interval_ms"`
+	Kind           string              `yaml:"kind" json:"kind"`
+	APIKey         string              `yaml:"api_key" json:"api_key"`
+	TeamKey        string              `yaml:"team_key" json:"team_key"`
+	ProjectSlug    string              `yaml:"project_slug" json:"project_slug"`
+	ActiveStates   []string            `yaml:"active_states" json:"active_states"`
+	TerminalStates []string            `yaml:"terminal_states" json:"terminal_states"`
+	PollIntervalMs int                 `yaml:"poll_interval_ms" json:"poll_interval_ms"`
+	Statuses       TrackerStatusConfig `yaml:"statuses" json:"statuses"`
+}
+
+// TrackerStatusConfig names the workflow states the worker drives the
+// linked tracker issue through as a task progresses. The defaults
+// ("In Progress", "Human Review", "Rework") match the Linear template
+// used by the personal profile; teams that customize their workflow
+// states override the names without touching code.
+//
+// An empty Rework name is meaningful: it switches the failure path from
+// "move to Rework" to "post a failure comment" so the operator can opt
+// out of state mutation while still surfacing the failure on the issue.
+type TrackerStatusConfig struct {
+	InProgress  string `yaml:"in_progress" json:"in_progress"`
+	HumanReview string `yaml:"human_review" json:"human_review"`
+	Rework      string `yaml:"rework" json:"rework"`
 }
 
 type WorkspaceConfig struct {
@@ -161,6 +177,11 @@ func DefaultConfig() Config {
 			ActiveStates:   []string{"AI Ready", "In Progress", "Rework"},
 			TerminalStates: []string{"Done", "Canceled"},
 			PollIntervalMs: 30000,
+			Statuses: TrackerStatusConfig{
+				InProgress:  "In Progress",
+				HumanReview: "Human Review",
+				Rework:      "Rework",
+			},
 		},
 		Workspace: WorkspaceConfig{Root: "~/aiops-workspaces"},
 		// Agent.MaxTimeoutRetries is intentionally left nil here so the

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -398,6 +398,100 @@ func TestLoadOptionalHonorsExplicitZeroMaxTimeoutRetries(t *testing.T) {
 	}
 }
 
+// TestDefaultConfig_TrackerStatusesPopulated pins the schema-level
+// defaults for tracker.statuses. The names mirror Linear's stock
+// workflow ("In Progress", "Human Review", "Rework") so the personal
+// profile works without extra YAML; teams that customize their
+// workflow override only the names that differ.
+func TestDefaultConfig_TrackerStatusesPopulated(t *testing.T) {
+	got := DefaultConfig().Tracker.Statuses
+	want := TrackerStatusConfig{
+		InProgress:  "In Progress",
+		HumanReview: "Human Review",
+		Rework:      "Rework",
+	}
+	if got != want {
+		t.Fatalf("DefaultConfig().Tracker.Statuses = %#v, want %#v", got, want)
+	}
+}
+
+// TestLoad_TrackerStatusesPartialOverride verifies an operator can
+// override a single status name (here: in_progress) without restating
+// the others — expandConfig fills the remaining defaults so the
+// minimal-edit ergonomic from the issue's "Status names are
+// configurable" criterion is preserved.
+func TestLoad_TrackerStatusesPartialOverride(t *testing.T) {
+	dir := t.TempDir()
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  kind: linear
+  statuses:
+    in_progress: "Doing"
+---
+prompt
+`
+	p := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wf, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := wf.Config.Tracker.Statuses
+	want := TrackerStatusConfig{
+		InProgress:  "Doing",
+		HumanReview: "Human Review", // default
+		Rework:      "Rework",       // default
+	}
+	if got != want {
+		t.Fatalf("Tracker.Statuses = %#v, want %#v", got, want)
+	}
+}
+
+// TestLoad_TrackerStatusesAllOverride confirms all three names round-trip
+// from YAML, so workflows whose Linear board uses non-default labels
+// (e.g. "Coding" / "Review" / "Backlog") work as the issue's acceptance
+// criterion 4 requires.
+func TestLoad_TrackerStatusesAllOverride(t *testing.T) {
+	dir := t.TempDir()
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  kind: linear
+  statuses:
+    in_progress: "Coding"
+    human_review: "Review"
+    rework: "Backlog"
+---
+prompt
+`
+	p := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wf, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := wf.Config.Tracker.Statuses
+	want := TrackerStatusConfig{
+		InProgress:  "Coding",
+		HumanReview: "Review",
+		Rework:      "Backlog",
+	}
+	if got != want {
+		t.Fatalf("Tracker.Statuses = %#v, want %#v", got, want)
+	}
+}
+
 func TestLoad_VerifyTimeoutAndAllowFailureRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	body := "---\n" +

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -169,6 +169,19 @@ func expandConfig(cfg *Config) {
 	if cfg.Tracker.PollIntervalMs <= 0 {
 		cfg.Tracker.PollIntervalMs = 30000
 	}
+	// Tracker.Statuses defaults are applied per-field so a YAML override of
+	// a single name (e.g. `statuses.in_progress: "Doing"`) does not require
+	// the operator to also restate the unchanged ones. The defaults match
+	// the Linear template the personal profile ships with.
+	if cfg.Tracker.Statuses.InProgress == "" {
+		cfg.Tracker.Statuses.InProgress = "In Progress"
+	}
+	if cfg.Tracker.Statuses.HumanReview == "" {
+		cfg.Tracker.Statuses.HumanReview = "Human Review"
+	}
+	if cfg.Tracker.Statuses.Rework == "" {
+		cfg.Tracker.Statuses.Rework = "Rework"
+	}
 }
 
 func expandPath(p string) string {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/policy"
@@ -191,6 +192,30 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		cmd.Dir = workdir
 		cmd.Stdout = buf
 		cmd.Stderr = buf
+		// Run each verify command in its own process group so a
+		// shell-spawned child (e.g. `sleep 5`) doesn't outlive
+		// cancellation as an orphan. Without Setpgid, exec's default
+		// Cancel hook only SIGKILLs the shell pid; the child keeps the
+		// stdout pipe open and cmd.Wait() stalls until the child exits
+		// on its own — turning a 200ms verify timeout into a 5s wait.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.Cancel = func() error {
+			// Negative pid sends to the whole process group. ESRCH
+			// is benign: the process already exited before we got
+			// here. Anything else is logged but not propagated; the
+			// goroutine that waits on the context owns the return
+			// value of Run, not us.
+			if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+				return err
+			}
+			return nil
+		}
+		// Final safety net for the rare case where a wedged
+		// grandchild keeps the pipe open even after the group SIGKILL
+		// (e.g. a process with PR_SET_PDEATHSIG suppressed by a
+		// container runtime). After this delay, Go forcibly closes
+		// the pipes so cmd.Wait returns and we unblock.
+		cmd.WaitDelay = 2 * time.Second
 		runErr := cmd.Run()
 		// Nil-guard ProcessState: when the context expires between the
 		// pre-loop check and exec.Cmd.Start(), Go returns an error without


### PR DESCRIPTION
Wire the worker to update the linked Linear issue as a task moves
through claim, PR handoff, and failure stages. Status names are
configurable via tracker.statuses in WORKFLOW.md so teams whose
boards use non-default labels can opt in without code changes.

- Add TrackerStatusConfig (in_progress / human_review / rework)
  with sane defaults applied per-field by the loader.
- Extend LinearClient with MoveIssueToState (workflowStates
  lookup -> issueUpdate) and AddComment mutations behind a new
  tracker.Transitioner interface.
- Add OnClaim / OnPRCreated / OnFailure hooks in the worker. The
  failure path moves to Rework, falling back to a comment when the
  state mutation errors so the human still sees the failure.
- Resolve the transitioner per-task via a Config.NewTransitioner
  factory (production builds a LinearClient from wcfg.Tracker; the
  factory returns nil for non-Linear or unkeyed configs and nil is
  a documented no-op for the hooks).

https://claude.ai/code/session_01UpQiWeKQCFX3XshxTQWzUW