### PR TITLE
feat(orchestrator): add actor + Dispatcher seam (#73, #95)

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -1,0 +1,464 @@
+package orchestrator
+
+// actor.go is the SPEC §7.4 "single authority" goroutine that serializes
+// every mutation against OrchestratorState. The pure data types and
+// transition methods live in state.go; this file owns the goroutine,
+// the seams the actor uses to spawn workers and pick retry delays, and
+// the small set of public entry points (RequestDispatch, ScheduleRetry,
+// Snapshot) that callers from outside the actor use to drive it.
+//
+// Mutation discipline is supplied by an unbuffered ops channel and one
+// reader (Run). Every mutation is a stateOp; apply runs on the actor
+// goroutine with exclusive access to the state. Long side-effects
+// (timer setup, dispatcher.Spawn, follow-up state mutations) belong in
+// the followup func returned by apply, which the actor launches on a
+// fresh goroutine after apply returns. apply MUST NOT call submit from
+// inside itself — the actor is the same goroutine reading from ops and
+// would deadlock against itself.
+//
+// The Elixir reference uses one GenServer per orchestrator with every
+// mutation flowing through handle_call / handle_cast / handle_info
+// (orchestrator.ex:6,52,74-217); the Go actor here is the direct analog.
+//
+// PR 2 of the D21+D6 migration plan only ships this actor, the
+// Dispatcher seam, and the FixedDelayScheduler matching the legacy
+// queue's 60-second behavior. The poll-tick loop (PR 3) and the worker
+// rewire (PR 4) layer on top without further changes to the actor's
+// shape; D16 swaps FixedDelayScheduler for the SPEC §8.4 exponential
+// formula by replacing the Scheduler binding only.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// WorkerResult is the per-run outcome the Dispatcher delivers when its
+// spawned worker exits. Err is nil for SPEC §7.3 normal exit; any
+// non-nil Err is treated as abnormal exit and triggers
+// ScheduleRetry(attempt+1). Elapsed is folded into
+// CodexTotals.SecondsRunning per SPEC §13.3.
+type WorkerResult struct {
+	Err     error
+	Elapsed time.Duration
+}
+
+// Dispatcher is the seam through which the actor spawns a per-issue
+// worker goroutine. The returned channel must yield exactly one
+// WorkerResult and then close (or close without yielding to signal
+// cancellation). The actor watches it to drive normal/abnormal exit
+// transitions.
+//
+// PR 2 only ships the seam — the production binding to internal/worker
+// arrives in PR 4 of the migration plan
+// (docs/design/d21-d6-orchestrator-state.md).
+type Dispatcher interface {
+	Spawn(ctx context.Context, issue tracker.Issue, attempt *int) <-chan WorkerResult
+}
+
+// Scheduler computes the delay before the next retry of a given
+// 1-based attempt counter. PR 2 ships FixedDelayScheduler matching the
+// legacy queue's 60-second retry so behavior is unchanged when the
+// worker migrates to the actor; D16 (#90) swaps in the SPEC §8.4
+// exponential-backoff formula by replacing the Scheduler binding only.
+type Scheduler interface {
+	NextDelay(attempt int) time.Duration
+}
+
+// FixedDelayScheduler returns the same delay regardless of attempt.
+// Matches the existing internal/queue/postgres.go retry interval so the
+// PR 4 cutover is observably equivalent.
+type FixedDelayScheduler struct {
+	Delay time.Duration
+}
+
+// NextDelay implements Scheduler.
+func (f FixedDelayScheduler) NextDelay(int) time.Duration { return f.Delay }
+
+// Deps bundles construction-time dependencies so adding a new one
+// later doesn't ripple through every call site.
+type Deps struct {
+	Dispatcher Dispatcher
+	Scheduler  Scheduler
+}
+
+// Orchestrator is the SPEC §3.1 / §7.4 "single authority" that owns
+// OrchestratorState. All mutations flow through the actor goroutine
+// started by Run; reads via Snapshot also serialize through the actor
+// so callers always observe a consistent view.
+type Orchestrator struct {
+	ops chan stateOp
+
+	state      *OrchestratorState
+	dispatcher Dispatcher
+	scheduler  Scheduler
+
+	// runCtx is captured by Run so followup goroutines can cancel
+	// their work when the actor stops. Set once at the top of Run
+	// before close(started); reads from outside the actor synchronize
+	// via the started channel close.
+	runCtx  context.Context
+	started chan struct{}
+}
+
+// New constructs an Orchestrator over an existing state value. Callers
+// must call Run(ctx) in a separate goroutine before the actor processes
+// any submitted op; tests can wait via WaitStarted.
+func New(state *OrchestratorState, deps Deps) *Orchestrator {
+	return &Orchestrator{
+		ops:        make(chan stateOp),
+		state:      state,
+		dispatcher: deps.Dispatcher,
+		scheduler:  deps.Scheduler,
+		started:    make(chan struct{}),
+	}
+}
+
+// Run is the actor loop. It drains the ops channel until ctx is
+// cancelled, applying each op against the state and (if the op
+// returns one) launching its followup on a fresh goroutine so the
+// followup can do I/O or submit further ops without deadlocking.
+//
+// Run must be called exactly once per Orchestrator and exits when ctx
+// is cancelled. Pending submits at that point return ctx.Err() via
+// the caller's context, not the orchestrator's — see submit.
+func (o *Orchestrator) Run(ctx context.Context) {
+	o.runCtx = ctx
+	close(o.started)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case op := <-o.ops:
+			if followup := op.apply(o.state); followup != nil {
+				go followup()
+			}
+		}
+	}
+}
+
+// WaitStarted blocks until Run has begun executing or ctx is cancelled.
+// Tests use it to avoid races between setup goroutines and the actor's
+// initialization; production callers usually construct + Run together.
+func (o *Orchestrator) WaitStarted(ctx context.Context) error {
+	select {
+	case <-o.started:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// submit delivers op to the actor. It blocks until the actor reads the
+// op or ctx is cancelled. Callers outside the actor (tests, timer
+// callbacks, follow-up closures) use this helper. The actor itself
+// MUST NOT call submit from inside an apply method — the unbuffered
+// ops channel has exactly one reader (the actor goroutine), and a
+// re-entrant send would deadlock against it.
+func (o *Orchestrator) submit(ctx context.Context, op stateOp) error {
+	select {
+	case o.ops <- op:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// stateOp is one mutation against OrchestratorState. apply runs on the
+// actor goroutine; the optional followup runs on a fresh goroutine
+// after apply returns. apply MUST NOT block on the ops channel.
+type stateOp interface {
+	apply(*OrchestratorState) (followup func())
+}
+
+// opFunc adapts a function literal to stateOp so simple ops don't need
+// a struct just to carry their behavior.
+type opFunc func(*OrchestratorState) func()
+
+func (f opFunc) apply(st *OrchestratorState) func() { return f(st) }
+
+// Snapshot returns a SPEC §13.3-shaped view of the orchestrator state.
+// The snapshot is taken on the actor goroutine so it observes a
+// consistent state between mutations. Returns ctx.Err() if ctx is
+// cancelled before the actor produces the view.
+func (o *Orchestrator) Snapshot(ctx context.Context) (StateView, error) {
+	reply := make(chan StateView, 1)
+	op := opFunc(func(st *OrchestratorState) func() {
+		reply <- st.Snapshot()
+		return nil
+	})
+	if err := o.submit(ctx, op); err != nil {
+		return StateView{}, err
+	}
+	select {
+	case v := <-reply:
+		return v, nil
+	case <-ctx.Done():
+		return StateView{}, ctx.Err()
+	}
+}
+
+// ErrNotDispatched is returned by RequestDispatch when the issue was
+// already claimed (running, retry-queued, or otherwise reserved) and
+// dispatch was therefore deduped. It is not an error condition — SPEC
+// §7.4's duplicate-dispatch guard is doing its job — but callers
+// distinguish "rejected" from "succeeded" by inspecting it.
+var ErrNotDispatched = errors.New("orchestrator: issue already claimed")
+
+// RequestDispatch is the public entry to dispatch issue if no other
+// claim exists. It returns nil on accepted dispatch (a worker is being
+// spawned) and ErrNotDispatched if the actor saw an existing claim.
+//
+// Dispatch decisions are serialized through the actor: concurrent calls
+// for the same issue produce at most one Running entry, even when many
+// goroutines race on the same id.
+func (o *Orchestrator) RequestDispatch(ctx context.Context, issue tracker.Issue, attempt *int) error {
+	reply := make(chan bool, 1)
+	op := &dispatchOp{o: o, issue: issue, attempt: attempt, accepted: reply}
+	if err := o.submit(ctx, op); err != nil {
+		return err
+	}
+	select {
+	case ok := <-reply:
+		if !ok {
+			return ErrNotDispatched
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// ScheduleRetry enters the SPEC §7.1 retry-queued substate for issue.
+// The orchestrator picks a delay via Scheduler.NextDelay(attempt),
+// stores a RetryEntry under RetryAttempts, holds the Claimed slot so
+// concurrent ticks cannot dispatch the issue, and starts a timer that
+// re-dispatches through the actor when it fires.
+//
+// The 1-based attempt counter is the attempt number this retry will
+// run as (i.e. the prior run was attempt-1, or 0 for first-run).
+func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string) error {
+	delay := o.scheduler.NextDelay(attempt)
+	op := &scheduleRetryOp{
+		o:          o,
+		issue:      issue,
+		identifier: identifier,
+		attempt:    attempt,
+		delay:      delay,
+		runErr:     runErr,
+	}
+	return o.submit(ctx, op)
+}
+
+// dispatchOp is the actor-side half of RequestDispatch: it checks
+// IsClaimed and either reserves the slot (followup spawns + records
+// Running) or signals dispatch denied. The two-step design keeps the
+// dispatch decision atomic against concurrent claims while keeping I/O
+// off the actor goroutine.
+type dispatchOp struct {
+	o        *Orchestrator
+	issue    tracker.Issue
+	attempt  *int
+	accepted chan<- bool
+}
+
+func (d *dispatchOp) apply(st *OrchestratorState) func() {
+	id := IssueID(d.issue.ID)
+	if st.IsClaimed(id) {
+		d.accepted <- false
+		return nil
+	}
+	// Reserve the slot synchronously so a concurrent dispatchOp aborts
+	// on its IsClaimed check. The followup records Running once the
+	// worker is spawned.
+	st.Claimed[id] = struct{}{}
+	o := d.o
+	issue := d.issue
+	attempt := d.attempt
+	accepted := d.accepted
+	return func() {
+		o.spawn(id, issue, attempt)
+		accepted <- true
+	}
+}
+
+// scheduleRetryOp is the actor-side half of ScheduleRetry: it stores
+// the RetryEntry through OrchestratorState.ScheduleRetry (which stops
+// any prior timer for the same id) and starts a new timer whose
+// callback submits a retryFireOp.
+type scheduleRetryOp struct {
+	o          *Orchestrator
+	issue      tracker.Issue
+	identifier string
+	attempt    int
+	delay      time.Duration
+	runErr     string
+}
+
+func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
+	id := IssueID(s.issue.ID)
+	o := s.o
+	issue := s.issue
+	attempt := s.attempt
+	// time.AfterFunc schedules immediately and is cheap (no goroutine
+	// until fire), so we can safely create the timer on the actor
+	// without blocking. ScheduleRetry needs the Timer set on the entry
+	// before storing so a stale prior timer is stopped atomically.
+	entry := &RetryEntry{
+		IssueID:    id,
+		Identifier: s.identifier,
+		Attempt:    attempt,
+		DueAt:      time.Now().Add(s.delay),
+		Error:      s.runErr,
+	}
+	entry.Timer = time.AfterFunc(s.delay, func() {
+		_ = o.submit(o.runCtx, &retryFireOp{
+			o:       o,
+			id:      id,
+			issue:   issue,
+			attempt: attempt,
+		})
+	})
+	st.ScheduleRetry(entry)
+	return nil
+}
+
+// retryFireOp is the actor-side handler for a fired retry timer. The
+// SPEC §16.6 retry path is "if the entry is still queued, re-dispatch;
+// otherwise drop the fire." Two timers may race here in pathological
+// cases (a ScheduleRetry replace where the prior timer's Stop missed
+// because the callback was already queued); the attempt-equality
+// guard makes the stale fire a no-op.
+type retryFireOp struct {
+	o       *Orchestrator
+	id      IssueID
+	issue   tracker.Issue
+	attempt int
+}
+
+func (r *retryFireOp) apply(st *OrchestratorState) func() {
+	entry, ok := st.RetryAttempts[r.id]
+	if !ok {
+		// Already consumed by reconciliation (ReleaseClaim) or by an
+		// earlier fire of the same retry. Either is correct.
+		return nil
+	}
+	if entry.Attempt != r.attempt {
+		// A newer ScheduleRetry replaced this entry; the older timer
+		// fired late. Drop the stale fire — the newer entry will
+		// re-dispatch on its own timer.
+		return nil
+	}
+	// Consume the retry entry but keep Claimed: the re-dispatch
+	// immediately re-adds Running, and dropping Claimed in between
+	// would let a concurrent tick race in.
+	delete(st.RetryAttempts, r.id)
+	o := r.o
+	issue := r.issue
+	attempt := r.attempt
+	return func() {
+		o.spawn(r.id, issue, &attempt)
+	}
+}
+
+// finalizeRunOp is the actor-side handler for a worker exit. Result.Err
+// drives the SPEC §7.3 normal/abnormal exit branch; the followup
+// schedules a retry on abnormal exit.
+type finalizeRunOp struct {
+	o          *Orchestrator
+	id         IssueID
+	issue      tracker.Issue
+	identifier string
+	attempt    *int
+	result     WorkerResult
+	started    time.Time
+	done       chan struct{}
+}
+
+func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
+	elapsed := f.result.Elapsed
+	if elapsed == 0 {
+		elapsed = time.Since(f.started)
+	}
+	if f.result.Err == nil {
+		st.FinishRunSucceeded(f.id, elapsed)
+	} else {
+		st.FinishRunFailed(f.id, elapsed)
+	}
+	close(f.done)
+	if f.result.Err == nil {
+		return nil
+	}
+	// Schedule a retry with attempt+1. Per SPEC §4.1.5 the first run's
+	// RetryAttempt is nil; the first retry is attempt 1, the second 2,
+	// and so on.
+	nextAttempt := 1
+	if f.attempt != nil {
+		nextAttempt = *f.attempt + 1
+	}
+	o := f.o
+	issue := f.issue
+	identifier := f.identifier
+	runErr := f.result.Err.Error()
+	return func() {
+		_ = o.ScheduleRetry(o.runCtx, issue, identifier, nextAttempt, runErr)
+	}
+}
+
+// spawn asks the dispatcher for a worker, records the Running entry
+// through the actor, and starts the watcher goroutine that submits
+// finalizeRunOp on worker exit. The caller must already hold the
+// Claimed slot for id (set by dispatchOp.apply or persisted across
+// retryFireOp.apply); spawn does not check IsClaimed.
+//
+// spawn is invoked from a followup goroutine, never from inside an
+// apply method, so its calls into o.submit are safe.
+func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int) {
+	runCtx, cancel := context.WithCancel(o.runCtx)
+	resultCh := o.dispatcher.Spawn(runCtx, issue, attempt)
+	startedAt := time.Now()
+	workerDone := make(chan struct{})
+	entry := &RunningEntry{
+		Issue:        issue,
+		Identifier:   issue.Identifier,
+		StartedAt:    startedAt,
+		RetryAttempt: attempt,
+		CancelWorker: cancel,
+		Done:         workerDone,
+	}
+	_ = o.submit(o.runCtx, opFunc(func(st *OrchestratorState) func() {
+		st.Running[id] = entry
+		return nil
+	}))
+	go func() {
+		var res WorkerResult
+		select {
+		case r, ok := <-resultCh:
+			cancel()
+			if ok {
+				res = r
+			} else {
+				// Dispatcher closed without yielding a result: treat
+				// as a cancellation, which becomes an abnormal exit
+				// and triggers a retry per SPEC §7.3.
+				res = WorkerResult{Err: context.Canceled, Elapsed: time.Since(startedAt)}
+			}
+		case <-o.runCtx.Done():
+			cancel()
+			close(workerDone)
+			return
+		}
+		_ = o.submit(o.runCtx, &finalizeRunOp{
+			o:          o,
+			id:         id,
+			issue:      issue,
+			identifier: issue.Identifier,
+			attempt:    attempt,
+			result:     res,
+			started:    startedAt,
+			done:       workerDone,
+		})
+	}()
+}

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -384,13 +384,21 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 	}
 	if f.result.Err == nil {
 		st.FinishRunSucceeded(f.id, elapsed)
-	} else {
-		st.FinishRunFailed(f.id, elapsed)
-	}
-	close(f.done)
-	if f.result.Err == nil {
+		close(f.done)
 		return nil
 	}
+	st.FinishRunFailed(f.id, elapsed)
+	// Hold the Claimed slot across the gap between this apply (which
+	// returns control to the actor's select loop) and the
+	// scheduleRetryOp that the followup enqueues. Without this re-set,
+	// any RequestDispatch op already queued behind finalizeRunOp would
+	// observe IsClaimed=false (Running gone, Claimed gone, RetryAttempts
+	// not yet set) and dispatch the issue immediately — bypassing
+	// backoff and racing a phantom retry timer against a live worker.
+	// scheduleRetryOp's call to OrchestratorState.ScheduleRetry re-sets
+	// Claimed idempotently, so this is safe.
+	st.Claimed[f.id] = struct{}{}
+	close(f.done)
 	// Schedule a retry with attempt+1. Per SPEC §4.1.5 the first run's
 	// RetryAttempt is nil; the first retry is attempt 1, the second 2,
 	// and so on.

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -1,0 +1,416 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// fakeDispatcher records every Spawn call and lets the test control
+// when each spawned worker "exits" by closing/sending on the per-call
+// result channel. Concurrent calls are safe: spawnCount and the
+// results slice are guarded by a mutex.
+type fakeDispatcher struct {
+	mu         sync.Mutex
+	spawnCount int
+	results    []chan WorkerResult
+	contexts   []context.Context
+	issues     []tracker.Issue
+	attempts   []*int
+
+	// onSpawn, if set, runs synchronously inside Spawn so tests can
+	// inject scheduling pressure or block until they want the worker
+	// to "start running".
+	onSpawn func(ctx context.Context, issue tracker.Issue, attempt *int)
+}
+
+func (f *fakeDispatcher) Spawn(ctx context.Context, issue tracker.Issue, attempt *int) <-chan WorkerResult {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.onSpawn != nil {
+		f.onSpawn(ctx, issue, attempt)
+	}
+	ch := make(chan WorkerResult, 1)
+	f.results = append(f.results, ch)
+	f.contexts = append(f.contexts, ctx)
+	f.issues = append(f.issues, issue)
+	f.attempts = append(f.attempts, attempt)
+	f.spawnCount++
+	return ch
+}
+
+func (f *fakeDispatcher) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.spawnCount
+}
+
+// finishAt completes the i-th spawned worker with the given result.
+// Tests use this to drive the worker-exit path through the actor.
+func (f *fakeDispatcher) finishAt(i int, res WorkerResult) {
+	f.mu.Lock()
+	ch := f.results[i]
+	f.mu.Unlock()
+	ch <- res
+	close(ch)
+}
+
+func startActor(t *testing.T, deps Deps) (*Orchestrator, context.CancelFunc) {
+	t.Helper()
+	st := NewOrchestratorState(15000, 4)
+	o := New(st, deps)
+	ctx, cancel := context.WithCancel(context.Background())
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+	return o, cancel
+}
+
+// TestRequestDispatch_ConcurrentSameIssueProducesOneRunning is the
+// first of the two concurrency invariants the D21+D6 design names for
+// PR 2: under N goroutines racing to claim the same issue, exactly one
+// dispatch is accepted, exactly one Running entry exists, and the
+// dispatcher is asked to spawn exactly one worker. SPEC §7.4 calls
+// this the "duplicate-dispatch guard"; the actor's serialization is
+// the mechanism that delivers it.
+func TestRequestDispatch_ConcurrentSameIssueProducesOneRunning(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-1", Identifier: "ENG-1", Title: "race"}
+
+	const N = 64
+	var (
+		wg       sync.WaitGroup
+		accepted atomic.Int32
+		denied   atomic.Int32
+	)
+	wg.Add(N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			err := o.RequestDispatch(context.Background(), iss, nil)
+			switch {
+			case err == nil:
+				accepted.Add(1)
+			case errors.Is(err, ErrNotDispatched):
+				denied.Add(1)
+			default:
+				t.Errorf("unexpected RequestDispatch error: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := accepted.Load(); got != 1 {
+		t.Errorf("accepted dispatches = %d, want 1 (SPEC §7.4 duplicate-dispatch guard)", got)
+	}
+	if got := denied.Load(); got != N-1 {
+		t.Errorf("denied dispatches = %d, want %d", got, N-1)
+	}
+
+	// Snapshot also serializes through the actor, so by the time it
+	// returns the registerRunningOp from the accepted dispatch has
+	// been applied.
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 1 {
+		t.Errorf("Running view = %d entries, want 1: %+v", len(view.Running), view.Running)
+	}
+	if got := disp.count(); got != 1 {
+		t.Errorf("Dispatcher.Spawn calls = %d, want 1", got)
+	}
+}
+
+// TestScheduleRetry_TimerFireProducesExactlyOneReDispatch is the second
+// invariant: when a retry timer fires, the actor's serialization
+// guarantees exactly one re-dispatch. The classical race we're guarding
+// against is "the timer callback submits retryFireOp; meanwhile a
+// concurrent ScheduleRetry replaces the entry; the late retryFireOp
+// arrives at the actor". The attempt-equality guard in retryFireOp
+// makes the late fire a no-op, so the dispatcher sees exactly one Spawn
+// for the latest scheduled attempt.
+func TestScheduleRetry_TimerFireProducesExactlyOneReDispatch(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  FixedDelayScheduler{Delay: 5 * time.Millisecond},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-9", Identifier: "ENG-9", Title: "retry"}
+
+	// Schedule the retry many times concurrently. Each call replaces
+	// the prior entry's timer (via OrchestratorState.ScheduleRetry's
+	// timer.Stop) but every call also submits a retryFireOp when its
+	// timer fires. The actor's serialization is what makes the count
+	// of re-dispatches deterministic: at most one for the entry that
+	// "wins" the race.
+	const N = 32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, i+1, "boom"); err != nil {
+				t.Errorf("ScheduleRetry: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// Wait long enough for every scheduled timer (delay 5ms) to fire
+	// and for any retryFireOps to be processed by the actor.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		view, err := o.Snapshot(context.Background())
+		if err != nil {
+			t.Fatalf("Snapshot: %v", err)
+		}
+		if len(view.Retrying) == 0 && disp.count() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := disp.count(); got != 1 {
+		t.Errorf("Dispatcher.Spawn calls after retry fires = %d, want exactly 1", got)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 0 {
+		t.Errorf("Retrying view = %+v, want empty after re-dispatch", view.Retrying)
+	}
+	if len(view.Running) != 1 {
+		t.Errorf("Running view = %+v, want 1 entry from the re-dispatch", view.Running)
+	}
+}
+
+// TestRequestDispatch_DedupesAgainstRunning verifies that once a
+// dispatch is accepted and Running, a second RequestDispatch for the
+// same issue is denied — even though the Claimed window between
+// dispatchOp.apply and registerRunningOp could in principle be racy.
+// The spawn helper's submit-then-spawn ordering is what closes that
+// window; this test pins the behavior so a future refactor cannot
+// silently regress it.
+func TestRequestDispatch_DedupesAgainstRunning(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-2", Identifier: "ENG-2", Title: "dedupe"}
+
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("first RequestDispatch: %v", err)
+	}
+	// At this point the accepted reply has been sent. The Running
+	// entry is recorded asynchronously via registerRunningOp; before
+	// it lands, IsClaimed still returns true via Claimed[id].
+	if err := o.RequestDispatch(context.Background(), iss, nil); !errors.Is(err, ErrNotDispatched) {
+		t.Errorf("second RequestDispatch err = %v, want ErrNotDispatched", err)
+	}
+	if got := disp.count(); got != 1 {
+		t.Errorf("Dispatcher.Spawn calls = %d, want 1", got)
+	}
+}
+
+// TestFinalize_NormalExitMarksCompletedNoRetry covers the §7.3 normal
+// exit branch end-to-end through the actor: dispatch, the dispatcher
+// returns a successful WorkerResult, the finalize op moves the entry
+// into Completed and does not schedule a retry.
+func TestFinalize_NormalExitMarksCompletedNoRetry(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-3", Identifier: "ENG-3", Title: "ok"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	// Wait until the dispatcher has been called so we can complete it.
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Err: nil, Elapsed: 100 * time.Millisecond})
+
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.Completed) == 1 && len(v.Retrying) == 0
+	}, time.Second)
+}
+
+// TestFinalize_AbnormalExitSchedulesRetry covers the §7.3 abnormal exit
+// branch: the dispatcher reports an error, finalize records elapsed
+// without marking Completed, and schedules a retry through the actor.
+// The retry's attempt is 1 (first retry of a first run, SPEC §4.1.5).
+func TestFinalize_AbnormalExitSchedulesRetry(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  FixedDelayScheduler{Delay: 250 * time.Millisecond},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-4", Identifier: "ENG-4", Title: "fail"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Err: errors.New("kaboom"), Elapsed: 50 * time.Millisecond})
+
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.Retrying) == 1 && len(v.Completed) == 0
+	}, time.Second)
+
+	v, _ := o.Snapshot(context.Background())
+	if len(v.Retrying) != 1 || v.Retrying[0].Attempt != 1 {
+		t.Errorf("retry view = %+v, want one entry with Attempt=1", v.Retrying)
+	}
+	if v.Retrying[0].Error != "kaboom" {
+		t.Errorf("retry Error = %q, want %q", v.Retrying[0].Error, "kaboom")
+	}
+}
+
+// TestApply_FollowupRunsOffActorAndCanResubmit pins the design's
+// "apply must not block on the ops channel" invariant: a followup
+// returned by apply runs on a fresh goroutine, so it can submit
+// further ops without deadlocking against the actor. If a future
+// refactor inlined the followup call into the actor loop, this test
+// would deadlock and time out.
+func TestApply_FollowupRunsOffActorAndCanResubmit(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	defer cancel()
+
+	resubmitted := make(chan struct{})
+	first := opFunc(func(*OrchestratorState) func() {
+		return func() {
+			// This runs in the goroutine the actor spawned for the
+			// followup. Submitting another op here must not deadlock,
+			// because the actor is already back in its select loop
+			// reading from o.ops.
+			second := opFunc(func(*OrchestratorState) func() {
+				close(resubmitted)
+				return nil
+			})
+			_ = o.submit(context.Background(), second)
+		}
+	})
+	if err := o.submit(context.Background(), first); err != nil {
+		t.Fatalf("submit first op: %v", err)
+	}
+
+	select {
+	case <-resubmitted:
+	case <-time.After(time.Second):
+		t.Fatal("re-submitted op never ran — actor likely deadlocked on followup")
+	}
+}
+
+// TestRun_ContextCancelStopsActor verifies the actor terminates when
+// its run ctx is cancelled. After cancel, in-flight submits return
+// promptly via their own ctx; ops queued before cancel may or may not
+// be applied (the loop drains nothing extra after seeing ctx.Done).
+func TestRun_ContextCancelStopsActor(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 4)
+	o := New(st, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		o.Run(ctx)
+		close(done)
+	}()
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit within 1s of ctx cancel")
+	}
+}
+
+// TestSnapshot_SerializedThroughActor demonstrates that Snapshot sees
+// state mutations atomically: after RequestDispatch returns success,
+// a Snapshot call serializes after the registerRunningOp the dispatch
+// followup submitted, so the Running entry is always visible.
+func TestSnapshot_SerializedThroughActor(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	defer cancel()
+
+	for i := 0; i < 10; i++ {
+		iss := tracker.Issue{ID: idForIndex(i), Identifier: idForIndex(i)}
+		if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+			t.Fatalf("RequestDispatch[%d]: %v", i, err)
+		}
+		v, err := o.Snapshot(context.Background())
+		if err != nil {
+			t.Fatalf("Snapshot[%d]: %v", i, err)
+		}
+		if len(v.Running) != i+1 {
+			t.Errorf("Running view after dispatch[%d] = %d entries, want %d", i, len(v.Running), i+1)
+		}
+	}
+}
+
+// TestFixedDelayScheduler_NextDelay is a one-line guard so the legacy
+// 60-second behavior the PR 4 cutover preserves cannot drift silently.
+func TestFixedDelayScheduler_NextDelay(t *testing.T) {
+	s := FixedDelayScheduler{Delay: 60 * time.Second}
+	for attempt := 1; attempt <= 5; attempt++ {
+		if got := s.NextDelay(attempt); got != 60*time.Second {
+			t.Errorf("NextDelay(%d) = %v, want 60s", attempt, got)
+		}
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+}
+
+func idForIndex(i int) string {
+	const digits = "0123456789"
+	if i == 0 {
+		return "ENG-0"
+	}
+	out := []byte{'E', 'N', 'G', '-'}
+	var buf []byte
+	for i > 0 {
+		buf = append([]byte{digits[i%10]}, buf...)
+		i /= 10
+	}
+	return string(append(out, buf...))
+}

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -291,6 +291,84 @@ func TestFinalize_AbnormalExitSchedulesRetry(t *testing.T) {
 	}
 }
 
