### PR TITLE
feat: add optional runner sandbox enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,15 @@ agent:
 
 See [`docs/security-posture.md`](docs/security-posture.md) for the current
 sandbox model, threat model, and operator checklist. In short: this platform
-currently relies on the coding agent's own sandbox/approval behavior, such as
-Codex CLI's sandbox selected by `codex.profile`; it does not yet add OS-level,
-container, VM, or network-egress isolation around the agent process.
+always relies on the coding agent's own sandbox/approval behavior, such as Codex
+CLI's sandbox selected by `codex.profile`, and can optionally wrap agent
+invocation with a Linux `bubblewrap` or `firejail` sandbox configured by the
+workflow `sandbox:` block. That wrapper is disabled by default and is not a
+container/VM isolation layer.
 
 - Do not use this platform against untrusted issue authors, untrusted
   repositories, or shared production secrets until external sandboxing and
-  per-run credential scoping are implemented.
+  per-run credential scoping are enabled and validated for your worker host.
 - Keep branch protection enabled.
 - The agent opens PRs through its workflow/tool surface; the worker does not
   push, open, or merge PRs.

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -7,23 +7,52 @@ harness hardening as part of the core safety model, not as an optional add-on.
 
 ## Current sandbox model
 
-`aiops-platform` currently relies on the selected coding agent's own sandbox and
+`aiops-platform` always relies on the selected coding agent's own sandbox and
 approval behavior. For Codex runs, that means the Codex CLI sandbox selected by
 `codex.profile` in `WORKFLOW.md`.
 
-The platform does not currently add an external OS, container, VM, or network
-sandbox around the agent process. In particular, it does not yet provide:
+The platform now also supports an optional Linux process sandbox wrapper for
+agent invocation. It is disabled by default; operators enable it explicitly with
+the worker-enforced `sandbox:` workflow block when the host has a supported
+backend installed:
 
-- bubblewrap, firejail, `sandbox-exec`, or VM isolation;
+```yaml
+sandbox:
+  enabled: true
+  backend: firejail        # firejail or bubblewrap
+  network: allowlist       # none or allowlist
+  network_allowlist_cidrs:
+    - 203.0.113.10/32
+  env_allowlist:
+    - PATH
+    - AIOPS_RUN_TOKEN
+  credential_files:
+    - ~/.config/aiops/run-token
+```
+
+Supported enforcement today:
+
+- `bubblewrap` or `firejail` wraps the agent process when configured;
+- the agent working directory must remain under `workspace.root` before the
+  sandbox wrapper is applied;
+- the child process environment is reduced to `sandbox.env_allowlist`;
+- explicitly listed credential files are checked for readability and bound into
+  the sandbox read-only;
+- `network: none` disables network access for supported backends;
+- `network: allowlist` is supported through `firejail --netfilter` and CIDR
+  allowlist rules.
+
+Still not provided:
+
 - Docker-per-run workspace isolation;
-- a sandbox-layer network egress allowlist;
-- a filesystem allowlist beyond the workspace and policy checks already wired in
-  the worker;
+- VM isolation or macOS `sandbox-exec` support;
 - a credential vault that mints per-run credentials.
 
-This is the tracked D5 deviation: the present posture is acceptable for personal
-repositories and trusted internal codebases where the operator understands the
-risk, but it is not a hardened untrusted-code execution environment.
+Docker-based workspace isolation should be a follow-up rather than part of this
+phase: it changes workspace creation, cache ownership, Git remotes/credentials,
+and artifact handoff semantics, while the current phase only wraps the already
+selected agent invocation. Track Docker isolation separately so it can preserve
+the workspace-root invariant and SPEC workspace lifecycle behavior deliberately.
 
 ## Trust boundary
 
@@ -61,8 +90,8 @@ make arbitrary repositories, issue authors, dependencies, or commands safe.
 
 ## What is not defended today
 
-Until an external sandbox layer exists, do not assume the platform prevents a
-malicious or compromised agent run from:
+Unless the optional sandbox wrapper is enabled and validated on the worker host,
+do not assume the platform prevents a malicious or compromised agent run from:
 
 - reading host files that are accessible to the worker OS user;
 - reading credentials present in the process environment or filesystem;
@@ -83,9 +112,9 @@ for the workflow.
 
 Do not use this platform against untrusted issue authors, untrusted repositories,
 unreviewed third-party dependency trees, or shared production secrets. If you
-need that deployment model, first add and validate an external sandbox such as a
-container, VM, bubblewrap, or firejail profile plus network egress controls and
-per-run credential scoping.
+need that deployment model, first enable and validate an external sandbox such
+as bubblewrap or firejail, or add a stronger container/VM isolation layer, plus
+network egress controls and per-run credential scoping.
 
 ## Operator checklist
 
@@ -140,20 +169,19 @@ lands:
 If any item above is not available, do not run the coding agent on that company
 repository yet. Use mock or analysis-only workflows instead.
 
-## Phase 2 hardening roadmap
+## Remaining hardening roadmap
 
-The next enforcement phase should add optional external isolation rather than
-expanding the trust boundary of the current host process. Planned work includes:
+The Linux wrapper is a first enforcement layer, not a complete untrusted-code
+sandbox. Remaining work includes:
 
-- a Linux sandbox wrapper such as bubblewrap or firejail around the agent
-  invocation;
-- Docker-based workspace isolation as an alternative to bare-filesystem
+- Docker-based or VM workspace isolation as an alternative to bare-filesystem
   workspaces;
-- network egress allowlists enforced by the sandbox layer;
-- a documented way to pass only the minimum credentials needed by the run;
-- validation that the agent cwd and workspace path remain under the configured
-  workspace root after isolation is applied.
+- stronger credential-vault integration that mints per-run credentials instead
+  of binding existing files;
+- backend-specific operational validation on each supported host distribution;
+- broader lifecycle-hook integration once SPEC workspace hooks are implemented.
 
-Until those controls are implemented and tested, document this platform as a
-trusted-environment orchestrator with review and policy guardrails, not as a
-strong sandbox for untrusted code.
+Until those controls are implemented and tested for your deployment, document
+this platform as a trusted-environment orchestrator with optional process
+sandboxing, review, and policy guardrails, not as a strong sandbox for arbitrary
+untrusted code.

--- a/docs/workflows/company-cautious-WORKFLOW.md
+++ b/docs/workflows/company-cautious-WORKFLOW.md
@@ -62,9 +62,9 @@ policy:
   max_changed_files: 8
   max_changed_loc: 200
 
-# Safety policy for cautious company runs. These entries make the expected
-# network/path/command envelope explicit for the agent and reviewers; sandbox
-# enforcement beyond `policy.deny_paths` is still a separate hardening phase.
+# Safety policy for cautious company runs. These entries are descriptive: they
+# make the expected network/path/command envelope explicit for the agent and
+# reviewers. Worker-enforced process hardening lives under `sandbox:`.
 safety:
   allowed_networks:
     - company Git host for this repository
@@ -83,6 +83,19 @@ safety:
     - using production, customer, or personal credentials
     - contacting unrelated external services
     - modifying denied policy paths
+
+# Optional worker-enforced process hardening. Keep disabled while validating the
+# mock runner; enable only on worker hosts where the selected backend is
+# installed and tested. `network: allowlist` requires the firejail backend.
+sandbox:
+  enabled: false
+  backend: none
+  network: none
+  # network_allowlist_cidrs:
+  #   - 203.0.113.10/32
+  # env_allowlist:
+  #   - PATH
+  # credential_files: []
 
 verify:
   commands:

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -59,9 +59,9 @@ policy:
   max_changed_files: 12
   max_changed_loc: 300
 
-# Safety policy for the agent and human reviewers. The current worker records
-# these expectations in the repository-owned workflow, but network/path/command
-# enforcement beyond `policy.deny_paths` remains a Phase 2 hardening item.
+# Safety policy for the agent and human reviewers. This block is descriptive:
+# it documents the expected envelope but does not itself enforce network/path or
+# command controls. Worker-enforced process hardening lives under `sandbox:`.
 safety:
   allowed_networks:
     - git remote for this repository
@@ -79,6 +79,19 @@ safety:
     - using shared production secrets or personal credentials
     - contacting unrelated external services
     - changing deployment, infrastructure, migration, or secret paths
+
+# Optional worker-enforced process hardening. Disabled by default so personal
+# workflows continue to rely on the selected coding agent's own sandbox. Enable
+# only after installing and validating the backend on the worker host.
+sandbox:
+  enabled: false
+  backend: none      # none, bubblewrap, or firejail
+  network: none      # none, or allowlist (allowlist requires firejail)
+  # network_allowlist_cidrs:
+  #   - 203.0.113.10/32
+  # env_allowlist:
+  #   - PATH
+  # credential_files: []
 
 verify:
   commands:

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -41,6 +41,10 @@ func (CodexRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 		return Result{}, err
 	}
 	cmd.Dir = in.Workdir
+	cmd, err = applySandbox(ctx, in, cmd)
+	if err != nil {
+		return Result{}, err
+	}
 	configurePlatformKill(cmd)
 	cmd.WaitDelay = killGrace
 

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -38,6 +38,10 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		return Result{}, err
 	}
 	cmd.Dir = in.Workdir
