### PR TITLE
feat(runner): add Linear GraphQL dynamic tool

### DIFF
--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -17,8 +17,8 @@ Per-state rules:
 
 - `Backlog`: not picked up. Use this for anything you have not refined yet.
 - `AI Ready`: refined and small enough that an agent can attempt it. The poller picks these up.
-- `In Progress`: the worker has claimed an issue or you are iterating on it. Stays in `active_states` so re-runs after a push are allowed.
-- `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself.
+- `In Progress`: the agent has claimed an issue or you are iterating on it. Stays in `active_states` so re-runs after a push are allowed.
+- `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself. Per SPEC §1, the agent moves the issue here through its tool surface; the worker does not write tracker state on completion.
 - `Rework`: review found issues and you want another attempt. Moving the Linear issue into `Rework` re-enqueues a fresh task automatically. The poller composes `source_event_id` as `<issue.ID>|rework|<issue.updatedAt>` whenever the state is `Rework`, so each transition into Rework is a brand-new dedupe key and Postgres INSERTs a new task row. While the issue stays parked in Rework, repeated polls reuse the same `updatedAt` and dedupe (no enqueue loop). Non-Rework states still use plain `issue.ID`, so `AI Ready` -> `In Progress` iteration on a single task is unchanged. See `cmd/linear-poller/main.go` (`sourceEventID`) and `internal/queue/postgres.go` (`Enqueue`).
 - `Done` / `Canceled`: terminal. Listed under `tracker.terminal_states`.
 

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -18,7 +18,7 @@ Per-state rules:
 - `Backlog`: not picked up. Use this for anything you have not refined yet.
 - `AI Ready`: refined and small enough that an agent can attempt it. The poller picks these up.
 - `In Progress`: the agent has claimed an issue or you are iterating on it. Stays in `active_states` so re-runs after a push are allowed.
-- `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself. Per SPEC §1, the agent moves the issue here through its tool surface; the worker does not write tracker state on completion.
+- `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself. Per SPEC §1, tracker updates belong on the agent/tool side; while the app-server transport is still being wired, the transitional worker may still perform this handoff on behalf of the run.
 - `Rework`: review found issues and you want another attempt. Moving the Linear issue into `Rework` re-enqueues a fresh task automatically. The poller composes `source_event_id` as `<issue.ID>|rework|<issue.updatedAt>` whenever the state is `Rework`, so each transition into Rework is a brand-new dedupe key and Postgres INSERTs a new task row. While the issue stays parked in Rework, repeated polls reuse the same `updatedAt` and dedupe (no enqueue loop). Non-Rework states still use plain `issue.ID`, so `AI Ready` -> `In Progress` iteration on a single task is unchanged. See `cmd/linear-poller/main.go` (`sourceEventID`) and `internal/queue/postgres.go` (`Enqueue`).
 - `Done` / `Canceled`: terminal. Listed under `tracker.terminal_states`.
 

--- a/docs/symphony-integration.md
+++ b/docs/symphony-integration.md
@@ -63,10 +63,11 @@ Implemented:
 - basic path policy
 - verification commands
 - Gitea PR client code for the agent-side PR tool
+- `linear_graphql` dynamic tool implementation that proxies Linear GraphQL using orchestrator-held auth without exposing the Linear token to the agent process
 
 Not yet implemented:
 
-- dynamic `linear_graphql` / PR tools exposed through the app-server protocol
+- full app-server protocol integration for dynamic tool advertisement/invocation (the `linear_graphql` proxy exists as the tool implementation used by that future transport)
 - pull request labels and reviewers
 - multi-run reconciliation
 - dashboard

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -16,12 +16,12 @@ tracker:
     - Done
     - Canceled
   poll_interval_ms: 30000
-  # statuses names the Linear workflow states the agent may move the
-  # issue through via the advertised tracker tool (for example claim ->
-  # in_progress, PR opened -> human_review, failure -> rework). The
-  # orchestrator reads tracker state; ticket writes are agent/tool actions.
-  # Defaults match Linear's stock template; uncomment and edit only if
-  # your board uses different labels.
+  # statuses names the Linear workflow states the agent may use when it
+  # writes tracker handoff updates through the advertised linear_graphql
+  # tool (for example claim -> in_progress, PR opened -> human_review,
+  # failure -> rework). The orchestrator reads tracker state; ticket
+  # writes are agent/tool actions. Defaults match Linear's stock template;
+  # uncomment and edit only if your board uses different labels.
   # statuses:
   #   in_progress: "In Progress"
   #   human_review: "Human Review"

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -16,11 +16,11 @@ tracker:
     - Done
     - Canceled
   poll_interval_ms: 30000
