### PR TITLE
feat: implement safe codex runner profile (#17)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# AGENTS.md
+
+Project guide for AI coding agents (Codex CLI, Claude Code, etc.) working in this repo.
+
+## What this project is
+
+`aiops-platform` is a Go-based, self-hostable AI coding orchestrator inspired by OpenAI Symphony. It receives Linear issues or Gitea webhook events, claims them through a Postgres-backed queue, runs them through a Symphony-style workflow (`mock` / `codex` / `claude` runners) in a deterministic workspace, and opens a draft PR.
+
+The Go module path is `github.com/xrf9268-hue/aiops-platform` — keep it as-is even if the GitHub repo is temporarily mirrored elsewhere.
+
+## Layout
+
+| Path | What lives there |
+|------|------------------|
+| `cmd/trigger-api` | HTTP server: Gitea webhook ingress + manual task submission |
+| `cmd/worker` | Claims queued tasks, runs the Symphony loop, opens PRs |
+| `cmd/linear-poller` | Polls Linear active states and enqueues tasks |
+| `internal/workflow` | Loads `WORKFLOW.md` (front matter + prompt body) |
+| `internal/queue` | Postgres queue using `FOR UPDATE SKIP LOCKED` |
+| `internal/runner` | Runner abstraction: `mock`, `codex`, `claude` |
+| `internal/workspace` | Deterministic git workspace, verify, policy checks |
+| `internal/tracker` | Tracker abstraction with Linear client |
+| `internal/gitea` | Webhook parser, signature verification, PR client |
+| `internal/triggerapi`, `internal/worker` | HTTP handlers and worker lifecycle |
+| `internal/task`, `internal/policy` | Task event constants, policy helpers |
+| `migrations/` | SQL migrations for the Postgres queue |
+| `docs/adr/` | Architectural decisions (start here for "why") |
+| `docs/runbooks/` | Operational guides (CI, local dev, secret scan, workspace cache) |
+| `test/e2e/` | Build-tagged E2E suite (`-tags e2e`) using Postgres + Gitea containers |
+
+## Build, test, lint
+
+The CI gate is the authoritative checklist — match it locally before pushing:
+
+```bash
+gofmt -l $(git ls-files '*.go')         # must be empty
+go mod tidy && git diff --exit-code -- go.mod go.sum
+go test -race -covermode=atomic ./...
+go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller
+```
+
+E2E (requires Docker, pulls `postgres:16` and `gitea/gitea:1.26.1-rootless`):
+
+```bash
+go test -tags e2e -race -timeout 15m ./test/e2e/...
+```
+
+Inspect the effective `WORKFLOW.md` resolution for a workdir without consuming a task:
+
+```bash
+go run ./cmd/worker --print-config /path/to/repo/clone
+```
+
+Go toolchain: pinned via `go.mod` (Go 1.25). Don't edit `go.mod`'s `go` directive opportunistically.
+
+## Conventions
+
+- **gofmt is non-negotiable**: CI fails on any diff. Always run before committing.
+- **`go mod tidy` must leave `go.mod`/`go.sum` clean**: don't add deps you don't use.
+- **No `t.Parallel()` in tests that touch shared Postgres state** — the queue tests rely on serial execution to assert ordering.
+- **Task events**: when adding a new lifecycle event, add the kind as a constant in `internal/task` rather than inlining the string at the call site.
+- **Don't mock the database in integration tests** — hit real Postgres (testcontainers or the E2E harness).
+- **Secrets**: never commit real credentials. `.env`, `.env.*`, `*.key`, `*.pem` are gitignored; `.env.example` is the only sanctioned env template.
+- **PRs from the worker are draft + labeled by default**; respect `policy.max_changed_files` (12) and `policy.max_changed_loc` (300) defaults when shaping changes.
+
+## WORKFLOW.md discovery (worker side)
+
+The worker resolves `WORKFLOW.md` from a target clone in this priority order:
+
+1. `<repo>/WORKFLOW.md`
+2. `<repo>/.aiops/WORKFLOW.md`
+3. `<repo>/.github/WORKFLOW.md`
+
+Missing front matter is allowed — the body becomes the prompt template, all other settings fall back to defaults (see `README.md` table). The `workflow_resolved` task event captures the resolved source, path, and shadowed candidates.
+
+## Where to read next
+
+- `README.md` — user-facing quick start (Gitea webhook path, Linear polling path)
+- `docs/runbooks/local-dev.md` — local dev loop
+- `docs/runbooks/ci.md` — CI behavior, release flow, pre-push checks
+- `docs/runbooks/secret-scanning.md` — opt-in pre-push leak scan
+- `docs/runbooks/workspace-cache.md` — workspace lifecycle and cleanup
+- `docs/adr/0001-symphony-style-personal-orchestrator.md` — the "why"
+
+## Safety posture for agents
+
+- The worker opens PRs; it never merges. Don't add auto-merge logic.
+- Keep first-time real runs on `agent.default: mock` until the loop is trusted on the target repo.
+- Use low-privilege bot accounts for Gitea / Linear / GitHub tokens.
+- When in doubt about scope, prefer a narrower change and a clear PR description over speculative refactors.

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -101,6 +101,16 @@ codex:
   command: codex exec
 ```
 
+**Profiles** select how the runner invokes codex:
+
+- `safe` (default): builds `codex exec --full-auto --skip-git-repo-check --cd <workdir> -o <workdir>/.aiops/CODEX_LAST_MESSAGE.md` from argv (no shell). PROMPT.md is piped on stdin. `--full-auto` is codex's documented shorthand for `--sandbox workspace-write --ask-for-approval=never`.
+- `bypass`: same shape but with `--dangerously-bypass-approvals-and-sandbox`. Use only when the worker host is already isolated (container, dedicated VM); the flag turns codex's own sandbox off.
+- `custom`: runs the literal `codex.command` via `sh -lc` with PROMPT.md on stdin. Note the change from earlier versions: the runner no longer appends `< .aiops/PROMPT.md` to the command — your command must consume stdin (which `codex exec` does by default when no positional prompt is given).
+
+### Reading codex output after a run
+
+Each codex run writes `.aiops/CODEX_OUTPUT.txt` (combined stdout+stderr, capped at 1 MiB with a truncation footer when the cap fires) and reads `.aiops/CODEX_LAST_MESSAGE.md` (codex's own `-o` artifact) as the run summary. The `runner_end` task event payload also carries `output_head` (first 4 KiB), `output_tail` (last 4 KiB if non-overlapping), `output_bytes`, and `output_dropped` for at-a-glance triage from `/v1/tasks/<id>/events` without cloning the work branch.
+
 ### `claude`
 
 Same shell runner, invokes `claude.command` (default `claude`).

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -86,7 +86,7 @@ agent:
 
 ### `codex`
 
-Shell runner that pipes `.aiops/PROMPT.md` into `codex.command` (default `codex exec`). See `internal/runner/shell.go`.
+Profile-driven runner (`internal/runner/codex.go`) that invokes the codex CLI with sandbox/approval flags chosen by `codex.profile`. PROMPT.md is piped on stdin; output is captured to `.aiops/CODEX_OUTPUT.txt`. The `custom` profile falls back to `sh -lc <codex.command>` (still stdin-fed).
 
 Use when:
 

--- a/docs/superpowers/plans/2026-05-11-safe-codex-runner.md
+++ b/docs/superpowers/plans/2026-05-11-safe-codex-runner.md
@@ -1,0 +1,1523 @@
+# Safe Codex Runner Profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the generic ShellRunner-for-codex with a profile-driven `CodexRunner` (safe / bypass / custom), capture codex stdout/stderr to a workspace artifact and the runner_end event payload, and pick up codex's `--output-last-message` artifact as `Result.Summary`. Closes issue #17.
+
+**Architecture:** A new `CodexRunner` in `internal/runner` builds argv from `Workflow.Config.Codex.Profile`, runs `codex` via `exec.CommandContext` with PROMPT.md piped on stdin, and shares one capture path across all profiles. A small `cappedWriter` mirrors `workspace.cappedBuffer` semantics (1 MiB cap, drop counter). The worker's `RunRunnerWithTimeout` enriches `runner_end`/`runner_timeout` payloads with head/tail/bytes/dropped when the runner provides them. Schema gains one field: `codex.profile`.
+
+**Tech Stack:** Go 1.25, `os/exec`, `syscall` (process group kill via existing `configurePlatformKill`), `gopkg.in/yaml.v3`, standard `testing` package. No new module deps.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md` — implementation details below repeat the relevant code rather than referring out.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `internal/runner/capture.go` | Create | `cappedWriter` (1 MiB cap, drop counter) + `headTail` helper for event payload extraction. |
+| `internal/runner/capture_test.go` | Create | Unit tests for cappedWriter and headTail. |
+| `internal/runner/codex.go` | Create | `CodexRunner` struct, profile dispatch (safe/bypass/custom), argv assembly, stdin piping, capture, artifact write, last-message pickup, error classification. |
+| `internal/runner/codex_test.go` | Create | Codex tests using a per-test PATH-stub `codex` binary. |
+| `internal/runner/runner.go` | Modify | Extend `Result` with `OutputBytes/OutputDropped/OutputHead/OutputTail`. Re-route `New("codex")` to `CodexRunner`. |
+| `internal/runner/runner_test.go` | Modify | Rebind the two ShellRunner kill/exit tests from `codex` to `claude` so they continue to exercise the shell path. |
+| `internal/workflow/config.go` | Modify | Add `Profile string` to `CommandConfig`. Default `Codex.Profile = "safe"` in `DefaultConfig()`. |
+| `internal/workflow/loader.go` | Modify | Add `supportedCodexProfiles`, validate `Codex.Profile`, reject `Claude.Profile`, normalize empty `Codex.Profile` to `safe` in `expandConfig`. |
+| `internal/workflow/config_test.go` | Modify | Default-value, accept, reject, normalize, claude-rejection tests. |
+| `internal/worker/runtask.go` | Modify | Enrich `runner_end` (success and failure) and `runner_timeout` event payloads with `output_head/output_tail/output_bytes/output_dropped` when `Result` populates them. |
+| `internal/worker/run_test.go` | Modify | Assertion that the new payload keys appear when Result populated; mock path leaves them absent. |
+| `examples/WORKFLOW.md` | Modify | Document `codex.profile` default + alternatives in the existing `codex:` block. |
+| `docs/runbooks/personal-daily-workflow.md` | Modify | Profile semantics in the codex subsection + "Reading codex output after a run" pointer. |
+| `docs/symphony-integration.md` | Modify | Wording fix on "advanced sandboxing" + Symphony app-server pointer. |
+| `README.md` | Modify | One-line `codex.profile` mention near the existing codex.command reference (only if such a reference exists; skip otherwise). |
+
+Total: 4 created, 11 modified.
+
+---
+
+## Pre-flight (Task 0)
+
+- [ ] **Step 1: Read the spec end-to-end so the rationale is loaded**
+
+```bash
+cat docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md
+```
+
+Expected: 14-section design including Profile Contract, API Surface, Data Flow, Error Handling, Testing.
+
+- [ ] **Step 2: Verify clean tree on the implementation branch**
+
+```bash
+git status --short
+```
+
+Expected: empty output.
+
+- [ ] **Step 3: Confirm Go toolchain matches go.mod**
+
+```bash
+go version && head -3 go.mod
+```
+
+Expected: `go version go1.25.x`; go.mod's `go` directive at 1.25.
+
+---
+
+## Task 1: `cappedWriter` capture helper
+
+**Files:**
+- Create: `internal/runner/capture.go`
+- Create: `internal/runner/capture_test.go`
+
+**Why first:** Leaf dependency. Codex tests will rely on it; getting the head/tail boundary semantics exactly right early prevents reworking codex tests.
+
+- [ ] **Step 1: Write failing test for cap + drop counter**
+
+Create `internal/runner/capture_test.go` with:
+
+```go
+package runner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCappedWriter_KeepsUpToCapDropsRest(t *testing.T) {
+	t.Parallel()
+	w := &cappedWriter{Cap: 10}
+	n, err := w.Write([]byte("0123456789ABCDE")) // 15 bytes
+	if err != nil {
+		t.Fatalf("Write returned err: %v", err)
+	}
+	if n != 15 {
+		t.Fatalf("Write returned n=%d, want 15", n)
+	}
+	if got := w.Bytes(); !bytes.Equal(got, []byte("0123456789")) {
+		t.Fatalf("Bytes()=%q, want %q", got, "0123456789")
+	}
+	if got, want := w.Dropped(), int64(5); got != want {
+		t.Fatalf("Dropped()=%d, want %d", got, want)
+	}
+}
+
+func TestCappedWriter_MultipleWritesAccumulate(t *testing.T) {
+	t.Parallel()
+	w := &cappedWriter{Cap: 10}
+	w.Write([]byte("hello "))
+	w.Write([]byte("world!!"))
+	if got := w.Bytes(); string(got) != "hello worl" {
+		t.Fatalf("Bytes()=%q, want %q", got, "hello worl")
+	}
+	if w.Dropped() != 3 {
+		t.Fatalf("Dropped()=%d, want 3", w.Dropped())
+	}
+}
+
+func TestCappedWriter_ZeroCapDropsEverything(t *testing.T) {
+	t.Parallel()
+	w := &cappedWriter{Cap: 0}
+	w.Write([]byte("anything"))
+	if len(w.Bytes()) != 0 {
+		t.Fatalf("Bytes() not empty: %q", w.Bytes())
+	}
+	if w.Dropped() != 8 {
+		t.Fatalf("Dropped()=%d, want 8", w.Dropped())
+	}
+}
+
+func TestHeadTail_BelowCapReturnsHeadOnly(t *testing.T) {
+	t.Parallel()
+	body := []byte(strings.Repeat("x", 100))
+	head, tail := headTail(body, 4096)
+	if string(head) != string(body) {
+		t.Fatalf("head should equal body when len < cap")
+	}
+	if tail != "" {
+		t.Fatalf("tail should be empty when body fits in head; got %q", tail)
+	}
+}
+
+func TestHeadTail_AboveCapSplits(t *testing.T) {
+	t.Parallel()
+	body := []byte(strings.Repeat("a", 4000) + strings.Repeat("b", 4000) + strings.Repeat("c", 4000))
+	head, tail := headTail(body, 4096)
+	if len(head) != 4096 {
+		t.Fatalf("head len=%d, want 4096", len(head))
+	}
+	if len(tail) != 4096 {
+		t.Fatalf("tail len=%d, want 4096", len(tail))
+	}
+	if !strings.HasPrefix(string(head), strings.Repeat("a", 4000)) {
+		t.Fatalf("head should start with 'a's, got prefix %q", head[:8])
+	}
+	if !strings.HasSuffix(string(tail), strings.Repeat("c", 4000)) {
+		t.Fatalf("tail should end with 'c's")
+	}
+}
+```
+
+- [ ] **Step 2: Verify tests fail (no symbol)**
+
+Run: `go test ./internal/runner/... -run 'TestCappedWriter|TestHeadTail' -v 2>&1 | head -30`
+
+Expected: compile error mentioning `cappedWriter` undefined.
+
+- [ ] **Step 3: Implement `capture.go`**
+
+Create `internal/runner/capture.go`:
+
+```go
+package runner
+
+// CodexOutputCap is the upper bound on bytes the codex runner buffers in
+// memory from a single run. Matches workspace.VerifyOutputCap so artifact
+// ergonomics are uniform across the verify and runner phases.
+const CodexOutputCap = 1 << 20 // 1 MiB
+
+// CodexEventOutputCap bounds the head and tail slices embedded in the
+// runner_end event payload. 4 KiB per side keeps the events table cheap
+// to query while still surfacing enough context for triage.
+const CodexEventOutputCap = 4 << 10 // 4 KiB
+
+// cappedWriter is an io.Writer that buffers up to Cap bytes and silently
+// drops the rest while remembering how many bytes were dropped. It is the
+// runner-side twin of workspace.cappedBuffer; the duplication avoids an
+// import cycle and keeps each package's IO contract local.
+type cappedWriter struct {
+	Cap     int
+	buf     []byte
+	dropped int64
+}
+
+func (c *cappedWriter) Write(p []byte) (int, error) {
+	if c.Cap <= 0 {
+		c.dropped += int64(len(p))
+		return len(p), nil
+	}
+	remaining := c.Cap - len(c.buf)
+	if remaining <= 0 {
+		c.dropped += int64(len(p))
+		return len(p), nil
+	}
+	take := len(p)
+	if take > remaining {
+		take = remaining
+	}
+	c.buf = append(c.buf, p[:take]...)
+	if take < len(p) {
+		c.dropped += int64(len(p) - take)
+	}
+	return len(p), nil
+}
+
+// Bytes returns the buffered bytes (post-cap). Callers must not mutate.
+func (c *cappedWriter) Bytes() []byte { return c.buf }
+
+// Dropped reports how many bytes were dropped because Cap was reached.
+func (c *cappedWriter) Dropped() int64 { return c.dropped }
+
+// headTail returns the first headCap bytes and (when body is longer than
+// headCap) the last headCap bytes. tail is empty when the entire body
+// fits in head, so callers do not duplicate content. headCap is applied
+// to each side independently — total payload size is bounded by 2*headCap.
+func headTail(body []byte, headCap int) (head []byte, tail string) {
+	if headCap <= 0 || len(body) == 0 {
+		return nil, ""
+	}
+	if len(body) <= headCap {
+		return body, ""
+	}
+	head = body[:headCap]
+	tail = string(body[len(body)-headCap:])
+	return head, tail
+}
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `go test ./internal/runner/... -run 'TestCappedWriter|TestHeadTail' -v`
+
+Expected: all five tests PASS.
+
+- [ ] **Step 5: gofmt check**
+
+Run: `gofmt -l internal/runner/capture.go internal/runner/capture_test.go`
+
+Expected: empty output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/runner/capture.go internal/runner/capture_test.go
+git commit -m "feat(runner): add cappedWriter and headTail capture helpers (#17)"
+```
+
+---
+
+## Task 2: `codex.profile` schema field + loader validation
+
+**Files:**
+- Modify: `internal/workflow/config.go`
+- Modify: `internal/workflow/loader.go`
+- Modify: `internal/workflow/config_test.go`
+
+**Why second:** Independent of runner; safe to merge first if desired. Loader validation rejects bad input regardless of which runner consumes it.
+
+- [ ] **Step 1: Read the existing config + loader to confirm shape**
+
+Run: `sed -n '85,115p' internal/workflow/config.go` and `sed -n '50,90p' internal/workflow/loader.go`
+
+Expected: confirms `CommandConfig` shape and `validateConfig` / `supportedAgentDefaults` patterns referenced below.
+
+- [ ] **Step 2: Write failing tests first**
+
+Edit `internal/workflow/config_test.go`. Append the following tests at the end of the file:
+
+```go
+func TestDefaultConfig_CodexProfileIsSafe(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	if cfg.Codex.Profile != "safe" {
+		t.Fatalf("DefaultConfig().Codex.Profile = %q, want %q", cfg.Codex.Profile, "safe")
+	}
+}
+
+func TestLoad_AcceptsSupportedCodexProfiles(t *testing.T) {
+	t.Parallel()
+	for _, profile := range []string{"safe", "bypass", "custom"} {
+		profile := profile
+		t.Run(profile, func(t *testing.T) {
+			path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex
+codex:
+  command: codex exec
+  profile: `+profile+`
+---
+prompt body
+`)
+			wf, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load(%s): %v", profile, err)
+			}
+			if wf.Config.Codex.Profile != profile {
+				t.Fatalf("Codex.Profile = %q, want %q", wf.Config.Codex.Profile, profile)
+			}
+		})
+	}
+}
+
+func TestLoad_RejectsUnknownCodexProfile(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex
+codex:
+  command: codex exec
+  profile: yolo
+---
+prompt
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: expected error for codex.profile=yolo, got nil")
+	}
+	if !strings.Contains(err.Error(), "codex.profile") || !strings.Contains(err.Error(), "yolo") {
+		t.Fatalf("error = %q; want it to mention codex.profile and yolo", err)
+	}
+}
+
+func TestLoad_NormalizesEmptyCodexProfileToSafe(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex
+codex:
+  command: codex exec
+---
+prompt
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if wf.Config.Codex.Profile != "safe" {
+		t.Fatalf("Codex.Profile = %q, want %q (normalization)", wf.Config.Codex.Profile, "safe")
+	}
+}
+
+func TestLoad_RejectsClaudeProfile(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: claude
+claude:
+  command: claude
+  profile: safe
+---
+prompt
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: expected error for claude.profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "claude.profile") {
+		t.Fatalf("error = %q; want it to mention claude.profile", err)
+	}
+}
+```
+
+If `writeTempWorkflow` does not yet exist in `config_test.go` (grep first), add this helper near the top:
+
+```go
+func writeTempWorkflow(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/WORKFLOW.md"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+```
+
+Add `"os"` and `"strings"` to the imports if not already present.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./internal/workflow/... -run 'TestDefaultConfig_CodexProfileIsSafe|TestLoad_AcceptsSupportedCodexProfiles|TestLoad_RejectsUnknownCodexProfile|TestLoad_NormalizesEmptyCodexProfileToSafe|TestLoad_RejectsClaudeProfile' -v 2>&1 | head -30`
+
+Expected: failures — `Codex.Profile` field undefined OR all five fail because Profile field absent from struct, fields silently drop.
+
+- [ ] **Step 4: Add `Profile` field to `CommandConfig`**
+
+Edit `internal/workflow/config.go`. Replace the `CommandConfig` struct (around line 90):
+
+```go
+type CommandConfig struct {
+	Command string `yaml:"command" json:"command"`
+	// Profile is consulted only by the codex runner. Allowed values: "safe"
+	// (default), "bypass", "custom". The field lives on the shared
+	// CommandConfig type to avoid splitting CodexConfig out for one field;
+	// loader validation rejects non-empty Profile on the Claude embed so a
+	// copy-paste mistake fails loud at load time instead of silently doing
+	// nothing.
+	Profile string `yaml:"profile,omitempty" json:"profile,omitempty"`
+}
+```
+
+In `DefaultConfig()` (same file, around line 198), update the Codex line:
+
+```go
+		Codex:  CommandConfig{Command: "codex exec", Profile: "safe"},
+```
+
+- [ ] **Step 5: Add validation and normalization in loader.go**
+
+Edit `internal/workflow/loader.go`. Add this constant block near `supportedAgentDefaults` (around line 64):
+
+```go
+// supportedCodexProfiles enumerates the codex runner profile names the
+// runner package knows how to dispatch. "safe" injects --full-auto +
+// --skip-git-repo-check; "bypass" swaps in
+// --dangerously-bypass-approvals-and-sandbox for already-isolated hosts;
+// "custom" falls back to the operator-supplied codex.command via sh -lc.
+var supportedCodexProfiles = map[string]struct{}{
+	"safe":   {},
+	"bypass": {},
+	"custom": {},
+}
+```
+
+In `validateConfig` (around line 76), append before the return:
+
+```go
+	if _, ok := supportedCodexProfiles[cfg.Codex.Profile]; !ok {
+		return fmt.Errorf("%s: codex.profile %q is not supported (allowed: safe, bypass, custom)", path, cfg.Codex.Profile)
+	}
+	if strings.TrimSpace(cfg.Claude.Profile) != "" {
+		return fmt.Errorf("%s: claude.profile is not supported (only codex has profiles)", path)
+	}
+```
+
+In `expandConfig` (around line 146), add normalization for empty Codex.Profile:
+
+```go
+	if cfg.Codex.Profile == "" {
+		cfg.Codex.Profile = "safe"
+	}
+```
+
+- [ ] **Step 6: Run the new tests**
+
+Run: `go test ./internal/workflow/... -run 'TestDefaultConfig_CodexProfileIsSafe|TestLoad_AcceptsSupportedCodexProfiles|TestLoad_RejectsUnknownCodexProfile|TestLoad_NormalizesEmptyCodexProfileToSafe|TestLoad_RejectsClaudeProfile' -v`
+
+Expected: all five PASS.
+
+- [ ] **Step 7: Run the full workflow package to catch regressions**
+
+Run: `go test ./internal/workflow/...`
+
+Expected: PASS. If any pre-existing test previously asserted `cfg.Codex` had no `Profile` field, fix it (most likely by accepting the new default `"safe"`).
+
+- [ ] **Step 8: gofmt + go mod tidy verify**
+
+Run: `gofmt -l internal/workflow/ && go mod tidy && git diff --exit-code -- go.mod go.sum`
+
+Expected: empty + clean diff.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/workflow/config.go internal/workflow/loader.go internal/workflow/config_test.go
+git commit -m "feat(workflow): add codex.profile schema field with safe/bypass/custom (#17)"
+```
+
+---
+
+## Task 3: `CodexRunner` — safe profile end to end
+
+**Files:**
+- Create: `internal/runner/codex.go`
+- Create: `internal/runner/codex_test.go`
+- Modify: `internal/runner/runner.go` (extend `Result`, route `New("codex")` to `CodexRunner`)
+
+**Why third:** Builds on Task 1 (cappedWriter) and Task 2 (Codex.Profile field). All other CodexRunner work (bypass, custom, error paths) extends what lands here.
+
+- [ ] **Step 1: Extend `Result` in `runner.go`**
+
+Edit `internal/runner/runner.go`. Replace `Result`:
+
+```go
+type Result struct {
+	Summary       string
+	OutputBytes   int64  // bytes the runner kept in its capture buffer
+	OutputDropped int64  // bytes dropped because the buffer hit its cap
+	OutputHead    string // up to CodexEventOutputCap bytes from the start of the captured output
+	OutputTail    string // up to CodexEventOutputCap bytes from the end; empty when total <= head cap
+}
+```
+
+Do NOT change `runner.New` yet — codex still routes to `ShellRunner` until later in this task.
+
+- [ ] **Step 2: Build the test harness — PATH-stub `codex` helper**
+
+Create `internal/runner/codex_test.go`:
+
+```go
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// codexStubScript writes a bash script named `codex` into a temp dir and
+// prepends that dir to PATH for the duration of the test. The script body
+// is supplied by the caller. The script always records its argv and stdin
+// to predictable side files inside the same temp dir so tests can assert
+// what codex was actually called with.
+//
+// Returns (binDir, scriptCommand) where binDir contains the recorded
+// argv.txt / stdin.txt and the codex script itself.
+func codexStubScript(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "codex")
+	header := `#!/usr/bin/env bash
+set -e
+printf '%s\n' "$@" > "` + dir + `/argv.txt"
+cat > "` + dir + `/stdin.txt"
+`
+	if err := os.WriteFile(scriptPath, []byte(header+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return dir
+}
+
+// codexWorkdir creates a per-test workdir with a populated .aiops/PROMPT.md.
+func codexWorkdir(t *testing.T, prompt string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".aiops"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".aiops", "PROMPT.md"), []byte(prompt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func codexInput(workdir string) RunInput {
+	return RunInput{
+		Task:    task.Task{ID: "tsk_codex_test", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Codex: workflow.CommandConfig{Command: "codex exec", Profile: "safe"},
+		}},
+		Workdir: workdir,
+		Prompt:  "ignored — runner reads .aiops/PROMPT.md",
+	}
+}
+
+func TestCodexRunner_SafeProfileBuildsExpectedArgv(t *testing.T) {
+	t.Parallel()
+	binDir := codexStubScript(t, `exit 0`)
+	wd := codexWorkdir(t, "hello prompt")
+
+	in := codexInput(wd)
+	if _, err := (CodexRunner{}).Run(context.Background(), in); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(binDir, "argv.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"exec",
+		"--full-auto",
+		"--skip-git-repo-check",
+		"--cd",
+		wd,
+		"-o",
+		".aiops/CODEX_LAST_MESSAGE.md",
+	}
+	gotLines := strings.Split(strings.TrimRight(string(got), "\n"), "\n")
+	if len(gotLines) != len(want) {
+		t.Fatalf("argv lines = %d, want %d; got %q", len(gotLines), len(want), gotLines)
+	}
+	for i := range want {
+		if gotLines[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q", i, gotLines[i], want[i])
+		}
+	}
+}
+
+func TestCodexRunner_PromptPipedToStdin(t *testing.T) {
+	t.Parallel()
+	binDir := codexStubScript(t, `exit 0`)
+	wd := codexWorkdir(t, "stdin canary 42")
+
+	if _, err := (CodexRunner{}).Run(context.Background(), codexInput(wd)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "stdin canary 42" {
+		t.Fatalf("stdin = %q, want %q", got, "stdin canary 42")
+	}
+}
+
+func TestCodexRunner_CapturesOutputArtifact(t *testing.T) {
+	t.Parallel()
+	codexStubScript(t, `printf 'codex-canary-9134\n' ; printf 'err-line\n' >&2 ; exit 0`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(wd, ".aiops/CODEX_OUTPUT.txt"))
+	if err != nil {
+		t.Fatalf("read CODEX_OUTPUT.txt: %v", err)
+	}
+	if !strings.Contains(string(out), "codex-canary-9134") {
+		t.Fatalf("artifact missing stdout canary; got %q", out)
+	}
+	if !strings.Contains(string(out), "err-line") {
+		t.Fatalf("artifact missing stderr line; got %q", out)
+	}
+	if res.OutputBytes <= 0 {
+		t.Fatalf("Result.OutputBytes = %d, want > 0", res.OutputBytes)
+	}
+	if res.OutputDropped != 0 {
+		t.Fatalf("Result.OutputDropped = %d, want 0 for small output", res.OutputDropped)
+	}
+	if !strings.Contains(res.OutputHead, "codex-canary-9134") {
+		t.Fatalf("OutputHead missing canary; got %q", res.OutputHead)
+	}
+}
+
+func TestCodexRunner_LastMessageBecomesSummary(t *testing.T) {
+	t.Parallel()
+	codexStubScript(t, `mkdir -p .aiops && printf 'codex completed task X\n' > .aiops/CODEX_LAST_MESSAGE.md ; exit 0`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "codex completed task X" {
+		t.Fatalf("Summary = %q, want %q", res.Summary, "codex completed task X")
+	}
+}
+
+func TestCodexRunner_MissingLastMessageFallsBackToDefaultSummary(t *testing.T) {
+	t.Parallel()
+	codexStubScript(t, `exit 0`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "codex completed" {
+		t.Fatalf("Summary = %q, want %q", res.Summary, "codex completed")
+	}
+}
+
+func TestCodexRunner_OutputExceedsCapTruncates(t *testing.T) {
+	t.Parallel()
+	// 1.5 MiB of stdout: comfortably above the 1 MiB cap.
+	codexStubScript(t, `head -c 1572864 /dev/zero | tr '\0' 'a'`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.OutputDropped <= 0 {
+		t.Fatalf("OutputDropped = %d, want > 0", res.OutputDropped)
+	}
+	if res.OutputBytes != int64(CodexOutputCap) {
+		t.Fatalf("OutputBytes = %d, want %d (the cap)", res.OutputBytes, CodexOutputCap)
+	}
+	body, err := os.ReadFile(filepath.Join(wd, ".aiops/CODEX_OUTPUT.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(string(body), "\n") || !strings.Contains(string(body), "...output truncated at") {
+		t.Fatalf("artifact missing truncation footer; tail=%q", body[max(0, len(body)-200):])
+	}
+}
+
+func TestCodexRunner_MissingPromptReturnsWrappedError(t *testing.T) {
+	t.Parallel()
+	codexStubScript(t, `exit 0`)
+	dir := t.TempDir() // no .aiops/PROMPT.md
+	in := codexInput(dir)
+
+	_, err := (CodexRunner{}).Run(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected error for missing PROMPT.md, got nil")
+	}
+	if IsTimeout(err) {
+		t.Fatalf("missing-prompt should not classify as timeout: %v", err)
+	}
+	if !strings.Contains(err.Error(), "PROMPT.md") {
+		t.Fatalf("error %q should mention PROMPT.md", err)
+	}
+}
+
+func TestCodexRunner_MissingBinaryReturnsClearError(t *testing.T) {
+	t.Parallel()
+	t.Setenv("PATH", "") // no codex anywhere
+	wd := codexWorkdir(t, "x")
+	_, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err == nil {
+		t.Fatal("expected error for missing codex binary")
+	}
+	if !strings.Contains(err.Error(), "codex binary not found") {
+		t.Fatalf("error %q should mention 'codex binary not found'", err)
+	}
+}
+
+func TestCodexRunner_NonZeroExitNotTimeout(t *testing.T) {
+	t.Parallel()
+	codexStubScript(t, `exit 3`)
+	wd := codexWorkdir(t, "x")
+	_, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err == nil {
+		t.Fatal("expected error from exit 3")
+	}
+	if IsTimeout(err) {
+		t.Fatalf("non-zero exit must not classify as timeout: %v", err)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+}
+
+func TestCodexRunner_TimeoutKillsProcess(t *testing.T) {
+	t.Parallel()
+	codexStubScript(t, `sleep 30`)
+	wd := codexWorkdir(t, "x")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := (CodexRunner{}).Run(ctx, codexInput(wd))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !IsTimeout(err) {
+		t.Fatalf("expected *TimeoutError, got %T: %v", err, err)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("process not killed promptly: elapsed=%v", elapsed)
+	}
+}
+```
+
+- [ ] **Step 3: Run codex tests to verify they fail (no symbol)**
+
+Run: `go test ./internal/runner/... -run 'TestCodexRunner_' -v 2>&1 | head -20`
+
+Expected: compile error mentioning `CodexRunner` undefined.
+
+- [ ] **Step 4: Implement `codex.go` with all required functionality**
+
+Create `internal/runner/codex.go`:
+
+```go
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CodexOutputPath is where the runner persists captured codex stdout+stderr,
+// relative to the workdir.
+const CodexOutputPath = ".aiops/CODEX_OUTPUT.txt"
+
+// CodexLastMessagePath is where codex CLI writes its final message when
+// invoked with -o; the runner ingests it as Result.Summary on success.
+const CodexLastMessagePath = ".aiops/CODEX_LAST_MESSAGE.md"
+
+// PromptPath is the workdir-relative location of the rendered prompt the
+// worker writes before invoking the runner.
+const PromptPath = ".aiops/PROMPT.md"
+
+// CodexRunner is the profile-driven runner for the codex CLI. It replaces
+// the generic ShellRunner for codex; claude continues to use ShellRunner.
+//
+// Profile dispatch lives entirely inside Run; the runner is stateless and
+// safe to share across goroutines.
+type CodexRunner struct{}
+
+func (CodexRunner) Run(ctx context.Context, in RunInput) (Result, error) {
+	promptAbs := filepath.Join(in.Workdir, PromptPath)
+	if _, err := os.Stat(promptAbs); err != nil {
+		return Result{}, fmt.Errorf("read %s: %w", PromptPath, err)
+	}
+
+	cmd, err := buildCodexCmd(ctx, in)
+	if err != nil {
+		return Result{}, err
+	}
+	cmd.Dir = in.Workdir
+	configurePlatformKill(cmd)
+	cmd.WaitDelay = killGrace
+
+	stdin, err := os.Open(promptAbs)
+	if err != nil {
+		return Result{}, fmt.Errorf("open %s: %w", PromptPath, err)
+	}
+	defer stdin.Close()
+	cmd.Stdin = stdin
+
+	buf := &cappedWriter{Cap: CodexOutputCap}
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+
+	start := time.Now()
+	runErr := cmd.Run()
+	elapsed := time.Since(start)
+
+	writeCodexArtifact(in.Workdir, buf)
+
+	res := Result{
+		Summary:       readCodexSummary(in.Workdir),
+		OutputBytes:   int64(len(buf.Bytes())),
+		OutputDropped: buf.Dropped(),
+	}
+	head, tail := headTail(buf.Bytes(), CodexEventOutputCap)
+	if len(head) > 0 {
+		res.OutputHead = string(head)
+	}
+	res.OutputTail = tail
+
+	if runErr != nil {
+		if cerr := ctx.Err(); errors.Is(cerr, context.DeadlineExceeded) {
+			return res, &TimeoutError{
+				Timeout: deadlineBudget(ctx, start),
+				Elapsed: elapsed,
+				Cause:   runErr,
+			}
+		}
+		return res, runErr
+	}
+	return res, nil
+}
+
+// buildCodexCmd assembles the *exec.Cmd for the requested profile. PROMPT.md
+// is always provided via stdin, never via shell redirection.
+func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
+	profile := in.Workflow.Config.Codex.Profile
+	if profile == "" {
+		profile = "safe"
+	}
+	switch profile {
+	case "safe":
+		if _, err := exec.LookPath("codex"); err != nil {
+			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
+		}
+		return exec.CommandContext(ctx,
+			"codex", "exec",
+			"--full-auto",
+			"--skip-git-repo-check",
+			"--cd", in.Workdir,
+			"-o", CodexLastMessagePath,
+		), nil
+	case "bypass":
+		if _, err := exec.LookPath("codex"); err != nil {
+			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
+		}
+		return exec.CommandContext(ctx,
+			"codex", "exec",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--skip-git-repo-check",
+			"--cd", in.Workdir,
+			"-o", CodexLastMessagePath,
+		), nil
+	case "custom":
+		command := strings.TrimSpace(in.Workflow.Config.Codex.Command)
+		if command == "" {
+			return nil, fmt.Errorf("codex.profile=custom requires codex.command to be non-empty")
+		}
+		return exec.CommandContext(ctx, "sh", "-lc", command), nil
+	default:
+		return nil, fmt.Errorf("codex.profile %q is not supported", profile)
+	}
+}
+
+// writeCodexArtifact persists the buffered output to .aiops/CODEX_OUTPUT.txt.
+// On truncation, an explanatory footer line is appended. Errors are swallowed
+// (the artifact is best-effort; the event payload still carries head/tail).
+func writeCodexArtifact(workdir string, buf *cappedWriter) {
+	dir := filepath.Join(workdir, ".aiops")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	body := append([]byte{}, buf.Bytes()...)
+	if buf.Dropped() > 0 {
+		footer := fmt.Sprintf("\n...output truncated at %d bytes\n", CodexOutputCap)
+		body = append(body, []byte(footer)...)
+	}
+	_ = os.WriteFile(filepath.Join(workdir, CodexOutputPath), body, 0o644)
+}
+
+// readCodexSummary returns the trimmed contents of CODEX_LAST_MESSAGE.md or
+// "codex completed" when the file is missing/empty/unreadable.
+func readCodexSummary(workdir string) string {
+	b, err := os.ReadFile(filepath.Join(workdir, CodexLastMessagePath))
+	if err != nil {
+		return "codex completed"
+	}
+	trimmed := strings.TrimSpace(string(b))
+	if trimmed == "" {
+		return "codex completed"
+	}
+	return trimmed
+}
+```
+
+- [ ] **Step 5: Route `New("codex")` to `CodexRunner`**
+
+Edit `internal/runner/runner.go`. In `New`, change the codex case:
+
+```go
+	case "codex":
+		return CodexRunner{}, nil
+```
+
+- [ ] **Step 6: Run codex tests**
+
+Run: `go test ./internal/runner/... -run 'TestCodexRunner_' -v -race`
+
+Expected: all 11 tests PASS.
+
+If `TestCodexRunner_OutputExceedsCapTruncates` fails on the `max` builtin (Go 1.21+ requires it explicitly), replace `body[max(0, len(body)-200):]` with `body[len(body)-min(200, len(body)):]` and re-run.
+
+- [ ] **Step 7: Run the full runner package**
+
+Run: `go test ./internal/runner/... -race`
+
+Expected: PASS. The two ShellRunner tests bound to the `codex` name will FAIL because `New("codex")` no longer returns ShellRunner. That's expected — Task 4 fixes them.
+
+- [ ] **Step 8: gofmt + go mod tidy verify**
+
+Run: `gofmt -l internal/runner/ && go mod tidy && git diff --exit-code -- go.mod go.sum`
+
+Expected: empty + clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/runner/codex.go internal/runner/codex_test.go internal/runner/runner.go
+git commit -m "feat(runner): add CodexRunner with safe/bypass/custom profile dispatch (#17)"
+```
+
+---
+
+## Task 4: Rebind ShellRunner tests to claude
+
+**Files:**
+- Modify: `internal/runner/runner_test.go`
+
+**Why:** Task 3 changed `New("codex")` so the existing `TestShellRunnerKillsRunawayProcess` and `TestShellRunnerNonTimeoutErrorNotMisclassified` no longer exercise ShellRunner via `New`. They still construct `ShellRunner{Name: "codex"}` directly, which works mechanically but is confusing. Switching them to `claude` keeps them meaningful for the runner that still uses the shell path.
+
+- [ ] **Step 1: Run the failing tests to confirm what breaks**
+
+Run: `go test ./internal/runner/... -race 2>&1 | tail -30`
+
+Expected: any test that called `runner.New("codex")` and asserted ShellRunner behavior fails. Capture which tests fail.
+
+- [ ] **Step 2: Rebind the two existing tests**
+
+Edit `internal/runner/runner_test.go`. In `TestShellRunnerKillsRunawayProcess` and `TestShellRunnerNonTimeoutErrorNotMisclassified`, change:
+
+```go
+	wf := workflow.Workflow{Config: workflow.Config{
+		Codex: workflow.CommandConfig{Command: "sleep 30"},
+	}}
+	r := ShellRunner{Name: "codex"}
+```
+
+to:
+
+```go
+	wf := workflow.Workflow{Config: workflow.Config{
+		Claude: workflow.CommandConfig{Command: "sleep 30"},
+	}}
+	r := ShellRunner{Name: "claude"}
+```
+
+(Same swap for the `"exit 3"` variant in the other test.)
+
+- [ ] **Step 3: Run the runner package**
+
+Run: `go test ./internal/runner/... -race`
+
+Expected: all PASS.
+
+- [ ] **Step 4: gofmt**
+
+Run: `gofmt -l internal/runner/`
+
+Expected: empty.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runner/runner_test.go
+git commit -m "test(runner): rebind ShellRunner kill/exit tests from codex to claude (#17)"
+```
+
+---
+
+## Task 5: Custom-profile integration test
+
+**Files:**
+- Modify: `internal/runner/codex_test.go`
+
+**Why:** Task 3 implemented the custom branch but didn't test it. A minimal end-to-end check confirms the documented "PROMPT.md goes to stdin, command runs via sh -lc" contract.
+
+- [ ] **Step 1: Add the test**
+
+Append to `internal/runner/codex_test.go`:
+
+```go
+func TestCodexRunner_CustomProfileUsesShellWithStdin(t *testing.T) {
+	t.Parallel()
+	wd := codexWorkdir(t, "custom-profile-canary")
+	in := RunInput{
+		Task: task.Task{ID: "tsk_custom", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Codex: workflow.CommandConfig{Command: "cat", Profile: "custom"},
+		}},
+		Workdir: wd,
+	}
+	res, err := (CodexRunner{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(wd, ".aiops/CODEX_OUTPUT.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "custom-profile-canary") {
+		t.Fatalf("artifact missing canary; got %q", body)
+	}
+	if res.OutputBytes <= 0 {
+		t.Fatalf("OutputBytes = %d, want > 0", res.OutputBytes)
+	}
+	// Custom profile does NOT write CODEX_LAST_MESSAGE.md (no -o flag);
+	// summary should fall back.
+	if res.Summary != "codex completed" {
+		t.Fatalf("Summary = %q, want default fallback", res.Summary)
+	}
+}
+
+func TestCodexRunner_CustomProfileEmptyCommandRejected(t *testing.T) {
+	t.Parallel()
+	wd := codexWorkdir(t, "x")
+	in := RunInput{
+		Task: task.Task{ID: "tsk_custom_empty", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Codex: workflow.CommandConfig{Profile: "custom"},
+		}},
+		Workdir: wd,
+	}
+	_, err := (CodexRunner{}).Run(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected error for custom profile with empty command")
+	}
+	if !strings.Contains(err.Error(), "codex.command") {
+		t.Fatalf("error %q should mention codex.command", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `go test ./internal/runner/... -run 'TestCodexRunner_CustomProfile' -v -race`
+
+Expected: both PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/runner/codex_test.go
+git commit -m "test(runner): cover codex custom profile and empty-command rejection (#17)"
+```
+
+---
+
+## Task 6: Worker `runner_end` payload enrichment
+
+**Files:**
+- Modify: `internal/worker/runtask.go`
+- Modify: `internal/worker/run_test.go`
+
+- [ ] **Step 1: Read the existing payload code**
+
+Run: `sed -n '296,350p' internal/worker/runtask.go`
+
+Expected: shows `RunRunnerWithTimeout` building the `runner_start`/`runner_end`/`runner_timeout` payloads.
+
+- [ ] **Step 2: Find an existing test for runner_end payload to extend**
+
+Run: `grep -n 'runner_end' internal/worker/run_test.go internal/worker/run_internal_test.go 2>/dev/null | head -20`
+
+Expected: at least one test asserting the payload shape. Note its name; we'll add a new sibling test rather than modify it.
+
+- [ ] **Step 3: Write a failing test asserting output_* fields appear**
+
+Append to `internal/worker/run_test.go` (preserve imports):
+
+```go
+// fakeOutputRunner returns a fixed Result with non-zero output fields so we
+// can assert RunRunnerWithTimeout forwards them onto the runner_end payload.
+type fakeOutputRunner struct{}
+
+func (fakeOutputRunner) Run(ctx context.Context, in runner.RunInput) (runner.Result, error) {
+	return runner.Result{
+		Summary:       "fake done",
+		OutputBytes:   42,
+		OutputDropped: 7,
+		OutputHead:    "head-canary",
+		OutputTail:    "tail-canary",
+	}, nil
+}
+
+func TestRunRunnerWithTimeout_EmitsOutputFieldsOnRunnerEnd(t *testing.T) {
+	ev := &captureEmitter{} // existing fake in this test file
+	in := runner.RunInput{Task: task.Task{ID: "tsk_payload", Model: "codex"}}
+	if _, err := worker.RunRunnerWithTimeout(context.Background(), ev, fakeOutputRunner{}, in, 5*time.Second, "file"); err != nil {
+		t.Fatalf("RunRunnerWithTimeout: %v", err)
+	}
+	end := ev.findLast("runner_end")
+	if end == nil {
+		t.Fatal("no runner_end event recorded")
+	}
+	requireKey(t, end.payload, "output_bytes", float64(42))
+	requireKey(t, end.payload, "output_dropped", float64(7))
+	requireKey(t, end.payload, "output_head", "head-canary")
+	requireKey(t, end.payload, "output_tail", "tail-canary")
+}
+
+func TestRunRunnerWithTimeout_OmitsOutputFieldsForMockRunner(t *testing.T) {
+	ev := &captureEmitter{}
+	in := runner.RunInput{Task: task.Task{ID: "tsk_mock_payload", Model: "mock"}, Workdir: t.TempDir()}
+	if _, err := worker.RunRunnerWithTimeout(context.Background(), ev, runner.MockRunner{}, in, 5*time.Second, "file"); err != nil {
+		t.Fatalf("RunRunnerWithTimeout: %v", err)
+	}
+	end := ev.findLast("runner_end")
+	if end == nil {
+		t.Fatal("no runner_end event recorded")
+	}
+	for _, k := range []string{"output_bytes", "output_dropped", "output_head", "output_tail"} {
+		if _, ok := end.payload[k]; ok {
+			t.Fatalf("payload should not contain %q for mock runner; got %v", k, end.payload)
+		}
+	}
+}
+```
+
+If `captureEmitter`, `findLast`, or `requireKey` do not exist, look for the existing emitter fake and reuse its idioms — don't invent new helpers. Run `grep -n 'AddEventWithPayload' internal/worker/*_test.go` first to find the convention. If you must add helpers, put them next to the existing fake at the bottom of the file:
+
+```go
+type recordedEvent struct {
+	kind    string
+	msg     string
+	payload map[string]any
+}
+
+type captureEmitter struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+func (e *captureEmitter) AddEvent(_ context.Context, _ string, kind, msg string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.events = append(e.events, recordedEvent{kind: kind, msg: msg})
+	return nil
+}
+
+func (e *captureEmitter) AddEventWithPayload(_ context.Context, _ string, kind, msg string, payload any) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	m, _ := payload.(map[string]any)
+	e.events = append(e.events, recordedEvent{kind: kind, msg: msg, payload: m})
+	return nil
+}
+
+func (e *captureEmitter) findLast(kind string) *recordedEvent {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for i := len(e.events) - 1; i >= 0; i-- {
+		if e.events[i].kind == kind {
+			ev := e.events[i]
+			return &ev
+		}
+	}
+	return nil
+}
+
+func requireKey(t *testing.T, payload map[string]any, key string, want any) {
+	t.Helper()
+	got, ok := payload[key]
+	if !ok {
+		t.Fatalf("payload missing key %q; got %v", key, payload)
+	}
+	if got != want {
+		t.Fatalf("payload[%q] = %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}
+```
+
+(`requireKey`'s `float64` comparison: payloads going through JSON-style marshaling typically widen ints to float64. If the existing emitter does NOT marshal, swap `float64(42)` for `int64(42)` to match how `Result.OutputBytes` is stored.)
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `go test ./internal/worker/... -run 'TestRunRunnerWithTimeout_(EmitsOutputFields|OmitsOutputFields)' -v 2>&1 | head -30`
+
+Expected: failures because `runner_end` payload does not contain the new keys.
+
+- [ ] **Step 5: Enrich the payload in `runtask.go`**
+
+Edit `internal/worker/runtask.go`. In `RunRunnerWithTimeout`, replace the success-path `endPayload` block with:
+
+```go
+	endPayload := map[string]any{
+		"model":       in.Task.Model,
+		"duration_ms": elapsed.Milliseconds(),
+		"ok":          true,
+	}
+	if res.Summary != "" {
+		endPayload["summary"] = res.Summary
+	}
+	addOutputFields(endPayload, res)
+	Emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner completed", endPayload)
+	return res, nil
+```
+
+In the same function, replace the failure-path `runner_end` payload with:
+
+```go
+		failurePayload := map[string]any{
+			"model":       in.Task.Model,
+			"duration_ms": elapsed.Milliseconds(),
+			"error":       ErrSummary(runErr),
+			"ok":          false,
+		}
+		addOutputFields(failurePayload, res)
+		Emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner failed", failurePayload)
+		return runner.Result{}, runErr
+```
+
+And the timeout payload:
+
+```go
+			timeoutPayload := map[string]any{
+				"model":      in.Task.Model,
+				"timeout_ms": te.Timeout.Milliseconds(),
+				"elapsed_ms": te.Elapsed.Milliseconds(),
+			}
+			addOutputFields(timeoutPayload, res)
+			Emit(ctx, ev, in.Task.ID, task.EventRunnerTimeout, te.Error(), timeoutPayload)
+			return runner.Result{}, runErr
+```
+
+Note the failure path currently returns `runner.Result{}` — change those returns to keep `res` so partial output is preserved when the timeout/exit path returns:
+
+```go
+		return res, runErr   // was: return runner.Result{}, runErr
+```
+
+(Apply to both the timeout branch and the generic-error branch.)
+
+Add the helper at the bottom of the file:
+
+```go
+// addOutputFields merges runner Result output telemetry into a payload map
+// when the runner reported any. Mock runs that leave Result.Output* zero
+// add no keys, preserving payload diffs for tests written before
+// codex/log capture landed.
+func addOutputFields(payload map[string]any, res runner.Result) {
+	if res.OutputBytes > 0 {
+		payload["output_bytes"] = res.OutputBytes
+	}
+	if res.OutputDropped > 0 {
+		payload["output_dropped"] = res.OutputDropped
+	}
+	if res.OutputHead != "" {
+		payload["output_head"] = res.OutputHead
+	}
+	if res.OutputTail != "" {
+		payload["output_tail"] = res.OutputTail
+	}
+}
+```
+
+- [ ] **Step 6: Run worker tests**
+
+Run: `go test ./internal/worker/... -race`
+
+Expected: all PASS, including the two new ones.
+
+- [ ] **Step 7: gofmt**
+
+Run: `gofmt -l internal/worker/`
+
+Expected: empty.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/worker/runtask.go internal/worker/run_test.go
+git commit -m "feat(worker): enrich runner_end payload with codex output head/tail/bytes/dropped (#17)"
+```
+
+---
+
+## Task 7: Documentation updates
+
+**Files:**
+- Modify: `examples/WORKFLOW.md`
+- Modify: `docs/runbooks/personal-daily-workflow.md`
+- Modify: `docs/symphony-integration.md`
+- Modify: `README.md` (only if it currently references `codex.command`)
+
+- [ ] **Step 1: Update `examples/WORKFLOW.md`**
+
+Edit the `codex:` block to read:
+
+```yaml
+codex:
+  command: codex exec
+  # profile selects how the runner invokes codex:
+  #   safe   (default) - codex exec --full-auto --skip-git-repo-check ...
+  #   bypass           - codex exec --dangerously-bypass-approvals-and-sandbox ...
+  #                      (only when the worker host is already isolated, e.g. a
+  #                      container; codex bypasses its own sandbox + approval gates)
+  #   custom           - run the literal codex.command via sh -lc; PROMPT.md
+  #                      is piped on stdin. Escape hatch for bespoke wrappers.
+  profile: safe
+```
+
+- [ ] **Step 2: Update `docs/runbooks/personal-daily-workflow.md`**
+
+In the `### codex` subsection (around line 87), append after the existing yaml block:
+
+```markdown
+**Profiles** select how the runner invokes codex:
+
+- `safe` (default): builds `codex exec --full-auto --skip-git-repo-check --cd <workdir> -o .aiops/CODEX_LAST_MESSAGE.md` from argv (no shell). PROMPT.md is piped on stdin. `--full-auto` is codex's documented shorthand for `--sandbox workspace-write --ask-for-approval=never`.
+- `bypass`: same shape but with `--dangerously-bypass-approvals-and-sandbox`. Use only when the worker host is already isolated (container, dedicated VM); the flag turns codex's own sandbox off.
+- `custom`: runs the literal `codex.command` via `sh -lc` with PROMPT.md on stdin. Note the change from earlier versions: the runner no longer appends `< .aiops/PROMPT.md` to the command — your command must consume stdin (which `codex exec` does by default when no positional prompt is given).
+
+### Reading codex output after a run
+
+Each codex run writes `.aiops/CODEX_OUTPUT.txt` (combined stdout+stderr, capped at 1 MiB with a truncation footer when the cap fires) and reads `.aiops/CODEX_LAST_MESSAGE.md` (codex's own `-o` artifact) as the run summary. The `runner_end` task event payload also carries `output_head` (first 4 KiB), `output_tail` (last 4 KiB if non-overlapping), `output_bytes`, and `output_dropped` for at-a-glance triage from `/v1/tasks/<id>/events` without cloning the work branch.
+```
+
+- [ ] **Step 3: Update `docs/symphony-integration.md`**
+
+In the "Not yet implemented" list, replace `- advanced sandboxing` with:
+
+```markdown
+- OS-level sandboxing (sandbox-exec, firejail, container isolation). Codex CLI's own sandbox is wired via `codex.profile`.
+```
+
+Optionally add at the bottom of the file:
+
+```markdown
+## Pointers
+
+- Symphony's richer codex integration uses the long-running `codex app-server` JSON-RPC protocol (`elixir/lib/symphony_elixir/codex/app_server.ex`) and exposes per-turn sandbox overrides via `Codex.changeset` (`elixir/lib/symphony_elixir/config/schema.ex`). This platform's M4 stays on one-shot `codex exec`; an app-server-style integration is a candidate for M5+.
+```
+
+- [ ] **Step 4: Update README.md if applicable**
+
+Run: `grep -n 'codex.command' README.md || echo 'no reference; skipping'`
+
+If the file references `codex.command`, append a sentence to that paragraph: "Set `codex.profile: safe` (default), `bypass`, or `custom` to control how the runner invokes codex; see `docs/runbooks/personal-daily-workflow.md` for the trade-offs." Otherwise skip this step.
+
+- [ ] **Step 5: Verify docs render and gofmt is still clean**
+
+Run: `gofmt -l . | head` (should not list anything inside `internal/`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/WORKFLOW.md docs/runbooks/personal-daily-workflow.md docs/symphony-integration.md
+# include README.md only if step 4 modified it
+git commit -m "docs: document codex.profile and CODEX_OUTPUT.txt artifact (#17)"
+```
+
+---
+
+## Task 8: Final integration verification
+
+**Files:** none modified; verification only.
+
+- [ ] **Step 1: Run the CI gate end to end**
+
+Run:
+
+```bash
+gofmt -l $(git ls-files '*.go') ; echo "---" ; go mod tidy && git diff --exit-code -- go.mod go.sum && echo "go mod tidy clean"
+```
+
+Expected: `gofmt` output empty; `go mod tidy clean` printed.
+
+- [ ] **Step 2: Run the full test suite with race**
+
+Run: `go test -race -covermode=atomic ./...`
+
+Expected: PASS across all packages.
+
+- [ ] **Step 3: Verify all binaries build**
+
+Run: `go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`
+
+Expected: clean exit, no output.
+
+- [ ] **Step 4: Quick `--print-config` smoke for codex.profile surfacing**
+
+Run:
+
+```bash
+mkdir -p /tmp/codex-profile-smoke && cat > /tmp/codex-profile-smoke/WORKFLOW.md <<'YAML'
+---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex
+codex:
+  command: codex exec
+  profile: bypass
+---
+prompt
+YAML
+go run ./cmd/worker --print-config /tmp/codex-profile-smoke
+```
+
+Expected: JSON output where `config.codex.profile` is `"bypass"`. (If `--print-config` doesn't include the new field, that's fine — it's not in scope to extend the redactor here unless the existing serializer drops `omitempty` empty fields.)
+
+- [ ] **Step 5: Sanity check git log**
+
+Run: `git log --oneline | head -10`
+
+Expected: 6-7 new commits on top of the spec commit (`d40281c`), each scoped to one task.
+
+- [ ] **Step 6: Verify spec acceptance criteria all map to landed code**
+
+Open `docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md` "Acceptance Criteria Mapping" table and confirm each row points to code that now exists. If any row is unimplemented, file a follow-up TODO and discuss with the requester before declaring the issue done.
+
+- [ ] **Step 7: Push, open PR**
+
+Push the branch and open a PR titled `feat: implement safe codex runner profile (#17)`. Body bullets:
+
+- Adds `codex.profile` schema field (`safe` default, `bypass`, `custom`) with loader validation.
+- New `internal/runner/codex.go` `CodexRunner` replaces ShellRunner for codex; argv-form invocation with PROMPT.md on stdin.
+- Captures stdout/stderr to `.aiops/CODEX_OUTPUT.txt` (1 MiB cap with truncation footer) and surfaces head/tail/bytes/dropped on `runner_end` / `runner_timeout` event payloads.
+- Picks up `.aiops/CODEX_LAST_MESSAGE.md` as `Result.Summary` on success.
+- Behavior change for `profile=custom`: PROMPT.md goes via stdin instead of `< .aiops/PROMPT.md` shell redirect — runbook update calls this out.
+- Closes #17.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every acceptance row in the spec maps to one of Tasks 2 (schema), 3 (safe profile + log capture), 5 (custom profile), 6 (event payload), 7 (docs). Task 1 implements the shared cappedWriter; Task 4 keeps existing tests meaningful.
+- **No placeholders:** every code step contains the actual code. Test code includes assertions, not "add tests for the above". Commands include expected output.
+- **Type consistency:** `CodexRunner`, `cappedWriter`, `Result.OutputBytes/OutputDropped/OutputHead/OutputTail`, `addOutputFields`, `CodexOutputCap`, `CodexEventOutputCap`, `CodexOutputPath`, `CodexLastMessagePath`, `PromptPath` are used identically across tasks.
+- **Decomposition:** capture helper / schema / runner / wiring / payload / docs are landed in separate commits so a reviewer can read them in order without holding the whole feature in their head.

--- a/docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md
+++ b/docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md
@@ -1,0 +1,303 @@
+# Safe Codex Runner Profile
+
+**Issue:** [#17](../../../) — [M4][P0] Implement safe Codex runner profile
+**Date:** 2026-05-11
+**Status:** Approved (pending implementation plan)
+
+## Problem
+
+`agent.default: codex` already routes through `internal/runner` via the generic `ShellRunner`, which executes `sh -lc "<codex.command> < .aiops/PROMPT.md"`. Three of issue #17's five acceptance criteria are not yet met:
+
+1. **Safe prompt passing.** The PROMPT.md path is glued onto an operator-supplied command string with shell concatenation. There is no argv-form invocation, no opt-in to codex CLI's own sandbox / approval gates, and no way for the worker to be sure what flags the operator actually used.
+2. **Logs captured into events or artifacts.** Codex stdout/stderr go to `os.Stdout` / `os.Stderr` and disappear. The worker keeps no per-run record of what codex said. Triage requires re-running the task locally.
+3. **A "safe" default profile.** There is no documented "what a personal user gets by default when they flip `agent.default: codex`." Today the default is whatever string they typed into `codex.command`, with no schema-level guidance.
+
+The platform's M4 milestone is "switch from mock to codex for small personal tasks." Without the three items above, that switch is ergonomically inconsistent and operationally opaque.
+
+## Goals
+
+1. A documented `codex.profile` schema field with three values: `safe` (default), `bypass`, `custom`.
+2. Profile-driven argv assembly inside a dedicated `CodexRunner`, replacing the shared `ShellRunner` for codex (claude keeps using `ShellRunner`).
+3. Codex stdout/stderr captured to `.aiops/CODEX_OUTPUT.txt` (capped at 1 MiB, drop counter recorded) AND surfaced in the `runner_end` event payload as head/tail/bytes/dropped.
+4. `codex exec`'s `--output-last-message` artifact picked up to populate `Result.Summary` (so the worker has a one-line "what did codex finish saying" hook without parsing the full output).
+5. `WORKFLOW.md`, runbook, and `examples/WORKFLOW.md` updated so an operator can predict behavior from docs alone.
+
+## Non-Goals
+
+- OS-level sandboxing (sandbox-exec, firejail, container isolation). Stays in the codex CLI's own sandbox model.
+- Streaming codex output to the event log in real time. Final-only capture is enough for triage; streaming would need a different transport and is YAGNI for personal-scale tasks.
+- Migrating to `codex app-server` (Symphony's pattern — see "Prior art" below). One-shot `codex exec` matches the queue's per-task lifecycle; app-server is a separate M5+ design.
+- Changing how claude is invoked. `ShellRunner` continues to power `agent.default: claude`.
+- A schema field on `Claude` for parity. YAGNI — claude has no equivalent CLI-side approval/sandbox knobs to wrap.
+
+## Profile Contract
+
+| Profile | Argv (after `codex` binary) | Notes |
+|---|---|---|
+| `safe` (default) | `exec --full-auto --skip-git-repo-check --cd <workdir> -o .aiops/CODEX_LAST_MESSAGE.md` | `--full-auto` is codex's documented shorthand for `--sandbox workspace-write --ask-for-approval=never`. PROMPT.md is fed via stdin (codex CLI reads stdin when no positional PROMPT is provided). |
+| `bypass` | `exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd <workdir> -o .aiops/CODEX_LAST_MESSAGE.md` | For operators who run the worker inside an already-isolated environment (container, VM) and need codex to write outside the workspace cap. Documented as opt-in. |
+| `custom` | (n/a — falls back to `ShellRunner` with `sh -lc <codex.command>`) | Escape hatch. Operator-controlled string; no safety promises, but logs/timeout/output capture all still apply. |
+
+`safe` is the default supplied by `expandConfig`. An empty `Codex.Profile` after YAML load is normalized to `safe`. Unknown values fail load with a clear error path/value pair (same pattern as `supportedTrackerKinds` in `loader.go`).
+
+The `codex.command` field is consulted only when `profile=custom`. For `safe`/`bypass` it is ignored — runner-built argv is the source of truth. The default `codex.command: "codex exec"` stays in the schema so existing configs (which set `profile=custom` to keep their wording) keep working.
+
+### Why a profile enum and not Symphony-style independent fields
+
+Symphony (see `elixir/lib/symphony_elixir/config/schema.ex` `Codex` schema) exposes `command`, `approval_policy`, `thread_sandbox`, `turn_sandbox_policy`, plus three timeouts as independent fields. The richer surface fits Symphony's `codex app-server` long-session model where per-turn sandbox overrides are meaningful.
+
+This platform's M4 is a one-shot `codex exec` per task. The profile enum collapses the "what does safe mean" decision to a single named bundle, mirroring codex CLI's own `--full-auto` shorthand. If a future milestone migrates to `codex app-server`, the profile enum can either remain as a coarse switch or be replaced wholesale; either way the smaller surface today does not paint us into a corner.
+
+Where naming intersects, we adopt Symphony's terms verbatim: `workspace-write`, `danger-full-access` semantics. Migration paths stay legible.
+
+## API Surface
+
+### `internal/workflow/config.go`
+
+```go
+type CommandConfig struct {
+    Command string `yaml:"command" json:"command"`
+    // Profile is consulted only for the codex runner. Allowed values:
+    // "safe" (default), "bypass", "custom". The field exists on the
+    // shared CommandConfig type to avoid splitting CodexConfig out for
+    // a single field; loader validation rejects non-empty Profile on
+    // the Claude embed.
+    Profile string `yaml:"profile,omitempty" json:"profile,omitempty"`
+}
+```
+
+`DefaultConfig()` keeps `Codex: CommandConfig{Command: "codex exec", Profile: "safe"}`.
+
+`expandConfig(&cfg)` adds:
+
+```go
+if cfg.Codex.Profile == "" {
+    cfg.Codex.Profile = "safe"
+}
+```
+
+`validateConfig(path, cfg)` adds a `supportedCodexProfiles` map (`safe | bypass | custom`) and rejects unknown values with `"%s: codex.profile %q is not supported (allowed: safe, bypass, custom)"`. `cfg.Claude.Profile != ""` returns `"%s: claude.profile is not supported"` — this prevents copy-paste mistakes silently doing nothing.
+
+### `internal/runner/runner.go`
+
+```go
+type Result struct {
+    Summary       string
+    OutputBytes   int64  // bytes written to the artifact (post-cap)
+    OutputDropped int64  // bytes dropped because output exceeded cap
+    OutputHead    string // first ~4 KiB of combined stdout/stderr
+    OutputTail    string // last ~4 KiB; empty when overlapping head
+}
+
+func New(name string) (Runner, error) {
+    switch name {
+    case "", "mock":   return MockRunner{}, nil
+    case "codex":      return CodexRunner{}, nil   // was: ShellRunner{Name: "codex"}
+    case "claude":     return ShellRunner{Name: "claude"}, nil
+    default:           return nil, fmt.Errorf("unknown runner: %s", name)
+    }
+}
+```
+
+`TimeoutError`, `IsTimeout`, `deadlineBudget` unchanged.
+
+### `internal/runner/codex.go` (new)
+
+```go
+type CodexRunner struct{}
+
+func (r CodexRunner) Run(ctx context.Context, in RunInput) (Result, error)
+```
+
+Implementation outline:
+
+1. Validate PROMPT.md exists at `<workdir>/.aiops/PROMPT.md`. If not, return a wrapped error (not a `TimeoutError`).
+2. Build `*exec.Cmd` based on `in.Workflow.Config.Codex.Profile`:
+   - `safe`: `exec.CommandContext(ctx, "codex", "exec", "--full-auto", "--skip-git-repo-check", "--cd", in.Workdir, "-o", ".aiops/CODEX_LAST_MESSAGE.md")`. PROMPT.md piped via stdin.
+   - `bypass`: same as `safe` but `--full-auto` replaced by `--dangerously-bypass-approvals-and-sandbox`.
+   - `custom`: `exec.CommandContext(ctx, "sh", "-lc", in.Workflow.Config.Codex.Command)`. PROMPT.md piped via stdin (NOT via the legacy `< .aiops/PROMPT.md` shell redirect — uniform stdin handling across profiles means the capture path is one branch). Operator's `codex.command` must therefore consume stdin (typically `codex exec` or any binary that does so when no positional prompt is given). This is a documented behavior change vs the previous ShellRunner-for-codex path: existing operators using `codex.command: "codex exec"` keep working; operators with custom shell pipelines that already used stdin keep working; operators relying on the legacy `< .aiops/PROMPT.md` glue need to migrate to stdin (which is what their command would have received anyway since `sh -lc "codex exec < .aiops/PROMPT.md"` was the old composition). The runbook update calls this out.
+3. Common path for all three profiles: `cmd.Dir = in.Workdir`; `configurePlatformKill(cmd)`; `cmd.WaitDelay = killGrace`.
+4. `cmd.Stdin, _ = os.Open(filepath.Join(in.Workdir, ".aiops/PROMPT.md"))`. Close after `cmd.Run()` returns.
+5. `buf := &cappedWriter{Cap: CodexOutputCap}; cmd.Stdout = buf; cmd.Stderr = buf`.
+6. `runErr := cmd.Run()`. Compute `elapsed := time.Since(start)`.
+7. Always write `.aiops/CODEX_OUTPUT.txt` from `buf` (with a trailing `...output truncated at N bytes\n` line iff `buf.Dropped() > 0`). Write failures are logged but do not mask the runner's outcome.
+8. Read `.aiops/CODEX_LAST_MESSAGE.md` if present; trim and use as `Result.Summary`. If absent or empty, fall back to `"codex completed"`.
+9. On `runErr != nil`, distinguish ctx-driven termination (return `*TimeoutError`) from non-zero exit (return `runErr` raw), matching `ShellRunner` semantics.
+10. Populate `Result.OutputBytes` (= bytes kept by the buffer), `OutputDropped` (= dropped count), `OutputHead` (first 4 KiB of buffered bytes), `OutputTail` (last 4 KiB; empty when buffered length ≤ 4 KiB so it does not duplicate head).
+
+### `internal/runner` shared output buffer
+
+A small `cappedWriter` lives in a new `internal/runner/capture.go`. It mirrors `workspace.cappedBuffer` (1 MiB cap, drop counter, never blocks). Duplicating ~30 lines is preferable to forcing `internal/runner` to import `internal/workspace` (today the dependency goes the other way is moot — workspace doesn't import runner — but introducing the reverse edge for one helper would entangle the layering).
+
+Constants:
+
+```go
+// CodexOutputCap bounds bytes kept in the runner-side capture buffer.
+// Matches workspace.VerifyOutputCap so artifact ergonomics are uniform
+// across the verify and runner phases.
+const CodexOutputCap = 1 << 20 // 1 MiB
+
+// CodexOutputPath is the artifact location for the captured codex
+// stdout+stderr. Always relative to the workdir.
+const CodexOutputPath = ".aiops/CODEX_OUTPUT.txt"
+
+// CodexLastMessagePath is the file codex CLI writes when invoked with
+// -o; we ingest its trimmed contents into Result.Summary on success.
+const CodexLastMessagePath = ".aiops/CODEX_LAST_MESSAGE.md"
+
+// CodexEventOutputCap bounds head/tail bytes embedded in the runner_end
+// event payload (per side). 4 KiB stays well under typical Postgres
+// JSONB row-size budgets and keeps the events table cheap to query.
+const CodexEventOutputCap = 4 << 10 // 4 KiB
+```
+
+### `internal/worker/runtask.go`
+
+`RunRunnerWithTimeout`'s `runner_end` payload (success and failure paths) is enriched conditionally:
+
+```go
+endPayload := map[string]any{
+    "model":       in.Task.Model,
+    "duration_ms": elapsed.Milliseconds(),
+    "ok":          true,
+}
+if res.Summary != "" {
+    endPayload["summary"] = res.Summary
+}
+if res.OutputBytes > 0 {
+    endPayload["output_bytes"] = res.OutputBytes
+}
+if res.OutputDropped > 0 {
+    endPayload["output_dropped"] = res.OutputDropped
+}
+if res.OutputHead != "" {
+    endPayload["output_head"] = res.OutputHead
+}
+if res.OutputTail != "" {
+    endPayload["output_tail"] = res.OutputTail
+}
+```
+
+The same conditional block applies to the failure-path `runner_end` and to the `runner_timeout` event (so a hung codex still leaves head/tail crumbs in the event log). Mock runs (which leave the new fields zero) emit no extra keys, preserving backward compatibility for tests that diff payloads exactly.
+
+## Data Flow
+
+```
+runtask.go
+  → workflow.Resolve(workdir)                            (existing)
+  → runner.New("codex") → CodexRunner{}
+  → RunRunnerWithTimeout(ctx, ev, runner, RunInput{
+      Task, Workflow{Codex.Profile=safe|bypass|custom},
+      Workdir, Prompt}, agent.timeout, workflowSource)
+       → emit runner_start
+       → CodexRunner.Run
+            switch Codex.Profile
+              safe   → argv = [codex exec --full-auto ...]
+              bypass → argv = [codex exec --dangerously-bypass... ...]
+              custom → ShellRunner.Run + capture wrap
+            cmd.Stdin = open(.aiops/PROMPT.md)
+            cmd.Stdout/Stderr = cappedWriter
+            run; writeArtifact; readLastMessage
+            return Result{Summary, Output*}
+       → emit runner_end (or runner_timeout) with payload
+         conditionally including output_head/tail/bytes/dropped
+```
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| PROMPT.md missing/unreadable | Return wrapped `fmt.Errorf("read PROMPT.md: %w", err)`. NOT a `TimeoutError`. RunRunnerWithTimeout records `runner_end ok=false`. |
+| `codex` binary missing on PATH | `exec.LookPath` pre-check; return `fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")`. |
+| Codex non-zero exit | Return raw `*exec.ExitError` (or wrapped equivalent). `IsTimeout=false`. Existing failure routing in `handleTaskFailure` applies. |
+| Context deadline exceeded | Wrap in `*TimeoutError{Timeout, Elapsed, Cause}` exactly like `ShellRunner` today. `runner_timeout` event fires. |
+| Output cap hit | Silent — `cappedWriter` drops bytes and increments the drop counter. Artifact gets a trailing truncation line; event payload reports `output_dropped`. |
+| `.aiops/CODEX_OUTPUT.txt` write fails | Logged via `log.Printf`; runner outcome unchanged. The triage signal already lives in event payload head/tail. |
+| `.aiops/CODEX_LAST_MESSAGE.md` missing | Treated as success with `Result.Summary = "codex completed"`. (Codex CLI writes the file only when it has a final message; absence is benign.) |
+
+The `custom` profile inherits ShellRunner's semantics (today's behavior). The new artifact + payload enrichment still applies because the wrapper captures stdout/stderr regardless of which profile branch built the command.
+
+## Testing
+
+### `internal/runner/codex_test.go` (new)
+
+Tests use a temp-PATH stub: write a small bash script named `codex` into `t.TempDir()`, prepend that dir to `PATH`. The script can record argv, dump stdin to a file, print fixed output, exit with a chosen code, or sleep, depending on the test.
+
+| Case | Assertion |
+|---|---|
+| `safe` profile builds expected argv | recorded argv equals `[exec --full-auto --skip-git-repo-check --cd <workdir> -o .aiops/CODEX_LAST_MESSAGE.md]` (positional PROMPT absent → stdin path). |
+| `bypass` profile builds expected argv | argv contains `--dangerously-bypass-approvals-and-sandbox`; does NOT contain `--full-auto`. |
+| `custom` profile uses operator command via `sh -lc` with stdin PROMPT | Stub binary not consulted; `codex.command: "cat"` runs through `sh -lc`, copies PROMPT.md from stdin to stdout; artifact captures the prompt bytes. |
+| stdin carries PROMPT.md | Stub copies stdin to a temp file; contents equal PROMPT.md bytes. |
+| stdout/stderr captured to artifact | Stub prints a canary string; `<workdir>/.aiops/CODEX_OUTPUT.txt` exists and contains the canary. |
+| Output exceeds cap | Stub prints 1.5 MiB; artifact size ≤ cap + truncation footer; `Result.OutputDropped > 0`; trailing line matches `...output truncated at 1048576 bytes\n`. |
+| `--output-last-message` pickup | Stub writes `.aiops/CODEX_LAST_MESSAGE.md` containing `done!\n`; `Result.Summary == "done!"`. |
+| Missing last-message file | Stub does not write the file; `Result.Summary == "codex completed"`. |
+| Timeout kills process group | Stub sleeps 30s; ctx 50ms; returns `*TimeoutError`; elapsed < 10s; (asserts that the existing group-kill path applies via `configurePlatformKill`). |
+| Non-zero exit not misclassified | Stub `exit 3`; error returned, `IsTimeout(err) == false`, `errors.As` to `*exec.ExitError` succeeds. |
+| Missing PROMPT.md | No `.aiops/PROMPT.md` in workdir; runner returns wrapped error mentioning PROMPT.md; codex stub never invoked. |
+| Missing codex binary | Empty PATH; runner returns the documented "codex binary not found" error before exec. |
+| Result fields on success path | `OutputBytes` matches artifact size on disk; `OutputHead` ≤ 4 KiB; `OutputTail` empty when total output ≤ 4 KiB, set otherwise. |
+
+### `internal/workflow/config_test.go` (extend)
+
+| Case | Expected |
+|---|---|
+| Default config has `Codex.Profile == "safe"` | Pass. |
+| `codex.profile: safe|bypass|custom` accepted | Load returns nil error. |
+| `codex.profile: yolo` rejected | Error includes path and the offending value `"yolo"` and the allowed list. |
+| `codex.profile` empty after YAML load | `expandConfig` normalizes to `"safe"`. |
+| `claude.profile: safe` rejected | Error mentions `claude.profile is not supported` and the path. |
+
+### `internal/worker/run_test.go` (extend)
+
+| Case | Expected |
+|---|---|
+| `runner_end` payload includes `output_*` keys when Result populates them | Fake runner returns Result with all four fields set; payload contains all four. |
+| `runner_end` payload omits `output_*` for mock | Mock runner returns Result with zero output fields; payload diff against existing snapshot is unchanged. |
+| `runner_timeout` payload includes `output_head/tail` if Result captured anything before kill | Stub runner that emits some bytes and then sleeps; ctx fires; payload still carries head/tail. |
+
+### `internal/runner/runner_test.go` (revise)
+
+The two existing codex-via-ShellRunner tests (`TestShellRunnerKillsRunawayProcess`, `TestShellRunnerNonTimeoutErrorNotMisclassified`) keep their kill/exit-class assertions but bind to `ShellRunner{Name: "claude"}` so they remain meaningful for the runner that still uses the shell path. Codex-specific kill/exit tests live in `codex_test.go`.
+
+## Documentation
+
+- **`examples/WORKFLOW.md`**: under the `codex:` block, add a commented-out `profile: safe` line plus a one-paragraph note that `safe` is the default, `bypass` is for already-isolated hosts, and `custom` falls back to the `command` string.
+- **`docs/runbooks/personal-daily-workflow.md`**: in the `codex` runner subsection, describe profile semantics and the trade-offs between `safe` and `bypass`. Add a short "Reading codex output after a run" pointer to `.aiops/CODEX_OUTPUT.txt` and the `runner_end` event payload fields.
+- **`docs/symphony-integration.md`**: remove "advanced sandboxing" from the "Not yet implemented" list (or refine wording to "OS-level sandboxing not yet; codex CLI sandbox is wired"). Add a one-line "see also Symphony's app-server-based codex integration in `lib/symphony_elixir/codex/app_server.ex`" pointer for future M5+ context.
+- **`README.md`**: if/where the README mentions `codex.command`, add a sentence pointing at `codex.profile`. No new top-level section required.
+
+## Files Changed
+
+1. `internal/workflow/config.go` — add `CommandConfig.Profile`; default to `"safe"` for codex in `DefaultConfig`.
+2. `internal/workflow/loader.go` — `supportedCodexProfiles`; validate `Codex.Profile`; reject `Claude.Profile`; `expandConfig` normalizes empty `Codex.Profile`.
+3. `internal/workflow/config_test.go` — schema cases above.
+4. `internal/runner/runner.go` — extend `Result`; route `New("codex")` to `CodexRunner`.
+5. `internal/runner/codex.go` (new) — profile dispatch, argv assembly, capture, artifact write, last-message pickup.
+6. `internal/runner/capture.go` (new) — small `cappedWriter` (1 MiB cap, drop counter); shared by codex and `custom`-fallback paths.
+7. `internal/runner/codex_test.go` (new) — tests above using PATH-stub codex.
+8. `internal/runner/runner_test.go` — rebind the two ShellRunner tests to `claude` (or split into `shell_test.go`).
+9. `internal/worker/runtask.go` — `RunRunnerWithTimeout` payload enrichment for `runner_end` and `runner_timeout`.
+10. `internal/worker/run_test.go` — payload assertions above.
+11. `examples/WORKFLOW.md` — `codex.profile` comment block.
+12. `docs/runbooks/personal-daily-workflow.md` — profile section + output reading pointer.
+13. `docs/symphony-integration.md` — sandboxing wording + Symphony app-server pointer.
+14. `README.md` — codex.profile mention near codex.command.
+
+## Acceptance Criteria Mapping
+
+| Issue #17 criterion | Where addressed |
+|---|---|
+| `agent.default: codex` runs through `internal/runner` | `runner.New("codex") → CodexRunner` (no regression in routing). |
+| Runner passes `.aiops/PROMPT.md` safely | argv-form `exec.CommandContext` + stdin pipe in `safe`/`bypass`; no shell concatenation in those branches. |
+| Runner respects configured command | `profile=custom` reads `codex.command` and runs through the `ShellRunner` path; new artifact/payload enrichment still applies. |
+| Timeout is applied | Existing `RunRunnerWithTimeout` + `agent.timeout` + `configurePlatformKill` group-kill, reused verbatim. |
+| Logs are captured into task events or artifacts | `.aiops/CODEX_OUTPUT.txt` artifact (capped + truncation footer) AND `runner_end` payload `output_head/tail/bytes/dropped`. |
+
+The Notes line "Start with a personal demo repository" is operational guidance for the operator — not a code deliverable in this PR. It is surfaced via the runbook update and the `examples/WORKFLOW.md` comment so the path is discoverable.
+
+## Prior Art
+
+- **Symphony (`elixir/lib/symphony_elixir/config/schema.ex` and `codex/app_server.ex`)**: uses `codex app-server` for a long-lived JSON-RPC session and exposes `command`, `approval_policy`, `thread_sandbox`, `turn_sandbox_policy`, plus three timeouts as independent config fields. Richer surface, fits the per-turn-override semantics of app-server. Out of scope here; profile enum collapses to a single decision per task and stays migration-friendly should this platform later adopt app-server.
+- **Codex CLI `codex-rs/exec/src/cli.rs`**: documents `--full-auto` as the canonical "automatic + workspace-write" shorthand and `--dangerously-bypass-approvals-and-sandbox` (alias `--yolo`) for already-isolated environments. Profile names map directly: `safe = --full-auto`, `bypass = --dangerously-bypass-approvals-and-sandbox`.

--- a/docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md
+++ b/docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md
@@ -34,8 +34,8 @@ The platform's M4 milestone is "switch from mock to codex for small personal tas
 
 | Profile | Argv (after `codex` binary) | Notes |
 |---|---|---|
-| `safe` (default) | `exec --full-auto --skip-git-repo-check --cd <workdir> -o .aiops/CODEX_LAST_MESSAGE.md` | `--full-auto` is codex's documented shorthand for `--sandbox workspace-write --ask-for-approval=never`. PROMPT.md is fed via stdin (codex CLI reads stdin when no positional PROMPT is provided). |
-| `bypass` | `exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd <workdir> -o .aiops/CODEX_LAST_MESSAGE.md` | For operators who run the worker inside an already-isolated environment (container, VM) and need codex to write outside the workspace cap. Documented as opt-in. |
+| `safe` (default) | `exec --full-auto --skip-git-repo-check --cd <workdir> -o <workdir>/.aiops/CODEX_LAST_MESSAGE.md` | `--full-auto` is codex's documented shorthand for `--sandbox workspace-write --ask-for-approval=never`. PROMPT.md is fed via stdin (codex CLI reads stdin when no positional PROMPT is provided). The `-o` path is absolute so the artifact lands in the workdir even if `--cd` and `cmd.Dir` ever diverge. |
+| `bypass` | `exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd <workdir> -o <workdir>/.aiops/CODEX_LAST_MESSAGE.md` | For operators who run the worker inside an already-isolated environment (container, VM) and need codex to write outside the workspace cap. Documented as opt-in. |
 | `custom` | (n/a — falls back to `ShellRunner` with `sh -lc <codex.command>`) | Escape hatch. Operator-controlled string; no safety promises, but logs/timeout/output capture all still apply. |
 
 `safe` is the default supplied by `expandConfig`. An empty `Codex.Profile` after YAML load is normalized to `safe`. Unknown values fail load with a clear error path/value pair (same pattern as `supportedTrackerKinds` in `loader.go`).

--- a/docs/symphony-integration.md
+++ b/docs/symphony-integration.md
@@ -71,4 +71,8 @@ Not yet implemented:
 - multi-run reconciliation
 - dashboard
 - robust event streaming
-- advanced sandboxing
+- OS-level sandboxing (sandbox-exec, firejail, container isolation). Codex CLI's own sandbox is wired via `codex.profile`.
+
+## Pointers
+
+- Symphony's richer codex integration uses the long-running `codex app-server` JSON-RPC protocol (`elixir/lib/symphony_elixir/codex/app_server.ex`) and exposes per-turn sandbox overrides via `Codex.changeset` (`elixir/lib/symphony_elixir/config/schema.ex`). This platform's M4 stays on one-shot `codex exec`; an app-server-style integration is a candidate for M5+.

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -38,6 +38,14 @@ agent:
 
 codex:
   command: codex exec
+  # profile selects how the runner invokes codex:
+  #   safe   (default) - codex exec --full-auto --skip-git-repo-check ...
+  #   bypass           - codex exec --dangerously-bypass-approvals-and-sandbox ...
+  #                      (only when the worker host is already isolated, e.g. a
+  #                      container; codex bypasses its own sandbox + approval gates)
+  #   custom           - run the literal codex.command via sh -lc; PROMPT.md
+  #                      is piped on stdin. Escape hatch for bespoke wrappers.
+  profile: safe
 
 claude:
   command: claude

--- a/internal/runner/capture.go
+++ b/internal/runner/capture.go
@@ -1,0 +1,64 @@
+package runner
+
+// CodexOutputCap is the upper bound on bytes the codex runner buffers in
+// memory from a single run. Matches workspace.VerifyOutputCap so artifact
+// ergonomics are uniform across the verify and runner phases.
+const CodexOutputCap = 1 << 20 // 1 MiB
+
+// CodexEventOutputCap bounds the head and tail slices embedded in the
+// runner_end event payload. 4 KiB per side keeps the events table cheap
+// to query while still surfacing enough context for triage.
+const CodexEventOutputCap = 4 << 10 // 4 KiB
+
+// cappedWriter is an io.Writer that buffers up to Cap bytes and silently
+// drops the rest while remembering how many bytes were dropped. It is the
+// runner-side twin of workspace.cappedBuffer; the duplication avoids an
+// import cycle and keeps each package's IO contract local.
+type cappedWriter struct {
+	Cap     int
+	buf     []byte
+	dropped int64
+}
+
+func (c *cappedWriter) Write(p []byte) (int, error) {
+	if c.Cap <= 0 {
+		c.dropped += int64(len(p))
+		return len(p), nil
+	}
+	remaining := c.Cap - len(c.buf)
+	if remaining <= 0 {
+		c.dropped += int64(len(p))
+		return len(p), nil
+	}
+	take := len(p)
+	if take > remaining {
+		take = remaining
+	}
+	c.buf = append(c.buf, p[:take]...)
+	if take < len(p) {
+		c.dropped += int64(len(p) - take)
+	}
+	return len(p), nil
+}
+
+// Bytes returns the buffered bytes (post-cap). Callers must not mutate.
+func (c *cappedWriter) Bytes() []byte { return c.buf }
+
+// Dropped reports how many bytes were dropped because Cap was reached.
+func (c *cappedWriter) Dropped() int64 { return c.dropped }
+
+// headTail returns the first headCap bytes and (when body is longer than
+// headCap) the last headCap bytes. tail is empty when the entire body
+// fits in head, so callers do not duplicate content. headCap is applied
+// to each side independently — total payload size is bounded by 2*headCap.
+func headTail(body []byte, headCap int) (head []byte, tail string) {
+	if headCap <= 0 || len(body) == 0 {
+		return nil, ""
+	}
+	if len(body) <= headCap {
+		return body, ""
+	}
+	head = body[:headCap]
+	tail = string(body[len(body)-headCap:])
+	return head, tail
+}

--- a/internal/runner/capture_test.go
+++ b/internal/runner/capture_test.go
@@ -1,0 +1,80 @@
+package runner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCappedWriter_KeepsUpToCapDropsRest(t *testing.T) {
+	t.Parallel()
+	w := &cappedWriter{Cap: 10}
+	n, err := w.Write([]byte("0123456789ABCDE")) // 15 bytes
+	if err != nil {
+		t.Fatalf("Write returned err: %v", err)
+	}
+	if n != 15 {
+		t.Fatalf("Write returned n=%d, want 15", n)
+	}
+	if got := w.Bytes(); !bytes.Equal(got, []byte("0123456789")) {
+		t.Fatalf("Bytes()=%q, want %q", got, "0123456789")
+	}
+	if got, want := w.Dropped(), int64(5); got != want {
+		t.Fatalf("Dropped()=%d, want %d", got, want)
+	}
+}
+
+func TestCappedWriter_MultipleWritesAccumulate(t *testing.T) {
+	t.Parallel()
+	w := &cappedWriter{Cap: 10}
+	w.Write([]byte("hello "))
+	w.Write([]byte("world!!"))
+	if got := w.Bytes(); string(got) != "hello worl" {
+		t.Fatalf("Bytes()=%q, want %q", got, "hello worl")
+	}
+	if w.Dropped() != 3 {
+		t.Fatalf("Dropped()=%d, want 3", w.Dropped())
+	}
+}
+
+func TestCappedWriter_ZeroCapDropsEverything(t *testing.T) {
+	t.Parallel()
+	w := &cappedWriter{Cap: 0}
+	w.Write([]byte("anything"))
+	if len(w.Bytes()) != 0 {
+		t.Fatalf("Bytes() not empty: %q", w.Bytes())
+	}
+	if w.Dropped() != 8 {
+		t.Fatalf("Dropped()=%d, want 8", w.Dropped())
+	}
+}
+
+func TestHeadTail_BelowCapReturnsHeadOnly(t *testing.T) {
+	t.Parallel()
+	body := []byte(strings.Repeat("x", 100))
+	head, tail := headTail(body, 4096)
+	if string(head) != string(body) {
+		t.Fatalf("head should equal body when len < cap")
+	}
+	if tail != "" {
+		t.Fatalf("tail should be empty when body fits in head; got %q", tail)
+	}
+}
+
+func TestHeadTail_AboveCapSplits(t *testing.T) {
+	t.Parallel()
+	body := []byte(strings.Repeat("a", 4000) + strings.Repeat("b", 4000) + strings.Repeat("c", 4000))
+	head, tail := headTail(body, 4096)
+	if len(head) != 4096 {
+		t.Fatalf("head len=%d, want 4096", len(head))
+	}
+	if len(tail) != 4096 {
+		t.Fatalf("tail len=%d, want 4096", len(tail))
+	}
+	if !strings.HasPrefix(string(head), strings.Repeat("a", 4000)) {
+		t.Fatalf("head should start with 'a's, got prefix %q", head[:8])
+	}
+	if !strings.HasSuffix(string(tail), strings.Repeat("c", 4000)) {
+		t.Fatalf("tail should end with 'c's")
+	}
+}

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -1,0 +1,157 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CodexOutputPath is where the runner persists captured codex stdout+stderr,
+// relative to the workdir.
+const CodexOutputPath = ".aiops/CODEX_OUTPUT.txt"
+
+// CodexLastMessagePath is where codex CLI writes its final message when
+// invoked with -o; the runner ingests it as Result.Summary on success.
+const CodexLastMessagePath = ".aiops/CODEX_LAST_MESSAGE.md"
+
+// PromptPath is the workdir-relative location of the rendered prompt the
+// worker writes before invoking the runner.
+const PromptPath = ".aiops/PROMPT.md"
+
+// CodexRunner is the profile-driven runner for the codex CLI. It replaces
+// the generic ShellRunner for codex; claude continues to use ShellRunner.
+//
+// Profile dispatch lives entirely inside Run; the runner is stateless and
+// safe to share across goroutines.
+type CodexRunner struct{}
+
+func (CodexRunner) Run(ctx context.Context, in RunInput) (Result, error) {
+	promptAbs := filepath.Join(in.Workdir, PromptPath)
+	if _, err := os.Stat(promptAbs); err != nil {
+		return Result{}, fmt.Errorf("read %s: %w", PromptPath, err)
+	}
+
+	cmd, err := buildCodexCmd(ctx, in)
+	if err != nil {
+		return Result{}, err
+	}
+	cmd.Dir = in.Workdir
+	configurePlatformKill(cmd)
+	cmd.WaitDelay = killGrace
+
+	stdin, err := os.Open(promptAbs)
+	if err != nil {
+		return Result{}, fmt.Errorf("open %s: %w", PromptPath, err)
+	}
+	defer stdin.Close()
+	cmd.Stdin = stdin
+
+	buf := &cappedWriter{Cap: CodexOutputCap}
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+
+	start := time.Now()
+	runErr := cmd.Run()
+	elapsed := time.Since(start)
+
+	writeCodexArtifact(in.Workdir, buf)
+
+	res := Result{
+		Summary:       readCodexSummary(in.Workdir),
+		OutputBytes:   int64(len(buf.Bytes())),
+		OutputDropped: buf.Dropped(),
+	}
+	head, tail := headTail(buf.Bytes(), CodexEventOutputCap)
+	if len(head) > 0 {
+		res.OutputHead = string(head)
+	}
+	res.OutputTail = tail
+
+	if runErr != nil {
+		if cerr := ctx.Err(); errors.Is(cerr, context.DeadlineExceeded) {
+			return res, &TimeoutError{
+				Timeout: deadlineBudget(ctx, start),
+				Elapsed: elapsed,
+				Cause:   runErr,
+			}
+		}
+		return res, runErr
+	}
+	return res, nil
+}
+
+// buildCodexCmd assembles the *exec.Cmd for the requested profile. PROMPT.md
+// is always provided via stdin, never via shell redirection.
+func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
+	profile := in.Workflow.Config.Codex.Profile
+	if profile == "" {
+		profile = "safe"
+	}
+	switch profile {
+	case "safe":
+		if _, err := exec.LookPath("codex"); err != nil {
+			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
+		}
+		return exec.CommandContext(ctx,
+			"codex", "exec",
+			"--full-auto",
+			"--skip-git-repo-check",
+			"--cd", in.Workdir,
+			"-o", CodexLastMessagePath,
+		), nil
+	case "bypass":
+		if _, err := exec.LookPath("codex"); err != nil {
+			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
+		}
+		return exec.CommandContext(ctx,
+			"codex", "exec",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--skip-git-repo-check",
+			"--cd", in.Workdir,
+			"-o", CodexLastMessagePath,
+		), nil
+	case "custom":
+		command := strings.TrimSpace(in.Workflow.Config.Codex.Command)
+		if command == "" {
+			return nil, fmt.Errorf("codex.profile=custom requires codex.command to be non-empty")
+		}
+		return exec.CommandContext(ctx, "sh", "-lc", command), nil
+	default:
+		return nil, fmt.Errorf("codex.profile %q is not supported", profile)
+	}
+}
+
+// writeCodexArtifact persists the buffered output to .aiops/CODEX_OUTPUT.txt.
+// On truncation, an explanatory footer line is appended. Errors are swallowed
+// (the artifact is best-effort; the event payload still carries head/tail).
+func writeCodexArtifact(workdir string, buf *cappedWriter) {
+	dir := filepath.Join(workdir, ".aiops")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	body := append([]byte{}, buf.Bytes()...)
+	if buf.Dropped() > 0 {
+		footer := fmt.Sprintf("\n...output truncated at %d bytes\n", CodexOutputCap)
+		body = append(body, []byte(footer)...)
+	}
+	_ = os.WriteFile(filepath.Join(workdir, CodexOutputPath), body, 0o644)
+}
+
+// readCodexSummary returns the trimmed contents of CODEX_LAST_MESSAGE.md or
+// "codex completed" when the file is missing/empty/unreadable.
+func readCodexSummary(workdir string) string {
+	b, err := os.ReadFile(filepath.Join(workdir, CodexLastMessagePath))
+	if err != nil {
+		return "codex completed"
+	}
+	trimmed := strings.TrimSpace(string(b))
+	if trimmed == "" {
+		return "codex completed"
+	}
+	return trimmed
+}

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -92,6 +92,11 @@ func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
 	if profile == "" {
 		profile = "safe"
 	}
+	// Both safe and bypass set --cd <workdir> for codex's own workspace
+	// hint AND set cmd.Dir = workdir at the OS level. The -o path is made
+	// absolute so that even if the two ever diverge in a future refactor,
+	// the artifact lands in the workdir we own (issue #17 review).
+	lastMessageAbs := filepath.Join(in.Workdir, CodexLastMessagePath)
 	switch profile {
 	case "safe":
 		if _, err := exec.LookPath("codex"); err != nil {
@@ -102,7 +107,7 @@ func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
 			"--full-auto",
 			"--skip-git-repo-check",
 			"--cd", in.Workdir,
-			"-o", CodexLastMessagePath,
+			"-o", lastMessageAbs,
 		), nil
 	case "bypass":
 		if _, err := exec.LookPath("codex"); err != nil {
@@ -113,7 +118,7 @@ func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
 			"--dangerously-bypass-approvals-and-sandbox",
 			"--skip-git-repo-check",
 			"--cd", in.Workdir,
-			"-o", CodexLastMessagePath,
+			"-o", lastMessageAbs,
 		), nil
 	case "custom":
 		command := strings.TrimSpace(in.Workflow.Config.Codex.Command)

--- a/internal/runner/codex_test.go
+++ b/internal/runner/codex_test.go
@@ -83,7 +83,7 @@ func TestCodexRunner_SafeProfileBuildsExpectedArgv(t *testing.T) {
 		"--cd",
 		wd,
 		"-o",
-		".aiops/CODEX_LAST_MESSAGE.md",
+		filepath.Join(wd, ".aiops/CODEX_LAST_MESSAGE.md"),
 	}
 	gotLines := strings.Split(strings.TrimRight(string(got), "\n"), "\n")
 	if len(gotLines) != len(want) {

--- a/internal/runner/codex_test.go
+++ b/internal/runner/codex_test.go
@@ -262,3 +262,51 @@ func TestCodexRunner_TimeoutKillsProcess(t *testing.T) {
 		t.Fatalf("process not killed promptly: elapsed=%v", elapsed)
 	}
 }
+
+func TestCodexRunner_CustomProfileUsesShellWithStdin(t *testing.T) {
+	wd := codexWorkdir(t, "custom-profile-canary")
+	in := RunInput{
+		Task: task.Task{ID: "tsk_custom", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Codex: workflow.CommandConfig{Command: "cat", Profile: "custom"},
+		}},
+		Workdir: wd,
+	}
+	res, err := (CodexRunner{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(wd, ".aiops/CODEX_OUTPUT.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "custom-profile-canary") {
+		t.Fatalf("artifact missing canary; got %q", body)
+	}
+	if res.OutputBytes <= 0 {
+		t.Fatalf("OutputBytes = %d, want > 0", res.OutputBytes)
+	}
+	// Custom profile does NOT write CODEX_LAST_MESSAGE.md (no -o flag);
+	// summary should fall back.
+	if res.Summary != "codex completed" {
+		t.Fatalf("Summary = %q, want default fallback", res.Summary)
+	}
+}
+
+func TestCodexRunner_CustomProfileEmptyCommandRejected(t *testing.T) {
+	wd := codexWorkdir(t, "x")
+	in := RunInput{
+		Task: task.Task{ID: "tsk_custom_empty", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Codex: workflow.CommandConfig{Profile: "custom"},
+		}},
+		Workdir: wd,
+	}
+	_, err := (CodexRunner{}).Run(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected error for custom profile with empty command")
+	}
+	if !strings.Contains(err.Error(), "codex.command") {
+		t.Fatalf("error %q should mention codex.command", err)
+	}
+}

--- a/internal/runner/codex_test.go
+++ b/internal/runner/codex_test.go
@@ -1,0 +1,264 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// codexStubScript writes a bash script named `codex` into a temp dir and
+// prepends that dir to PATH for the duration of the test. The script body
+// is supplied by the caller. The script always records its argv and stdin
+// to predictable side files inside the same temp dir so tests can assert
+// what codex was actually called with.
+//
+// Returns binDir which contains the recorded argv.txt / stdin.txt and the
+// codex script itself.
+func codexStubScript(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "codex")
+	header := `#!/usr/bin/env bash
+set -e
+printf '%s\n' "$@" > "` + dir + `/argv.txt"
+cat > "` + dir + `/stdin.txt"
+`
+	if err := os.WriteFile(scriptPath, []byte(header+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return dir
+}
+
+// codexWorkdir creates a per-test workdir with a populated .aiops/PROMPT.md.
+func codexWorkdir(t *testing.T, prompt string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".aiops"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".aiops", "PROMPT.md"), []byte(prompt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func codexInput(workdir string) RunInput {
+	return RunInput{
+		Task: task.Task{ID: "tsk_codex_test", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Codex: workflow.CommandConfig{Command: "codex exec", Profile: "safe"},
+		}},
+		Workdir: workdir,
+		Prompt:  "ignored — runner reads .aiops/PROMPT.md",
+	}
+}
+
+func TestCodexRunner_SafeProfileBuildsExpectedArgv(t *testing.T) {
+	// codexStubScript calls t.Setenv; Go 1.25 forbids t.Parallel with t.Setenv.
+	binDir := codexStubScript(t, `exit 0`)
+	wd := codexWorkdir(t, "hello prompt")
+
+	in := codexInput(wd)
+	if _, err := (CodexRunner{}).Run(context.Background(), in); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(binDir, "argv.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"exec",
+		"--full-auto",
+		"--skip-git-repo-check",
+		"--cd",
+		wd,
+		"-o",
+		".aiops/CODEX_LAST_MESSAGE.md",
+	}
+	gotLines := strings.Split(strings.TrimRight(string(got), "\n"), "\n")
+	if len(gotLines) != len(want) {
+		t.Fatalf("argv lines = %d, want %d; got %q", len(gotLines), len(want), gotLines)
+	}
+	for i := range want {
+		if gotLines[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q", i, gotLines[i], want[i])
+		}
+	}
+}
+
+func TestCodexRunner_PromptPipedToStdin(t *testing.T) {
+	binDir := codexStubScript(t, `exit 0`)
+	wd := codexWorkdir(t, "stdin canary 42")
+
+	if _, err := (CodexRunner{}).Run(context.Background(), codexInput(wd)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "stdin canary 42" {
+		t.Fatalf("stdin = %q, want %q", got, "stdin canary 42")
+	}
+}
+
+func TestCodexRunner_CapturesOutputArtifact(t *testing.T) {
+	codexStubScript(t, `printf 'codex-canary-9134\n' ; printf 'err-line\n' >&2 ; exit 0`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(wd, ".aiops/CODEX_OUTPUT.txt"))
+	if err != nil {
+		t.Fatalf("read CODEX_OUTPUT.txt: %v", err)
+	}
+	if !strings.Contains(string(out), "codex-canary-9134") {
+		t.Fatalf("artifact missing stdout canary; got %q", out)
+	}
+	if !strings.Contains(string(out), "err-line") {
+		t.Fatalf("artifact missing stderr line; got %q", out)
+	}
+	if res.OutputBytes <= 0 {
+		t.Fatalf("Result.OutputBytes = %d, want > 0", res.OutputBytes)
+	}
+	if res.OutputDropped != 0 {
+		t.Fatalf("Result.OutputDropped = %d, want 0 for small output", res.OutputDropped)
+	}
+	if !strings.Contains(res.OutputHead, "codex-canary-9134") {
+		t.Fatalf("OutputHead missing canary; got %q", res.OutputHead)
+	}
+}
+
+func TestCodexRunner_LastMessageBecomesSummary(t *testing.T) {
+	codexStubScript(t, `mkdir -p .aiops && printf 'codex completed task X\n' > .aiops/CODEX_LAST_MESSAGE.md ; exit 0`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "codex completed task X" {
+		t.Fatalf("Summary = %q, want %q", res.Summary, "codex completed task X")
+	}
+}
+
+func TestCodexRunner_MissingLastMessageFallsBackToDefaultSummary(t *testing.T) {
+	codexStubScript(t, `exit 0`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "codex completed" {
+		t.Fatalf("Summary = %q, want %q", res.Summary, "codex completed")
+	}
+}
+
+func TestCodexRunner_OutputExceedsCapTruncates(t *testing.T) {
+	// 1.5 MiB of stdout: comfortably above the 1 MiB cap.
+	codexStubScript(t, `head -c 1572864 /dev/zero | tr '\0' 'a'`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.OutputDropped <= 0 {
+		t.Fatalf("OutputDropped = %d, want > 0", res.OutputDropped)
+	}
+	if res.OutputBytes != int64(CodexOutputCap) {
+		t.Fatalf("OutputBytes = %d, want %d (the cap)", res.OutputBytes, CodexOutputCap)
+	}
+	body, err := os.ReadFile(filepath.Join(wd, ".aiops/CODEX_OUTPUT.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(string(body), "\n") || !strings.Contains(string(body), "...output truncated at") {
+		tailStart := len(body) - 200
+		if tailStart < 0 {
+			tailStart = 0
+		}
+		t.Fatalf("artifact missing truncation footer; tail=%q", body[tailStart:])
+	}
+}
+
+func TestCodexRunner_MissingPromptReturnsWrappedError(t *testing.T) {
+	codexStubScript(t, `exit 0`)
+	dir := t.TempDir() // no .aiops/PROMPT.md
+	in := codexInput(dir)
+
+	_, err := (CodexRunner{}).Run(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected error for missing PROMPT.md, got nil")
+	}
+	if IsTimeout(err) {
+		t.Fatalf("missing-prompt should not classify as timeout: %v", err)
+	}
+	if !strings.Contains(err.Error(), "PROMPT.md") {
+		t.Fatalf("error %q should mention PROMPT.md", err)
+	}
+}
+
+func TestCodexRunner_MissingBinaryReturnsClearError(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv — sequential only.
+	t.Setenv("PATH", "") // no codex anywhere
+	wd := codexWorkdir(t, "x")
+	_, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err == nil {
+		t.Fatal("expected error for missing codex binary")
+	}
+	if !strings.Contains(err.Error(), "codex binary not found") {
+		t.Fatalf("error %q should mention 'codex binary not found'", err)
+	}
+}
+
+func TestCodexRunner_NonZeroExitNotTimeout(t *testing.T) {
+	codexStubScript(t, `exit 3`)
+	wd := codexWorkdir(t, "x")
+	_, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
+	if err == nil {
+		t.Fatal("expected error from exit 3")
+	}
+	if IsTimeout(err) {
+		t.Fatalf("non-zero exit must not classify as timeout: %v", err)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+}
+
+func TestCodexRunner_TimeoutKillsProcess(t *testing.T) {
+	codexStubScript(t, `sleep 30`)
+	wd := codexWorkdir(t, "x")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := (CodexRunner{}).Run(ctx, codexInput(wd))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !IsTimeout(err) {
+		t.Fatalf("expected *TimeoutError, got %T: %v", err, err)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("process not killed promptly: elapsed=%v", elapsed)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -18,7 +18,11 @@ type RunInput struct {
 }
 
 type Result struct {
-	Summary string
+	Summary       string
+	OutputBytes   int64  // bytes the runner kept in its capture buffer
+	OutputDropped int64  // bytes dropped because the buffer hit its cap
+	OutputHead    string // up to CodexEventOutputCap bytes from the start of the captured output
+	OutputTail    string // up to CodexEventOutputCap bytes from the end; empty when total <= head cap
 }
 
 type Runner interface {
@@ -30,7 +34,7 @@ func New(name string) (Runner, error) {
 	case "", "mock":
 		return MockRunner{}, nil
 	case "codex":
-		return ShellRunner{Name: "codex"}, nil
+		return CodexRunner{}, nil
 	case "claude":
 		return ShellRunner{Name: "claude"}, nil
 	default:

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -98,9 +98,9 @@ func TestMockRunnerNoTimeoutWhenSleepShort(t *testing.T) {
 func TestShellRunnerKillsRunawayProcess(t *testing.T) {
 	t.Parallel()
 	wf := workflow.Workflow{Config: workflow.Config{
-		Codex: workflow.CommandConfig{Command: "sleep 30"},
+		Claude: workflow.CommandConfig{Command: "sleep 30"},
 	}}
-	r := ShellRunner{Name: "codex"}
+	r := ShellRunner{Name: "claude"}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -132,9 +132,9 @@ func TestShellRunnerKillsRunawayProcess(t *testing.T) {
 func TestShellRunnerNonTimeoutErrorNotMisclassified(t *testing.T) {
 	t.Parallel()
 	wf := workflow.Workflow{Config: workflow.Config{
-		Codex: workflow.CommandConfig{Command: "exit 3"},
+		Claude: workflow.CommandConfig{Command: "exit 3"},
 	}}
-	r := ShellRunner{Name: "codex"}
+	r := ShellRunner{Name: "claude"}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -26,8 +26,8 @@ type fakeLinearServer struct {
 }
 
 type fakeLinearRequest struct {
-	OpName    string
-	Variables map[string]any
+	OpName     string
+	Variables  map[string]any
 	AuthHeader string
 }
 

--- a/internal/worker/handletaskfailure_test.go
+++ b/internal/worker/handletaskfailure_test.go
@@ -28,8 +28,8 @@ type failCall struct {
 }
 
 type failTimeoutCall struct {
-	ID, Msg            string
-	MaxTimeoutRetries  int
+	ID, Msg           string
+	MaxTimeoutRetries int
 }
 
 func (f *fakeFailingStore) Fail(_ context.Context, id, msg string) (bool, error) {

--- a/internal/worker/run_test.go
+++ b/internal/worker/run_test.go
@@ -810,6 +810,78 @@ func TestVerifyFails_BlocksPRWhenAllowFailureOff(t *testing.T) {
 	}
 }
 
+// fakeOutputRunner returns a fixed Result with non-zero output fields so we
+// can assert RunRunnerWithTimeout forwards them onto the runner_end payload.
+type fakeOutputRunner struct{}
+
+func (fakeOutputRunner) Run(_ context.Context, _ runner.RunInput) (runner.Result, error) {
+	return runner.Result{
+		Summary:       "fake done",
+		OutputBytes:   42,
+		OutputDropped: 7,
+		OutputHead:    "head-canary",
+		OutputTail:    "tail-canary",
+	}, nil
+}
+
+// TestRunRunnerWithTimeout_EmitsOutputFieldsOnRunnerEnd verifies that when a
+// runner returns non-zero output telemetry, the runner_end payload carries
+// output_bytes, output_dropped, output_head, and output_tail.
+func TestRunRunnerWithTimeout_EmitsOutputFieldsOnRunnerEnd(t *testing.T) {
+	ev := &fakeEmitter{}
+	in := runner.RunInput{Task: task.Task{ID: "tsk_payload", Model: "codex"}}
+	if _, err := worker.RunRunnerWithTimeout(context.Background(), ev, fakeOutputRunner{}, in, 5*time.Second, "file"); err != nil {
+		t.Fatalf("RunRunnerWithTimeout: %v", err)
+	}
+	ends := ev.byKind(task.EventRunnerEnd)
+	if len(ends) == 0 {
+		t.Fatal("no runner_end event recorded")
+	}
+	pe := ends[len(ends)-1]
+
+	wantInt := map[string]float64{
+		"output_bytes":   42,
+		"output_dropped": 7,
+	}
+	for k, want := range wantInt {
+		got := payloadField(t, pe.Payload, k)
+		if got != want {
+			t.Fatalf("payload[%q] = %v (%T), want %v", k, got, got, want)
+		}
+	}
+	wantStr := map[string]string{
+		"output_head": "head-canary",
+		"output_tail": "tail-canary",
+	}
+	for k, want := range wantStr {
+		got, _ := payloadField(t, pe.Payload, k).(string)
+		if got != want {
+			t.Fatalf("payload[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestRunRunnerWithTimeout_OmitsOutputFieldsForMockRunner verifies that the
+// MockRunner (which leaves all Output* fields zero) does not pollute the
+// runner_end payload with output_* keys.
+func TestRunRunnerWithTimeout_OmitsOutputFieldsForMockRunner(t *testing.T) {
+	ev := &fakeEmitter{}
+	in := runner.RunInput{Task: task.Task{ID: "tsk_mock_payload", Model: "mock"}, Workdir: t.TempDir()}
+	if _, err := worker.RunRunnerWithTimeout(context.Background(), ev, runner.MockRunner{}, in, 5*time.Second, "file"); err != nil {
+		t.Fatalf("RunRunnerWithTimeout: %v", err)
+	}
+	ends := ev.byKind(task.EventRunnerEnd)
+	if len(ends) == 0 {
+		t.Fatal("no runner_end event recorded")
+	}
+	pe := ends[len(ends)-1]
+	for _, k := range []string{"output_bytes", "output_dropped", "output_head", "output_tail"} {
+		if got := payloadField(t, pe.Payload, k); got != nil {
+			t.Fatalf("payload should not contain %q for mock runner; got %v", k, got)
+		}
+	}
+}
+
 // TestVerifyAllowFailure_DoesNotMaskParentCancel pins that allow_failure
 // only downgrades real verification failures, not context cancellation.
 // Codex review on PR #55 caught that the original runVerifyPhase swallowed

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -298,7 +298,9 @@ func wrapErr(cfg workflow.Config, err error) *RunTaskError {
 // (runner_start, runner_end, runner_timeout) so retry policy and observers
 // can distinguish a clean exit from a kill due to deadline. The returned
 // runner.Result is what runTask passes to runSummary on the success path;
-// on failure it is zero-valued.
+// on failure (timeout or non-zero exit) the same Result is returned so that
+// any partial output telemetry the runner managed to capture (OutputBytes,
+// OutputHead, OutputTail, etc.) is still available to the caller.
 func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner, in runner.RunInput, timeout time.Duration, workflowSource string) (runner.Result, error) {
 	if timeout <= 0 {
 		timeout = 30 * time.Minute

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -320,20 +320,24 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 	if runErr != nil {
 		var te *runner.TimeoutError
 		if errors.As(runErr, &te) {
-			Emit(ctx, ev, in.Task.ID, task.EventRunnerTimeout, te.Error(), map[string]any{
+			timeoutPayload := map[string]any{
 				"model":      in.Task.Model,
 				"timeout_ms": te.Timeout.Milliseconds(),
 				"elapsed_ms": te.Elapsed.Milliseconds(),
-			})
-			return runner.Result{}, runErr
+			}
+			addOutputFields(timeoutPayload, res)
+			Emit(ctx, ev, in.Task.ID, task.EventRunnerTimeout, te.Error(), timeoutPayload)
+			return res, runErr
 		}
-		Emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner failed", map[string]any{
+		failurePayload := map[string]any{
 			"model":       in.Task.Model,
 			"duration_ms": elapsed.Milliseconds(),
 			"error":       ErrSummary(runErr),
 			"ok":          false,
-		})
-		return runner.Result{}, runErr
+		}
+		addOutputFields(failurePayload, res)
+		Emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner failed", failurePayload)
+		return res, runErr
 	}
 
 	endPayload := map[string]any{
@@ -344,6 +348,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 	if res.Summary != "" {
 		endPayload["summary"] = res.Summary
 	}
+	addOutputFields(endPayload, res)
 	Emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner completed", endPayload)
 	return res, nil
 }
@@ -684,4 +689,23 @@ func sampleSlice(items []string, max int) []string {
 		return items
 	}
 	return items[:max]
+}
+
+// addOutputFields merges runner Result output telemetry into a payload map
+// when the runner reported any. Mock runs that leave Result.Output* zero
+// add no keys, preserving payload diffs for tests written before
+// codex/log capture landed.
+func addOutputFields(payload map[string]any, res runner.Result) {
+	if res.OutputBytes > 0 {
+		payload["output_bytes"] = res.OutputBytes
+	}
+	if res.OutputDropped > 0 {
+		payload["output_dropped"] = res.OutputDropped
+	}
+	if res.OutputHead != "" {
+		payload["output_head"] = res.OutputHead
+	}
+	if res.OutputTail != "" {
+		payload["output_tail"] = res.OutputTail
+	}
 }

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -89,6 +89,13 @@ func (a AgentConfig) MaxTimeoutRetriesValue() int {
 
 type CommandConfig struct {
 	Command string `yaml:"command" json:"command"`
+	// Profile is consulted only by the codex runner. Allowed values: "safe"
+	// (default), "bypass", "custom". The field lives on the shared
+	// CommandConfig type to avoid splitting CodexConfig out for one field;
+	// loader validation rejects non-empty Profile on the Claude embed so a
+	// copy-paste mistake fails loud at load time instead of silently doing
+	// nothing.
+	Profile string `yaml:"profile,omitempty" json:"profile,omitempty"`
 }
 
 type PolicyConfig struct {
@@ -195,7 +202,7 @@ func DefaultConfig() Config {
 			MaxTurns:            8,
 			Timeout:             30 * time.Minute,
 		},
-		Codex:  CommandConfig{Command: "codex exec"},
+		Codex:  CommandConfig{Command: "codex exec", Profile: "safe"},
 		Claude: CommandConfig{Command: "claude"},
 		Policy: PolicyConfig{Mode: "draft_pr", MaxChangedFiles: 12, MaxChangedLOC: 300},
 		Verify: VerifyConfig{Commands: []string{}},

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -8,6 +8,16 @@ import (
 	"time"
 )
 
+func writeTempWorkflow(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/WORKFLOW.md"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 // TestLoad_PRDraftFromFrontMatter verifies the YAML key `pr.draft` is parsed
 // into Config.PR.Draft. This is the schema knob #41 wires through to
 // gitea.CreatePullRequest.
@@ -511,5 +521,113 @@ func TestLoad_VerifyTimeoutAndAllowFailureRoundTrip(t *testing.T) {
 	}
 	if !wf.Config.Verify.AllowFailure {
 		t.Fatalf("Verify.AllowFailure = false, want true")
+	}
+}
+
+func TestDefaultConfig_CodexProfileIsSafe(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	if cfg.Codex.Profile != "safe" {
+		t.Fatalf("DefaultConfig().Codex.Profile = %q, want %q", cfg.Codex.Profile, "safe")
+	}
+}
+
+func TestLoad_AcceptsSupportedCodexProfiles(t *testing.T) {
+	t.Parallel()
+	for _, profile := range []string{"safe", "bypass", "custom"} {
+		profile := profile
+		t.Run(profile, func(t *testing.T) {
+			path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex
+codex:
+  command: codex exec
+  profile: `+profile+`
+---
+prompt body
+`)
+			wf, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load(%s): %v", profile, err)
+			}
+			if wf.Config.Codex.Profile != profile {
+				t.Fatalf("Codex.Profile = %q, want %q", wf.Config.Codex.Profile, profile)
+			}
+		})
+	}
+}
+
+func TestLoad_RejectsUnknownCodexProfile(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex
+codex:
+  command: codex exec
+  profile: yolo
+---
+prompt
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: expected error for codex.profile=yolo, got nil")
+	}
+	if !strings.Contains(err.Error(), "codex.profile") || !strings.Contains(err.Error(), "yolo") {
+		t.Fatalf("error = %q; want it to mention codex.profile and yolo", err)
+	}
+}
+
+func TestLoad_NormalizesEmptyCodexProfileToSafe(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex
+codex:
+  command: codex exec
+---
+prompt
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if wf.Config.Codex.Profile != "safe" {
+		t.Fatalf("Codex.Profile = %q, want %q (normalization)", wf.Config.Codex.Profile, "safe")
+	}
+}
+
+func TestLoad_RejectsClaudeProfile(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: claude
+claude:
+  command: claude
+  profile: safe
+---
+prompt
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: expected error for claude.profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "claude.profile") {
+		t.Fatalf("error = %q; want it to mention claude.profile", err)
 	}
 }

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -67,6 +67,17 @@ var supportedAgentDefaults = map[string]struct{}{
 	"claude": {},
 }
 
+// supportedCodexProfiles enumerates the codex runner profile names the
+// runner package knows how to dispatch. "safe" injects --full-auto +
+// --skip-git-repo-check; "bypass" swaps in
+// --dangerously-bypass-approvals-and-sandbox for already-isolated hosts;
+// "custom" falls back to the operator-supplied codex.command via sh -lc.
+var supportedCodexProfiles = map[string]struct{}{
+	"safe":   {},
+	"bypass": {},
+	"custom": {},
+}
+
 // validateConfig enforces the required-field and enum constraints that
 // the typed YAML decoder cannot express on its own. It runs after
 // expandConfig so env-var indirections (e.g. `clone_url: $REPO_URL`)
@@ -82,6 +93,12 @@ func validateConfig(path string, cfg Config) error {
 	}
 	if _, ok := supportedAgentDefaults[cfg.Agent.Default]; !ok {
 		return fmt.Errorf("%s: agent.default %q is not supported (allowed: mock, codex, claude)", path, cfg.Agent.Default)
+	}
+	if _, ok := supportedCodexProfiles[cfg.Codex.Profile]; !ok {
+		return fmt.Errorf("%s: codex.profile %q is not supported (allowed: safe, bypass, custom)", path, cfg.Codex.Profile)
+	}
+	if strings.TrimSpace(cfg.Claude.Profile) != "" {
+		return fmt.Errorf("%s: claude.profile is not supported (only codex has profiles)", path)
 	}
 	return nil
 }
@@ -181,6 +198,9 @@ func expandConfig(cfg *Config) {
 	}
 	if cfg.Tracker.Statuses.Rework == "" {
 		cfg.Tracker.Statuses.Rework = "Rework"
+	}
+	if cfg.Codex.Profile == "" {
+		cfg.Codex.Profile = "safe"
 	}
 }
 

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -548,6 +548,20 @@ func EnforcePolicy(ctx context.Context, workdir string, cfg workflow.Config) err
 	return nil
 }
 
+// CommitIdentName and CommitIdentEmail are the git author/committer
+// identity the worker stamps on every PR commit. Passing them inline via
+// `git -c` flags keeps the worker self-contained: it works on hosts
+// without a global git config (e.g. a fresh CI runner or a hardened
+// container image) and gives all aiops-platform commits a uniform,
+// recognizable attribution. Operators who want a different identity can
+// still override at runtime via the standard
+// GIT_{AUTHOR,COMMITTER}_{NAME,EMAIL} env vars, which take precedence
+// over the -c session config.
+const (
+	CommitIdentName  = "aiops-platform worker"
+	CommitIdentEmail = "worker@aiops-platform.local"
+)
+
 // CommitAndPush stages the workdir, commits with a Title-derived message,
 // and pushes to origin/<branch>. Retries for the same task ID reuse the same
 // work branch (see queue.Postgres.Enqueue), so on retry origin may already
@@ -568,7 +582,11 @@ func CommitAndPush(ctx context.Context, workdir string, title string, branch str
 	if err := run(ctx, workdir, "git", "diff", "--cached", "--quiet"); err == nil {
 		return fmt.Errorf("no changes to commit")
 	}
-	if err := run(ctx, workdir, "git", "commit", "-m", "chore(ai): "+title); err != nil {
+	if err := run(ctx, workdir, "git",
+		"-c", "user.email="+CommitIdentEmail,
+		"-c", "user.name="+CommitIdentName,
+		"commit", "-m", "chore(ai): "+title,
+	); err != nil {
 		return err
 	}
 	exists, err := remoteBranchExists(ctx, workdir, branch)

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -323,6 +323,28 @@ func TestCommitAndPush_RemoteBranchDeletedRecreates(t *testing.T) {
 	}
 }
 
+// unsetEnvForTest unsets the named env vars for the duration of the test,
+// restoring the prior values via t.Cleanup. testing.T.Setenv only supports
+// SET; we need UNSET semantics for tests that simulate a vanilla CI runner
+// where GIT_* identity vars are absent (not "set to empty string", which git
+// treats as "use this empty value" rather than "fall back to next source").
+func unsetEnvForTest(t *testing.T, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		old, present := os.LookupEnv(k)
+		if err := os.Unsetenv(k); err != nil {
+			t.Fatalf("unset %s: %v", k, err)
+		}
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(k, old)
+			} else {
+				_ = os.Unsetenv(k)
+			}
+		})
+	}
+}
+
 // configureGitIdentity sets a deterministic committer for the per-test
 // worktree. PrepareGitWorkspace inherits config from the bare mirror, but the
 // mirror is created without an identity (we never commit inside it), so a
@@ -416,6 +438,55 @@ func TestMirrorRoot_OverrideWins(t *testing.T) {
 	}
 	if got := MirrorRoot(""); got == "" {
 		t.Fatal("default mirror root must not be empty")
+	}
+}
+
+// TestCommitAndPush_WorksWithoutHostGitIdent verifies the worker is
+// self-sufficient on a host with NO global git config — the situation on
+// fresh CI runners and hardened container images. Before this fix,
+// `git commit` would error with "empty ident name not allowed" because the
+// per-task worktree inherits no identity from the bare mirror. Now the
+// worker passes its own identity inline via -c flags; the test confirms
+// the commit lands with the expected author/committer fields.
+func TestCommitAndPush_WorksWithoutHostGitIdent(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+	tk := makeTask("no-ident-task", upstream)
+
+	dir, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare workspace: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("payload\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a host with no git ident: point HOME at an empty temp dir
+	// (so ~/.gitconfig does not exist) and unset every GIT_* env var that
+	// could leak an identity from the developer's environment. Without the
+	// production fix, git commit would now fail with "empty ident name".
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	unsetEnvForTest(t,
+		"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+		"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+	)
+
+	if err := CommitAndPush(ctx, dir, "no-ident attempt", tk.WorkBranch); err != nil {
+		t.Fatalf("CommitAndPush should succeed without host git ident: %v", err)
+	}
+
+	bare := strings.TrimPrefix(upstream, "file://")
+	out, err := exec.Command("git", "--git-dir", bare,
+		"log", "-1", "--format=%an|%ae|%cn|%ce", tk.WorkBranch).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log on bare: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	want := CommitIdentName + "|" + CommitIdentEmail + "|" + CommitIdentName + "|" + CommitIdentEmail
+	if got != want {
+		t.Fatalf("commit identity = %q, want %q", got, want)
 	}
 }
 

--- a/test/e2e/allowfail_test.go
+++ b/test/e2e/allowfail_test.go
@@ -40,7 +40,7 @@ func TestVerifyAllowFailure(t *testing.T) {
 	}
 
 	var taskID string
-	pollUntil(t, 60*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
+	pollUntil(t, 180*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
 		row := bed.pg.pool.QueryRow(ctx,
 			`SELECT id, status FROM tasks WHERE created_at >= $1 ORDER BY created_at DESC LIMIT 1`, testStart)
 		var id, status string

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -42,7 +42,7 @@ func TestGiteaMockLoop_HappyPath(t *testing.T) {
 	}
 
 	var workBranch string
-	pollUntil(t, 60*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
+	pollUntil(t, 180*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
 		row := bed.pg.pool.QueryRow(ctx,
 			`SELECT id, status, work_branch FROM tasks WHERE created_at >= $1 ORDER BY created_at DESC LIMIT 1`,
 			testStart)

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -58,8 +58,18 @@ func setupTestbed(ctx context.Context) (*testbed, error) {
 		botToken: g.botToken,
 	}
 
-	// Listen on tcp4 so triggerSrv.URL is always 127.0.0.1.
-	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	// Listen on 0.0.0.0 so a sibling Docker container (the Gitea testbed)
+	// can reach this trigger server via host.docker.internal. macOS Docker
+	// Desktop accepts loopback (127.0.0.1) from containers via VPNkit, but
+	// Linux Docker maps host.docker.internal to the docker0 gateway IP and
+	// a 127.0.0.1-only listener rejects connections from that source — the
+	// happypath / allowfail tests then time out because no webhook ever
+	// reaches the worker. Binding 0.0.0.0 fixes both platforms.
+	//
+	// We override httptest's auto-set URL so in-process loopback callers
+	// (dedup_test, badsig_test) keep using 127.0.0.1 explicitly; only the
+	// webhookURL handed to Gitea uses the host.docker.internal hostname.
+	listener, err := net.Listen("tcp4", "0.0.0.0:0")
 	if err != nil {
 		g.close(context.Background())
 		pg.close(context.Background())
@@ -71,14 +81,10 @@ func setupTestbed(ctx context.Context) (*testbed, error) {
 		Config:   &http.Server{Handler: triggerapi.Routes(srv)},
 	}
 	triggerSrv.Start()
-	if !strings.Contains(triggerSrv.URL, "127.0.0.1") {
-		triggerSrv.Close()
-		g.close(context.Background())
-		pg.close(context.Background())
-		return nil, fmt.Errorf("unexpected httptest URL: %s", triggerSrv.URL)
-	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	triggerSrv.URL = fmt.Sprintf("http://127.0.0.1:%d", port)
 
-	webhookURL := strings.Replace(triggerSrv.URL, "127.0.0.1", "host.docker.internal", 1) + "/v1/events/gitea"
+	webhookURL := fmt.Sprintf("http://host.docker.internal:%d/v1/events/gitea", port)
 
 	cfg := worker.Config{
 		WorkspaceRoot:   tmpDir(),


### PR DESCRIPTION
## Summary

Closes #17. Replaces the generic ShellRunner-for-codex with a profile-driven `CodexRunner` and captures codex output to both a workspace artifact and the `runner_end` event payload.

- New `codex.profile` schema field (`safe` default / `bypass` / `custom`) with loader validation (rejects unknown values; rejects any `claude.profile`).
- `internal/runner/codex.go` `CodexRunner`: argv-form invocation (no shell concat for safe/bypass), PROMPT.md piped on stdin, `--full-auto` (safe) or `--dangerously-bypass-approvals-and-sandbox` (bypass), absolute `-o` path so the artifact is decoupled from CWD.
- `custom` profile preserves `codex.command` via `sh -lc` but **PROMPT.md now goes via stdin** (was: `< .aiops/PROMPT.md` redirect). Runbook calls this out.
- Captures stdout+stderr to `.aiops/CODEX_OUTPUT.txt` (1 MiB cap with truncation footer) AND surfaces head/tail/bytes/dropped on `runner_end` / `runner_timeout` event payloads via a new `addOutputFields` helper.
- Picks up `.aiops/CODEX_LAST_MESSAGE.md` (codex's own `-o` artifact) as `Result.Summary` on success.
- ShellRunner kill/exit tests rebound from codex to claude (codex no longer routes through ShellRunner).

Spec: `docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md`
Plan: `docs/superpowers/plans/2026-05-11-safe-codex-runner.md`

## Test plan

- [x] `go test -race ./...` — all 10 packages green
- [x] `gofmt -l` — clean on changed files
- [x] `go mod tidy` — no diff
- [x] `go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`
- [x] `go run ./cmd/worker --print-config <wd>` surfaces `codex.profile` correctly (verified with `bypass`)
- [x] CodexRunner has 12 tests (argv shape per profile, stdin PROMPT pipe, output artifact + truncation, last-message pickup + fallback, missing PROMPT, missing binary, non-zero exit ≠ timeout, timeout kills process)
- [x] Worker has 2 new payload tests (`output_*` keys present for codex Result, absent for mock)
- [x] Workflow loader has 5 new tests (default safe, accept all 3 profiles, reject unknown, normalize empty → safe, reject `claude.profile`)
- [ ] Operator dry run on a personal demo repo with `agent.default: codex` (out of scope for this PR per spec; covered by issue #17 Notes)