+	cmd, err = applySandbox(ctx, in, cmd)
+	if err != nil {
+		return Result{}, err
+	}
 	configurePlatformKill(cmd)
 	cmd.WaitDelay = killGrace
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -14,7 +14,11 @@ type RunInput struct {
 	Task     task.Task
 	Workflow workflow.Workflow
 	Workdir  string
-	Prompt   string
+	// WorkspaceRoot is the runtime root that created Workdir. When set,
+	// sandbox invariant checks must use this value instead of the workflow
+	// default so runner sandboxing matches the worker's actual checkout root.
+	WorkspaceRoot string
+	Prompt        string
 }
 
 type Result struct {

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -1,0 +1,240 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func applySandbox(ctx context.Context, in RunInput, cmd *exec.Cmd) (*exec.Cmd, error) {
+	cfg := in.Workflow.Config.Sandbox
+	if !cfg.Enabled || cfg.Backend == "" || cfg.Backend == "none" {
+		return cmd, nil
+	}
+	if runtime.GOOS != "linux" {
+		return nil, fmt.Errorf("sandbox.backend %q requires linux host OS; current host OS is %s", cfg.Backend, runtime.GOOS)
+	}
+	if cfg.NetworkMode == "allowlist" {
+		if cfg.Backend != "firejail" {
+			return nil, fmt.Errorf("sandbox network allowlist requires sandbox.backend firejail")
+		}
+		if len(cfg.NetworkAllowlistCIDRs) == 0 {
+			return nil, fmt.Errorf("sandbox.network=allowlist requires sandbox.network_allowlist_cidrs")
+		}
+	}
+	workdir, err := filepath.Abs(in.Workdir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox workdir: %w", err)
+	}
+	root := strings.TrimSpace(in.Workflow.Config.Workspace.Root)
+	if root == "" {
+		return nil, fmt.Errorf("sandbox requires workspace.root so the workspace-root invariant can be enforced")
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace root: %w", err)
+	}
+	if err := ensurePathWithinRoot(workdir, rootAbs); err != nil {
+		return nil, err
+	}
+
+	childArgs := append([]string{}, cmd.Args...)
+	if len(childArgs) == 0 {
+		return nil, fmt.Errorf("sandbox cannot wrap empty command")
+	}
+	env := scopedEnv(cfg.EnvAllowlist)
+
+	switch cfg.Backend {
+	case "bubblewrap":
+		return bubblewrapCommand(ctx, cfg, workdir, childArgs, env)
+	case "firejail":
+		return firejailCommand(ctx, cfg, workdir, childArgs, env)
+	default:
+		return nil, fmt.Errorf("sandbox.backend %q is not supported (allowed: none, bubblewrap, firejail)", cfg.Backend)
+	}
+}
+
+func ensurePathWithinRoot(path, root string) error {
+	canonicalPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return fmt.Errorf("check workspace root invariant for %q: %w", path, err)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("check workspace root invariant for root %q: %w", root, err)
+	}
+	rel, err := filepath.Rel(canonicalRoot, canonicalPath)
+	if err != nil {
+		return fmt.Errorf("check workspace root invariant: %w", err)
+	}
+	if rel == "." || (rel != "" && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)) {
+		return nil
+	}
+	return fmt.Errorf("sandbox workdir %q is outside workspace root %q", path, root)
+}
+
+func scopedEnv(allow []string) []string {
+	if len(allow) == 0 {
+		return []string{}
+	}
+	seen := map[string]struct{}{}
+	var env []string
+	for _, name := range allow {
+		name = strings.TrimSpace(name)
+		if name == "" || strings.Contains(name, "=") {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		if value, ok := os.LookupEnv(name); ok {
+			env = append(env, name+"="+value)
+		}
+	}
+	return env
+}
+
+func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir string, childArgs []string, env []string) (*exec.Cmd, error) {
+	bwrap, err := exec.LookPath("bwrap")
+	if err != nil {
+		return nil, fmt.Errorf("bubblewrap sandbox requested but bwrap binary not found in PATH: %w", err)
+	}
+	if len(childArgs) == 0 {
+		return nil, fmt.Errorf("sandbox cannot wrap empty command")
+	}
+	if !filepath.IsAbs(childArgs[0]) && !strings.ContainsAny(childArgs[0], `/\\`) {
+		resolved, err := exec.LookPath(childArgs[0])
+		if err != nil {
+			return nil, fmt.Errorf("sandbox child binary %q not found in PATH: %w", childArgs[0], err)
+		}
+		childArgs = append([]string{resolved}, childArgs[1:]...)
+	}
+	if cfg.NetworkMode == "allowlist" || len(cfg.NetworkAllowlistCIDRs) > 0 {
+		return nil, fmt.Errorf("sandbox network allowlist requires firejail --netfilter support; bubblewrap only supports network: none via --unshare-net")
+	}
+	args := []string{
+		"--die-with-parent",
+		"--new-session",
+		"--unshare-pid",
+		"--unshare-ipc",
+		"--unshare-uts",
+		"--proc", "/proc",
+		"--dev", "/dev",
+		"--ro-bind", "/usr", "/usr",
+		"--ro-bind", "/bin", "/bin",
+		"--ro-bind", "/lib", "/lib",
+		"--ro-bind", "/lib64", "/lib64",
+		"--tmpfs", "/tmp",
+		"--bind", workdir, workdir,
+		"--chdir", workdir,
+	}
+	if cfg.NetworkMode == "none" || cfg.NetworkMode == "" {
+		args = append(args, "--unshare-net")
+	}
+	for _, envPair := range env {
+		name, value, _ := strings.Cut(envPair, "=")
+		args = append(args, "--setenv", name, value)
+	}
+	for _, f := range cfg.CredentialFiles {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		if _, err := os.Stat(f); err != nil {
+			return nil, fmt.Errorf("sandbox credential file %q is not readable: %w", f, err)
+		}
+		args = append(args, "--ro-bind", f, f)
+	}
+	args = append(args, "--")
+	args = append(args, childArgs...)
+	wrapped := exec.CommandContext(ctx, bwrap, args...)
+	wrapped.Dir = workdir
+	wrapped.Env = env
+	return wrapped, nil
+}
+
+func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir string, childArgs []string, env []string) (*exec.Cmd, error) {
+	firejail, err := exec.LookPath("firejail")
+	if err != nil {
+		return nil, fmt.Errorf("firejail sandbox requested but firejail binary not found in PATH: %w", err)
+	}
+	if len(childArgs) == 0 {
+		return nil, fmt.Errorf("sandbox cannot wrap empty command")
+	}
+	if !filepath.IsAbs(childArgs[0]) && !strings.ContainsAny(childArgs[0], `/\\`) {
+		resolved, err := exec.LookPath(childArgs[0])
+		if err != nil {
+			return nil, fmt.Errorf("sandbox child binary %q not found in PATH: %w", childArgs[0], err)
+		}
+		childArgs = append([]string{resolved}, childArgs[1:]...)
+	}
+	args := []string{"--quiet", "--private=" + workdir, "--whitelist=" + workdir, "--private-tmp"}
+	if cfg.NetworkMode == "allowlist" || len(cfg.NetworkAllowlistCIDRs) > 0 {
+		filter, err := writeFirejailNetfilter(cfg.NetworkAllowlistCIDRs)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "--netfilter="+filter)
+	} else {
+		args = append(args, "--net=none")
+	}
+	for _, envPair := range env {
+		name, _, _ := strings.Cut(envPair, "=")
+		args = append(args, "--env="+name)
+	}
+	for _, f := range cfg.CredentialFiles {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		if _, err := os.Stat(f); err != nil {
+			return nil, fmt.Errorf("sandbox credential file %q is not readable: %w", f, err)
+		}
+		args = append(args, "--read-only="+f, "--whitelist="+f)
+	}
+	args = append(args, "--")
+	args = append(args, childArgs...)
+	wrapped := exec.CommandContext(ctx, firejail, args...)
+	wrapped.Dir = workdir
+	wrapped.Env = env
+	return wrapped, nil
+}
+
+func writeFirejailNetfilter(cidrs []string) (string, error) {
+	if len(cidrs) == 0 {
+		return "", fmt.Errorf("sandbox network allowlist requires at least one CIDR")
+	}
+	var b strings.Builder
+	b.WriteString("*filter\n:OUTPUT DROP [0:0]\n")
+	for _, cidr := range cidrs {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		_, parsed, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return "", fmt.Errorf("sandbox network allowlist contains invalid CIDR %q: %w", cidr, err)
+		}
+		b.WriteString("-A OUTPUT -d ")
+		b.WriteString(parsed.String())
+		b.WriteString(" -j ACCEPT\n")
+	}
+	b.WriteString("COMMIT\n")
+	f, err := os.CreateTemp("", "aiops-firejail-netfilter-*.conf")
+	if err != nil {
+		return "", fmt.Errorf("create firejail netfilter allowlist: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(b.String()); err != nil {
+		return "", fmt.Errorf("write firejail netfilter allowlist: %w", err)
+	}
+	return f.Name(), nil
+}

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -184,7 +184,7 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 			return nil, err
 		}
 		cleanupFiles = append(cleanupFiles, filter)
-		args = append(args, "--netfilter="+filter)
+		args = append(args, "--net=none", "--netfilter="+filter)
 	} else {
 		args = append(args, "--net=none")
 	}

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -214,7 +214,7 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 		}
 		cleanupScript := `cleanup_file=$1; shift; "$@"; status=$?; rm -f "$cleanup_file"; exit "$status"`
 		shellArgs := []string{"-c", cleanupScript, "aiops-firejail-cleanup", cleanupFiles[0], firejail}
-		shellArgs = append(shellArgs, args[1:]...)
+		shellArgs = append(shellArgs, args...)
 		wrapped = exec.CommandContext(ctx, "/bin/sh", shellArgs...)
 	}
 	wrapped.Dir = workdir

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -184,7 +184,7 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 			return nil, err
 		}
 		cleanupFiles = append(cleanupFiles, filter)
-		args = append(args, "--net=none", "--netfilter="+filter)
+		args = append(args, firejailAllowlistNetArg(cfg), "--netfilter="+filter)
 	} else {
 		args = append(args, "--net=none")
 	}
@@ -227,6 +227,19 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 		}
 	}
 	return wrapped, nil
