### PR TITLE
feat: add Gitea aiops label reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Symphony implementation while D1–D24 are closed systematically.
 
 - `cmd/trigger-api`: receives Gitea webhooks and manual task submissions.
 - `cmd/linear-poller`: polls Linear issues in configured active states and enqueues tasks.
+- `cmd/gitea-poller`: polls Gitea issues whose mutually-exclusive `aiops/*` labels map to configured active states and enqueues tasks.
 - `cmd/worker`: claims/dispatches tasks and runs the Symphony-style workflow.
 - `internal/workflow`: loads repo-owned `WORKFLOW.md` configuration and prompt body.
 - `internal/tracker`: tracker abstraction with a Linear client.
@@ -148,6 +149,28 @@ docker compose --env-file .env -f deploy/docker-compose.yml --profile linear up 
 ```
 
 The poller watches active Linear states such as `AI Ready`, `In Progress`, and `Rework`, then enqueues tasks for the worker.
+
+## Quick start: Gitea polling path
+
+For SPEC-aligned Gitea polling, encode issue state as exactly one `aiops/*` label:
+
+| Workflow state | Gitea label |
+| --- | --- |
+| `AI Ready` | `aiops/todo` |
+| `In Progress` | `aiops/in-progress` |
+| `Rework` | `aiops/rework` |
+| `Done` | `aiops/done` |
+| `Canceled` | `aiops/canceled` |
+
+Then run the poller from source:
+
+```bash
+export GITEA_BASE_URL=https://gitea.example.com
+export GITEA_TOKEN=your-gitea-bot-token
+go run ./cmd/gitea-poller examples/WORKFLOW.md
+```
+
+The poller reads issues whose labels map to configured active states and enqueues them for the worker. State changes are still performed by the agent through the advertised tool surface, not by the poller.
 
 ## First safe mode
 

--- a/cmd/gitea-poller/main.go
+++ b/cmd/gitea-poller/main.go
@@ -32,7 +32,7 @@ func main() {
 	if wf.Config.Tracker.Kind != "gitea" {
 		log.Fatalf("tracker.kind must be gitea, got %q", wf.Config.Tracker.Kind)
 	}
-	dsn := env("DATABASE_URL", "postgres://aiops:***@localhost:5432/aiops?sslmode=disable")
+	dsn := databaseURL()
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
 		log.Fatal(err)
@@ -95,6 +95,10 @@ func giteaBaseURL(cfg workflow.TrackerConfig) string {
 		return strings.TrimRight(cfg.ProjectSlug, "/")
 	}
 	return env("GITEA_BASE_URL", "http://localhost:3000")
+}
+
+func databaseURL() string {
+	return env("DATABASE_URL", "postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable")
 }
 
 func env(k, d string) string {

--- a/cmd/gitea-poller/main.go
+++ b/cmd/gitea-poller/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
+	"github.com/xrf9268-hue/aiops-platform/internal/queue"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+type enqueuer interface {
+	Enqueue(ctx context.Context, t task.Task) (task.Task, bool, error)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("usage: gitea-poller /path/to/WORKFLOW.md")
+	}
+	ctx := context.Background()
+	wf, err := workflow.Load(os.Args[1])
+	if err != nil {
+		log.Fatal(err)
+	}
+	if wf.Config.Tracker.Kind != "gitea" {
+		log.Fatalf("tracker.kind must be gitea, got %q", wf.Config.Tracker.Kind)
+	}
+	dsn := env("DATABASE_URL", "postgres://aiops:***@localhost:5432/aiops?sslmode=disable")
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer pool.Close()
+	store := queue.New(pool)
+	baseURL := giteaBaseURL(wf.Config.Tracker)
+	client := gitea.NewTrackerClient(wf.Config.Tracker, baseURL, wf.Config.Repo.Owner, wf.Config.Repo.Name)
+	client.Logf = log.Printf
+	interval := time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond
+
+	for {
+		issues, err := client.ListActiveIssues(ctx)
+		if err != nil {
+			log.Printf("gitea poll error: %v", err)
+			time.Sleep(interval)
+			continue
+		}
+		processIssues(ctx, store, &wf.Config, issues)
+		time.Sleep(interval)
+	}
+}
+
+func processIssues(ctx context.Context, store enqueuer, cfg *workflow.Config, issues []tracker.Issue) {
+	for _, issue := range issues {
+		if cfg.Repo.CloneURL == "" {
+			log.Printf("skip %s: repo.clone_url missing in WORKFLOW.md", issue.Identifier)
+			continue
+		}
+		out, deduped, err := store.Enqueue(ctx, task.Task{
+			SourceType:    "gitea_issue",
+			SourceEventID: sourceEventID(issue),
+			RepoOwner:     cfg.Repo.Owner,
+			RepoName:      cfg.Repo.Name,
+			CloneURL:      cfg.Repo.CloneURL,
+			BaseBranch:    cfg.Repo.DefaultBranch,
+			Title:         fmt.Sprintf("%s %s", issue.Identifier, issue.Title),
+			Description:   issue.Description + "\n\nGitea: " + issue.URL,
+			Actor:         "gitea",
+			Model:         cfg.Agent.Default,
+			Priority:      50,
+		})
+		if err != nil {
+			log.Printf("enqueue %s error: %v", issue.Identifier, err)
+			continue
+		}
+		log.Printf("issue %s -> task %s deduped=%v", issue.Identifier, out.ID, deduped)
+	}
+}
+
+func sourceEventID(issue tracker.Issue) string {
+	if strings.EqualFold(issue.State, "Rework") && issue.UpdatedAt != "" {
+		return issue.ID + "|rework|" + issue.UpdatedAt
+	}
+	return issue.ID
+}
+
+func giteaBaseURL(cfg workflow.TrackerConfig) string {
+	if cfg.ProjectSlug != "" {
+		return strings.TrimRight(cfg.ProjectSlug, "/")
+	}
+	return env("GITEA_BASE_URL", "http://localhost:3000")
+}
+
+func env(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}

--- a/cmd/gitea-poller/main_test.go
+++ b/cmd/gitea-poller/main_test.go
@@ -19,6 +19,13 @@ func (f *fakeStore) Enqueue(_ context.Context, in task.Task) (task.Task, bool, e
 	return in, false, nil
 }
 
+func TestDefaultDatabaseURLIsUsablePostgresDSN(t *testing.T) {
+	got := databaseURL()
+	if got == "" || got == "postgres://aiops:***@localhost:5432/aiops?sslmode=disable" {
+		t.Fatalf("databaseURL default = %q, want usable local Postgres DSN without placeholder credentials", got)
+	}
+}
+
 func TestProcessIssuesEnqueuesGiteaIssueTasks(t *testing.T) {
 	store := &fakeStore{}
 	cfg := &workflow.Config{

--- a/cmd/gitea-poller/main_test.go
+++ b/cmd/gitea-poller/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+type fakeStore struct {
+	tasks []task.Task
+}
+
+func (f *fakeStore) Enqueue(_ context.Context, in task.Task) (task.Task, bool, error) {
+	in.ID = "tsk_1"
+	f.tasks = append(f.tasks, in)
+	return in, false, nil
+}
+
+func TestProcessIssuesEnqueuesGiteaIssueTasks(t *testing.T) {
+	store := &fakeStore{}
+	cfg := &workflow.Config{
+		Repo:  workflow.RepoConfig{Owner: "owner", Name: "repo", CloneURL: "git@example.com:owner/repo.git", DefaultBranch: "main"},
+		Agent: workflow.AgentConfig{Default: "mock"},
+	}
+
+	processIssues(context.Background(), store, cfg, []tracker.Issue{{
+		ID:          "101",
+		Identifier:  "#7",
+		Title:       "ship feature",
+		Description: "body",
+		URL:         "https://gitea.local/owner/repo/issues/7",
+		State:       "AI Ready",
+	}})
+
+	if len(store.tasks) != 1 {
+		t.Fatalf("enqueued tasks = %d, want 1", len(store.tasks))
+	}
+	got := store.tasks[0]
+	if got.SourceType != "gitea_issue" || got.SourceEventID != "101" || got.Actor != "gitea" {
+		t.Fatalf("task source = (%q,%q,%q), want gitea issue source", got.SourceType, got.SourceEventID, got.Actor)
+	}
+	if got.Title != "#7 ship feature" {
+		t.Fatalf("title = %q", got.Title)
+	}
+}
+
+func TestSourceEventIDReworkUsesUpdatedAt(t *testing.T) {
+	got := sourceEventID(tracker.Issue{ID: "101", State: "Rework", UpdatedAt: "2026-05-17T00:00:00Z"})
+	if got != "101|rework|2026-05-17T00:00:00Z" {
+		t.Fatalf("sourceEventID = %q", got)
+	}
+}

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -120,9 +120,13 @@ docker compose --env-file .env -f deploy/docker-compose.yml up -d worker
 
 For first-time local testing, keep `agent.default: mock` in `examples/WORKFLOW.md`. The mock runner produces a deterministic change without calling any external model.
 
-## 5. Run the Linear poller (optional)
+## 5. Run a tracker poller (optional)
 
-The poller reads `examples/WORKFLOW.md` for the repo, tracker, and poll interval, then enqueues a task per active Linear issue.
+The Linear and Gitea pollers read `examples/WORKFLOW.md` for the repo, tracker, and poll interval, then enqueue a task per active issue.
+
+### Linear
+
+The Linear poller enqueues issues in configured active Linear workflow states.
 
 Option A: from source.
 
@@ -139,6 +143,29 @@ docker compose --env-file .env -f deploy/docker-compose.yml --profile linear up 
 ```
 
 The poller exits immediately with `tracker.kind must be linear` if `examples/WORKFLOW.md` is not configured for Linear, and logs `skip <issue>: repo.clone_url missing in WORKFLOW.md` if `repo.clone_url` is empty.
+
+### Gitea
+
+The Gitea poller treats Gitea as a tracker reader: issues are selected by `aiops/*` state labels, and label writes happen through the agent tool surface rather than the poller. The default state labels are:
+
+| Workflow state | Gitea label |
+| --- | --- |
+| `AI Ready` | `aiops/todo` |
+| `In Progress` | `aiops/in-progress` |
+| `Rework` | `aiops/rework` |
+| `Done` | `aiops/done` |
+| `Canceled` | `aiops/canceled` |
+
+Option A: from source.
+
+```bash
+export DATABASE_URL=postgres://aiops:***@localhost:5432/aiops?sslmode=disable
+export GITEA_BASE_URL=http://localhost:3000
+export GITEA_TOKEN=your-gitea-bot-token
+go run ./cmd/gitea-poller examples/WORKFLOW.md
+```
+
+The poller exits immediately with `tracker.kind must be gitea` if `examples/WORKFLOW.md` is not configured for Gitea. It logs `skip <issue>: repo.clone_url missing in WORKFLOW.md` if `repo.clone_url` is empty.
 
 ## 6. Smoke test
 

--- a/internal/gitea/label_state.go
+++ b/internal/gitea/label_state.go
@@ -1,0 +1,135 @@
+package gitea
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+const stateLabelPrefix = "aiops/"
+
+// Label is the subset of a Gitea issue label needed to derive the
+// orchestrator-visible workflow state.
+type Label struct {
+	Name string `json:"name"`
+}
+
+// StateLabelMapping maps one mutually-exclusive aiops/* label to the workflow
+// state name exposed through tracker.Issue.State.
+type StateLabelMapping struct {
+	Label string
+	State string
+}
+
+// StateDiagnostic records non-fatal label-state problems discovered while
+// reading a Gitea issue. The poller can log these diagnostics without turning a
+// malformed issue into an orchestrator-side write.
+type StateDiagnostic struct {
+	Code    string
+	Message string
+	Labels  []string
+}
+
+// DefaultStateLabelMappings defines the repo's Gitea tracker label convention.
+// The order is also the deterministic conflict priority: active/rework labels
+// win over terminal labels so an issue is not silently dropped when a stale
+// terminal label remains alongside a label that requests work.
+func DefaultStateLabelMappings() []StateLabelMapping {
+	return []StateLabelMapping{
+		{Label: "aiops/rework", State: "Rework"},
+		{Label: "aiops/in-progress", State: "In Progress"},
+		{Label: "aiops/human-review", State: "Human Review"},
+		{Label: "aiops/todo", State: "AI Ready"},
+		{Label: "aiops/done", State: "Done"},
+		{Label: "aiops/canceled", State: "Canceled"},
+	}
+}
+
+// IssueStateFromLabels derives a workflow state from Gitea aiops/* labels. It
+// is read-only by design: conflicts and malformed labels are reported as
+// diagnostics for humans/agents, but this function never mutates labels.
+func IssueStateFromLabels(labels []Label, mappings []StateLabelMapping) (string, []StateDiagnostic) {
+	if len(mappings) == 0 {
+		mappings = DefaultStateLabelMappings()
+	}
+	known := make(map[string]string, len(mappings))
+	priority := make(map[string]int, len(mappings))
+	for i, mapping := range mappings {
+		label := strings.ToLower(strings.TrimSpace(mapping.Label))
+		if label == "" || mapping.State == "" {
+			continue
+		}
+		known[label] = mapping.State
+		priority[label] = i
+	}
+
+	matches := make([]string, 0, 1)
+	unknown := make([]string, 0)
+	for _, label := range labels {
+		name := strings.ToLower(strings.TrimSpace(label.Name))
+		if name == "" || !strings.HasPrefix(name, stateLabelPrefix) {
+			continue
+		}
+		if _, ok := known[name]; ok {
+			if !slices.Contains(matches, name) {
+				matches = append(matches, name)
+			}
+			continue
+		}
+		if !slices.Contains(unknown, name) {
+			unknown = append(unknown, name)
+		}
+	}
+
+	var diagnostics []StateDiagnostic
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		diagnostics = append(diagnostics, StateDiagnostic{
+			Code:    "unknown_aiops_label",
+			Message: fmt.Sprintf("unknown aiops state label(s): %s", strings.Join(unknown, ", ")),
+			Labels:  slices.Clone(unknown),
+		})
+	}
+	if len(matches) == 0 {
+		diagnostics = append(diagnostics, StateDiagnostic{
+			Code:    "missing_aiops_state_label",
+			Message: "issue has no configured aiops/* state label",
+		})
+		return "", diagnostics
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool { return priority[matches[i]] < priority[matches[j]] })
+	if len(matches) > 1 {
+		diagnostics = append(diagnostics, StateDiagnostic{
+			Code:    "conflicting_aiops_state_labels",
+			Message: fmt.Sprintf("multiple aiops state labels present; using %s by deterministic priority: %s", matches[0], strings.Join(matches, ", ")),
+			Labels:  slices.Clone(matches),
+		})
+	}
+	return known[matches[0]], diagnostics
+}
+
+// StateLabelNamesForStates returns configured aiops/* label names for the named
+// workflow states. It lets pollers query the tracker by active or terminal
+// state sets without hard-coding label names outside the Gitea adapter.
+func StateLabelNamesForStates(states []string, mappings []StateLabelMapping) []string {
+	if len(mappings) == 0 {
+		mappings = DefaultStateLabelMappings()
+	}
+	byState := make(map[string]string, len(mappings))
+	for _, mapping := range mappings {
+		state := strings.ToLower(strings.TrimSpace(mapping.State))
+		label := strings.ToLower(strings.TrimSpace(mapping.Label))
+		if state != "" && label != "" {
+			byState[state] = label
+		}
+	}
+	labels := make([]string, 0, len(states))
+	for _, state := range states {
+		if label, ok := byState[strings.ToLower(strings.TrimSpace(state))]; ok && !slices.Contains(labels, label) {
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}

--- a/internal/gitea/label_state_test.go
+++ b/internal/gitea/label_state_test.go
@@ -1,0 +1,72 @@
+package gitea
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestIssueStateFromLabelsMapsSingleAIOpsLabel(t *testing.T) {
+	state, diagnostics := IssueStateFromLabels([]Label{{Name: "bug"}, {Name: "aiops/in-progress"}}, DefaultStateLabelMappings())
+
+	if state != "In Progress" {
+		t.Fatalf("state = %q, want In Progress", state)
+	}
+	if len(diagnostics) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", diagnostics)
+	}
+}
+
+func TestIssueStateFromLabelsReportsMissingState(t *testing.T) {
+	state, diagnostics := IssueStateFromLabels([]Label{{Name: "bug"}}, DefaultStateLabelMappings())
+
+	if state != "" {
+		t.Fatalf("state = %q, want empty for missing aiops state label", state)
+	}
+	if !hasDiagnostic(diagnostics, "missing_aiops_state_label") {
+		t.Fatalf("diagnostics = %#v, want missing_aiops_state_label", diagnostics)
+	}
+}
+
+func TestIssueStateFromLabelsUsesDeterministicPriorityForConflicts(t *testing.T) {
+	state, diagnostics := IssueStateFromLabels([]Label{{Name: "aiops/done"}, {Name: "aiops/rework"}}, DefaultStateLabelMappings())
+
+	if state != "Rework" {
+		t.Fatalf("state = %q, want Rework to win conflict priority over Done", state)
+	}
+	if !hasDiagnostic(diagnostics, "conflicting_aiops_state_labels") {
+		t.Fatalf("diagnostics = %#v, want conflicting_aiops_state_labels", diagnostics)
+	}
+	if !strings.Contains(diagnostics[0].Message, "aiops/rework") || !strings.Contains(diagnostics[0].Message, "aiops/done") {
+		t.Fatalf("diagnostic message = %q, want conflicting labels named", diagnostics[0].Message)
+	}
+}
+
+func TestIssueStateFromLabelsIgnoresUnknownAIOpsLabels(t *testing.T) {
+	state, diagnostics := IssueStateFromLabels([]Label{{Name: "aiops/backlog"}, {Name: "aiops/todo"}}, DefaultStateLabelMappings())
+
+	if state != "AI Ready" {
+		t.Fatalf("state = %q, want AI Ready", state)
+	}
+	if !hasDiagnostic(diagnostics, "unknown_aiops_label") {
+		t.Fatalf("diagnostics = %#v, want unknown_aiops_label", diagnostics)
+	}
+}
+
+func TestStateLabelNamesForStatesFiltersConfiguredStates(t *testing.T) {
+	got := StateLabelNamesForStates([]string{"AI Ready", "Rework", "Done", "Not Configured"}, DefaultStateLabelMappings())
+	want := []string{"aiops/todo", "aiops/rework", "aiops/done"}
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("StateLabelNamesForStates = %#v, want %#v", got, want)
+	}
+}
+
+func hasDiagnostic(diagnostics []StateDiagnostic, code string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -1,0 +1,163 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+const (
+	listIssuesPageSize = 50
+	listIssuesMaxPages = 20
+)
+
+// Issue is the subset of Gitea's issue JSON used by the tracker reader.
+type Issue struct {
+	ID        int64   `json:"id"`
+	Number    int     `json:"number"`
+	Title     string  `json:"title"`
+	Body      string  `json:"body"`
+	HTMLURL   string  `json:"html_url"`
+	UpdatedAt string  `json:"updated_at"`
+	Labels    []Label `json:"labels"`
+}
+
+// TrackerClient is the Gitea issue reader used by pollers/reconciliation. It
+// intentionally exposes no label mutation methods; Gitea writes belong on the
+// agent-side dynamic tool surface per SPEC §1.
+type TrackerClient struct {
+	BaseURL string
+	Token   string
+	Owner   string
+	Repo    string
+	Config  workflow.TrackerConfig
+	HTTP    *http.Client
+	Logf    func(format string, args ...any)
+}
+
+func NewTrackerClient(cfg workflow.TrackerConfig, baseURL, owner, repo string) *TrackerClient {
+	return &TrackerClient{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		Token:   cfg.APIKey,
+		Owner:   owner,
+		Repo:    repo,
+		Config:  cfg,
+		HTTP:    http.DefaultClient,
+	}
+}
+
+func (c *TrackerClient) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	return c.ListIssuesByStates(ctx, c.Config.ActiveStates)
+}
+
+func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string) ([]tracker.Issue, error) {
+	if c.BaseURL == "" || c.Token == "" {
+		return nil, fmt.Errorf("GITEA_BASE_URL and Gitea tracker api_key are required")
+	}
+	if c.Owner == "" || c.Repo == "" {
+		return nil, fmt.Errorf("repo.owner and repo.name are required for Gitea tracker polling")
+	}
+	wantedStates := normalizedStateSet(states)
+	labelNames := StateLabelNamesForStates(states, DefaultStateLabelMappings())
+
+	var out []tracker.Issue
+	for page := 1; page <= listIssuesMaxPages; page++ {
+		batch, err := c.listIssuesPage(ctx, labelNames, page)
+		if err != nil {
+			return nil, err
+		}
+		for _, issue := range batch {
+			state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
+			c.logDiagnostics(issue, diagnostics)
+			if state == "" {
+				continue
+			}
+			if len(wantedStates) > 0 {
+				if _, ok := wantedStates[strings.ToLower(state)]; !ok {
+					continue
+				}
+			}
+			out = append(out, tracker.Issue{
+				ID:          strconv.FormatInt(issue.ID, 10),
+				Identifier:  fmt.Sprintf("#%d", issue.Number),
+				Title:       issue.Title,
+				Description: issue.Body,
+				URL:         issue.HTMLURL,
+				State:       state,
+				UpdatedAt:   issue.UpdatedAt,
+			})
+		}
+		if len(batch) < listIssuesPageSize {
+			return out, nil
+		}
+	}
+	return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
+}
+
+func (c *TrackerClient) listIssuesPage(ctx context.Context, labelNames []string, page int) ([]Issue, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo))
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("state", "open")
+	q.Set("type", "issues")
+	q.Set("page", strconv.Itoa(page))
+	q.Set("limit", strconv.Itoa(listIssuesPageSize))
+	if len(labelNames) > 0 {
+		q.Set("labels", strings.Join(labelNames, ","))
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "token "+c.Token)
+	client := c.HTTP
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("list Gitea issues failed: %s", resp.Status)
+	}
+	var issues []Issue
+	if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
+		return nil, err
+	}
+	return issues, nil
+}
+
+func (c *TrackerClient) logDiagnostics(issue Issue, diagnostics []StateDiagnostic) {
+	if c.Logf == nil {
+		return
+	}
+	identifier := issue.Number
+	for _, diagnostic := range diagnostics {
+		c.Logf("gitea issue #%d label diagnostic %s: %s", identifier, diagnostic.Code, diagnostic.Message)
+	}
+}
+
+func normalizedStateSet(states []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		state = strings.ToLower(strings.TrimSpace(state))
+		if state != "" {
+			set[state] = struct{}{}
+		}
+	}
+	return set
+}

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -68,10 +68,16 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	labelNames := StateLabelNamesForStates(states, DefaultStateLabelMappings())
 
 	var out []tracker.Issue
-	for page := 1; page <= listIssuesMaxPages; page++ {
+	for page := 1; page <= listIssuesMaxPages+1; page++ {
 		batch, err := c.listIssuesPage(ctx, labelNames, page)
 		if err != nil {
 			return nil, err
+		}
+		if page > listIssuesMaxPages {
+			if len(batch) == 0 {
+				return out, nil
+			}
+			return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
 		}
 		for _, issue := range batch {
 			state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -86,7 +86,7 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, issueState string, wantedStates map[string]struct{}, seenIssues map[string]struct{}) ([]tracker.Issue, error) {
 	var out []tracker.Issue
 	for page := 1; page <= listIssuesMaxPages+1; page++ {
-		batch, err := c.listIssuesPage(ctx, labelName, issueState, page)
+		batch, hasNext, err := c.listIssuesPage(ctx, labelName, issueState, page)
 		if err != nil {
 			return nil, err
 		}
@@ -125,18 +125,18 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 				UpdatedAt:   issue.UpdatedAt,
 			})
 		}
-		if len(batch) < listIssuesPageSize {
+		if !hasNext && len(batch) < listIssuesPageSize {
 			return out, nil
 		}
 	}
 	return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
 }
 
-func (c *TrackerClient) listIssuesPage(ctx context.Context, labelName string, issueState string, page int) ([]Issue, error) {
+func (c *TrackerClient) listIssuesPage(ctx context.Context, labelName string, issueState string, page int) ([]Issue, bool, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo))
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	q := u.Query()
 	q.Set("state", issueState)
@@ -150,7 +150,7 @@ func (c *TrackerClient) listIssuesPage(ctx context.Context, labelName string, is
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	req.Header.Set("Authorization", "token "+c.Token)
 	client := c.HTTP
@@ -159,17 +159,28 @@ func (c *TrackerClient) listIssuesPage(ctx context.Context, labelName string, is
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("list Gitea issues failed: %s", resp.Status)
+		return nil, false, fmt.Errorf("list Gitea issues failed: %s", resp.Status)
 	}
 	var issues []Issue
 	if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return issues, nil
+	return issues, hasNextPage(resp.Header.Values("Link")), nil
+}
+
+func hasNextPage(linkHeaders []string) bool {
+	for _, header := range linkHeaders {
+		for _, part := range strings.Split(header, ",") {
+			if strings.Contains(part, `rel="next"`) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func giteaAPIStateForWorkflowStates(states, terminalStateNames []string) string {

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -66,7 +66,7 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	}
 	wantedStates := normalizedStateSet(states)
 	labelNames := StateLabelNamesForStates(states, DefaultStateLabelMappings())
-	issueState := giteaAPIStateForWorkflowStates(states)
+	issueState := giteaAPIStateForWorkflowStates(states, c.Config.TerminalStates)
 
 	var out []tracker.Issue
 	for page := 1; page <= listIssuesMaxPages+1; page++ {
@@ -148,8 +148,11 @@ func (c *TrackerClient) listIssuesPage(ctx context.Context, labelNames []string,
 	return issues, nil
 }
 
-func giteaAPIStateForWorkflowStates(states []string) string {
-	terminalStates := normalizedStateSet(workflow.DefaultConfig().Tracker.TerminalStates)
+func giteaAPIStateForWorkflowStates(states, terminalStateNames []string) string {
+	terminalStates := normalizedStateSet(terminalStateNames)
+	if len(terminalStates) == 0 {
+		terminalStates = normalizedStateSet(workflow.DefaultConfig().Tracker.TerminalStates)
+	}
 	for _, state := range states {
 		if _, ok := terminalStates[strings.ToLower(strings.TrimSpace(state))]; ok {
 			return "all"

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -65,6 +65,9 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 		return nil, fmt.Errorf("repo.owner and repo.name are required for Gitea tracker polling")
 	}
 	wantedStates := normalizedStateSet(states)
+	if len(wantedStates) == 0 {
+		return nil, nil
+	}
 	labelNames := StateLabelNamesForStates(states, DefaultStateLabelMappings())
 	issueState := giteaAPIStateForWorkflowStates(states, c.Config.TerminalStates)
 
@@ -94,7 +97,10 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 			if len(batch) == 0 {
 				return out, nil
 			}
-			return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
+			if c.Logf != nil {
+				c.Logf("gitea issue pagination exceeded %d pages for label %q; returning capped result set", listIssuesMaxPages, labelName)
+			}
+			return out, nil
 		}
 		for _, issue := range batch {
 			issueKey := strconv.FormatInt(issue.ID, 10)

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -69,8 +69,24 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	issueState := giteaAPIStateForWorkflowStates(states, c.Config.TerminalStates)
 
 	var out []tracker.Issue
+	seenIssues := map[string]struct{}{}
+	if len(labelNames) == 0 {
+		return c.listIssuesByStateLabel(ctx, "", issueState, wantedStates, seenIssues)
+	}
+	for _, labelName := range labelNames {
+		issues, err := c.listIssuesByStateLabel(ctx, labelName, issueState, wantedStates, seenIssues)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, issues...)
+	}
+	return out, nil
+}
+
+func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, issueState string, wantedStates map[string]struct{}, seenIssues map[string]struct{}) ([]tracker.Issue, error) {
+	var out []tracker.Issue
 	for page := 1; page <= listIssuesMaxPages+1; page++ {
-		batch, err := c.listIssuesPage(ctx, labelNames, issueState, page)
+		batch, err := c.listIssuesPage(ctx, labelName, issueState, page)
 		if err != nil {
 			return nil, err
 		}
@@ -81,6 +97,13 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 			return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
 		}
 		for _, issue := range batch {
+			issueKey := strconv.FormatInt(issue.ID, 10)
+			if issueKey == "0" {
+				issueKey = strconv.Itoa(issue.Number)
+			}
+			if _, ok := seenIssues[issueKey]; ok {
+				continue
+			}
 			state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
 			c.logDiagnostics(issue, diagnostics)
 			if state == "" {
@@ -91,6 +114,7 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 					continue
 				}
 			}
+			seenIssues[issueKey] = struct{}{}
 			out = append(out, tracker.Issue{
 				ID:          strconv.FormatInt(issue.ID, 10),
 				Identifier:  fmt.Sprintf("#%d", issue.Number),
@@ -108,7 +132,7 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
 }
 
-func (c *TrackerClient) listIssuesPage(ctx context.Context, labelNames []string, issueState string, page int) ([]Issue, error) {
+func (c *TrackerClient) listIssuesPage(ctx context.Context, labelName string, issueState string, page int) ([]Issue, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo))
 	u, err := url.Parse(endpoint)
 	if err != nil {
@@ -119,8 +143,8 @@ func (c *TrackerClient) listIssuesPage(ctx context.Context, labelNames []string,
 	q.Set("type", "issues")
 	q.Set("page", strconv.Itoa(page))
 	q.Set("limit", strconv.Itoa(listIssuesPageSize))
-	if len(labelNames) > 0 {
-		q.Set("labels", strings.Join(labelNames, ","))
+	if labelName != "" {
+		q.Set("labels", labelName)
 	}
 	u.RawQuery = q.Encode()
 

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -66,10 +66,11 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	}
 	wantedStates := normalizedStateSet(states)
 	labelNames := StateLabelNamesForStates(states, DefaultStateLabelMappings())
+	issueState := giteaAPIStateForWorkflowStates(states)
 
 	var out []tracker.Issue
 	for page := 1; page <= listIssuesMaxPages+1; page++ {
-		batch, err := c.listIssuesPage(ctx, labelNames, page)
+		batch, err := c.listIssuesPage(ctx, labelNames, issueState, page)
 		if err != nil {
 			return nil, err
 		}
@@ -107,14 +108,14 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
 }
 
-func (c *TrackerClient) listIssuesPage(ctx context.Context, labelNames []string, page int) ([]Issue, error) {
+func (c *TrackerClient) listIssuesPage(ctx context.Context, labelNames []string, issueState string, page int) ([]Issue, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo))
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
 	q := u.Query()
-	q.Set("state", "open")
+	q.Set("state", issueState)
 	q.Set("type", "issues")
 	q.Set("page", strconv.Itoa(page))
 	q.Set("limit", strconv.Itoa(listIssuesPageSize))
@@ -145,6 +146,16 @@ func (c *TrackerClient) listIssuesPage(ctx context.Context, labelNames []string,
 		return nil, err
 	}
 	return issues, nil
+}
+
+func giteaAPIStateForWorkflowStates(states []string) string {
+	terminalStates := normalizedStateSet(workflow.DefaultConfig().Tracker.TerminalStates)
+	for _, state := range states {
+		if _, ok := terminalStates[strings.ToLower(strings.TrimSpace(state))]; ok {
+			return "all"
+		}
+	}
+	return "open"
 }
 
 func (c *TrackerClient) logDiagnostics(issue Issue, diagnostics []StateDiagnostic) {

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -100,5 +101,38 @@ func TestTrackerClientListIssuesByStatesUsesDeterministicConflictState(t *testin
 	}
 	if len(diagnostics) == 0 || !strings.Contains(diagnostics[0], "gitea issue #1 label diagnostic") {
 		t.Fatalf("diagnostics = %#v, want logged conflict diagnostic", diagnostics)
+	}
+}
+
+func TestTrackerClientListIssuesByStatesAllowsExactlyFullMaxPages(t *testing.T) {
+	var requestedPages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPages = append(requestedPages, r.URL.Query().Get("page"))
+		w.Header().Set("Content-Type", "application/json")
+		page := r.URL.Query().Get("page")
+		if page == strconv.Itoa(listIssuesMaxPages+1) {
+			_ = json.NewEncoder(w).Encode([]Issue{})
+			return
+		}
+		issues := make([]Issue, listIssuesPageSize)
+		for i := range issues {
+			number := (len(requestedPages)-1)*listIssuesPageSize + i + 1
+			issues[i] = Issue{ID: int64(number), Number: number, Title: "todo", HTMLURL: fmt.Sprintf("https://gitea.local/o/r/issues/%d", number), Labels: []Label{{Name: "aiops/todo"}}}
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates returned error for exactly full max pages: %v", err)
+	}
+	if len(issues) != listIssuesMaxPages*listIssuesPageSize {
+		t.Fatalf("issues len = %d, want %d", len(issues), listIssuesMaxPages*listIssuesPageSize)
+	}
+	if got, want := requestedPages[len(requestedPages)-1], strconv.Itoa(listIssuesMaxPages+1); got != want {
+		t.Fatalf("last requested page = %s, want probe page %s", got, want)
 	}
 }

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -56,7 +56,9 @@ func TestTrackerClientListIssuesByStatesMapsAIOpsLabels(t *testing.T) {
 }
 
 func TestTrackerClientListIssuesByStatesFiltersTerminalAndMissingStates(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var requestedState string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedState = r.URL.Query().Get("state")
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]Issue{
 			{ID: 201, Number: 1, Title: "done", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/done"}}},
@@ -74,6 +76,34 @@ func TestTrackerClientListIssuesByStatesFiltersTerminalAndMissingStates(t *testi
 	}
 	if len(issues) != 1 || issues[0].Identifier != "#3" || issues[0].State != "AI Ready" {
 		t.Fatalf("issues = %#v, want only AI Ready issue", issues)
+	}
+	if requestedState != "open" {
+		t.Fatalf("state query = %q, want open for active states", requestedState)
+	}
+}
+
+func TestTrackerClientListIssuesByStatesQueriesAllForTerminalStates(t *testing.T) {
+	var requestedState string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedState = r.URL.Query().Get("state")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 211, Number: 11, Title: "closed done", HTMLURL: "https://gitea.local/o/r/issues/11", Labels: []Label{{Name: "aiops/done"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Done"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if requestedState != "all" {
+		t.Fatalf("state query = %q, want all for terminal states", requestedState)
+	}
+	if len(issues) != 1 || issues[0].Identifier != "#11" || issues[0].State != "Done" {
+		t.Fatalf("issues = %#v, want Done issue", issues)
 	}
 }
 

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,19 +15,62 @@ import (
 )
 
 func TestTrackerClientListIssuesByStatesMapsAIOpsLabels(t *testing.T) {
-	var requestedPath string
+	var requestedLabels []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestedPath = r.URL.String()
+		requestedLabels = append(requestedLabels, r.URL.Query().Get("labels"))
 		if r.Header.Get("Authorization") != "token secret" {
 			t.Fatalf("Authorization = %q, want token secret", r.Header.Get("Authorization"))
 		}
-		if !strings.Contains(r.URL.Query().Get("labels"), "aiops/todo") || !strings.Contains(r.URL.Query().Get("labels"), "aiops/rework") {
-			t.Fatalf("labels query = %q, want active aiops labels", r.URL.Query().Get("labels"))
+		if r.URL.Path != "/api/v1/repos/owner/repo/issues" {
+			t.Fatalf("requested path = %q", r.URL.Path)
 		}
+		if r.URL.Query().Get("labels") == "aiops/todo" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]Issue{
+				{ID: 101, Number: 1, Title: "first", Body: "body", HTMLURL: "https://gitea.local/o/r/issues/1", UpdatedAt: "2026-05-17T00:00:00Z", Labels: []Label{{Name: "aiops/todo"}}},
+			})
+			return
+		}
+		if r.URL.Query().Get("labels") == "aiops/rework" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]Issue{
+				{ID: 102, Number: 2, Title: "second", Body: "body", HTMLURL: "https://gitea.local/o/r/issues/2", UpdatedAt: "2026-05-17T00:01:00Z", Labels: []Label{{Name: "aiops/rework"}}},
+			})
+			return
+		}
+		t.Fatalf("labels query = %q, want one active aiops label per request", r.URL.Query().Get("labels"))
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{
+		APIKey:       "secret",
+		ActiveStates: []string{"AI Ready", "Rework"},
+	}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	issues, err := client.ListActiveIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListActiveIssues: %v", err)
+	}
+	if !slices.Equal(requestedLabels, []string{"aiops/todo", "aiops/rework"}) {
+		t.Fatalf("labels queries = %#v, want one request per active aiops label", requestedLabels)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("issues len = %d, want 2", len(issues))
+	}
+	if issues[0].ID != "101" || issues[0].Identifier != "#1" || issues[0].State != "AI Ready" {
+		t.Fatalf("first issue = %#v, want mapped AI Ready state", issues[0])
+	}
+	if issues[1].State != "Rework" {
+		t.Fatalf("second issue state = %q, want Rework", issues[1].State)
+	}
+}
+
+func TestTrackerClientListIssuesByStatesDeduplicatesIssuesReturnedForMultipleLabels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]Issue{
-			{ID: 101, Number: 1, Title: "first", Body: "body", HTMLURL: "https://gitea.local/o/r/issues/1", UpdatedAt: "2026-05-17T00:00:00Z", Labels: []Label{{Name: "aiops/todo"}}},
-			{ID: 102, Number: 2, Title: "second", Body: "body", HTMLURL: "https://gitea.local/o/r/issues/2", UpdatedAt: "2026-05-17T00:01:00Z", Labels: []Label{{Name: "aiops/rework"}}},
+			{ID: 101, Number: 1, Title: "conflict", Body: "body", HTMLURL: "https://gitea.local/o/r/issues/1", UpdatedAt: "2026-05-17T00:00:00Z", Labels: []Label{{Name: "aiops/todo"}, {Name: "aiops/rework"}}},
 		})
 	}))
 	defer server.Close()
@@ -41,17 +85,11 @@ func TestTrackerClientListIssuesByStatesMapsAIOpsLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListActiveIssues: %v", err)
 	}
-	if !strings.HasPrefix(requestedPath, "/api/v1/repos/owner/repo/issues?") {
-		t.Fatalf("requested path = %q", requestedPath)
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want deduplicated issue", len(issues))
 	}
-	if len(issues) != 2 {
-		t.Fatalf("issues len = %d, want 2", len(issues))
-	}
-	if issues[0].ID != "101" || issues[0].Identifier != "#1" || issues[0].State != "AI Ready" {
-		t.Fatalf("first issue = %#v, want mapped AI Ready state", issues[0])
-	}
-	if issues[1].State != "Rework" {
-		t.Fatalf("second issue state = %q, want Rework", issues[1].State)
+	if issues[0].ID != "101" || issues[0].State != "Rework" {
+		t.Fatalf("issue = %#v, want conflict resolved once", issues[0])
 	}
 }
 

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -226,3 +226,42 @@ func TestTrackerClientListIssuesByStatesAllowsExactlyFullMaxPages(t *testing.T) 
 		t.Fatalf("last requested page = %s, want probe page %s", got, want)
 	}
 }
+
+func TestTrackerClientListIssuesByStatesContinuesWhenServerCapsPageBelowRequestedLimit(t *testing.T) {
+	var requestedPages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPages = append(requestedPages, r.URL.Query().Get("page"))
+		w.Header().Set("Content-Type", "application/json")
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil {
+			t.Fatalf("page query = %q: %v", r.URL.Query().Get("page"), err)
+		}
+		if page < 2 {
+			w.Header().Add("Link", fmt.Sprintf(`<%s%s?page=%d>; rel="next"`, serverURL(r), r.URL.Path, page+1))
+		}
+		issues := make([]Issue, 2)
+		for i := range issues {
+			number := (page-1)*2 + i + 1
+			issues[i] = Issue{ID: int64(number), Number: number, Title: "todo", HTMLURL: fmt.Sprintf("https://gitea.local/o/r/issues/%d", number), Labels: []Label{{Name: "aiops/todo"}}}
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 4 {
+		t.Fatalf("issues len = %d, want all 4 issues across server-capped pages", len(issues))
+	}
+	if !slices.Equal(requestedPages, []string{"1", "2"}) {
+		t.Fatalf("requested pages = %#v, want pagination to follow Link rel=next", requestedPages)
+	}
+}
+
+func serverURL(r *http.Request) string {
+	return "http://" + r.Host
+}

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -107,6 +107,28 @@ func TestTrackerClientListIssuesByStatesQueriesAllForTerminalStates(t *testing.T
 	}
 }
 
+func TestTrackerClientListIssuesByStatesUsesConfiguredTerminalStatesForGiteaState(t *testing.T) {
+	var requestedState string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedState = r.URL.Query().Get("state")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 212, Number: 12, Title: "custom closed", HTMLURL: "https://gitea.local/o/r/issues/12", Labels: []Label{{Name: "aiops/done"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", TerminalStates: []string{"Shipped"}}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	_, err := client.ListIssuesByStates(context.Background(), []string{"Shipped"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if requestedState != "all" {
+		t.Fatalf("state query = %q, want all for configured terminal state", requestedState)
+	}
+}
+
 func TestTrackerClientListIssuesByStatesUsesDeterministicConflictState(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -14,6 +14,31 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+func TestTrackerClientListIssuesByStatesReturnsNoIssuesWhenNoStatesRequested(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 100, Number: 100, Title: "todo", HTMLURL: "https://gitea.local/o/r/issues/100", Labels: []Label{{Name: "aiops/todo"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	issues, err := client.ListIssuesByStates(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want no issues for an empty workflow state filter", issues)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want no unfiltered Gitea request for empty states", requests)
+	}
+}
+
 func TestTrackerClientListIssuesByStatesMapsAIOpsLabels(t *testing.T) {
 	var requestedLabels []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -224,6 +249,41 @@ func TestTrackerClientListIssuesByStatesAllowsExactlyFullMaxPages(t *testing.T) 
 	}
 	if got, want := requestedPages[len(requestedPages)-1], strconv.Itoa(listIssuesMaxPages+1); got != want {
 		t.Fatalf("last requested page = %s, want probe page %s", got, want)
+	}
+}
+
+func TestTrackerClientListIssuesByStatesReturnsCappedResultsInsteadOfFailingWhenPageLimitExceeded(t *testing.T) {
+	var logs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil {
+			t.Fatalf("page query = %q: %v", r.URL.Query().Get("page"), err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Add("Link", fmt.Sprintf(`<%s%s?page=%d>; rel="next"`, serverURL(r), r.URL.Path, page+1))
+		issues := make([]Issue, listIssuesPageSize)
+		for i := range issues {
+			number := (page-1)*listIssuesPageSize + i + 1
+			issues[i] = Issue{ID: int64(number), Number: number, Title: "todo", HTMLURL: fmt.Sprintf("https://gitea.local/o/r/issues/%d", number), Labels: []Label{{Name: "aiops/todo"}}}
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	client.Logf = func(format string, args ...any) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	}
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates must return capped results instead of failing the poll cycle: %v", err)
+	}
+	if len(issues) != listIssuesMaxPages*listIssuesPageSize {
+		t.Fatalf("issues len = %d, want capped %d issues", len(issues), listIssuesMaxPages*listIssuesPageSize)
+	}
+	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "gitea issue pagination exceeded") {
+		t.Fatalf("logs = %#v, want pagination cap diagnostic", logs)
 	}
 }
 

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -1,0 +1,104 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestTrackerClientListIssuesByStatesMapsAIOpsLabels(t *testing.T) {
+	var requestedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.String()
+		if r.Header.Get("Authorization") != "token secret" {
+			t.Fatalf("Authorization = %q, want token secret", r.Header.Get("Authorization"))
+		}
+		if !strings.Contains(r.URL.Query().Get("labels"), "aiops/todo") || !strings.Contains(r.URL.Query().Get("labels"), "aiops/rework") {
+			t.Fatalf("labels query = %q, want active aiops labels", r.URL.Query().Get("labels"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 101, Number: 1, Title: "first", Body: "body", HTMLURL: "https://gitea.local/o/r/issues/1", UpdatedAt: "2026-05-17T00:00:00Z", Labels: []Label{{Name: "aiops/todo"}}},
+			{ID: 102, Number: 2, Title: "second", Body: "body", HTMLURL: "https://gitea.local/o/r/issues/2", UpdatedAt: "2026-05-17T00:01:00Z", Labels: []Label{{Name: "aiops/rework"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{
+		APIKey:       "secret",
+		ActiveStates: []string{"AI Ready", "Rework"},
+	}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	issues, err := client.ListActiveIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListActiveIssues: %v", err)
+	}
+	if !strings.HasPrefix(requestedPath, "/api/v1/repos/owner/repo/issues?") {
+		t.Fatalf("requested path = %q", requestedPath)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("issues len = %d, want 2", len(issues))
+	}
+	if issues[0].ID != "101" || issues[0].Identifier != "#1" || issues[0].State != "AI Ready" {
+		t.Fatalf("first issue = %#v, want mapped AI Ready state", issues[0])
+	}
+	if issues[1].State != "Rework" {
+		t.Fatalf("second issue state = %q, want Rework", issues[1].State)
+	}
+}
+
+func TestTrackerClientListIssuesByStatesFiltersTerminalAndMissingStates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 201, Number: 1, Title: "done", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/done"}}},
+			{ID: 202, Number: 2, Title: "missing", HTMLURL: "https://gitea.local/o/r/issues/2", Labels: []Label{{Name: "bug"}}},
+			{ID: 203, Number: 3, Title: "todo", HTMLURL: "https://gitea.local/o/r/issues/3", Labels: []Label{{Name: "aiops/todo"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Identifier != "#3" || issues[0].State != "AI Ready" {
+		t.Fatalf("issues = %#v, want only AI Ready issue", issues)
+	}
+}
+
+func TestTrackerClientListIssuesByStatesUsesDeterministicConflictState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 301, Number: 1, Title: "conflict", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/done"}, {Name: "aiops/rework"}}},
+		})
+	}))
+	defer server.Close()
+
+	var diagnostics []string
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	client.Logf = func(format string, args ...any) {
+		diagnostics = append(diagnostics, fmt.Sprintf(format, args...))
+	}
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Rework"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 || issues[0].State != "Rework" {
+		t.Fatalf("issues = %#v, want conflict resolved to Rework", issues)
+	}
+	if len(diagnostics) == 0 || !strings.Contains(diagnostics[0], "gitea issue #1 label diagnostic") {
+		t.Fatalf("diagnostics = %#v, want logged conflict diagnostic", diagnostics)
+	}
+}

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -41,6 +41,11 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 				"error": map[string]any{"message": "gitea_issue_labels only accepts aiops/* labels"},
 			})
 		}
+		if _, ok := validGiteaStateLabels()[strings.ToLower(label)]; !ok {
+			return dynamicToolFailure(map[string]any{
+				"error": map[string]any{"message": "gitea_issue_labels label must be one of: aiops/canceled, aiops/done, aiops/human-review, aiops/in-progress, aiops/rework, aiops/todo"},
+			})
+		}
 		desiredStateLabels = append(desiredStateLabels, label)
 	}
 
@@ -139,6 +144,17 @@ func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *h
 		}
 	}
 	return out, ""
+}
+
+func validGiteaStateLabels() map[string]struct{} {
+	return map[string]struct{}{
+		"aiops/canceled":     {},
+		"aiops/done":         {},
+		"aiops/human-review": {},
+		"aiops/in-progress":  {},
+		"aiops/rework":       {},
+		"aiops/todo":         {},
+	}
 }
 
 func replaceAIOpsLabels(currentLabels, desiredStateLabels []string) []string {

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -63,58 +63,78 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 	if failure != "" {
 		return failure, nil
 	}
+	staleStateLabels := make([]giteaIssueLabel, 0, len(currentLabels))
 	for _, label := range currentLabels {
 		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(label.Name)), "aiops/") && !containsLabelFold(desiredStateLabels, label.Name) {
-			if label.ID == 0 {
-				return dynamicToolFailure(map[string]any{
-					"error": map[string]any{"message": "Gitea label response omitted id for stale aiops label", "label": label.Name},
-				})
-			}
-			if failure := p.deleteIssueLabel(ctx, client, endpoint, label.ID); failure != "" {
-				return failure, nil
-			}
+			staleStateLabels = append(staleStateLabels, label)
 		}
 	}
 	labelsToAdd := missingLabels(currentLabels, desiredStateLabels)
-	if len(labelsToAdd) == 0 {
-		return dynamicToolResult(true, `{"labels":[]}`)
+	var result string
+	if len(labelsToAdd) > 0 {
+		var failure string
+		result, failure = p.addIssueLabels(ctx, client, endpoint, labelsToAdd)
+		if failure != "" {
+			return failure, nil
+		}
+	} else {
+		result, _ = dynamicToolResult(true, `{"labels":[]}`)
 	}
-	payload := map[string]any{"labels": labelsToAdd}
+	for _, label := range staleStateLabels {
+		if label.ID == 0 {
+			return dynamicToolFailure(map[string]any{
+				"error": map[string]any{"message": "Gitea label response omitted id for stale aiops label", "label": label.Name},
+			})
+		}
+		if failure := p.deleteIssueLabel(ctx, client, endpoint, label.ID); failure != "" {
+			return failure, nil
+		}
+	}
+	return result, nil
+}
+
+func (p giteaIssueLabelsProxy) addIssueLabels(ctx context.Context, client *http.Client, endpoint string, labels []string) (string, string) {
+	payload := map[string]any{"labels": labels}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return dynamicToolFailure(map[string]any{
+		failure, _ := dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "gitea_issue_labels payload could not be encoded", "reason": err.Error()},
 		})
+		return "", failure
 	}
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return dynamicToolFailure(map[string]any{
+		failure, _ := dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "Gitea label request could not be built", "reason": err.Error()},
 		})
+		return "", failure
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "token "+strings.TrimSpace(p.token))
 	resp, err := client.Do(req)
 	if err != nil {
-		return dynamicToolFailure(map[string]any{
+		failure, _ := dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "Gitea label request failed during transport", "reason": err.Error()},
 		})
+		return "", failure
 	}
 	defer resp.Body.Close()
 	var respBody bytes.Buffer
 	_, readErr := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
 	if readErr != nil {
-		return dynamicToolFailure(map[string]any{
+		failure, _ := dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "Gitea label response body could not be read", "reason": readErr.Error()},
 		})
+		return "", failure
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return dynamicToolFailure(map[string]any{
+		failure, _ := dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "Gitea label request failed", "status": resp.Status, "body": respBody.String()},
 		})
+		return "", failure
 	}
-	return dynamicToolResult(true, respBody.String())
+	result, _ := dynamicToolResult(true, respBody.String())
+	return result, ""
 }
 
 func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *http.Client, endpoint string) ([]giteaIssueLabel, string) {

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -171,5 +172,8 @@ func replaceAIOpsLabels(currentLabels, desiredStateLabels []string) []string {
 }
 
 func giteaBaseURLFromTracker(cfg workflow.TrackerConfig) string {
-	return strings.TrimRight(cfg.ProjectSlug, "/")
+	if cfg.ProjectSlug != "" {
+		return strings.TrimRight(cfg.ProjectSlug, "/")
+	}
+	return strings.TrimRight(os.Getenv("GITEA_BASE_URL"), "/")
 }

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -223,6 +223,9 @@ func (p giteaIssueLabelsProxy) deleteIssueLabel(ctx context.Context, client *htt
 		})
 		return failure
 	}
+	if resp.StatusCode == http.StatusNotFound {
+		return ""
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		failure, _ := dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "Gitea label delete request failed", "status": resp.Status, "body": respBody.String()},

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -77,6 +77,17 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 		if failure != "" {
 			return failure, nil
 		}
+		confirmedLabels, confirmationFailure := p.decodeIssueLabelsFromToolResult(result, "Gitea label add response")
+		if confirmationFailure != "" {
+			return confirmationFailure, nil
+		}
+		for _, desired := range desiredStateLabels {
+			if !containsIssueLabelFold(confirmedLabels, desired) {
+				return dynamicToolFailure(map[string]any{
+					"error": map[string]any{"message": "Gitea label add response did not include desired aiops label", "label": desired},
+				})
+			}
+		}
 	} else {
 		result, _ = dynamicToolResult(true, `{"labels":[]}`)
 	}
@@ -219,6 +230,37 @@ func (p giteaIssueLabelsProxy) deleteIssueLabel(ctx context.Context, client *htt
 		return failure
 	}
 	return ""
+}
+
+func (p giteaIssueLabelsProxy) decodeIssueLabelsFromToolResult(result, source string) ([]giteaIssueLabel, string) {
+	var envelope struct {
+		Output string `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(result), &envelope); err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": source + " envelope could not be decoded", "reason": err.Error()},
+		})
+		return nil, failure
+	}
+	var payload struct {
+		Labels []struct {
+			ID   int64  `json:"id"`
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal([]byte(envelope.Output), &payload); err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": source + " body could not be decoded", "reason": err.Error(), "body": envelope.Output},
+		})
+		return nil, failure
+	}
+	out := make([]giteaIssueLabel, 0, len(payload.Labels))
+	for _, label := range payload.Labels {
+		if strings.TrimSpace(label.Name) != "" {
+			out = append(out, giteaIssueLabel{ID: label.ID, Name: label.Name})
+		}
+	}
+	return out, ""
 }
 
 func validGiteaStateLabels() map[string]struct{} {

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -22,6 +22,11 @@ type giteaIssueLabelsProxy struct {
 	http    *http.Client
 }
 
+type giteaIssueLabel struct {
+	ID   int64
+	Name string
+}
+
 func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string, error) {
 	if call.IssueNumber <= 0 {
 		return dynamicToolFailure(map[string]any{
@@ -58,8 +63,23 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 	if failure != "" {
 		return failure, nil
 	}
-	labels := replaceAIOpsLabels(currentLabels, desiredStateLabels)
-	payload := map[string]any{"labels": labels}
+	for _, label := range currentLabels {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(label.Name)), "aiops/") && !containsLabelFold(desiredStateLabels, label.Name) {
+			if label.ID == 0 {
+				return dynamicToolFailure(map[string]any{
+					"error": map[string]any{"message": "Gitea label response omitted id for stale aiops label", "label": label.Name},
+				})
+			}
+			if failure := p.deleteIssueLabel(ctx, client, endpoint, label.ID); failure != "" {
+				return failure, nil
+			}
+		}
+	}
+	labelsToAdd := missingLabels(currentLabels, desiredStateLabels)
+	if len(labelsToAdd) == 0 {
+		return dynamicToolResult(true, `{"labels":[]}`)
+	}
+	payload := map[string]any{"labels": labelsToAdd}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return dynamicToolFailure(map[string]any{
@@ -67,7 +87,7 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 		})
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "Gitea label request could not be built", "reason": err.Error()},
@@ -97,7 +117,7 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 	return dynamicToolResult(true, respBody.String())
 }
 
-func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *http.Client, endpoint string) ([]string, string) {
+func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *http.Client, endpoint string) ([]giteaIssueLabel, string) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		failure, _ := dynamicToolFailure(map[string]any{
@@ -129,6 +149,7 @@ func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *h
 		return nil, failure
 	}
 	var labels []struct {
+		ID   int64  `json:"id"`
 		Name string `json:"name"`
 	}
 	if err := json.Unmarshal(respBody.Bytes(), &labels); err != nil {
@@ -137,13 +158,47 @@ func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *h
 		})
 		return nil, failure
 	}
-	out := make([]string, 0, len(labels))
+	out := make([]giteaIssueLabel, 0, len(labels))
 	for _, label := range labels {
 		if strings.TrimSpace(label.Name) != "" {
-			out = append(out, label.Name)
+			out = append(out, giteaIssueLabel{ID: label.ID, Name: label.Name})
 		}
 	}
 	return out, ""
+}
+
+func (p giteaIssueLabelsProxy) deleteIssueLabel(ctx context.Context, client *http.Client, endpoint string, labelID int64) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf("%s/%d", endpoint, labelID), nil)
+	if err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label delete request could not be built", "reason": err.Error()},
+		})
+		return failure
+	}
+	req.Header.Set("Authorization", "token "+strings.TrimSpace(p.token))
+	resp, err := client.Do(req)
+	if err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label delete request failed during transport", "reason": err.Error()},
+		})
+		return failure
+	}
+	defer resp.Body.Close()
+	var respBody bytes.Buffer
+	_, readErr := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
+	if readErr != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label delete response body could not be read", "reason": readErr.Error()},
+		})
+		return failure
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label delete request failed", "status": resp.Status, "body": respBody.String()},
+		})
+		return failure
+	}
+	return ""
 }
 
 func validGiteaStateLabels() map[string]struct{} {
@@ -185,6 +240,36 @@ func replaceAIOpsLabels(currentLabels, desiredStateLabels []string) []string {
 		labels = append(labels, trimmed)
 	}
 	return labels
+}
+
+func containsLabelFold(labels []string, label string) bool {
+	want := strings.ToLower(strings.TrimSpace(label))
+	for _, candidate := range labels {
+		if strings.ToLower(strings.TrimSpace(candidate)) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func missingLabels(currentLabels []giteaIssueLabel, desiredLabels []string) []string {
+	out := make([]string, 0, len(desiredLabels))
+	for _, desired := range desiredLabels {
+		if !containsIssueLabelFold(currentLabels, desired) {
+			out = append(out, strings.TrimSpace(desired))
+		}
+	}
+	return out
+}
+
+func containsIssueLabelFold(labels []giteaIssueLabel, label string) bool {
+	want := strings.ToLower(strings.TrimSpace(label))
+	for _, candidate := range labels {
+		if strings.ToLower(strings.TrimSpace(candidate.Name)) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func giteaBaseURLFromTracker(cfg workflow.TrackerConfig) string {

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -13,8 +13,6 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
-const defaultGiteaBaseURL = "http://localhost:3000"
-
 type giteaIssueLabelsProxy struct {
 	token   string
 	baseURL string
@@ -173,8 +171,5 @@ func replaceAIOpsLabels(currentLabels, desiredStateLabels []string) []string {
 }
 
 func giteaBaseURLFromTracker(cfg workflow.TrackerConfig) string {
-	if cfg.ProjectSlug != "" {
-		return strings.TrimRight(cfg.ProjectSlug, "/")
-	}
-	return defaultGiteaBaseURL
+	return strings.TrimRight(cfg.ProjectSlug, "/")
 }

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -1,0 +1,180 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+const defaultGiteaBaseURL = "http://localhost:3000"
+
+type giteaIssueLabelsProxy struct {
+	token   string
+	baseURL string
+	owner   string
+	repo    string
+	http    *http.Client
+}
+
+func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string, error) {
+	if call.IssueNumber <= 0 {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels issue_number is required"},
+		})
+	}
+	if len(call.Labels) == 0 {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels labels must contain at least one aiops/* label"},
+		})
+	}
+	desiredStateLabels := make([]string, 0, len(call.Labels))
+	for _, label := range call.Labels {
+		label = strings.TrimSpace(label)
+		if label == "" || !strings.HasPrefix(strings.ToLower(label), "aiops/") {
+			return dynamicToolFailure(map[string]any{
+				"error": map[string]any{"message": "gitea_issue_labels only accepts aiops/* labels"},
+			})
+		}
+		desiredStateLabels = append(desiredStateLabels, label)
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues/%d/labels", strings.TrimRight(p.baseURL, "/"), url.PathEscape(p.owner), url.PathEscape(p.repo), call.IssueNumber)
+	client := p.http
+	if client == nil {
+		client = http.DefaultClient
+	}
+	currentLabels, failure := p.currentIssueLabels(ctx, client, endpoint)
+	if failure != "" {
+		return failure, nil
+	}
+	labels := replaceAIOpsLabels(currentLabels, desiredStateLabels)
+	payload := map[string]any{"labels": labels}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels payload could not be encoded", "reason": err.Error()},
+		})
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label request could not be built", "reason": err.Error()},
+		})
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "token "+strings.TrimSpace(p.token))
+	resp, err := client.Do(req)
+	if err != nil {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label request failed during transport", "reason": err.Error()},
+		})
+	}
+	defer resp.Body.Close()
+	var respBody bytes.Buffer
+	_, readErr := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
+	if readErr != nil {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label response body could not be read", "reason": readErr.Error()},
+		})
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label request failed", "status": resp.Status, "body": respBody.String()},
+		})
+	}
+	return dynamicToolResult(true, respBody.String())
+}
+
+func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *http.Client, endpoint string) ([]string, string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label read request could not be built", "reason": err.Error()},
+		})
+		return nil, failure
+	}
+	req.Header.Set("Authorization", "token "+strings.TrimSpace(p.token))
+	resp, err := client.Do(req)
+	if err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label read request failed during transport", "reason": err.Error()},
+		})
+		return nil, failure
+	}
+	defer resp.Body.Close()
+	var respBody bytes.Buffer
+	_, readErr := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
+	if readErr != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label read response body could not be read", "reason": readErr.Error()},
+		})
+		return nil, failure
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label read request failed", "status": resp.Status, "body": respBody.String()},
+		})
+		return nil, failure
+	}
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(respBody.Bytes(), &labels); err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "Gitea label read response body could not be decoded", "reason": err.Error()},
+		})
+		return nil, failure
+	}
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if strings.TrimSpace(label.Name) != "" {
+			out = append(out, label.Name)
+		}
+	}
+	return out, ""
+}
+
+func replaceAIOpsLabels(currentLabels, desiredStateLabels []string) []string {
+	labels := make([]string, 0, len(currentLabels)+len(desiredStateLabels))
+	seen := make(map[string]struct{}, len(currentLabels)+len(desiredStateLabels))
+	for _, label := range currentLabels {
+		trimmed := strings.TrimSpace(label)
+		if trimmed == "" || strings.HasPrefix(strings.ToLower(trimmed), "aiops/") {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		labels = append(labels, trimmed)
+	}
+	for _, label := range desiredStateLabels {
+		trimmed := strings.TrimSpace(label)
+		key := strings.ToLower(trimmed)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		labels = append(labels, trimmed)
+	}
+	return labels
+}
+
+func giteaBaseURLFromTracker(cfg workflow.TrackerConfig) string {
+	if cfg.ProjectSlug != "" {
+		return strings.TrimRight(cfg.ProjectSlug, "/")
+	}
+	return defaultGiteaBaseURL
+}

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -29,9 +29,9 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 			"error": map[string]any{"message": "gitea_issue_labels issue_number is required"},
 		})
 	}
-	if len(call.Labels) == 0 {
+	if len(call.Labels) != 1 {
 		return dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "gitea_issue_labels labels must contain at least one aiops/* label"},
+			"error": map[string]any{"message": "gitea_issue_labels labels must contain exactly one aiops/* state label"},
 		})
 	}
 	desiredStateLabels := make([]string, 0, len(call.Labels))

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -242,20 +242,27 @@ func (p giteaIssueLabelsProxy) decodeIssueLabelsFromToolResult(result, source st
 		})
 		return nil, failure
 	}
-	var payload struct {
-		Labels []struct {
-			ID   int64  `json:"id"`
-			Name string `json:"name"`
-		} `json:"labels"`
+	var rawLabels []struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
 	}
-	if err := json.Unmarshal([]byte(envelope.Output), &payload); err != nil {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": source + " body could not be decoded", "reason": err.Error(), "body": envelope.Output},
-		})
-		return nil, failure
+	if err := json.Unmarshal([]byte(envelope.Output), &rawLabels); err != nil {
+		var payload struct {
+			Labels []struct {
+				ID   int64  `json:"id"`
+				Name string `json:"name"`
+			} `json:"labels"`
+		}
+		if objectErr := json.Unmarshal([]byte(envelope.Output), &payload); objectErr != nil {
+			failure, _ := dynamicToolFailure(map[string]any{
+				"error": map[string]any{"message": source + " body could not be decoded", "reason": err.Error(), "body": envelope.Output},
+			})
+			return nil, failure
+		}
+		rawLabels = payload.Labels
 	}
-	out := make([]giteaIssueLabel, 0, len(payload.Labels))
-	for _, label := range payload.Labels {
+	out := make([]giteaIssueLabel, 0, len(rawLabels))
+	for _, label := range rawLabels {
 		if strings.TrimSpace(label.Name) != "" {
 			out = append(out, giteaIssueLabel{ID: label.ID, Name: label.Name})
 		}

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -314,6 +314,44 @@ func TestGiteaIssueLabelsDoesNotDeleteExistingStateWhenDesiredStateIsMissingAfte
 	}
 }
 
+func TestGiteaIssueLabelsAcceptsGiteaAddLabelArrayResponse(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/todo"}]`)
+		case http.MethodPost:
+			_, _ = io.WriteString(w, `[{"id":303,"name":"aiops/in-progress"},{"id":202,"name":"bug"}]`)
+		case http.MethodDelete:
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: server.URL, owner: "owner", repo: "repo", http: server.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress"}})
+	if err != nil {
+		t.Fatalf("gitea_issue_labels call: %v", err)
+	}
+	if !strings.Contains(result, `"success":true`) {
+		t.Fatalf("result = %q, want success", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,POST,DELETE" {
+		t.Fatalf("methods = %#v, want GET, POST, DELETE after array add response confirms desired label", methods)
+	}
+}
+
 func TestDynamicToolsDoNotExposeGiteaToolsWithoutGiteaToken(t *testing.T) {
 	for _, wf := range []workflow.Workflow{
 		{},

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -110,19 +110,21 @@ func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
 		t.Fatalf("tool result leaked Gitea token: %q", result)
 	}
 
-	auth, method, path, body, requests := server.recorded()
+	auth, _, _, body, requests := server.recorded()
 	if requests != 3 {
 		t.Fatalf("requests = %d, want GET, DELETE, POST", requests)
 	}
 	if auth != "token "+token {
 		t.Fatalf("Authorization = %q, want token auth", auth)
 	}
-	if method != http.MethodPost {
-		t.Fatalf("method = %q, want POST", method)
+	methods, paths, bodies := server.recordedSequence()
+	if strings.Join(methods, ",") != "GET,POST,DELETE" {
+		t.Fatalf("methods = %#v, want GET, POST desired label, DELETE stale label", methods)
 	}
-	if path != "/api/v1/repos/owner/repo/issues/7/labels" {
-		t.Fatalf("path = %q", path)
+	if paths[1] != "/api/v1/repos/owner/repo/issues/7/labels" || paths[2] != "/api/v1/repos/owner/repo/issues/7/labels/101" {
+		t.Fatalf("paths = %#v", paths)
 	}
+	body = bodies[1]
 	if strings.Contains(body, token) || !strings.Contains(body, "aiops/in-progress") {
 		t.Fatalf("unexpected request body: %s", body)
 	}
@@ -143,14 +145,14 @@ func TestGiteaIssueLabelsPreservesNonAIOpsLabelsWhenReplacingState(t *testing.T)
 	}
 
 	methods, paths, bodies := server.recordedSequence()
-	if len(methods) != 3 || methods[0] != http.MethodGet || methods[1] != http.MethodDelete || methods[2] != http.MethodPost {
-		t.Fatalf("methods = %#v, want GET then DELETE stale aiops label then POST desired label", methods)
+	if len(methods) != 3 || methods[0] != http.MethodGet || methods[1] != http.MethodPost || methods[2] != http.MethodDelete {
+		t.Fatalf("methods = %#v, want GET then POST desired aiops label then DELETE stale label", methods)
 	}
-	if paths[0] != "/api/v1/repos/owner/repo/issues/7/labels" || paths[1] != "/api/v1/repos/owner/repo/issues/7/labels/101" || paths[2] != "/api/v1/repos/owner/repo/issues/7/labels" {
+	if paths[0] != "/api/v1/repos/owner/repo/issues/7/labels" || paths[1] != "/api/v1/repos/owner/repo/issues/7/labels" || paths[2] != "/api/v1/repos/owner/repo/issues/7/labels/101" {
 		t.Fatalf("paths = %#v", paths)
 	}
-	if strings.Contains(bodies[2], "bug") || !strings.Contains(bodies[2], "aiops/in-progress") || strings.Contains(bodies[2], "aiops/todo") {
-		t.Fatalf("POST body = %s, want only desired aiops label added without replacing non-aiops labels", bodies[2])
+	if strings.Contains(bodies[1], "bug") || !strings.Contains(bodies[1], "aiops/in-progress") || strings.Contains(bodies[1], "aiops/todo") {
+		t.Fatalf("POST body = %s, want only desired aiops label added without replacing non-aiops labels", bodies[1])
 	}
 }
 
@@ -193,14 +195,89 @@ func TestGiteaIssueLabelsDoesNotOverwriteConcurrentNonAIOpsLabelChanges(t *testi
 
 	mu.Lock()
 	defer mu.Unlock()
-	if strings.Join(methods, ",") != "GET,DELETE,POST" {
-		t.Fatalf("methods = %#v, want GET, DELETE, POST", methods)
+	if strings.Join(methods, ",") != "GET,POST,DELETE" {
+		t.Fatalf("methods = %#v, want GET, POST, DELETE", methods)
 	}
-	if paths[1] != "/api/v1/repos/owner/repo/issues/7/labels/101" {
-		t.Fatalf("DELETE path = %q, want stale aiops label id endpoint", paths[1])
+	if paths[2] != "/api/v1/repos/owner/repo/issues/7/labels/101" {
+		t.Fatalf("DELETE path = %q, want stale aiops label id endpoint", paths[2])
 	}
-	if !strings.Contains(bodies[2], "aiops/in-progress") {
-		t.Fatalf("POST body = %s, want desired aiops label", bodies[2])
+	if !strings.Contains(bodies[1], "aiops/in-progress") {
+		t.Fatalf("POST body = %s, want desired aiops label", bodies[1])
+	}
+}
+
+func TestGiteaIssueLabelsAddsDesiredStateBeforeDeletingStaleState(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/todo"},{"id":202,"name":"bug"}]`)
+		case http.MethodPost:
+			if !strings.Contains(string(body), "aiops/in-progress") {
+				t.Fatalf("POST body = %s, want desired state label", body)
+			}
+			_, _ = io.WriteString(w, `{"labels":[{"name":"aiops/in-progress"}]}`)
+		case http.MethodDelete:
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: server.URL, owner: "owner", repo: "repo", http: server.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress"}})
+	if err != nil {
+		t.Fatalf("gitea_issue_labels call: %v", err)
+	}
+	if !strings.Contains(result, `"success":true`) {
+		t.Fatalf("result = %q, want success", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,POST,DELETE" {
+		t.Fatalf("methods = %#v, want GET, POST desired state, DELETE stale state", methods)
+	}
+}
+
+func TestGiteaIssueLabelsDoesNotDeleteExistingStateWhenAddingDesiredStateFails(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/todo"}]`)
+		case http.MethodPost:
+			http.Error(w, `{"message":"temporary failure"}`, http.StatusBadGateway)
+		case http.MethodDelete:
+			t.Fatalf("DELETE must not run after desired state add fails")
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: server.URL, owner: "owner", repo: "repo", http: server.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress"}})
+	assertStructuredFailure(t, result, err, "Gitea label request failed")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,POST" {
+		t.Fatalf("methods = %#v, want GET then failed POST only", methods)
 	}
 }
 

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -352,6 +352,44 @@ func TestGiteaIssueLabelsAcceptsGiteaAddLabelArrayResponse(t *testing.T) {
 	}
 }
 
+func TestGiteaIssueLabelsTreatsMissingStaleStateAsSuccess(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/todo"}]`)
+		case http.MethodPost:
+			_, _ = io.WriteString(w, `[{"id":303,"name":"aiops/in-progress"}]`)
+		case http.MethodDelete:
+			http.Error(w, `{"message":"label not found"}`, http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: server.URL, owner: "owner", repo: "repo", http: server.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress"}})
+	if err != nil {
+		t.Fatalf("gitea_issue_labels call: %v", err)
+	}
+	if !strings.Contains(result, `"success":true`) {
+		t.Fatalf("result = %q, want success when stale aiops label is already missing", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,POST,DELETE" {
+		t.Fatalf("methods = %#v, want GET, POST, DELETE", methods)
+	}
+}
+
 func TestDynamicToolsDoNotExposeGiteaToolsWithoutGiteaToken(t *testing.T) {
 	for _, wf := range []workflow.Workflow{
 		{},

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -161,6 +161,20 @@ func TestDynamicToolsDoNotExposeGiteaToolsWithoutGiteaToken(t *testing.T) {
 	}
 }
 
+func TestGiteaIssueLabelsRejectsMultipleAIOpsStateLabelsWithoutHTTPRequest(t *testing.T) {
+	server := &fakeGiteaLabelServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: httpServer.URL, owner: "owner", repo: "repo", http: httpServer.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress", "aiops/done"}})
+	assertStructuredFailure(t, result, err, "gitea_issue_labels labels must contain exactly one aiops/* state label")
+	_, _, _, _, requests := server.recorded()
+	if requests != 0 {
+		t.Fatalf("server received %d requests, want 0", requests)
+	}
+}
+
 func TestGiteaIssueLabelsRejectsMissingIssueNumberWithoutHTTPRequest(t *testing.T) {
 	server := &fakeGiteaLabelServer{}
 	httpServer := httptest.NewServer(server.handler())

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -69,8 +69,9 @@ func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
 	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
 		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo"},
 		Tracker: workflow.TrackerConfig{
-			Kind:   "gitea",
-			APIKey: token,
+			Kind:        "gitea",
+			APIKey:      token,
+			ProjectSlug: "https://gitea.example.test/",
 		},
 	}})
 
@@ -158,6 +159,19 @@ func TestDynamicToolsDoNotExposeGiteaToolsWithoutGiteaToken(t *testing.T) {
 		if _, ok := tools.Lookup("gitea_issue_labels"); ok {
 			t.Fatalf("gitea_issue_labels advertised without configured Gitea token: %#v", wf.Config.Tracker)
 		}
+	}
+}
+
+func TestDynamicToolsDoNotExposeGiteaToolsWithoutBaseURL(t *testing.T) {
+	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo"},
+		Tracker: workflow.TrackerConfig{
+			Kind:   "gitea",
+			APIKey: "token",
+		},
+	}})
+	if _, ok := tools.Lookup("gitea_issue_labels"); ok {
+		t.Fatalf("gitea_issue_labels advertised without configured Gitea base URL")
 	}
 }
 

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -1,0 +1,176 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+type fakeGiteaLabelServer struct {
+	mu         sync.Mutex
+	authHeader string
+	methods    []string
+	paths      []string
+	bodies     []string
+	requests   int
+}
+
+func (f *fakeGiteaLabelServer) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		f.mu.Lock()
+		f.requests++
+		f.authHeader = r.Header.Get("Authorization")
+		f.methods = append(f.methods, r.Method)
+		f.paths = append(f.paths, r.URL.String())
+		f.bodies = append(f.bodies, string(body))
+		f.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_, _ = io.WriteString(w, `[{"name":"bug"},{"name":"aiops/todo"}]`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"labels":[{"name":"aiops/in-progress"}]}`)
+	})
+}
+
+func (f *fakeGiteaLabelServer) recorded() (string, string, string, string, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	method, path, body := "", "", ""
+	if len(f.methods) > 0 {
+		method = f.methods[len(f.methods)-1]
+	}
+	if len(f.paths) > 0 {
+		path = f.paths[len(f.paths)-1]
+	}
+	if len(f.bodies) > 0 {
+		body = f.bodies[len(f.bodies)-1]
+	}
+	return f.authHeader, method, path, body, f.requests
+}
+
+func (f *fakeGiteaLabelServer) recordedSequence() ([]string, []string, []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.methods...), append([]string(nil), f.paths...), append([]string(nil), f.bodies...)
+}
+
+func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
+	token := "gitea_super_secret_token"
+	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo"},
+		Tracker: workflow.TrackerConfig{
+			Kind:   "gitea",
+			APIKey: token,
+		},
+	}})
+
+	tool, ok := tools.Lookup("gitea_issue_labels")
+	if !ok {
+		t.Fatalf("gitea_issue_labels tool not advertised; tools=%#v", tools.Names())
+	}
+	if strings.Contains(tool.Description, token) {
+		t.Fatalf("tool description leaked Gitea token: %q", tool.Description)
+	}
+	schemaBytes, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("tool input schema is not JSON-marshalable: %v", err)
+	}
+	if !strings.Contains(string(schemaBytes), `"issue_number"`) || strings.Contains(string(schemaBytes), token) {
+		t.Fatalf("tool input schema = %s, want issue_number field and no token leak", schemaBytes)
+	}
+
+	server := &fakeGiteaLabelServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+	proxy := giteaIssueLabelsProxy{token: token, baseURL: httpServer.URL, owner: "owner", repo: "repo", http: httpServer.Client()}
+	result, err := proxy.call(context.Background(), ToolCall{
+		IssueNumber: 7,
+		Labels:      []string{"aiops/in-progress"},
+	})
+	if err != nil {
+		t.Fatalf("gitea_issue_labels call: %v", err)
+	}
+	if strings.Contains(result, token) {
+		t.Fatalf("tool result leaked Gitea token: %q", result)
+	}
+
+	auth, method, path, body, requests := server.recorded()
+	if requests != 2 {
+		t.Fatalf("requests = %d, want GET then PUT", requests)
+	}
+	if auth != "token "+token {
+		t.Fatalf("Authorization = %q, want token auth", auth)
+	}
+	if method != http.MethodPut {
+		t.Fatalf("method = %q, want PUT", method)
+	}
+	if path != "/api/v1/repos/owner/repo/issues/7/labels" {
+		t.Fatalf("path = %q", path)
+	}
+	if strings.Contains(body, token) || !strings.Contains(body, "aiops/in-progress") {
+		t.Fatalf("unexpected request body: %s", body)
+	}
+}
+
+func TestGiteaIssueLabelsPreservesNonAIOpsLabelsWhenReplacingState(t *testing.T) {
+	server := &fakeGiteaLabelServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: httpServer.URL, owner: "owner", repo: "repo", http: httpServer.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress"}})
+	if err != nil {
+		t.Fatalf("gitea_issue_labels call: %v", err)
+	}
+	if !strings.Contains(result, `"success":true`) {
+		t.Fatalf("result = %q, want success", result)
+	}
+
+	methods, paths, bodies := server.recordedSequence()
+	if len(methods) != 2 || methods[0] != http.MethodGet || methods[1] != http.MethodPut {
+		t.Fatalf("methods = %#v, want GET then PUT", methods)
+	}
+	if paths[0] != "/api/v1/repos/owner/repo/issues/7/labels" || paths[1] != "/api/v1/repos/owner/repo/issues/7/labels" {
+		t.Fatalf("paths = %#v", paths)
+	}
+	if !strings.Contains(bodies[1], "bug") || !strings.Contains(bodies[1], "aiops/in-progress") || strings.Contains(bodies[1], "aiops/todo") {
+		t.Fatalf("PUT body = %s, want existing non-aiops label preserved and stale aiops state removed", bodies[1])
+	}
+}
+
+func TestDynamicToolsDoNotExposeGiteaToolsWithoutGiteaToken(t *testing.T) {
+	for _, wf := range []workflow.Workflow{
+		{},
+		{Config: workflow.Config{Tracker: workflow.TrackerConfig{Kind: "gitea"}}},
+		{Config: workflow.Config{Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "token"}}},
+	} {
+		tools := DynamicToolsForWorkflow(wf)
+		if _, ok := tools.Lookup("gitea_issue_labels"); ok {
+			t.Fatalf("gitea_issue_labels advertised without configured Gitea token: %#v", wf.Config.Tracker)
+		}
+	}
+}
+
+func TestGiteaIssueLabelsRejectsMissingIssueNumberWithoutHTTPRequest(t *testing.T) {
+	server := &fakeGiteaLabelServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: httpServer.URL, owner: "owner", repo: "repo", http: httpServer.Client()}.
+		call(context.Background(), ToolCall{Labels: []string{"aiops/in-progress"}})
+	assertStructuredFailure(t, result, err, "gitea_issue_labels issue_number is required")
+	_, _, _, _, requests := server.recorded()
+	if requests != 0 {
+		t.Fatalf("server received %d requests, want 0", requests)
+	}
+}

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -204,6 +204,20 @@ func TestGiteaIssueLabelsRejectsMultipleAIOpsStateLabelsWithoutHTTPRequest(t *te
 	}
 }
 
+func TestGiteaIssueLabelsRejectsUnknownAIOpsStateLabelWithoutHTTPRequest(t *testing.T) {
+	server := &fakeGiteaLabelServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: httpServer.URL, owner: "owner", repo: "repo", http: httpServer.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/inprogress"}})
+	assertStructuredFailure(t, result, err, "gitea_issue_labels label must be one of: aiops/canceled, aiops/done, aiops/human-review, aiops/in-progress, aiops/rework, aiops/todo")
+	_, _, _, _, requests := server.recorded()
+	if requests != 0 {
+		t.Fatalf("server received %d requests, want 0", requests)
+	}
+}
+
 func TestGiteaIssueLabelsRejectsMissingIssueNumberWithoutHTTPRequest(t *testing.T) {
 	server := &fakeGiteaLabelServer{}
 	httpServer := httptest.NewServer(server.handler())

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -281,6 +281,39 @@ func TestGiteaIssueLabelsDoesNotDeleteExistingStateWhenAddingDesiredStateFails(t
 	}
 }
 
+func TestGiteaIssueLabelsDoesNotDeleteExistingStateWhenDesiredStateIsMissingAfterAdd(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/todo"}]`)
+		case http.MethodPost:
+			_, _ = io.WriteString(w, `{"labels":[{"name":"aiops/todo"}]}`)
+		case http.MethodDelete:
+			t.Fatalf("DELETE must not run until the desired aiops label is confirmed present")
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: server.URL, owner: "owner", repo: "repo", http: server.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress"}})
+	assertStructuredFailure(t, result, err, "Gitea label add response did not include desired aiops label")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,POST" {
+		t.Fatalf("methods = %#v, want GET then POST only", methods)
+	}
+}
+
 func TestDynamicToolsDoNotExposeGiteaToolsWithoutGiteaToken(t *testing.T) {
 	for _, wf := range []workflow.Workflow{
 		{},

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -34,11 +34,16 @@ func (f *fakeGiteaLabelServer) handler() http.Handler {
 		f.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
-		if r.Method == http.MethodGet {
-			_, _ = io.WriteString(w, `[{"name":"bug"},{"name":"aiops/todo"}]`)
-			return
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/todo"},{"id":202,"name":"bug"}]`)
+		case http.MethodDelete:
+			_, _ = io.WriteString(w, `{}`)
+		case http.MethodPost:
+			_, _ = io.WriteString(w, `{"labels":[{"name":"aiops/in-progress"}]}`)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
 		}
-		_, _ = io.WriteString(w, `{"labels":[{"name":"aiops/in-progress"}]}`)
 	})
 }
 
@@ -106,14 +111,14 @@ func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
 	}
 
 	auth, method, path, body, requests := server.recorded()
-	if requests != 2 {
-		t.Fatalf("requests = %d, want GET then PUT", requests)
+	if requests != 3 {
+		t.Fatalf("requests = %d, want GET, DELETE, POST", requests)
 	}
 	if auth != "token "+token {
 		t.Fatalf("Authorization = %q, want token auth", auth)
 	}
-	if method != http.MethodPut {
-		t.Fatalf("method = %q, want PUT", method)
+	if method != http.MethodPost {
+		t.Fatalf("method = %q, want POST", method)
 	}
 	if path != "/api/v1/repos/owner/repo/issues/7/labels" {
 		t.Fatalf("path = %q", path)
@@ -138,14 +143,64 @@ func TestGiteaIssueLabelsPreservesNonAIOpsLabelsWhenReplacingState(t *testing.T)
 	}
 
 	methods, paths, bodies := server.recordedSequence()
-	if len(methods) != 2 || methods[0] != http.MethodGet || methods[1] != http.MethodPut {
-		t.Fatalf("methods = %#v, want GET then PUT", methods)
+	if len(methods) != 3 || methods[0] != http.MethodGet || methods[1] != http.MethodDelete || methods[2] != http.MethodPost {
+		t.Fatalf("methods = %#v, want GET then DELETE stale aiops label then POST desired label", methods)
 	}
-	if paths[0] != "/api/v1/repos/owner/repo/issues/7/labels" || paths[1] != "/api/v1/repos/owner/repo/issues/7/labels" {
+	if paths[0] != "/api/v1/repos/owner/repo/issues/7/labels" || paths[1] != "/api/v1/repos/owner/repo/issues/7/labels/101" || paths[2] != "/api/v1/repos/owner/repo/issues/7/labels" {
 		t.Fatalf("paths = %#v", paths)
 	}
-	if !strings.Contains(bodies[1], "bug") || !strings.Contains(bodies[1], "aiops/in-progress") || strings.Contains(bodies[1], "aiops/todo") {
-		t.Fatalf("PUT body = %s, want existing non-aiops label preserved and stale aiops state removed", bodies[1])
+	if strings.Contains(bodies[2], "bug") || !strings.Contains(bodies[2], "aiops/in-progress") || strings.Contains(bodies[2], "aiops/todo") {
+		t.Fatalf("POST body = %s, want only desired aiops label added without replacing non-aiops labels", bodies[2])
+	}
+}
+
+func TestGiteaIssueLabelsDoesNotOverwriteConcurrentNonAIOpsLabelChanges(t *testing.T) {
+	var mu sync.Mutex
+	var methods, paths, bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		methods = append(methods, r.Method)
+		paths = append(paths, r.URL.String())
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/todo"},{"id":202,"name":"bug"}]`)
+		case http.MethodDelete:
+			_, _ = io.WriteString(w, `{}`)
+		case http.MethodPost:
+			if strings.Contains(string(body), "bug") || strings.Contains(string(body), "urgent") {
+				t.Fatalf("POST body = %s, must not replace a full label snapshot that can drop concurrent labels", body)
+			}
+			_, _ = io.WriteString(w, `{"labels":[{"name":"aiops/in-progress"},{"name":"bug"},{"name":"urgent"}]}`)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: server.URL, owner: "owner", repo: "repo", http: server.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress"}})
+	if err != nil {
+		t.Fatalf("gitea_issue_labels call: %v", err)
+	}
+	if !strings.Contains(result, `"success":true`) {
+		t.Fatalf("result = %q, want success", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,DELETE,POST" {
+		t.Fatalf("methods = %#v, want GET, DELETE, POST", methods)
+	}
+	if paths[1] != "/api/v1/repos/owner/repo/issues/7/labels/101" {
+		t.Fatalf("DELETE path = %q, want stale aiops label id endpoint", paths[1])
+	}
+	if !strings.Contains(bodies[2], "aiops/in-progress") {
+		t.Fatalf("POST body = %s, want desired aiops label", bodies[2])
 	}
 }
 

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -163,6 +163,7 @@ func TestDynamicToolsDoNotExposeGiteaToolsWithoutGiteaToken(t *testing.T) {
 }
 
 func TestDynamicToolsDoNotExposeGiteaToolsWithoutBaseURL(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "")
 	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
 		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo"},
 		Tracker: workflow.TrackerConfig{
@@ -172,6 +173,20 @@ func TestDynamicToolsDoNotExposeGiteaToolsWithoutBaseURL(t *testing.T) {
 	}})
 	if _, ok := tools.Lookup("gitea_issue_labels"); ok {
 		t.Fatalf("gitea_issue_labels advertised without configured Gitea base URL")
+	}
+}
+
+func TestDynamicToolsExposeGiteaIssueLabelsWithEnvBaseURL(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "https://gitea.env.example/")
+	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo"},
+		Tracker: workflow.TrackerConfig{
+			Kind:   "gitea",
+			APIKey: "token",
+		},
+	}})
+	if _, ok := tools.Lookup("gitea_issue_labels"); !ok {
+		t.Fatalf("gitea_issue_labels not advertised with env Gitea base URL; tools=%#v", tools.Names())
 	}
 }
 

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -100,7 +100,7 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 		}
 		tools.tools["linear_ai_workpad"] = NewLinearWorkpadTool(tools.tools["linear_graphql"])
 	}
-	if strings.EqualFold(trackerCfg.Kind, "gitea") && trackerCfg.APIKey != "" && wf.Config.Repo.Owner != "" && wf.Config.Repo.Name != "" {
+	if strings.EqualFold(trackerCfg.Kind, "gitea") && trackerCfg.APIKey != "" && wf.Config.Repo.Owner != "" && wf.Config.Repo.Name != "" && giteaBaseURLFromTracker(trackerCfg) != "" {
 		client := giteaIssueLabelsProxy{
 			token:   trackerCfg.APIKey,
 			baseURL: giteaBaseURLFromTracker(trackerCfg),

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -110,7 +110,7 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 		}
 		tools.tools["gitea_issue_labels"] = DynamicTool{
 			Name:        "gitea_issue_labels",
-			Description: "Replace the aiops/* labels on one Gitea issue using orchestrator-configured Gitea auth. Input: {issue_number:number, labels:string[]}. The Gitea API token is never exposed to the agent process.",
+			Description: "Replace the aiops/* state label on one Gitea issue using orchestrator-configured Gitea auth. Input: {issue_number:number, labels:string[]} with exactly one aiops/* label. The Gitea API token is never exposed to the agent process.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -120,8 +120,10 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 					},
 					"labels": map[string]any{
 						"type":        "array",
-						"description": "Complete desired aiops/* state label set for the issue, usually exactly one label.",
+						"description": "Complete desired aiops/* state label set for the issue; exactly one label is accepted.",
 						"items":       map[string]any{"type": "string"},
+						"minItems":    1,
+						"maxItems":    1,
 					},
 				},
 				"required":             []string{"issue_number", "labels"},

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -18,8 +18,10 @@ import (
 // by the orchestrator-side proxy and is not part of this public call shape, so
 // an agent cannot redirect the orchestrator-held token to another host.
 type ToolCall struct {
-	Query     string         `json:"query"`
-	Variables map[string]any `json:"variables,omitempty"`
+	Query       string         `json:"query"`
+	Variables   map[string]any `json:"variables,omitempty"`
+	IssueNumber int            `json:"issue_number,omitempty"`
+	Labels      []string       `json:"labels,omitempty"`
 }
 
 // DynamicTool is a client-side tool implemented by the orchestrator and made
@@ -97,6 +99,36 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 			Call: client.call,
 		}
 		tools.tools["linear_ai_workpad"] = NewLinearWorkpadTool(tools.tools["linear_graphql"])
+	}
+	if strings.EqualFold(trackerCfg.Kind, "gitea") && trackerCfg.APIKey != "" && wf.Config.Repo.Owner != "" && wf.Config.Repo.Name != "" {
+		client := giteaIssueLabelsProxy{
+			token:   trackerCfg.APIKey,
+			baseURL: giteaBaseURLFromTracker(trackerCfg),
+			owner:   wf.Config.Repo.Owner,
+			repo:    wf.Config.Repo.Name,
+			http:    http.DefaultClient,
+		}
+		tools.tools["gitea_issue_labels"] = DynamicTool{
+			Name:        "gitea_issue_labels",
+			Description: "Replace the aiops/* labels on one Gitea issue using orchestrator-configured Gitea auth. Input: {issue_number:number, labels:string[]}. The Gitea API token is never exposed to the agent process.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"issue_number": map[string]any{
+						"type":        "integer",
+						"description": "Gitea issue number whose aiops/* state labels should be replaced.",
+					},
+					"labels": map[string]any{
+						"type":        "array",
+						"description": "Complete desired aiops/* state label set for the issue, usually exactly one label.",
+						"items":       map[string]any{"type": "string"},
+					},
+				},
+				"required":             []string{"issue_number", "labels"},
+				"additionalProperties": false,
+			},
+			Call: client.call,
+		}
 	}
 	return tools
 }


### PR DESCRIPTION
## Summary
- Add a Gitea tracker reader/poller that maps mutually-exclusive `aiops/*` labels to workflow states for active issue selection.
- Add deterministic label-state parsing diagnostics for missing, unknown, and conflicting state labels.
- Add token-isolated `gitea_issue_labels` dynamic tool so label writes remain agent-side rather than worker lifecycle mutations.
- Document the Gitea label convention and reader-vs-writer boundary.

## Test Plan
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- `/home/pi/.local/go1.25.10/bin/go mod tidy && git diff --exit-code -- go.mod go.sum`
- `/home/pi/.local/go1.25.10/bin/go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- `gofmt -l ...` (clean)

## Notes
- `go test -race -covermode=atomic ./...` was attempted on this Raspberry Pi host but failed before running tests with ThreadSanitizer `unsupported VMA range` / `Found 47 - Supported 48`, which is an environment/toolchain limitation on this host rather than a package test failure.

Closes #71
