### PR TITLE
docs(decision): reverse to "continue Go port in this repo"

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -1,184 +1,163 @@
-# Decision: stop Go port; adopt a Symphony fork as the new base
+# Decision: continue the Go port in this repo; SPEC.md is the contract
 
-> **Status:** In progress. The high-level decision (stop Go port, switch to a
-> fork) is made. The specific fork to adopt is open and depends on
-> [`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md).
+> **Status:** Active. Reverses the 2026-05-13 "stop the Go port; adopt a Symphony fork" decision.
 >
-> **Date:** 2026-05-13
-> **Branch where this was decided:** `claude/handle-issue-3DyNV`
-> **See also:** [`AGENTS.md`](AGENTS.md), [`DEVIATIONS.md`](DEVIATIONS.md)
+> **Date:** 2026-05-15
+> **Branch where this was decided:** `docs/reverse-decision-continue-go-2026-05-15`
+> **See also:** [`AGENTS.md`](AGENTS.md), [`DEVIATIONS.md`](DEVIATIONS.md), [`docs/audits/2026-05-15-spec-vs-go-gap-audit.md`](docs/audits/2026-05-15-spec-vs-go-gap-audit.md)
+> **Earlier version:** preserved in git history at commit `4f9e98d` ("docs: record decision to stop Go port and adopt a Symphony fork"). Read in conjunction with this document for the full reasoning chain.
 
 ## TL;DR
 
-`aiops-platform` was started as a from-scratch Go implementation of OpenAI
-Symphony. After deep reading of the upstream `SPEC.md`, the Elixir reference
-implementation, the OpenAI announcement post, and two practitioner accounts
-([George](docs/research/2026-05-george-symphony-electron-rewrite.md) and
-[Addy Osmani](docs/research/2026-05-addy-osmani-harness-engineering.md)),
-the Go implementation accumulated **nine** SPEC deviations
-([D1–D9](DEVIATIONS.md)). Four are `Reverting`, one is `P0`, and the project
-"can't even run end to end yet" per the operator's assessment.
+`aiops-platform` was started as a Go implementation of OpenAI Symphony. The
+2026-05-13 decision was to stop the Go port and adopt a Symphony fork as the
+new upstream base. That decision is reversed.
 
-Under the operator's stated criteria —
+`aiops-platform` continues as a Go implementation of Symphony, **in this
+repository**. `SPEC.md` is the contract. The Elixir reference implementation
+is one author's interpretation of `SPEC.md`, useful as a disambiguation oracle
+when SPEC text is ambiguous, but it is **not** the artifact we align to.
 
-> "实现错误,违反规范才是最大问题,都要推倒重来。"
-> "时间是重要的但不急。"
-> "现在都是 Claude code, codex 来接手维护写代码,人只是一个导航员。"
+The 9 known deviations (D1–D9) plus 15 new deviations surfaced by the
+[2026-05-15 SPEC.md vs Go gap audit](docs/audits/2026-05-15-spec-vs-go-gap-audit.md)
+(D10–D24) become the work backlog. AI agents (Claude Code, Codex) close them
+against `SPEC.md` as the review target, with the Elixir reference available as
+a disambiguation oracle.
 
-— the right move is **not** to spend 2–4 weeks rewriting the Go orchestrator
-to match the Elixir reference. The right move is to **stop the Go port and
-adopt one of the existing working Symphony implementations as the new
-upstream**, then layer Gitea support and the harness-engineering gates we
-have already proven valuable (policy / verify / secret-scan) on top.
+## Background
 
-## Context
+The 2026-05-13 decision to fork rested on three arguments:
 
-When this project was started, the assumption was that a Go-native
-implementation would be the cleanest path. The harness-engineering gates
-under `internal/policy`, `internal/workspace.RunVerify`, and the secret-scan
-hook are genuine value-adds; the runner abstraction is direction-correct;
-the workflow loader is mostly right.
+1. **Forking gives day-1 SPEC fidelity.**
+2. **Verification surface doubles for the human under a Go port** (review the
+   AI's Go diff, then cross-check against Elixir).
+3. **Maintenance gradient**: a Go port has to track every upstream change as
+   a fresh porting task; a fork picks up upstream changes by merge.
 
-What turned out to be wrong was the **orchestrator core**. Reading
-`SPEC.md` §1 and the Elixir
-[`orchestrator.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/orchestrator.ex)
-made it clear that:
-
-- Scheduling state belongs in process memory, not a Postgres table (D6, #73).
-- Triggers are polling-only, not webhook-based (D7, #74).
-- `WORKFLOW.md` is a single source, not a three-path search (D4, #72).
-- PR creation, git push, and ticket state writes belong to the **agent**,
-  not the orchestrator (D8, P0, #76).
-- Reconciliation runs on every tick to stop active runs when their tracker
-  state changes (D9, #78), in addition to a startup pass (D3, #68).
-- The agent runner uses long-running JSON-RPC over stdio (`codex app-server`),
-  not one-shot `codex exec` (D1, #64).
-
-These are not surface-level corrections. They reshape the worker loop, the
-runner protocol, the trigger ingress, and the queue. Re-implementing the Go
-core to match `orchestrator.ex` is essentially writing a Go version of the
-Elixir reference — which is itself an artifact OpenAI published as the
-reference, not a stand-alone product to maintain.
+After running the full audit (see audit doc + PR #82) and re-examining the
+premises, all three arguments are weakened enough that they no longer carry
+the decision.
 
 ## Decision
 
-**Stop the Go port. Adopt a working Symphony implementation as the new
-upstream base, then add Gitea support and the harness-engineering gates on
-top.**
+**Continue the Go port in this repository. `SPEC.md` is the contract. Close
+D1–D24 systematically.**
 
-The specific fork to adopt is **open** and tracked in
-[`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md).
-Initial scan suggests the strongest candidates are:
+Calibration from the audit:
 
-- **`junhoyeo/contrabass`** (Go, Codex + Claude, ~475 commits, packaged via
-  Homebrew, active as of 2026-05-10). Best fit if its SPEC alignment passes
-  a quick code-read review.
-- **`openai/symphony`** (Elixir, canonical). Strongest SPEC fidelity by
-  definition; more work to add Claude and Gitea on top.
-- **`mksglu/hatice`** (TypeScript, Claude Code SDK, GitLab adapter present).
-  Worth a look if Claude-Code-native integration matters more than SPEC
-  fidelity.
+- ~58 SPEC `MUST` / `REQUIRED` clauses examined; 6 aligned today.
+- 9 known deviations (D1–D9) confirmed; D1, D3, D9 understate scope; D4
+  description is stale (revert never landed).
+- 15 new deviations (D10–D24), of which 7 are SPEC-`MUST` failures (D10,
+  D11, D12, D13, D16, D20, D21).
+- 12 silent-area categories (entire features unimplemented).
+- ~800 of the current ~3,500 non-test LOC are reusable as behavioral spec;
+  the rest will be rewritten during alignment.
+- 4-week scope closes peripheral gaps; core loop still SPEC-non-aligned at
+  that point.
+- 12-week scope ≈ full SPEC alignment.
 
-See the evaluation doc for the full table and the verification checklist.
+This work happens through AI agents under the operator-as-navigator model
+([`AGENTS.md` §Harness engineering principles](AGENTS.md#harness-engineering-principles)).
 
-## Why not just finish the Go port
+## Why we reversed the fork decision
 
-Considered. Rejected. The two strongest reasons:
+### 1. "Forking gives day-1 SPEC fidelity" — false framing
 
-1. **Verification surface.** A Go port has to be verified against the Elixir
-   reference module-by-module, behavior-by-behavior. Under the "human is
-   navigator, AI does the writing" model, that doubles the review cost on
-   every change: read the AI's Go diff, then cross-check against the
-   corresponding Elixir source. A fork (or a community port that already
-   passes muster) shrinks the verification surface to just the deltas we
-   add — Gitea adapter, harness gates port. The reviewer's job becomes
-   "does this delta match the local convention" rather than "does this
-   diff faithfully reproduce reference behavior."
+`SPEC.md` is the contract, not the `openai/symphony` repo. OpenAI has stated
+the Elixir repo is a reference implementation and will not be maintained as
+a product. Forking it gets us code that one author once interpreted as
+SPEC-aligned — it does not get us SPEC fidelity by construction. Any forked
+code still needs to be audited against `SPEC.md`. The "fork starts at zero
+deviations" claim conflates repo with spec.
 
-2. **Maintenance gradient.** A Go port has to track every upstream change
-   as a fresh porting task. A fork picks up upstream changes by merge.
-   Over months, the cumulative porting debt for a from-scratch Go
-   implementation grows linearly; the maintenance burden of a fork is
-   roughly flat. Under the "AI does maintenance" model this still matters
-   — a smaller surface is easier for AI to keep correct, and easier for
-   the human navigator to review.
+### 2. "Verification surface doubles for the human" — invalid under the workflow model
 
-The "Go is more familiar" argument that motivated the original choice no
-longer applies: the operator's stated maintenance model is that AI agents
-(Claude Code, Codex) write and maintain code, and the human role is
-navigation. AI fluency in Go vs. TypeScript vs. Elixir vs. Rust is a real
-gradient (Go and TS highest, Elixir lower), but it does not justify
-maintaining 3-5k LOC of orchestrator behavior to a known reference when
-the alternative is to keep just the deltas.
+The operator's stated workflow model is that AI agents (Claude Code, Codex)
+write code AND review code; the human role is navigation and outcome
+judgment, not line-by-line review of AI diffs. Cross-language verification
+(Go behavior vs Elixir behavior) is an AI task that costs AI tokens, not
+human attention. The original framing treated verification as a human
+bottleneck; it is not.
 
-Full alternatives discussed in
-[`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md).
+Same-language pattern matching is still easier for AI than cross-language
+behavioral equivalence, so this consideration is not zero — but it is a
+gradient of AI cost, not a hard cap on what is feasible.
 
-## What this means for this repository
+### 3. "Maintenance gradient — upstream changes cost less in a fork" — moot
 
-This repo will be **archived** once a new base is chosen and the migration
-landings below complete. Until then:
+OpenAI has stated the Elixir repo will not be maintained as a product.
+There are no future upstream changes to inherit by merge. Both paths (Go
+port and Elixir fork) become "we own this code" from day one. The
+gradient flattens to zero.
 
-- The branch `claude/handle-issue-3DyNV` carries the in-progress
-  SPEC-alignment documentation work and **stays open** as the historical
-  record. Do not force-push or rewrite it.
-- `main` continues to receive doc-only changes (research mirrors, this
-  decision, evaluation drafts) but **does not** receive new architectural
-  code. The open alignment issues (#14, #64, #67, #68, #70, #72, #73,
-  #74, #76, #78) will not be worked in this repo; they will be
-  re-filed (or closed as "wontfix — moved to fork") in the new repo.
-- The harness-engineering posture written into `AGENTS.md` and the
-  evaluation work in `DEVIATIONS.md` are the durable artifacts. Both
-  move to the new repo.
+### What is left
 
-### What transfers to the new repo
+- **AI per-token throughput** on Go is higher than on Elixir (training
+  corpus). Under "AI does the writing", this favors Go.
+- **Existing Go code (~800 LOC)** is salvageable infrastructure
+  (`internal/policy`, `internal/workspace.RunVerify`, `internal/workspace.secretscan`,
+  workflow loader, mock runner, `--print-config`).
+- **No language switch tax** — neither the operator nor AI needs to take on
+  Elixir/BEAM operational surface.
+- **Elixir reference remains accessible** as a disambiguation oracle (via
+  the public repo) without requiring us to maintain it.
 
-| Asset | Where it goes | Why it transfers |
-|---|---|---|
-| `examples/WORKFLOW.md` | New repo's `examples/` | Prompt content is language-agnostic |
-| `docs/research/*` (4 files) | New repo's `docs/research/` | The decision basis itself |
-| `AGENTS.md` §SPEC alignment, §Harness engineering principles | New repo's `AGENTS.md` | The posture that will keep the fork from drifting |
-| `DEVIATIONS.md` structure | New repo's `DEVIATIONS.md` (likely empty initially) | Vocabulary for tracking new deviations if/when they emerge |
-| Issues #71 (Gitea label state machine) | New repo issue | Gitea support is still needed |
-| Policy / verify / secret-scan logic | Re-implemented in new repo's runtime | Harness-engineering gates that pass the "behavior first" test |
+## Scope
 
-### What is discarded
+### In scope
 
-Everything under `internal/queue/`, `migrations/`, `cmd/trigger-api/`,
-`internal/triggerapi/`, `internal/gitea/webhook*.go`, the orchestrator
-state-write paths in `internal/worker/runtask.go` (`OnClaim`,
-`OnPRCreated`, `CreatePR`, `BuildPRBody`), and the entire Postgres
-dependency. These either violate SPEC or only existed to compensate for
-the Go port architecture.
+- Closing D1–D24 against `SPEC.md`, in some order (see Open question).
+- Treating `SPEC.md` as the review target. Where `SPEC.md` is ambiguous,
+  the Elixir [`orchestrator.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/orchestrator.ex)
+  and related modules are the tie-breaking oracle.
+- Refreshing `DEVIATIONS.md` to include D10–D24 alongside D1–D9.
+- Keeping the harness-engineering posture in `AGENTS.md` and applying its
+  "name the behavior it delivers" test to anything that survives `Reverting`
+  status.
 
-The current `internal/runner/`, `internal/workspace/`, `internal/workflow/`,
-`internal/policy/` packages are useful **as a reference for the harness
-gates we want re-implemented in the new base** — they are not transferred
-as code, but the test suite is a behavioral spec for the re-implementation.
+### Out of scope
+
+- Forking `openai/symphony` or any third-party reimplementation.
+- Maintaining behavioral equivalence with the Elixir reference at the
+  module level. The Elixir code is a disambiguation oracle, not a porting
+  target — Go modules are organized for Go, not for line-for-line
+  correspondence with Elixir.
+- Anything that fails `AGENTS.md`'s SPEC-alignment-is-a-hard-requirement
+  test without an explicit accepted-deviation entry.
 
 ## Open question
 
-**Which fork.** The evaluation doc has the candidates, the comparison
-table, and a verification checklist. The operator picks after reading
-the evaluation; the deciding factors are likely Gitea-distance and
-Claude-distance from each candidate.
+**Sequencing.** With 24 deviations on the backlog, the order matters.
+Two candidate sequences:
+
+1. **Bottom-up structural first.** Start with D21 (single-source orchestrator
+   state) and D6 (Postgres queue removal), since most other deviations
+   depend on the orchestrator-state model. Then D10/D11 (workflow file
+   model), D13 (workspace key), D1 (app-server). Then peripheral.
+
+2. **Top-down behavioral first.** Start with isolated, low-coupling gaps
+   that exercise the harness end-to-end (D17 template engine, D11 reload,
+   D20 Linear pagination, D14 stall detection). Build operator confidence
+   that the loop produces useful PRs at all, then tackle structural.
+
+The operator picks; both are defensible.
 
 ## Next steps
 
-1. **Read** [`docs/research/symphony-fork-evaluation.md`](docs/research/symphony-fork-evaluation.md)
-   and pick a primary candidate.
-2. **Spend 1–2 hours code-reading** the chosen candidate against `SPEC.md`
-   to confirm its alignment claims. The evaluation doc has the checklist.
-3. **Stand up the new repo** (fork the chosen base; rename or namespace
-   appropriately).
-4. **Migrate** the assets listed above. AI-led; human approves the
-   migration commits.
-5. **Land Gitea + harness gates** on the new base. Track work in the
-   new repo's issues.
-6. **Archive this repo.** README updated with a pointer to the new repo;
-   open issues closed with `state_reason: not_planned` and a link to
-   the equivalent issue in the new repo (or to "subsumed by upstream").
+1. **File D10–D24 as tracked issues** against this repo (no longer "moved to
+   fork repo"). Cross-reference the audit doc and PR #82 for evidence.
+2. **Update `DEVIATIONS.md`** to include D10–D24 rows alongside D1–D9, fix
+   D1/D3/D9 scope wording, mark D4's "Reverting" status as not-yet-landed,
+   correct D2's framing (writes happen from the wrong side, not "missing").
+3. **Pick sequencing** (Open question above).
+4. **Begin closing deviations.** AI-led; human approves at the outcome level.
 
-This document stays in place at `DECISION.md` at the repo root after
-archive so anyone landing here understands what happened and where the
-project went.
+## Historical note
+
+The 2026-05-13 fork decision was a reasonable read of the state at that
+moment (9 known deviations, no audit yet, the fork option not stress-tested).
+The audit's concrete file:line evidence and the operator's clarifications on
+the workflow model (AI does writing AND review) and SPEC's role (`SPEC.md` is
+the artifact, not the repo) changed the calculus enough to flip the
+decision. The earlier document is preserved in git history at `4f9e98d`.


### PR DESCRIPTION
## Summary

Reverses the 2026-05-13 decision to stop the Go port and adopt a Symphony fork. `aiops-platform` continues as a Go implementation of Symphony, **in this repository**, with `SPEC.md` as the contract.

Earlier version preserved in git history at `4f9e98d`.

## Why the reversal

The 2026-05-13 fork decision rested on three arguments. All three are weakened after the 2026-05-15 audit ([PR #82](https://github.com/xrf9268-hue/aiops-platform/pull/82)) and operator clarifications:

1. **"Forking gives day-1 SPEC fidelity"** — false framing. `SPEC.md` is the contract, not the `openai/symphony` repo (which OpenAI has stated is a reference, not a maintained product). Forking the demo gets us one author's interpretation of SPEC, not SPEC fidelity by construction.

2. **"Verification surface doubles for the human under a Go port"** — invalid premise. The operator's stated workflow model is that AI agents write AND review code; the human role is navigation. Cross-language verification is an AI-token cost, not human attention.

3. **"Maintenance gradient — upstream changes cost less in a fork"** — moot. With the Elixir repo frozen as a reference, both Go port and Elixir fork become "we own this code" from day one.

What is left favors continuing in Go:
- AI per-token throughput on Go > Elixir (training corpus)
- Existing Go infrastructure (~800 reusable LOC)
- No language switch tax
- Elixir reference remains accessible as a disambiguation oracle without requiring us to maintain it

## What changes

| Aspect | Before this PR | After this PR |
|---|---|---|
| Decision | Stop Go port, adopt a Symphony fork | Continue Go port in this repo |
| Review target | Forked code's behavior | `SPEC.md` directly |
| Elixir reference role | Source of truth (porting target) | Disambiguation oracle only |
| This repo | Will be archived | Active codebase |
| D1–D24 backlog | "Will be re-filed or closed in new repo" | Tracked here as work |
| `internal/queue/`, `cmd/trigger-api/`, etc. | Discarded on migration | Refactored in place as deviations are closed |

## Next steps after merge

1. **File D10–D24** as tracked issues in this repo (paused pending this PR).
2. **Refresh `DEVIATIONS.md`** to include D10–D24, fix D1/D3/D9 scope wording, mark D4 status accurately, correct D2 framing.
3. **Pick sequencing** — bottom-up structural (D21/D6 first) vs top-down behavioral (D17/D11/D20 first). Both defensible; operator picks.
4. Begin closing deviations.

## Test plan

This is a doc-only PR.

- [ ] Operator reads §"Why we reversed the fork decision" and confirms the three rebuttals match their reasoning
- [ ] Operator reads §"Open question" and indicates a sequencing preference (or defers)
- [ ] After merge: D10–D24 issue filing resumes; `DEVIATIONS.md` refresh PR follows