### PR TITLE
feat(runner): add Codex app-server transport

### DIFF
--- a/.hermes/issue-automation-ledger.md
+++ b/.hermes/issue-automation-ledger.md
@@ -1,0 +1,51 @@
+# AIOps Platform Issue Automation Ledger
+
+Updated: 2026-05-16T10:15:00+00:00
+
+## Operating policy
+- Global goal: close all open issues in xrf9268-hue/aiops-platform with high-quality implementation.
+- Order: P0 first, then P1, then P2.
+- Quality gate for every implementation issue: fresh main, isolated branch/worktree, local gofmt/go test ./..., PR, independent review, @codex review completion (no 👀), GitHub Actions green, delayed recheck, squash merge.
+- GitHub Claude review is not configured for this repo; do not trigger or wait for @claude review as a quality gate.
+- Do not stop after a single PR unless blocked by an external dependency; update this ledger after every issue/PR state transition.
+
+## Current work
+- #87 merged via PR #105; #68 prerequisite is unblocked.
+- #68 branch `feat/issue-68-startup-reconcile` is in progress locally.
+- This tick added/verified startup reconciliation implementation and tests; local `/home/pi/.local/go1.25.10/bin/go test ./...` passes.
+- Next: inspect final diff, create commit, push branch, open PR for #68, trigger @codex review, then follow CI/review gates to merge.
+
+## Open issue queue
+### P0
+- [ ] #13 [M3][P0] Validate Linear poller against real Linear workspace (area:linear, milestone:m3, priority:p0, type:validation)
+- [ ] #14 [M3][P0] Add Linear status transitions after task handoff (area:linear, milestone:m3, priority:p0, type:feature)
+- [~] #68 [M5][P0][spec-alignment] D3 Reconcile in-flight workspaces with tracker on worker startup — IN PROGRESS; implementation local, tests green, PR pending
+### P1
+- [ ] #15 [M3][P1] Add Linear workpad comments (area:linear, milestone:m3, priority:p1, type:feature)
+- [ ] #16 [M3][P1] Add repo routing for Linear issues (area:linear, milestone:m3, priority:p1, type:feature)
+- [ ] #19 [M4][P1] Add Claude analysis-only runner mode (area:runner, milestone:m4, priority:p1, type:feature)
+- [ ] #26 [M6][P1] Add lightweight task CLI or dashboard (area:observability, milestone:m6, priority:p1, type:feature)
+- [ ] #64 [M5][P1][spec-alignment] D1 Adopt Codex app-server protocol per SPEC §Agent Runner (area:runner, milestone:m5, priority:p1, type:feature, area:spec-alignment)
+- [ ] #67 [meta][spec-alignment] SPEC.md deviations tracker (priority:p1, type:docs, area:spec-alignment)
+- [ ] #70 [security][P1][spec-alignment] D5 Document and harden sandbox posture per SPEC §safety (priority:p1, type:feature, area:spec-alignment, area:security)
+- [ ] #71 [M5][P1][spec-alignment] Adopt aiops/* label state machine for Gitea tracker (area:gitea, milestone:m5, priority:p1, type:feature, area:spec-alignment)
+- [ ] #73 [P1][spec-alignment] Replace Postgres queue with SPEC's tracker+filesystem recovery model (priority:p1, area:spec-alignment, area:queue, type:refactor)
+- [ ] #74 [P1][spec-alignment] Replace Gitea webhook trigger with Gitea poller (mirror cmd/linear-poller) (area:gitea, priority:p1, area:spec-alignment, type:refactor)
+- [ ] #78 [P1][spec-alignment] Per-tick reconciliation: stop active runs when tracker state changes (SPEC §2.1) (area:linear, area:workspace, priority:p1, type:feature, area:spec-alignment)
+- [ ] #84 [P1][spec-alignment] D10 Workflow file is per-service, not per-repo-per-task (SPEC §5.1) (area:workflow, priority:p1, area:spec-alignment, type:refactor)
+- [ ] #85 [P1][spec-alignment] D11 Dynamic WORKFLOW.md watch/reload (SPEC §6.2) (area:workflow, priority:p1, type:feature, area:spec-alignment)
+- [ ] #86 [P1][spec-alignment] D12 Workspace lifecycle hooks (after_create/before_run/after_run/before_remove) (SPEC §5.3.4, §9.4, §18.1) (area:workspace, priority:p1, type:feature, area:spec-alignment)
+- [x] #87 [P1][spec-alignment] D13 Workspace key by sanitized issue identifier, not task ID (SPEC §4.2, §9.1) — merged in PR #105
+- [ ] #90 [P1][spec-alignment] D16 Exponential backoff and continuation retries (SPEC §7.3, §8.4) (priority:p1, type:feature, area:spec-alignment, area:queue)
+- [ ] #93 [P1][spec-alignment] D19 Candidate selection, Todo blocker rule, dispatch sort (SPEC §8.2) (area:linear, priority:p1, type:feature, area:spec-alignment)
+- [ ] #94 [P1][spec-alignment] D20 Linear GraphQL: project.slugId filter, pagination, state-refresh query (SPEC §11.2) (area:linear, priority:p1, type:feature, area:spec-alignment)
+- [ ] #95 [P1][spec-alignment] D21 Single-source-of-truth orchestrator state (SPEC §3.1, §4.1.8, §7.4) (priority:p1, area:spec-alignment, area:queue, type:refactor)
+### P2
+- [ ] #72 [P2][spec-alignment] Revert WORKFLOW.md discovery to single-source per SPEC §workflow file (area:workflow, priority:p2, area:spec-alignment, type:cleanup)
+- [ ] #88 [P2][spec-alignment] D14 Stall detection + turn/read/stall timeouts (SPEC §5.3.6, §8.5) (area:runner, type:feature, priority:p2, area:spec-alignment)
+- [ ] #89 [P2][spec-alignment] D15 Per-state concurrency limits (max_concurrent_agents_by_state) (SPEC §5.3.5, §8.3) (type:feature, priority:p2, area:spec-alignment, area:queue)
+- [ ] #91 [P2][spec-alignment] D17 Liquid-strict template rendering + attempt variable (SPEC §5.4, §12.2) (area:workflow, type:feature, priority:p2, area:spec-alignment)
+- [ ] #92 [P2][spec-alignment] D18 Issue domain model missing priority/labels/blocked_by/branch_name/timestamps (SPEC §4.1.1) (area:linear, type:feature, priority:p2, area:spec-alignment)
+- [ ] #96 [P2][spec-alignment] D22 Run attempt phases and runtime events vocabulary (SPEC §7.2, §10.4) (area:runner, type:feature, priority:p2, area:spec-alignment)
+- [ ] #97 [P2][spec-alignment] D23 linear_graphql client-side tool advertisement (SPEC §10.5) (area:linear, area:runner, type:feature, priority:p2, area:spec-alignment)
+- [ ] #98 [P2][spec-alignment] D24 Workflow front-matter schema deviations (SPEC §5.3) (area:workflow, priority:p2, area:spec-alignment, type:refactor)

--- a/internal/runner/capture.go
+++ b/internal/runner/capture.go
@@ -1,5 +1,7 @@
 package runner
 
+import "sync"
+
 // CodexOutputCap is the upper bound on bytes the codex runner buffers in
 // memory from a single run. Matches workspace.VerifyOutputCap so artifact
 // ergonomics are uniform across the verify and runner phases.
@@ -15,12 +17,16 @@ const CodexEventOutputCap = 4 << 10 // 4 KiB
 // runner-side twin of workspace.cappedBuffer; the duplication avoids an
 // import cycle and keeps each package's IO contract local.
 type cappedWriter struct {
+	mu      sync.Mutex
 	Cap     int
 	buf     []byte
 	dropped int64
 }
 
 func (c *cappedWriter) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Cap <= 0 {
 		c.dropped += int64(len(p))
 		return len(p), nil
@@ -42,10 +48,20 @@ func (c *cappedWriter) Write(p []byte) (int, error) {
 }
 
 // Bytes returns the buffered bytes (post-cap). Callers must not mutate.
-func (c *cappedWriter) Bytes() []byte { return c.buf }
+func (c *cappedWriter) Bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.buf
+}
 
 // Dropped reports how many bytes were dropped because Cap was reached.
