### PR TITLE
chore: promote tracker lifecycle event kinds to task.Event constants (#59)

### DIFF
--- a/docs/runbooks/task-api.md
+++ b/docs/runbooks/task-api.md
@@ -42,6 +42,14 @@ failed run can be reconstructed from the event timeline alone:
 - `pr_reused` — emitted instead of `pr_created` when the work branch already
   has an open PR from a previous attempt; the worker reuses it (number,
   html_url, title) and skips the create call so retries do not duplicate PRs
+- `tracker_transition` — Linear issue successfully moved to the configured
+  target state (in-progress on claim, human-review on PR open, rework on
+  failure); payload carries `issue_id`, `target_state`, and `reason`
+- `tracker_transition_error` — issue move or fallback comment failed at the
+  Linear API; payload includes the error excerpt so the task can still
+  complete without aborting on a tracker hiccup
+- `tracker_comment` — failure comment posted as a fallback after a rework
+  transition failed, so the human still has visibility on the issue
 - `succeeded`, `failed_attempt` — terminal outcomes
 
 The worker also writes the following artifacts under `.aiops/` in the

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -33,6 +33,10 @@ const (
 	EventPRReused         = "pr_reused"
 	EventSucceeded        = "succeeded"
 	EventFailedAttempt    = "failed_attempt"
+
+	EventTrackerTransition      = "tracker_transition"
+	EventTrackerTransitionError = "tracker_transition_error"
+	EventTrackerComment         = "tracker_comment"
 )
 
 type Task struct {

--- a/internal/worker/run_test.go
+++ b/internal/worker/run_test.go
@@ -324,6 +324,9 @@ func TestEventKindConstantsAreSnakeCase(t *testing.T) {
 		task.EventPush,
 		task.EventPRCreated,
 		task.EventPRReused,
+		task.EventTrackerTransition,
+		task.EventTrackerTransitionError,
+		task.EventTrackerComment,
 	}
 	for _, kind := range required {
 		if kind == "" {

--- a/internal/worker/transitions.go
+++ b/internal/worker/transitions.go
@@ -76,7 +76,7 @@ func OnFailure(ctx context.Context, ev EventEmitter, tr Transitioner, t task.Tas
 	state := cfg.Tracker.Statuses.Rework
 	moveErr := tr.MoveIssueToState(ctx, issueID, state)
 	if moveErr == nil {
-		Emit(ctx, ev, t.ID, "tracker_transition", "issue moved to rework", map[string]any{
+		Emit(ctx, ev, t.ID, task.EventTrackerTransition, "issue moved to rework", map[string]any{
 			"issue_id":     issueID,
 			"target_state": state,
 			"reason":       "failure",
@@ -85,20 +85,20 @@ func OnFailure(ctx context.Context, ev EventEmitter, tr Transitioner, t task.Tas
 	}
 	// Record the move failure, then fall through to the comment path so
 	// the human still sees the failure on the issue.
-	Emit(ctx, ev, t.ID, "tracker_transition_error", "move to rework failed", map[string]any{
+	Emit(ctx, ev, t.ID, task.EventTrackerTransitionError, "move to rework failed", map[string]any{
 		"issue_id":     issueID,
 		"target_state": state,
 		"error":        ErrSummary(moveErr),
 	})
 	body := fmt.Sprintf("AI run failed for task `%s`: %s", t.ID, ErrSummary(runErr))
 	if err := tr.AddComment(ctx, issueID, body); err != nil {
-		Emit(ctx, ev, t.ID, "tracker_transition_error", "failure comment failed", map[string]any{
+		Emit(ctx, ev, t.ID, task.EventTrackerTransitionError, "failure comment failed", map[string]any{
 			"issue_id": issueID,
 			"error":    ErrSummary(err),
 		})
 		return
 	}
-	Emit(ctx, ev, t.ID, "tracker_comment", "failure comment posted", map[string]any{
+	Emit(ctx, ev, t.ID, task.EventTrackerComment, "failure comment posted", map[string]any{
 		"issue_id": issueID,
 	})
 }
@@ -123,8 +123,8 @@ func transitionTo(ctx context.Context, ev EventEmitter, tr Transitioner, t task.
 	}
 	if err := tr.MoveIssueToState(ctx, issueID, target); err != nil {
 		payload["error"] = ErrSummary(err)
-		Emit(ctx, ev, t.ID, "tracker_transition_error", "issue transition failed", payload)
+		Emit(ctx, ev, t.ID, task.EventTrackerTransitionError, "issue transition failed", payload)
 		return
 	}
-	Emit(ctx, ev, t.ID, "tracker_transition", "issue transitioned", payload)
+	Emit(ctx, ev, t.ID, task.EventTrackerTransition, "issue transitioned", payload)
 }


### PR DESCRIPTION
## Summary

Closes #59. Pure rename refactor — promotes the three tracker lifecycle event kinds emitted by `internal/worker/transitions.go` (added in PR #58) to named constants in `internal/task/task.go`, matching the rest of the event-kind vocabulary.

- Add `EventTrackerTransition`, `EventTrackerTransitionError`, `EventTrackerComment` constants in `internal/task/task.go`.
- Replace the four inline string literals in `internal/worker/transitions.go` with the constants.
- Extend `TestEventKindConstantsAreSnakeCase` in `internal/worker/run_test.go` to assert the new constants are non-empty snake_case.
- Document the three `tracker_*` events in `docs/runbooks/task-api.md` alongside the other per-stage event kinds.

No behavior change. The wire format is preserved: `internal/worker/transitions_test.go` keeps asserting on raw `"tracker_transition"` etc. string values, so any consumer parsing the event stream stays unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/task/... ./internal/worker/...`
- [x] `go test ./...`