### PR TITLE
docs: document sandbox security posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,18 @@ agent:
 
 ## Safety notes
 
+See [`docs/security-posture.md`](docs/security-posture.md) for the current
+sandbox model, threat model, and operator checklist. In short: this platform
+currently relies on the coding agent's own sandbox/approval behavior, such as
+Codex CLI's sandbox selected by `codex.profile`; it does not yet add OS-level,
+container, VM, or network-egress isolation around the agent process.
+
+- Do not use this platform against untrusted issue authors, untrusted
+  repositories, or shared production secrets until external sandboxing and
+  per-run credential scoping are implemented.
 - Keep branch protection enabled.
 - The agent opens PRs through its workflow/tool surface; the worker does not
   push, open, or merge PRs.
-- Use a low-privilege bot account for Gitea.
+- Use a low-privilege bot account for Git hosting and tracker access.
 - Keep company repositories in draft-PR or analysis-only mode until the workflow is trusted.
 - Do not commit real credentials to `.env`, `.env.example`, or `WORKFLOW.md`.

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -1,0 +1,159 @@
+# Security posture
+
+This runbook documents the current safety model for `aiops-platform` and the
+controls operators should apply before connecting it to real repositories or
+trackers. It is intentionally conservative: OpenAI Symphony SPEC §15 treats
+harness hardening as part of the core safety model, not as an optional add-on.
+
+## Current sandbox model
+
+`aiops-platform` currently relies on the selected coding agent's own sandbox and
+approval behavior. For Codex runs, that means the Codex CLI sandbox selected by
+`codex.profile` in `WORKFLOW.md`.
+
+The platform does not currently add an external OS, container, VM, or network
+sandbox around the agent process. In particular, it does not yet provide:
+
+- bubblewrap, firejail, `sandbox-exec`, or VM isolation;
+- Docker-per-run workspace isolation;
+- a sandbox-layer network egress allowlist;
+- a filesystem allowlist beyond the workspace and policy checks already wired in
+  the worker;
+- a credential vault that mints per-run credentials.
+
+This is the tracked D5 deviation: the present posture is acceptable for personal
+repositories and trusted internal codebases where the operator understands the
+risk, but it is not a hardened untrusted-code execution environment.
+
+## Trust boundary
+
+Treat all of these inputs as potentially hostile unless you control them:
+
+- issue titles, descriptions, comments, and labels;
+- repository contents, build scripts, dependency install hooks, tests, and
+  generated files;
+- `WORKFLOW.md` prompt text and hooks;
+- tool arguments passed to client-side tools such as tracker or PR APIs.
+
+The worker creates or reuses a per-issue workspace and runs the coding agent with
+that workspace as the current directory. Workspace path validation is a baseline
+control and must keep workspaces under the configured workspace root, but SPEC
+§15.1 is explicit that path validation is not a substitute for approval policy,
+credential scoping, or external sandboxing.
+
+## What is defended today
+
+The current Go implementation provides these safety controls:
+
+- per-issue workspaces under a configured workspace root;
+- sanitized workspace identifiers;
+- coding-agent execution from the per-issue workspace directory;
+- workflow-configured policy limits such as `deny_paths`, `max_changed_files`,
+  and `max_changed_loc`;
+- draft-PR mode for human review before merge;
+- `$VAR` indirection for secrets in workflow configuration;
+- masking of secret values in configuration inspection output;
+- optional pre-push secret scanning;
+- branch protection and review gates when configured on the remote repository.
+
+These controls reduce accidental damage and make changes reviewable. They do not
+make arbitrary repositories, issue authors, dependencies, or commands safe.
+
+## What is not defended today
+
+Until an external sandbox layer exists, do not assume the platform prevents a
+malicious or compromised agent run from:
+
+- reading host files that are accessible to the worker OS user;
+- reading credentials present in the process environment or filesystem;
+- making arbitrary outbound network connections allowed by the host;
+- running destructive commands as the worker OS user;
+- executing malicious dependency lifecycle hooks or test scripts;
+- exfiltrating repository, tracker, or environment data through logs, PR text,
+  tracker comments, or network requests;
+- mutating repositories or trackers beyond what the configured credentials can
+  access.
+
+A prompt-injection in a trusted-looking issue or repository can still try to
+convince the agent to use its available tools unsafely. Keep the available tools,
+credentials, filesystem paths, and network destinations to the minimum needed
+for the workflow.
+
+## Explicit untrusted-use warning
+
+Do not use this platform against untrusted issue authors, untrusted repositories,
+unreviewed third-party dependency trees, or shared production secrets. If you
+need that deployment model, first add and validate an external sandbox such as a
+container, VM, bubblewrap, or firejail profile plus network egress controls and
+per-run credential scoping.
+
+## Operator checklist
+
+Before pointing `aiops-platform` at any repository, especially a company
+repository:
+
+1. Use a dedicated low-privilege bot account for Git hosting and tracker access.
+   Grant only the repositories, projects, teams, and labels needed for the
+   workflow.
+2. Keep branch protection enabled on the default branch. Require human review and
+   passing CI before merge.
+3. Keep `policy.mode: draft_pr` and `pr.draft: true` until several runs have
+   been reviewed cleanly.
+4. Start with `agent.default: mock`. Only switch to a real coding agent after the
+   mock loop has proven clone, branch, PR, label, and policy behavior.
+5. Do not pass shared production secrets, broad cloud credentials, personal
+   tokens, SSH agents, or customer data into the worker environment or workspace.
+6. Keep `.env`, `.env.*`, private keys, and service-account files outside the
+   repository and workspace unless a specific run absolutely requires them.
+7. Configure `policy.deny_paths` for sensitive directories such as deployment
+   manifests, infrastructure, migrations, billing, auth, and secrets.
+8. Keep `policy.max_changed_files` and `policy.max_changed_loc` small enough for
+   reliable review.
+9. Restrict tracker eligibility to trusted projects, teams, labels, and workflow
+   states. Do not let arbitrary tracker items automatically reach the agent.
+10. Prefer project-scoped tracker tools. If `linear_graphql` is available, scope
+    credentials and prompts so it only operates on the intended project.
+11. Review every agent-authored PR before merge, including generated files,
+    workflow changes, dependency updates, and scripts run by CI.
+12. Enable the optional secret-scan hook where practical; see
+    `docs/runbooks/secret-scanning.md`.
+13. Run workers under a dedicated OS user and keep the workspace root permissions
+    restricted to that user.
+14. Treat logs, run summaries, PR bodies, and tracker comments as data exfiltration
+    surfaces. Do not include raw secrets or customer data.
+
+## Company repository minimum posture
+
+For company repositories, use `docs/workflows/company-cautious-WORKFLOW.md` as the
+starting point and keep the following minimum posture until an external sandbox
+lands:
+
+- `agent.default: mock` for initial validation;
+- `policy.mode: draft_pr`;
+- `pr.draft: true`;
+- conservative changed-file and changed-LOC limits;
+- explicit denied paths for sensitive directories;
+- low-privilege bot credentials;
+- branch protection with required human review;
+- no shared secrets in the worker environment or workspace.
+
+If any item above is not available, do not run the coding agent on that company
+repository yet. Use mock or analysis-only workflows instead.
+
+## Phase 2 hardening roadmap
+
+The next enforcement phase should add optional external isolation rather than
+expanding the trust boundary of the current host process. Planned work includes:
+
+- a Linux sandbox wrapper such as bubblewrap or firejail around the agent
+  invocation;
+- Docker-based workspace isolation as an alternative to bare-filesystem
+  workspaces;
+- network egress allowlists enforced by the sandbox layer;
+- a documented way to pass only the minimum credentials needed by the run;
+- validation that the agent cwd and workspace path remain under the configured
+  workspace root after isolation is applied.
+
+Until those controls are implemented and tested, document this platform as a
+trusted-environment orchestrator with review and policy guardrails, not as a
+strong sandbox for untrusted code.