-func (c *cappedWriter) Dropped() int64 { return c.dropped }
+func (c *cappedWriter) Dropped() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.dropped
+}
 
 // headTail returns the first headCap bytes and (when body is longer than
 // headCap) the last headCap bytes. tail is empty when the entire body

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -72,6 +72,9 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		out:    buf,
 	}
 	runErr := client.run(ctx, in, string(prompt))
+	if runErr != nil && !errors.Is(runErr, context.DeadlineExceeded) && ctx.Err() == nil {
+		terminateProcess(cmd)
+	}
 	_ = stdin.Close()
 	waitErr := cmd.Wait()
 	<-stderrDone
@@ -307,6 +310,9 @@ func (c *appServerClient) readLine(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("codex app-server read timeout after %dms", c.readTimeoutMs)
 	case res := <-ch:
 		if res.err != nil {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, ctx.Err()
+			}
 			return nil, res.err
 		}
 		return res.line, nil
@@ -336,6 +342,12 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 					return err
 				}
 			default:
+				if _, ok := msg["id"]; ok {
+					if err := c.replyUnsupportedServerRequest(msg); err != nil {
+						return err
+					}
+					continue
+				}
 				if c.stallTimeoutMs > 0 && time.Since(c.lastTerminal) > time.Duration(c.stallTimeoutMs)*time.Millisecond {
 					return fmt.Errorf("codex app-server stall timeout after %dms without terminal progress", c.stallTimeoutMs)
 				}