+}
+
+func firejailAllowlistNetArg(cfg workflow.SandboxConfig) string {
+	iface := strings.TrimSpace(cfg.NetworkInterface)
+	if iface == "" {
+		// Firejail only applies --netfilter inside a Firejail-created network
+		// namespace; --net=none would create an unconnected namespace and make
+		// allowlist mode equivalent to total network denial. Default to the
+		// conventional default route interface while allowing operators to set a
+		// host-specific interface explicitly in WORKFLOW.md.
+		iface = "eth0"
+	}
+	return "--net=" + iface
 }
 
 func writeFirejailNetfilter(cidrs []string) (string, error) {

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -279,9 +279,12 @@ func writeFirejailNetfilter(cidrs []string) (string, error) {
 		if cidr == "" {
 			continue
 		}
-		_, parsed, err := net.ParseCIDR(cidr)
+		ip, parsed, err := net.ParseCIDR(cidr)
 		if err != nil {
 			return "", fmt.Errorf("sandbox network allowlist contains invalid CIDR %q: %w", cidr, err)
+		}
+		if ip.To4() == nil {
+			return "", fmt.Errorf("sandbox network allowlist CIDR %q is IPv6; Firejail --netfilter supports IPv4 rules only", cidr)
 		}
 		b.WriteString("-A OUTPUT -d ")
 		b.WriteString(parsed.String())

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -178,13 +178,17 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 	}
 	args := []string{"--quiet", "--noprofile", "--private=" + workdir, "--whitelist=" + workdir, "--private-tmp"}
 	var cleanupFiles []string
-	if cfg.NetworkMode == "allowlist" || len(cfg.NetworkAllowlistCIDRs) > 0 {
+	if cfg.NetworkMode == "allowlist" {
 		filter, err := writeFirejailNetfilter(cfg.NetworkAllowlistCIDRs)
 		if err != nil {
 			return nil, err
 		}
 		cleanupFiles = append(cleanupFiles, filter)
-		args = append(args, firejailAllowlistNetArg(cfg), "--netfilter="+filter)
+		netArg, err := firejailAllowlistNetArg(cfg)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, netArg, "--netfilter="+filter)
 	} else {
 		args = append(args, "--net=none")
 	}
@@ -229,17 +233,12 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 	return wrapped, nil
 }
 
-func firejailAllowlistNetArg(cfg workflow.SandboxConfig) string {
+func firejailAllowlistNetArg(cfg workflow.SandboxConfig) (string, error) {
 	iface := strings.TrimSpace(cfg.NetworkInterface)
 	if iface == "" {
-		// Firejail only applies --netfilter inside a Firejail-created network
-		// namespace; --net=none would create an unconnected namespace and make
-		// allowlist mode equivalent to total network denial. Default to the
-		// conventional default route interface while allowing operators to set a
-		// host-specific interface explicitly in WORKFLOW.md.
-		iface = "eth0"
+		return "", fmt.Errorf("sandbox.network=allowlist requires sandbox.network_interface because Firejail --netfilter must attach to an explicit host interface")
 	}
-	return "--net=" + iface
+	return "--net=" + iface, nil
 }
 
 func writeFirejailNetfilter(cidrs []string) (string, error) {

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -117,7 +117,7 @@ func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir 
 		}
 		childArgs = append([]string{resolved}, childArgs[1:]...)
 	}