+// TestFinalize_AbnormalExitHoldsClaimAcrossScheduleRetryGap is a
+// regression for the gap that Codex flagged on PR #102: finalizeRunOp's
+// apply ran FinishRunFailed (which dropped Claimed[id]) and then
+// returned a followup that enqueued ScheduleRetry asynchronously.
+// Between the actor returning to its select loop and the
+// scheduleRetryOp being processed, any RequestDispatch op already
+// queued for the same id observed IsClaimed=false and dispatched the
+// issue immediately — bypassing backoff and racing a phantom retry
+// timer against a live worker.
+//
+// This test pins the fix: spam RequestDispatch from many goroutines
+// while the worker is exiting abnormally, and verify the dispatcher
+// is asked to spawn exactly once for the lifetime of the issue. With
+// the bug present, additional Spawn calls slip through the gap; with
+// the fix (Claimed re-set inside apply before the followup runs), the
+// gap is invisible to other ops.
+func TestFinalize_AbnormalExitHoldsClaimAcrossScheduleRetryGap(t *testing.T) {
+	disp := &fakeDispatcher{}
+	// Long delay so the retry timer never fires during the test;
+	// we're testing the gap, not the eventual re-dispatch.
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-RACE", Identifier: "ENG-RACE"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("first RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	// Start spammers BEFORE finishAt so the actor's ops channel is
+	// hot with dispatchOps the instant finalizeRunOp returns. Whoever
+	// wins the channel-send race lands behind finalizeRunOp; with the
+	// bug, those dispatchOps would see IsClaimed=false in the gap.
+	stop := make(chan struct{})
+	var spammerWG sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		spammerWG.Add(1)
+		go func() {
+			defer spammerWG.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = o.RequestDispatch(context.Background(), iss, nil)
+			}
+		}()
+	}
+	// Give the spammers a moment to ramp up so several dispatchOps
+	// are guaranteed to be queued behind finalizeRunOp by the time
+	// the actor processes it.
+	time.Sleep(10 * time.Millisecond)
+
+	disp.finishAt(0, WorkerResult{Err: errors.New("fail"), Elapsed: 0})
+
+	// Wait for the retry to be scheduled (the followup's
+	// scheduleRetryOp has been processed by the actor).
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 1 && len(v.Running) == 0
+	}, 2*time.Second)
+
+	// Stop spammers and let in-flight RequestDispatch attempts drain.
+	close(stop)
+	spammerWG.Wait()
+
+	// The single accepted dispatch from the start of the test is the
+	// only one that should have reached the dispatcher. Any extra
+	// Spawn means a spammer slipped through the gap.
+	if got := disp.count(); got != 1 {
+		t.Errorf("Dispatcher.Spawn calls = %d, want 1 (Claimed must be held across FinishRunFailed → ScheduleRetry gap)", got)
+	}
+}
+
 // TestApply_FollowupRunsOffActorAndCanResubmit pins the design's
 // "apply must not block on the ops channel" invariant: a followup
 // returned by apply runs on a fresh goroutine, so it can submit