--- a/docs/workflows/company-cautious-WORKFLOW.md
+++ b/docs/workflows/company-cautious-WORKFLOW.md
@@ -62,6 +62,28 @@ policy:
   max_changed_files: 8
   max_changed_loc: 200
 
+# Safety policy for cautious company runs. These entries make the expected
+# network/path/command envelope explicit for the agent and reviewers; sandbox
+# enforcement beyond `policy.deny_paths` is still a separate hardening phase.
+safety:
+  allowed_networks:
+    - company Git host for this repository
+    - configured Linear/Gitea tracker API
+    - configured pull-request host
+    - package registries required by the repository lockfiles
+  allowed_paths:
+    - repository workspace for this task
+    - tool caches without shared credentials
+  allowed_commands:
+    - repository build, test, lint, and formatting commands
+    - git commands for the work branch
+    - tracker/PR tool calls needed for draft handoff
+  forbidden:
+    - reading files outside the workspace unless explicitly required
+    - using production, customer, or personal credentials
+    - contacting unrelated external services
+    - modifying denied policy paths
+
 verify:
   commands:
     - go test ./...

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -59,6 +59,27 @@ policy:
   max_changed_files: 12
   max_changed_loc: 300
 
+# Safety policy for the agent and human reviewers. The current worker records
+# these expectations in the repository-owned workflow, but network/path/command
+# enforcement beyond `policy.deny_paths` remains a Phase 2 hardening item.
+safety:
+  allowed_networks:
+    - git remote for this repository
+    - configured issue tracker API
+    - configured pull-request host
+  allowed_paths:
+    - repository workspace for this task
+    - language/tool caches that do not contain shared credentials
+  allowed_commands:
+    - repository build, test, lint, and formatting commands
+    - git commands needed to commit and push the work branch
+    - tracker/PR tool calls needed for the workflow handoff
+  forbidden:
+    - reading host files outside the workspace unless explicitly required
+    - using shared production secrets or personal credentials
+    - contacting unrelated external services
+    - changing deployment, infrastructure, migration, or secret paths
+
 verify:
   commands:
     - go test ./...

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Codex     CommandConfig   `yaml:"codex" json:"codex"`
 	Claude    CommandConfig   `yaml:"claude" json:"claude"`
 	Policy    PolicyConfig    `yaml:"policy" json:"policy"`
