### PR TITLE
feat: add Linear AI workpad dynamic tool

### DIFF
--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -155,8 +155,12 @@ for line in sys.stdin:
     elif msg.get('method') == 'thread/start':
         tools = msg.get('params', {}).get('dynamicTools', [])
         linear = next((tool for tool in tools if tool.get('name') == 'linear_graphql'), None)
+        workpad = next((tool for tool in tools if tool.get('name') == 'linear_ai_workpad'), None)
         if linear is None or 'inputSchema' not in linear or 'query' not in linear.get('inputSchema', {}).get('properties', {}):
             print(json.dumps({'id': msg['id'], 'error': {'message': 'linear_graphql missing inputSchema', 'tool': linear}}), flush=True)
+            break
+        if workpad is None or 'inputSchema' not in workpad or 'variables' not in workpad.get('inputSchema', {}).get('properties', {}):
+            print(json.dumps({'id': msg['id'], 'error': {'message': 'linear_ai_workpad missing inputSchema', 'tool': workpad}}), flush=True)
             break
         print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
     elif msg.get('method') == 'turn/start':

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -96,6 +96,7 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 			},
 			Call: client.call,
 		}
+		tools.tools["linear_ai_workpad"] = NewLinearWorkpadTool(tools.tools["linear_graphql"])
 	}
 	return tools
 }

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -129,15 +129,17 @@ func TestLinearGraphQLIgnoresAgentSuppliedEndpoint(t *testing.T) {
 	}
 }
 