@@ -343,6 +355,19 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (c *appServerClient) replyUnsupportedServerRequest(msg map[string]any) error {
+	method, _ := msg["method"].(string)
+	result, err := dynamicToolResult(false, "unsupported server request: "+method)
+	if err != nil {
+		return err
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		payload = map[string]any{"success": false, "output": result}
+	}
+	return c.send(map[string]any{"jsonrpc": "2.0", "id": msg["id"], "result": payload})
 }
 
 func (c *appServerClient) handleNotification(msg map[string]any) {

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -123,20 +123,24 @@ func buildCodexAppServerCmd(ctx context.Context, in RunInput) (*exec.Cmd, error)
 }
 
 type appServerClient struct {
-	stdin       io.Writer
-	reader      *bufio.Reader
-	out         io.Writer
-	nextID      int
-	threadID    string
-	lastMessage string
-	continueRun bool
-	tools       DynamicToolSet
+	stdin          io.Writer
+	reader         *bufio.Reader
+	out            io.Writer
+	nextID         int
+	threadID       string
+	lastMessage    string
+	continueRun    bool
+	tools          DynamicToolSet
+	readTimeoutMs  int
+	stallTimeoutMs int
 }
 
 func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) error {
 	c.nextID = 1
 	c.continueRun = false
 	c.tools = DynamicToolsForWorkflow(workflow.Workflow{Config: in.Workflow.Config})
+	c.readTimeoutMs = in.Workflow.Config.Codex.ReadTimeoutMs
+	c.stallTimeoutMs = in.Workflow.Config.Codex.StallTimeoutMs
 	if _, err := c.request(ctx, "initialize", map[string]any{
 		"capabilities": map[string]any{"experimentalApi": true},
 		"clientInfo": map[string]any{
@@ -248,7 +252,7 @@ func (c *appServerClient) readMessage(ctx context.Context) (map[string]any, erro
 		return nil, ctx.Err()
 	default:
 	}
-	line, err := c.reader.ReadBytes('\n')
+	line, err := c.readLine(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -260,6 +264,37 @@ func (c *appServerClient) readMessage(ctx context.Context) (map[string]any, erro
 	return msg, nil
 }
 
+func (c *appServerClient) readLine(ctx context.Context) ([]byte, error) {
+	type readResult struct {
+		line []byte
+		err  error
+	}
+	ch := make(chan readResult, 1)
+	go func() {
+		line, err := c.reader.ReadBytes('\n')
+		ch <- readResult{line: line, err: err}
+	}()
+
+	var timeout <-chan time.Time
+	if c.readTimeoutMs > 0 {
+		timer := time.NewTimer(time.Duration(c.readTimeoutMs) * time.Millisecond)
+		defer timer.Stop()
+		timeout = timer.C
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timeout:
+		return nil, fmt.Errorf("codex app-server read timeout after %dms", c.readTimeoutMs)
+	case res := <-ch:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return res.line, nil
+	}
+}
+
 func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 	for {
 		msg, err := c.readMessage(ctx)
@@ -269,6 +304,9 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 		if method, _ := msg["method"].(string); method != "" {
 			switch method {
 			case "turn/completed":
+				if err := completedTurnError(msg); err != nil {
+					return err
+				}
 				c.handleNotification(msg)
 				return nil
 			case "turn/failed", "turn/cancelled":
@@ -295,6 +333,26 @@ func (c *appServerClient) handleNotification(msg map[string]any) {
 			return
 		}
 	}
+}
+
+func completedTurnError(msg map[string]any) error {
+	params, _ := msg["params"].(map[string]any)
+	status, _ := params["status"].(string)
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "" || status == "completed" || status == "succeeded" || status == "success" {
+		return nil
+	}
+	reason := ""
+	for _, key := range []string{"reason", "error", "message"} {
+		if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
+			reason = strings.TrimSpace(v)
+			break
+		}
+	}
+	if reason == "" {
+		reason = fmt.Sprint(params)
+	}
+	return fmt.Errorf("turn/completed failed with status %q: %s", status, reason)
 }
 
 func (c *appServerClient) handleDynamicToolCall(ctx context.Context, msg map[string]any) error {

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -380,8 +380,7 @@ func protocolValidApprovalResult(method string, msg map[string]any) (map[string]
 		return map[string]any{"decision": "acceptForSession"}, true
 	case "item/permissions/requestApproval":
 		params, _ := msg["params"].(map[string]any)
-		permissions, _ := params["permissions"].([]any)
-		return map[string]any{"permissions": permissions}, true
+		return map[string]any{"permissions": params["permissions"]}, true
 	default:
 		return nil, false
 	}

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -359,6 +359,10 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 
 func (c *appServerClient) replyUnsupportedServerRequest(msg map[string]any) error {
 	method, _ := msg["method"].(string)
+	if result, ok := protocolValidApprovalResult(method, msg); ok {
+		return c.send(map[string]any{"jsonrpc": "2.0", "id": msg["id"], "result": result})
+	}
+
 	result, err := dynamicToolResult(false, "unsupported server request: "+method)
 	if err != nil {
 		return err
@@ -368,6 +372,19 @@ func (c *appServerClient) replyUnsupportedServerRequest(msg map[string]any) erro
 		payload = map[string]any{"success": false, "output": result}
 	}
 	return c.send(map[string]any{"jsonrpc": "2.0", "id": msg["id"], "result": payload})
+}
+
+func protocolValidApprovalResult(method string, msg map[string]any) (map[string]any, bool) {
+	switch method {
+	case "item/commandExecution/requestApproval", "item/fileChange/requestApproval":
+		return map[string]any{"decision": "acceptForSession"}, true
+	case "item/permissions/requestApproval":
+		params, _ := msg["params"].(map[string]any)
+		permissions, _ := params["permissions"].([]any)
+		return map[string]any{"permissions": permissions}, true
+	default:
+		return nil, false
+	}
 }
 
 func (c *appServerClient) handleNotification(msg map[string]any) {
@@ -391,7 +408,7 @@ func completedTurnError(msg map[string]any) error {
 		status, _ = turn["status"].(string)
 	}
 	status = strings.ToLower(strings.TrimSpace(status))
-	if status == "" || status == "completed" || status == "succeeded" || status == "success" {
+	if status == "" || status == "completed" || status == "succeeded" || status == "success" || status == "interrupted" {
 		return nil
 	}
 	reason := ""

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -1,0 +1,418 @@
+package runner
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// CodexAppServerRunner talks to `codex app-server` over JSON-RPC 2.0 stdio.
+// It is intentionally separate from CodexRunner so the existing one-shot
+// `codex exec` path remains backwards-compatible while the app-server transport
+// can grow toward the Symphony protocol.
+type CodexAppServerRunner struct{}
+
+const (
+	codexAppServerOutputPath = ".aiops/CODEX_APP_SERVER_OUTPUT.txt"
+)
+
+func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error) {
+	promptAbs := filepath.Join(in.Workdir, PromptPath)
+	prompt, err := os.ReadFile(promptAbs)
+	if err != nil {
+		return Result{}, fmt.Errorf("read %s: %w", PromptPath, err)
+	}
+
+	cmd, err := buildCodexAppServerCmd(ctx, in)
+	if err != nil {
+		return Result{}, err
+	}
+	cmd.Dir = in.Workdir
+	configurePlatformKill(cmd)
+	cmd.WaitDelay = killGrace
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return Result{}, fmt.Errorf("open codex app-server stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return Result{}, fmt.Errorf("open codex app-server stdout: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return Result{}, fmt.Errorf("open codex app-server stderr: %w", err)
+	}
+
+	buf := &cappedWriter{Cap: CodexOutputCap}
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		_, _ = io.Copy(buf, stderr)
+	}()
+
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		return Result{}, err
+	}
+
+	client := &appServerClient{
+		stdin:  stdin,
+		reader: bufio.NewReader(stdout),
+		out:    buf,
+	}
+	runErr := client.run(ctx, in, string(prompt))
+	_ = stdin.Close()
+	waitErr := cmd.Wait()
+	<-stderrDone
+	elapsed := time.Since(start)
+
+	writeAppServerArtifact(in.Workdir, buf)
+	res := Result{
+		Summary:       client.summary(),
+		OutputBytes:   int64(len(buf.Bytes())),
+		OutputDropped: buf.Dropped(),
+	}
+	head, tail := headTail(buf.Bytes(), CodexEventOutputCap)
+	if len(head) > 0 {
+		res.OutputHead = string(head)
+	}
+	res.OutputTail = tail
+
+	if runErr != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: runErr}
+		}
+		return res, runErr
+	}
+	if waitErr != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: waitErr}
+		}
+		return res, waitErr
+	}
+	return res, nil
+}
+
+func buildCodexAppServerCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
+	command := strings.TrimSpace(in.Workflow.Config.Codex.Command)
+	if command == "" {
+		command = "codex app-server"
+	}
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("codex app-server command is empty")
+	}
+	if fields[0] == "codex" {
+		if _, err := exec.LookPath("codex"); err != nil {
+			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
+		}
+		return exec.CommandContext(ctx, fields[0], fields[1:]...), nil
+	}
+	return exec.CommandContext(ctx, "sh", "-lc", command), nil
+}
+
+type appServerClient struct {
+	stdin       io.Writer
+	reader      *bufio.Reader
+	out         io.Writer
+	nextID      int
+	threadID    string
+	lastMessage string
+	continueRun bool
+	tools       DynamicToolSet
+}
+
+func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) error {
+	c.nextID = 1
+	c.continueRun = false
+	c.tools = DynamicToolsForWorkflow(workflow.Workflow{Config: in.Workflow.Config})
+	if _, err := c.request(ctx, "initialize", map[string]any{
+		"capabilities": map[string]any{"experimentalApi": true},
+		"clientInfo": map[string]any{
+			"name":    "aiops-platform",
+			"title":   "AIOps Platform",
+			"version": "0.1.0",
+		},
+	}); err != nil {
+		return fmt.Errorf("codex app-server initialize: %w", err)
+	}
+	if err := c.notify("initialized", map[string]any{}); err != nil {
+		return err
+	}
+
+	threadResult, err := c.request(ctx, "thread/start", map[string]any{
+		"approvalPolicy": in.Workflow.Config.Codex.ApprovalPolicy,
+		"sandbox":        in.Workflow.Config.Codex.ThreadSandbox,
+		"cwd":            in.Workdir,
+		"dynamicTools":   appServerDynamicToolSpecs(in.Workflow.Config),
+	})
+	if err != nil {
+		return fmt.Errorf("codex app-server thread/start: %w", err)
+	}
+	threadID, err := extractString(threadResult, "thread", "id")
+	if err != nil {
+		return fmt.Errorf("codex app-server thread/start: %w", err)
+	}
+	c.threadID = threadID
+
+	maxTurns := in.Workflow.Config.Agent.MaxTurns
+	if maxTurns <= 0 {
+		maxTurns = 20
+	}
+	for turn := 1; turn <= maxTurns; turn++ {
+		input := []map[string]any(nil)
+		if turn == 1 {
+			input = []map[string]any{{
+				"type": "text",
+				"text": prompt,
+			}}
+		}
+		turnResult, err := c.request(ctx, "turn/start", map[string]any{
+			"threadId":       threadID,
+			"input":          input,
+			"cwd":            in.Workdir,
+			"title":          appServerTurnTitle(in),
+			"approvalPolicy": in.Workflow.Config.Codex.ApprovalPolicy,
+			"sandboxPolicy":  in.Workflow.Config.Codex.TurnSandboxPolicy,
+		})
+		if err != nil {
+			return fmt.Errorf("codex app-server turn/start: %w", err)
+		}
+		if _, err := extractString(turnResult, "turn", "id"); err != nil {
+			return fmt.Errorf("codex app-server turn/start: %w", err)
+		}
+		c.continueRun = false
+		if err := c.awaitTurnCompletion(ctx); err != nil {
+			return err
+		}
+		if !c.continueRun {
+			return nil
+		}
+	}
+	return fmt.Errorf("codex app-server exceeded agent.max_turns=%d", maxTurns)
+}
+
+func (c *appServerClient) request(ctx context.Context, method string, params map[string]any) (map[string]any, error) {
+	id := c.nextID
+	c.nextID++
+	if err := c.send(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params}); err != nil {
+		return nil, err
+	}
+	for {
+		msg, err := c.readMessage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if gotID, ok := numberID(msg["id"]); ok && gotID == id {
+			if e, ok := msg["error"]; ok {
+				return nil, fmt.Errorf("rpc error: %v", e)
+			}
+			result, _ := msg["result"].(map[string]any)
+			if result == nil {
+				result = map[string]any{}
+			}
+			return result, nil
+		}
+		c.handleNotification(msg)
+	}
+}
+
+func (c *appServerClient) notify(method string, params map[string]any) error {
+	return c.send(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
+}
+
+func (c *appServerClient) send(msg map[string]any) error {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	_, err = c.stdin.Write(b)
+	return err
+}
+
+func (c *appServerClient) readMessage(ctx context.Context) (map[string]any, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	line, err := c.reader.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+	_, _ = c.out.Write(line)
+	var msg map[string]any
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return nil, fmt.Errorf("decode codex app-server message: %w", err)
+	}
+	return msg, nil
+}
+
+func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
+	for {
+		msg, err := c.readMessage(ctx)
+		if err != nil {
+			return err
+		}
+		if method, _ := msg["method"].(string); method != "" {
+			switch method {
+			case "turn/completed":
+				c.handleNotification(msg)
+				return nil
+			case "turn/failed", "turn/cancelled":
+				return fmt.Errorf("%s: %v", method, msg["params"])
+			case "item/tool/call":
+				if err := c.handleDynamicToolCall(ctx, msg); err != nil {
+					return err
+				}
+			default:
+				c.handleNotification(msg)
+			}
+		}
+	}
+}
+
+func (c *appServerClient) handleNotification(msg map[string]any) {
+	params, _ := msg["params"].(map[string]any)
+	if v, ok := params["continue"].(bool); ok {
+		c.continueRun = v
+	}
+	for _, key := range []string{"lastAssistantMessage", "last_message", "message", "summary"} {
+		if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
+			c.lastMessage = strings.TrimSpace(v)
+			return
+		}
+	}
+}
+
+func (c *appServerClient) handleDynamicToolCall(ctx context.Context, msg map[string]any) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	params, _ := msg["params"].(map[string]any)
+	name := appServerToolCallName(params)
+	arguments := appServerToolCallArguments(params)
+	result, err := dynamicToolResult(false, "unsupported dynamic tool: "+name)
+	if err != nil {
+		return err
+	}
+	if tool, ok := c.tools.Lookup(name); ok {
+		call := ToolCall{}
+		if err := json.Unmarshal(arguments, &call); err != nil {
+			result, err = dynamicToolFailure(err.Error())
+		} else {
+			result, err = tool.Call(ctx, call)
+			if err != nil {
+				result, err = dynamicToolFailure(err.Error())
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		payload = map[string]any{"success": false, "output": result}
+	}
+	return c.send(map[string]any{"jsonrpc": "2.0", "id": msg["id"], "result": payload})
+}
+
+func appServerToolCallName(params map[string]any) string {
+	for _, key := range []string{"tool", "name"} {
+		if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func appServerToolCallArguments(params map[string]any) json.RawMessage {
+	if raw, ok := params["arguments"]; ok && raw != nil {
+		b, err := json.Marshal(raw)
+		if err == nil {
+			return b
+		}
+	}
+	return json.RawMessage(`{}`)
+}
+
+func (c *appServerClient) summary() string {
+	if strings.TrimSpace(c.lastMessage) != "" {
+		return strings.TrimSpace(c.lastMessage)
+	}
+	return "codex app-server completed"
+}
+
+func appServerDynamicToolSpecs(cfg workflow.Config) []map[string]any {
+	toolSet := DynamicToolsForWorkflow(workflow.Workflow{Config: cfg})
+	names := toolSet.Names()
+	specs := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		tool, ok := toolSet.Lookup(name)
+		if !ok {
+			continue
+		}
+		specs = append(specs, map[string]any{"name": tool.Name, "description": tool.Description})
+	}
+	return specs
+}
+
+func appServerTurnTitle(in RunInput) string {
+	if in.Task.ID != "" && in.Task.Title != "" {
+		return in.Task.ID + ": " + in.Task.Title
+	}
+	if in.Task.Title != "" {
+		return in.Task.Title
+	}
+	return in.Task.ID
+}
+
+func extractString(m map[string]any, outer, inner string) (string, error) {
+	o, _ := m[outer].(map[string]any)
+	if o == nil {
+		return "", fmt.Errorf("missing %s", outer)
+	}
+	v, _ := o[inner].(string)
+	if v == "" {
+		return "", fmt.Errorf("missing %s.%s", outer, inner)
+	}
+	return v, nil
+}
+
+func numberID(v any) (int, bool) {
+	switch x := v.(type) {
+	case float64:
+		return int(x), true
+	case int:
+		return x, true
+	default:
+		return 0, false
+	}
+}
+
+func writeAppServerArtifact(workdir string, buf *cappedWriter) {
+	dir := filepath.Join(workdir, ".aiops")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	body := append([]byte{}, buf.Bytes()...)
+	if buf.Dropped() > 0 {
+		footer := fmt.Sprintf("\n...output truncated at %d bytes\n", CodexOutputCap)
+		body = append(body, []byte(footer)...)
+	}
+	_ = os.WriteFile(filepath.Join(workdir, codexAppServerOutputPath), body, 0o644)
+}

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -106,7 +106,7 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 
 func buildCodexAppServerCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
 	command := strings.TrimSpace(in.Workflow.Config.Codex.Command)
-	if command == "" {
+	if command == "" || command == "codex exec" {
 		command = "codex app-server"
 	}
 	fields := strings.Fields(command)
@@ -175,7 +175,10 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 		maxTurns = 20
 	}
 	for turn := 1; turn <= maxTurns; turn++ {
-		input := []map[string]any(nil)
+		input := []map[string]any{{
+			"type": "text",
+			"text": appServerContinuationPrompt(in, turn),
+		}}
 		if turn == 1 {
 			input = []map[string]any{{
 				"type": "text",
@@ -338,15 +341,36 @@ func (c *appServerClient) handleNotification(msg map[string]any) {
 func completedTurnError(msg map[string]any) error {
 	params, _ := msg["params"].(map[string]any)
 	status, _ := params["status"].(string)
+	if status == "" {
+		turn, _ := params["turn"].(map[string]any)
+		status, _ = turn["status"].(string)
+	}
 	status = strings.ToLower(strings.TrimSpace(status))
 	if status == "" || status == "completed" || status == "succeeded" || status == "success" {
 		return nil
 	}
 	reason := ""
-	for _, key := range []string{"reason", "error", "message"} {
-		if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
-			reason = strings.TrimSpace(v)
+	reasonSources := []map[string]any{params}
+	if turn, _ := params["turn"].(map[string]any); turn != nil {
+		reasonSources = append(reasonSources, turn)
+	}
+	for _, source := range reasonSources {
+		for _, key := range []string{"reason", "error", "message"} {
+			if v, _ := source[key].(string); strings.TrimSpace(v) != "" {
+				reason = strings.TrimSpace(v)
+				break
+			}
+		}
+		if reason != "" {
 			break
+		}
+	}
+	if reason == "" {
+		for _, key := range []string{"reason", "error", "message"} {
+			if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
+				reason = strings.TrimSpace(v)
+				break
+			}
 		}
 	}
 	if reason == "" {
@@ -437,6 +461,14 @@ func appServerTurnTitle(in RunInput) string {
 		return in.Task.Title
 	}
 	return in.Task.ID
+}
+
+func appServerContinuationPrompt(in RunInput, turn int) string {
+	subject := appServerTurnTitle(in)
+	if strings.TrimSpace(subject) == "" {
+		subject = "the current task"
+	}
+	return fmt.Sprintf("Continue working on %s. This is continuation turn %d; use the existing thread context, address any remaining requirements, and finish only when the task is complete.", subject, turn)
 }
 
 func extractString(m map[string]any, outer, inner string) (string, error) {

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -131,14 +131,17 @@ type appServerClient struct {
 	lastMessage    string
 	continueRun    bool
 	tools          DynamicToolSet
+	turnTimeoutMs  int
 	readTimeoutMs  int
 	stallTimeoutMs int
+	lastTerminal   time.Time
 }
 
 func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) error {
 	c.nextID = 1
 	c.continueRun = false
 	c.tools = DynamicToolsForWorkflow(workflow.Workflow{Config: in.Workflow.Config})
+	c.turnTimeoutMs = in.Workflow.Config.Codex.TurnTimeoutMs
 	c.readTimeoutMs = in.Workflow.Config.Codex.ReadTimeoutMs
 	c.stallTimeoutMs = in.Workflow.Config.Codex.StallTimeoutMs
 	if _, err := c.request(ctx, "initialize", map[string]any{
@@ -200,7 +203,19 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 			return fmt.Errorf("codex app-server turn/start: %w", err)
 		}
 		c.continueRun = false
-		if err := c.awaitTurnCompletion(ctx); err != nil {
+		turnCtx := ctx
+		var cancel context.CancelFunc
+		if c.turnTimeoutMs > 0 {
+			turnCtx, cancel = context.WithTimeout(ctx, time.Duration(c.turnTimeoutMs)*time.Millisecond)
+		}
+		err = c.awaitTurnCompletion(turnCtx)
+		if cancel != nil {
+			cancel()
+		}
+		if err != nil {
+			if c.turnTimeoutMs > 0 && errors.Is(err, context.DeadlineExceeded) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("codex app-server turn timeout after %dms", c.turnTimeoutMs)
+			}
 			return err
 		}
 		if !c.continueRun {
@@ -299,6 +314,7 @@ func (c *appServerClient) readLine(ctx context.Context) ([]byte, error) {
 }
 
 func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
+	c.lastTerminal = time.Now()
 	for {
 		msg, err := c.readMessage(ctx)
 		if err != nil {
@@ -315,10 +331,14 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 			case "turn/failed", "turn/cancelled":
 				return fmt.Errorf("%s: %v", method, msg["params"])
 			case "item/tool/call":
+				c.lastTerminal = time.Now()
 				if err := c.handleDynamicToolCall(ctx, msg); err != nil {
 					return err
 				}
 			default:
+				if c.stallTimeoutMs > 0 && time.Since(c.lastTerminal) > time.Duration(c.stallTimeoutMs)*time.Millisecond {
+					return fmt.Errorf("codex app-server stall timeout after %dms without terminal progress", c.stallTimeoutMs)
+				}
 				c.handleNotification(msg)
 			}
 		}

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -509,7 +509,11 @@ func appServerDynamicToolSpecs(cfg workflow.Config) []map[string]any {
 		if !ok {
 			continue
 		}
-		specs = append(specs, map[string]any{"name": tool.Name, "description": tool.Description})
+		schema := tool.InputSchema
+		if schema == nil {
+			schema = map[string]any{"type": "object"}
+		}
+		specs = append(specs, map[string]any{"name": tool.Name, "description": tool.Description, "inputSchema": schema})
 	}
 	return specs
 }

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -459,3 +459,77 @@ for line in sys.stdin:
 		t.Fatalf("Run error = %v, want app-server stall timeout", err)
 	}
 }
+
+func TestCodexAppServerRunnerReturnsTurnTimeoutWithoutWaitingForOuterContext(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json, time
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        time.sleep(2)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.TurnTimeoutMs = 25
+	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := (CodexAppServerRunner{}).Run(ctx, in)
+	elapsed := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "turn timeout") {
+		t.Fatalf("Run error = %v, want app-server turn timeout", err)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("Run elapsed %s, want return before outer context deadline", elapsed)
+	}
+}
+
+func TestCodexAppServerRunnerRepliesToUnsupportedServerRequests(t *testing.T) {
+	binDir := codexAppServerStubScript(t, `
+import json
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'jsonrpc': '2.0', 'id': 'approval-1', 'method': 'approval/request', 'params': {'reason': 'need approval'}}), flush=True)
+    elif msg.get('id') == 'approval-1':
+        result = msg.get('result', {})
+        if result.get('success') is not False or 'unsupported server request' not in result.get('output', ''):
+            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'unexpected unsupported request response', 'got': result}}), flush=True)
+            break
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'request rejected'}}), flush=True)
+        break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "request rejected" {
+		t.Fatalf("Summary = %q, want request rejected", res.Summary)
+	}
+	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stdin), `"id":"approval-1"`) || !strings.Contains(string(stdin), "unsupported server request") {
+		t.Fatalf("stdin did not include unsupported server request response: %s", stdin)
+	}
+}

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -153,6 +153,11 @@ for line in sys.stdin:
     if msg.get('method') == 'initialize':
         print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
     elif msg.get('method') == 'thread/start':
+        tools = msg.get('params', {}).get('dynamicTools', [])
+        linear = next((tool for tool in tools if tool.get('name') == 'linear_graphql'), None)
+        if linear is None or 'inputSchema' not in linear or 'query' not in linear.get('inputSchema', {}).get('properties', {}):
+            print(json.dumps({'id': msg['id'], 'error': {'message': 'linear_graphql missing inputSchema', 'tool': linear}}), flush=True)
+            break
         print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
     elif msg.get('method') == 'turn/start':
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -524,7 +524,12 @@ log=open(os.environ['CODEX_STDIN_LOG'], 'w')
 approval_methods = [
     ('approval-command', 'item/commandExecution/requestApproval', {'command': 'go test ./...'}, {'decision': 'acceptForSession'}),
     ('approval-file', 'item/fileChange/requestApproval', {'path': 'main.go'}, {'decision': 'acceptForSession'}),
-    ('approval-permissions', 'item/permissions/requestApproval', {'permissions': ['filesystem.write']}, {'permissions': ['filesystem.write']}),
+    (
+        'approval-permissions',
+        'item/permissions/requestApproval',
+        {'permissions': {'filesystem': {'write': True}, 'network': {'enabled': False}}},
+        {'permissions': {'filesystem': {'write': True}, 'network': {'enabled': False}}},
+    ),
 ]
 pending = list(approval_methods)
 for line in sys.stdin:
@@ -566,7 +571,7 @@ for line in sys.stdin:
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{`"decision":"acceptForSession"`, `"permissions":["filesystem.write"]`} {
+	for _, want := range []string{`"decision":"acceptForSession"`, `"permissions":{"filesystem":{"write":true},"network":{"enabled":false}}`} {
 		if !strings.Contains(string(stdin), want) {
 			t.Fatalf("stdin missing %s in approval responses: %s", want, stdin)
 		}

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -276,6 +276,31 @@ for line in sys.stdin:
 	}
 }
 
+func TestCodexAppServerRunnerTreatsInterruptedTurnCompletedAsSuccess(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'status': 'interrupted', 'lastAssistantMessage': 'cancelled cleanly'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v, want interrupted turn/completed to be a normal terminal state", err)
+	}
+	if res.Summary != "cancelled cleanly" {
+		t.Fatalf("Summary = %q, want interrupted turn summary", res.Summary)
+	}
+}
+
 func TestCodexAppServerRunnerUsesReadTimeout(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json, time
@@ -489,6 +514,62 @@ for line in sys.stdin:
 	}
 	if elapsed >= time.Second {
 		t.Fatalf("Run elapsed %s, want return before outer context deadline", elapsed)
+	}
+}
+
+func TestCodexAppServerRunnerRepliesToApprovalRequestsWithProtocolValidResults(t *testing.T) {
+	binDir := codexAppServerStubScript(t, `
+import json
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+approval_methods = [
+    ('approval-command', 'item/commandExecution/requestApproval', {'command': 'go test ./...'}, {'decision': 'acceptForSession'}),
+    ('approval-file', 'item/fileChange/requestApproval', {'path': 'main.go'}, {'decision': 'acceptForSession'}),
+    ('approval-permissions', 'item/permissions/requestApproval', {'permissions': ['filesystem.write']}, {'permissions': ['filesystem.write']}),
+]
+pending = list(approval_methods)
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        req_id, method, params, expected = pending.pop(0)
+        print(json.dumps({'jsonrpc': '2.0', 'id': req_id, 'method': method, 'params': params}), flush=True)
+    elif msg.get('id', '').startswith('approval-'):
+        req_id = msg['id']
+        expected = next(item[3] for item in approval_methods if item[0] == req_id)
+        if msg.get('result') != expected:
+            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'unexpected approval response', 'got': msg.get('result'), 'want': expected}}), flush=True)
+            break
+        if pending:
+            req_id, method, params, _expected = pending.pop(0)
+            print(json.dumps({'jsonrpc': '2.0', 'id': req_id, 'method': method, 'params': params}), flush=True)
+        else:
+            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'approvals handled'}}), flush=True)
+            break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "approvals handled" {
+		t.Fatalf("Summary = %q, want approvals handled", res.Summary)
+	}
+	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"decision":"acceptForSession"`, `"permissions":["filesystem.write"]`} {
+		if !strings.Contains(string(stdin), want) {
+			t.Fatalf("stdin missing %s in approval responses: %s", want, stdin)
+		}
 	}
 }
 

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1,0 +1,254 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func appServerInput(workdir string) RunInput {
+	return RunInput{
+		Task: task.Task{ID: "AIOPS-64", Title: "Wire Codex app-server", Model: "codex-app-server"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Agent: workflow.AgentConfig{MaxTurns: 8},
+			Codex: workflow.CommandConfig{
+				Command:        "codex app-server",
+				ApprovalPolicy: "never",
+				ThreadSandbox:  "workspace-write",
+				TurnSandboxPolicy: map[string]any{
+					"mode": "workspace-write",
+				},
+				TurnTimeoutMs:  1000,
+				ReadTimeoutMs:  100,
+				StallTimeoutMs: 1000,
+			},
+		}},
+		Workdir: workdir,
+		Prompt:  "ignored — runner reads .aiops/PROMPT.md",
+	}
+}
+
+func codexAppServerStubScript(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "codex")
+	header := `#!/usr/bin/env python3
+import os, sys
+with open(os.environ['CODEX_ARGV_LOG'], 'w') as f:
+    f.write('\n'.join(sys.argv[1:]))
+    f.write('\n')
+`
+	if err := os.WriteFile(scriptPath, []byte(header+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CODEX_ARGV_LOG", filepath.Join(dir, "argv.txt"))
+	t.Setenv("CODEX_STDIN_LOG", filepath.Join(dir, "stdin.txt"))
+	return dir
+}
+
+func TestNewSupportsCodexAppServerRunner(t *testing.T) {
+	r, err := New("codex-app-server")
+	if err != nil {
+		t.Fatalf("New(codex-app-server): %v", err)
+	}
+	if _, ok := r.(CodexAppServerRunner); !ok {
+		t.Fatalf("New(codex-app-server) = %T, want CodexAppServerRunner", r)
+	}
+}
+
+func TestCodexAppServerRunnerSendsInitializeThreadAndTurn(t *testing.T) {
+	binDir := codexAppServerStubScript(t, `
+import json
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {'protocolVersion': '0.1.0'}}), flush=True)
+    elif method == 'initialized':
+        pass
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'turnId': 'turn-1', 'lastAssistantMessage': 'done via app server'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "app-server prompt canary")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "done via app server" {
+		t.Fatalf("Summary = %q, want app-server completion summary", res.Summary)
+	}
+
+	argv, err := os.ReadFile(filepath.Join(binDir, "argv.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(argv)); got != "app-server" {
+		t.Fatalf("codex argv = %q, want app-server", got)
+	}
+
+	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var messages []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(stdin)), "\n") {
+		if line == "" {
+			continue
+		}
+		var msg map[string]any
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			t.Fatalf("decode stdin JSON line %q: %v", line, err)
+		}
+		messages = append(messages, msg)
+	}
+	if len(messages) != 4 {
+		t.Fatalf("sent %d messages, want initialize/initialized/thread/start/turn/start; stdin=%s", len(messages), stdin)
+	}
+	if messages[0]["method"] != "initialize" || messages[1]["method"] != "initialized" || messages[2]["method"] != "thread/start" || messages[3]["method"] != "turn/start" {
+		t.Fatalf("unexpected method sequence: %#v", messages)
+	}
+	threadParams := messages[2]["params"].(map[string]any)
+	if threadParams["cwd"] != wd {
+		t.Fatalf("thread cwd = %#v, want %q", threadParams["cwd"], wd)
+	}
+	if threadParams["approvalPolicy"] != "never" {
+		t.Fatalf("approvalPolicy = %#v, want never", threadParams["approvalPolicy"])
+	}
+	if threadParams["sandbox"] != "workspace-write" {
+		t.Fatalf("sandbox = %#v, want workspace-write", threadParams["sandbox"])
+	}
+	turnParams := messages[3]["params"].(map[string]any)
+	input := turnParams["input"].([]any)[0].(map[string]any)
+	if input["text"] != "app-server prompt canary" {
+		t.Fatalf("turn prompt text = %#v, want prompt file contents", input["text"])
+	}
+	if turnParams["title"] != "AIOPS-64: Wire Codex app-server" {
+		t.Fatalf("turn title = %#v", turnParams["title"])
+	}
+}
+
+func TestCodexAppServerRunnerDoesNotPutLinearTokenOnWire(t *testing.T) {
+	secret := "lin_api_secret_should_not_leak"
+	binDir := codexAppServerStubScript(t, `
+import json
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Tracker = workflow.TrackerConfig{Kind: "linear", APIKey: secret}
+
+	_, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(stdin), secret) {
+		t.Fatalf("app-server stdin leaked tracker api key: %s", stdin)
+	}
+}
+
+func TestCodexAppServerRunnerHandlesDynamicToolCallsAndContinuesSession(t *testing.T) {
+	binDir := codexAppServerStubScript(t, `
+import json
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'jsonrpc': '2.0', 'id': 'call-1', 'method': 'item/tool/call', 'params': {'name': 'missing_tool', 'arguments': {'query': 'query { viewer { id } }'}}}), flush=True)
+    elif msg.get('id') == 'call-1':
+        result=msg.get('result', {})
+        if result.get('success') is not False or 'unsupported dynamic tool' not in result.get('output', ''):
+            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'unsupported tool did not return structured failure', 'got': result}}), flush=True)
+            break
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'continued after unsupported tool'}}), flush=True)
+        break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "x")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "continued after unsupported tool" {
+		t.Fatalf("Summary = %q, want continued turn completion", res.Summary)
+	}
+	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stdin), `"id":"call-1"`) || !strings.Contains(string(stdin), `"success":false`) {
+		t.Fatalf("stdin did not include structured unsupported-tool response: %s", stdin)
+	}
+}
+
+func TestCodexAppServerRunnerHonorsMaxTurnsForContinuationRequests(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+turns=0
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        turns += 1
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
+        if turns < 3:
+            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'needs another turn', 'continue': True}}), flush=True)
+        else:
+            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'done after turn 3'}}), flush=True)
+            break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Agent.MaxTurns = 3
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "done after turn 3" {
+		t.Fatalf("Summary = %q, want final third-turn summary", res.Summary)
+	}
+}

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -250,5 +251,54 @@ for line in sys.stdin:
 	}
 	if res.Summary != "done after turn 3" {
 		t.Fatalf("Summary = %q, want final third-turn summary", res.Summary)
+	}
+}
+
+func TestCodexAppServerRunnerTreatsFailedTurnCompletedAsError(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'status': 'failed', 'reason': 'tool crashed'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+
+	_, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err == nil || !strings.Contains(err.Error(), "turn/completed failed") || !strings.Contains(err.Error(), "tool crashed") {
+		t.Fatalf("Run error = %v, want failed turn/completed error with reason", err)
+	}
+}
+
+func TestCodexAppServerRunnerUsesReadTimeout(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json, time
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        time.sleep(2)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.ReadTimeoutMs = 25
+	in.Workflow.Config.Codex.StallTimeoutMs = 5000
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := (CodexAppServerRunner{}).Run(ctx, in)
+	if err == nil || !strings.Contains(err.Error(), "read timeout") {
+		t.Fatalf("Run error = %v, want app-server read timeout", err)
 	}
 }

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -26,7 +26,7 @@ func appServerInput(workdir string) RunInput {
 					"mode": "workspace-write",
 				},
 				TurnTimeoutMs:  1000,