+	Safety    SafetyConfig    `yaml:"safety" json:"safety"`
 	Verify    VerifyConfig    `yaml:"verify" json:"verify"`
 	PR        PRConfig        `yaml:"pr" json:"pr"`
 }
@@ -123,6 +124,16 @@ func (p PolicyConfig) LineLimit() int {
 		return p.MaxChangedLines
 	}
 	return p.MaxChangedLOC
+}
+
+// SafetyConfig documents the policy envelope operators expect agents and
+// reviewers to honor. It is intentionally descriptive in this phase: enforcement
+// beyond PolicyConfig remains a separate sandbox-hardening task.
+type SafetyConfig struct {
+	AllowedNetworks []string `yaml:"allowed_networks" json:"allowed_networks"`
+	AllowedPaths    []string `yaml:"allowed_paths" json:"allowed_paths"`
+	AllowedCommands []string `yaml:"allowed_commands" json:"allowed_commands"`
+	Forbidden       []string `yaml:"forbidden" json:"forbidden"`
 }
 
 type VerifyConfig struct {

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -629,6 +630,43 @@ prompt
 	}
 	if !strings.Contains(err.Error(), "claude.profile") {
 		t.Fatalf("error = %q; want it to mention claude.profile", err)
+	}
+}
+
+func TestLoad_PreservesSafetyPolicyForOperatorInspection(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+safety:
+  allowed_networks:
+    - git remote for this repository
+  allowed_paths:
+    - repository workspace for this task
+  allowed_commands:
+    - go test ./...
+  forbidden:
+    - reading host files outside the workspace
+---
+prompt
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := wf.Config.Safety.AllowedNetworks, []string{"git remote for this repository"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Safety.AllowedNetworks = %#v, want %#v", got, want)
+	}
+	if got, want := wf.Config.Safety.AllowedPaths, []string{"repository workspace for this task"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Safety.AllowedPaths = %#v, want %#v", got, want)
+	}
+	if got, want := wf.Config.Safety.AllowedCommands, []string{"go test ./..."}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Safety.AllowedCommands = %#v, want %#v", got, want)
+	}
+	if got, want := wf.Config.Safety.Forbidden, []string{"reading host files outside the workspace"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Safety.Forbidden = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a security posture runbook documenting the current Codex-only sandbox model, threat model, and operator checklist.
- Add explicit safety policy sections to the example and company-cautious WORKFLOW templates.
- Link README safety notes to the new runbook and warn against untrusted issue authors/repos until external sandboxing lands.

## Test Plan
- `gofmt -l $(git ls-files '*.go')`
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- `/home/pi/.local/go1.25.10/bin/go mod tidy && git diff --exit-code -- go.mod go.sum`
- `/home/pi/.local/go1.25.10/bin/go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`

Closes #70
