### PR TITLE
fix(orchestrator): ignore stale run finalization

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -374,6 +374,7 @@ type finalizeRunOp struct {
 	attempt    *int
 	result     WorkerResult
 	started    time.Time
+	entry      *RunningEntry
 	done       chan struct{}
 }
 
@@ -383,11 +384,17 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		elapsed = time.Since(f.started)
 	}
 	if f.result.Err == nil {
-		st.FinishRunSucceeded(f.id, elapsed)
+		if !st.FinishRunSucceeded(f.id, f.entry, elapsed) {
+			close(f.done)
+			return nil
+		}
 		close(f.done)
 		return nil
 	}
-	st.FinishRunFailed(f.id, elapsed)
+	if !st.FinishRunFailed(f.id, f.entry, elapsed) {
+		close(f.done)
+		return nil
+	}
 	// Hold the Claimed slot across the gap between this apply (which
 	// returns control to the actor's select loop) and the
 	// scheduleRetryOp that the followup enqueues. Without this re-set,
@@ -466,6 +473,7 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int) {
 			attempt:    attempt,
 			result:     res,
 			started:    startedAt,
+			entry:      entry,
 			done:       workerDone,
 		})
 	}()

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -199,8 +199,8 @@ func (s *OrchestratorState) BeginDispatch(id IssueID, entry *RunningEntry) {
 //     is NOT consulted for dispatch gating; it exists so operator views
 //     and §13.7's /api/v1/state can report it).
 //   - Folds elapsed into CodexTotals.SecondsRunning.
-func (s *OrchestratorState) FinishRunSucceeded(id IssueID, elapsed time.Duration) bool {
-	if _, ok := s.Running[id]; !ok {
+func (s *OrchestratorState) FinishRunSucceeded(id IssueID, run *RunningEntry, elapsed time.Duration) bool {
+	if current, ok := s.Running[id]; !ok || current != run {
 		return false
 	}
 	delete(s.Running, id)
@@ -216,8 +216,8 @@ func (s *OrchestratorState) FinishRunSucceeded(id IssueID, elapsed time.Duration
 // the next migration step; this method only releases the run slot and
 // folds elapsed time so the caller can decide whether to enqueue a
 // retry via ScheduleRetry.
-func (s *OrchestratorState) FinishRunFailed(id IssueID, elapsed time.Duration) bool {
-	if _, ok := s.Running[id]; !ok {
+func (s *OrchestratorState) FinishRunFailed(id IssueID, run *RunningEntry, elapsed time.Duration) bool {
+	if current, ok := s.Running[id]; !ok || current != run {
 		return false
 	}
 	delete(s.Running, id)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -199,11 +199,15 @@ func (s *OrchestratorState) BeginDispatch(id IssueID, entry *RunningEntry) {
 //     is NOT consulted for dispatch gating; it exists so operator views
 //     and §13.7's /api/v1/state can report it).
 //   - Folds elapsed into CodexTotals.SecondsRunning.
-func (s *OrchestratorState) FinishRunSucceeded(id IssueID, elapsed time.Duration) {
+func (s *OrchestratorState) FinishRunSucceeded(id IssueID, elapsed time.Duration) bool {
+	if _, ok := s.Running[id]; !ok {
+		return false
+	}
 	delete(s.Running, id)
 	delete(s.Claimed, id)
 	s.Completed[id] = struct{}{}
 	s.CodexTotals.AddSeconds(elapsed)
+	return true
 }
 
 // FinishRunFailed is the transition for a worker that exited abnormally
@@ -212,10 +216,14 @@ func (s *OrchestratorState) FinishRunSucceeded(id IssueID, elapsed time.Duration
 // the next migration step; this method only releases the run slot and
 // folds elapsed time so the caller can decide whether to enqueue a
 // retry via ScheduleRetry.
-func (s *OrchestratorState) FinishRunFailed(id IssueID, elapsed time.Duration) {
+func (s *OrchestratorState) FinishRunFailed(id IssueID, elapsed time.Duration) bool {
+	if _, ok := s.Running[id]; !ok {
+		return false
+	}
 	delete(s.Running, id)
 	delete(s.Claimed, id)
 	s.CodexTotals.AddSeconds(elapsed)
+	return true
 }
 
 // ScheduleRetry records a RetryEntry under RetryAttempts and keeps the

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -101,7 +101,9 @@ func TestFinishRunSucceeded_RemovesRunningAddsCompletedFoldsSeconds(t *testing.T
 	id := IssueID(iss.ID)
 	st.BeginDispatch(id, runningEntry(t, iss))
 
-	st.FinishRunSucceeded(id, 750*time.Millisecond)
+	if ok := st.FinishRunSucceeded(id, 750*time.Millisecond); !ok {
+		t.Fatalf("FinishRunSucceeded returned false for running issue %s", id)
+	}
 
 	if _, ok := st.Running[id]; ok {
 		t.Errorf("Running[%s] should be removed after FinishRunSucceeded", id)
@@ -127,7 +129,9 @@ func TestFinishRunFailed_RemovesRunningReleasesClaimDoesNotMarkCompleted(t *test
 	id := IssueID(iss.ID)
 	st.BeginDispatch(id, runningEntry(t, iss))
 
-	st.FinishRunFailed(id, 2*time.Second)
+	if ok := st.FinishRunFailed(id, 2*time.Second); !ok {
+		t.Fatalf("FinishRunFailed returned false for running issue %s", id)
+	}
 
 	if _, ok := st.Running[id]; ok {
 		t.Errorf("Running[%s] should be removed after FinishRunFailed", id)
@@ -227,6 +231,35 @@ func TestReleaseClaim_DoesNotTouchRunning(t *testing.T) {
 	// Done; ReleaseClaim is the non-running half of reconciliation.
 	if _, ok := st.Running[id]; !ok {
 		t.Errorf("ReleaseClaim must not remove Running[%s]; that's the worker goroutine's job", id)
+	}
+}
+
+func TestFinishRunIgnoresUnknownRunningEntry(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	id := IssueID("ENG-MISSING")
+	st.Claimed[id] = struct{}{}
+
+	if ok := st.FinishRunSucceeded(id, time.Second); ok {
+		t.Fatalf("FinishRunSucceeded returned true for issue with no Running entry")
+	}
+	if _, ok := st.Claimed[id]; !ok {
+		t.Fatalf("FinishRunSucceeded removed Claimed[%s] even though no Running entry existed", id)
+	}
+	if _, ok := st.Completed[id]; ok {
+		t.Fatalf("FinishRunSucceeded marked Completed[%s] even though no Running entry existed", id)
+	}
+	if got := st.CodexTotals.SecondsRunning; got != 0 {
+		t.Fatalf("FinishRunSucceeded added elapsed seconds for unknown run: %v", got)
+	}
+
+	if ok := st.FinishRunFailed(id, time.Second); ok {
+		t.Fatalf("FinishRunFailed returned true for issue with no Running entry")
+	}
+	if _, ok := st.Claimed[id]; !ok {
+		t.Fatalf("FinishRunFailed removed Claimed[%s] even though no Running entry existed", id)
+	}
+	if got := st.CodexTotals.SecondsRunning; got != 0 {
+		t.Fatalf("FinishRunFailed added elapsed seconds for unknown run: %v", got)
 	}
 }
 

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -99,9 +99,10 @@ func TestFinishRunSucceeded_RemovesRunningAddsCompletedFoldsSeconds(t *testing.T
 	st := NewOrchestratorState(15000, 4)
 	iss := issue("ENG-1")
 	id := IssueID(iss.ID)
-	st.BeginDispatch(id, runningEntry(t, iss))
+	entry := runningEntry(t, iss)
+	st.BeginDispatch(id, entry)
 
-	if ok := st.FinishRunSucceeded(id, 750*time.Millisecond); !ok {
+	if ok := st.FinishRunSucceeded(id, entry, 750*time.Millisecond); !ok {
 		t.Fatalf("FinishRunSucceeded returned false for running issue %s", id)
 	}
 
@@ -127,9 +128,10 @@ func TestFinishRunFailed_RemovesRunningReleasesClaimDoesNotMarkCompleted(t *test
 	st := NewOrchestratorState(15000, 4)
 	iss := issue("ENG-1")
 	id := IssueID(iss.ID)
-	st.BeginDispatch(id, runningEntry(t, iss))
+	entry := runningEntry(t, iss)
+	st.BeginDispatch(id, entry)
 
-	if ok := st.FinishRunFailed(id, 2*time.Second); !ok {
+	if ok := st.FinishRunFailed(id, entry, 2*time.Second); !ok {
 		t.Fatalf("FinishRunFailed returned false for running issue %s", id)
 	}
 
@@ -239,7 +241,7 @@ func TestFinishRunIgnoresUnknownRunningEntry(t *testing.T) {
 	id := IssueID("ENG-MISSING")
 	st.Claimed[id] = struct{}{}
 
-	if ok := st.FinishRunSucceeded(id, time.Second); ok {
+	if ok := st.FinishRunSucceeded(id, nil, time.Second); ok {
 		t.Fatalf("FinishRunSucceeded returned true for issue with no Running entry")
 	}
 	if _, ok := st.Claimed[id]; !ok {
@@ -252,7 +254,7 @@ func TestFinishRunIgnoresUnknownRunningEntry(t *testing.T) {
 		t.Fatalf("FinishRunSucceeded added elapsed seconds for unknown run: %v", got)
 	}
 
-	if ok := st.FinishRunFailed(id, time.Second); ok {
+	if ok := st.FinishRunFailed(id, nil, time.Second); ok {
 		t.Fatalf("FinishRunFailed returned true for issue with no Running entry")
 	}
 	if _, ok := st.Claimed[id]; !ok {
@@ -260,6 +262,46 @@ func TestFinishRunIgnoresUnknownRunningEntry(t *testing.T) {
 	}
 	if got := st.CodexTotals.SecondsRunning; got != 0 {
 		t.Fatalf("FinishRunFailed added elapsed seconds for unknown run: %v", got)
+	}
+}
+
+func TestFinishRunIgnoresStaleRunIdentity(t *testing.T) {
+	st := NewOrchestratorState(15000, 4)
+	iss := issue("ENG-1")
+	id := IssueID(iss.ID)
+	oldEntry := runningEntry(t, iss)
+	newEntry := runningEntry(t, iss)
+
+	st.BeginDispatch(id, oldEntry)
+	st.BeginDispatch(id, newEntry)
+
+	if ok := st.FinishRunSucceeded(id, oldEntry, time.Second); ok {
+		t.Fatalf("FinishRunSucceeded returned true for stale run identity")
+	}
+	if got := st.Running[id]; got != newEntry {
+		t.Fatalf("FinishRunSucceeded replaced/removed current run for stale finalization: got %p want %p", got, newEntry)
+	}
+	if _, ok := st.Claimed[id]; !ok {
+		t.Fatalf("FinishRunSucceeded released claim for stale finalization")
+	}
+	if _, ok := st.Completed[id]; ok {
+		t.Fatalf("FinishRunSucceeded marked Completed[%s] for stale finalization", id)
+	}
+	if got := st.CodexTotals.SecondsRunning; got != 0 {
+		t.Fatalf("FinishRunSucceeded added elapsed seconds for stale finalization: %v", got)
+	}
+
+	if ok := st.FinishRunFailed(id, oldEntry, time.Second); ok {
+		t.Fatalf("FinishRunFailed returned true for stale run identity")
+	}
+	if got := st.Running[id]; got != newEntry {
+		t.Fatalf("FinishRunFailed replaced/removed current run for stale finalization: got %p want %p", got, newEntry)
+	}
+	if _, ok := st.Claimed[id]; !ok {
+		t.Fatalf("FinishRunFailed released claim for stale finalization")
+	}
+	if got := st.CodexTotals.SecondsRunning; got != 0 {
+		t.Fatalf("FinishRunFailed added elapsed seconds for stale finalization: %v", got)
 	}
 }
 
@@ -316,8 +358,9 @@ func TestSnapshot_ShapeMatches13_3(t *testing.T) {
 		Error:      "bad",
 	})
 	// Completed is fed via FinishRunSucceeded.
-	st.BeginDispatch(id3, runningEntry(t, iss3))
-	st.FinishRunSucceeded(id3, 500*time.Millisecond)
+	entry3 := runningEntry(t, iss3)
+	st.BeginDispatch(id3, entry3)
+	st.FinishRunSucceeded(id3, entry3, 500*time.Millisecond)
 
 	view := st.Snapshot()
 


### PR DESCRIPTION
## Summary
- Ignore stale run-finalization calls when the orchestrator no longer has a matching `Running` entry.
- Return a boolean from `FinishRunSucceeded` / `FinishRunFailed` so callers can distinguish applied transitions from stale outcomes.
- Add regression coverage proving stale finalization does not release claims, mark completion, or inflate Codex runtime totals.

## Test Plan
- `/home/pi/.local/go1.25.10/bin/go test ./internal/orchestrator`
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- Diff-only independent review via `claude -p ... --allowedTools '' --max-turns 1` returned `LGTM`.

Refs #95