-	if cfg.NetworkMode == "allowlist" || len(cfg.NetworkAllowlistCIDRs) > 0 {
+	if cfg.NetworkMode == "allowlist" {
 		return nil, fmt.Errorf("sandbox network allowlist requires firejail --netfilter support; bubblewrap only supports network: none via --unshare-net")
 	}
 	args := []string{
@@ -232,11 +232,22 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 	wrapped.Env = env
 	if len(cleanupFiles) > 0 {
 		cleanupOnError = false
-		wrapped.Cancel = func() error {
-			return removeFiles(cleanupFiles)
-		}
+		wrapped.Cancel = cleanupCancel(wrapped, wrapped.Cancel, cleanupFiles)
+		wrapped.WaitDelay = 1
 	}
 	return wrapped, nil
+}
+
+func cleanupCancel(cmd *exec.Cmd, previousCancel func() error, cleanupFiles []string) func() error {
+	return func() error {
+		cleanupErr := removeFiles(cleanupFiles)
+		if previousCancel != nil && cmd.Process != nil {
+			if err := previousCancel(); err != nil {
+				return err
+			}
+		}
+		return cleanupErr
+	}
 }
 
 func removeFiles(paths []string) error {

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -232,21 +232,15 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 	wrapped.Env = env
 	if len(cleanupFiles) > 0 {
 		cleanupOnError = false
-		wrapped.Cancel = cleanupCancel(wrapped, wrapped.Cancel, cleanupFiles)
+		wrapped.Cancel = cleanupCancel(cleanupFiles)
 		wrapped.WaitDelay = 1
 	}
 	return wrapped, nil
 }
 
-func cleanupCancel(cmd *exec.Cmd, previousCancel func() error, cleanupFiles []string) func() error {
+func cleanupCancel(cleanupFiles []string) func() error {
 	return func() error {
-		cleanupErr := removeFiles(cleanupFiles)
-		if previousCancel != nil && cmd.Process != nil {
-			if err := previousCancel(); err != nil {
-				return err
-			}
-		}
-		return cleanupErr
+		return removeFiles(cleanupFiles)
 	}
 }
 

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -33,13 +33,16 @@ func applySandbox(ctx context.Context, in RunInput, cmd *exec.Cmd) (*exec.Cmd, e
 	if err != nil {
 		return nil, fmt.Errorf("resolve sandbox workdir: %w", err)
 	}
-	root := strings.TrimSpace(in.Workflow.Config.Workspace.Root)
+	root := strings.TrimSpace(in.WorkspaceRoot)
 	if root == "" {
-		return nil, fmt.Errorf("sandbox requires workspace.root so the workspace-root invariant can be enforced")
+		root = strings.TrimSpace(in.Workflow.Config.Workspace.Root)
+	}
+	if root == "" {
+		return nil, fmt.Errorf("sandbox requires runtime workspace root so the workspace-root invariant can be enforced")
 	}
 	rootAbs, err := filepath.Abs(root)
 	if err != nil {
-		return nil, fmt.Errorf("resolve workspace root: %w", err)
+		return nil, fmt.Errorf("resolve runtime workspace root: %w", err)
 	}
 	if err := ensurePathWithinRoot(workdir, rootAbs); err != nil {
 		return nil, err

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -176,19 +176,20 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 		}
 		childArgs = append([]string{resolved}, childArgs[1:]...)
 	}
-	args := []string{"--quiet", "--private=" + workdir, "--whitelist=" + workdir, "--private-tmp"}
+	args := []string{"--quiet", "--noprofile", "--private=" + workdir, "--whitelist=" + workdir, "--private-tmp"}
+	var cleanupFiles []string
 	if cfg.NetworkMode == "allowlist" || len(cfg.NetworkAllowlistCIDRs) > 0 {
 		filter, err := writeFirejailNetfilter(cfg.NetworkAllowlistCIDRs)
 		if err != nil {
 			return nil, err
 		}
+		cleanupFiles = append(cleanupFiles, filter)
 		args = append(args, "--netfilter="+filter)
 	} else {
 		args = append(args, "--net=none")
 	}
 	for _, envPair := range env {
-		name, _, _ := strings.Cut(envPair, "=")
-		args = append(args, "--env="+name)
+		args = append(args, "--env="+envPair)
 	}
 	for _, f := range cfg.CredentialFiles {
 		f = strings.TrimSpace(f)
@@ -203,8 +204,28 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 	args = append(args, "--")
 	args = append(args, childArgs...)
 	wrapped := exec.CommandContext(ctx, firejail, args...)
+	if len(cleanupFiles) > 0 {
+		if len(cleanupFiles) != 1 {
+			return nil, fmt.Errorf("firejail sandbox expected one cleanup file, got %d", len(cleanupFiles))
+		}
+		cleanupScript := `cleanup_file=$1; shift; "$@"; status=$?; rm -f "$cleanup_file"; exit "$status"`
+		shellArgs := []string{"-c", cleanupScript, "aiops-firejail-cleanup", cleanupFiles[0], firejail}
+		shellArgs = append(shellArgs, args[1:]...)
+		wrapped = exec.CommandContext(ctx, "/bin/sh", shellArgs...)
+	}
 	wrapped.Dir = workdir
 	wrapped.Env = env
+	if len(cleanupFiles) > 0 {
+		wrapped.Cancel = func() error {
+			var firstErr error
+			for _, path := range cleanupFiles {
+				if err := os.Remove(path); err != nil && !os.IsNotExist(err) && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		}
+	}
 	return wrapped, nil
 }
 

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -131,10 +131,14 @@ func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir 
 		"--ro-bind", "/usr", "/usr",
 		"--ro-bind", "/bin", "/bin",
 		"--ro-bind", "/lib", "/lib",
-		"--ro-bind", "/lib64", "/lib64",
 		"--tmpfs", "/tmp",
 		"--bind", workdir, workdir,
 		"--chdir", workdir,
+	}
+	if _, err := os.Stat("/lib64"); err == nil {
+		args = append(args, "--ro-bind", "/lib64", "/lib64")
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("check optional bubblewrap /lib64 bind source: %w", err)
 	}
 	if cfg.NetworkMode == "none" || cfg.NetworkMode == "" {
 		args = append(args, "--unshare-net")
@@ -178,12 +182,19 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 	}
 	args := []string{"--quiet", "--noprofile", "--private=" + workdir, "--whitelist=" + workdir, "--private-tmp"}
 	var cleanupFiles []string
+	cleanupOnError := false
 	if cfg.NetworkMode == "allowlist" {
 		filter, err := writeFirejailNetfilter(cfg.NetworkAllowlistCIDRs)
 		if err != nil {
 			return nil, err
 		}
 		cleanupFiles = append(cleanupFiles, filter)
+		cleanupOnError = true
+		defer func() {
+			if cleanupOnError {
+				removeFiles(cleanupFiles)
+			}
+		}()
 		netArg, err := firejailAllowlistNetArg(cfg)
 		if err != nil {
 			return nil, err
@@ -220,17 +231,22 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 	wrapped.Dir = workdir
 	wrapped.Env = env
 	if len(cleanupFiles) > 0 {
+		cleanupOnError = false
 		wrapped.Cancel = func() error {
-			var firstErr error
-			for _, path := range cleanupFiles {
-				if err := os.Remove(path); err != nil && !os.IsNotExist(err) && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
+			return removeFiles(cleanupFiles)
 		}
 	}
 	return wrapped, nil
+}
+
+func removeFiles(paths []string) error {
+	var firstErr error
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func firejailAllowlistNetArg(cfg workflow.SandboxConfig) (string, error) {

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -215,6 +215,45 @@ func TestSandboxRejectsSymlinkEscapeOutsideWorkspaceRoot(t *testing.T) {
 	}
 }
 
+func TestSandboxAllowsWorkdirUnderRuntimeWorkspaceRootWhenWorkflowRootDiffers(t *testing.T) {
+	binDir := t.TempDir()
+	bwrap := filepath.Join(binDir, "bwrap")
+	if err := os.WriteFile(bwrap, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	runtimeRoot := t.TempDir()
+	workdir := filepath.Join(runtimeRoot, "issue-123")
+	if err := os.Mkdir(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflowRoot := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "exec")
+	base.Dir = workdir
+	in := RunInput{
+		Task: task.Task{ID: "tsk_sandbox", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Workspace: workflow.WorkspaceConfig{Root: workflowRoot},
+			Sandbox:   workflow.SandboxConfig{Enabled: true, Backend: "bubblewrap", EnvAllowlist: []string{"PATH"}},
+		}},
+		Workdir:       workdir,
+		WorkspaceRoot: runtimeRoot,
+	}
+
+	wrapped, err := applySandbox(context.Background(), in, base)
+	if err != nil {
+		t.Fatalf("applySandbox should validate against runtime workspace root: %v", err)
+	}
+	if wrapped.Dir != workdir {
+		t.Fatalf("wrapped.Dir = %q, want %q", wrapped.Dir, workdir)
+	}
+}
+
 func TestSandboxNetworkAllowlistRequiresFirejail(t *testing.T) {
 	binDir := t.TempDir()
 	bwrap := filepath.Join(binDir, "bwrap")

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -1,0 +1,265 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func sandboxInput(t *testing.T, workdir string, cfg workflow.SandboxConfig) RunInput {
+	t.Helper()
+	root := filepath.Dir(workdir)
+	return RunInput{
+		Task: task.Task{ID: "tsk_sandbox", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Workspace: workflow.WorkspaceConfig{Root: root},
+			Sandbox:   cfg,
+		}},
+		Workdir: workdir,
+		Prompt:  "ignored",
+	}
+}
+
+func TestSandboxDisabledLeavesCommandUnwrappedAndEnvironmentInherited(t *testing.T) {
+	base := exec.CommandContext(context.Background(), "codex", "exec")
+	base.Dir = t.TempDir()
+	base.Env = nil
+
+	wrapped, err := applySandbox(context.Background(), sandboxInput(t, base.Dir, workflow.SandboxConfig{}), base)
+	if err != nil {
+		t.Fatalf("applySandbox: %v", err)
+	}
+	if wrapped != base {
+		t.Fatalf("disabled sandbox should return original command")
+	}
+	if wrapped.Env != nil {
+		t.Fatalf("disabled sandbox should not scope environment, got %q", wrapped.Env)
+	}
+}
+
+func TestSandboxBubblewrapBuildsWrappedCommandAndScopesEnvironment(t *testing.T) {
+	binDir := t.TempDir()
+	bwrap := filepath.Join(binDir, "bwrap")
+	if err := os.WriteFile(bwrap, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GITHUB_TOKEN", "must-not-leak")
+	t.Setenv("AIOPS_RUN_TOKEN", "allowed-secret")
+
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "exec", "--cd", workdir)
+	base.Dir = workdir
+
+	wrapped, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:      true,
+		Backend:      "bubblewrap",
+		NetworkMode:  "none",
+		EnvAllowlist: []string{"AIOPS_RUN_TOKEN"},
+	}), base)
+	if err != nil {
+		t.Fatalf("applySandbox: %v", err)
+	}
+	if filepath.Base(wrapped.Path) != "bwrap" {
+		t.Fatalf("wrapped.Path = %q, want bwrap", wrapped.Path)
+	}
+	joined := strings.Join(wrapped.Args, "\x00")
+	for _, want := range []string{"--die-with-parent", "--unshare-net", "--bind", workdir, "--chdir", workdir, "--setenv", "AIOPS_RUN_TOKEN", "allowed-secret", "--", "codex", "exec"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("wrapped args missing %q in %#v", want, wrapped.Args)
+		}
+	}
+	for _, env := range wrapped.Env {
+		if strings.HasPrefix(env, "GITHUB_TOKEN=") {
+			t.Fatalf("sandbox env leaked non-allowlisted credential: %q", wrapped.Env)
+		}
+	}
+}
+
+func TestSandboxEnabledFailsWhenDependencyMissing(t *testing.T) {
+	t.Setenv("PATH", "")
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "exec")
+	base.Dir = workdir
+
+	_, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{Enabled: true, Backend: "bubblewrap"}), base)
+	if err == nil {
+		t.Fatal("expected missing bubblewrap dependency error")
+	}
+	if !strings.Contains(err.Error(), "bubblewrap") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %q, want missing bubblewrap dependency", err)
+	}
+}
+
+func TestSandboxEnabledFailsFastOnUnsupportedHostOS(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("Linux hosts support bubblewrap/firejail discovery; unsupported-OS behavior is covered by the helper")
+	}
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "exec")
+	base.Dir = workdir
+
+	_, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{Enabled: true, Backend: "bubblewrap"}), base)
+	if err == nil {
+		t.Fatal("expected unsupported host OS error")
+	}
+	if !strings.Contains(err.Error(), "linux") || !strings.Contains(err.Error(), runtime.GOOS) {
+		t.Fatalf("error = %q, want linux-only guidance for %s", err, runtime.GOOS)
+	}
+}
+
+func TestSandboxRejectsWorkdirOutsideWorkspaceRoot(t *testing.T) {
+	binDir := t.TempDir()
+	bwrap := filepath.Join(binDir, "bwrap")
+	if err := os.WriteFile(bwrap, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	root := t.TempDir()
+	outside := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "exec")
+	base.Dir = outside
+	in := RunInput{
+		Task: task.Task{ID: "tsk_sandbox", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Workspace: workflow.WorkspaceConfig{Root: root},
+			Sandbox:   workflow.SandboxConfig{Enabled: true, Backend: "bubblewrap"},
+		}},
+		Workdir: outside,
+	}
+
+	_, err := applySandbox(context.Background(), in, base)
+	if err == nil {
+		t.Fatal("expected workspace-root invariant error")
+	}
+	if !strings.Contains(err.Error(), "workspace root") {
+		t.Fatalf("error = %q, want workspace root invariant", err)
+	}
+}
+
+func TestSandboxRejectsSymlinkEscapeOutsideWorkspaceRoot(t *testing.T) {
+	binDir := t.TempDir()
+	bwrap := filepath.Join(binDir, "bwrap")
+	if err := os.WriteFile(bwrap, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "link-outside")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+	base := exec.CommandContext(context.Background(), "codex", "exec")
+	base.Dir = link
+	in := RunInput{
+		Task: task.Task{ID: "tsk_sandbox", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Workspace: workflow.WorkspaceConfig{Root: root},
+			Sandbox:   workflow.SandboxConfig{Enabled: true, Backend: "bubblewrap", EnvAllowlist: []string{"PATH"}},
+		}},
+		Workdir: link,
+	}
+
+	_, err := applySandbox(context.Background(), in, base)
+	if err == nil {
+		t.Fatal("expected workspace-root invariant error for symlink escape")
+	}
+	if !strings.Contains(err.Error(), "workspace root") {
+		t.Fatalf("error = %q, want workspace root invariant", err)
+	}
+}
+
+func TestSandboxNetworkAllowlistRequiresFirejail(t *testing.T) {
+	binDir := t.TempDir()
+	bwrap := filepath.Join(binDir, "bwrap")
+	if err := os.WriteFile(bwrap, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "exec")
+	base.Dir = workdir
+
+	_, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:               true,
+		Backend:               "bubblewrap",
+		NetworkMode:           "allowlist",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+	}), base)
+	if err == nil {
+		t.Fatal("expected network allowlist unsupported error")
+	}
+	if !strings.Contains(err.Error(), "network allowlist") || !strings.Contains(err.Error(), "firejail") {
+		t.Fatalf("error = %q, want firejail network allowlist guidance", err)
+	}
+}
+
+func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
+	binDir := t.TempDir()
+	firejail := filepath.Join(binDir, "firejail")
+	if err := os.WriteFile(firejail, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AIOPS_RUN_TOKEN", "allowed-secret")
+	t.Setenv("GITHUB_TOKEN", "must-not-leak")
+
+	workdir := t.TempDir()
+	credential := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(credential, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := exec.CommandContext(context.Background(), "codex", "app-server")
+	base.Dir = workdir
+
+	wrapped, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:               true,
+		Backend:               "firejail",
+		NetworkMode:           "allowlist",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+		EnvAllowlist:          []string{"AIOPS_RUN_TOKEN"},
+		CredentialFiles:       []string{credential},
+	}), base)
+	if err != nil {
+		t.Fatalf("applySandbox: %v", err)
+	}
+	if filepath.Base(wrapped.Path) != "firejail" {
+		t.Fatalf("wrapped.Path = %q, want firejail", wrapped.Path)
+	}
+	joined := strings.Join(wrapped.Args, "\x00")
+	for _, want := range []string{"--netfilter=", "--env=AIOPS_RUN_TOKEN", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("wrapped args missing %q in %#v", want, wrapped.Args)
+		}
+	}
+	for _, arg := range wrapped.Args {
+		if arg == "--net=none" {
+			t.Fatalf("network allowlist must not also disable all networking with --net=none: %#v", wrapped.Args)
+		}
+	}
+	for _, env := range wrapped.Env {
+		if strings.HasPrefix(env, "GITHUB_TOKEN=") {
+			t.Fatalf("sandbox env leaked non-allowlisted credential: %q", wrapped.Env)
+		}
+	}
+}

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -210,6 +210,70 @@ func TestSandboxNetworkAllowlistRequiresFirejail(t *testing.T) {
 	}
 }
 
