### PR TITLE
fix(worker): log startup reconcile workflow source

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -30,9 +30,36 @@ func main() {
 
 func loadWorkflowForStartupReconcile() (*workflow.Workflow, error) {
 	if path := os.Getenv("AIOPS_WORKFLOW_PATH"); path != "" {
-		return workflow.Load(path)
+		wf, err := workflow.Load(path)
+		if err != nil {
+			return nil, err
+		}
+		logStartupReconcileWorkflow(&workflow.Resolution{Source: workflow.SourceFile, Path: path}, wf)
+		return wf, nil
 	}
-	return workflow.LoadOptional("WORKFLOW.md")
+
+	workdir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	wf, resolution, err := workflow.Resolve(workdir)
+	if err != nil {
+		return nil, err
+	}
+	logStartupReconcileWorkflow(resolution, wf)
+	return wf, nil
+}
+
+func logStartupReconcileWorkflow(resolution *workflow.Resolution, wf *workflow.Workflow) {
+	if resolution.Source == workflow.SourceDefault {
+		log.Printf("startup reconciliation: workflow source=%s tracker.kind=%s; reconciliation will be skipped unless tracker.kind is linear", resolution.Source, wf.Config.Tracker.Kind)
+		return
+	}
+	if wf.Config.Tracker.Kind != "linear" {
+		log.Printf("startup reconciliation: workflow source=%s path=%s tracker.kind=%s; reconciliation will be skipped unless tracker.kind is linear", resolution.Source, resolution.Path, wf.Config.Tracker.Kind)
+		return
+	}
+	log.Printf("startup reconciliation: workflow source=%s path=%s tracker.kind=%s", resolution.Source, resolution.Path, wf.Config.Tracker.Kind)
 }
 
 func run() error {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -34,7 +34,15 @@ func loadWorkflowForStartupReconcile() (*workflow.Workflow, error) {
 		if err != nil {
 			return nil, err
 		}
-		logStartupReconcileWorkflow(&workflow.Resolution{Source: workflow.SourceFile, Path: path}, wf)
+		hasFront, err := workflow.HasFrontMatterAt(path)
+		if err != nil {
+			return nil, err
+		}
+		source := workflow.SourceFile
+		if !hasFront {
+			source = workflow.SourcePromptOnly
+		}
+		logStartupReconcileWorkflow(&workflow.Resolution{Source: source, Path: path}, wf)
 		return wf, nil
 	}
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -75,6 +75,38 @@ func TestLoadWorkflowForStartupReconcileWarnsWhenConfiguredWorkflowIsNonLinear(t
 	}
 }
 
+func TestLoadWorkflowForStartupReconcileClassifiesConfiguredPromptOnlyWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "prompt-only-workflow.md")
+	body := "Follow the repository workflow without YAML front matter.\n"
+	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	t.Setenv("AIOPS_WORKFLOW_PATH", workflowPath)
+
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(oldOutput)
+
+	wf, err := loadWorkflowForStartupReconcile()
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	if wf.Config.Tracker.Kind != workflow.DefaultConfig().Tracker.Kind {
+		t.Fatalf("tracker kind = %q, want default %q", wf.Config.Tracker.Kind, workflow.DefaultConfig().Tracker.Kind)
+	}
+	gotLog := logs.String()
+	for _, want := range []string{"startup reconciliation: workflow source=prompt_only", "path=" + workflowPath, "tracker.kind=gitea", "reconciliation will be skipped"} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("startup reconciliation log = %q, want substring %q", gotLog, want)
+		}
+	}
+	if strings.Contains(gotLog, "workflow source=file") {
+		t.Fatalf("startup reconciliation log = %q, did not expect file source for prompt-only workflow", gotLog)
+	}
+}
+
 func TestLoadWorkflowForStartupReconcileResolvesCWDWorkflowAndLogsSource(t *testing.T) {
 	dir := t.TempDir()
 	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n---\nprompt\n"

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -17,6 +20,11 @@ func TestLoadWorkflowForStartupReconcileUsesConfiguredWorkflowPath(t *testing.T)
 	}
 	t.Setenv("AIOPS_WORKFLOW_PATH", workflowPath)
 
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(oldOutput)
+
 	wf, err := loadWorkflowForStartupReconcile()
 	if err != nil {
 		t.Fatalf("load workflow: %v", err)
@@ -27,9 +35,47 @@ func TestLoadWorkflowForStartupReconcileUsesConfiguredWorkflowPath(t *testing.T)
 	if wf.Config.Tracker.Kind != "linear" {
 		t.Fatalf("tracker kind = %q, want linear", wf.Config.Tracker.Kind)
 	}
+	gotLog := logs.String()
+	for _, want := range []string{"startup reconciliation: workflow source=file", "path=" + workflowPath, "tracker.kind=linear"} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("startup reconciliation log = %q, want substring %q", gotLog, want)
+		}
+	}
+	if strings.Contains(gotLog, "reconciliation will be skipped") {
+		t.Fatalf("startup reconciliation log = %q, did not expect skip diagnostic for linear tracker", gotLog)
+	}
 }
 
