### PR TITLE
fix(worker): address PR #103 directive review

### DIFF
--- a/internal/worker/run_test.go
+++ b/internal/worker/run_test.go
@@ -127,29 +127,49 @@ func TestSummarizeVerifyResultsIncludesError(t *testing.T) {
 }
 
 // TestAppendRunSummaryDirectiveAppendsRunSummaryContract verifies the runner
-// contract is appended and remains focused on the pre-publication summary gate.
+// contract is appended without overriding workflow-directed publication steps.
 func TestAppendRunSummaryDirectiveAppendsOnce(t *testing.T) {
 	plain := "do the work"
 	out := worker.AppendRunSummaryDirective(plain)
 	if !strings.Contains(out, "RUN_SUMMARY.md") {
 		t.Fatalf("directive not appended: %q", out)
 	}
-	if !strings.Contains(out, "Do not push branches or open pull requests") {
-		t.Fatalf("directive must prevent in-run publication before worker gates: %q", out)
+	if strings.Contains(out, "Do not push branches or open pull requests") {
+		t.Fatalf("directive must not forbid in-run publication without a post-gate handoff: %q", out)
 	}
 
 	// A prompt that merely mentions RUN_SUMMARY.md still receives the full
-	// no-publication guidance; old workflows commonly mentioned the artifact
+	// worker-enforced contract; old workflows commonly mentioned the artifact
 	// without knowing about the SPEC §1 boundary fix.
-	already := "please write .aiops/RUN_SUMMARY.md when done"
-	got := worker.AppendRunSummaryDirective(already)
-	if !strings.Contains(got, "Do not push branches or open pull requests") {
-		t.Fatalf("expected publication guidance even when summary is mentioned, got %q", got)
+	mentionsSummary := "please write .aiops/RUN_SUMMARY.md when done"
+	got := worker.AppendRunSummaryDirective(mentionsSummary)
+	if got == mentionsSummary {
+		t.Fatalf("expected full directive even when summary is mentioned, got %q", got)
 	}
 
 	// Idempotent once the full directive is already present.
 	if gotAgain := worker.AppendRunSummaryDirective(got); gotAgain != got {
 		t.Fatalf("expected no-op when full directive is present, got %q", gotAgain)
+	}
+}
+
+func TestAppendRunSummaryDirectiveDoesNotSuppressOnPartialLegacyPhrases(t *testing.T) {
+	cases := []string{
+		"do not push from inside this runner",
+		"wait until worker-side gates pass",
+		"inside this runner, do the work; worker-side gates pass later",
+	}
+
+	for _, prompt := range cases {
+		t.Run(prompt, func(t *testing.T) {
+			got := worker.AppendRunSummaryDirective(prompt)
+			if got == prompt {
+				t.Fatalf("directive was suppressed by partial legacy phrase: %q", prompt)
+			}
+			if !strings.Contains(got, "RUN_SUMMARY.md") {
+				t.Fatalf("directive missing RUN_SUMMARY.md: %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -518,25 +518,18 @@ func SummarizeVerifyResults(results []workspace.VerifyResult) []map[string]any {
 }
 
 // runSummaryDirective is appended to every rendered prompt so runners know the
-// worker requires a RUN_SUMMARY.md artifact. The directive intentionally does
-// not tell the in-run agent to push or open a PR: worker-side policy,
-// verification, summary, and secret-scan gates run after the runner exits, so
-// publication must happen only in a post-gate agent/tool handoff. Per SPEC §1,
-// push and PR creation are not orchestrator responsibilities either.
+// worker requires a RUN_SUMMARY.md artifact. Per SPEC §1, push, PR creation,
+// and tracker writes are not orchestrator responsibilities; workflow/tooling
+// instructions control whether the in-run agent performs those actions.
 const runSummaryDirective = "\n\n---\n\n" +
-	"**Required output:** before exiting, you MUST:\n" +
-	"1. Write `.aiops/RUN_SUMMARY.md` describing what you changed, why, and how " +
-	"it was verified. The task will fail if this file is missing, empty, or " +
-	"contains only a placeholder.\n" +
-	"2. Do not push branches or open pull requests from inside this runner. " +
-	"Those publication steps are performed by agent/tool handoff only after " +
-	"worker-side gates pass."
+	"**Required output:** before exiting, you MUST write `.aiops/RUN_SUMMARY.md` " +
+	"describing what you changed, why, and how it was verified. The task will " +
+	"fail if this file is missing, empty, or contains only a placeholder."
 
 // AppendRunSummaryDirective adds the RUN_SUMMARY.md contract to the rendered
-// prompt unless it is already present (so workflow templates that already
-// include the directive do not get a duplicate).
+// prompt unless the full directive is already present.
 func AppendRunSummaryDirective(prompt string) string {
-	if strings.Contains(prompt, "worker-side gates pass") || strings.Contains(prompt, "inside this runner") {
+	if strings.Contains(prompt, strings.TrimSpace(runSummaryDirective)) {
 		return prompt
 	}
 	return prompt + runSummaryDirective


### PR DESCRIPTION
## Summary
- Follow up on PR #103 Codex review feedback after the original PR was merged
- Remove the appended runner prompt language that forbade in-run branch/PR publication despite no implemented post-gate handoff
- Make `AppendRunSummaryDirective` idempotence require the full directive body, not partial legacy phrases such as `inside this runner` or `worker-side gates pass`

## Spec alignment
- SPEC §1 boundary: worker/orchestrator still do not directly push branches, open PRs, or write tracker state
- The worker appends only its enforced `.aiops/RUN_SUMMARY.md` artifact contract; workflow/tooling instructions decide runner-side publication behavior

## Review follow-up
Addresses Codex review comments from PR #103:
- https://github.com/xrf9268-hue/aiops-platform/pull/103#discussion_r3252240658
- https://github.com/xrf9268-hue/aiops-platform/pull/103#discussion_r3252240660

## Test plan
- [x] `PATH=$HOME/.local/go1.25.10/bin:$PATH go test ./internal/worker -run 'TestAppendRunSummaryDirective' -count=1`
- [x] `PATH=$HOME/.local/go1.25.10/bin:$PATH go test ./internal/worker -count=1`
- [x] `PATH=$HOME/.local/go1.25.10/bin:$PATH go test ./...`
- [x] `PATH=$HOME/.local/go1.25.10/bin:$PATH go test -tags e2e -run '^$' ./test/e2e/...`
- [x] `git diff --check`