-				ReadTimeoutMs:  100,
+				ReadTimeoutMs:  1000,
 				StallTimeoutMs: 1000,
 			},
 		}},

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -402,3 +402,60 @@ func TestBuildCodexAppServerCmdUsesAppServerWhenDefaultCodexExecCommandIsUnchang
 		t.Fatalf("cmd.Args = %#v, want codex app-server", cmd.Args)
 	}
 }
+
+func TestCodexAppServerRunnerUsesTurnTimeout(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json, time
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        time.sleep(2)
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'too late'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.TurnTimeoutMs = 25
+	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := (CodexAppServerRunner{}).Run(ctx, in)
+	if err == nil || !strings.Contains(err.Error(), "turn timeout") {
+		t.Fatalf("Run error = %v, want app-server turn timeout", err)
+	}
+}
+
+func TestCodexAppServerRunnerUsesStallTimeoutForNonTerminalTraffic(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json, time
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        for i in range(20):
+            print(json.dumps({'method': 'item/updated', 'params': {'message': 'progress %d' % i}}), flush=True)
+            time.sleep(0.02)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
+	in.Workflow.Config.Codex.StallTimeoutMs = 25
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := (CodexAppServerRunner{}).Run(ctx, in)
+	if err == nil || !strings.Contains(err.Error(), "stall timeout") {
+		t.Fatalf("Run error = %v, want app-server stall timeout", err)
+	}
+}

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -302,3 +302,103 @@ for line in sys.stdin:
 		t.Fatalf("Run error = %v, want app-server read timeout", err)
 	}
 }