-func TestLoadWorkflowForStartupReconcileFallsBackToCWDWorkflow(t *testing.T) {
+func TestLoadWorkflowForStartupReconcileWarnsWhenConfiguredWorkflowIsNonLinear(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "gitea-workflow.md")
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: gitea\n---\nprompt\n"
+	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	t.Setenv("AIOPS_WORKFLOW_PATH", workflowPath)
+
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(oldOutput)
+
+	wf, err := loadWorkflowForStartupReconcile()
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	if wf.Config.Tracker.Kind != "gitea" {
+		t.Fatalf("tracker kind = %q, want gitea", wf.Config.Tracker.Kind)
+	}
+	gotLog := logs.String()
+	for _, want := range []string{"startup reconciliation: workflow source=file", "path=" + workflowPath, "tracker.kind=gitea", "reconciliation will be skipped"} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("startup reconciliation log = %q, want substring %q", gotLog, want)
+		}
+	}
+}
+
+func TestLoadWorkflowForStartupReconcileResolvesCWDWorkflowAndLogsSource(t *testing.T) {
 	dir := t.TempDir()
 	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n---\nprompt\n"
 	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
@@ -48,15 +94,26 @@ func TestLoadWorkflowForStartupReconcileFallsBackToCWDWorkflow(t *testing.T) {
 		}
 	}()
 
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(oldOutput)
+
 	wf, err := loadWorkflowForStartupReconcile()
 	if err != nil {
 		t.Fatalf("load workflow: %v", err)
 	}
-	if wf.Path != "WORKFLOW.md" {
-		t.Fatalf("workflow path = %q, want WORKFLOW.md", wf.Path)
+	if wf.Path != filepath.Join(dir, "WORKFLOW.md") {
+		t.Fatalf("workflow path = %q, want %q", wf.Path, filepath.Join(dir, "WORKFLOW.md"))
 	}
 	if wf.Config.Tracker.Kind != "linear" {
 		t.Fatalf("tracker kind = %q, want linear", wf.Config.Tracker.Kind)
+	}
+	gotLog := logs.String()
+	for _, want := range []string{"startup reconciliation: workflow source=file", "path=WORKFLOW.md", "tracker.kind=linear"} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("startup reconciliation log = %q, want substring %q", gotLog, want)
+		}
 	}
 }
 
@@ -75,11 +132,22 @@ func TestLoadWorkflowForStartupReconcileDefaultsWhenNoWorkflowExists(t *testing.
 		}
 	}()
 
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(oldOutput)
+
 	wf, err := loadWorkflowForStartupReconcile()
 	if err != nil {
 		t.Fatalf("load workflow: %v", err)
 	}
 	if wf.Config.Tracker.Kind != workflow.DefaultConfig().Tracker.Kind {
 		t.Fatalf("tracker kind = %q, want default %q", wf.Config.Tracker.Kind, workflow.DefaultConfig().Tracker.Kind)
+	}
+	gotLog := logs.String()
+	for _, want := range []string{"startup reconciliation: workflow source=default", "tracker.kind=gitea", "reconciliation will be skipped"} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("startup reconciliation log = %q, want substring %q", gotLog, want)
+		}
 	}
 }

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -82,7 +82,7 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	hasFront, err := hasFrontMatterAt(abs)
+	hasFront, err := HasFrontMatterAt(abs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -93,12 +93,13 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 	return wf, &Resolution{Source: src, Path: found, ShadowedBy: shadows}, nil
 }
 
-// hasFrontMatterAt returns true when path begins with a YAML front
+// HasFrontMatterAt returns true when path begins with a YAML front
 // matter fence (`---\n` or `---\r\n`) followed somewhere by a closing
-// fence. Used by Resolve to distinguish prompt-only files from full
-// workflow files without threading a flag out of Load. Mirrors the
-// detection logic in splitFrontMatter (loader.go) — keep the two in
-// sync if the front-matter syntax ever changes.
+// fence. Used by Resolve and explicit workflow-path callers to
+// distinguish prompt-only files from full workflow files without
+// threading a flag out of Load. Mirrors the detection logic in
+// splitFrontMatter (loader.go) — keep the two in sync if the
+// front-matter syntax ever changes.
 //
 // Returns the read error rather than silently classifying as false:
 // after Load(path) has succeeded, a read failure here means the file
@@ -106,7 +107,7 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 // network filesystems). Misclassifying that as prompt_only would put
 // a wrong Source value on the workflow_resolved event for a file
 // whose contents we successfully parsed moments earlier.
-func hasFrontMatterAt(path string) (bool, error) {
+func HasFrontMatterAt(path string) (bool, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary
- resolve startup reconciliation workflow discovery via `workflow.Resolve` when `AIOPS_WORKFLOW_PATH` is unset
- log the startup reconciliation workflow source/path/tracker kind every time
- warn loudly whenever the loaded workflow is not Linear and reconciliation will be skipped

Closes #107

## Test Plan
- [x] `go test ./cmd/worker -run 'TestLoadWorkflowForStartupReconcile(ResolvesCWDWorkflowAndLogsSource|DefaultsWhenNoWorkflowExists|UsesConfiguredWorkflowPath)' -count=1`
- [x] `go test ./cmd/worker -count=1`
- [x] `go test ./...`
- [x] `go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`
- [x] independent diff-only Claude review: LGTM

Note: `go test -race -covermode=atomic ./...` was attempted but this Raspberry Pi host's ThreadSanitizer runtime fails before tests with `unsupported VMA range (Found 47 - Supported 48)`, a host/toolchain limitation rather than a code failure.