-  # statuses names the Linear workflow states the agent may use when it
-  # writes tracker handoff updates through the advertised linear_graphql
-  # tool (for example claim -> in_progress, PR opened -> human_review,
-  # failure -> rework). The orchestrator reads tracker state; ticket
-  # writes are agent/tool actions. Defaults match Linear's stock template;
+  # statuses names the Linear workflow states used for handoff updates
+  # (for example claim -> in_progress, PR opened -> human_review, failure
+  # -> rework). Per SPEC §1, ticket writes belong on the agent/tool side;
+  # transitional worker-side writes remain only until app-server tool
+  # transport is complete. Defaults match Linear's stock template;
   # uncomment and edit only if your board uses different labels.
   # statuses:
   #   in_progress: "In Progress"

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -1,0 +1,192 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// ToolCall is the JSON-shaped input accepted by the dynamic linear_graphql
+// tool. Query and Variables are agent-controlled; endpoint is test-only and is
+// intentionally ignored by the advertised schema/description so production
+// calls always use the configured Linear endpoint held by the orchestrator.
+type ToolCall struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+	Endpoint  string         `json:"-"`
+}
+
+// DynamicTool is a client-side tool implemented by the orchestrator and made
+// available to an app-server-capable agent session. Tool metadata must never
+// include raw tracker tokens; Call closes over orchestrator config instead.
+type DynamicTool struct {
+	Name        string
+	Description string
+	Call        func(context.Context, ToolCall) (string, error)
+}
+
+type dynamicToolResponse struct {
+	Success      bool                     `json:"success"`
+	Output       string                   `json:"output"`
+	ContentItems []dynamicToolContentItem `json:"contentItems"`
+}
+
+type dynamicToolContentItem struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// DynamicToolSet is the runtime tool surface advertised to the coding agent.
+type DynamicToolSet struct {
+	tools map[string]DynamicTool
+}
+
+func (s DynamicToolSet) Lookup(name string) (DynamicTool, bool) {
+	tool, ok := s.tools[name]
+	return tool, ok
+}
+
+func (s DynamicToolSet) Names() []string {
+	names := make([]string, 0, len(s.tools))
+	for name := range s.tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// DynamicToolsForWorkflow builds the SPEC §10.5 client-side tool surface for
+// the runner. linear_graphql is advertised only when Linear auth is configured;
+// the token stays captured in this process and is never copied into tool
+// metadata, agent environment, prompt text, or the GraphQL JSON payload.
+func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
+	tools := DynamicToolSet{tools: map[string]DynamicTool{}}
+	trackerCfg := wf.Config.Tracker
+	if strings.EqualFold(trackerCfg.Kind, "linear") && trackerCfg.APIKey != "" {
+		client := linearGraphQLProxy{
+			apiKey:  trackerCfg.APIKey,
+			baseURL: defaultLinearGraphQLEndpoint,
+			http:    http.DefaultClient,
+		}
+		tools.tools["linear_graphql"] = DynamicTool{
+			Name:        "linear_graphql",
+			Description: "Execute a raw Linear GraphQL query or mutation using the orchestrator-configured Linear auth. Input: {query:string, variables?:object}. The Linear API token is never exposed to the agent process.",
+			Call:        client.call,
+		}
+	}
+	return tools
+}
+
+const defaultLinearGraphQLEndpoint = "https://api.linear.app/graphql"
+
+type linearGraphQLProxy struct {
+	apiKey  string
+	baseURL string
+	http    *http.Client
+}
+
+func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, error) {
+	query := strings.TrimSpace(call.Query)
+	if query == "" {
+		return "", fmt.Errorf("linear_graphql query is required")
+	}
+	endpoint := p.baseURL
+	if call.Endpoint != "" {
+		endpoint = call.Endpoint
+	}
+	if endpoint == "" {
+		endpoint = defaultLinearGraphQLEndpoint
+	}
+
+	payload := map[string]any{"query": query}
+	if call.Variables != nil {
+		payload["variables"] = call.Variables
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "`linear_graphql.variables` must be a JSON object that can be encoded as GraphQL variables.",
+				"reason":  err.Error(),
+			},
+		})
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	httpClient := p.http
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var respBody bytes.Buffer
+	if _, err := respBody.ReadFrom(resp.Body); err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "Linear GraphQL request failed before receiving a successful response.",
+				"status":  resp.Status,
+				"body":    respBody.String(),
+			},
+		})
+	}
+	return linearGraphQLToolResponse(respBody.Bytes())
+}
+
+func linearGraphQLToolResponse(body []byte) (string, error) {
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "Linear GraphQL response was not valid JSON.",
+				"reason":  err.Error(),
+				"body":    string(body),
+			},
+		})
+	}
+	success := true
+	if errors, ok := decoded["errors"].([]any); ok && len(errors) > 0 {
+		success = false
+	}
+	return dynamicToolResult(success, string(body))
+}
+
+func dynamicToolFailure(payload any) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		body = []byte(fmt.Sprintf(`{"error":{"message":"Linear GraphQL tool execution failed.","reason":%q}}`, err.Error()))
+	}
+	return dynamicToolResult(false, string(body))
+}
+
+func dynamicToolResult(success bool, output string) (string, error) {
+	body, err := json.Marshal(dynamicToolResponse{
+		Success: success,
+		Output:  output,
+		ContentItems: []dynamicToolContentItem{{
+			Type: "inputText",
+			Text: output,
+		}},
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -84,6 +85,8 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 
 const defaultLinearGraphQLEndpoint = "https://api.linear.app/graphql"
 
+var graphQLOperationRegexp = regexp.MustCompile(`\b(query|mutation|subscription)\b`)
+
 type linearGraphQLProxy struct {
 	apiKey  string
 	baseURL string
@@ -96,6 +99,14 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 		return dynamicToolFailure(map[string]any{
 			"error": map[string]any{
 				"message": "linear_graphql query is required",
+			},
+		})
+	}
+	operations := graphQLOperationRegexp.FindAllString(query, -1)
+	if len(operations) > 1 {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "linear_graphql query must contain exactly one operation",
 			},
 		})
 	}

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -85,8 +84,6 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 
 const defaultLinearGraphQLEndpoint = "https://api.linear.app/graphql"
 
-var graphQLOperationRegexp = regexp.MustCompile(`\b(query|mutation|subscription)\b`)
-
 type linearGraphQLProxy struct {
 	apiKey  string
 	baseURL string
@@ -102,8 +99,7 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 			},
 		})
 	}