### PR DESCRIPTION
PR 2 of 6 in the D21+D6 SPEC alignment plan
(docs/design/d21-d6-orchestrator-state.md). Layers the SPEC §7.4
"single authority" actor goroutine on top of the state types from
PR 1, plus the Dispatcher and Scheduler seams the worker rewire
(PR 4) and exponential-backoff swap (D16) bind to.

Mutation discipline: every mutation is a stateOp; one goroutine
(Run) reads the unbuffered ops channel, calls op.apply on the
state, and launches op's optional followup on a fresh goroutine so
the followup can do I/O or submit further ops without deadlocking.
The Elixir reference uses one GenServer with handle_call /
handle_cast / handle_info (orchestrator.ex:6,52,74-217); the actor
here is the direct analog.

Public surface kept minimal — only what PR 3's tick loop needs:
RequestDispatch, ScheduleRetry, Snapshot. Snapshot also serializes
through the actor so reads observe a consistent state between
mutations. ErrNotDispatched distinguishes "deduped by §7.4 guard"
from real errors.

Concurrency tests (-race, 20x stress passes) cover the two
invariants the design names for this PR:

  1. Concurrent claim attempts on the same issue produce exactly
     one Running entry. The dispatchOp's apply reserves Claimed
     synchronously so subsequent dispatchOps see IsClaimed=true
     before their own apply runs.

  2. Retry-timer races produce exactly one re-dispatch. The
     retryFireOp's attempt-equality guard drops late fires when
     ScheduleRetry has replaced the entry.

Plus invariant tests for the deadlock-avoidance pattern (followup
can resubmit), §7.3 normal/abnormal exit branches end-to-end,
Snapshot serialization, and ctx-cancel shutdown. Package coverage
92.9%; uncovered lines are ctx-cancel error paths.

No production callers wired yet — the worker still claims via the
Postgres queue. PR 3 migrates the poll tick; PR 4 moves the worker
loop under Orchestrator.spawn.

https://claude.ai/code/session_019rggd8ffs3i21GfL2fbhT6