+func TestSandboxFirejailNetworkNoneIgnoresStaleAllowlistCIDRs(t *testing.T) {
+	binDir := t.TempDir()
+	firejail := filepath.Join(binDir, "firejail")
+	if err := os.WriteFile(firejail, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "app-server")
+	base.Dir = workdir
+
+	wrapped, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:               true,
+		Backend:               "firejail",
+		NetworkMode:           "none",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+	}), base)
+	if err != nil {
+		t.Fatalf("applySandbox: %v", err)
+	}
+	joined := strings.Join(wrapped.Args, "\x00")
+	if !strings.Contains(joined, "--net=none") {
+		t.Fatalf("network none must disable egress even when stale allowlist CIDRs are present, args=%#v", wrapped.Args)
+	}
+	if strings.Contains(joined, "--netfilter=") || strings.Contains(joined, "--net=eth0") {
+		t.Fatalf("network none must not enable firejail allowlist mode from stale CIDRs, args=%#v", wrapped.Args)
+	}
+}
+
+func TestSandboxFirejailAllowlistRequiresExplicitNetworkInterface(t *testing.T) {
+	binDir := t.TempDir()
+	firejail := filepath.Join(binDir, "firejail")
+	if err := os.WriteFile(firejail, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "app-server")
+	base.Dir = workdir
+
+	_, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:               true,
+		Backend:               "firejail",
+		NetworkMode:           "allowlist",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+	}), base)
+	if err == nil {
+		t.Fatal("expected explicit firejail allowlist network_interface error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.network_interface") || !strings.Contains(err.Error(), "allowlist") {
+		t.Fatalf("error = %q, want explicit network_interface guidance", err)
+	}
+}
+
 func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 	binDir := t.TempDir()
 	firejail := filepath.Join(binDir, "firejail")
@@ -313,6 +377,7 @@ func firejailAllowlistCommandForCleanupTest(t *testing.T) (string, *exec.Cmd) {
 		Backend:               "firejail",
 		NetworkMode:           "allowlist",
 		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+		NetworkInterface:      "aiops0",
 	}), base)
 	if err != nil {
 		t.Fatalf("applySandbox: %v", err)

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -237,6 +237,7 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 		Backend:               "firejail",
 		NetworkMode:           "allowlist",
 		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+		NetworkInterface:      "aiops0",
 		EnvAllowlist:          []string{"AIOPS_RUN_TOKEN"},
 		CredentialFiles:       []string{credential},
 	}), base)
@@ -247,7 +248,7 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 	if filepath.Base(wrapped.Path) != "firejail" && !strings.Contains(joined, "firejail") {
 		t.Fatalf("wrapped command should execute firejail directly or via cleanup wrapper, path=%q args=%#v", wrapped.Path, wrapped.Args)
 	}
-	for _, want := range []string{"--noprofile", "--net=", "--netfilter=", "--env=AIOPS_RUN_TOKEN=allowed-secret", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
+	for _, want := range []string{"--noprofile", "--net=aiops0", "--netfilter=", "--env=AIOPS_RUN_TOKEN=allowed-secret", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("wrapped args missing %q in %#v", want, wrapped.Args)
 		}
@@ -255,6 +256,9 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 	for _, arg := range wrapped.Args {
 		if arg == "--env=AIOPS_RUN_TOKEN" {
 			t.Fatalf("firejail env allowlist must preserve values with name=value args, got %#v", wrapped.Args)
+		}
+		if arg == "--net=none" {
+			t.Fatalf("firejail allowlist mode must use a connected network namespace, got %#v", wrapped.Args)
 		}
 	}
 	for _, env := range wrapped.Env {
@@ -264,7 +268,31 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 	}
 }
 
+func TestFirejailNetfilterFileIsRemovedWhenSandboxCommandIsCanceled(t *testing.T) {
+	filterPath, wrapped := firejailAllowlistCommandForCleanupTest(t)
+	configurePlatformKill(wrapped)
+
+	if err := wrapped.Cancel(); err != nil {
+		t.Fatalf("cancel failed: %v", err)
+	}
+	if _, err := os.Stat(filterPath); !os.IsNotExist(err) {
+		t.Fatalf("netfilter file should be removed when sandbox command is canceled, stat err = %v", err)
+	}
+}
+
 func TestFirejailNetfilterFileIsRemovedWhenWrappedCommandExits(t *testing.T) {
+	filterPath, wrapped := firejailAllowlistCommandForCleanupTest(t)
+
+	if err := wrapped.Run(); err != nil {
+		t.Fatalf("wrapped command failed: %v", err)
+	}
+	if _, err := os.Stat(filterPath); !os.IsNotExist(err) {
+		t.Fatalf("netfilter file should be removed after command exit, stat err = %v", err)
+	}
+}
+
+func firejailAllowlistCommandForCleanupTest(t *testing.T) (string, *exec.Cmd) {
+	t.Helper()
 	binDir := t.TempDir()
 	firejail := filepath.Join(binDir, "firejail")
 	if err := os.WriteFile(firejail, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
@@ -301,10 +329,5 @@ func TestFirejailNetfilterFileIsRemovedWhenWrappedCommandExits(t *testing.T) {
 	if _, err := os.Stat(filterPath); err != nil {
 		t.Fatalf("netfilter file should exist before command starts: %v", err)
 	}
-	if err := wrapped.Run(); err != nil {
-		t.Fatalf("wrapped command failed: %v", err)
-	}
-	if _, err := os.Stat(filterPath); !os.IsNotExist(err) {
-		t.Fatalf("netfilter file should be removed after command exit, stat err = %v", err)
-	}
+	return filterPath, wrapped
 }

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -441,6 +441,32 @@ func TestFirejailNetfilterFileIsRemovedWhenTerminateProcessKillsWrapper(t *testi
 	}
 }
 
+func TestFirejailNetfilterRejectsIPv6CIDR(t *testing.T) {
+	_, err := writeFirejailNetfilter([]string{"2001:db8::/32"})
+	if err == nil {
+		t.Fatal("expected IPv6 CIDR to be rejected for firejail IPv4 netfilter")
+	}
+	if !strings.Contains(err.Error(), "IPv4") || !strings.Contains(err.Error(), "2001:db8::/32") {
+		t.Fatalf("error = %q, want IPv4-only guidance for IPv6 CIDR", err)
+	}
+}
+
+func TestFirejailNetfilterAcceptsIPv4CIDR(t *testing.T) {
+	path, err := writeFirejailNetfilter([]string{"203.0.113.10/32"})
+	if err != nil {
+		t.Fatalf("writeFirejailNetfilter: %v", err)
+	}
+	defer os.Remove(path)
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read netfilter file: %v", err)
+	}
+	if !strings.Contains(string(content), "-A OUTPUT -d 203.0.113.10/32 -j ACCEPT") {
+		t.Fatalf("netfilter file missing IPv4 allow rule: %s", content)
+	}
+}
+
 func TestFirejailNetfilterFileIsRemovedWhenCredentialValidationFails(t *testing.T) {
 	binDir := t.TempDir()
 	firejail := filepath.Join(binDir, "firejail")

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -312,7 +312,7 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 	if filepath.Base(wrapped.Path) != "firejail" && !strings.Contains(joined, "firejail") {
 		t.Fatalf("wrapped command should execute firejail directly or via cleanup wrapper, path=%q args=%#v", wrapped.Path, wrapped.Args)
 	}
-	for _, want := range []string{"--noprofile", "--net=aiops0", "--netfilter=", "--env=AIOPS_RUN_TOKEN=allowed-secret", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
+	for _, want := range []string{"--quiet", "--noprofile", "--net=aiops0", "--netfilter=", "--env=AIOPS_RUN_TOKEN=allowed-secret", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("wrapped args missing %q in %#v", want, wrapped.Args)
 		}

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -247,7 +247,7 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 	if filepath.Base(wrapped.Path) != "firejail" && !strings.Contains(joined, "firejail") {
 		t.Fatalf("wrapped command should execute firejail directly or via cleanup wrapper, path=%q args=%#v", wrapped.Path, wrapped.Args)
 	}
-	for _, want := range []string{"--noprofile", "--netfilter=", "--env=AIOPS_RUN_TOKEN=allowed-secret", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
+	for _, want := range []string{"--noprofile", "--net=", "--netfilter=", "--env=AIOPS_RUN_TOKEN=allowed-secret", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("wrapped args missing %q in %#v", want, wrapped.Args)
 		}
@@ -255,11 +255,6 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 	for _, arg := range wrapped.Args {
 		if arg == "--env=AIOPS_RUN_TOKEN" {
 			t.Fatalf("firejail env allowlist must preserve values with name=value args, got %#v", wrapped.Args)
-		}
-	}
-	for _, arg := range wrapped.Args {
-		if arg == "--net=none" {
-			t.Fatalf("network allowlist must not also disable all networking with --net=none: %#v", wrapped.Args)
 		}
 	}
 	for _, env := range wrapped.Env {

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -243,13 +243,18 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applySandbox: %v", err)
 	}
-	if filepath.Base(wrapped.Path) != "firejail" {
-		t.Fatalf("wrapped.Path = %q, want firejail", wrapped.Path)
-	}
 	joined := strings.Join(wrapped.Args, "\x00")
-	for _, want := range []string{"--netfilter=", "--env=AIOPS_RUN_TOKEN", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
+	if filepath.Base(wrapped.Path) != "firejail" && !strings.Contains(joined, "firejail") {
+		t.Fatalf("wrapped command should execute firejail directly or via cleanup wrapper, path=%q args=%#v", wrapped.Path, wrapped.Args)
+	}
+	for _, want := range []string{"--noprofile", "--netfilter=", "--env=AIOPS_RUN_TOKEN=allowed-secret", "--read-only=" + credential, "--whitelist=" + credential, "--", "codex", "app-server"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("wrapped args missing %q in %#v", want, wrapped.Args)
+		}
+	}
+	for _, arg := range wrapped.Args {
+		if arg == "--env=AIOPS_RUN_TOKEN" {
+			t.Fatalf("firejail env allowlist must preserve values with name=value args, got %#v", wrapped.Args)
 		}
 	}
 	for _, arg := range wrapped.Args {
@@ -261,5 +266,50 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 		if strings.HasPrefix(env, "GITHUB_TOKEN=") {
 			t.Fatalf("sandbox env leaked non-allowlisted credential: %q", wrapped.Env)
 		}
+	}
+}
+
+func TestFirejailNetfilterFileIsRemovedWhenWrappedCommandExits(t *testing.T) {
+	binDir := t.TempDir()
+	firejail := filepath.Join(binDir, "firejail")
+	if err := os.WriteFile(firejail, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "app-server")
+	base.Dir = workdir
+
+	wrapped, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:               true,
+		Backend:               "firejail",
+		NetworkMode:           "allowlist",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+	}), base)
+	if err != nil {
+		t.Fatalf("applySandbox: %v", err)
+	}
+	var filterPath string
+	for _, arg := range wrapped.Args {
+		if strings.HasPrefix(arg, "--netfilter=") {
+			filterPath = strings.TrimPrefix(arg, "--netfilter=")
+		}
+	}
+	if filterPath == "" {
+		t.Fatalf("wrapped args missing --netfilter path: %#v", wrapped.Args)
+	}
+	if _, err := os.Stat(filterPath); err != nil {
+		t.Fatalf("netfilter file should exist before command starts: %v", err)
+	}
+	if err := wrapped.Run(); err != nil {
+		t.Fatalf("wrapped command failed: %v", err)
+	}
+	if _, err := os.Stat(filterPath); !os.IsNotExist(err) {
+		t.Fatalf("netfilter file should be removed after command exit, stat err = %v", err)
 	}
 }

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -278,6 +278,40 @@ func TestSandboxFirejailNetworkNoneIgnoresStaleAllowlistCIDRs(t *testing.T) {
 	}
 }
 