+
+func TestCodexAppServerRunnerTreatsNestedFailedTurnCompletedAsError(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'turn': {'status': 'failed', 'error': 'nested tool failure'}}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+
+	_, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err == nil || !strings.Contains(err.Error(), "turn/completed failed") || !strings.Contains(err.Error(), "nested tool failure") {
+		t.Fatalf("Run error = %v, want nested failed turn/completed error with reason", err)
+	}
+}
+
+func TestCodexAppServerRunnerSendsContinuationInputAfterContinueRequest(t *testing.T) {
+	binDir := codexAppServerStubScript(t, `
+import json
+turns=0
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        turns += 1
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
+        if turns == 1:
+            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'needs follow-up', 'continue': True}}), flush=True)
+        else:
+            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'done'}}), flush=True)
+            break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Agent.MaxTurns = 2
+
+	_, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var turnInputs []any
+	for _, line := range strings.Split(strings.TrimSpace(string(stdin)), "\n") {
+		if line == "" {
+			continue
+		}
+		var msg map[string]any
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			t.Fatalf("decode stdin JSON line %q: %v", line, err)
+		}
+		if msg["method"] == "turn/start" {
+			params := msg["params"].(map[string]any)
+			turnInputs = append(turnInputs, params["input"])
+		}
+	}
+	if len(turnInputs) != 2 {
+		t.Fatalf("turn/start count = %d, want 2", len(turnInputs))
+	}
+	items, ok := turnInputs[1].([]any)
+	if !ok || len(items) == 0 {
+		t.Fatalf("second turn input = %#v, want non-empty continuation guidance items", turnInputs[1])
+	}
+	text, _ := items[0].(map[string]any)["text"].(string)
+	if !strings.Contains(strings.ToLower(text), "continue") || !strings.Contains(text, "AIOPS-64") {
+		t.Fatalf("continuation text = %q, want task-specific continuation guidance", text)
+	}
+}
+
+func TestBuildCodexAppServerCmdUsesAppServerWhenDefaultCodexExecCommandIsUnchanged(t *testing.T) {
+	codexAppServerStubScript(t, `
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.Command = "codex exec"
+
+	cmd, err := buildCodexAppServerCmd(context.Background(), in)
+	if err != nil {
+		t.Fatalf("buildCodexAppServerCmd: %v", err)
+	}
+	if len(cmd.Args) < 2 || cmd.Args[0] != "codex" || cmd.Args[1] != "app-server" {
+		t.Fatalf("cmd.Args = %#v, want codex app-server", cmd.Args)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -35,6 +35,8 @@ func New(name string) (Runner, error) {
 		return MockRunner{}, nil
 	case "codex":
 		return CodexRunner{}, nil
+	case "codex-app-server":
+		return CodexAppServerRunner{}, nil
 	case "claude":
 		return ShellRunner{Name: "claude"}, nil
 	default:

--- a/internal/runner/shell_unix.go
+++ b/internal/runner/shell_unix.go
@@ -16,18 +16,22 @@ import (
 func configurePlatformKill(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		// Negative pid targets the process group leader created above.
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-		// Backstop: if the group is still alive after killGrace, send
-		// SIGKILL to the whole group. cmd.WaitDelay only handles the
-		// direct child; grandchildren can survive otherwise.
-		go func(pid int) {
-			time.Sleep(killGrace)
-			_ = syscall.Kill(-pid, syscall.SIGKILL)
-		}(cmd.Process.Pid)
+		terminateProcess(cmd)
 		return nil
 	}
+}
+
+func terminateProcess(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	// Negative pid targets the process group leader created above.
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	// Backstop: if the group is still alive after killGrace, send
+	// SIGKILL to the whole group. cmd.WaitDelay only handles the
+	// direct child; grandchildren can survive otherwise.
+	go func(pid int) {
+		time.Sleep(killGrace)
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}(cmd.Process.Pid)
 }

--- a/internal/runner/shell_windows.go
+++ b/internal/runner/shell_windows.go
@@ -10,3 +10,10 @@ import "os/exec"
 // Job-object based group kill could be added later if Windows worker
 // hosting becomes a real target.
 func configurePlatformKill(_ *exec.Cmd) {}
+
+func terminateProcess(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+}

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -28,6 +28,7 @@ type ToolCall struct {
 type DynamicTool struct {
 	Name        string
 	Description string
+	InputSchema map[string]any
 	Call        func(context.Context, ToolCall) (string, error)
 }
 
@@ -77,7 +78,23 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 		tools.tools["linear_graphql"] = DynamicTool{
 			Name:        "linear_graphql",
 			Description: "Execute a raw Linear GraphQL query or mutation using the orchestrator-configured Linear auth. Input: {query:string, variables?:object}. The Linear API token is never exposed to the agent process.",
-			Call:        client.call,
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{
+						"type":        "string",
+						"description": "A single Linear GraphQL query or mutation.",
+					},
+					"variables": map[string]any{
+						"type":                 "object",
+						"description":          "Optional GraphQL variables object.",
+						"additionalProperties": true,
+					},
+				},
+				"required":             []string{"query"},
+				"additionalProperties": false,
+			},
+			Call: client.call,
 		}
 	}
 	return tools

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -61,6 +61,13 @@ func TestDynamicToolsExposeLinearGraphQLWithTokenIsolation(t *testing.T) {
 	if strings.Contains(tool.Description, token) {
 		t.Fatalf("tool description leaked Linear token: %q", tool.Description)
 	}
+	schemaBytes, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("tool input schema is not JSON-marshalable: %v", err)
+	}
+	if !strings.Contains(string(schemaBytes), `"query"`) || strings.Contains(string(schemaBytes), token) {
+		t.Fatalf("tool input schema = %s, want query field and no token leak", schemaBytes)
+	}
 
 	proxy := linearGraphQLProxy{apiKey: token, baseURL: httpServer.URL, http: httpServer.Client()}
 	result, err := proxy.call(context.Background(), ToolCall{

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -92,6 +92,16 @@ type CommandConfig struct {
 	// copy-paste mistake fails loud at load time instead of silently doing
 	// nothing.
 	Profile string `yaml:"profile,omitempty" json:"profile,omitempty"`
+	// App-server runtime settings mirror the Symphony/Codex app-server
+	// protocol fields. They are pass-through values for the Codex runtime,
+	// so the loader validates only presence/timeout bounds rather than
+	// maintaining Codex-owned enums.
+	ApprovalPolicy    any            `yaml:"approval_policy,omitempty" json:"approval_policy,omitempty"`
+	ThreadSandbox     string         `yaml:"thread_sandbox,omitempty" json:"thread_sandbox,omitempty"`
+	TurnSandboxPolicy map[string]any `yaml:"turn_sandbox_policy,omitempty" json:"turn_sandbox_policy,omitempty"`
+	TurnTimeoutMs     int            `yaml:"turn_timeout_ms,omitempty" json:"turn_timeout_ms,omitempty"`
+	ReadTimeoutMs     int            `yaml:"read_timeout_ms,omitempty" json:"read_timeout_ms,omitempty"`
+	StallTimeoutMs    int            `yaml:"stall_timeout_ms,omitempty" json:"stall_timeout_ms,omitempty"`
 }
 
 type PolicyConfig struct {
@@ -195,10 +205,18 @@ func DefaultConfig() Config {
 		Agent: AgentConfig{
 			Default:             "mock",
 			MaxConcurrentAgents: 1,
-			MaxTurns:            8,
+			MaxTurns:            20,
 			Timeout:             30 * time.Minute,
 		},
-		Codex:  CommandConfig{Command: "codex exec", Profile: "safe"},
+		Codex: CommandConfig{
+			Command:        "codex exec",
+			Profile:        "safe",
+			ApprovalPolicy: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true, "mcp_elicitations": true}},
+			ThreadSandbox:  "workspace-write",
+			TurnTimeoutMs:  3600000,
+			ReadTimeoutMs:  5000,
+			StallTimeoutMs: 300000,
+		},
 		Claude: CommandConfig{Command: "claude"},
 		Policy: PolicyConfig{Mode: "draft_pr", MaxChangedFiles: 12, MaxChangedLOC: 300},
 		Verify: VerifyConfig{Commands: []string{}},

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -631,3 +631,92 @@ prompt
 		t.Fatalf("error = %q; want it to mention claude.profile", err)
 	}
 }
+
+func TestLoad_AcceptsCodexAppServerRunnerAndRuntimeSettings(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex-app-server
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    mode: workspace-write
+  turn_timeout_ms: 120000
+  read_timeout_ms: 250
+  stall_timeout_ms: 0
+---
+prompt
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if wf.Config.Agent.Default != "codex-app-server" {
+		t.Fatalf("Agent.Default = %q, want codex-app-server", wf.Config.Agent.Default)
+	}
+	if wf.Config.Codex.Command != "codex app-server" {
+		t.Fatalf("Codex.Command = %q, want codex app-server", wf.Config.Codex.Command)
+	}
+	if wf.Config.Codex.ApprovalPolicy != "never" {
+		t.Fatalf("Codex.ApprovalPolicy = %#v, want never", wf.Config.Codex.ApprovalPolicy)
+	}
+	if wf.Config.Codex.ThreadSandbox != "workspace-write" {
+		t.Fatalf("Codex.ThreadSandbox = %q, want workspace-write", wf.Config.Codex.ThreadSandbox)
+	}
+	if got := wf.Config.Codex.TurnSandboxPolicy["mode"]; got != "workspace-write" {
+		t.Fatalf("Codex.TurnSandboxPolicy[mode] = %#v, want workspace-write", got)
+	}
+	if wf.Config.Codex.TurnTimeoutMs != 120000 || wf.Config.Codex.ReadTimeoutMs != 250 || wf.Config.Codex.StallTimeoutMs != 0 {
+		t.Fatalf("Codex timeouts = turn %d read %d stall %d, want 120000/250/0", wf.Config.Codex.TurnTimeoutMs, wf.Config.Codex.ReadTimeoutMs, wf.Config.Codex.StallTimeoutMs)
+	}
+}
+
+func TestDefaultConfig_CodexAppServerDefaultsPreserveOneShotCommand(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	if cfg.Codex.Command != "codex exec" {
+		t.Fatalf("Default Codex.Command = %q, want legacy codex exec", cfg.Codex.Command)
+	}
+	if cfg.Agent.MaxTurns != 20 {
+		t.Fatalf("Default Agent.MaxTurns = %d, want Symphony default 20", cfg.Agent.MaxTurns)
+	}
+	if cfg.Codex.ThreadSandbox != "workspace-write" {
+		t.Fatalf("Default Codex.ThreadSandbox = %q, want workspace-write", cfg.Codex.ThreadSandbox)
+	}
+	if cfg.Codex.TurnTimeoutMs != 3600000 || cfg.Codex.ReadTimeoutMs != 5000 || cfg.Codex.StallTimeoutMs != 300000 {
+		t.Fatalf("Codex timeout defaults = turn %d read %d stall %d", cfg.Codex.TurnTimeoutMs, cfg.Codex.ReadTimeoutMs, cfg.Codex.StallTimeoutMs)
+	}
+}
+
+func TestLoad_RejectsInvalidCodexAppServerTimeouts(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+agent:
+  default: codex-app-server
+codex:
+  turn_timeout_ms: 0
+  read_timeout_ms: 0
+  stall_timeout_ms: -1
+---
+prompt
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: expected error for invalid codex app-server timeouts, got nil")
+	}
+	for _, want := range []string{"codex.turn_timeout_ms", "codex.read_timeout_ms", "codex.stall_timeout_ms"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q; want substring %q", err, want)
+		}
+	}
+}

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -62,9 +62,10 @@ var supportedTrackerKinds = map[string]struct{}{
 // claimed and the workspace prepared — into a load-time configuration
 // error with the workflow file path attached.
 var supportedAgentDefaults = map[string]struct{}{
-	"mock":   {},
-	"codex":  {},
-	"claude": {},
+	"mock":             {},
+	"codex":            {},
+	"codex-app-server": {},
+	"claude":           {},
 }
 
 // supportedCodexProfiles enumerates the codex runner profile names the
@@ -92,13 +93,26 @@ func validateConfig(path string, cfg Config) error {
 		return fmt.Errorf("%s: tracker.kind %q is not supported (allowed: gitea, linear)", path, cfg.Tracker.Kind)
 	}
 	if _, ok := supportedAgentDefaults[cfg.Agent.Default]; !ok {
-		return fmt.Errorf("%s: agent.default %q is not supported (allowed: mock, codex, claude)", path, cfg.Agent.Default)
+		return fmt.Errorf("%s: agent.default %q is not supported (allowed: mock, codex, codex-app-server, claude)", path, cfg.Agent.Default)
 	}
 	if _, ok := supportedCodexProfiles[cfg.Codex.Profile]; !ok {
 		return fmt.Errorf("%s: codex.profile %q is not supported (allowed: safe, bypass, custom)", path, cfg.Codex.Profile)
 	}
 	if strings.TrimSpace(cfg.Claude.Profile) != "" {
 		return fmt.Errorf("%s: claude.profile is not supported (only codex has profiles)", path)
+	}
+	var invalid []string
+	if cfg.Codex.TurnTimeoutMs <= 0 {
+		invalid = append(invalid, "codex.turn_timeout_ms")
+	}
+	if cfg.Codex.ReadTimeoutMs <= 0 {
+		invalid = append(invalid, "codex.read_timeout_ms")
+	}
+	if cfg.Codex.StallTimeoutMs < 0 {
+		invalid = append(invalid, "codex.stall_timeout_ms")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("%s: invalid codex app-server timeout settings: %s", path, strings.Join(invalid, ", "))
 	}
 	return nil
 }