-func TestDynamicToolsDoNotExposeLinearGraphQLWithoutLinearToken(t *testing.T) {
+func TestDynamicToolsDoNotExposeLinearToolsWithoutLinearToken(t *testing.T) {
 	for _, wf := range []workflow.Workflow{
 		{},
 		{Config: workflow.Config{Tracker: workflow.TrackerConfig{Kind: "linear"}}},
 		{Config: workflow.Config{Tracker: workflow.TrackerConfig{Kind: "gitea", APIKey: "token"}}},
 	} {
 		tools := DynamicToolsForWorkflow(wf)
-		if _, ok := tools.Lookup("linear_graphql"); ok {
-			t.Fatalf("linear_graphql advertised without configured Linear token: %#v", wf.Config.Tracker)
+		for _, name := range []string{"linear_graphql", "linear_ai_workpad"} {
+			if _, ok := tools.Lookup(name); ok {
+				t.Fatalf("%s advertised without configured Linear token: %#v", name, wf.Config.Tracker)
+			}
 		}
 	}
 }

--- a/internal/runner/workpad.go
+++ b/internal/runner/workpad.go
@@ -105,6 +105,11 @@ func (p linearWorkpadProxy) call(ctx context.Context, call ToolCall) (string, er
 	if !ok {
 		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad mutation returned a failure", "output": mutateResult}})
 	}
+	if ok, err := linearWorkpadMutationSucceeded(mutateOutput); err != nil {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad mutation response could not be decoded", "reason": err.Error()}})
+	} else if !ok {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad mutation did not succeed", "output": mutateOutput}})
+	}
 	return dynamicToolResult(true, mutateOutput)
 }
 
@@ -179,6 +184,29 @@ func decodeSuccessfulToolOutput(result string) (string, bool) {
 		return "", false
 	}
 	return payload.Output, payload.Success
+}
+
+func linearWorkpadMutationSucceeded(output string) (bool, error) {
+	var payload struct {
+		Data struct {
+			CommentCreate *struct {
+				Success bool `json:"success"`
+			} `json:"commentCreate"`
+			CommentUpdate *struct {
+				Success bool `json:"success"`
+			} `json:"commentUpdate"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		return false, err
+	}
+	if payload.Data.CommentCreate != nil {
+		return payload.Data.CommentCreate.Success, nil
+	}
+	if payload.Data.CommentUpdate != nil {
+		return payload.Data.CommentUpdate.Success, nil
+	}
+	return false, nil
 }
 
 type linearWorkpadCommentPage struct {

--- a/internal/runner/workpad.go
+++ b/internal/runner/workpad.go
@@ -1,0 +1,202 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	linearWorkpadToolName = "linear_ai_workpad"
+	linearWorkpadMarker   = "<!-- aiops:ai-workpad -->"
+)
+
+// NewLinearWorkpadTool returns a thin helper over linear_graphql. The helper is
+// still agent-side tracker interaction: it only composes deterministic Linear
+// GraphQL calls through the token-isolated linear_graphql tool instead of
+// adding worker-owned Linear comment writes.
+func NewLinearWorkpadTool(linearGraphQL DynamicTool) DynamicTool {
+	return DynamicTool{
+		Name:        linearWorkpadToolName,
+		Description: "Find, create, or update the single AI Workpad Linear comment for an issue by calling the token-isolated linear_graphql tool. Input: {variables:{issueId:string, branch?:string, prUrl?:string, summary?:string, blocker?:string, next?:string}}. No Linear token is exposed.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"variables": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"issueId": map[string]any{"type": "string", "description": "Linear issue identifier or ID to attach the AI Workpad comment to."},
+						"branch":  map[string]any{"type": "string", "description": "Current branch name, when known."},
+						"prUrl":   map[string]any{"type": "string", "description": "Pull request URL, when known."},
+						"summary": map[string]any{"type": "string", "description": "Current run summary or handoff note."},
+						"blocker": map[string]any{"type": "string", "description": "Last error or blocker, when any."},
+						"next":    map[string]any{"type": "string", "description": "Next action, when known."},
+					},
+					"required":             []string{"issueId"},
+					"additionalProperties": false,
+				},
+			},
+			"required":             []string{"variables"},
+			"additionalProperties": false,
+		},
+		Call: linearWorkpadProxy{linearGraphQL: linearGraphQL}.call,
+	}
+}
+
+type linearWorkpadProxy struct {
+	linearGraphQL DynamicTool
+}
+
+type linearWorkpadInput struct {
+	IssueID string
+	Branch  string
+	PRURL   string
+	Summary string
+	Blocker string
+	Next    string
+}
+
+type linearToolPayload struct {
+	Success bool   `json:"success"`
+	Output  string `json:"output"`
+}
+
+func (p linearWorkpadProxy) call(ctx context.Context, call ToolCall) (string, error) {
+	input := normalizeLinearWorkpadInput(call)
+	if strings.TrimSpace(input.IssueID) == "" {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "linear_ai_workpad variables.issueId is required"}})
+	}
+	if p.linearGraphQL.Call == nil {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "linear_ai_workpad requires the linear_graphql dynamic tool"}})
+	}
+
+	findResult, err := p.linearGraphQL.Call(ctx, ToolCall{
+		Query: `query AIWorkpadFind($issueId: String!) {
+  issue(id: $issueId) {
+    comments(first: 50) {
+      nodes { id body }
+    }
+  }
+}`,
+		Variables: map[string]any{"issueId": input.IssueID},
+	})
+	if err != nil {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad lookup failed", "reason": err.Error()}})
+	}
+	findOutput, ok := decodeSuccessfulToolOutput(findResult)
+	if !ok {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad lookup returned a failure", "output": findResult}})
+	}
+
+	commentID, err := findLinearWorkpadCommentID(findOutput)
+	if err != nil {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad lookup response could not be decoded", "reason": err.Error()}})
+	}
+
+	body := renderLinearWorkpadBody(input)
+	var mutation string
+	variables := map[string]any{"body": body}
+	if commentID != "" {
+		mutation = `mutation AIWorkpadUpdate($commentId: String!, $body: String!) {
+  commentUpdate(id: $commentId, input: { body: $body }) {
+    success
+    comment { id }
+  }
+}`
+		variables["commentId"] = commentID
+	} else {
+		mutation = `mutation AIWorkpadCreate($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment { id }
+  }
+}`
+		variables["issueId"] = input.IssueID
+	}
+
+	mutateResult, err := p.linearGraphQL.Call(ctx, ToolCall{Query: mutation, Variables: variables})
+	if err != nil {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad mutation failed", "reason": err.Error()}})
+	}
+	mutateOutput, ok := decodeSuccessfulToolOutput(mutateResult)
+	if !ok {
+		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad mutation returned a failure", "output": mutateResult}})
+	}
+	return dynamicToolResult(true, mutateOutput)
+}
+
+func normalizeLinearWorkpadInput(call ToolCall) linearWorkpadInput {
+	vars := call.Variables
+	if nested, ok := vars["variables"].(map[string]any); ok {
+		vars = nested
+	}
+	return linearWorkpadInput{
+		IssueID: stringVariable(vars, "issueId"),
+		Branch:  stringVariable(vars, "branch"),
+		PRURL:   stringVariable(vars, "prUrl"),
+		Summary: stringVariable(vars, "summary"),
+		Blocker: stringVariable(vars, "blocker"),
+		Next:    stringVariable(vars, "next"),
+	}
+}
+
+func stringVariable(vars map[string]any, name string) string {
+	if vars == nil {
+		return ""
+	}
+	value, _ := vars[name].(string)
+	return strings.TrimSpace(value)
+}
+
+func decodeSuccessfulToolOutput(result string) (string, bool) {
+	var payload linearToolPayload
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		return "", false
+	}
+	return payload.Output, payload.Success
+}
+
+func findLinearWorkpadCommentID(output string) (string, error) {
+	var payload struct {
+		Data struct {
+			Issue struct {
+				Comments struct {
+					Nodes []struct {
+						ID   string `json:"id"`
+						Body string `json:"body"`
+					} `json:"nodes"`
+				} `json:"comments"`
+			} `json:"issue"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		return "", err
+	}
+	for _, node := range payload.Data.Issue.Comments.Nodes {
+		if strings.Contains(node.Body, linearWorkpadMarker) {
+			return node.ID, nil
+		}
+	}
+	return "", nil
+}
+
+func renderLinearWorkpadBody(input linearWorkpadInput) string {
+	return fmt.Sprintf(`%s
+# AI Workpad
+
+- Current branch: %s
+- Pull request: %s
+- Run summary: %s
+- Last error/blocker: %s
+- Next action: %s
+`, linearWorkpadMarker, workpadValue(input.Branch), workpadValue(input.PRURL), workpadValue(input.Summary), workpadValue(input.Blocker), workpadValue(input.Next))
+}
+
+func workpadValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}