-	operations := graphQLOperationRegexp.FindAllString(query, -1)
-	if len(operations) > 1 {
+	if countGraphQLOperations(query) > 1 {
 		return dynamicToolFailure(map[string]any{
 			"error": map[string]any{
 				"message": "linear_graphql query must contain exactly one operation",
@@ -174,6 +170,85 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 		})
 	}
 	return linearGraphQLToolResponse(respBody.Bytes())
+}
+
+func countGraphQLOperations(query string) int {
+	count := 0
+	depth := 0
+	for i := 0; i < len(query); {
+		ch := query[i]
+		switch ch {
+		case '#':
+			for i < len(query) && query[i] != '\n' && query[i] != '\r' {
+				i++
+			}
+			continue
+		case '"':
+			if strings.HasPrefix(query[i:], `"""`) {
+				i += 3
+				for i < len(query) && !strings.HasPrefix(query[i:], `"""`) {
+					i++
+				}
+				if i < len(query) {
+					i += 3
+				}
+				continue
+			}
+			i++
+			for i < len(query) {
+				if query[i] == '\\' {
+					i += 2
+					continue
+				}
+				if query[i] == '"' {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		case '{':
+			depth++
+			i++
+			continue
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+			i++
+			continue
+		case '\n', '\r':
+			i++
+			continue
+		case ' ', '\t', ',':
+			i++
+			continue
+		}
+
+		if depth == 0 && isGraphQLNameStart(ch) {
+			start := i
+			i++
+			for i < len(query) && isGraphQLNameContinue(query[i]) {
+				i++
+			}
+			switch query[start:i] {
+			case "query", "mutation", "subscription":
+				count++
+			}
+			continue
+		}
+
+		i++
+	}
+	return count
+}
+
+func isGraphQLNameStart(ch byte) bool {
+	return ch == '_' || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+}
+
+func isGraphQLNameContinue(ch byte) bool {
+	return isGraphQLNameStart(ch) || (ch >= '0' && ch <= '9')
 }
 
 func linearGraphQLToolResponse(body []byte) (string, error) {

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -223,6 +223,12 @@ func countGraphQLOperations(query string) int {
 		case ' ', '\t', ',':
 			i++
 			continue
+		case '$':
+			i++
+			for i < len(query) && isGraphQLNameContinue(query[i]) {
+				i++
+			}
+			continue
 		}
 
 		if depth == 0 && isGraphQLNameStart(ch) {

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -139,7 +139,7 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 		})
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", p.apiKey)
+	req.Header.Set("Authorization", linearAuthorizationHeader(p.apiKey))
 
 	httpClient := p.http
 	if httpClient == nil {
@@ -183,6 +183,14 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 		})
 	}
 	return linearGraphQLToolResponse(respBody.Bytes())
+}
+
+func linearAuthorizationHeader(apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if strings.HasPrefix(strings.ToLower(apiKey), "bearer ") {
+		return apiKey
+	}
+	return "Bearer " + apiKey
 }
 
 func countGraphQLOperations(query string) int {

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -175,6 +175,8 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 func countGraphQLOperations(query string) int {
 	count := 0
 	depth := 0
+	parenDepth := 0
+	operationHeader := false
 	for i := 0; i < len(query); {
 		ch := query[i]
 		switch ch {
@@ -209,11 +211,22 @@ func countGraphQLOperations(query string) int {
 			continue
 		case '{':
 			depth++
+			operationHeader = false
 			i++
 			continue
 		case '}':
 			if depth > 0 {
 				depth--
+			}
+			i++
+			continue
+		case '(':
+			parenDepth++
+			i++
+			continue
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
 			}
 			i++
 			continue
@@ -231,15 +244,19 @@ func countGraphQLOperations(query string) int {
 			continue
 		}
 
-		if depth == 0 && isGraphQLNameStart(ch) {
+		if depth == 0 && parenDepth == 0 && isGraphQLNameStart(ch) {
 			start := i
 			i++
 			for i < len(query) && isGraphQLNameContinue(query[i]) {
 				i++
 			}
-			switch query[start:i] {
-			case "query", "mutation", "subscription":
-				count++
+			name := query[start:i]
+			if !operationHeader {
+				switch name {
+				case "query", "mutation", "subscription":
+					count++
+					operationHeader = true
+				}
 			}
 			continue
 		}

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -13,13 +13,12 @@ import (
 )
 
 // ToolCall is the JSON-shaped input accepted by the dynamic linear_graphql
-// tool. Query and Variables are agent-controlled; endpoint is test-only and is
-// intentionally ignored by the advertised schema/description so production
-// calls always use the configured Linear endpoint held by the orchestrator.
+// tool. Query and Variables are agent-controlled. The Linear endpoint is held
+// by the orchestrator-side proxy and is not part of this public call shape, so
+// an agent cannot redirect the orchestrator-held token to another host.
 type ToolCall struct {
 	Query     string         `json:"query"`
 	Variables map[string]any `json:"variables,omitempty"`
-	Endpoint  string         `json:"-"`
 }
 
 // DynamicTool is a client-side tool implemented by the orchestrator and made
@@ -94,12 +93,13 @@ type linearGraphQLProxy struct {
 func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, error) {
 	query := strings.TrimSpace(call.Query)
 	if query == "" {
-		return "", fmt.Errorf("linear_graphql query is required")
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "linear_graphql query is required",
+			},
+		})
 	}
 	endpoint := p.baseURL
-	if call.Endpoint != "" {
-		endpoint = call.Endpoint
-	}
 	if endpoint == "" {
 		endpoint = defaultLinearGraphQLEndpoint
 	}
@@ -120,10 +120,15 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return "", err
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "Linear GraphQL request could not be built.",
+				"reason":  err.Error(),
+			},
+		})
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Authorization", p.apiKey)
 
 	httpClient := p.http
 	if httpClient == nil {
@@ -131,12 +136,22 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "Linear GraphQL request failed during transport.",
+				"reason":  err.Error(),
+			},
+		})
 	}
 	defer resp.Body.Close()
 	var respBody bytes.Buffer
 	if _, err := respBody.ReadFrom(resp.Body); err != nil {
-		return "", err
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "Linear GraphQL response body could not be read.",
+				"reason":  err.Error(),
+			},
+		})
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return dynamicToolFailure(map[string]any{

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -82,7 +83,10 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 	return tools
 }
 
-const defaultLinearGraphQLEndpoint = "https://api.linear.app/graphql"
+const (
+	defaultLinearGraphQLEndpoint  = "https://api.linear.app/graphql"
+	maxLinearGraphQLResponseBytes = 1 << 20
+)
 
 type linearGraphQLProxy struct {
 	apiKey  string
@@ -152,11 +156,20 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 	}
 	defer resp.Body.Close()
 	var respBody bytes.Buffer
-	if _, err := respBody.ReadFrom(resp.Body); err != nil {
+	n, err := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
+	if err != nil {
 		return dynamicToolFailure(map[string]any{
 			"error": map[string]any{
 				"message": "Linear GraphQL response body could not be read.",
 				"reason":  err.Error(),
+			},
+		})
+	}
+	if n > maxLinearGraphQLResponseBytes {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{
+				"message": "Linear GraphQL response exceeded maximum size.",
+				"limit":   maxLinearGraphQLResponseBytes,
 			},
 		})
 	}

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -231,6 +231,9 @@ func countGraphQLOperations(query string) int {
 			}
 			continue
 		case '{':