+func TestSandboxBubblewrapNetworkNoneIgnoresStaleAllowlistCIDRs(t *testing.T) {
+	binDir := t.TempDir()
+	bwrap := filepath.Join(binDir, "bwrap")
+	if err := os.WriteFile(bwrap, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "app-server")
+	base.Dir = workdir
+
+	wrapped, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:               true,
+		Backend:               "bubblewrap",
+		NetworkMode:           "none",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+	}), base)
+	if err != nil {
+		t.Fatalf("applySandbox: %v", err)
+	}
+	joined := strings.Join(wrapped.Args, "\x00")
+	if !strings.Contains(joined, "--unshare-net") {
+		t.Fatalf("bubblewrap network none must disable egress even when stale allowlist CIDRs are present, args=%#v", wrapped.Args)
+	}
+	if strings.Contains(joined, "--netfilter=") {
+		t.Fatalf("bubblewrap network none must not enable allowlist mode from stale CIDRs, args=%#v", wrapped.Args)
+	}
+}
+
 func TestSandboxFirejailAllowlistRequiresExplicitNetworkInterface(t *testing.T) {
 	binDir := t.TempDir()
 	firejail := filepath.Join(binDir, "firejail")
@@ -367,8 +401,7 @@ func TestSandboxFirejailBuildsNetworkAllowlistAndCredentialScope(t *testing.T) {
 }
 
 func TestFirejailNetfilterFileIsRemovedWhenSandboxCommandIsCanceled(t *testing.T) {
-	filterPath, wrapped := firejailAllowlistCommandForCleanupTest(t)
-	configurePlatformKill(wrapped)
+	filterPath, wrapped := firejailAllowlistCommandForCleanupTest(t, "#!/usr/bin/env sh\nsleep 30\n")
 
 	if err := wrapped.Cancel(); err != nil {
 		t.Fatalf("cancel failed: %v", err)
@@ -379,13 +412,32 @@ func TestFirejailNetfilterFileIsRemovedWhenSandboxCommandIsCanceled(t *testing.T
 }
 
 func TestFirejailNetfilterFileIsRemovedWhenWrappedCommandExits(t *testing.T) {
-	filterPath, wrapped := firejailAllowlistCommandForCleanupTest(t)
+	filterPath, wrapped := firejailAllowlistCommandForCleanupTest(t, "#!/usr/bin/env sh\nexit 0\n")
 
 	if err := wrapped.Run(); err != nil {
 		t.Fatalf("wrapped command failed: %v", err)
 	}
 	if _, err := os.Stat(filterPath); !os.IsNotExist(err) {
 		t.Fatalf("netfilter file should be removed after command exit, stat err = %v", err)
+	}
+}
+
+func TestFirejailNetfilterFileIsRemovedWhenTerminateProcessKillsWrapper(t *testing.T) {
+	filterPath, wrapped := firejailAllowlistCommandForCleanupTest(t, "#!/usr/bin/env sh\nsleep 30\n")
+	configurePlatformKill(wrapped)
+
+	if err := wrapped.Start(); err != nil {
+		t.Fatalf("start wrapped command: %v", err)
+	}
+	if wrapped.Cancel == nil {
+		t.Fatal("expected sandbox command to register cleanup cancellation hook")
+	}
+	if err := wrapped.Cancel(); err != nil {
+		t.Fatalf("cancel wrapped command: %v", err)
+	}
+	_ = wrapped.Wait()
+	if _, err := os.Stat(filterPath); !os.IsNotExist(err) {
+		t.Fatalf("netfilter file should be removed after forced process termination, stat err = %v", err)
 	}
 }
 
@@ -428,11 +480,11 @@ func TestFirejailNetfilterFileIsRemovedWhenCredentialValidationFails(t *testing.
 	}
 }
 
-func firejailAllowlistCommandForCleanupTest(t *testing.T) (string, *exec.Cmd) {
+func firejailAllowlistCommandForCleanupTest(t *testing.T, firejailScript string) (string, *exec.Cmd) {
 	t.Helper()
 	binDir := t.TempDir()
 	firejail := filepath.Join(binDir, "firejail")
-	if err := os.WriteFile(firejail, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(firejail, []byte(firejailScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	codex := filepath.Join(binDir, "codex")

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -87,6 +87,40 @@ func TestSandboxBubblewrapBuildsWrappedCommandAndScopesEnvironment(t *testing.T)
 	}
 }
 
+func TestSandboxBubblewrapSkipsMissingLib64Bind(t *testing.T) {
+	binDir := t.TempDir()
+	bwrap := filepath.Join(binDir, "bwrap")
+	if err := os.WriteFile(bwrap, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "exec")
+	base.Dir = workdir
+
+	wrapped, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:     true,
+		Backend:     "bubblewrap",
+		NetworkMode: "none",
+	}), base)
+	if err != nil {
+		t.Fatalf("applySandbox: %v", err)
+	}
+
+	for i := 0; i+2 < len(wrapped.Args); i++ {
+		if wrapped.Args[i] == "--ro-bind" && wrapped.Args[i+1] == "/lib64" && wrapped.Args[i+2] == "/lib64" {
+			if _, err := os.Stat("/lib64"); os.IsNotExist(err) {
+				t.Fatalf("bubblewrap must not require missing /lib64 source, args=%#v", wrapped.Args)
+			}
+		}
+	}
+}
+
 func TestSandboxEnabledFailsWhenDependencyMissing(t *testing.T) {
 	t.Setenv("PATH", "")
 	workdir := t.TempDir()
@@ -352,6 +386,45 @@ func TestFirejailNetfilterFileIsRemovedWhenWrappedCommandExits(t *testing.T) {
 	}
 	if _, err := os.Stat(filterPath); !os.IsNotExist(err) {
 		t.Fatalf("netfilter file should be removed after command exit, stat err = %v", err)
+	}
+}
+
+func TestFirejailNetfilterFileIsRemovedWhenCredentialValidationFails(t *testing.T) {
+	binDir := t.TempDir()
+	firejail := filepath.Join(binDir, "firejail")
+	if err := os.WriteFile(firejail, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMPDIR", t.TempDir())
+
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "app-server")
+	base.Dir = workdir
+
+	missingCredential := filepath.Join(t.TempDir(), "missing-token")
+	_, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:               true,
+		Backend:               "firejail",
+		NetworkMode:           "allowlist",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+		NetworkInterface:      "aiops0",
+		CredentialFiles:       []string{missingCredential},
+	}), base)
+	if err == nil {
+		t.Fatal("expected missing credential file error")
+	}
+
+	matches, globErr := filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "aiops-firejail-netfilter-*.conf"))
+	if globErr != nil {
+		t.Fatalf("glob netfilter files: %v", globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("firejail setup error should remove netfilter files, left %v", matches)
 	}
 }
 

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -34,6 +34,11 @@ func (r ShellRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 	start := time.Now()
 	cmd := exec.CommandContext(ctx, "sh", "-lc", command+" < .aiops/PROMPT.md")
 	cmd.Dir = in.Workdir
+	wrapped, err := applySandbox(ctx, in, cmd)
+	if err != nil {
+		return Result{}, err
+	}
+	cmd = wrapped
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	// Wire platform-specific group-kill semantics. On Unix we put the
@@ -43,7 +48,7 @@ func (r ShellRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 	configurePlatformKill(cmd)
 	cmd.WaitDelay = killGrace
 
-	err := cmd.Run()
+	err = cmd.Run()
 	elapsed := time.Since(start)
 	if err != nil {
 		// Distinguish ctx-driven termination (timeout/cancel) from a

--- a/internal/runner/shell_unix.go
+++ b/internal/runner/shell_unix.go
@@ -15,13 +15,17 @@ import (
 // grandchildren orphaned, blocking workspace cleanup.
 func configurePlatformKill(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	previousCancel := cmd.Cancel
+	cleanupCancel := cmd.Cancel
+	if cmd.WaitDelay == 0 {
+		cleanupCancel = nil
+	}
 	cmd.Cancel = func() error {
-		terminateProcess(cmd)
-		if previousCancel != nil {
-			return previousCancel()
+		var cleanupErr error
+		if cleanupCancel != nil {
+			cleanupErr = cleanupCancel()
 		}
-		return nil
+		terminateProcess(cmd)
+		return cleanupErr
 	}
 }
 

--- a/internal/runner/shell_unix.go
+++ b/internal/runner/shell_unix.go
@@ -15,8 +15,12 @@ import (
 // grandchildren orphaned, blocking workspace cleanup.
 func configurePlatformKill(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	previousCancel := cmd.Cancel
 	cmd.Cancel = func() error {
 		terminateProcess(cmd)
+		if previousCancel != nil {
+			return previousCancel()
+		}
 		return nil
 	}
 }

--- a/internal/runner/shell_unix_test.go
+++ b/internal/runner/shell_unix_test.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package runner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestConfigurePlatformKillDoesNotInvokeDefaultCancel(t *testing.T) {
+	probe := filepath.Join(t.TempDir(), "default-cancel-called")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", "exit 0")
+	cmd.Cancel = func() error {
+		return os.WriteFile(probe, []byte("called"), 0o600)
+	}
+	configurePlatformKill(cmd)
+	if cmd.Cancel == nil {
+		t.Fatal("expected configurePlatformKill to install a cancel hook")
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start command: %v", err)
+	}
+	if err := cmd.Cancel(); err != nil {
+		t.Fatalf("cancel command: %v", err)
+	}
+	_ = cmd.Wait()
+
+	if _, err := os.Stat(probe); err == nil {
+		t.Fatal("configurePlatformKill must not invoke exec.CommandContext default Cancel because it bypasses killGrace with immediate Kill")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat default cancel probe: %v", err)
+	}
+}
+
+func TestConfigurePlatformKillRunsCleanupCancelWhenWaitDelayAlreadySet(t *testing.T) {
+	probe := filepath.Join(t.TempDir(), "cleanup-called")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", "exit 0")
+	cmd.WaitDelay = time.Nanosecond
+	cmd.Cancel = func() error {
+		return os.WriteFile(probe, []byte("called"), 0o600)
+	}
+	configurePlatformKill(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start command: %v", err)
+	}
+	if err := cmd.Cancel(); err != nil {
+		t.Fatalf("cancel command: %v", err)
+	}
+	_ = cmd.Wait()
+
+	if _, err := os.Stat(probe); err != nil {
+		t.Fatalf("expected preinstalled cleanup Cancel to run when WaitDelay marks it as non-default cleanup, stat err = %v", err)
+	}
+}

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -177,7 +177,7 @@ func runTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 		return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("reset run summary: %w", err)}
 	}
 
-	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, Prompt: prompt}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
+	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: cfg.WorkspaceRoot, Prompt: prompt}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
 		WriteFailureArtifacts(ctx, workdir, nil, "runner failed: "+ErrSummary(runErr))
 		return &RunTaskError{Cfg: wcfg, Err: runErr}
 	}

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Claude    CommandConfig   `yaml:"claude" json:"claude"`
 	Policy    PolicyConfig    `yaml:"policy" json:"policy"`
 	Safety    SafetyConfig    `yaml:"safety" json:"safety"`
+	Sandbox   SandboxConfig   `yaml:"sandbox" json:"sandbox"`
 	Verify    VerifyConfig    `yaml:"verify" json:"verify"`
 	PR        PRConfig        `yaml:"pr" json:"pr"`
 }
