### PR TITLE
docs(spec-alignment): record SPEC-alignment investigation and decision to fork Symphony

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -1,0 +1,184 @@
+# Decision: stop Go port; adopt a Symphony fork as the new base
+
+> **Status:** In progress. The high-level decision (stop Go port, switch to a
+> fork) is made. The specific fork to adopt is open and depends on
+> [`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md).
+>
+> **Date:** 2026-05-13
+> **Branch where this was decided:** `claude/handle-issue-3DyNV`
+> **See also:** [`AGENTS.md`](AGENTS.md), [`DEVIATIONS.md`](DEVIATIONS.md)
+
+## TL;DR
+
+`aiops-platform` was started as a from-scratch Go implementation of OpenAI
+Symphony. After deep reading of the upstream `SPEC.md`, the Elixir reference
+implementation, the OpenAI announcement post, and two practitioner accounts
+([George](docs/research/2026-05-george-symphony-electron-rewrite.md) and
+[Addy Osmani](docs/research/2026-05-addy-osmani-harness-engineering.md)),
+the Go implementation accumulated **nine** SPEC deviations
+([D1–D9](DEVIATIONS.md)). Four are `Reverting`, one is `P0`, and the project
+"can't even run end to end yet" per the operator's assessment.
+
+Under the operator's stated criteria —
+
+> "实现错误,违反规范才是最大问题,都要推倒重来。"
+> "时间是重要的但不急。"
+> "现在都是 Claude code, codex 来接手维护写代码,人只是一个导航员。"
+
+— the right move is **not** to spend 2–4 weeks rewriting the Go orchestrator
+to match the Elixir reference. The right move is to **stop the Go port and
+adopt one of the existing working Symphony implementations as the new
+upstream**, then layer Gitea support and the harness-engineering gates we
+have already proven valuable (policy / verify / secret-scan) on top.
+
+## Context
+
+When this project was started, the assumption was that a Go-native
+implementation would be the cleanest path. The harness-engineering gates
+under `internal/policy`, `internal/workspace.RunVerify`, and the secret-scan
+hook are genuine value-adds; the runner abstraction is direction-correct;
+the workflow loader is mostly right.
+
+What turned out to be wrong was the **orchestrator core**. Reading
+`SPEC.md` §1 and the Elixir
+[`orchestrator.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/orchestrator.ex)
+made it clear that:
+
+- Scheduling state belongs in process memory, not a Postgres table (D6, #73).
+- Triggers are polling-only, not webhook-based (D7, #74).
+- `WORKFLOW.md` is a single source, not a three-path search (D4, #72).
+- PR creation, git push, and ticket state writes belong to the **agent**,
+  not the orchestrator (D8, P0, #76).
+- Reconciliation runs on every tick to stop active runs when their tracker
+  state changes (D9, #78), in addition to a startup pass (D3, #68).
+- The agent runner uses long-running JSON-RPC over stdio (`codex app-server`),
+  not one-shot `codex exec` (D1, #64).
+
+These are not surface-level corrections. They reshape the worker loop, the
+runner protocol, the trigger ingress, and the queue. Re-implementing the Go
+core to match `orchestrator.ex` is essentially writing a Go version of the
+Elixir reference — which is itself an artifact OpenAI published as the
+reference, not a stand-alone product to maintain.
+
+## Decision
+
+**Stop the Go port. Adopt a working Symphony implementation as the new
+upstream base, then add Gitea support and the harness-engineering gates on
+top.**
+
+The specific fork to adopt is **open** and tracked in
+[`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md).
+Initial scan suggests the strongest candidates are:
+
+- **`junhoyeo/contrabass`** (Go, Codex + Claude, ~475 commits, packaged via
+  Homebrew, active as of 2026-05-10). Best fit if its SPEC alignment passes
+  a quick code-read review.
+- **`openai/symphony`** (Elixir, canonical). Strongest SPEC fidelity by
+  definition; more work to add Claude and Gitea on top.
+- **`mksglu/hatice`** (TypeScript, Claude Code SDK, GitLab adapter present).
+  Worth a look if Claude-Code-native integration matters more than SPEC
+  fidelity.
+
+See the evaluation doc for the full table and the verification checklist.
+
+## Why not just finish the Go port
+
+Considered. Rejected. The two strongest reasons:
+
+1. **Verification surface.** A Go port has to be verified against the Elixir
+   reference module-by-module, behavior-by-behavior. Under the "human is
+   navigator, AI does the writing" model, that doubles the review cost on
+   every change: read the AI's Go diff, then cross-check against the
+   corresponding Elixir source. A fork (or a community port that already
+   passes muster) shrinks the verification surface to just the deltas we
+   add — Gitea adapter, harness gates port. The reviewer's job becomes
+   "does this delta match the local convention" rather than "does this
+   diff faithfully reproduce reference behavior."
+
+2. **Maintenance gradient.** A Go port has to track every upstream change
+   as a fresh porting task. A fork picks up upstream changes by merge.
+   Over months, the cumulative porting debt for a from-scratch Go
+   implementation grows linearly; the maintenance burden of a fork is
+   roughly flat. Under the "AI does maintenance" model this still matters
+   — a smaller surface is easier for AI to keep correct, and easier for
+   the human navigator to review.
+
+The "Go is more familiar" argument that motivated the original choice no
+longer applies: the operator's stated maintenance model is that AI agents
+(Claude Code, Codex) write and maintain code, and the human role is
+navigation. AI fluency in Go vs. TypeScript vs. Elixir vs. Rust is a real
+gradient (Go and TS highest, Elixir lower), but it does not justify
+maintaining 3-5k LOC of orchestrator behavior to a known reference when
+the alternative is to keep just the deltas.
+
+Full alternatives discussed in
+[`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md).
+
+## What this means for this repository
+
+This repo will be **archived** once a new base is chosen and the migration
+landings below complete. Until then:
+
+- The branch `claude/handle-issue-3DyNV` carries the in-progress
+  SPEC-alignment documentation work and **stays open** as the historical
+  record. Do not force-push or rewrite it.
+- `main` continues to receive doc-only changes (research mirrors, this
+  decision, evaluation drafts) but **does not** receive new architectural
+  code. The nine open alignment issues (#14, #64, #67, #68, #70, #72,
+  #73, #74, #76, #78) will not be worked in this repo; they will be
+  re-filed (or closed as "wontfix — moved to fork") in the new repo.
+- The harness-engineering posture written into `AGENTS.md` and the
+  evaluation work in `DEVIATIONS.md` are the durable artifacts. Both
+  move to the new repo.
+
+### What transfers to the new repo
+
+| Asset | Where it goes | Why it transfers |
+|---|---|---|
+| `examples/WORKFLOW.md` | New repo's `examples/` | Prompt content is language-agnostic |
+| `docs/research/*` (4 files) | New repo's `docs/research/` | The decision basis itself |
+| `AGENTS.md` §SPEC alignment, §Harness engineering principles | New repo's `AGENTS.md` | The posture that will keep the fork from drifting |
+| `DEVIATIONS.md` structure | New repo's `DEVIATIONS.md` (likely empty initially) | Vocabulary for tracking new deviations if/when they emerge |
+| Issues #71 (Gitea label state machine) | New repo issue | Gitea support is still needed |
+| Policy / verify / secret-scan logic | Re-implemented in new repo's runtime | Harness-engineering gates that pass the "behavior first" test |
+
+### What is discarded
+
+Everything under `internal/queue/`, `migrations/`, `cmd/trigger-api/`,
+`internal/triggerapi/`, `internal/gitea/webhook*.go`, the orchestrator
+state-write paths in `internal/worker/runtask.go` (`OnClaim`,
+`OnPRCreated`, `CreatePR`, `BuildPRBody`), and the entire Postgres
+dependency. These either violate SPEC or only existed to compensate for
+the Go port architecture.
+
+The current `internal/runner/`, `internal/workspace/`, `internal/workflow/`,
+`internal/policy/` packages are useful **as a reference for the harness
+gates we want re-implemented in the new base** — they are not transferred
+as code, but the test suite is a behavioral spec for the re-implementation.
+
+## Open question
+
+**Which fork.** The evaluation doc has the candidates, the comparison
+table, and a verification checklist. The operator picks after reading
+the evaluation; the deciding factors are likely Gitea-distance and
+Claude-distance from each candidate.
+
+## Next steps
+
+1. **Read** [`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md)
+   and pick a primary candidate.
+2. **Spend 1–2 hours code-reading** the chosen candidate against `SPEC.md`
+   to confirm its alignment claims. The evaluation doc has the checklist.
+3. **Stand up the new repo** (fork the chosen base; rename or namespace
+   appropriately).
+4. **Migrate** the assets listed above. AI-led; human approves the
+   migration commits.
+5. **Land Gitea + harness gates** on the new base. Track work in the
+   new repo's issues.
+6. **Archive this repo.** README updated with a pointer to the new repo;
+   open issues closed with `state_reason: not_planned` and a link to
+   the equivalent issue in the new repo (or to "subsumed by upstream").
+
+This document stays in place at `DECISION.md` at the repo root after
+archive so anyone landing here understands what happened and where the
+project went.

--- a/DECISION.md
+++ b/DECISION.md
@@ -124,8 +124,8 @@ landings below complete. Until then:
   record. Do not force-push or rewrite it.
 - `main` continues to receive doc-only changes (research mirrors, this
   decision, evaluation drafts) but **does not** receive new architectural
-  code. The nine open alignment issues (#14, #64, #67, #68, #70, #72,
-  #73, #74, #76, #78) will not be worked in this repo; they will be
+  code. The open alignment issues (#14, #64, #67, #68, #70, #72, #73,
+  #74, #76, #78) will not be worked in this repo; they will be
   re-filed (or closed as "wontfix — moved to fork") in the new repo.
 - The harness-engineering posture written into `AGENTS.md` and the
   evaluation work in `DEVIATIONS.md` are the durable artifacts. Both

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # aiops-platform
 
+> **⚠️ Direction change in progress (2026-05-13).** This repo's Go
+> implementation accumulated nine SPEC deviations from upstream Symphony.
+> Rather than rewrite the orchestrator core in Go, we are switching to
+> fork an existing Symphony implementation as the new base. See
+> [`DECISION.md`](DECISION.md) for the reasoning and
+> [`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md)
+> for the candidate comparison.
+>
+> The content below describes the current Go implementation as it stood
+> before this decision. New architectural work happens on the new repo
+> once the fork is chosen; this repo will be archived with a pointer.
+
 A personal-productivity AI coding orchestrator inspired by OpenAI Symphony.
 
 The goal is not to build a heavy enterprise platform first. The goal is to run a practical loop:

--- a/docs/research/symphony-fork-evaluation.md
+++ b/docs/research/symphony-fork-evaluation.md
@@ -1,0 +1,252 @@
+# Symphony fork evaluation
+
+> **Status:** Initial scan; **SPEC alignment claims have NOT been verified
+> by code-read**. The READMEs are summarized below for triage; before
+> committing to any candidate, spend 1–2 hours reading its actual
+> orchestrator/runner/tracker source against `SPEC.md`.
+>
+> **Date:** 2026-05-13
+> **Context:** [`DECISION.md`](../../DECISION.md) — why we are forking
+> instead of completing the Go port.
+
+## Operator's hard requirements
+
+Carried over from this repo's posture:
+
+1. **Codex AND Claude runners** — both, eventually. Codex is the canonical
+   Symphony agent; Claude Code is what the operator runs day-to-day.
+2. **Gitea** — primary tracker for personal/internal repos. (Linear is
+   nice-to-have for inter-team work; GitHub Issues is a secondary path.)
+3. **SPEC alignment is non-negotiable** — see
+   [`AGENTS.md` §SPEC alignment is a hard requirement](../../AGENTS.md#spec-alignment-is-a-hard-requirement).
+4. **Harness-engineering posture** — earned rules, behavior-first
+   components, see
+   [`AGENTS.md` §Harness engineering principles](../../AGENTS.md#harness-engineering-principles).
+5. **AI-as-maintainer** — pick a base that AI agents can sustain. Lower
+   verification surface preferred over greenfield familiarity.
+
+## Candidates
+
+### Candidate A — `openai/symphony` (Elixir, canonical)
+
+**Source:** https://github.com/openai/symphony
+
+| Dimension | Status |
+|---|---|
+| Language / runtime | Elixir / BEAM |
+| Tracker support | Linear only |
+| Agent runners | Codex `app-server` only |
+| SPEC alignment | Definitionally aligned (this is the reference) |
+| Activity | Reference, not maintained as a product per the announcement |
+| Setup story | Manual: clone, `mise`, configure |
+| Packaging | None (run from source) |
+| Gitea distance | High — need a `Tracker.Behaviour` adapter from scratch |
+| Claude distance | High — need a `claude/app_server.ex` analog |
+| AI-fluency for maintenance | Lower than Go/TS (Elixir is a niche training corpus) |
+
+**Pros:**
+- Zero day-1 SPEC deviations. Anything we add is delta we own.
+- The Elixir reference's `orchestrator.ex` is the artifact every other
+  candidate is implicitly graded against.
+- BEAM/OTP gives us supervision semantics for free; no need to
+  re-implement that part of the harness.
+
+**Cons:**
+- Two large additions required (Gitea adapter, Claude runner) before
+  the operator can run their primary use case.
+- Niche language reduces AI per-line throughput on additions, though
+  not on pattern-matching against existing modules.
+- BEAM deployment is a new ops surface (Docker fine, but releases /
+  observability / hot-reload all differ from Go binary norms).
+
+### Candidate B — `odysseus0/symphony` (Elixir, friendly fork)
+
+**Source:** https://github.com/odysseus0/symphony
+
+| Dimension | Status |
+|---|---|
+| Language / runtime | Elixir / BEAM (fork of A) |
+| Tracker support | Linear only |
+| Agent runners | Codex only |
+| SPEC alignment | A + a few polish patches; assumed close |
+| Activity | ~10 commits on top of upstream |
+| Setup story | `npx skills add odysseus0/symphony -s symphony-setup -y` then "set up Symphony for my repo" |
+| Packaging | Skill-based onboarding |
+| Gitea distance | Same as A |
+| Claude distance | Same as A |
+| AI-fluency for maintenance | Same as A |
+
+**Pros over A:**
+- Better first-run experience via the setup skill.
+- "Cheaper Linear API calls", corrected sandbox for git, native Linear
+  media upload — small QoL fixes the operator would otherwise re-derive.
+
+**Cons:**
+- Adds a community dependency for marginal gains. If upstream merges
+  the patches, A is strictly better. If it does not, we inherit the
+  fork's maintenance.
+- Same Gitea / Claude distance as A.
+
+**Verdict:** Use A as the base and cherry-pick what is useful from B;
+do not adopt B as the upstream root unless setup ergonomics are the
+critical factor.
+
+### Candidate C — `mksglu/hatice` (TypeScript, Claude Code SDK)
+
+**Source:** https://github.com/mksglu/hatice
+
+| Dimension | Status |
+|---|---|
+| Language / runtime | TypeScript / Node |
+| Tracker support | Linear, GitHub Issues, GitLab (CE/EE, self-hosted) |
+| Agent runners | Claude Code Agent SDK |
+| SPEC alignment | Re-implementation, not a fork; **claims explicit alignment** but no deviations doc |
+| Activity | ~16 commits |
+| Setup story | `npm install` then `npx tsx bin/hatice.ts start` (demo mode works without API keys) |
+| Packaging | npm/npx |
+| Gitea distance | Low — GitLab REST adapter is structurally close to Gitea's REST API |
+| Claude distance | Zero — native |
+| AI-fluency for maintenance | High (TypeScript is one of the strongest AI corpora) |
+
+**Pros:**
+- Native Claude Code integration via the official Agent SDK; we do
+  not maintain a Claude runner ourselves.
+- GitLab adapter probably ports to Gitea with limited delta —
+  Gitea's REST API is GitLab-shaped, more so than Linear's GraphQL.
+- TS is a high-fluency target for AI maintenance.
+- Demo mode without API keys is a strong harness-engineering signal
+  (the maintainer cares about onboarding ergonomics).
+
+**Cons:**
+- Re-implementation, not a fork. SPEC alignment claim is unverified.
+- Smaller community / activity than D below.
+- Codex is **not** supported — would need to be added if the operator
+  wants both. (Less likely needed in practice if Claude Code is the
+  daily driver.)
+- ~16 commits is a younger codebase; risk of half-built corners.
+
+### Candidate D — `junhoyeo/contrabass` (Go, Charm TUI stack)
+
+**Source:** https://github.com/junhoyeo/contrabass
+
+| Dimension | Status |
+|---|---|
+| Language / runtime | Go (+ Charm TUI) |
+| Tracker support | Linear, GitHub Issues, Internal Board (filesystem-backed) |
+| Agent runners | Codex `app-server`, oh-my-claudecode, OpenCode, oh-my-opencode |
+| SPEC alignment | Re-implementation, not a fork; **alignment claim is unverified** |
+| Activity | v0.4.1 (2026-05-10), 475 commits, 137 ⭐ / 15 forks, **active** |
+| Setup story | `brew install junhoyeo/contrabass/contrabass` or pre-built binary |
+| Packaging | Homebrew + GitHub Releases (macOS/Linux, amd64/arm64) |
+| Gitea distance | Low — GitHub Issues adapter is structurally close to Gitea |
+| Claude distance | Zero — `oh-my-claudecode` is shipped |
+| AI-fluency for maintenance | High (Go) |
+
+**Pros:**
+- **Already supports both Codex and Claude Code as runners.** Eliminates
+  the largest piece of work that A/B would require.
+- Active and packaged: 475 commits, fresh release, Homebrew. The most
+  "real product" of the four candidates.
+- Go ecosystem matches the operator's existing dev environment.
+- Internal Board (filesystem tracker) is a useful local-dev affordance
+  the canonical reference does not have.
+- GitHub Issues adapter is structurally similar to Gitea; the Gitea
+  adapter is the closest delta of any candidate.
+
+**Cons:**
+- Re-implementation, not a fork. SPEC alignment claim must be
+  verified by code-read.
+- Charm TUI is a stack choice that may or may not match the operator's
+  intended runtime mode (headless service vs. interactive TUI).
+- Older than the announcement post would suggest the SPEC is settled
+  on — possible drift if the maintainer made decisions before some
+  SPEC clarifications landed.
+
+## Comparison summary
+
+| | A: openai/symphony | B: odysseus0/symphony | C: mksglu/hatice | **D: junhoyeo/contrabass** |
+|---|---|---|---|---|
+| Codex | ✅ | ✅ | ❌ | ✅ |
+| Claude | ❌ (add) | ❌ (add) | ✅ | ✅ |
+| Gitea | ❌ (full add) | ❌ (full add) | ❌ (adapt from GitLab, **near**) | ❌ (adapt from GitHub Issues, **near**) |
+| SPEC alignment | Reference | ≈ Reference | Claimed, unverified | Claimed, unverified |
+| Activity | Reference | Low | Low | **High** |
+| Packaging | None | Skill | npm | **Homebrew + binaries** |
+| AI fluency (language) | Low | Low | High | High |
+| Risk surface for the operator's use case | High (build Claude + Gitea) | High (same) | Medium (verify SPEC + add Codex + adapt Gitea) | **Low (verify SPEC + adapt Gitea)** |
+
+## Recommendation
+
+**Primary:** Candidate **D — `junhoyeo/contrabass`**, contingent on the
+SPEC-alignment verification below passing. It is the only candidate that
+matches all of the operator's hard requirements (Codex + Claude + a tracker
+that is structurally close to Gitea) without requiring a runner to be
+added. It is also the most production-ready of the four (Homebrew,
+binaries, active releases).
+
+**Backup:** Candidate **A — `openai/symphony`**, if D fails the alignment
+verification. We get maximum SPEC fidelity and inherit OTP's supervision
+semantics for free, at the cost of building a Claude runner and a Gitea
+adapter ourselves.
+
+**Not recommended:** B (strictly dominated by A for the operator's
+requirements) and C (adopting a TS re-implementation costs us the SPEC
+fidelity argument while still requiring Codex to be added).
+
+## Verification checklist for the chosen candidate
+
+Before adopting any candidate as the new upstream root, spend 60–90
+minutes confirming:
+
+1. **Orchestrator state model.** Is scheduling state in process memory
+   (per SPEC §2.1 / Elixir `orchestrator.ex`), or is there a hidden
+   database / queue table? Grep for `Repo`, `Ecto`, `pgx`, `database/sql`,
+   or any persistent-store driver.
+2. **Trigger model.** Polling on a tick, or webhooks? Confirm there is
+   no HTTP ingress receiving issue updates (per SPEC §triggers / D7).
+3. **WORKFLOW.md discovery.** Single path at repo root? Or a multi-path
+   search (per the D4 anti-pattern)?
+4. **Boundary at SPEC §1.** Does the orchestrator open PRs / push
+   commits / write ticket state directly? Or are those agent actions
+   via advertised tools (per D8)? Look for `git push`, PR-creation HTTP
+   calls, or tracker-state-mutation calls outside the agent's tool
+   dispatch path.
+5. **Per-tick reconciliation.** Does the poll loop re-fetch in-flight
+   issue states and cancel the runner context if an issue moves to a
+   terminal/ineligible state (per SPEC §2.1 / D9)?
+6. **Agent runner protocol.** `codex app-server` (long-running
+   JSON-RPC over stdio) or one-shot `codex exec` (per D1)?
+7. **Dynamic tool advertisement.** Does the runner expose a
+   `linear_graphql` (or equivalent) dynamic tool that holds the
+   tracker token in-process and proxies GraphQL/REST calls without
+   leaking credentials to the subprocess (per SPEC §tools and the
+   blog's token-isolation requirement)?
+8. **Workspace boundary.** Are agent commands constrained to operate
+   under `workspace.root` (per SPEC §safety)?
+
+If the candidate passes 1–7 cleanly and either passes 8 or documents
+how it intends to (and we are comfortable with the threat model), adopt.
+If it fails 1–4, treat as a fundamental SPEC deviation and prefer A.
+If it fails only 5–8, adopt and file deviation issues on the new repo,
+following the same pattern that produced this repo's `DEVIATIONS.md`.
+
+## Open questions for the operator
+
+- **Tracker priority.** If the operator's day-to-day driver is Gitea and
+  Linear is occasional, the adapter-distance metric above is correct.
+  If Linear is primary, both A and D need a Gitea adapter eventually
+  but the timing is different — A starts Linear-only and adds Gitea
+  later; D starts with GitHub Issues + can adapt to Gitea soon.
+- **Runner priority.** Codex-only is acceptable for the first phase if
+  Claude support can be added later (in which case A becomes more
+  competitive). If both are wanted from day 1, D is the clear pick.
+- **TUI vs. headless.** D ships a Charm TUI. If the operator wants a
+  background service with structured logs and no terminal UI, the TUI
+  may be unwanted weight (deletable but accounts for some of the LOC).
+
+## Next step
+
+Once the candidate is picked, the next document to write is the new
+repo's `MIGRATION.md` describing exactly which files from this repo
+move to the new repo and where they land. That doc is out of scope
+here — it depends on the fork's directory layout.


### PR DESCRIPTION
## Summary

This branch is the historical record of a multi-step SPEC-alignment
investigation that ended with the decision to stop the Go port and
adopt a Symphony fork as the new upstream base. No production code is
intended for daily use from this branch; it is doc-only landing of the
investigation artifacts.

## What's in this PR

- **Initial alignment work** (later superseded): observability for the
  multi-path WORKFLOW.md discovery (#69), kept as historical record;
  this behavior is being reverted under #72 on whatever base we adopt.
- **DEVIATIONS.md** tracking D1–D9 with status (Open / Reverting),
  citing SPEC.md, the Elixir reference, and the OpenAI announcement
  post as three jointly-authoritative sources.
- **AGENTS.md** posture sections: "SPEC alignment is a hard
  requirement" and "Harness engineering principles" (Addy Osmani's
  five rules applied to component evaluation).
- **Research mirrors** (`docs/research/`): the OpenAI Symphony
  announcement post, George's practitioner thread, Addy's
  harness-engineering thread. Authoritative + practitioner sources
  archived in-repo so they cannot drift.
- **DECISION.md** at the repo root and
  `docs/research/symphony-fork-evaluation.md`: the decision record and
  the four-candidate fork comparison
  (`openai/symphony`, `odysseus0/symphony`, `mksglu/hatice`,
  `junhoyeo/contrabass`) with an 8-item SPEC-alignment verification
  checklist.
- README banner pointing readers at DECISION.md.
- Eleven GitHub issues commented with their disposition under the
  fork decision (closed-by-construction vs. transferring): #14, #64,
  #67, #68, #70, #71, #72, #73, #74, #76, #78.

## Why merge this

The branch will not see further architectural work — it is being landed
for the historical record before the repository is archived in favor of
the chosen fork. Merging makes `DECISION.md`, `DEVIATIONS.md`,
`AGENTS.md`, and the research material available on `main` so anyone
landing on this repo through normal navigation sees the direction-change
record without having to know to switch branches.

After merge, the repo continues to receive doc-only changes until the
fork is selected; at that point this repo is archived with README
pointing at the new repo (per `DECISION.md` "What this means for this
repository").

## No new dependencies, no architectural code

This PR adds:
- `DECISION.md`, `DEVIATIONS.md`,
  `docs/research/symphony-fork-evaluation.md`
- Three archived sources under `docs/research/`
  (OpenAI announcement, George's thread, Addy's thread)
- README banner
- AGENTS.md `SPEC alignment` + `Harness engineering principles`
  sections
- `internal/worker/print_config*.go`, `internal/worker/runtask.go`,
  `internal/worker/run_test.go` (the #69 observability work; pending
  revert under #72 on the new base — kept here for historical record)
- Minor updates to `docs/symphony-integration.md` and `README.md`
  "Architecture notes" reflecting the deviation tracking

No new Go dependencies, no migration steps, no schema changes.

## Test plan

- [x] `gofmt -l internal/worker/` clean
- [x] `go build ./...` clean
- [x] New worker tests for the #69 observability work pass
  (`TestPrintConfig_TopLevelSourceAndShadowedBy`,
  `TestPrintConfig_TopLevelOmitsEmptyShadowedBy`,
  `TestResolveWorkflow_LogsResolutionLine`,
  `TestResolveWorkflow_LogsResolutionLineOmitsEmptyShadowed`)
- [x] Pre-existing failing tests
  (`TestRunTask_FiresClaimThenPRCreatedOnSuccess`,
  `TestRunTask_FiresPRCreatedOnReusePath`) confirmed unrelated to this
  branch — they fail on stash-compared pre-change tree due to sandbox
  git-signing service returning 400; environmental, not blocking.

## Follow-ups (not in this PR)

- Pick the fork (see `docs/research/symphony-fork-evaluation.md`)
- Verify the chosen candidate against the 8-item alignment checklist
- Stand up the new repo and migrate the assets listed in `DECISION.md`
- Archive this repo with README pointer to the new repo

This PR is the predecessor to all of that work — landing the record so
the next phase can start from a clear baseline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5hMnq78qaDaQP4aEUMXm5)_