### PR TITLE
fix: use raw Linear API key for GraphQL auth

### DIFF
--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -220,7 +220,7 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Authorization", c.APIKey)
 	httpClient := c.HTTP
 	if httpClient == nil {
 		httpClient = http.DefaultClient

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -123,8 +123,8 @@ func TestMoveIssueToState_LooksUpStateThenMutates(t *testing.T) {
 	if lookup.Variables["teamKey"] != "ENG" {
 		t.Fatalf("lookup teamKey = %v, want \"ENG\"", lookup.Variables["teamKey"])
 	}
-	if lookup.AuthHeader != "Bearer test-key" {
-		t.Fatalf("lookup Authorization = %q, want Bearer token", lookup.AuthHeader)
+	if lookup.AuthHeader != "test-key" {
+		t.Fatalf("lookup Authorization = %q, want raw Linear API key", lookup.AuthHeader)
 	}
 
 	mutate := srv.requests[1]


### PR DESCRIPTION
## Summary
- Fix Linear GraphQL authentication to send the raw API key in the `Authorization` header instead of a Bearer token wrapper.
- Update the Linear client unit test to pin the raw-key header expected by Linear.
- Verified the configured `LINEAR_API_KEY` with a live read-only Linear GraphQL probe without printing credentials.

## Test Plan
- [x] `/home/pi/.local/go1.25.10/bin/go test ./cmd/linear-poller ./internal/tracker -count=1`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./...`
- [x] `/home/pi/.local/go1.25.10/bin/go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`
- [x] `/home/pi/.local/go1.25.10/bin/go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `/home/pi/.local/go1.25.10/bin/gofmt -w internal/tracker/linear.go internal/tracker/linear_test.go`
- [x] `python3 tmp/linear_validate.py` (temporary local script; removed before commit; confirmed raw-key auth succeeds and required Linear schema fields exist)

## Notes
- `go test -race -covermode=atomic ./cmd/linear-poller ./internal/tracker` is blocked on this Raspberry Pi host by ThreadSanitizer environment support: `FATAL: ThreadSanitizer: unsupported VMA range` / `FATAL: Found 47 - Supported 48`.

Closes #13