@@ -201,6 +215,12 @@ func expandConfig(cfg *Config) {
 	}
 	if cfg.Codex.Profile == "" {
 		cfg.Codex.Profile = "safe"
+	}
+	if cfg.Codex.ThreadSandbox == "" {
+		cfg.Codex.ThreadSandbox = "workspace-write"
+	}
+	if cfg.Codex.ApprovalPolicy == nil {
+		cfg.Codex.ApprovalPolicy = map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true, "mcp_elicitations": true}}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add the `codex-app-server` runner and wire it into runner selection / workflow schema validation.
- Implement JSON-RPC stdio lifecycle for `codex app-server`: initialize, thread/start, turn/start, dynamic tool callbacks, continuation turns, timeout/error propagation, and capped output artifact capture.
- Add app-server config defaults for approval policy, sandbox, and read/turn/stall timeout settings while preserving token isolation for dynamic tools.

## Test Plan
- `/home/pi/.local/go1.25.10/bin/go test ./internal/runner ./internal/workflow`
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- `/home/pi/.local/go1.25.10/bin/gofmt -l $(git ls-files '*.go') internal/runner/codex_app_server.go internal/runner/codex_app_server_test.go`
- `/home/pi/.local/go1.25.10/bin/go mod tidy && git diff --exit-code -- go.mod go.sum`
- `/home/pi/.local/go1.25.10/bin/go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`

Closes #64