--- a/internal/runner/workpad.go
+++ b/internal/runner/workpad.go
@@ -71,27 +71,9 @@ func (p linearWorkpadProxy) call(ctx context.Context, call ToolCall) (string, er
 		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "linear_ai_workpad requires the linear_graphql dynamic tool"}})
 	}
 
-	findResult, err := p.linearGraphQL.Call(ctx, ToolCall{
-		Query: `query AIWorkpadFind($issueId: String!) {
-  issue(id: $issueId) {
-    comments(first: 50) {
-      nodes { id body }
-    }
-  }
-}`,
-		Variables: map[string]any{"issueId": input.IssueID},
-	})
+	commentID, err := p.findLinearWorkpadCommentID(ctx, input.IssueID)
 	if err != nil {
 		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad lookup failed", "reason": err.Error()}})
-	}
-	findOutput, ok := decodeSuccessfulToolOutput(findResult)
-	if !ok {
-		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad lookup returned a failure", "output": findResult}})
-	}
-
-	commentID, err := findLinearWorkpadCommentID(findOutput)
-	if err != nil {
-		return dynamicToolFailure(map[string]any{"error": map[string]any{"message": "AI Workpad lookup response could not be decoded", "reason": err.Error()}})
 	}
 
 	body := renderLinearWorkpadBody(input)
@@ -126,6 +108,48 @@ func (p linearWorkpadProxy) call(ctx context.Context, call ToolCall) (string, er
 	return dynamicToolResult(true, mutateOutput)
 }
 
