### PR TITLE
feat(orchestrator): introduce state types and transitions (#95, #73)

### DIFF
--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -1,0 +1,42 @@
+package orchestrator
+
+import "time"
+
+// RetryEntry is the SPEC §4.1.7 record stored under
+// OrchestratorState.RetryAttempts while an issue is in the retry-queued
+// substate (SPEC §7.1). Fields match SPEC §4.1.7 exactly:
+//
+//   - IssueID, Identifier — which issue this retry is for.
+//   - Attempt — 1-based retry counter; SPEC §8.4 bounds it via
+//     `max_retry_attempts`.
+//   - DueAt — absolute deadline at which the retry should fire. Go's
+//     time.Time carries a monotonic reading on construction so SPEC's
+//     "due_at_ms (monotonic)" requirement is satisfied without a
+//     separate field.
+//   - Timer — the scheduling handle SPEC calls `timer_handle`. The
+//     scheduler that owns the timer (introduced in the next migration
+//     step) is responsible for calling Stop when an entry is replaced
+//     or released; OrchestratorState.ReleaseClaim performs that stop
+//     for the reconciliation/release paths.
+//   - Error — the abnormal-exit message that caused the retry, surfaced
+//     through SPEC §13.3's retrying view so operators can see why an
+//     issue is in backoff.
+type RetryEntry struct {
+	IssueID    IssueID
+	Identifier string
+	Attempt    int
+	DueAt      time.Time
+	Timer      *time.Timer
+	Error      string
+}
+
+// IsDue reports whether the retry's DueAt has passed relative to now.
+// Useful for the actor's tick path when it needs to walk RetryAttempts
+// independently of timer callbacks (e.g. after a long pause where
+// multiple timers may have piled up).
+func (r *RetryEntry) IsDue(now time.Time) bool {
+	if r == nil {
+		return false
+	}
+	return !now.Before(r.DueAt)
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -1,0 +1,330 @@
+// Package orchestrator owns the single in-memory authoritative state
+// described by Symphony SPEC §4.1.8: the orchestrator's runtime state
+// owned by a single authority, mutated via serialized operations.
+//
+// This file (state.go) defines the data types and pure state-transition
+// methods. It deliberately contains no goroutines, timers, or I/O: those
+// belong to the actor + scheduler that arrive in a later step of the
+// D21+D6 migration plan (docs/design/d21-d6-orchestrator-state.md).
+// During this step the package has no production callers; the worker
+// still claims tasks through the Postgres queue.
+//
+// Field names mirror SPEC §4.1.8 exactly so future cross-references to
+// the protocol contract are mechanical.
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// IssueID is the tracker-assigned stable identifier (tracker.Issue.ID).
+// SPEC §4.1.1 calls this the issue's id; we alias it here so map keys
+// in OrchestratorState are self-documenting.
+type IssueID string
+
+// Workspace is the orchestrator's view of an on-disk per-issue workspace.
+// SPEC §4.2 / §9.1 want workspaces keyed by sanitized issue identifier;
+// today the Manager keys them by task ID (deviation D13, tracked under
+// #87). The rekey lands separately; until then Key holds whatever the
+// workspace.Manager produced and CreatedNow tells reconciliation
+// whether this run created the directory or reused an existing one.
+type Workspace struct {
+	Path       string
+	Key        string
+	CreatedNow bool
+}
+
+// LiveSession captures the SPEC §4.1.6 live-session fields populated
+// by the app-server runner once deviation D1 (#64) lands. PR 1 ships
+// it as an empty struct so the field exists on RunningEntry without
+// pulling the app-server protocol forward.
+type LiveSession struct{}
+
+// RateLimitSnapshot is the SPEC §13.3 rate-limits view emitted by the
+// runner. Same deferral story as LiveSession: shape lands with D1.
+type RateLimitSnapshot struct{}
+
+// CodexTotals accumulates the SPEC §4.1.8 / §13.3 codex totals across
+// all runs the orchestrator dispatches in this process. Token counts
+// and seconds-running are monotonically increasing for the process'
+// lifetime; restart resets them per SPEC §14.3 (no persistence).
+type CodexTotals struct {
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	SecondsRunning float64
+}
+
+// AddTokens folds a per-run codex token delta into the running totals.
+// SPEC §13.3 reports input and output separately and the sum as
+// `total_tokens`; we keep all three fields rather than recomputing on
+// read so the snapshot never drifts from what was observed.
+func (c *CodexTotals) AddTokens(input, output int64) {
+	c.InputTokens += input
+	c.OutputTokens += output
+	c.TotalTokens += input + output
+}
+
+// AddSeconds folds elapsed wall-clock time from a single run into the
+// running totals. Wall clock is fine here: SPEC §13.3 specifies seconds
+// observed by the orchestrator, not monotonic-clock deltas.
+func (c *CodexTotals) AddSeconds(d time.Duration) {
+	if d < 0 {
+		return
+	}
+	c.SecondsRunning += d.Seconds()
+}
+
+// RunningEntry is the per-issue record in OrchestratorState.Running.
+// It bundles the data the actor needs to drive a single in-flight run
+// from dispatch through normal exit, abnormal exit, or reconciliation
+// termination.
+//
+// CancelWorker and Done are the only termination handles per SPEC §8.5
+// Part B; the actor calls CancelWorker(), then waits on Done for the
+// worker goroutine to finish before mutating other state fields.
+type RunningEntry struct {
+	Issue        tracker.Issue
+	Identifier   string
+	StartedAt    time.Time
+	RetryAttempt *int // nil on first run (SPEC §4.1.5)
+	Workspace    Workspace
+
+	Session     LiveSession
+	LastCodexAt time.Time // SPEC §8.5 Part A input (D14)
+
+	CancelWorker context.CancelFunc
+	Done         <-chan struct{}
+}
+
+// OrchestratorState is the single authoritative in-memory state owned
+// by the orchestrator (SPEC §4.1.8). Every field name matches the SPEC
+// section exactly.
+//
+// This type is NOT safe for concurrent use on its own: mutation
+// discipline (SPEC §7.4 "serialize state mutations through one
+// authority") is supplied by the actor goroutine introduced in the
+// next migration step. Tests in this package construct it directly
+// because they exercise the transitions, not the discipline.
+type OrchestratorState struct {
+	PollIntervalMs      int64
+	MaxConcurrentAgents int
+
+	Running       map[IssueID]*RunningEntry
+	Claimed       map[IssueID]struct{}
+	RetryAttempts map[IssueID]*RetryEntry
+	Completed     map[IssueID]struct{} // bookkeeping only per SPEC §4.1.8
+
+	CodexTotals     CodexTotals
+	CodexRateLimits *RateLimitSnapshot // nil until the runner populates it
+}
+
+// NewOrchestratorState mirrors the SPEC §16.1 reference initializer:
+//
+//	state = { running: {}, claimed: set(), retry_attempts: {},
+//	          completed: set(), codex_totals: {...},
+//	          codex_rate_limits: null }
+//
+// followed by `startup_terminal_workspace_cleanup()` and
+// `schedule_tick(delay_ms=0)`. The startup cleanup and first tick are
+// orchestrator-level concerns and live with the actor; this
+// constructor only produces the empty maps so callers can never panic
+// on a nil-map write.
+func NewOrchestratorState(pollIntervalMs int64, maxConcurrentAgents int) *OrchestratorState {
+	return &OrchestratorState{
+		PollIntervalMs:      pollIntervalMs,
+		MaxConcurrentAgents: maxConcurrentAgents,
+		Running:             map[IssueID]*RunningEntry{},
+		Claimed:             map[IssueID]struct{}{},
+		RetryAttempts:       map[IssueID]*RetryEntry{},
+		Completed:           map[IssueID]struct{}{},
+	}
+}
+
+// IsClaimed reports whether id is currently held by any of Running,
+// RetryAttempts, or the "claimed but not yet running" window. SPEC §7.4
+// REQUIRES this check before launching any worker; making it a method
+// on the state keeps the rule discoverable.
+func (s *OrchestratorState) IsClaimed(id IssueID) bool {
+	_, ok := s.Claimed[id]
+	return ok
+}
+
+// BeginDispatch records the SPEC §16.4 dispatch step: an eligible
+// candidate transitions from "fetched" to "claimed and running".
+//
+//   - Adds id to Claimed (SPEC §4.1.8 set membership).
+//   - Adds entry to Running.
+//   - Clears any RetryAttempts record (the scheduled retry is being
+//     consumed; its timer must already be stopped by the caller, since
+//     RetryEntry.Timer is owned outside this struct).
+//
+// Per SPEC §7.4 the caller MUST first verify the issue is not already
+// in Claimed; BeginDispatch does not perform that check because the
+// duplicate-dispatch guard is a property of the actor, not of pure
+// state mutation.
+func (s *OrchestratorState) BeginDispatch(id IssueID, entry *RunningEntry) {
+	s.Claimed[id] = struct{}{}
+	s.Running[id] = entry
+	delete(s.RetryAttempts, id)
+}
+
+// FinishRunSucceeded is the transition for a worker that exited cleanly
+// (SPEC §7.3 normal exit).
+//
+//   - Removes from Running.
+//   - Releases Claimed (the §8.4 continuation retry, if any, is
+//     scheduled by a separate call to ScheduleRetry which re-adds the
+//     claim).
+//   - Adds id to Completed for bookkeeping (SPEC §4.1.8 says completed
+//     is NOT consulted for dispatch gating; it exists so operator views
+//     and §13.7's /api/v1/state can report it).
+//   - Folds elapsed into CodexTotals.SecondsRunning.
+func (s *OrchestratorState) FinishRunSucceeded(id IssueID, elapsed time.Duration) {
+	delete(s.Running, id)
+	delete(s.Claimed, id)
+	s.Completed[id] = struct{}{}
+	s.CodexTotals.AddSeconds(elapsed)
+}
+
+// FinishRunFailed is the transition for a worker that exited abnormally
+// (SPEC §7.3 abnormal exit). The retry policy itself (exponential
+// backoff per SPEC §8.4, currently D16) is owned by the scheduler in
+// the next migration step; this method only releases the run slot and
+// folds elapsed time so the caller can decide whether to enqueue a
+// retry via ScheduleRetry.
+func (s *OrchestratorState) FinishRunFailed(id IssueID, elapsed time.Duration) {
+	delete(s.Running, id)
+	delete(s.Claimed, id)
+	s.CodexTotals.AddSeconds(elapsed)
+}
+
+// ScheduleRetry records a RetryEntry under RetryAttempts and keeps the
+// issue Claimed so a parallel tick cannot dispatch it again. The actual
+// timer lives on entry.Timer and is started by the caller; this method
+// is the pure-state half of "enter the retry-queued substate" from
+// SPEC §7.1.
+//
+// If a prior retry entry exists for the same issue (e.g. backoff
+// rescheduled) ScheduleRetry stops the old timer before replacing it
+// so we never leak a goroutine in time.AfterFunc.
+func (s *OrchestratorState) ScheduleRetry(entry *RetryEntry) {
+	if prev, ok := s.RetryAttempts[entry.IssueID]; ok && prev.Timer != nil {
+		prev.Timer.Stop()
+	}
+	s.RetryAttempts[entry.IssueID] = entry
+	s.Claimed[entry.IssueID] = struct{}{}
+}
+
+// ReleaseClaim removes id from Claimed and tears down any pending
+// retry. It does NOT touch Running because reconciliation termination
+// (SPEC §8.5 Part B) handles the Running entry separately via
+// CancelWorker + Done. The two cases ReleaseClaim serves:
+//
+//   - Retry timer expired and the candidate is no longer eligible.
+//   - Reconciliation found the tracker state non-active, non-terminal
+//     (row 6 in the design's state-transition table).
+func (s *OrchestratorState) ReleaseClaim(id IssueID) {
+	delete(s.Claimed, id)
+	if entry, ok := s.RetryAttempts[id]; ok {
+		if entry.Timer != nil {
+			entry.Timer.Stop()
+		}
+		delete(s.RetryAttempts, id)
+	}
+}
+
+// RecordCodexTokens folds a per-event token delta into CodexTotals.
+// Equivalent to s.CodexTotals.AddTokens but discoverable on the state
+// type itself so callers don't need to reach through the field name.
+func (s *OrchestratorState) RecordCodexTokens(input, output int64) {
+	s.CodexTotals.AddTokens(input, output)
+}
+
+// RecordRateLimits replaces the current rate-limit snapshot. SPEC
+// §13.3 treats it as last-write-wins because the runner emits the full
+// view, not a delta.
+func (s *OrchestratorState) RecordRateLimits(snap *RateLimitSnapshot) {
+	s.CodexRateLimits = snap
+}
+
+// StateView is the SPEC §13.3 / §13.7 shape the orchestrator publishes
+// for /api/v1/state, CLI status, and tests. It is intentionally a
+// value type with slices so callers cannot mutate the orchestrator's
+// internal maps through it. The HTTP wrapper is deferred (see the
+// design doc's "HTTP surface" section) but Snapshot() ships now so
+// tests have a stable read API.
+type StateView struct {
+	PollIntervalMs      int64
+	MaxConcurrentAgents int
+
+	Running         []RunningView
+	Retrying        []RetryView
+	Completed       []IssueID
+	CodexTotals     CodexTotals
+	CodexRateLimits *RateLimitSnapshot
+}
+
+// RunningView is the per-running-entry projection in StateView. It
+// omits unexported / non-serializable fields like CancelWorker and Done.
+type RunningView struct {
+	IssueID       IssueID
+	Identifier    string
+	StartedAt     time.Time
+	RetryAttempt  *int
+	WorkspacePath string
+	LastCodexAt   time.Time
+}
+
+// RetryView is the per-retry-entry projection in StateView. Omits the
+// *time.Timer handle because it is not meaningful outside the process.
+type RetryView struct {
+	IssueID    IssueID
+	Identifier string
+	Attempt    int
+	DueAt      time.Time
+	Error      string
+}
+
+// Snapshot returns a read-only view of the orchestrator state. The
+// returned slices are freshly allocated so the caller may sort or
+// truncate them without affecting future snapshots. Map iteration
+// order is unspecified in Go, but downstream consumers (the §13.7 HTTP
+// handler, CLI status) sort by IssueID before display.
+func (s *OrchestratorState) Snapshot() StateView {
+	view := StateView{
+		PollIntervalMs:      s.PollIntervalMs,
+		MaxConcurrentAgents: s.MaxConcurrentAgents,
+		Running:             make([]RunningView, 0, len(s.Running)),
+		Retrying:            make([]RetryView, 0, len(s.RetryAttempts)),
+		Completed:           make([]IssueID, 0, len(s.Completed)),
+		CodexTotals:         s.CodexTotals,
+		CodexRateLimits:     s.CodexRateLimits,
+	}
+	for id, r := range s.Running {
+		view.Running = append(view.Running, RunningView{
+			IssueID:       id,
+			Identifier:    r.Identifier,
+			StartedAt:     r.StartedAt,
+			RetryAttempt:  r.RetryAttempt,
+			WorkspacePath: r.Workspace.Path,
+			LastCodexAt:   r.LastCodexAt,
+		})
+	}
+	for id, r := range s.RetryAttempts {
+		view.Retrying = append(view.Retrying, RetryView{
+			IssueID:    id,
+			Identifier: r.Identifier,
+			Attempt:    r.Attempt,
+			DueAt:      r.DueAt,
+			Error:      r.Error,
+		})
+	}
+	for id := range s.Completed {
+		view.Completed = append(view.Completed, id)
+	}
+	return view
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -145,12 +145,28 @@ func NewOrchestratorState(pollIntervalMs int64, maxConcurrentAgents int) *Orches
 }
 
 // IsClaimed reports whether id is currently held by any of Running,
-// RetryAttempts, or the "claimed but not yet running" window. SPEC §7.4
-// REQUIRES this check before launching any worker; making it a method
-// on the state keeps the rule discoverable.
+// RetryAttempts, or the "claimed but not yet running" Claimed set. SPEC
+// §7.4 REQUIRES this check before launching any worker; making it a
+// method on the state keeps the rule discoverable.
+//
+// All three maps are checked because the invariants are intentionally
+// asymmetric: ReleaseClaim (used by reconciliation, SPEC §8.5 Part B)
+// removes the Claimed entry immediately, but the Running entry is
+// removed asynchronously by the worker goroutine exiting after
+// CancelWorker. During that window Running[id] still exists with no
+// Claimed[id] backing it, and a second dispatch for the same issue
+// would violate SPEC §7.4 unless this check looks at Running too.
 func (s *OrchestratorState) IsClaimed(id IssueID) bool {
-	_, ok := s.Claimed[id]
-	return ok
+	if _, ok := s.Claimed[id]; ok {
+		return true
+	}
+	if _, ok := s.Running[id]; ok {
+		return true
+	}
+	if _, ok := s.RetryAttempts[id]; ok {
+		return true
+	}
+	return false
 }
 
 // BeginDispatch records the SPEC §16.4 dispatch step: an eligible
@@ -305,11 +321,20 @@ func (s *OrchestratorState) Snapshot() StateView {
 		CodexRateLimits:     s.CodexRateLimits,
 	}
 	for id, r := range s.Running {
+		// Deep-copy RetryAttempt so a snapshot consumer mutating the
+		// pointee cannot reach back into orchestrator state. The
+		// pointer-vs-nil distinction matters (SPEC §4.1.5 first-run
+		// semantic) so we cannot flatten to an int.
+		var retryAttempt *int
+		if r.RetryAttempt != nil {
+			n := *r.RetryAttempt
+			retryAttempt = &n
+		}
 		view.Running = append(view.Running, RunningView{
 			IssueID:       id,
 			Identifier:    r.Identifier,
 			StartedAt:     r.StartedAt,
-			RetryAttempt:  r.RetryAttempt,
+			RetryAttempt:  retryAttempt,
 			WorkspacePath: r.Workspace.Path,
 			LastCodexAt:   r.LastCodexAt,
 		})

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -245,20 +245,25 @@ func TestCodexTotals_AddTokensAndSeconds(t *testing.T) {
 	}
 }
 
-func TestRecordRateLimits_LastWriteWins(t *testing.T) {
+func TestRecordRateLimits_NilToValueAndBack(t *testing.T) {
 	st := NewOrchestratorState(15000, 4)
 	if st.CodexRateLimits != nil {
 		t.Fatalf("initial CodexRateLimits should be nil")
 	}
-	a := &RateLimitSnapshot{}
-	st.RecordRateLimits(a)
-	if st.CodexRateLimits != a {
-		t.Errorf("RecordRateLimits did not store snapshot a")
+	// RateLimitSnapshot is currently a zero-sized struct (D1 fills it
+	// in). Go reserves the right to alias pointers to zero-sized
+	// allocations (runtime.zerobase), so pointer-identity comparisons
+	// between two `&RateLimitSnapshot{}` values are a no-op assertion.
+	// Until D1 adds fields, exercise the nil-vs-non-nil transition
+	// instead, which is what callers actually depend on.
+	snap := &RateLimitSnapshot{}
+	st.RecordRateLimits(snap)
+	if st.CodexRateLimits == nil {
+		t.Errorf("RecordRateLimits did not store snapshot (still nil)")
 	}
-	b := &RateLimitSnapshot{}
-	st.RecordRateLimits(b)
-	if st.CodexRateLimits != b {
-		t.Errorf("RecordRateLimits did not replace with snapshot b")
+	st.RecordRateLimits(nil)
+	if st.CodexRateLimits != nil {
+		t.Errorf("RecordRateLimits(nil) should clear the field")
 	}
 }
 
@@ -304,6 +309,86 @@ func TestSnapshot_ShapeMatches13_3(t *testing.T) {
 	again := st.Snapshot()
 	if again.Completed[0] != id3 {
 		t.Errorf("Snapshot returned a slice aliased to internal state")
+	}
+}
+
+// Regression for the IsClaimed window: after ReleaseClaim (used by
+// reconciliation) the Running entry persists until the worker goroutine
+// exits and the actor processes the FinishRun* op. During that window
+// IsClaimed must still report true, otherwise SPEC §7.4's
+// duplicate-dispatch guard fails and a second tick dispatches a second
+// worker for the same issue.
+func TestIsClaimed_CoversRunningAfterReleaseClaim(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+
+	st.BeginDispatch(id, runningEntry(t, iss))
+	st.ReleaseClaim(id)
+
+	if !st.IsClaimed(id) {
+		t.Errorf("IsClaimed must remain true while Running[%s] still holds the entry", id)
+	}
+}
+
+// Same idea, but for the retry-queued window: ScheduleRetry adds to
+// Claimed + RetryAttempts; if a future change ever drops the Claimed
+// add (or the actor races on ReleaseClaim mid-retry), IsClaimed must
+// still report claimed via RetryAttempts.
+func TestIsClaimed_CoversRetryAttemptsWhenClaimedMissing(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	id := IssueID("ENG-1")
+	st.RetryAttempts[id] = &RetryEntry{IssueID: id, Identifier: "ENG-1", Attempt: 1}
+	// Deliberately do not seed Claimed[id]; the test asserts the
+	// fallback through RetryAttempts.
+	if !st.IsClaimed(id) {
+		t.Errorf("IsClaimed must report true when only RetryAttempts[%s] is set", id)
+	}
+}
+
+// Snapshot must deep-copy RetryAttempt so a consumer mutating the
+// pointee cannot reach back into orchestrator state.
+func TestSnapshot_DeepCopiesRetryAttemptPointer(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+	attempt := 3
+	entry := runningEntry(t, iss)
+	entry.RetryAttempt = &attempt
+	st.BeginDispatch(id, entry)
+
+	view := st.Snapshot()
+	if len(view.Running) != 1 {
+		t.Fatalf("expected one Running entry in snapshot, got %d", len(view.Running))
+	}
+	got := view.Running[0].RetryAttempt
+	if got == nil || *got != 3 {
+		t.Fatalf("RetryAttempt not surfaced: %v", got)
+	}
+	if got == entry.RetryAttempt {
+		t.Errorf("Snapshot aliased RetryAttempt pointer; consumer mutation would leak into state")
+	}
+	*got = 999
+	if *entry.RetryAttempt != 3 {
+		t.Errorf("mutating snapshot's RetryAttempt mutated live state: %d", *entry.RetryAttempt)
+	}
+}
+
+// Nil RetryAttempt (first-run, SPEC §4.1.5) must survive the deep copy
+// as still-nil — flattening to a zero int would silently turn a first
+// run into "attempt 0".
+func TestSnapshot_NilRetryAttemptStaysNil(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+	st.BeginDispatch(id, runningEntry(t, iss))
+
+	view := st.Snapshot()
+	if len(view.Running) != 1 {
+		t.Fatalf("expected one Running entry, got %d", len(view.Running))
+	}
+	if view.Running[0].RetryAttempt != nil {
+		t.Errorf("first-run RetryAttempt must stay nil, got %d", *view.Running[0].RetryAttempt)
 	}
 }
 

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -1,0 +1,324 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// These tests walk the state-transition table from
+// docs/design/d21-d6-orchestrator-state.md ("State transitions") row by
+// row. Each test is intentionally small — the design separates "what
+// the state must look like after operation X" (covered here) from "who
+// decides to call X and in what order" (covered by the actor tests in
+// the next migration step).
+
+func issue(id string) tracker.Issue {
+	return tracker.Issue{ID: id, Identifier: id, Title: "t-" + id}
+}
+
+func runningEntry(t *testing.T, iss tracker.Issue) *RunningEntry {
+	t.Helper()
+	_, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	return &RunningEntry{
+		Issue:        iss,
+		Identifier:   iss.Identifier,
+		StartedAt:    time.Now(),
+		Workspace:    Workspace{Path: "/tmp/" + iss.ID, Key: iss.Identifier, CreatedNow: true},
+		CancelWorker: cancel,
+		Done:         done,
+	}
+}
+
+func TestNewOrchestratorState_MatchesSpec16_1Initializer(t *testing.T) {
+	// SPEC §16.1: state = { running: {}, claimed: set(),
+	// retry_attempts: {}, completed: set(), codex_totals: {...},
+	// codex_rate_limits: null }.
+	st := NewOrchestratorState(15000, 4)
+
+	if st.PollIntervalMs != 15000 {
+		t.Errorf("PollIntervalMs = %d, want 15000", st.PollIntervalMs)
+	}
+	if st.MaxConcurrentAgents != 4 {
+		t.Errorf("MaxConcurrentAgents = %d, want 4", st.MaxConcurrentAgents)
+	}
+	if st.Running == nil || len(st.Running) != 0 {
+		t.Errorf("Running not initialized to empty map: %v", st.Running)
+	}
+	if st.Claimed == nil || len(st.Claimed) != 0 {
+		t.Errorf("Claimed not initialized to empty set: %v", st.Claimed)
+	}
+	if st.RetryAttempts == nil || len(st.RetryAttempts) != 0 {
+		t.Errorf("RetryAttempts not initialized to empty map: %v", st.RetryAttempts)
+	}
+	if st.Completed == nil || len(st.Completed) != 0 {
+		t.Errorf("Completed not initialized to empty set: %v", st.Completed)
+	}
+	if st.CodexRateLimits != nil {
+		t.Errorf("CodexRateLimits expected nil per SPEC §16.1, got %v", st.CodexRateLimits)
+	}
+	if (st.CodexTotals != CodexTotals{}) {
+		t.Errorf("CodexTotals not zero-initialized: %+v", st.CodexTotals)
+	}
+}
+
+// Row 1: poll tick dispatches an eligible candidate (SPEC §16.4).
+func TestBeginDispatch_AddsClaimAndRunningAndClearsRetry(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+
+	// Seed a stale retry entry to prove dispatch consumes it. The
+	// caller is expected to stop the timer before calling
+	// BeginDispatch; we don't start one in the test.
+	st.RetryAttempts[id] = &RetryEntry{IssueID: id, Identifier: iss.Identifier, Attempt: 2}
+
+	entry := runningEntry(t, iss)
+	st.BeginDispatch(id, entry)
+
+	if !st.IsClaimed(id) {
+		t.Errorf("expected %s claimed after BeginDispatch", id)
+	}
+	if got, ok := st.Running[id]; !ok || got != entry {
+		t.Errorf("Running[%s] = %v ok=%v, want entry %p", id, got, ok, entry)
+	}
+	if _, ok := st.RetryAttempts[id]; ok {
+		t.Errorf("RetryAttempts[%s] should be cleared by BeginDispatch", id)
+	}
+}
+
+// Row 2: worker exits normally (SPEC §7.3 normal exit + §8.4 continuation).
+//
+// FinishRunSucceeded handles the state-mutation half: Running cleared,
+// claim released, Completed marked, seconds folded. The continuation
+// retry is scheduled by a separate call (verified in TestScheduleRetry).
+func TestFinishRunSucceeded_RemovesRunningAddsCompletedFoldsSeconds(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+	st.BeginDispatch(id, runningEntry(t, iss))
+
+	st.FinishRunSucceeded(id, 750*time.Millisecond)
+
+	if _, ok := st.Running[id]; ok {
+		t.Errorf("Running[%s] should be removed after FinishRunSucceeded", id)
+	}
+	if st.IsClaimed(id) {
+		t.Errorf("Claim for %s should be released after FinishRunSucceeded", id)
+	}
+	if _, ok := st.Completed[id]; !ok {
+		t.Errorf("Completed[%s] should be set after FinishRunSucceeded", id)
+	}
+	// 750ms == 0.75s; floating-point comparison is exact here because
+	// 0.75 has a finite binary representation.
+	if st.CodexTotals.SecondsRunning != 0.75 {
+		t.Errorf("CodexTotals.SecondsRunning = %v, want 0.75", st.CodexTotals.SecondsRunning)
+	}
+}
+
+// Row 3: worker exits abnormally (SPEC §7.3 abnormal exit). State
+// releases the slot; the retry decision is the scheduler's job.
+func TestFinishRunFailed_RemovesRunningReleasesClaimDoesNotMarkCompleted(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+	st.BeginDispatch(id, runningEntry(t, iss))
+
+	st.FinishRunFailed(id, 2*time.Second)
+
+	if _, ok := st.Running[id]; ok {
+		t.Errorf("Running[%s] should be removed after FinishRunFailed", id)
+	}
+	if st.IsClaimed(id) {
+		t.Errorf("Claim for %s should be released after FinishRunFailed", id)
+	}
+	if _, ok := st.Completed[id]; ok {
+		t.Errorf("Completed[%s] must NOT be set on abnormal exit (SPEC §4.1.8)", id)
+	}
+	if st.CodexTotals.SecondsRunning != 2.0 {
+		t.Errorf("CodexTotals.SecondsRunning = %v, want 2.0", st.CodexTotals.SecondsRunning)
+	}
+}
+
+// Row 4: retry-queued substate. ScheduleRetry must claim the issue so
+// concurrent ticks cannot dispatch it again before the timer fires.
+func TestScheduleRetry_RecordsEntryAndKeepsClaim(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+
+	entry := &RetryEntry{
+		IssueID:    id,
+		Identifier: iss.Identifier,
+		Attempt:    1,
+		DueAt:      time.Now().Add(1 * time.Second),
+		Error:      "boom",
+	}
+	st.ScheduleRetry(entry)
+
+	if got, ok := st.RetryAttempts[id]; !ok || got != entry {
+		t.Errorf("RetryAttempts[%s] = %v ok=%v, want entry %p", id, got, ok, entry)
+	}
+	if !st.IsClaimed(id) {
+		t.Errorf("ScheduleRetry must hold the claim so SPEC §7.4 duplicate-dispatch guard works")
+	}
+}
+
+// ScheduleRetry replacing an existing entry must stop the old timer to
+// avoid leaking the goroutine inside time.AfterFunc.
+func TestScheduleRetry_ReplacingEntryStopsOldTimer(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+
+	fired := make(chan struct{}, 1)
+	oldTimer := time.AfterFunc(50*time.Millisecond, func() { fired <- struct{}{} })
+	st.ScheduleRetry(&RetryEntry{IssueID: id, Identifier: iss.Identifier, Attempt: 1, Timer: oldTimer})
+	st.ScheduleRetry(&RetryEntry{IssueID: id, Identifier: iss.Identifier, Attempt: 2})
+
+	select {
+	case <-fired:
+		t.Errorf("old timer fired even though ScheduleRetry should have stopped it")
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// Rows 5 and 6: reconciliation releases a claim. ReleaseClaim must stop
+// any pending retry timer and clear both Claimed and RetryAttempts; it
+// must not touch Running (rows 5/6 cover the non-running case — running
+// termination is the worker's CancelWorker + Done).
+func TestReleaseClaim_ClearsClaimAndRetryAndStopsTimer(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+
+	fired := make(chan struct{}, 1)
+	timer := time.AfterFunc(50*time.Millisecond, func() { fired <- struct{}{} })
+	st.ScheduleRetry(&RetryEntry{IssueID: id, Identifier: iss.Identifier, Attempt: 1, Timer: timer})
+
+	st.ReleaseClaim(id)
+
+	if st.IsClaimed(id) {
+		t.Errorf("Claimed[%s] not cleared", id)
+	}
+	if _, ok := st.RetryAttempts[id]; ok {
+		t.Errorf("RetryAttempts[%s] not cleared", id)
+	}
+	select {
+	case <-fired:
+		t.Errorf("retry timer fired after ReleaseClaim — timer.Stop missed")
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestReleaseClaim_DoesNotTouchRunning(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+	entry := runningEntry(t, iss)
+	st.BeginDispatch(id, entry)
+
+	st.ReleaseClaim(id)
+
+	// SPEC §8.5 Part B says running termination uses CancelWorker +
+	// Done; ReleaseClaim is the non-running half of reconciliation.
+	if _, ok := st.Running[id]; !ok {
+		t.Errorf("ReleaseClaim must not remove Running[%s]; that's the worker goroutine's job", id)
+	}
+}
+
+func TestCodexTotals_AddTokensAndSeconds(t *testing.T) {
+	var c CodexTotals
+	c.AddTokens(100, 250)
+	c.AddTokens(50, 0)
+	c.AddSeconds(1500 * time.Millisecond)
+	c.AddSeconds(-time.Second) // negative deltas must be ignored
+
+	if c.InputTokens != 150 || c.OutputTokens != 250 || c.TotalTokens != 400 {
+		t.Errorf("token totals wrong: %+v", c)
+	}
+	if c.SecondsRunning != 1.5 {
+		t.Errorf("SecondsRunning = %v, want 1.5", c.SecondsRunning)
+	}
+}
+
+func TestRecordRateLimits_LastWriteWins(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	if st.CodexRateLimits != nil {
+		t.Fatalf("initial CodexRateLimits should be nil")
+	}
+	a := &RateLimitSnapshot{}
+	st.RecordRateLimits(a)
+	if st.CodexRateLimits != a {
+		t.Errorf("RecordRateLimits did not store snapshot a")
+	}
+	b := &RateLimitSnapshot{}
+	st.RecordRateLimits(b)
+	if st.CodexRateLimits != b {
+		t.Errorf("RecordRateLimits did not replace with snapshot b")
+	}
+}
+
+func TestSnapshot_ShapeMatches13_3(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss1 := issue("ENG-1")
+	iss2 := issue("ENG-2")
+	iss3 := issue("ENG-3")
+	id1, id2, id3 := IssueID(iss1.ID), IssueID(iss2.ID), IssueID(iss3.ID)
+
+	st.BeginDispatch(id1, runningEntry(t, iss1))
+	st.ScheduleRetry(&RetryEntry{
+		IssueID:    id2,
+		Identifier: iss2.Identifier,
+		Attempt:    3,
+		DueAt:      time.Unix(1_700_000_000, 0),
+		Error:      "bad",
+	})
+	// Completed is fed via FinishRunSucceeded.
+	st.BeginDispatch(id3, runningEntry(t, iss3))
+	st.FinishRunSucceeded(id3, 500*time.Millisecond)
+
+	view := st.Snapshot()
+
+	if view.PollIntervalMs != 15000 || view.MaxConcurrentAgents != 4 {
+		t.Errorf("config not surfaced in snapshot: %+v", view)
+	}
+	if len(view.Running) != 1 || view.Running[0].IssueID != id1 {
+		t.Errorf("Running view wrong: %+v", view.Running)
+	}
+	if len(view.Retrying) != 1 || view.Retrying[0].IssueID != id2 || view.Retrying[0].Attempt != 3 {
+		t.Errorf("Retrying view wrong: %+v", view.Retrying)
+	}
+	if len(view.Completed) != 1 || view.Completed[0] != id3 {
+		t.Errorf("Completed view wrong: %+v", view.Completed)
+	}
+	if view.CodexTotals.SecondsRunning != 0.5 {
+		t.Errorf("CodexTotals not surfaced: %+v", view.CodexTotals)
+	}
+
+	// Mutating the returned slice must not affect future snapshots.
+	view.Completed[0] = "tampered"
+	again := st.Snapshot()
+	if again.Completed[0] != id3 {
+		t.Errorf("Snapshot returned a slice aliased to internal state")
+	}
+}
+
+func TestRetryEntry_IsDue(t *testing.T) {
+	now := time.Now()
+	r := &RetryEntry{DueAt: now.Add(-time.Second)}
+	if !r.IsDue(now) {
+		t.Errorf("retry due in the past should be IsDue=true")
+	}
+	r2 := &RetryEntry{DueAt: now.Add(time.Second)}
+	if r2.IsDue(now) {
+		t.Errorf("retry due in the future should be IsDue=false")
+	}
+	var nilEntry *RetryEntry
+	if nilEntry.IsDue(now) {
+		t.Errorf("nil retry entry should not be due")
+	}
+}


### PR DESCRIPTION
PR 1 of 6 in the D21+D6 SPEC alignment plan
(docs/design/d21-d6-orchestrator-state.md). Adds the internal/orchestrator
package with the SPEC §4.1.8 OrchestratorState type, the SPEC §4.1.7
RetryEntry type, pure state-transition methods covering the design's
state-transition table, and the §13.3-shaped Snapshot view.

No production callers yet — the worker still claims via the Postgres
queue. This step exists so the next PR can layer the actor goroutine
and scheduler seam (SPEC §7.4 mutation discipline) on top of a settled
shape without mixing data and control flow in one review.

Transition-table unit tests cover every row of the design table
(dispatch, normal exit, abnormal exit, retry scheduling, retry
replacement timer cleanup, reconciliation claim release) plus the
SPEC §16.1 initializer and the Snapshot projection. Tests run under
-race and reach 97.6% coverage of the new package.