### PR TITLE
chore: capture unresolved merged PR reviews

### DIFF
--- a/.github/scripts/capture-unresolved-reviews.mjs
+++ b/.github/scripts/capture-unresolved-reviews.mjs
@@ -1,0 +1,363 @@
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const apiVersion = '2022-11-28';
+const defaultLabels = ['type:chore'];
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function githubToken() {
+  return process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? requiredEnv('GITHUB_TOKEN');
+}
+
+async function githubRequest(path, { method = 'GET', body } = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${githubToken()}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'aiops-platform-capture-unresolved-reviews',
+      'X-GitHub-Api-Version': apiVersion,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    const details = JSON.stringify(payload ?? text, null, 2);
+    throw new Error(`GitHub REST request failed ${method} ${path}: ${details}`);
+  }
+  return payload;
+}
+
+async function graphqlRequest(query, variables) {
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${githubToken()}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'aiops-platform-capture-unresolved-reviews',
+      'X-GitHub-Api-Version': apiVersion,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const payload = await response.json();
+  if (!response.ok || payload.errors?.length) {
+    const details = JSON.stringify(payload.errors ?? payload, null, 2);
+    throw new Error(`GraphQL request failed: ${details}`);
+  }
+  return payload.data;
+}
+
+export function extractPriorityLabel(body) {
+  const match = body.match(/\[(P[0-3])\]/i);
+  if (!match) {
+    return 'priority:p2';
+  }
+  return `priority:${match[1].toLowerCase()}`;
+}
+
+export function normalizeDiscussionPermalink(url) {
+  const parsed = new URL(url);
+  const discussion = parsed.hash.match(/^#discussion_r\d+$/)?.[0];
+  if (!discussion) {
+    throw new Error(`Review comment URL is missing a discussion anchor: ${url}`);
+  }
+  parsed.hash = discussion;
+  parsed.search = '';
+  parsed.pathname = parsed.pathname.replace(/\/files$/, '');
+  return parsed.toString();
+}
+
+function firstComment(thread) {
+  if (Array.isArray(thread.comments)) {
+    return thread.comments[0] ?? {};
+  }
+  return thread.comments?.nodes?.[0] ?? {};
+}
+
+function authorLogin(comment) {
+  return comment.author?.login ?? comment.author ?? 'ghost';
+}
+
+function commentBody(comment) {
+  return comment.bodyText ?? comment.body ?? '';
+}
+
+function commentUrl(comment) {
+  return comment.url ?? comment.htmlUrl ?? comment.html_url;
+}
+
+function threadLine(thread) {
+  return thread.line ?? thread.originalLine ?? thread.startLine ?? thread.originalStartLine ?? null;
+}
+
+function classifyThreads(reviewThreads) {
+  const seen = new Set();
+  const actionable = [];
+  const nonActionable = [];
+
+  for (const thread of reviewThreads) {
+    const comment = firstComment(thread);
+    const url = commentUrl(comment);
+    if (!url) {
+      console.warn(`Skipping review thread ${thread.id ?? '<unknown>'}: first comment has no URL.`);
+      continue;
+    }
+
+    const permalink = normalizeDiscussionPermalink(url);
+    if (seen.has(permalink)) {
+      continue;
+    }
+    seen.add(permalink);
+
+    if (!thread.isResolved && !thread.isOutdated) {
+      actionable.push({ ...thread, discussionPermalink: permalink });
+    } else if (!thread.isResolved && thread.isOutdated) {
+      nonActionable.push({ ...thread, discussionPermalink: permalink, nonActionableReason: 'outdated' });
+    }
+  }
+
+  return { actionable, nonActionable };
+}
+
+export function buildFollowUpIssue({ repository, pullRequest, thread }) {
+  const comment = firstComment(thread);
+  const permalink = thread.discussionPermalink ?? normalizeDiscussionPermalink(commentUrl(comment));
+  const line = threadLine(thread);
+  const location = line ? `${thread.path}:${line}` : thread.path;
+  const body = commentBody(comment);
+  const priorityLabel = extractPriorityLabel(body);
+  const prUrl = pullRequest.url ?? `https://github.com/${repository.owner}/${repository.name}/pull/${pullRequest.number}`;
+
+  return {
+    title: `Follow up unresolved review thread from PR #${pullRequest.number}`,
+    labels: [priorityLabel, ...defaultLabels],
+    body: [
+      'A merged PR still had an unresolved, non-outdated review discussion. This issue was filed automatically so the feedback is not lost after merge.',
+      '',
+      `Merged PR: ${prUrl}`,
+      `Discussion: ${permalink}`,
+      `Location: \`${location}\``,
+      `Author: @${authorLogin(comment)}`,
+      '',
+      'Original review body:',
+      '',
+      '```',
+      body.trim(),
+      '```',
+    ].join('\n'),
+  };
+}
+
+export async function captureUnresolvedReviewThreads({ repository, pullRequest, github, dryRun = false }) {
+  const created = [];
+  const skippedAlreadyTracked = [];
+  const skippedNonActionableAlreadyTracked = [];
+  const { actionable, nonActionable } = classifyThreads(pullRequest.reviewThreads ?? []);
+
+  for (const thread of actionable) {
+    const permalink = thread.discussionPermalink;
+    const existingIssues = await github.searchIssuesByDiscussionPermalink({ repository, permalink });
+    if (existingIssues.length > 0) {
+      console.log(
+        `Skipping ${permalink}; already tracked by ${existingIssues
+          .map((issue) => `#${issue.number}`)
+          .join(', ')}.`,
+      );
+      skippedAlreadyTracked.push({ permalink, issues: existingIssues });
+      continue;
+    }
+
+    const issue = buildFollowUpIssue({ repository, pullRequest, thread });
+    if (dryRun) {
+      console.log(`Dry run: would create follow-up issue for ${permalink}.`);
+      created.push({ ...issue, dryRun: true });
+      continue;
+    }
+
+    const response = await github.createIssue(issue);
+    console.log(`Created follow-up issue #${response.number} for ${permalink}.`);
+    created.push(response);
+  }
+
+  for (const thread of nonActionable) {
+    const permalink = thread.discussionPermalink;
+    const existingIssues = await github.searchIssuesByDiscussionPermalink({ repository, permalink });
+    if (existingIssues.length > 0) {
+      console.log(
+        `Non-actionable ${thread.nonActionableReason} thread ${permalink} is already tracked by ${existingIssues
+          .map((issue) => `#${issue.number}`)
+          .join(', ')}.`,
+      );
+      skippedNonActionableAlreadyTracked.push({
+        permalink,
+        issues: existingIssues,
+        reason: thread.nonActionableReason,
+      });
+    }
+  }
+
+  return {
+    created,
+    skippedAlreadyTracked,
+    skippedNonActionableAlreadyTracked,
+    actionableCount: actionable.length,
+  };
+}
+
+async function loadPullRequest({ owner, repo, pullNumber }) {
+  const reviewThreads = [];
+  let after = null;
+  let pullRequest = null;
+
+  do {
+    const data = await graphqlRequest(
+      `
+      query ReviewThreads($owner: String!, $repo: String!, $pullNumber: Int!, $after: String) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $pullNumber) {
+            number
+            title
+            url
+            reviewThreads(first: 100, after: $after) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                id
+                isResolved
+                isOutdated
+                path
+                line
+                originalLine
+                startLine
+                originalStartLine
+                comments(first: 1) {
+                  nodes {
+                    url
+                    author {
+                      login
+                    }
+                    bodyText
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      `,
+      { owner, repo, pullNumber, after },
+    );
+
+    pullRequest = data.repository.pullRequest;
+    if (!pullRequest) {
+      throw new Error(`Pull request #${pullNumber} was not found.`);
+    }
+
+    reviewThreads.push(...pullRequest.reviewThreads.nodes);
+    after = pullRequest.reviewThreads.pageInfo.hasNextPage ? pullRequest.reviewThreads.pageInfo.endCursor : null;
+  } while (after);
+
+  return { number: pullRequest.number, title: pullRequest.title, url: pullRequest.url, reviewThreads };
+}
+
+function searchQuery({ repository, permalink }) {
+  return `${JSON.stringify(permalink)} repo:${repository.owner}/${repository.name} in:body type:issue`;
+}
+
+function createGitHubClient() {
+  return {
+    async searchIssuesByDiscussionPermalink({ repository, permalink }) {
+      const query = new URLSearchParams({ q: searchQuery({ repository, permalink }), per_page: '20' });
+      const payload = await githubRequest(`/search/issues?${query.toString()}`);
+      return (payload.items ?? []).map((issue) => ({ number: issue.number, state: issue.state, url: issue.html_url }));
+    },
+    async createIssue({ title, body, labels }) {
+      const owner = requiredEnv('REPO_OWNER');
+      const repo = requiredEnv('REPO_NAME');
+      const issue = await githubRequest(`/repos/${owner}/${repo}/issues`, {
+        method: 'POST',
+        body: { title, body, labels },
+      });
+      return { number: issue.number, url: issue.html_url };
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const args = { dryRun: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--dry-run') {
+      args.dryRun = true;
+    } else if (arg === '--pull-number') {
+      args.pullNumber = Number(argv[++index]);
+    } else if (arg.startsWith('--pull-number=')) {
+      args.pullNumber = Number(arg.slice('--pull-number='.length));
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+async function resolveEventPullNumber(args) {
+  if (args.pullNumber) {
+    return args.pullNumber;
+  }
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    throw new Error('Pass --pull-number or run inside a GitHub pull_request/workflow_dispatch event.');
+  }
+
+  const event = JSON.parse(await readFile(eventPath, 'utf8'));
+  const pullNumber = event.pull_request?.number ?? Number(event.inputs?.pull_number);
+  if (!pullNumber) {
+    throw new Error('Could not resolve pull request number from the GitHub event payload.');
+  }
+  return pullNumber;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const owner = process.env.REPO_OWNER ?? process.env.GITHUB_REPOSITORY_OWNER;
+  const repo = process.env.REPO_NAME ?? process.env.GITHUB_REPOSITORY?.split('/')[1];
+  if (!owner || !repo) {
+    throw new Error('Repository owner/name not found; set REPO_OWNER and REPO_NAME.');
+  }
+
+  const pullNumber = await resolveEventPullNumber(args);
+  const repository = { owner, name: repo };
+  const pullRequest = await loadPullRequest({ owner, repo, pullNumber });
+  const result = await captureUnresolvedReviewThreads({
+    repository,
+    pullRequest,
+    github: createGitHubClient(),
+    dryRun: args.dryRun,
+  });
+
+  console.log(
+    `Capture complete: ${result.actionableCount} actionable thread(s), ${result.created.length} created/would-create, ${result.skippedAlreadyTracked.length} already tracked.`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/capture-unresolved-reviews.test.mjs
+++ b/.github/scripts/capture-unresolved-reviews.test.mjs
@@ -1,0 +1,204 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildFollowUpIssue,
+  captureUnresolvedReviewThreads,
+  extractPriorityLabel,
+  normalizeDiscussionPermalink,
+} from './capture-unresolved-reviews.mjs';
+
+const repository = {
+  owner: 'xrf9268-hue',
+  name: 'aiops-platform',
+};
+
+const pullRequest = {
+  number: 106,
+  title: 'feat: reconcile workspaces on worker startup',
+  url: 'https://github.com/xrf9268-hue/aiops-platform/pull/106',
+  reviewThreads: [
+    {
+      id: 'PRRT_kwDOExample1',
+      isResolved: false,
+      isOutdated: false,
+      path: 'internal/worker/startup_reconcile.go',
+      line: 42,
+      originalLine: 40,
+      comments: [
+        {
+          url: 'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252794498',
+          author: 'chatgpt-codex-connector',
+          body: '[P1] Startup reconcile silently falls back to defaults when workflow config is missing.',
+        },
+      ],
+    },
+    {
+      id: 'PRRT_kwDOExample2',
+      isResolved: false,
+      isOutdated: true,
+      path: 'internal/worker/startup_reconcile.go',
+      line: null,
+      originalLine: 41,
+      comments: [
+        {
+          url: 'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252781671',
+          author: 'chatgpt-codex-connector',
+          body: '[P2] This outdated comment should not file an issue.',
+        },
+      ],
+    },
+    {
+      id: 'PRRT_kwDOExample3',
+      isResolved: true,
+      isOutdated: false,
+      path: 'internal/worker/startup_reconcile.go',
+      line: 45,
+      originalLine: 45,
+      comments: [
+        {
+          url: 'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252799999',
+          author: 'human-reviewer',
+          body: '[P0] Resolved feedback should not file an issue.',
+        },
+      ],
+    },
+  ],
+};
+
+test('extractPriorityLabel maps Codex-style priority badges and defaults to P2', () => {
+  assert.equal(extractPriorityLabel('[P0] data loss risk'), 'priority:p0');
+  assert.equal(extractPriorityLabel('nit: [p3] wording'), 'priority:p3');
+  assert.equal(extractPriorityLabel('no priority badge'), 'priority:p2');
+});
+
+test('normalizeDiscussionPermalink keeps the discussion anchor as the idempotency key', () => {
+  assert.equal(
+    normalizeDiscussionPermalink('https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252794498'),
+    'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252794498',
+  );
+  assert.equal(
+    normalizeDiscussionPermalink('https://github.com/xrf9268-hue/aiops-platform/pull/106/files#discussion_r3252794498'),
+    'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252794498',
+  );
+});
+
+test('buildFollowUpIssue includes PR link, discussion permalink, file line, author, and body', () => {
+  const issue = buildFollowUpIssue({ repository, pullRequest, thread: pullRequest.reviewThreads[0] });
+
+  assert.equal(issue.title, 'Follow up unresolved review thread from PR #106');
+  assert.deepEqual(issue.labels, ['priority:p1', 'type:chore']);
+  assert.match(issue.body, /Merged PR: https:\/\/github\.com\/xrf9268-hue\/aiops-platform\/pull\/106/);
+  assert.match(issue.body, /Discussion: https:\/\/github\.com\/xrf9268-hue\/aiops-platform\/pull\/106#discussion_r3252794498/);
+  assert.match(issue.body, /Location: `internal\/worker\/startup_reconcile\.go:42`/);
+  assert.match(issue.body, /Author: @chatgpt-codex-connector/);
+  assert.match(issue.body, /Startup reconcile silently falls back to defaults/);
+});
+
+test('captureUnresolvedReviewThreads skips already tracked permalinks and files author-agnostic actionable threads', async () => {
+  const created = [];
+  const searches = [];
+  const result = await captureUnresolvedReviewThreads({
+    repository,
+    pullRequest,
+    dryRun: false,
+    github: {
+      async searchIssuesByDiscussionPermalink({ permalink }) {
+        searches.push(permalink);
+        return permalink.endsWith('discussion_r3252794498') ? [{ number: 107, state: 'closed' }] : [];
+      },
+      async createIssue(issue) {
+        created.push(issue);
+        return { number: 123, url: 'https://github.com/xrf9268-hue/aiops-platform/issues/123' };
+      },
+    },
+  });
+
+  assert.deepEqual(searches, [
+    'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252794498',
+    'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252781671',
+  ]);
+  assert.equal(created.length, 0);
+  assert.equal(result.created.length, 0);
+  assert.deepEqual(result.skippedAlreadyTracked, [
+    {
+      permalink: 'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252794498',
+      issues: [{ number: 107, state: 'closed' }],
+    },
+  ]);
+});
+
+test('captureUnresolvedReviewThreads reports already tracked unresolved outdated threads without creating issues', async () => {
+  const searches = [];
+  const result = await captureUnresolvedReviewThreads({
+    repository,
+    pullRequest,
+    dryRun: true,
+    github: {
+      async searchIssuesByDiscussionPermalink({ permalink }) {
+        searches.push(permalink);
+        if (permalink.endsWith('discussion_r3252781671')) {
+          return [{ number: 108, state: 'open' }];
+        }
+        return [];
+      },
+      async createIssue() {
+        throw new Error('dry-run should not create issues');
+      },
+    },
+  });
+
+  assert.deepEqual(searches, [
+    'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252794498',
+    'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252781671',
+  ]);
+  assert.deepEqual(result.skippedNonActionableAlreadyTracked, [
+    {
+      permalink: 'https://github.com/xrf9268-hue/aiops-platform/pull/106#discussion_r3252781671',
+      issues: [{ number: 108, state: 'open' }],
+      reason: 'outdated',
+    },
+  ]);
+});
+
+test('captureUnresolvedReviewThreads creates one issue per unique unresolved non-outdated discussion permalink', async () => {
+  const humanThread = {
+    id: 'PRRT_kwDOExample4',
+    isResolved: false,
+    isOutdated: false,
+    path: 'README.md',
+    line: null,
+    originalLine: 12,
+    comments: [
+      {
+        url: 'https://github.com/xrf9268-hue/aiops-platform/pull/106/files#discussion_r3252800000',
+        author: 'human-reviewer',
+        body: 'Please document this behavior.',
+      },
+    ],
+  };
+  const created = [];
+  const result = await captureUnresolvedReviewThreads({
+    repository,
+    pullRequest: { ...pullRequest, reviewThreads: [pullRequest.reviewThreads[0], humanThread] },
+    dryRun: false,
+    github: {
+      async searchIssuesByDiscussionPermalink() {
+        return [];
+      },
+      async createIssue(issue) {
+        created.push(issue);
+        return { number: 124, url: 'https://github.com/xrf9268-hue/aiops-platform/issues/124' };
+      },
+    },
+  });
+
+  assert.equal(created.length, 2);
+  assert.deepEqual(created.map((issue) => issue.labels), [
+    ['priority:p1', 'type:chore'],
+    ['priority:p2', 'type:chore'],
+  ]);
+  assert.match(created[1].body, /Author: @human-reviewer/);
+  assert.match(created[1].body, /Location: `README\.md:12`/);
+  assert.deepEqual(result.created.map((issue) => issue.number), [124, 124]);
+});

--- a/.github/scripts/capture-unresolved-reviews.test.mjs
+++ b/.github/scripts/capture-unresolved-reviews.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 
 import {
   buildFollowUpIssue,
@@ -159,6 +160,15 @@ test('captureUnresolvedReviewThreads reports already tracked unresolved outdated
       reason: 'outdated',
     },
   ]);
+});
+
+test('capture workflow uses pull_request_target so fork-origin merges can file follow-up issues', async () => {
+  const workflow = await readFile(new URL('../workflows/capture-unresolved-reviews.yml', import.meta.url), 'utf8');
+
+  assert.match(workflow, /^  pull_request_target:\n    types:\n      - closed$/m);
+  assert.match(workflow, /github\.event_name == 'pull_request_target'/);
+  assert.doesNotMatch(workflow, /^  pull_request:\n/m);
+  assert.doesNotMatch(workflow, /github\.event_name == 'pull_request'/);
 });
 
 test('captureUnresolvedReviewThreads creates one issue per unique unresolved non-outdated discussion permalink', async () => {

--- a/.github/workflows/capture-unresolved-reviews.yml
+++ b/.github/workflows/capture-unresolved-reviews.yml
@@ -1,7 +1,7 @@
 name: Capture unresolved reviews
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
   workflow_dispatch:
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
 
     steps:
       - name: Checkout

--- a/.github/workflows/capture-unresolved-reviews.yml
+++ b/.github/workflows/capture-unresolved-reviews.yml
@@ -1,0 +1,61 @@
+name: Capture unresolved reviews
+
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: Pull request number to scan retroactively
+        required: true
+        type: number
+      dry_run:
+        description: Log follow-up issues without creating them
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: capture-unresolved-reviews-${{ github.event.pull_request.number || inputs.pull_number }}
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    name: Capture unresolved review threads
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Capture unresolved review threads
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          args=()
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            args+=(--pull-number "${{ inputs.pull_number }}")
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              args+=(--dry-run)
+            fi
+          fi
+          node .github/scripts/capture-unresolved-reviews.mjs "${args[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
             go.mod
             go.sum
 
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Run GitHub script tests
+        run: node --test .github/scripts/capture-unresolved-reviews.test.mjs
+
       - name: Download dependencies
         run: go mod download
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ Go toolchain: pinned via `go.mod` (Go 1.25). Don't edit `go.mod`'s `go` directiv
 - **Don't mock the database in integration tests** — hit real Postgres (testcontainers or the E2E harness).
 - **Secrets**: never commit real credentials. `.env`, `.env.*`, `*.key`, `*.pem` are gitignored; `.env.example` is the only sanctioned env template.
 - **PRs from the worker are draft + labeled by default**; respect `policy.max_changed_files` (12) and `policy.max_changed_loc` (300) defaults when shaping changes.
+- **Merged PR review feedback is captured non-blockingly**: `.github/workflows/capture-unresolved-reviews.yml` scans merged PRs for unresolved, non-outdated review discussions and files follow-up GitHub issues keyed by the discussion permalink. This is a recovery guardrail, not a required merge check; agents should still handle actionable review feedback before merging.
 
 ## WORKFLOW.md discovery (worker side)
 


### PR DESCRIPTION
## Summary
- Add a non-blocking merged-PR workflow that captures unresolved, non-outdated review threads as follow-up GitHub issues.
- Add a Node script with fixture/unit coverage for priority labels, discussion-permalink idempotency, issue body fields, author-agnostic capture, and PR #106 dry-run tracking logs.
- Document the guardrail in AGENTS.md and run the script tests in CI without adding any required status check.

## Test Plan
- [x] RED: `node --test .github/scripts/capture-unresolved-reviews.test.mjs` failed before the script existed.
- [x] `node --test .github/scripts/capture-unresolved-reviews.test.mjs`
- [x] `GITHUB_TOKEN=$(gh auth token) REPO_OWNER=xrf9268-hue REPO_NAME=aiops-platform node .github/scripts/capture-unresolved-reviews.mjs --pull-number 106 --dry-run` (0 created/would-create; both PR #106 discussion permalinks logged as already tracked by #107/#108)
- [x] `go test ./...`
- [x] `go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`
- [x] `go test -race -covermode=atomic ./...` attempted; blocked locally by Raspberry Pi 16KB-page ThreadSanitizer unsupported VMA range, so CI remains the race gate.

Closes #108