+			if depth == 0 && !operationHeader {
+				count++
+			}
 			depth++
 			operationHeader = false
 			i++

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -220,6 +220,46 @@ func TestLinearGraphQLRejectsMultipleOperationsWithoutHTTPRequest(t *testing.T) 
 	}
 }
 
+func TestLinearGraphQLRejectsMultipleAnonymousOperationsWithoutHTTPRequest(t *testing.T) {
+	server := &fakeLinearGraphQLServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
+		call(context.Background(), ToolCall{Query: `{ viewer { id } }
+{ issue(id: "1") { title } }`})
+	assertStructuredFailure(t, result, err, "linear_graphql query must contain exactly one operation")
+	_, _, requests := server.recorded()
+	if requests != 0 {
+		t.Fatalf("server received %d requests, want 0", requests)
+	}
+}
+
+func TestLinearGraphQLAllowsSingleAnonymousOperation(t *testing.T) {
+	server := &fakeLinearGraphQLServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
+		call(context.Background(), ToolCall{Query: `{ viewer { id } }`})
+	if err != nil {
+		t.Fatalf("linear_graphql call: %v", err)
+	}
+	var payload struct {
+		Success bool `json:"success"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("result is not structured JSON: %v", err)
+	}
+	if !payload.Success {
+		t.Fatalf("success = false, want true; result=%s", result)
+	}
+	_, _, requests := server.recorded()
+	if requests != 1 {
+		t.Fatalf("server received %d requests, want 1", requests)
+	}
+}
+
 func TestLinearGraphQLAllowsOperationWordsInsideSingleOperationBody(t *testing.T) {
 	server := &fakeLinearGraphQLServer{}
 	httpServer := httptest.NewServer(server.handler())

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -285,6 +285,19 @@ func TestLinearGraphQLReturnsStructuredFailureForBodyReadError(t *testing.T) {
 	assertStructuredFailure(t, result, err, "Linear GraphQL response body could not be read", "read boom")
 }
 
+func TestLinearGraphQLReturnsStructuredFailureForOversizedResponse(t *testing.T) {
+	oversized := strings.Repeat("a", maxLinearGraphQLResponseBytes+1)
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, oversized)
+	}))
+	defer httpServer.Close()
+
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
+		call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	assertStructuredFailure(t, result, err, "Linear GraphQL response exceeded maximum size")
+}
+
 func TestDynamicToolResultUsesSymphonyContentItemType(t *testing.T) {
 	result, err := dynamicToolResult(true, `{"data":{}}`)
 	if err != nil {

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -220,6 +220,35 @@ func TestLinearGraphQLRejectsMultipleOperationsWithoutHTTPRequest(t *testing.T) 
 	}
 }
 
+func TestLinearGraphQLAllowsOperationWordsInsideSingleOperationBody(t *testing.T) {
+	server := &fakeLinearGraphQLServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
+		call(context.Background(), ToolCall{Query: `query Viewer {
+  # mutation and subscription are words inside this operation body, not operations.
+  mutation: viewer { id }
+  search(term: "query mutation subscription") { id }
+}`})
+	if err != nil {
+		t.Fatalf("linear_graphql call: %v", err)
+	}
+	var payload struct {
+		Success bool `json:"success"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("result is not structured JSON: %v", err)
+	}
+	if !payload.Success {
+		t.Fatalf("success = false, want true; result=%s", result)
+	}
+	_, _, requests := server.recorded()
+	if requests != 1 {
+		t.Fatalf("server received %d requests, want 1", requests)
+	}
+}
+
 func TestLinearGraphQLReturnsStructuredFailureForHTTPStatus(t *testing.T) {
 	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, `{"errors":[{"message":"unauthorized"}]}`, http.StatusUnauthorized)

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -206,6 +206,20 @@ func TestLinearGraphQLReturnsStructuredFailureForEmptyQuery(t *testing.T) {
 	assertStructuredFailure(t, result, err, "linear_graphql query is required")
 }
 
