### PR TITLE
test: add integration coverage for worker tracker hooks (#60)

### DIFF
--- a/internal/worker/export_test.go
+++ b/internal/worker/export_test.go
@@ -1,0 +1,7 @@
+package worker
+
+// RunTaskForTest re-exports the unexported runTask orchestration so the
+// external worker_test package can exercise the full lifecycle (workspace
+// prep, runner, summary gate, push, PR handoff, tracker hooks) without
+// promoting runTask itself to a stable public API.
+var RunTaskForTest = runTask

--- a/internal/worker/run.go
+++ b/internal/worker/run.go
@@ -7,10 +7,22 @@ import (
 	"os"
 	"time"
 
-	"github.com/xrf9268-hue/aiops-platform/internal/queue"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+// runStore is the subset of queue.Store that Run actually exercises:
+// claim/complete on the loop, AddEvent* via the EventEmitter contract, and
+// Fail/FailTimeout via the failingStore contract. Defined as an interface
+// so the worker loop's tracker-hook gating can be tested against a fake
+// without standing up Postgres. *queue.Store satisfies it implicitly.
+type runStore interface {
+	Claim(ctx context.Context) (*task.Task, error)
+	Complete(ctx context.Context, id string) error
+	EventEmitter
+	failingStore
+}
 
 // Config holds the runtime parameters for the worker process. Fields that were
 // previously read via os.Getenv inside the request path are now threaded
@@ -31,6 +43,11 @@ type Config struct {
 	// nil disables the hooks (e.g. for non-Linear trackers, empty
 	// API keys, or tests that do not exercise this path).
 	NewTransitioner func(workflow.TrackerConfig) Transitioner
+	// NewPRClient builds the per-call PRClient used by CreatePR. When
+	// nil, the default gitea.Client built from GiteaBaseURL/Token is
+	// used. Tests inject a fake here so runTask can be exercised
+	// without a live Gitea server.
+	NewPRClient func() PRClient
 }
 
 // LoadConfigFromEnv reads the worker configuration from the environment using
@@ -69,7 +86,7 @@ func PrintConfig(workdir string, stdout, stderr io.Writer) int {
 
 // Run is the worker's main loop. It claims tasks from the store and executes
 // them until ctx is canceled.
-func Run(ctx context.Context, store *queue.Store, cfg Config) {
+func Run(ctx context.Context, store runStore, cfg Config) {
 	for {
 		t, err := store.Claim(ctx)
 		if err != nil {

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -497,7 +497,12 @@ func recordPolicyViolation(ctx context.Context, ev EventEmitter, taskID string, 
 // CreatePR creates a pull request using the gitea client configured from
 // the worker Config. Use CreatePRWith to inject a custom client.
 func CreatePR(ctx context.Context, ev EventEmitter, t task.Task, wcfg workflow.Config, workerCfg Config, summary string, verifyDegraded bool) error {
-	client := gitea.Client{BaseURL: workerCfg.GiteaBaseURL, Token: workerCfg.GiteaToken}
+	var client PRClient
+	if workerCfg.NewPRClient != nil {
+		client = workerCfg.NewPRClient()
+	} else {
+		client = gitea.Client{BaseURL: workerCfg.GiteaBaseURL, Token: workerCfg.GiteaToken}
+	}
 	return CreatePRWith(ctx, ev, t, wcfg, summary, verifyDegraded, client)
 }
 

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -1,0 +1,387 @@
+package worker_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	worker "github.com/xrf9268-hue/aiops-platform/internal/worker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// initBareUpstreamWithWorkflow seeds a bare upstream repo containing the
+// given WORKFLOW.md body plus a README so the worker's worktree-add lands
+// on a non-empty base branch. Returns the file:// URL of the bare repo
+// and a sample task pre-wired to that URL so the test only has to set
+// source identity fields.
+func initBareUpstreamWithWorkflow(t *testing.T, workflowBody string) (cloneURL string, baseTask task.Task) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	work := filepath.Join(root, "seed")
+	bare := filepath.Join(root, "upstream.git")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "init", "-q", "-b", "main", work},
+		{"git", "-C", work, "config", "user.email", "u@example.com"},
+		{"git", "-C", work, "config", "user.name", "u"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if workflowBody != "" {
+		if err := os.WriteFile(filepath.Join(work, "WORKFLOW.md"), []byte(workflowBody), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, args := range [][]string{
+		{"git", "-C", work, "add", "."},
+		{"git", "-C", work, "commit", "-q", "-m", "seed"},
+		{"git", "init", "--bare", "-q", "-b", "main", bare},
+		{"git", "-C", work, "remote", "add", "origin", bare},
+		{"git", "-C", work, "push", "-q", "origin", "main"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	cloneURL = "file://" + bare
+	baseTask = task.Task{
+		ID:            "tsk_int",
+		Title:         "integration",
+		Description:   "exercise runTask",
+		Actor:         "tester",
+		Model:         "mock",
+		RepoOwner:     "acme",
+		RepoName:      "demo",
+		CloneURL:      cloneURL,
+		BaseBranch:    "main",
+		WorkBranch:    "ai/tsk_int",
+		SourceType:    "linear_issue",
+		SourceEventID: "issue-uuid",
+	}
+	return cloneURL, baseTask
+}
+
+// linearWorkflowBody is a minimal front-matter that satisfies validateConfig
+// while routing the worker's tracker hooks down the linear branch. clone_url
+// is overridden at runtime via the env-var expansion (loader expands
+// $REPO_URL on every Load), so a single body string can be reused across
+// tests that target different temp repos.
+const linearWorkflowBody = `---
+repo:
+  owner: acme
+  name: demo
+  clone_url: $REPO_URL
+tracker:
+  kind: linear
+agent:
+  default: mock
+---
+do the work for {{task.title}}
+`
+
+// workerCfgForIntegration assembles the Config the integration tests share:
+// per-test workspace/mirror roots plus the fake transitioner/PR-client
+// factories. Returns the cfg with fakes already wired.
+func workerCfgForIntegration(t *testing.T, tr *fakeTransitioner, pr *fakePRClient) worker.Config {
+	t.Helper()
+	return worker.Config{
+		WorkspaceRoot: t.TempDir(),
+		MirrorRoot:    t.TempDir(),
+		NewTransitioner: func(_ workflow.TrackerConfig) worker.Transitioner {
+			return tr
+		},
+		NewPRClient: func() worker.PRClient { return pr },
+	}
+}
+
+// TestRunTask_FiresClaimThenPRCreatedOnSuccess pins acceptance criterion 1
+// for issue #60: when runTask completes successfully against a linear
+// tracker config, the transitioner sees the move calls in order
+// (InProgress on claim, then HumanReview on PR open), and the
+// tracker_transition events are sequenced after workflow_resolved so a
+// future refactor that reorders OnClaim ahead of ResolveWorkflow is
+// caught.
+func TestRunTask_FiresClaimThenPRCreatedOnSuccess(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+
+	tr := &fakeTransitioner{}
+	pr := &fakePRClient{
+		createPR: &gitea.PullRequest{Number: 7, HTMLURL: "http://gitea.local/acme/demo/pulls/7", Title: "chore(ai): integration"},
+	}
+	ev := &fakeEmitter{}
+	cfg := workerCfgForIntegration(t, tr, pr)
+
+	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		t.Fatalf("runTask: %v", rterr.Err)
+	}
+
+	if len(tr.moves) != 2 {
+		t.Fatalf("MoveIssueToState calls = %d, want 2 (claim + pr); got %#v", len(tr.moves), tr.moves)
+	}
+	if tr.moves[0] != (moveCall{IssueID: "issue-uuid", State: "In Progress"}) {
+		t.Fatalf("first move = %#v, want issue-uuid -> In Progress", tr.moves[0])
+	}
+	if tr.moves[1] != (moveCall{IssueID: "issue-uuid", State: "Human Review"}) {
+		t.Fatalf("second move = %#v, want issue-uuid -> Human Review", tr.moves[1])
+	}
+
+	// The PR client must have been asked to create (not just looked up):
+	// guards the create-new path explicitly.
+	if len(pr.createCalls) != 1 {
+		t.Fatalf("CreatePullRequest calls = %d, want 1 on create-new path", len(pr.createCalls))
+	}
+
+	// Order: workflow_resolved (from ResolveWorkflow) must appear before
+	// the first tracker_transition (from OnClaim). Guards against a
+	// refactor that fires OnClaim before the workflow is loaded, which
+	// would race the per-task tracker config we resolve from
+	// wf.Config.Tracker.
+	idxResolved := indexOfEvent(ev, task.EventWorkflowResolved)
+	idxFirstTransition := indexOfEvent(ev, task.EventTrackerTransition)
+	if idxResolved < 0 {
+		t.Fatalf("workflow_resolved event not emitted; events=%#v", ev.events)
+	}
+	if idxFirstTransition < 0 {
+		t.Fatalf("tracker_transition event not emitted")
+	}
+	if idxFirstTransition < idxResolved {
+		t.Fatalf("tracker_transition (idx=%d) fired before workflow_resolved (idx=%d); OnClaim must run after ResolveWorkflow", idxFirstTransition, idxResolved)
+	}
+
+	// Order: pr_created must appear before the second tracker_transition,
+	// because OnPRCreated only runs when CreatePR returned nil.
+	idxPRCreated := indexOfEvent(ev, task.EventPRCreated)
+	idxLastTransition := lastIndexOfEvent(ev, task.EventTrackerTransition)
+	if idxPRCreated < 0 {
+		t.Fatalf("pr_created event not emitted")
+	}
+	if idxLastTransition <= idxPRCreated {
+		t.Fatalf("second tracker_transition (idx=%d) must fire after pr_created (idx=%d)", idxLastTransition, idxPRCreated)
+	}
+}
+
+// TestRunTask_FiresPRCreatedOnReusePath covers the second half of AC1:
+// when CreatePR takes the reuse-existing branch (FindOpenPullRequest
+// returns a PR), OnPRCreated must still fire so the linked Linear issue
+// flips to Human Review. A retry that lands on an already-open PR should
+// not skip the tracker handoff.
+func TestRunTask_FiresPRCreatedOnReusePath(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+
+	tr := &fakeTransitioner{}
+	pr := &fakePRClient{
+		findResult: &gitea.PullRequest{Number: 13, HTMLURL: "http://gitea.local/acme/demo/pulls/13", Title: "chore(ai): integration"},
+	}
+	cfg := workerCfgForIntegration(t, tr, pr)
+	ev := &fakeEmitter{}
+
+	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		t.Fatalf("runTask: %v", rterr.Err)
+	}
+
+	if len(pr.createCalls) != 0 {
+		t.Fatalf("CreatePullRequest must not be called on reuse path; got %d", len(pr.createCalls))
+	}
+	if len(tr.moves) != 2 {
+		t.Fatalf("MoveIssueToState calls = %d, want 2 even on reuse path; got %#v", len(tr.moves), tr.moves)
+	}
+	if tr.moves[1].State != "Human Review" {
+		t.Fatalf("second move state = %q, want \"Human Review\" on PR reuse", tr.moves[1].State)
+	}
+	if got := len(ev.byKind(task.EventPRReused)); got != 1 {
+		t.Fatalf("pr_reused events = %d, want 1", got)
+	}
+}
+
+// indexOfEvent returns the position of the first recorded event with the
+// given kind, or -1 if none exists. The events slice is read under the
+// emitter's lock to stay race-free with concurrent writers (in practice
+// runTask is single-goroutine but the lock keeps the helper honest).
+func indexOfEvent(ev *fakeEmitter, kind string) int {
+	ev.mu.Lock()
+	defer ev.mu.Unlock()
+	for i, e := range ev.events {
+		if e.Kind == kind {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastIndexOfEvent(ev *fakeEmitter, kind string) int {
+	ev.mu.Lock()
+	defer ev.mu.Unlock()
+	for i := len(ev.events) - 1; i >= 0; i-- {
+		if ev.events[i].Kind == kind {
+			return i
+		}
+	}
+	return -1
+}
+
+// fakeRunStore implements the structural contract Run requires from its
+// store (Claim/Complete + EventEmitter + failingStore) so Run can be
+// driven without Postgres. It hands out a single task, then synthesises
+// ctx cancellation via the onClaimed hook so the worker loop exits
+// deterministically after the failure path runs.
+type fakeRunStore struct {
+	task       *task.Task
+	failResult bool
+	failErr    error
+
+	mu        sync.Mutex
+	claimed   bool
+	events    []recordedEvent
+	failCalls int
+	onClaimed func()
+}
+
+func (s *fakeRunStore) Claim(ctx context.Context) (*task.Task, error) {
+	s.mu.Lock()
+	already := s.claimed
+	s.claimed = true
+	s.mu.Unlock()
+	if already {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return s.task, nil
+}
+
+func (s *fakeRunStore) Complete(_ context.Context, _ string) error { return nil }
+
+func (s *fakeRunStore) AddEvent(_ context.Context, _, kind, msg string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, recordedEvent{Kind: kind, Message: msg})
+	return nil
+}
+
+func (s *fakeRunStore) AddEventWithPayload(_ context.Context, _, kind, msg string, payload any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, recordedEvent{Kind: kind, Message: msg, Payload: payload})
+	return nil
+}
+
+func (s *fakeRunStore) Fail(_ context.Context, _, _ string) (bool, error) {
+	s.mu.Lock()
+	s.failCalls++
+	cb := s.onClaimed
+	s.mu.Unlock()
+	if cb != nil {
+		cb()
+	}
+	return s.failResult, s.failErr
+}
+
+func (s *fakeRunStore) FailTimeout(_ context.Context, _, _ string, _ int) (bool, error) {
+	// runTask in these tests fails at PrepareGitWorkspace, which is not a
+	// runner.TimeoutError, so handleTaskFailure always takes the Fail()
+	// path. Implementing FailTimeout here just keeps the interface satisfied.
+	return false, nil
+}
+
+// TestRun_OnFailureGatedByTerminality pins acceptance criterion 2: the
+// worker loop must call cfg.NewTransitioner(rterr.Cfg.Tracker) (the entry
+// point for OnFailure) only when handleTaskFailure reports terminal=true.
+// A re-queued failure (terminal=false) must skip the tracker write so the
+// linked Linear issue does not flicker between In Progress and Rework
+// during transient retries, which would otherwise trip the poller's
+// Rework re-enqueue path.
+func TestRun_OnFailureGatedByTerminality(t *testing.T) {
+	cases := []struct {
+		name          string
+		failResult    bool
+		wantNewTrCall int
+	}{
+		{"requeue_skips_onfailure", false, 0},
+		{"terminal_invokes_onfailure", true, 1},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Drive runTask to fail at PrepareGitWorkspace by pointing
+			// CloneURL at a path that cannot be cloned. This keeps
+			// rterr.Cfg empty (Kind="") so cfg.NewTransitioner's call
+			// count is the cleanest signal of which branch Run took.
+			tk := &task.Task{
+				ID:            "tsk_fail",
+				CloneURL:      "file:///definitely-not-a-real-path/" + tc.name,
+				BaseBranch:    "main",
+				WorkBranch:    "ai/tsk_fail",
+				SourceType:    "linear_issue",
+				SourceEventID: "issue-uuid",
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			store := &fakeRunStore{
+				task:       tk,
+				failResult: tc.failResult,
+			}
+			store.onClaimed = func() {
+				// Cancel after Fail returns so Run exits the loop
+				// before re-entering Claim. The brief delay defers
+				// cancellation until after the terminal-branch
+				// NewTransitioner call has happened.
+				go func() {
+					time.Sleep(20 * time.Millisecond)
+					cancel()
+				}()
+			}
+
+			var newTrCalls int
+			var trMu sync.Mutex
+			cfg := worker.Config{
+				WorkspaceRoot: t.TempDir(),
+				MirrorRoot:    t.TempDir(),
+				NewTransitioner: func(_ workflow.TrackerConfig) worker.Transitioner {
+					trMu.Lock()
+					newTrCalls++
+					trMu.Unlock()
+					return nil
+				},
+			}
+
+			done := make(chan struct{})
+			go func() {
+				worker.Run(ctx, store, cfg)
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				cancel()
+				t.Fatal("Run did not exit within 5s")
+			}
+
+			if store.failCalls != 1 {
+				t.Fatalf("Fail calls = %d, want 1", store.failCalls)
+			}
+			trMu.Lock()
+			got := newTrCalls
+			trMu.Unlock()
+			if got != tc.wantNewTrCall {
+				t.Fatalf("NewTransitioner calls = %d, want %d (terminal=%v)", got, tc.wantNewTrCall, tc.failResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #60. Adds end-to-end coverage that the worker invokes `OnClaim`, `OnPRCreated`, and `OnFailure` at the right lifecycle points. The hook bodies themselves were already unit-covered in `transitions_test.go` and `handletaskfailure_test.go` (added in PR #58), but nothing asserted that `runTask` + `Run` actually call them at the right moments — a naive future refactor of `internal/worker/runtask.go` or `internal/worker/run.go` could drop a call and nothing would catch it.

- Extract a narrow `runStore` interface in `internal/worker/run.go` so `Run` can be exercised against a fake without standing up Postgres. `*queue.Store` satisfies it implicitly (Claim/Complete + EventEmitter + failingStore).
- Add `Config.NewPRClient` factory hook mirroring `NewTransitioner` so `CreatePR` can be driven through a `fakePRClient` in tests. Production behavior unchanged when the factory is nil (default `gitea.Client` is used).
- `export_test.go` re-exports `runTask` as `RunTaskForTest` so the external `worker_test` package can drive the full lifecycle without promoting the orchestration entrypoint to a stable public API.
- Three new tests in `runtask_integration_test.go`:
  - `TestRunTask_FiresClaimThenPRCreatedOnSuccess` — bare upstream + linear-tracker `WORKFLOW.md` + mock runner + fake PR client. Asserts the two `MoveIssueToState` calls in order (`In Progress` on claim, `Human Review` on PR open) and that `tracker_transition` events are sequenced after `workflow_resolved` (guards against a refactor that fires `OnClaim` before `ResolveWorkflow`).
  - `TestRunTask_FiresPRCreatedOnReusePath` — `FindOpenPullRequest` returns an existing PR; asserts `OnPRCreated` still flips the issue to `Human Review` on retry so a re-entry into the worker after an earlier successful PR open does not strand the linked Linear issue in `In Progress`.
  - `TestRun_OnFailureGatedByTerminality` — drives `Run` against a fake `runStore` whose `Fail()` returns `terminal=false` vs `terminal=true`. Counts `cfg.NewTransitioner` invocations as a proxy for whether `Run` entered the `OnFailure` branch (`terminal=false` → 0, `terminal=true` → 1). Locks the gating that keeps transient retries from flickering the linked issue between `In Progress` and `Rework` (which would otherwise trip cmd/linear-poller's Rework re-enqueue path).

Tests run without Postgres; the integration tests use a `file://` bare upstream (mirrors the existing `internal/workspace/mirror_test` pattern) and the mock runner so the worker's `RUN_SUMMARY.md` gate accepts the output.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/worker/... -count=1`
- [x] `go test ./internal/worker/... -race -count=1 -run 'TestRunTask_|TestRun_OnFailure'`
- [x] `go test ./... -count=1` (whole tree green)