@@ -127,13 +128,26 @@ func (p PolicyConfig) LineLimit() int {
 }
 
 // SafetyConfig documents the policy envelope operators expect agents and
-// reviewers to honor. It is intentionally descriptive in this phase: enforcement
-// beyond PolicyConfig remains a separate sandbox-hardening task.
+// reviewers to honor. It remains descriptive and operator-facing; SandboxConfig
+// carries the opt-in worker-enforced controls.
 type SafetyConfig struct {
 	AllowedNetworks []string `yaml:"allowed_networks" json:"allowed_networks"`
 	AllowedPaths    []string `yaml:"allowed_paths" json:"allowed_paths"`
 	AllowedCommands []string `yaml:"allowed_commands" json:"allowed_commands"`
 	Forbidden       []string `yaml:"forbidden" json:"forbidden"`
+}
+
+// SandboxConfig controls optional worker-side process hardening around agent
+// invocation. It is disabled by default because Symphony does not mandate one
+// universal sandbox posture; operators opt in per workflow when the host has a
+// supported sandbox backend installed.
+type SandboxConfig struct {
+	Enabled               bool     `yaml:"enabled" json:"enabled"`
+	Backend               string   `yaml:"backend" json:"backend"`
+	NetworkMode           string   `yaml:"network" json:"network"`
+	NetworkAllowlistCIDRs []string `yaml:"network_allowlist_cidrs" json:"network_allowlist_cidrs"`
+	EnvAllowlist          []string `yaml:"env_allowlist" json:"env_allowlist"`
+	CredentialFiles       []string `yaml:"credential_files" json:"credential_files"`
 }
 
 type VerifyConfig struct {
@@ -228,9 +242,10 @@ func DefaultConfig() Config {
 			ReadTimeoutMs:  5000,
 			StallTimeoutMs: 300000,
 		},
-		Claude: CommandConfig{Command: "claude"},
-		Policy: PolicyConfig{Mode: "draft_pr", MaxChangedFiles: 12, MaxChangedLOC: 300},
-		Verify: VerifyConfig{Commands: []string{}},
+		Claude:  CommandConfig{Command: "claude"},
+		Policy:  PolicyConfig{Mode: "draft_pr", MaxChangedFiles: 12, MaxChangedLOC: 300},
+		Sandbox: SandboxConfig{Backend: "none", NetworkMode: "none"},
+		Verify:  VerifyConfig{Commands: []string{}},
 		// PR.Draft defaults to false so workflows that omit `pr.draft` keep
 		// the historical worker behavior of opening ready-for-review PRs.
 		// Profiles that want draft PRs (e.g. company-cautious) opt in by

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -146,6 +146,7 @@ type SandboxConfig struct {
 	Backend               string   `yaml:"backend" json:"backend"`
 	NetworkMode           string   `yaml:"network" json:"network"`
 	NetworkAllowlistCIDRs []string `yaml:"network_allowlist_cidrs" json:"network_allowlist_cidrs"`
+	NetworkInterface      string   `yaml:"network_interface" json:"network_interface"`
 	EnvAllowlist          []string `yaml:"env_allowlist" json:"env_allowlist"`
 	CredentialFiles       []string `yaml:"credential_files" json:"credential_files"`
 }

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -146,6 +146,7 @@ sandbox:
   network: allowlist
   network_allowlist_cidrs:
     - 203.0.113.10/32
+  network_interface: aiops0
   env_allowlist:
     - PATH
     - HOME
@@ -172,6 +173,9 @@ hello
 	}
 	if !reflect.DeepEqual(wf.Config.Sandbox.NetworkAllowlistCIDRs, []string{"203.0.113.10/32"}) {
 		t.Fatalf("NetworkAllowlistCIDRs = %#v", wf.Config.Sandbox.NetworkAllowlistCIDRs)
+	}
+	if wf.Config.Sandbox.NetworkInterface != "aiops0" {
+		t.Fatalf("NetworkInterface = %q, want aiops0", wf.Config.Sandbox.NetworkInterface)
 	}
 	if !reflect.DeepEqual(wf.Config.Sandbox.EnvAllowlist, []string{"PATH", "HOME"}) {
 		t.Fatalf("EnvAllowlist = %#v", wf.Config.Sandbox.EnvAllowlist)
@@ -271,6 +275,37 @@ hello
 	}
 }
 
+func TestLoadRejectsSandboxNetworkAllowlistWithoutInterface(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: firejail
+  network: allowlist
+  network_allowlist_cidrs:
+    - 203.0.113.10/32
+  env_allowlist:
+    - PATH
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected allowlist without network_interface error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.network=allowlist") || !strings.Contains(err.Error(), "network_interface") {
+		t.Fatalf("Load error = %q, want explicit network_interface guidance", err)
+	}
+}
+
 func TestLoadRejectsSandboxNetworkAllowlistInvalidCIDR(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
@@ -285,6 +320,7 @@ sandbox:
   network: allowlist
   network_allowlist_cidrs:
     - "0.0.0.0/0 -j ACCEPT\n-A OUTPUT -j ACCEPT"
+  network_interface: aiops0
   env_allowlist:
     - PATH
 ---

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -338,6 +338,38 @@ hello
 	}
 }
 