+func (p linearWorkpadProxy) findLinearWorkpadCommentID(ctx context.Context, issueID string) (string, error) {
+	var after any
+	for {
+		variables := map[string]any{"issueId": issueID}
+		if after != nil {
+			variables["after"] = after
+		}
+		findResult, err := p.linearGraphQL.Call(ctx, ToolCall{
+			Query: `query AIWorkpadFind($issueId: String!, $after: String) {
+  issue(id: $issueId) {
+    comments(first: 50, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id body }
+    }
+  }
+}`,
+			Variables: variables,
+		})
+		if err != nil {
+			return "", err
+		}
+		findOutput, ok := decodeSuccessfulToolOutput(findResult)
+		if !ok {
+			return "", fmt.Errorf("lookup returned a failure: %s", findResult)
+		}
+
+		page, err := decodeLinearWorkpadCommentPage(findOutput)
+		if err != nil {
+			return "", fmt.Errorf("lookup response could not be decoded: %w", err)
+		}
+		for _, node := range page.Nodes {
+			if strings.Contains(node.Body, linearWorkpadMarker) {
+				return node.ID, nil
+			}
+		}
+		if !page.HasNextPage || strings.TrimSpace(page.EndCursor) == "" {
+			return "", nil
+		}
+		after = page.EndCursor
+	}
+}
+
 func normalizeLinearWorkpadInput(call ToolCall) linearWorkpadInput {
 	vars := call.Variables
 	if nested, ok := vars["variables"].(map[string]any); ok {
@@ -157,11 +181,24 @@ func decodeSuccessfulToolOutput(result string) (string, bool) {
 	return payload.Output, payload.Success
 }
 
-func findLinearWorkpadCommentID(output string) (string, error) {
+type linearWorkpadCommentPage struct {
+	HasNextPage bool
+	EndCursor   string
+	Nodes       []struct {
+		ID   string `json:"id"`
+		Body string `json:"body"`
+	}
+}
+
+func decodeLinearWorkpadCommentPage(output string) (linearWorkpadCommentPage, error) {
 	var payload struct {
 		Data struct {
 			Issue struct {
 				Comments struct {
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
 					Nodes []struct {
 						ID   string `json:"id"`
 						Body string `json:"body"`
@@ -171,14 +208,13 @@ func findLinearWorkpadCommentID(output string) (string, error) {
 		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(output), &payload); err != nil {
-		return "", err
+		return linearWorkpadCommentPage{}, err
 	}
-	for _, node := range payload.Data.Issue.Comments.Nodes {
-		if strings.Contains(node.Body, linearWorkpadMarker) {
-			return node.ID, nil
-		}
-	}
-	return "", nil
+	return linearWorkpadCommentPage{
+		HasNextPage: payload.Data.Issue.Comments.PageInfo.HasNextPage,
+		EndCursor:   payload.Data.Issue.Comments.PageInfo.EndCursor,
+		Nodes:       payload.Data.Issue.Comments.Nodes,
+	}, nil
 }
 
 func renderLinearWorkpadBody(input linearWorkpadInput) string {

--- a/internal/runner/workpad.go
+++ b/internal/runner/workpad.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	linearWorkpadToolName = "linear_ai_workpad"
-	linearWorkpadMarker   = "<!-- aiops:ai-workpad -->"
+	linearWorkpadToolName       = "linear_ai_workpad"
+	linearWorkpadMarker         = "<!-- aiops:ai-workpad -->"
+	linearWorkpadMaxLookupPages = 100
 )
 
 // NewLinearWorkpadTool returns a thin helper over linear_graphql. The helper is
@@ -114,10 +115,10 @@ func (p linearWorkpadProxy) call(ctx context.Context, call ToolCall) (string, er
 }
 
 func (p linearWorkpadProxy) findLinearWorkpadCommentID(ctx context.Context, issueID string) (string, error) {
-	var after any
-	for {
+	var after string
+	for pageCount := 0; pageCount < linearWorkpadMaxLookupPages; pageCount++ {
 		variables := map[string]any{"issueId": issueID}
-		if after != nil {
+		if after != "" {
 			variables["after"] = after
 		}
 		findResult, err := p.linearGraphQL.Call(ctx, ToolCall{
@@ -151,8 +152,13 @@ func (p linearWorkpadProxy) findLinearWorkpadCommentID(ctx context.Context, issu
 		if !page.HasNextPage || strings.TrimSpace(page.EndCursor) == "" {
 			return "", nil
 		}
-		after = page.EndCursor
+		nextCursor := strings.TrimSpace(page.EndCursor)
+		if nextCursor == after {
+			return "", fmt.Errorf("lookup pagination did not advance after cursor %q", nextCursor)
+		}
+		after = nextCursor
 	}
+	return "", fmt.Errorf("lookup exceeded %d pages", linearWorkpadMaxLookupPages)
 }
 
 func normalizeLinearWorkpadInput(call ToolCall) linearWorkpadInput {

--- a/internal/runner/workpad.go
+++ b/internal/runner/workpad.go
@@ -145,7 +145,7 @@ func (p linearWorkpadProxy) findLinearWorkpadCommentID(ctx context.Context, issu
 			return "", fmt.Errorf("lookup response could not be decoded: %w", err)
 		}
 		for _, node := range page.Nodes {
-			if strings.Contains(node.Body, linearWorkpadMarker) {
+			if isLinearWorkpadCommentBody(node.Body) {
 				return node.ID, nil
 			}
 		}
@@ -249,6 +249,11 @@ func decodeLinearWorkpadCommentPage(output string) (linearWorkpadCommentPage, er
 		EndCursor:   payload.Data.Issue.Comments.PageInfo.EndCursor,
 		Nodes:       payload.Data.Issue.Comments.Nodes,
 	}, nil
+}
+
+func isLinearWorkpadCommentBody(body string) bool {
+	trimmed := strings.TrimLeft(body, " \t\r\n")
+	return strings.HasPrefix(trimmed, linearWorkpadMarker+"\n# AI Workpad") || strings.HasPrefix(trimmed, linearWorkpadMarker+"\r\n# AI Workpad")
 }
 
 func renderLinearWorkpadBody(input linearWorkpadInput) string {

--- a/internal/runner/workpad_test.go
+++ b/internal/runner/workpad_test.go
@@ -66,6 +66,38 @@ func TestLinearWorkpadUpsertsExistingWorkpadComment(t *testing.T) {
 	}
 }
 
+func TestLinearWorkpadIgnoresQuotedMarkerWithoutCanonicalHeading(t *testing.T) {
+	calls := []recordedToolCall{}
+	linearGraphQL := DynamicTool{
+		Name: "linear_graphql",
+		Call: func(_ context.Context, call ToolCall) (string, error) {
+			calls = append(calls, recordedToolCall{Query: call.Query, Variables: call.Variables})
+			switch len(calls) {
+			case 1:
+				return dynamicToolResult(true, `{"data":{"issue":{"comments":{"nodes":[{"id":"human-comment","body":"I copied this from the bot: <!-- aiops:ai-workpad -->"}]}}}}`)
+			case 2:
+				return dynamicToolResult(true, `{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-new"}}}}`)
+			default:
+				t.Fatalf("unexpected extra linear_graphql call %#v", call)
+				return "", nil
+			}
+		},
+	}
+	tool := NewLinearWorkpadTool(linearGraphQL)
+
+	result, err := tool.Call(context.Background(), ToolCall{Variables: map[string]any{"issueId": "LIN-123"}})
+	if err != nil {
+		t.Fatalf("linear_ai_workpad call: %v", err)
+	}
+	assertToolSuccess(t, result)
+	if len(calls) != 2 {
+		t.Fatalf("linear_graphql calls = %d, want lookup then create", len(calls))
+	}
+	if !strings.Contains(calls[1].Query, "commentCreate") || strings.Contains(calls[1].Query, "commentUpdate") {
+		t.Fatalf("quoted marker should not be updated as managed workpad: %s", calls[1].Query)
+	}
+}
+
 func TestLinearWorkpadFindsExistingWorkpadCommentPastFirstPage(t *testing.T) {
 	calls := []recordedToolCall{}
 	linearGraphQL := DynamicTool{

--- a/internal/runner/workpad_test.go
+++ b/internal/runner/workpad_test.go
@@ -145,6 +145,23 @@ func TestLinearWorkpadCreatesCommentWhenMissing(t *testing.T) {
 	}
 }
 
+func TestLinearWorkpadFailsWhenLinearMutationReportsFailure(t *testing.T) {
+	linearGraphQL := DynamicTool{
+		Name: "linear_graphql",
+		Call: func(_ context.Context, call ToolCall) (string, error) {
+			if strings.Contains(call.Query, "AIWorkpadFind") {
+				return dynamicToolResult(true, `{"data":{"issue":{"comments":{"nodes":[]}}}}`)
+			}
+			return dynamicToolResult(true, `{"data":{"commentCreate":{"success":false,"comment":null}}}`)
+		},
+	}
+	tool := NewLinearWorkpadTool(linearGraphQL)
+
+	result, err := tool.Call(context.Background(), ToolCall{Variables: map[string]any{"issueId": "LIN-123"}})
+
+	assertStructuredFailure(t, result, err, "AI Workpad mutation did not succeed")
+}
+
 func TestLinearWorkpadAcceptsSchemaNestedVariables(t *testing.T) {
 	calls := []recordedToolCall{}
 	linearGraphQL := DynamicTool{

--- a/internal/runner/workpad_test.go
+++ b/internal/runner/workpad_test.go
@@ -1,0 +1,197 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+type recordedToolCall struct {
+	Query     string
+	Variables map[string]any
+}
+
+func TestLinearWorkpadUpsertsExistingWorkpadComment(t *testing.T) {
+	calls := []recordedToolCall{}
+	linearGraphQL := DynamicTool{
+		Name:        "linear_graphql",
+		Description: "Execute Linear GraphQL without secrets.",
+		Call: func(_ context.Context, call ToolCall) (string, error) {
+			calls = append(calls, recordedToolCall{Query: call.Query, Variables: call.Variables})
+			switch len(calls) {
+			case 1:
+				return dynamicToolResult(true, `{"data":{"issue":{"comments":{"nodes":[{"id":"comment-1","body":"<!-- aiops:ai-workpad -->\n# AI Workpad\nold"},{"id":"comment-2","body":"human note"}]}}}}`)
+			case 2:
+				return dynamicToolResult(true, `{"data":{"commentUpdate":{"success":true,"comment":{"id":"comment-1"}}}}`)
+			default:
+				t.Fatalf("unexpected extra linear_graphql call %#v", call)
+				return "", nil
+			}
+		},
+	}
+	tool := NewLinearWorkpadTool(linearGraphQL)
+
+	result, err := tool.Call(context.Background(), ToolCall{Variables: map[string]any{
+		"issueId": "LIN-123",
+		"branch":  "feat/issue-15-linear-ai-workpad",
+		"prUrl":   "https://github.com/xrf9268-hue/aiops-platform/pull/123",
+		"summary": "Implemented workpad helper",
+		"blocker": "none",
+		"next":    "wait for CI",
+	}})
+	if err != nil {
+		t.Fatalf("linear_ai_workpad call: %v", err)
+	}
+	assertToolSuccess(t, result)
+	if len(calls) != 2 {
+		t.Fatalf("linear_graphql calls = %d, want query then update", len(calls))
+	}
+	if !strings.Contains(calls[0].Query, "comments") || !strings.Contains(calls[0].Query, "AIWorkpadFind") {
+		t.Fatalf("first call did not query comments for deterministic lookup: %s", calls[0].Query)
+	}
+	if !strings.Contains(calls[1].Query, "commentUpdate") || strings.Contains(calls[1].Query, "commentCreate") {
+		t.Fatalf("second call should update existing workpad only: %s", calls[1].Query)
+	}
+	if calls[1].Variables["commentId"] != "comment-1" {
+		t.Fatalf("commentId = %#v, want comment-1", calls[1].Variables["commentId"])
+	}
+	body, _ := calls[1].Variables["body"].(string)
+	for _, want := range []string{"<!-- aiops:ai-workpad -->", "# AI Workpad", "Current branch", "Pull request", "Run summary", "Last error/blocker", "Next action"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("workpad body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestLinearWorkpadCreatesCommentWhenMissing(t *testing.T) {
+	calls := []recordedToolCall{}
+	linearGraphQL := DynamicTool{
+		Name:        "linear_graphql",
+		Description: "Execute Linear GraphQL without secrets.",
+		Call: func(_ context.Context, call ToolCall) (string, error) {
+			calls = append(calls, recordedToolCall{Query: call.Query, Variables: call.Variables})
+			switch len(calls) {
+			case 1:
+				return dynamicToolResult(true, `{"data":{"issue":{"comments":{"nodes":[{"id":"comment-2","body":"human note"}]}}}}`)
+			case 2:
+				return dynamicToolResult(true, `{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-new"}}}}`)
+			default:
+				t.Fatalf("unexpected extra linear_graphql call %#v", call)
+				return "", nil
+			}
+		},
+	}
+	tool := NewLinearWorkpadTool(linearGraphQL)
+
+	result, err := tool.Call(context.Background(), ToolCall{Variables: map[string]any{"issueId": "LIN-123"}})
+	if err != nil {
+		t.Fatalf("linear_ai_workpad call: %v", err)
+	}
+	assertToolSuccess(t, result)
+	if len(calls) != 2 {
+		t.Fatalf("linear_graphql calls = %d, want query then create", len(calls))
+	}
+	if !strings.Contains(calls[1].Query, "commentCreate") || strings.Contains(calls[1].Query, "commentUpdate") {
+		t.Fatalf("second call should create missing workpad only: %s", calls[1].Query)
+	}
+	if calls[1].Variables["issueId"] != "LIN-123" {
+		t.Fatalf("issueId = %#v, want LIN-123", calls[1].Variables["issueId"])
+	}
+}
+
+func TestLinearWorkpadAcceptsSchemaNestedVariables(t *testing.T) {
+	calls := []recordedToolCall{}
+	linearGraphQL := DynamicTool{
+		Name: "linear_graphql",
+		Call: func(_ context.Context, call ToolCall) (string, error) {
+			calls = append(calls, recordedToolCall{Query: call.Query, Variables: call.Variables})
+			switch len(calls) {
+			case 1:
+				return dynamicToolResult(true, `{"data":{"issue":{"comments":{"nodes":[]}}}}`)
+			case 2:
+				return dynamicToolResult(true, `{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-new"}}}}`)
+			default:
+				t.Fatalf("unexpected extra linear_graphql call %#v", call)
+				return "", nil
+			}
+		},
+	}
+	tool := NewLinearWorkpadTool(linearGraphQL)
+
+	result, err := tool.Call(context.Background(), ToolCall{Variables: map[string]any{
+		"variables": map[string]any{
+			"issueId": "LIN-456",
+			"summary": "nested schema input",
+		},
+	}})
+	if err != nil {
+		t.Fatalf("linear_ai_workpad call: %v", err)
+	}
+	assertToolSuccess(t, result)
+	if len(calls) != 2 {
+		t.Fatalf("linear_graphql calls = %d, want query then create", len(calls))
+	}
+	if calls[0].Variables["issueId"] != "LIN-456" || calls[1].Variables["issueId"] != "LIN-456" {
+		t.Fatalf("nested variables were not normalized into GraphQL variables: %#v", calls)
+	}
+	body, _ := calls[1].Variables["body"].(string)
+	if !strings.Contains(body, "nested schema input") {
+		t.Fatalf("workpad body did not include nested summary: %s", body)
+	}
+}
+
+func TestLinearWorkpadToolMetadataDoesNotExposeLinearToken(t *testing.T) {
+	const token = "lin_super_secret_workpad_token"
+	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: token}}})
+	tool, ok := tools.Lookup("linear_ai_workpad")
+	if !ok {
+		t.Fatalf("linear_ai_workpad tool not advertised; tools=%#v", tools.Names())
+	}
+	metadata, err := json.Marshal(map[string]any{
+		"name":        tool.Name,
+		"description": tool.Description,
+		"schema":      tool.InputSchema,
+	})
+	if err != nil {
+		t.Fatalf("marshal tool metadata: %v", err)
+	}
+	if strings.Contains(string(metadata), token) {
+		t.Fatalf("workpad metadata leaked Linear token: %s", metadata)
+	}
+	if strings.Contains(string(metadata), "apiKey") || strings.Contains(string(metadata), "Authorization") {
+		t.Fatalf("workpad metadata exposes orchestrator auth details: %s", metadata)
+	}
+}
+
+func TestLinearWorkpadFailureWhenIssueIDMissing(t *testing.T) {
+	called := false
+	tool := DynamicTool{
+		Name: "linear_ai_workpad",
+		Call: NewLinearWorkpadTool(DynamicTool{Name: "linear_graphql", Call: func(context.Context, ToolCall) (string, error) {
+			called = true
+			return dynamicToolResult(true, `{}`)
+		}}).Call,
+	}
+	result, err := tool.Call(context.Background(), ToolCall{Variables: map[string]any{"branch": "feat/example"}})
+	assertStructuredFailure(t, result, err, "issueId is required")
+	if called {
+		t.Fatalf("linear_graphql was called even though issueId was missing")
+	}
+}
+
+func assertToolSuccess(t *testing.T, result string) {
+	t.Helper()
+	var payload struct {
+		Success bool   `json:"success"`
+		Output  string `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("result is not structured JSON: %v\n%s", err, result)
+	}
+	if !payload.Success {
+		t.Fatalf("success = false, want true; output=%s", payload.Output)
+	}
+}

--- a/internal/runner/workpad_test.go
+++ b/internal/runner/workpad_test.go
@@ -66,6 +66,49 @@ func TestLinearWorkpadUpsertsExistingWorkpadComment(t *testing.T) {
 	}
 }
 
+func TestLinearWorkpadFindsExistingWorkpadCommentPastFirstPage(t *testing.T) {
+	calls := []recordedToolCall{}
+	linearGraphQL := DynamicTool{
+		Name: "linear_graphql",
+		Call: func(_ context.Context, call ToolCall) (string, error) {
+			calls = append(calls, recordedToolCall{Query: call.Query, Variables: call.Variables})
+			switch len(calls) {
+			case 1:
+				if _, ok := call.Variables["after"]; ok {
+					t.Fatalf("first lookup should not pass an after cursor: %#v", call.Variables)
+				}
+				return dynamicToolResult(true, `{"data":{"issue":{"comments":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[{"id":"comment-1","body":"human note"}]}}}}`)
+			case 2:
+				if call.Variables["after"] != "cursor-1" {
+					t.Fatalf("second lookup after cursor = %#v, want cursor-1", call.Variables["after"])
+				}
+				return dynamicToolResult(true, `{"data":{"issue":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":"cursor-2"},"nodes":[{"id":"comment-2","body":"<!-- aiops:ai-workpad -->\n# AI Workpad\nold"}]}}}}`)
+			case 3:
+				return dynamicToolResult(true, `{"data":{"commentUpdate":{"success":true,"comment":{"id":"comment-2"}}}}`)
+			default:
+				t.Fatalf("unexpected extra linear_graphql call %#v", call)
+				return "", nil
+			}
+		},
+	}
+	tool := NewLinearWorkpadTool(linearGraphQL)
+
+	result, err := tool.Call(context.Background(), ToolCall{Variables: map[string]any{"issueId": "LIN-123"}})
+	if err != nil {
+		t.Fatalf("linear_ai_workpad call: %v", err)
+	}
+	assertToolSuccess(t, result)
+	if len(calls) != 3 {
+		t.Fatalf("linear_graphql calls = %d, want two lookup pages then update", len(calls))
+	}
+	if !strings.Contains(calls[2].Query, "commentUpdate") || strings.Contains(calls[2].Query, "commentCreate") {
+		t.Fatalf("final call should update existing paginated workpad only: %s", calls[2].Query)
+	}
+	if calls[2].Variables["commentId"] != "comment-2" {
+		t.Fatalf("commentId = %#v, want comment-2", calls[2].Variables["commentId"])
+	}
+}
+
 func TestLinearWorkpadCreatesCommentWhenMissing(t *testing.T) {
 	calls := []recordedToolCall{}
 	linearGraphQL := DynamicTool{

--- a/internal/runner/workpad_test.go
+++ b/internal/runner/workpad_test.go
@@ -109,6 +109,25 @@ func TestLinearWorkpadFindsExistingWorkpadCommentPastFirstPage(t *testing.T) {
 	}
 }
 
+func TestLinearWorkpadFailsWhenLookupCursorDoesNotAdvance(t *testing.T) {
+	calls := []recordedToolCall{}
+	linearGraphQL := DynamicTool{
+		Name: "linear_graphql",
+		Call: func(_ context.Context, call ToolCall) (string, error) {
+			calls = append(calls, recordedToolCall{Query: call.Query, Variables: call.Variables})
+			if len(calls) > 2 {
+				t.Fatalf("lookup continued after cursor stopped advancing: %#v", calls)
+			}
+			return dynamicToolResult(true, `{"data":{"issue":{"comments":{"pageInfo":{"hasNextPage":true,"endCursor":"same-cursor"},"nodes":[{"id":"comment-1","body":"human note"}]}}}}`)
+		},
+	}
+	tool := NewLinearWorkpadTool(linearGraphQL)
+
+	result, err := tool.Call(context.Background(), ToolCall{Variables: map[string]any{"issueId": "LIN-123"}})
+
+	assertStructuredFailure(t, result, err, "lookup pagination did not advance")
+}
+
 func TestLinearWorkpadCreatesCommentWhenMissing(t *testing.T) {
 	calls := []recordedToolCall{}
 	linearGraphQL := DynamicTool{


### PR DESCRIPTION
## Summary
- Add `linear_ai_workpad`, a token-isolated agent-side helper dynamic tool that composes deterministic Linear comment lookup/update/create calls through `linear_graphql`.
- Use a stable `<!-- aiops:ai-workpad -->` marker and structured body fields for current branch, PR URL, run summary, blocker, and next action to avoid duplicate workpad comments.
- Advertise the helper alongside `linear_graphql` for Linear workflows without adding worker-owned Linear comment writes or exposing the Linear API token on the app-server wire.

Closes #15

## Test Plan
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/runner -run 'TestLinearWorkpad|TestDynamicToolsDoNotExposeLinearToolsWithoutLinearToken|TestCodexAppServerRunnerDoesNotPutLinearTokenOnWire' -count=1`
- [x] `git diff --exit-code -- go.mod go.sum`
- [x] `/home/pi/.local/go1.25.10/bin/gofmt -l $(git ls-files '*.go')`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./...`
- [x] `/home/pi/.local/go1.25.10/bin/go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`
- [ ] `/home/pi/.local/go1.25.10/bin/go test -race -covermode=atomic ./...` — blocked on this Raspberry Pi host by Go ThreadSanitizer runtime: `FATAL: ThreadSanitizer: unsupported VMA range; FATAL: Found 47 - Supported 48`.