+func TestLinearGraphQLRejectsMultipleOperationsWithoutHTTPRequest(t *testing.T) {
+	server := &fakeLinearGraphQLServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
+		call(context.Background(), ToolCall{Query: "query Viewer { viewer { id } } mutation Update { issueUpdate(id: \"1\", input: {}) { success } }"})
+	assertStructuredFailure(t, result, err, "linear_graphql query must contain exactly one operation")
+	_, _, requests := server.recorded()
+	if requests != 0 {
+		t.Fatalf("server received %d requests, want 0", requests)
+	}
+}
+
 func TestLinearGraphQLReturnsStructuredFailureForHTTPStatus(t *testing.T) {
 	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, `{"errors":[{"message":"unauthorized"}]}`, http.StatusUnauthorized)

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -226,10 +226,11 @@ func TestLinearGraphQLAllowsOperationWordsInsideSingleOperationBody(t *testing.T
 	defer httpServer.Close()
 
 	result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
-		call(context.Background(), ToolCall{Query: `query Viewer {
+		call(context.Background(), ToolCall{Query: `query Viewer($query: String!, $mutation: String!) {
   # mutation and subscription are words inside this operation body, not operations.
   mutation: viewer { id }
   search(term: "query mutation subscription") { id }
+  issues(filter: { title: { contains: $query }, description: { contains: $mutation } }) { nodes { id } }
 }`})
 	if err != nil {
 		t.Fatalf("linear_graphql call: %v", err)

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -1,0 +1,169 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+type fakeLinearGraphQLServer struct {
+	mu         sync.Mutex
+	authHeader string
+	body       string
+	requests   int
+}
+
+func (f *fakeLinearGraphQLServer) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		f.mu.Lock()
+		f.requests++
+		f.authHeader = r.Header.Get("Authorization")
+		f.body = string(body)
+		f.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issueUpdate":{"success":true}}}`)
+	})
+}
+
+func (f *fakeLinearGraphQLServer) recorded() (string, string, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.authHeader, f.body, f.requests
+}
+
+func TestDynamicToolsExposeLinearGraphQLWithTokenIsolation(t *testing.T) {
+	server := &fakeLinearGraphQLServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	token := "lin_super_secret_test_token"
+	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
+		Tracker: workflow.TrackerConfig{
+			Kind:   "linear",
+			APIKey: token,
+		},
+	}})
+
+	tool, ok := tools.Lookup("linear_graphql")
+	if !ok {
+		t.Fatalf("linear_graphql tool not advertised; tools=%#v", tools.Names())
+	}
+	if strings.Contains(tool.Description, token) {
+		t.Fatalf("tool description leaked Linear token: %q", tool.Description)
+	}
+
+	result, err := tool.Call(context.Background(), ToolCall{
+		Query:     "mutation IssueUpdate($id: String!) { issueUpdate(id: $id, input: {}) { success } }",
+		Variables: map[string]any{"id": "issue-1"},
+		Endpoint:  httpServer.URL,
+	})
+	if err != nil {
+		t.Fatalf("linear_graphql call: %v", err)
+	}
+	if strings.Contains(result, token) {
+		t.Fatalf("tool result leaked Linear token: %q", result)
+	}
+
+	auth, body, _ := server.recorded()
+	if auth != "Bearer "+token {
+		t.Fatalf("Authorization = %q, want bearer token held by orchestrator", auth)
+	}
+	if strings.Contains(body, token) {
+		t.Fatalf("GraphQL request body leaked token to agent-controlled payload: %s", body)
+	}
+	var payload struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("request body is not JSON: %v", err)
+	}
+	if payload.Query == "" || payload.Variables["id"] != "issue-1" {
+		t.Fatalf("unexpected GraphQL payload: %#v", payload)
+	}
+}
+
+func TestDynamicToolsDoNotExposeLinearGraphQLWithoutLinearToken(t *testing.T) {
+	for _, wf := range []workflow.Workflow{
+		{},
+		{Config: workflow.Config{Tracker: workflow.TrackerConfig{Kind: "linear"}}},
+		{Config: workflow.Config{Tracker: workflow.TrackerConfig{Kind: "gitea", APIKey: "token"}}},
+	} {
+		tools := DynamicToolsForWorkflow(wf)
+		if _, ok := tools.Lookup("linear_graphql"); ok {
+			t.Fatalf("linear_graphql advertised without configured Linear token: %#v", wf.Config.Tracker)
+		}
+	}
+}
+
+func TestLinearGraphQLReturnsFailurePayloadForGraphQLErrors(t *testing.T) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"errors":[{"message":"bad mutation"}]}`)
+	}))
+	defer httpServer.Close()
+
+	tool := DynamicTool{
+		Name: "linear_graphql",
+		Call: linearGraphQLProxy{
+			apiKey:  "token",
+			baseURL: httpServer.URL,
+		}.call,
+	}
+
+	result, err := tool.Call(context.Background(), ToolCall{Query: "mutation { issueUpdate(id: \"1\", input: {}) { success } }"})
+	if err != nil {
+		t.Fatalf("linear_graphql transport returned error; want structured failure payload: %v", err)
+	}
+	var payload struct {
+		Success bool   `json:"success"`
+		Output  string `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("result is not structured JSON: %v\n%s", err, result)
+	}
+	if payload.Success {
+		t.Fatalf("success = true, want false for GraphQL errors; result=%s", result)
+	}
+	if !strings.Contains(payload.Output, "bad mutation") {
+		t.Fatalf("failure output did not preserve GraphQL response: %s", payload.Output)
+	}
+}
+
+func TestLinearGraphQLRejectsInvalidVariablesWithoutHTTPRequest(t *testing.T) {
+	server := &fakeLinearGraphQLServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	tool := DynamicTool{
+		Name: "linear_graphql",
+		Call: linearGraphQLProxy{
+			apiKey:  "token",
+			baseURL: httpServer.URL,
+		}.call,
+	}
+
+	result, err := tool.Call(context.Background(), ToolCall{
+		Query:     "query { viewer { id } }",
+		Variables: map[string]any{"bad": func() {}},
+	})
+	if err != nil {
+		t.Fatalf("invalid input returned Go error; want structured tool failure: %v", err)
+	}
+	_, _, requests := server.recorded()
+	if requests != 0 {
+		t.Fatalf("HTTP requests = %d, want 0 for invalid input", requests)
+	}
+	if !strings.Contains(result, "success") || !strings.Contains(result, "false") {
+		t.Fatalf("result did not look like structured failure payload: %s", result)
+	}
+}

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -226,7 +226,7 @@ func TestLinearGraphQLAllowsOperationWordsInsideSingleOperationBody(t *testing.T
 	defer httpServer.Close()
 
 	result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
-		call(context.Background(), ToolCall{Query: `query Viewer($query: String!, $mutation: String!) {
+		call(context.Background(), ToolCall{Query: `query Viewer(query: String, $query: String!, $mutation: String!) {
   # mutation and subscription are words inside this operation body, not operations.
   mutation: viewer { id }
   search(term: "query mutation subscription") { id }

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -75,8 +75,8 @@ func TestDynamicToolsExposeLinearGraphQLWithTokenIsolation(t *testing.T) {
 	}
 
 	auth, body, _ := server.recorded()
-	if auth != token {
-		t.Fatalf("Authorization = %q, want raw Linear token held by orchestrator", auth)
+	if auth != "Bearer "+token {
+		t.Fatalf("Authorization = %q, want Bearer token matching tracker client auth", auth)
 	}
 	if strings.Contains(body, token) {
 		t.Fatalf("GraphQL request body leaked token to agent-controlled payload: %s", body)

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -61,10 +62,10 @@ func TestDynamicToolsExposeLinearGraphQLWithTokenIsolation(t *testing.T) {
 		t.Fatalf("tool description leaked Linear token: %q", tool.Description)
 	}
 
-	result, err := tool.Call(context.Background(), ToolCall{
+	proxy := linearGraphQLProxy{apiKey: token, baseURL: httpServer.URL, http: httpServer.Client()}
+	result, err := proxy.call(context.Background(), ToolCall{
 		Query:     "mutation IssueUpdate($id: String!) { issueUpdate(id: $id, input: {}) { success } }",
 		Variables: map[string]any{"id": "issue-1"},
-		Endpoint:  httpServer.URL,
 	})
 	if err != nil {
 		t.Fatalf("linear_graphql call: %v", err)
@@ -74,8 +75,8 @@ func TestDynamicToolsExposeLinearGraphQLWithTokenIsolation(t *testing.T) {
 	}
 
 	auth, body, _ := server.recorded()
-	if auth != "Bearer "+token {
-		t.Fatalf("Authorization = %q, want bearer token held by orchestrator", auth)
+	if auth != token {
+		t.Fatalf("Authorization = %q, want raw Linear token held by orchestrator", auth)
 	}
 	if strings.Contains(body, token) {
 		t.Fatalf("GraphQL request body leaked token to agent-controlled payload: %s", body)
@@ -89,6 +90,35 @@ func TestDynamicToolsExposeLinearGraphQLWithTokenIsolation(t *testing.T) {
 	}
 	if payload.Query == "" || payload.Variables["id"] != "issue-1" {
 		t.Fatalf("unexpected GraphQL payload: %#v", payload)
+	}
+}
+
+func TestLinearGraphQLIgnoresAgentSuppliedEndpoint(t *testing.T) {
+	good := &fakeLinearGraphQLServer{}
+	goodServer := httptest.NewServer(good.handler())
+	defer goodServer.Close()
+
+	evil := &fakeLinearGraphQLServer{}
+	evilServer := httptest.NewServer(evil.handler())
+	defer evilServer.Close()
+
+	var call ToolCall
+	if err := json.Unmarshal([]byte(`{"query":"query { viewer { id } }","endpoint":"`+evilServer.URL+`"}`), &call); err != nil {
+		t.Fatalf("unmarshal ToolCall: %v", err)
+	}
+
+	proxy := linearGraphQLProxy{apiKey: "token", baseURL: goodServer.URL, http: goodServer.Client()}
+	if _, err := proxy.call(context.Background(), call); err != nil {
+		t.Fatalf("linear_graphql call: %v", err)
+	}
+
+	_, _, goodRequests := good.recorded()
+	_, _, evilRequests := evil.recorded()
+	if goodRequests != 1 {
+		t.Fatalf("configured endpoint requests = %d, want 1", goodRequests)
+	}
+	if evilRequests != 0 {
+		t.Fatalf("agent-supplied endpoint received %d requests, want 0", evilRequests)
 	}
 }
 
@@ -117,6 +147,7 @@ func TestLinearGraphQLReturnsFailurePayloadForGraphQLErrors(t *testing.T) {
 		Call: linearGraphQLProxy{
 			apiKey:  "token",
 			baseURL: httpServer.URL,
+			http:    httpServer.Client(),
 		}.call,
 	}
 
@@ -149,6 +180,7 @@ func TestLinearGraphQLRejectsInvalidVariablesWithoutHTTPRequest(t *testing.T) {
 		Call: linearGraphQLProxy{
 			apiKey:  "token",
 			baseURL: httpServer.URL,
+			http:    httpServer.Client(),
 		}.call,
 	}
 
@@ -165,5 +197,97 @@ func TestLinearGraphQLRejectsInvalidVariablesWithoutHTTPRequest(t *testing.T) {
 	}
 	if !strings.Contains(result, "success") || !strings.Contains(result, "false") {
 		t.Fatalf("result did not look like structured failure payload: %s", result)
+	}
+}
+
+func TestLinearGraphQLReturnsStructuredFailureForEmptyQuery(t *testing.T) {
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: defaultLinearGraphQLEndpoint}.
+		call(context.Background(), ToolCall{Query: "   "})
+	assertStructuredFailure(t, result, err, "linear_graphql query is required")
+}
+
+func TestLinearGraphQLReturnsStructuredFailureForHTTPStatus(t *testing.T) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"message":"unauthorized"}]}`, http.StatusUnauthorized)
+	}))
+	defer httpServer.Close()
+
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
+		call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	assertStructuredFailure(t, result, err, "401 Unauthorized", "unauthorized")
+}
+
+func TestLinearGraphQLReturnsStructuredFailureForRequestBuildError(t *testing.T) {
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: ":// bad-url"}.
+		call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	assertStructuredFailure(t, result, err, "Linear GraphQL request could not be built")
+}
+
+func TestLinearGraphQLReturnsStructuredFailureForTransportError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("network down")
+	})}
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: defaultLinearGraphQLEndpoint, http: client}.
+		call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	assertStructuredFailure(t, result, err, "Linear GraphQL request failed during transport", "network down")
+}
+
+func TestLinearGraphQLReturnsStructuredFailureForBodyReadError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: errReadCloser{}}, nil
+	})}
+	result, err := linearGraphQLProxy{apiKey: "token", baseURL: defaultLinearGraphQLEndpoint, http: client}.
+		call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	assertStructuredFailure(t, result, err, "Linear GraphQL response body could not be read", "read boom")
+}
+
+func TestDynamicToolResultUsesSymphonyContentItemType(t *testing.T) {
+	result, err := dynamicToolResult(true, `{"data":{}}`)
+	if err != nil {
+		t.Fatalf("dynamicToolResult: %v", err)
+	}
+	var payload struct {
+		ContentItems []struct {
+			Type string `json:"type"`
+		} `json:"contentItems"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("result is not JSON: %v", err)
+	}
+	if len(payload.ContentItems) != 1 || payload.ContentItems[0].Type != "inputText" {
+		t.Fatalf("contentItems = %#v, want Symphony inputText item", payload.ContentItems)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("read boom") }
+func (errReadCloser) Close() error             { return nil }
+
+func assertStructuredFailure(t *testing.T, result string, err error, substrings ...string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("returned Go error %v; want structured tool failure", err)
+	}
+	var payload struct {
+		Success bool   `json:"success"`
+		Output  string `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("result is not structured JSON: %v\n%s", err, result)
+	}
+	if payload.Success {
+		t.Fatalf("success = true, want false; result=%s", result)
+	}
+	for _, substring := range substrings {
+		if !strings.Contains(payload.Output, substring) {
+			t.Fatalf("output %q does not contain %q", payload.Output, substring)
+		}
 	}
 }

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -220,7 +220,7 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", c.APIKey)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 	httpClient := c.HTTP
 	if httpClient == nil {
 		httpClient = http.DefaultClient

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -220,7 +220,7 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Authorization", c.APIKey)
 	httpClient := c.HTTP
 	if httpClient == nil {
 		httpClient = http.DefaultClient

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -96,7 +96,7 @@ func newTestClient(t *testing.T, srv *httptest.Server, cfg workflow.TrackerConfi
 // TestMoveIssueToState_LooksUpStateThenMutates verifies the two-step
 // flow: a workflowStates lookup (scoped to TeamKey when present)
 // resolves the human-readable state name to its UUID, then issueUpdate
-// mutates the issue. Both calls must carry the bearer token.
+// mutates the issue. Both calls must carry the orchestrator-held Linear token.
 func TestMoveIssueToState_LooksUpStateThenMutates(t *testing.T) {
 	srv := newFakeLinearServer()
 	srv.responses["StateByName"] = `{"data":{"workflowStates":{"nodes":[{"id":"state-uuid-1","name":"In Progress"}]}}}`
@@ -123,8 +123,8 @@ func TestMoveIssueToState_LooksUpStateThenMutates(t *testing.T) {
 	if lookup.Variables["teamKey"] != "ENG" {
 		t.Fatalf("lookup teamKey = %v, want \"ENG\"", lookup.Variables["teamKey"])
 	}
-	if lookup.AuthHeader != "Bearer test-key" {
-		t.Fatalf("lookup Authorization = %q, want \"Bearer test-key\"", lookup.AuthHeader)
+	if lookup.AuthHeader != "test-key" {
+		t.Fatalf("lookup Authorization = %q, want raw Linear token", lookup.AuthHeader)
 	}
 
 	mutate := srv.requests[1]

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -123,8 +123,8 @@ func TestMoveIssueToState_LooksUpStateThenMutates(t *testing.T) {
 	if lookup.Variables["teamKey"] != "ENG" {
 		t.Fatalf("lookup teamKey = %v, want \"ENG\"", lookup.Variables["teamKey"])
 	}
-	if lookup.AuthHeader != "test-key" {
-		t.Fatalf("lookup Authorization = %q, want raw Linear token", lookup.AuthHeader)
+	if lookup.AuthHeader != "Bearer test-key" {
+		t.Fatalf("lookup Authorization = %q, want Bearer token", lookup.AuthHeader)
 	}
 
 	mutate := srv.requests[1]

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -32,12 +32,12 @@ type TrackerConfig struct {
 	Statuses       TrackerStatusConfig `yaml:"statuses" json:"statuses"`
 }
 
-// TrackerStatusConfig names the workflow states an agent may use when it
-// writes tracker handoff updates through the advertised tool surface. The
-// defaults ("In Progress", "Human Review", "Rework") match the Linear
-// template used by the personal profile; teams that customize their workflow
-// states override the names without touching code. Per SPEC §1, the worker
-// reads tracker state and runs agents; ticket writes are agent/tool actions.
+// TrackerStatusConfig names the workflow states used for tracker handoff
+// updates. The defaults ("In Progress", "Human Review", "Rework") match the
+// Linear template used by the personal profile; teams that customize their
+// workflow states override the names without touching code. Per SPEC §1,
+// tracker writes belong on the agent/tool side; transitional worker-side
+// writes remain only until the app-server tool transport is complete.
 type TrackerStatusConfig struct {
 	InProgress  string `yaml:"in_progress" json:"in_progress"`
 	HumanReview string `yaml:"human_review" json:"human_review"`

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -32,16 +32,12 @@ type TrackerConfig struct {
 	Statuses       TrackerStatusConfig `yaml:"statuses" json:"statuses"`
 }
 
-// TrackerStatusConfig names the workflow states the worker drives the
-// linked tracker issue through as a task progresses. The defaults
-// ("In Progress", "Human Review", "Rework") match the Linear template
-// used by the personal profile; teams that customize their workflow
-// states override the names without touching code.
-//
-// An unrecognized state name (typo, missing permission, deleted state)
-// surfaces from the Linear API as a MoveIssueToState error; the worker
-// then falls back to attaching a failure comment so the human still
-// has visibility on the issue.
+// TrackerStatusConfig names the workflow states an agent may use when it
+// writes tracker handoff updates through the advertised tool surface. The
+// defaults ("In Progress", "Human Review", "Rework") match the Linear
+// template used by the personal profile; teams that customize their workflow
+// states override the names without touching code. Per SPEC §1, the worker
+// reads tracker state and runs agents; ticket writes are agent/tool actions.
 type TrackerStatusConfig struct {
 	InProgress  string `yaml:"in_progress" json:"in_progress"`
 	HumanReview string `yaml:"human_review" json:"human_review"`

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -10,7 +10,7 @@ Read the task context, inspect the repository before editing, make the smallest 
 Handoff:
 - Push branches, open pull requests, and write tracker updates yourself using the tools available in the runtime environment.
 - If a linear_graphql tool is available, use it for Linear state transitions, comments, and PR-link handoff updates; the orchestrator keeps the Linear token isolated from your process.
-- The orchestrator is a scheduler/runner and tracker reader. Do not expect it to move tickets, add tracker comments, push branches, or open PRs after you exit.
+- The orchestrator is a scheduler/runner and tracker reader. Do not expect new workflow designs to rely on orchestrator-side ticket moves, comments, pushes, or pull-request handoffs after you exit.
 
 Rules:
 - Do not touch secrets, credentials, production deployment files, or database migrations unless explicitly requested.

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -7,6 +7,11 @@ func DefaultPrompt() string {
 
 Read the task context, inspect the repository before editing, make the smallest safe change, run verification commands, and produce a clear summary.
 
+Handoff:
+- Push branches, open pull requests, and write tracker updates yourself using the tools available in the runtime environment.
+- If a linear_graphql tool is available, use it for Linear state transitions, comments, and PR-link handoff updates; the orchestrator keeps the Linear token isolated from your process.
+- The orchestrator is a scheduler/runner and tracker reader. Do not expect it to move tickets, add tracker comments, push branches, or open PRs after you exit.
+
 Rules:
 - Do not touch secrets, credentials, production deployment files, or database migrations unless explicitly requested.
 - Prefer a small change over a broad refactor.


### PR DESCRIPTION
## Summary
- Add a SPEC §10.5 `linear_graphql` dynamic tool proxy that keeps Linear auth inside the orchestrator process while accepting agent-supplied GraphQL queries/variables.
- Return structured tool outputs with success/failure semantics, including GraphQL top-level errors and invalid-variable failures.
- Update the default workflow prompt and docs to make Linear handoff updates agent/tool responsibilities rather than worker-owned tracker writes.

## Test Plan
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/runner -run "TestLinearGraphQL(ReturnsFailurePayloadForGraphQLErrors|RejectsInvalidVariablesWithoutHTTPRequest)|TestDynamicToolsExposeLinearGraphQLWithTokenIsolation" -count=1 -v`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/runner ./internal/worker`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./...`

Closes #14



## Follow-through
- Addressed Codex review feedback by returning a structured failure payload for empty `linear_graphql` queries.
- Local gate: `/home/pi/.local/go1.25.10/bin/go test ./...` passed.
- CI run 25964446822 passed with no `warning:` lines in Go build/test, E2E, or Docker logs.
- Independent diff-only review: LGTM.