+func TestLoadRejectsSandboxNetworkAllowlistIPv6CIDR(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: firejail
+  network: allowlist
+  network_allowlist_cidrs:
+    - 2001:db8::/32
+  network_interface: aiops0
+  env_allowlist:
+    - PATH
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected IPv6 CIDR to be rejected at workflow load time")
+	}
+	if !strings.Contains(err.Error(), "sandbox.network_allowlist_cidrs") || !strings.Contains(err.Error(), "IPv4") || !strings.Contains(err.Error(), "2001:db8::/32") {
+		t.Fatalf("Load error = %q, want IPv4-only CIDR guidance", err)
+	}
+}
+
 func TestLoadRejectsEnabledSandboxWithoutEnvAllowlist(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -122,6 +122,264 @@ func TestDefaultConfigAgentTimeout(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigSandboxDisabled(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Sandbox.Enabled {
+		t.Fatal("sandbox hardening must be disabled by default for backward compatibility")
+	}
+	if cfg.Sandbox.Backend != "none" {
+		t.Fatalf("default Sandbox.Backend: got %q want none", cfg.Sandbox.Backend)
+	}
+}
+
+func TestLoadSandboxEnforcementConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: firejail
+  network: allowlist
+  network_allowlist_cidrs:
+    - 203.0.113.10/32
+  env_allowlist:
+    - PATH
+    - HOME
+  credential_files:
+    - ~/.config/aiops/token
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !wf.Config.Sandbox.Enabled {
+		t.Fatal("Sandbox.Enabled = false, want true")
+	}
+	if wf.Config.Sandbox.Backend != "firejail" {
+		t.Fatalf("Sandbox.Backend = %q, want firejail", wf.Config.Sandbox.Backend)
+	}
+	if wf.Config.Sandbox.NetworkMode != "allowlist" {
+		t.Fatalf("Sandbox.NetworkMode = %q, want allowlist", wf.Config.Sandbox.NetworkMode)
+	}
+	if !reflect.DeepEqual(wf.Config.Sandbox.NetworkAllowlistCIDRs, []string{"203.0.113.10/32"}) {
+		t.Fatalf("NetworkAllowlistCIDRs = %#v", wf.Config.Sandbox.NetworkAllowlistCIDRs)
+	}
+	if !reflect.DeepEqual(wf.Config.Sandbox.EnvAllowlist, []string{"PATH", "HOME"}) {
+		t.Fatalf("EnvAllowlist = %#v", wf.Config.Sandbox.EnvAllowlist)
+	}
+	wantCredential := filepath.Join(os.Getenv("HOME"), ".config/aiops/token")
+	if !reflect.DeepEqual(wf.Config.Sandbox.CredentialFiles, []string{wantCredential}) {
+		t.Fatalf("CredentialFiles = %#v, want %#v", wf.Config.Sandbox.CredentialFiles, []string{wantCredential})
+	}
+}
+
+func TestLoadRejectsSandboxNetworkAllowlistWithoutCIDRs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: firejail
+  network: allowlist
+  env_allowlist:
+    - PATH
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected allowlist without CIDRs error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.network=allowlist") || !strings.Contains(err.Error(), "network_allowlist_cidrs") {
+		t.Fatalf("Load error = %q, want allowlist CIDR guidance", err)
+	}
+}
+
+func TestLoadRejectsUnsupportedSandboxNetwork(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: firejail
+  network: open-internet
+  env_allowlist:
+    - PATH
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected unsupported sandbox network error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.network") || !strings.Contains(err.Error(), "open-internet") {
+		t.Fatalf("Load error = %q, want sandbox.network open-internet", err)
+	}
+}
+
+func TestLoadRejectsSandboxNetworkAllowlistWithoutFirejail(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: bubblewrap
+  network: allowlist
+  network_allowlist_cidrs:
+    - 203.0.113.10/32
+  env_allowlist:
+    - PATH
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected allowlist without firejail error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.network=allowlist") || !strings.Contains(err.Error(), "firejail") {
+		t.Fatalf("Load error = %q, want firejail allowlist guidance", err)
+	}
+}
+
+func TestLoadRejectsSandboxNetworkAllowlistInvalidCIDR(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: firejail
+  network: allowlist
+  network_allowlist_cidrs:
+    - "0.0.0.0/0 -j ACCEPT\n-A OUTPUT -j ACCEPT"
+  env_allowlist:
+    - PATH
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected invalid CIDR error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.network_allowlist_cidrs") || !strings.Contains(err.Error(), "invalid CIDR") {
+		t.Fatalf("Load error = %q, want invalid CIDR guidance", err)
+	}
+}
+
+func TestLoadRejectsEnabledSandboxWithoutEnvAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: bubblewrap
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected enabled sandbox without env_allowlist error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.env_allowlist") {
+		t.Fatalf("Load error = %q, want env_allowlist guidance", err)
+	}
+}
+
+func TestLoadRejectsUnsupportedSandboxBackend(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: vmagic
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected unsupported sandbox backend error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.backend") || !strings.Contains(err.Error(), "vmagic") {
+		t.Fatalf("Load error = %q, want sandbox.backend vmagic", err)
+	}
+}
+
+func TestLoadRejectsEnabledSandboxWithoutBackend(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+sandbox:
+  enabled: true
+  backend: none
+---
+hello
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected enabled sandbox without backend error")
+	}
+	if !strings.Contains(err.Error(), "sandbox.enabled") || !strings.Contains(err.Error(), "backend") {
+		t.Fatalf("Load error = %q, want sandbox.enabled backend guidance", err)
+	}
+}
+
 // TestLoadOptionalAppliesAgentTimeoutDefaults verifies that a workflow
 // missing agent.timeout in its front matter still ends up with the
 // schema default after expandConfig runs.

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,6 +80,17 @@ var supportedCodexProfiles = map[string]struct{}{
 	"custom": {},
 }
 
+var supportedSandboxBackends = map[string]struct{}{
+	"none":       {},
+	"bubblewrap": {},
+	"firejail":   {},
+}
+
+var supportedSandboxNetworks = map[string]struct{}{
+	"none":      {},
+	"allowlist": {},
+}
+
 // validateConfig enforces the required-field and enum constraints that
 // the typed YAML decoder cannot express on its own. It runs after
 // expandConfig so env-var indirections (e.g. `clone_url: $REPO_URL`)
@@ -97,6 +109,31 @@ func validateConfig(path string, cfg Config) error {
 	}
 	if _, ok := supportedCodexProfiles[cfg.Codex.Profile]; !ok {
 		return fmt.Errorf("%s: codex.profile %q is not supported (allowed: safe, bypass, custom)", path, cfg.Codex.Profile)
+	}
+	if _, ok := supportedSandboxBackends[cfg.Sandbox.Backend]; !ok {
+		return fmt.Errorf("%s: sandbox.backend %q is not supported (allowed: none, bubblewrap, firejail)", path, cfg.Sandbox.Backend)
+	}
+	if cfg.Sandbox.Enabled && cfg.Sandbox.Backend == "none" {
+		return fmt.Errorf("%s: sandbox.enabled requires sandbox.backend to be bubblewrap or firejail", path)
+	}
+	if cfg.Sandbox.Enabled && len(cfg.Sandbox.EnvAllowlist) == 0 {
+		return fmt.Errorf("%s: sandbox.enabled requires sandbox.env_allowlist to explicitly scope child environment", path)
+	}
+	if _, ok := supportedSandboxNetworks[cfg.Sandbox.NetworkMode]; !ok {
+		return fmt.Errorf("%s: sandbox.network %q is not supported (allowed: none, allowlist)", path, cfg.Sandbox.NetworkMode)
+	}
+	if cfg.Sandbox.NetworkMode == "allowlist" {
+		if cfg.Sandbox.Backend != "firejail" {
+			return fmt.Errorf("%s: sandbox.network=allowlist requires sandbox.backend firejail", path)
+		}
+		if len(cfg.Sandbox.NetworkAllowlistCIDRs) == 0 {
+			return fmt.Errorf("%s: sandbox.network=allowlist requires sandbox.network_allowlist_cidrs", path)
+		}
+		for _, cidr := range cfg.Sandbox.NetworkAllowlistCIDRs {
+			if _, _, err := net.ParseCIDR(strings.TrimSpace(cidr)); err != nil {
+				return fmt.Errorf("%s: sandbox.network_allowlist_cidrs contains invalid CIDR %q: %w", path, cidr, err)
+			}
+		}
 	}
 	if strings.TrimSpace(cfg.Claude.Profile) != "" {
 		return fmt.Errorf("%s: claude.profile is not supported (only codex has profiles)", path)
@@ -180,6 +217,9 @@ func expandConfig(cfg *Config) {
 	cfg.Workspace.Root = expandPath(os.ExpandEnv(cfg.Workspace.Root))
 	cfg.Codex.Command = os.ExpandEnv(cfg.Codex.Command)
 	cfg.Claude.Command = os.ExpandEnv(cfg.Claude.Command)
+	for i := range cfg.Sandbox.CredentialFiles {
+		cfg.Sandbox.CredentialFiles[i] = expandPath(os.ExpandEnv(cfg.Sandbox.CredentialFiles[i]))
+	}
 	if cfg.Repo.DefaultBranch == "" {
 		cfg.Repo.DefaultBranch = "main"
 	}
@@ -215,6 +255,12 @@ func expandConfig(cfg *Config) {
 	}
 	if cfg.Codex.Profile == "" {
 		cfg.Codex.Profile = "safe"
+	}
+	if cfg.Sandbox.Backend == "" {
+		cfg.Sandbox.Backend = "none"
+	}
+	if cfg.Sandbox.NetworkMode == "" {
+		cfg.Sandbox.NetworkMode = "none"
 	}
 	if cfg.Codex.ThreadSandbox == "" {
 		cfg.Codex.ThreadSandbox = "workspace-write"

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -129,6 +129,9 @@ func validateConfig(path string, cfg Config) error {
 		if len(cfg.Sandbox.NetworkAllowlistCIDRs) == 0 {
 			return fmt.Errorf("%s: sandbox.network=allowlist requires sandbox.network_allowlist_cidrs", path)
 		}
+		if strings.TrimSpace(cfg.Sandbox.NetworkInterface) == "" {
+			return fmt.Errorf("%s: sandbox.network=allowlist requires sandbox.network_interface so Firejail can attach --netfilter to an explicit host interface", path)
+		}
 		for _, cidr := range cfg.Sandbox.NetworkAllowlistCIDRs {
 			if _, _, err := net.ParseCIDR(strings.TrimSpace(cidr)); err != nil {
 				return fmt.Errorf("%s: sandbox.network_allowlist_cidrs contains invalid CIDR %q: %w", path, cidr, err)

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -133,8 +133,12 @@ func validateConfig(path string, cfg Config) error {
 			return fmt.Errorf("%s: sandbox.network=allowlist requires sandbox.network_interface so Firejail can attach --netfilter to an explicit host interface", path)
 		}
 		for _, cidr := range cfg.Sandbox.NetworkAllowlistCIDRs {
-			if _, _, err := net.ParseCIDR(strings.TrimSpace(cidr)); err != nil {
+			ip, _, err := net.ParseCIDR(strings.TrimSpace(cidr))
+			if err != nil {
 				return fmt.Errorf("%s: sandbox.network_allowlist_cidrs contains invalid CIDR %q: %w", path, cidr, err)
+			}
+			if ip.To4() == nil {
+				return fmt.Errorf("%s: sandbox.network_allowlist_cidrs contains non-IPv4 CIDR %q; Firejail netfilter allowlists currently support IPv4 only", path, cidr)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Add opt-in workflow `sandbox:` config for worker-enforced Linux process sandboxing.
- Wrap Codex, Codex app-server, and shell runners with bubblewrap/firejail when enabled.
- Scope sandbox child env/credential files, enforce workspace-root containment, and add firejail CIDR allowlist support.
- Update security posture docs and example workflows to distinguish descriptive `safety:` policy from enforced `sandbox:` policy.

## Test Plan
- `/home/pi/.local/go1.25.10/bin/go test ./internal/workflow ./internal/runner`
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- Independent diff-only Codex review: LGTM

Closes #114
