### PR TITLE
refactor: remove postgres scheduler dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ Symphony implementation while D1–D24 are closed systematically.
 
 ## Components
 
-- `cmd/trigger-api`: receives Gitea webhooks and manual task submissions.
-- `cmd/linear-poller`: polls Linear issues in configured active states and enqueues tasks.
-- `cmd/gitea-poller`: polls Gitea issues whose mutually-exclusive `aiops/*` labels map to configured active states and enqueues tasks.
-- `cmd/worker`: claims/dispatches tasks and runs the Symphony-style workflow.
+- `cmd/worker`: polls the configured tracker, reconciles startup workspaces, owns the in-memory orchestrator runtime state, dispatches eligible issues, and runs the Symphony-style workflow without Postgres.
+- `cmd/trigger-api`: transitional Gitea webhook/manual task ingress retained under the legacy queue profile until D7 cleanup.
+- `cmd/linear-poller`: transitional Linear-to-queue poller retained under the legacy queue profile; the worker now owns the SPEC-aligned poll tick.
+- `cmd/gitea-poller`: transitional Gitea-to-queue poller retained until D7 cleanup; the worker can read Gitea issues directly through `tracker.kind: gitea`.
 - `internal/workflow`: loads repo-owned `WORKFLOW.md` configuration and prompt body.
 - `internal/tracker`: tracker abstraction with a Linear client.
 - `internal/workspace`: deterministic Git workspace management, verification, and simple policy checks.
 - `internal/runner`: runner abstraction for `mock`, `codex`, and `claude`.
-- `internal/queue`: PostgreSQL-backed task queue using `FOR UPDATE SKIP LOCKED`.
+- `internal/orchestrator`: single in-memory runtime state, serialized dispatch authority, retry bookkeeping, and worker spawn bridge.
+- `internal/queue`: legacy PostgreSQL-backed task queue still used by transitional ingress binaries, not by `cmd/worker`.
 - `internal/gitea`: transitional webhook parser/signature verification plus the Gitea PR-tool implementation consumed through the agent/tool surface (not a worker-side PR handoff).
 
 ## WORKFLOW.md discovery
@@ -119,7 +120,33 @@ CI expectations on each run:
 See the [CI/CD runbook](docs/runbooks/ci.md) for triggers, security posture,
 release flow, and local pre-push checks.
 
-## Quick start: Gitea webhook path
+## Quick start: worker-owned tracker polling path
+
+Edit `examples/WORKFLOW.md` with your repository and tracker settings, then run the worker. The worker performs startup reconciliation before the first poll tick, then repeatedly fetches active issues and dispatches them through the in-memory orchestrator state:
+
+```bash
+export AIOPS_WORKFLOW_PATH=$PWD/examples/WORKFLOW.md
+export WORKSPACE_ROOT=$PWD/.aiops/workspaces
+
+# For tracker.kind: linear
+export LINEAR_API_KEY=your-linear-personal-key
+
+# For tracker.kind: gitea
+export GITEA_BASE_URL=https://gitea.example.com
+export GITEA_TOKEN=your-gitea-bot-token
+
+go run ./cmd/worker
+```
+
+No `DATABASE_URL` or Postgres service is required for `cmd/worker`. Restart recovery follows SPEC §14.3: the worker starts with fresh runtime state, cleans terminal workspaces from tracker state, and re-dispatches eligible active issues on the next poll rather than restoring queue rows, retry timers, or running sessions from a database.
+
+The default Compose service now starts only `worker` unless a legacy profile is requested:
+
+```bash
+docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
+```
+
+## Legacy quick start: Gitea webhook path
 
 ```bash
 cp .env.example .env
@@ -139,18 +166,18 @@ Comment on a Gitea issue:
 /ai-run
 ```
 
-## Quick start: Linear polling path
+## Legacy quick start: Linear queue polling path
 
 Edit `examples/WORKFLOW.md` with your repo and Linear settings, then run:
 
 ```bash
 export LINEAR_API_KEY=your-linear-personal-key
-docker compose --env-file .env -f deploy/docker-compose.yml --profile linear up --build
+docker compose --env-file .env -f deploy/docker-compose.yml --profile legacy-queue up --build linear-poller worker
 ```
 
 The poller watches active Linear states such as `AI Ready`, `In Progress`, and `Rework`, then enqueues tasks for the worker.
 
-## Quick start: Gitea polling path
+## Legacy quick start: Gitea queue polling path
 
 For SPEC-aligned Gitea polling, encode issue state as exactly one `aiops/*` label:
 
@@ -170,7 +197,7 @@ export GITEA_TOKEN=your-gitea-bot-token
 go run ./cmd/gitea-poller examples/WORKFLOW.md
 ```
 
-The poller reads issues whose labels map to configured active states and enqueues them for the worker. State changes are still performed by the agent through the advertised tool surface, not by the poller.
+The legacy poller reads issues whose labels map to configured active states and enqueues them for the transitional queue path. For SPEC-aligned operation, prefer running `cmd/worker` directly so the worker owns tracker polling and orchestrator runtime state.
 
 ## First safe mode
 

--- a/README.md
+++ b/README.md
@@ -166,16 +166,9 @@ Comment on a Gitea issue:
 /ai-run
 ```
 
-## Legacy quick start: Linear queue polling path
+## Legacy Linear queue polling path
 
-Edit `examples/WORKFLOW.md` with your repo and Linear settings, then run:
-
-```bash
-export LINEAR_API_KEY=your-linear-personal-key
-docker compose --env-file .env -f deploy/docker-compose.yml --profile legacy-queue up --build linear-poller worker
-```
-
-The poller watches active Linear states such as `AI Ready`, `In Progress`, and `Rework`, then enqueues tasks for the worker.
+`cmd/linear-poller` is retained only as transitional queue-ingress code until D7 cleanup. The SPEC-aligned `worker` no longer drains Postgres queue rows, so do not start `linear-poller worker` as a working legacy stack. For active Linear issue execution, configure `tracker.kind: linear` in `WORKFLOW.md` and run the worker-owned tracker polling path above.
 
 ## Legacy quick start: Gitea queue polling path
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
 ```bash
 cp .env.example .env
 # edit GITEA_BASE_URL, GITEA_TOKEN, GITEA_WEBHOOK_SECRET
-docker compose --env-file .env -f deploy/docker-compose.yml up --build
+docker compose --env-file .env -f deploy/docker-compose.yml --profile legacy-queue up --build trigger-api
 ```
 
 Configure a Gitea issue-comment webhook pointing at:

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -78,7 +78,10 @@ func logStartupReconcileWorkflow(resolution *workflow.Resolution, wf *workflow.W
 	log.Printf("startup reconciliation: workflow source=%s path=%s tracker.kind=%s", resolution.Source, resolution.Path, wf.Config.Tracker.Kind)
 }
 
-func validateWorkflowForRuntime(path string, cfg workflow.Config) error {
+func validateWorkflowForRuntime(path string, source workflow.Source, cfg workflow.Config) error {
+	if source != workflow.SourceFile {
+		return nil
+	}
 	if cfg.Repo.CloneURL == "" {
 		return fmt.Errorf("%s: repo.clone_url is required", path)
 	}
@@ -91,7 +94,7 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := validateWorkflowForRuntime(wf.Path, wf.Config); err != nil {
+	if err := validateWorkflowForRuntime(wf.Path, wf.Source, wf.Config); err != nil {
 		return err
 	}
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -78,10 +78,20 @@ func logStartupReconcileWorkflow(resolution *workflow.Resolution, wf *workflow.W
 	log.Printf("startup reconciliation: workflow source=%s path=%s tracker.kind=%s", resolution.Source, resolution.Path, wf.Config.Tracker.Kind)
 }
 
+func validateWorkflowForRuntime(path string, cfg workflow.Config) error {
+	if cfg.Repo.CloneURL == "" {
+		return fmt.Errorf("%s: repo.clone_url is required", path)
+	}
+	return nil
+}
+
 func run(ctx context.Context) error {
 	cfg := worker.LoadConfigFromEnv()
 	wf, err := loadWorkflowForStartupReconcile()
 	if err != nil {
+		return err
+	}
+	if err := validateWorkflowForRuntime(wf.Path, wf.Config); err != nil {
 		return err
 	}
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -79,11 +79,11 @@ func logStartupReconcileWorkflow(resolution *workflow.Resolution, wf *workflow.W
 }
 
 func validateWorkflowForRuntime(path string, source workflow.Source, cfg workflow.Config) error {
-	if source != workflow.SourceFile {
-		return nil
-	}
 	if cfg.Repo.CloneURL == "" {
-		return fmt.Errorf("%s: repo.clone_url is required", path)
+		if source == workflow.SourceDefault {
+			path = "built-in workflow defaults"
+		}
+		return fmt.Errorf("%s: repo.clone_url is required for poll-based worker runtime", path)
 	}
 	return nil
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -124,7 +124,10 @@ func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error)
 	case "linear":
 		return tracker.NewLinearClient(cfg.Tracker), nil
 	case "gitea":
-		baseURL := env("GITEA_BASE_URL", "http://localhost:3000")
+		baseURL := cfg.Tracker.ProjectSlug
+		if baseURL == "" {
+			baseURL = env("GITEA_BASE_URL", "http://localhost:3000")
+		}
 		return gitea.NewTrackerClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name), nil
 	default:
 		return nil, fmt.Errorf("unsupported tracker.kind %q", cfg.Tracker.Kind)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -26,13 +26,15 @@ func main() {
 		}
 		os.Exit(worker.PrintConfig(os.Args[2], os.Stdout, os.Stderr))
 	}
-	if err := normalizeRunError(run()); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := normalizeRunError(run(ctx), ctx.Err()); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func normalizeRunError(err error) error {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+func normalizeRunError(err error, runCtxErr error) error {
+	if runCtxErr != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return nil
 	}
 	return err
@@ -76,10 +78,7 @@ func logStartupReconcileWorkflow(resolution *workflow.Resolution, wf *workflow.W
 	log.Printf("startup reconciliation: workflow source=%s path=%s tracker.kind=%s", resolution.Source, resolution.Path, wf.Config.Tracker.Kind)
 }
 
-func run() error {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
+func run(ctx context.Context) error {
 	cfg := worker.LoadConfigFromEnv()
 	wf, err := loadWorkflowForStartupReconcile()
 	if err != nil {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/xrf9268-hue/aiops-platform/internal/queue"
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
+	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -60,11 +62,7 @@ func loadWorkflowForStartupReconcile() (*workflow.Workflow, error) {
 
 func logStartupReconcileWorkflow(resolution *workflow.Resolution, wf *workflow.Workflow) {
 	if resolution.Source == workflow.SourceDefault {
-		log.Printf("startup reconciliation: workflow source=%s tracker.kind=%s; reconciliation will be skipped unless tracker.kind is linear", resolution.Source, wf.Config.Tracker.Kind)
-		return
-	}
-	if wf.Config.Tracker.Kind != "linear" {
-		log.Printf("startup reconciliation: workflow source=%s path=%s tracker.kind=%s; reconciliation will be skipped unless tracker.kind is linear", resolution.Source, resolution.Path, wf.Config.Tracker.Kind)
+		log.Printf("startup reconciliation: workflow source=%s tracker.kind=%s", resolution.Source, wf.Config.Tracker.Kind)
 		return
 	}
 	log.Printf("startup reconciliation: workflow source=%s path=%s tracker.kind=%s", resolution.Source, resolution.Path, wf.Config.Tracker.Kind)
@@ -75,29 +73,67 @@ func run() error {
 	defer stop()
 
 	cfg := worker.LoadConfigFromEnv()
-	pool, err := pgxpool.New(ctx, cfg.DSN)
+	wf, err := loadWorkflowForStartupReconcile()
 	if err != nil {
 		return err
 	}
-	defer pool.Close()
 
-	store := queue.New(pool)
-	if wf, err := loadWorkflowForStartupReconcile(); err != nil {
+	trackerClient, err := trackerClientForWorkflow(wf.Config)
+	if err != nil {
 		return err
-	} else if wf.Config.Tracker.Kind == "linear" {
-		if err := worker.ReconcileStartup(ctx, worker.ReconcileConfig{
-			WorkspaceRoot:   cfg.WorkspaceRoot,
-			ActiveStates:    wf.Config.Tracker.ActiveStates,
-			TerminalStates:  wf.Config.Tracker.TerminalStates,
-			Tracker:         tracker.NewLinearClient(wf.Config.Tracker),
-			Emitter:         worker.LogEventEmitter{},
-			ReconcileTaskID: "reconcile-startup",
-		}); err != nil {
-			worker.LogReconcileError(err)
-			return err
-		}
+	}
+	if err := worker.ReconcileStartup(ctx, worker.ReconcileConfig{
+		WorkspaceRoot:   cfg.WorkspaceRoot,
+		ActiveStates:    wf.Config.Tracker.ActiveStates,
+		TerminalStates:  wf.Config.Tracker.TerminalStates,
+		Tracker:         trackerClient,
+		Emitter:         worker.LogEventEmitter{},
+		ReconcileTaskID: "reconcile-startup",
+	}); err != nil {
+		worker.LogReconcileError(err)
+		return err
 	}
 
-	worker.Run(ctx, store, cfg)
-	return nil
+	pollInterval := time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond
+	state := orchestrator.NewOrchestratorState(int64(wf.Config.Tracker.PollIntervalMs), wf.Config.Agent.MaxConcurrentAgents)
+	dispatcher := orchestrator.WorkerTaskDispatcher{
+		BuildTask: func(issue tracker.Issue) (task.Task, error) {
+			return orchestrator.TaskFromIssue(issue, wf.Config)
+		},
+		Config:  cfg,
+		Emitter: worker.LogEventEmitter{},
+	}
+	orch := orchestrator.New(state, orchestrator.Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  orchestrator.FixedDelayScheduler{Delay: 60 * time.Second},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		return err
+	}
+	return orchestrator.RunPollLoop(ctx, orchestrator.NewPoller(trackerClient, orch), pollInterval)
+}
+
+type trackerRuntimeClient interface {
+	orchestrator.ActiveIssueLister
+	worker.ReconcileTracker
+}
+
+func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error) {
+	switch cfg.Tracker.Kind {
+	case "linear":
+		return tracker.NewLinearClient(cfg.Tracker), nil
+	case "gitea":
+		baseURL := env("GITEA_BASE_URL", "http://localhost:3000")
+		return gitea.NewTrackerClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name), nil
+	default:
+		return nil, fmt.Errorf("unsupported tracker.kind %q", cfg.Tracker.Kind)
+	}
+}
+
+func env(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -25,9 +26,16 @@ func main() {
 		}
 		os.Exit(worker.PrintConfig(os.Args[2], os.Stdout, os.Stderr))
 	}
-	if err := run(); err != nil {
+	if err := normalizeRunError(run()); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func normalizeRunError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	return err
 }
 
 func loadWorkflowForStartupReconcile() (*workflow.Workflow, error) {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -93,6 +93,7 @@ func run(ctx context.Context) error {
 		WorkspaceRoot:   cfg.WorkspaceRoot,
 		ActiveStates:    wf.Config.Tracker.ActiveStates,
 		TerminalStates:  wf.Config.Tracker.TerminalStates,
+		TrackerKind:     wf.Config.Tracker.Kind,
 		Tracker:         trackerClient,
 		Emitter:         worker.LogEventEmitter{},
 		ReconcileTaskID: "reconcile-startup",

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -138,14 +138,42 @@ func TestTrackerClientForWorkflowUsesGiteaProjectSlugBeforeEnvBaseURL(t *testing
 	}
 }
 
-func TestValidateWorkflowForRuntimePreservesPromptOnlyWorkflowCompatibility(t *testing.T) {
+func TestValidateWorkflowForRuntimeRejectsPromptOnlyWorkflowMissingTaskFields(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 
-	if err := validateWorkflowForRuntime("WORKFLOW.md", workflow.SourcePromptOnly, cfg); err != nil {
-		t.Fatalf("validateWorkflowForRuntime(prompt-only defaults) = %v, want nil", err)
+	err := validateWorkflowForRuntime("WORKFLOW.md", workflow.SourcePromptOnly, cfg)
+	if err == nil {
+		t.Fatal("validateWorkflowForRuntime(prompt-only defaults) = nil, want repo.clone_url error")
 	}
-	if err := validateWorkflowForRuntime("WORKFLOW.md", workflow.SourceDefault, cfg); err != nil {
-		t.Fatalf("validateWorkflowForRuntime(default workflow) = %v, want nil", err)
+	for _, want := range []string{"WORKFLOW.md", "repo.clone_url", "poll-based worker runtime"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validateWorkflowForRuntime error = %v, want substring %q", err, want)
+		}
+	}
+}
+
+func TestValidateWorkflowForRuntimeRejectsDefaultWorkflowMissingTaskFields(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+
+	err := validateWorkflowForRuntime("WORKFLOW.md", workflow.SourceDefault, cfg)
+	if err == nil {
+		t.Fatal("validateWorkflowForRuntime(default workflow) = nil, want repo.clone_url error")
+	}
+	for _, want := range []string{"built-in workflow defaults", "repo.clone_url", "poll-based worker runtime"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validateWorkflowForRuntime error = %v, want substring %q", err, want)
+		}
+	}
+}
+
+func TestValidateWorkflowForRuntimeAcceptsWorkflowWithRuntimeTaskFields(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.CloneURL = "git@example.com:o/r.git"
+
+	for _, source := range []workflow.Source{workflow.SourceFile, workflow.SourcePromptOnly, workflow.SourceDefault} {
+		if err := validateWorkflowForRuntime("WORKFLOW.md", source, cfg); err != nil {
+			t.Fatalf("validateWorkflowForRuntime(source=%s) = %v, want nil", source, err)
+		}
 	}
 }
 
@@ -156,8 +184,10 @@ func TestValidateWorkflowForRuntimeRejectsFrontMatterWorkflowMissingTaskFields(t
 	if err == nil {
 		t.Fatal("validateWorkflowForRuntime(file source defaults) = nil, want repo.clone_url error")
 	}
-	if !strings.Contains(err.Error(), "WORKFLOW.md: repo.clone_url is required") {
-		t.Fatalf("validateWorkflowForRuntime error = %v, want repo.clone_url guidance", err)
+	for _, want := range []string{"WORKFLOW.md", "repo.clone_url", "poll-based worker runtime"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validateWorkflowForRuntime error = %v, want substring %q", err, want)
+		}
 	}
 }
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -96,11 +96,11 @@ func TestLoadWorkflowForStartupReconcileLogsConfiguredGiteaWorkflow(t *testing.T
 	}
 }
 
-func TestTrackerClientForWorkflowUsesGiteaBaseURLEvenWithProjectSlug(t *testing.T) {
-	t.Setenv("GITEA_BASE_URL", "https://gitea.example.test/")
+func TestTrackerClientForWorkflowUsesGiteaProjectSlugBeforeEnvBaseURL(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "https://gitea-env.example.test/")
 	cfg := workflow.DefaultConfig()
 	cfg.Tracker.Kind = "gitea"
-	cfg.Tracker.ProjectSlug = "owner/repo"
+	cfg.Tracker.ProjectSlug = "https://gitea-workflow.example.test/"
 	cfg.Repo.Owner = "owner"
 	cfg.Repo.Name = "repo"
 
@@ -112,8 +112,8 @@ func TestTrackerClientForWorkflowUsesGiteaBaseURLEvenWithProjectSlug(t *testing.
 	if !ok {
 		t.Fatalf("client type = %T, want *gitea.TrackerClient", client)
 	}
-	if giteaClient.BaseURL != "https://gitea.example.test" {
-		t.Fatalf("base URL = %q, want env GITEA_BASE_URL without trailing slash", giteaClient.BaseURL)
+	if giteaClient.BaseURL != "https://gitea-workflow.example.test" {
+		t.Fatalf("base URL = %q, want tracker.project_slug without trailing slash", giteaClient.BaseURL)
 	}
 }
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -138,12 +138,23 @@ func TestTrackerClientForWorkflowUsesGiteaProjectSlugBeforeEnvBaseURL(t *testing
 	}
 }
 
-func TestValidateWorkflowForRuntimeRejectsPromptOnlyWorkflowMissingTaskFields(t *testing.T) {
+func TestValidateWorkflowForRuntimePreservesPromptOnlyWorkflowCompatibility(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 
-	err := validateWorkflowForRuntime("WORKFLOW.md", cfg)
+	if err := validateWorkflowForRuntime("WORKFLOW.md", workflow.SourcePromptOnly, cfg); err != nil {
+		t.Fatalf("validateWorkflowForRuntime(prompt-only defaults) = %v, want nil", err)
+	}
+	if err := validateWorkflowForRuntime("WORKFLOW.md", workflow.SourceDefault, cfg); err != nil {
+		t.Fatalf("validateWorkflowForRuntime(default workflow) = %v, want nil", err)
+	}
+}
+
+func TestValidateWorkflowForRuntimeRejectsFrontMatterWorkflowMissingTaskFields(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+
+	err := validateWorkflowForRuntime("WORKFLOW.md", workflow.SourceFile, cfg)
 	if err == nil {
-		t.Fatal("validateWorkflowForRuntime(prompt-only defaults) = nil, want repo.clone_url error")
+		t.Fatal("validateWorkflowForRuntime(file source defaults) = nil, want repo.clone_url error")
 	}
 	if !strings.Contains(err.Error(), "WORKFLOW.md: repo.clone_url is required") {
 		t.Fatalf("validateWorkflowForRuntime error = %v, want repo.clone_url guidance", err)

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -8,8 +8,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+func TestWorkerEntrypointDoesNotRequirePostgresQueue(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	for _, forbidden := range []string{"internal/queue", "pgxpool", "DATABASE_URL"} {
+		if strings.Contains(string(src), forbidden) {
+			t.Fatalf("cmd/worker/main.go contains %q; worker startup must use tracker + orchestrator runtime state, not the Postgres queue", forbidden)
+		}
+	}
+	for _, required := range []string{"orchestrator.NewOrchestratorState", "orchestrator.NewPoller", "orchestrator.RunPollLoop"} {
+		if !strings.Contains(string(src), required) {
+			t.Fatalf("cmd/worker/main.go missing %q; worker startup must poll tracker issues through orchestrator runtime state", required)
+		}
+	}
+}
 
 func TestLoadWorkflowForStartupReconcileUsesConfiguredWorkflowPath(t *testing.T) {
 	dir := t.TempDir()
@@ -42,11 +60,11 @@ func TestLoadWorkflowForStartupReconcileUsesConfiguredWorkflowPath(t *testing.T)
 		}
 	}
 	if strings.Contains(gotLog, "reconciliation will be skipped") {
-		t.Fatalf("startup reconciliation log = %q, did not expect skip diagnostic for linear tracker", gotLog)
+		t.Fatalf("startup reconciliation log = %q, did not expect skip diagnostic", gotLog)
 	}
 }
 
-func TestLoadWorkflowForStartupReconcileWarnsWhenConfiguredWorkflowIsNonLinear(t *testing.T) {
+func TestLoadWorkflowForStartupReconcileLogsConfiguredGiteaWorkflow(t *testing.T) {
 	dir := t.TempDir()
 	workflowPath := filepath.Join(dir, "gitea-workflow.md")
 	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: gitea\n---\nprompt\n"
@@ -68,10 +86,34 @@ func TestLoadWorkflowForStartupReconcileWarnsWhenConfiguredWorkflowIsNonLinear(t
 		t.Fatalf("tracker kind = %q, want gitea", wf.Config.Tracker.Kind)
 	}
 	gotLog := logs.String()
-	for _, want := range []string{"startup reconciliation: workflow source=file", "path=" + workflowPath, "tracker.kind=gitea", "reconciliation will be skipped"} {
+	for _, want := range []string{"startup reconciliation: workflow source=file", "path=" + workflowPath, "tracker.kind=gitea"} {
 		if !strings.Contains(gotLog, want) {
 			t.Fatalf("startup reconciliation log = %q, want substring %q", gotLog, want)
 		}
+	}
+	if strings.Contains(gotLog, "reconciliation will be skipped") {
+		t.Fatalf("startup reconciliation log = %q, did not expect skip diagnostic", gotLog)
+	}
+}
+
+func TestTrackerClientForWorkflowUsesGiteaBaseURLEvenWithProjectSlug(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "https://gitea.example.test/")
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "gitea"
+	cfg.Tracker.ProjectSlug = "owner/repo"
+	cfg.Repo.Owner = "owner"
+	cfg.Repo.Name = "repo"
+
+	client, err := trackerClientForWorkflow(cfg)
+	if err != nil {
+		t.Fatalf("tracker client: %v", err)
+	}
+	giteaClient, ok := client.(*gitea.TrackerClient)
+	if !ok {
+		t.Fatalf("client type = %T, want *gitea.TrackerClient", client)
+	}
+	if giteaClient.BaseURL != "https://gitea.example.test" {
+		t.Fatalf("base URL = %q, want env GITEA_BASE_URL without trailing slash", giteaClient.BaseURL)
 	}
 }
 
@@ -97,13 +139,15 @@ func TestLoadWorkflowForStartupReconcileClassifiesConfiguredPromptOnlyWorkflow(t
 		t.Fatalf("tracker kind = %q, want default %q", wf.Config.Tracker.Kind, workflow.DefaultConfig().Tracker.Kind)
 	}
 	gotLog := logs.String()
-	for _, want := range []string{"startup reconciliation: workflow source=prompt_only", "path=" + workflowPath, "tracker.kind=gitea", "reconciliation will be skipped"} {
+	for _, want := range []string{"startup reconciliation: workflow source=prompt_only", "path=" + workflowPath, "tracker.kind=gitea"} {
 		if !strings.Contains(gotLog, want) {
 			t.Fatalf("startup reconciliation log = %q, want substring %q", gotLog, want)
 		}
 	}
-	if strings.Contains(gotLog, "workflow source=file") {
-		t.Fatalf("startup reconciliation log = %q, did not expect file source for prompt-only workflow", gotLog)
+	for _, forbidden := range []string{"workflow source=file", "reconciliation will be skipped"} {
+		if strings.Contains(gotLog, forbidden) {
+			t.Fatalf("startup reconciliation log = %q, did not expect %q", gotLog, forbidden)
+		}
 	}
 }
 
@@ -177,9 +221,12 @@ func TestLoadWorkflowForStartupReconcileDefaultsWhenNoWorkflowExists(t *testing.
 		t.Fatalf("tracker kind = %q, want default %q", wf.Config.Tracker.Kind, workflow.DefaultConfig().Tracker.Kind)
 	}
 	gotLog := logs.String()
-	for _, want := range []string{"startup reconciliation: workflow source=default", "tracker.kind=gitea", "reconciliation will be skipped"} {
+	for _, want := range []string{"startup reconciliation: workflow source=default", "tracker.kind=gitea"} {
 		if !strings.Contains(gotLog, want) {
 			t.Fatalf("startup reconciliation log = %q, want substring %q", gotLog, want)
 		}
+	}
+	if strings.Contains(gotLog, "reconciliation will be skipped") {
+		t.Fatalf("startup reconciliation log = %q, did not expect skip diagnostic", gotLog)
 	}
 }

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -11,6 +12,18 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+func TestRunTreatsCanceledPollContextAsGracefulShutdown(t *testing.T) {
+	if err := normalizeRunError(context.Canceled); err != nil {
+		t.Fatalf("normalizeRunError(context.Canceled) = %v, want nil", err)
+	}
+	if err := normalizeRunError(context.DeadlineExceeded); err != nil {
+		t.Fatalf("normalizeRunError(context.DeadlineExceeded) = %v, want nil", err)
+	}
+	if err := normalizeRunError(os.ErrNotExist); err == nil {
+		t.Fatal("normalizeRunError(non-context error) = nil, want original error")
+	}
+}
 
 func TestWorkerEntrypointDoesNotRequirePostgresQueue(t *testing.T) {
 	src, err := os.ReadFile("main.go")

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
@@ -14,14 +15,21 @@ import (
 )
 
 func TestRunTreatsCanceledPollContextAsGracefulShutdown(t *testing.T) {
-	if err := normalizeRunError(context.Canceled); err != nil {
-		t.Fatalf("normalizeRunError(context.Canceled) = %v, want nil", err)
+	if err := normalizeRunError(context.Canceled, context.Canceled); err != nil {
+		t.Fatalf("normalizeRunError(context.Canceled, context.Canceled) = %v, want nil", err)
 	}
-	if err := normalizeRunError(context.DeadlineExceeded); err != nil {
-		t.Fatalf("normalizeRunError(context.DeadlineExceeded) = %v, want nil", err)
+	if err := normalizeRunError(context.DeadlineExceeded, context.DeadlineExceeded); err != nil {
+		t.Fatalf("normalizeRunError(context.DeadlineExceeded, context.DeadlineExceeded) = %v, want nil", err)
 	}
-	if err := normalizeRunError(os.ErrNotExist); err == nil {
+	if err := normalizeRunError(os.ErrNotExist, nil); err == nil {
 		t.Fatal("normalizeRunError(non-context error) = nil, want original error")
+	}
+}
+
+func TestRunDoesNotTreatUnrelatedDeadlineErrorAsGracefulShutdown(t *testing.T) {
+	err := normalizeRunError(context.DeadlineExceeded, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("normalizeRunError(context.DeadlineExceeded, nil) = %v, want deadline error", err)
 	}
 }
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -138,6 +138,18 @@ func TestTrackerClientForWorkflowUsesGiteaProjectSlugBeforeEnvBaseURL(t *testing
 	}
 }
 
+func TestValidateWorkflowForRuntimeRejectsPromptOnlyWorkflowMissingTaskFields(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+
+	err := validateWorkflowForRuntime("WORKFLOW.md", cfg)
+	if err == nil {
+		t.Fatal("validateWorkflowForRuntime(prompt-only defaults) = nil, want repo.clone_url error")
+	}
+	if !strings.Contains(err.Error(), "WORKFLOW.md: repo.clone_url is required") {
+		t.Fatalf("validateWorkflowForRuntime error = %v, want repo.clone_url guidance", err)
+	}
+}
+
 func TestLoadWorkflowForStartupReconcileClassifiesConfiguredPromptOnlyWorkflow(t *testing.T) {
 	dir := t.TempDir()
 	workflowPath := filepath.Join(dir, "prompt-only-workflow.md")

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,4 +1,22 @@
 services:
+  worker:
+    build:
+      context: ..
+    command: ["worker"]
+    environment:
+      GITEA_BASE_URL: ${GITEA_BASE_URL}
+      GITEA_TOKEN: ${GITEA_TOKEN}
+      WORKSPACE_ROOT: /workspaces
+      AIOPS_WORKFLOW_PATH: /app/examples/WORKFLOW.md
+      LINEAR_API_KEY: ${LINEAR_API_KEY}
+    volumes:
+      - workspaces:/workspaces
+      - ../examples:/app/examples:ro
+      - ~/.ssh:/root/.ssh:ro
+
+  # Transitional services retained until D7 retires webhook/manual enqueue
+  # ingress. They still use the legacy queue and Postgres; cmd/worker no longer
+  # depends on either service for tracker polling or dispatch.
   postgres:
     image: postgres:16
     environment:
@@ -10,6 +28,8 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ../migrations:/docker-entrypoint-initdb.d:ro
+    profiles:
+      - legacy-queue
 
   trigger-api:
     build:
@@ -23,6 +43,8 @@ services:
       ADDR: :8080
     ports:
       - "8080:8080"
+    profiles:
+      - legacy-queue
 
   linear-poller:
     build:
@@ -36,25 +58,7 @@ services:
     volumes:
       - ../examples:/app/examples:ro
     profiles:
-      - linear
-
-  worker:
-    build:
-      context: ..
-    command: ["worker"]
-    depends_on:
-      - postgres
-    environment:
-      DATABASE_URL: postgres://aiops:aiops@postgres:5432/aiops?sslmode=disable
-      GITEA_BASE_URL: ${GITEA_BASE_URL}
-      GITEA_TOKEN: ${GITEA_TOKEN}
-      WORKSPACE_ROOT: /workspaces
-      AIOPS_WORKFLOW_PATH: /app/examples/WORKFLOW.md
-      LINEAR_API_KEY: ${LINEAR_API_KEY}
-    volumes:
-      - workspaces:/workspaces
-      - ../examples:/app/examples:ro
-      - ~/.ssh:/root/.ssh:ro
+      - legacy-queue
 
 volumes:
   pgdata:

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -2,11 +2,11 @@
 
 This runbook describes how to use `aiops-platform` day to day so it stays a useful tool instead of another system to babysit.
 
-The defaults below match `examples/WORKFLOW.md` and the active state list hardcoded in `internal/workflow/config.go`.
+The defaults below match `examples/WORKFLOW.md` and the active state list in `internal/workflow/config.go`. `cmd/worker` is now the day-to-day scheduler entrypoint: it reads the configured tracker directly, performs startup reconciliation, and dispatches through in-memory orchestrator runtime state. Postgres and the legacy queue remain only for transitional webhook/manual ingress while D7 cleanup is pending.
 
 ## Linear states
 
-The Linear poller in `cmd/linear-poller` only enqueues issues whose state name appears in `tracker.active_states` of your `WORKFLOW.md`. Use a simple lifecycle:
+The worker poll tick reads issues whose state name appears in `tracker.active_states` of your `WORKFLOW.md`. Use a simple lifecycle:
 
 ```text
 Backlog -> AI Ready -> In Progress -> Human Review -> Rework -> Done
@@ -16,10 +16,10 @@ Backlog -> AI Ready -> In Progress -> Human Review -> Rework -> Done
 Per-state rules:
 
 - `Backlog`: not picked up. Use this for anything you have not refined yet.
-- `AI Ready`: refined and small enough that an agent can attempt it. The poller picks these up.
+- `AI Ready`: refined and small enough that an agent can attempt it. The worker poll tick picks these up.
 - `In Progress`: the agent has claimed an issue or you are iterating on it. Stays in `active_states` so re-runs after a push are allowed.
-- `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself. Per SPEC §1, tracker updates belong on the agent/tool side; while the app-server transport is still being wired, the transitional worker may still perform this handoff on behalf of the run.
-- `Rework`: review found issues and you want another attempt. Moving the Linear issue into `Rework` re-enqueues a fresh task automatically. The poller composes `source_event_id` as `<issue.ID>|rework|<issue.updatedAt>` whenever the state is `Rework`, so each transition into Rework is a brand-new dedupe key and Postgres INSERTs a new task row. While the issue stays parked in Rework, repeated polls reuse the same `updatedAt` and dedupe (no enqueue loop). Non-Rework states still use plain `issue.ID`, so `AI Ready` -> `In Progress` iteration on a single task is unchanged. See `cmd/linear-poller/main.go` (`sourceEventID`) and `internal/queue/postgres.go` (`Enqueue`).
+- `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself. Per SPEC §1, tracker updates belong on the agent/tool side, not in the worker scheduler.
+- `Rework`: review found issues and you want another attempt. Keep `Rework` in `active_states` so the worker can pick the issue up again after the tracker state changes. The in-memory orchestrator state, not Postgres queue rows, is the scheduling authority for the running worker process.
 - `Done` / `Canceled`: terminal. Listed under `tracker.terminal_states`.
 
 Default `active_states` in code:
@@ -75,9 +75,9 @@ What it does: writes a stub file under `.aiops/<task-id>.md` and returns success
 
 Use when:
 
-- you just changed `WORKFLOW.md`, queue plumbing, or PR handoff and want to confirm the loop end-to-end.
+- you just changed `WORKFLOW.md`, tracker polling, startup reconciliation, or PR handoff and want to confirm the loop end-to-end.
 - you are onboarding a new repository and want a safe first PR before pointing a real model at it.
-- the model API is rate-limited or down and you still want to verify queue and worker behavior.
+- the model API is rate-limited or down and you still want to verify tracker polling and worker behavior.
 
 ```yaml
 agent:
@@ -148,7 +148,7 @@ multi-file or reasoning-heavy    -> claude
 
 ## Handling failed tasks
 
-A task is `failed` only after `attempts` reaches `max_attempts`. Until then, a failing attempt sets the status back to `queued` with a 60s backoff (`internal/queue/postgres.go`). Status values are defined in `internal/task/task.go`: `queued`, `running`, `succeeded`, `failed`.
+The SPEC-aligned worker does not persist scheduler attempts in Postgres. It polls the tracker, records in-flight/completed/retry state in the in-memory orchestrator runtime, and starts with fresh scheduler state after restart. Startup reconciliation compares tracker state with deterministic workspaces before the first poll so terminal/unknown workspace directories are cleaned without reading queue rows.
 
 ### Triage with the debugging API
 
@@ -160,7 +160,7 @@ curl 'http://localhost:8080/v1/tasks/<task-id>'
 curl 'http://localhost:8080/v1/tasks/<task-id>/events'
 ```
 
-`/events` is the most useful endpoint. Look for `enqueued`, `claimed`, `failed_attempt`, `succeeded`, `failed` in order, and read the messages.
+For legacy queue runs, `/events` is the most useful endpoint. Look for `enqueued`, `claimed`, `failed_attempt`, `succeeded`, `failed` in order, and read the messages. For the worker-owned poll path, prefer process logs and task events emitted by `worker.RunTask` such as `workflow_resolved`, `runner_start`, `verify_*`, and reconciliation events.
 
 ### Common causes and fixes
 
@@ -168,15 +168,15 @@ curl 'http://localhost:8080/v1/tasks/<task-id>/events'
 - Verification command failed (`go test ./...` non-zero): read `.aiops/RUN_SUMMARY.md` in the work branch if the runner produced one. Reproduce locally on the same branch.
 - Policy violation (deny path or size cap): re-scope the task into a smaller issue, or do it manually.
 - Runner command not found: confirm `codex.command` or `claude.command` resolves on the worker host. The shell runner uses `sh -lc`, so PATH must be set in the worker's login shell.
-- Empty diff: agent decided nothing to do. Tighten the issue body, then move it to `Rework`. The state change alone re-enqueues a fresh task (the poller keys Rework by `issue.ID|rework|updatedAt`). `/ai-run` on Gitea and `POST /v1/tasks` are still available as fallbacks if the poller is paused.
+- Empty diff: agent decided nothing to do. Tighten the issue body, then move it to `Rework` (or the equivalent active Gitea `aiops/*` state label). `/ai-run` on Gitea and `POST /v1/tasks` are legacy queue fallbacks only while D7 cleanup is pending.
 
 ### Re-running a failed task
 
 Three options, in order of preference:
 
-1. Move the Linear issue to `Rework`. The poller composes `source_event_id` as `<issue.ID>|rework|<updatedAt>` for the Rework state, so the transition INSERTs a new task row instead of deduping against the original. Subsequent polls while the issue stays in Rework reuse the same `updatedAt` and stay deduped, so you do not get an enqueue loop.
-2. Re-trigger from Gitea by commenting `/ai-run` on the issue. The trigger API uses the Gitea delivery ID (or `comment-<id>`) as `source_event_id`, so each comment produces a new queued task. Useful when you want to retry without changing Linear state.
-3. Manual enqueue against the trigger API (each call defaults `source_event_id` to `manual-<unix-nanos>`, so it is always fresh):
+1. Move the tracker issue to an active retry state such as `Rework`, or keep it in another configured `active_states` value after tightening the issue body. The worker poll tick sees active tracker state and asks the in-memory orchestrator to dispatch it.
+2. Restart the worker if you need to clear in-memory retry state. Startup reconciliation runs first, then the next poll can dispatch still-active tracker issues without reading queue rows.
+3. Legacy fallback only while D7 cleanup is pending: re-trigger from Gitea by commenting `/ai-run` or manually enqueue against the trigger API. The trigger API uses a fresh delivery/comment/manual key for queue dedupe.
 
    ```bash
    curl -X POST http://localhost:8080/v1/tasks \

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -76,6 +76,8 @@ type FixedDelayScheduler struct {
 	Delay time.Duration
 }
 
+const retryCapacityRecheckDelay = 100 * time.Millisecond
+
 // NextDelay implements Scheduler.
 func (f FixedDelayScheduler) NextDelay(int) time.Duration { return f.Delay }
 
@@ -365,12 +367,23 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		// Retry timers must obey the same capacity gate as fresh dispatch.
 		// Leave the retry queued and arm a short follow-up timer so the issue
 		// is retried after capacity can free instead of spawning over the cap.
+		if entry.Timer != nil {
+			entry.Timer.Stop()
+		}
 		o := r.o
+		id := r.id
 		issue := r.issue
 		attempt := r.attempt
-		return func() {
-			_ = o.ScheduleRetry(o.runCtx, issue, entry.Identifier, attempt, entry.Error)
-		}
+		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
+		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
+			_ = o.submit(o.runCtx, &retryFireOp{
+				o:       o,
+				id:      id,
+				issue:   issue,
+				attempt: attempt,
+			})
+		})
+		return nil
 	}
 	// Consume the retry entry but keep Claimed: the re-dispatch
 	// immediately re-adds Running, and dropping Claimed in between

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -36,13 +36,15 @@ import (
 )
 
 // WorkerResult is the per-run outcome the Dispatcher delivers when its
-// spawned worker exits. Err is nil for SPEC §7.3 normal exit; any
-// non-nil Err is treated as abnormal exit and triggers
-// ScheduleRetry(attempt+1). Elapsed is folded into
-// CodexTotals.SecondsRunning per SPEC §13.3.
+// spawned worker exits. Err is nil for SPEC §7.3 normal exit; retryable
+// errors are treated as abnormal exits and trigger ScheduleRetry(attempt+1).
+// NonRetryable errors fail fast and release the claim so deterministic
+// configuration/task-build failures do not spin forever. Elapsed is folded
+// into CodexTotals.SecondsRunning per SPEC §13.3.
 type WorkerResult struct {
-	Err     error
-	Elapsed time.Duration
+	Err          error
+	NonRetryable bool
+	Elapsed      time.Duration
 }
 
 // Dispatcher is the seam through which the actor spawns a per-issue
@@ -392,6 +394,10 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		return nil
 	}
 	if !st.FinishRunFailed(f.id, f.entry, elapsed) {
+		close(f.done)
+		return nil
+	}
+	if f.result.NonRetryable {
 		close(f.done)
 		return nil
 	}

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -271,6 +271,7 @@ type dispatchOp struct {
 
 func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	id := IssueID(d.issue.ID)
+	st.ReleaseFailedIfIssueChanged(d.issue)
 	if st.IsClaimed(id) {
 		d.result <- ErrNotDispatched
 		return nil

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -209,6 +209,12 @@ func (o *Orchestrator) Snapshot(ctx context.Context) (StateView, error) {
 // distinguish "rejected" from "succeeded" by inspecting it.
 var ErrNotDispatched = errors.New("orchestrator: issue already claimed")
 
+// ErrCapacityFull is returned by RequestDispatch when the issue is eligible and
+// unclaimed, but the orchestrator is already running the configured maximum
+// number of agents. Callers should keep the issue eligible for a future poll
+// tick rather than treating it as a duplicate dispatch.
+var ErrCapacityFull = errors.New("orchestrator: max_concurrent_agents reached")
+
 // RequestDispatch is the public entry to dispatch issue if no other
 // claim exists. It returns nil on accepted dispatch (a worker is being
 // spawned) and ErrNotDispatched if the actor saw an existing claim.
@@ -217,17 +223,14 @@ var ErrNotDispatched = errors.New("orchestrator: issue already claimed")
 // for the same issue produce at most one Running entry, even when many
 // goroutines race on the same id.
 func (o *Orchestrator) RequestDispatch(ctx context.Context, issue tracker.Issue, attempt *int) error {
-	reply := make(chan bool, 1)
-	op := &dispatchOp{o: o, issue: issue, attempt: attempt, accepted: reply}
+	reply := make(chan error, 1)
+	op := &dispatchOp{o: o, issue: issue, attempt: attempt, result: reply}
 	if err := o.submit(ctx, op); err != nil {
 		return err
 	}
 	select {
-	case ok := <-reply:
-		if !ok {
-			return ErrNotDispatched
-		}
-		return nil
+	case err := <-reply:
+		return err
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -260,16 +263,20 @@ func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, i
 // dispatch decision atomic against concurrent claims while keeping I/O
 // off the actor goroutine.
 type dispatchOp struct {
-	o        *Orchestrator
-	issue    tracker.Issue
-	attempt  *int
-	accepted chan<- bool
+	o       *Orchestrator
+	issue   tracker.Issue
+	attempt *int
+	result  chan<- error
 }
 
 func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	id := IssueID(d.issue.ID)
-	if st.IsClaimed(id) || st.RunningCount() >= st.MaxConcurrentAgents {
-		d.accepted <- false
+	if st.IsClaimed(id) {
+		d.result <- ErrNotDispatched
+		return nil
+	}
+	if st.RunningCount() >= st.MaxConcurrentAgents {
+		d.result <- ErrCapacityFull
 		return nil
 	}
 	// Reserve the slot synchronously so a concurrent dispatchOp aborts
@@ -279,10 +286,10 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	o := d.o
 	issue := d.issue
 	attempt := d.attempt
-	accepted := d.accepted
+	result := d.result
 	return func() {
 		o.spawn(id, issue, attempt)
-		accepted <- true
+		result <- nil
 	}
 }
 

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -361,6 +361,17 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		// re-dispatch on its own timer.
 		return nil
 	}
+	if st.RunningCount() >= st.MaxConcurrentAgents {
+		// Retry timers must obey the same capacity gate as fresh dispatch.
+		// Leave the retry queued and arm a short follow-up timer so the issue
+		// is retried after capacity can free instead of spawning over the cap.
+		o := r.o
+		issue := r.issue
+		attempt := r.attempt
+		return func() {
+			_ = o.ScheduleRetry(o.runCtx, issue, entry.Identifier, attempt, entry.Error)
+		}
+	}
 	// Consume the retry entry but keep Claimed: the re-dispatch
 	// immediately re-adds Running, and dropping Claimed in between
 	// would let a concurrent tick race in.

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -266,7 +266,7 @@ type dispatchOp struct {
 
 func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	id := IssueID(d.issue.ID)
-	if st.IsClaimed(id) {
+	if st.IsClaimed(id) || st.RunningCount() >= st.MaxConcurrentAgents {
 		d.accepted <- false
 		return nil
 	}

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -393,11 +393,15 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		close(f.done)
 		return nil
 	}
-	if !st.FinishRunFailed(f.id, f.entry, elapsed) {
+	if f.result.NonRetryable {
+		if !st.FinishRunNonRetryableFailed(f.id, f.entry, elapsed) {
+			close(f.done)
+			return nil
+		}
 		close(f.done)
 		return nil
 	}
-	if f.result.NonRetryable {
+	if !st.FinishRunFailed(f.id, f.entry, elapsed) {
 		close(f.done)
 		return nil
 	}

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -62,7 +62,7 @@ func (f *fakeDispatcher) finishAt(i int, res WorkerResult) {
 
 func startActor(t *testing.T, deps Deps) (*Orchestrator, context.CancelFunc) {
 	t.Helper()
-	st := NewOrchestratorState(15000, 4)
+	st := NewOrchestratorState(15000, 100)
 	o := New(st, deps)
 	ctx, cancel := context.WithCancel(context.Background())
 	go o.Run(ctx)

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -369,6 +369,61 @@ func TestFinalize_AbnormalExitHoldsClaimAcrossScheduleRetryGap(t *testing.T) {
 	}
 }
 
+// TestRetryFire_RespectsCapacityBeforeSpawning is a regression for retry
+// timers bypassing the max_concurrent_agents gate. A failed issue may sit in
+// RetryAttempts while another issue starts; when the retry timer fires, it must
+// not spawn over the configured cap.
+func TestRetryFire_RespectsCapacityBeforeSpawning(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 1)
+	o := New(st, Deps{
+		Dispatcher: disp,
+		Scheduler:  FixedDelayScheduler{Delay: 20 * time.Millisecond},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	issueA := tracker.Issue{ID: "ENG-A", Identifier: "ENG-A", Title: "retry later"}
+	issueB := tracker.Issue{ID: "ENG-B", Identifier: "ENG-B", Title: "running now"}
+	if err := o.RequestDispatch(context.Background(), issueA, nil); err != nil {
+		t.Fatalf("dispatch A: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.Retrying) == 1
+	}, time.Second)
+
+	if err := o.RequestDispatch(context.Background(), issueB, nil); err != nil {
+		t.Fatalf("dispatch B while A is retrying: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+
+	time.Sleep(80 * time.Millisecond)
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := disp.count(); got != 2 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 2; retry must not spawn while capacity is full", got)
+	}
+	if len(v.Running) != 1 || len(v.Retrying) != 1 {
+		t.Fatalf("state after retry fire at capacity: running=%+v retrying=%+v, want B running and A still retrying", v.Running, v.Retrying)
+	}
+	if v.Running[0].IssueID != IssueID(issueB.ID) {
+		t.Fatalf("running entries = %+v, want issue B to be the only running issue", v.Running)
+	}
+	if v.Retrying[0].IssueID != IssueID(issueA.ID) {
+		t.Fatalf("retrying entries = %+v, want issue A preserved for later retry", v.Retrying)
+	}
+}
+
 // TestApply_FollowupRunsOffActorAndCanResubmit pins the design's
 // "apply must not block on the ops channel" invariant: a followup
 // returned by apply runs on a fresh goroutine, so it can submit

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -29,6 +29,22 @@ type fakeDispatcher struct {
 	onSpawn func(ctx context.Context, issue tracker.Issue, attempt *int)
 }
 
+type sequenceScheduler struct {
+	mu     sync.Mutex
+	delays []time.Duration
+}
+
+func (s *sequenceScheduler) NextDelay(int) time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.delays) == 0 {
+		return time.Hour
+	}
+	d := s.delays[0]
+	s.delays = s.delays[1:]
+	return d
+}
+
 func (f *fakeDispatcher) Spawn(ctx context.Context, issue tracker.Issue, attempt *int) <-chan WorkerResult {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -421,6 +437,55 @@ func TestRetryFire_RespectsCapacityBeforeSpawning(t *testing.T) {
 	}
 	if v.Retrying[0].IssueID != IssueID(issueA.ID) {
 		t.Fatalf("retrying entries = %+v, want issue A preserved for later retry", v.Retrying)
+	}
+}
+
+// TestRetryFire_CapacityDeferralUsesShortRecheckDelay is a regression for
+// capacity-blocked retries being re-enqueued through the normal scheduler
+// backoff. Temporary capacity pressure should recheck soon, not wait a full
+// retry interval while the issue stays claimed and poll ticks cannot help it.
+func TestRetryFire_CapacityDeferralUsesShortRecheckDelay(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 1)
+	o := New(st, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{50 * time.Millisecond}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	issueA := tracker.Issue{ID: "ENG-A", Identifier: "ENG-A", Title: "retry soon"}
+	issueB := tracker.Issue{ID: "ENG-B", Identifier: "ENG-B", Title: "running now"}
+	if err := o.RequestDispatch(context.Background(), issueA, nil); err != nil {
+		t.Fatalf("dispatch A: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+	disp.finishAt(0, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 1
+	}, time.Second)
+
+	if err := o.RequestDispatch(context.Background(), issueB, nil); err != nil {
+		t.Fatalf("dispatch B while A is retrying: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+
+	// Let A's retry timer fire while B occupies the only slot; then free B.
+	time.Sleep(150 * time.Millisecond)
+	disp.finishAt(1, WorkerResult{Err: nil, Elapsed: time.Millisecond})
+
+	waitFor(t, func() bool { return disp.count() == 3 }, time.Second)
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(v.Running) != 1 || v.Running[0].IssueID != IssueID(issueA.ID) {
+		t.Fatalf("running entries after capacity frees = %+v, want retry issue A re-dispatched by short recheck", v.Running)
 	}
 }
 

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -73,13 +73,21 @@ func mergeOverflowCandidates(overflow, fresh []tracker.Issue) []tracker.Issue {
 		return fresh
 	}
 	candidates := make([]tracker.Issue, 0, len(overflow)+len(fresh))
+	freshByID := make(map[string]tracker.Issue, len(fresh))
 	seen := make(map[string]struct{}, len(overflow)+len(fresh))
-	for _, issue := range overflow {
+	for _, issue := range fresh {
 		if issue.ID == "" {
 			continue
 		}
+		freshByID[issue.ID] = issue
+	}
+	for _, issue := range overflow {
+		freshIssue, ok := freshByID[issue.ID]
+		if !ok {
+			continue
+		}
 		seen[issue.ID] = struct{}{}
-		candidates = append(candidates, issue)
+		candidates = append(candidates, freshIssue)
 	}
 	for _, issue := range fresh {
 		if _, ok := seen[issue.ID]; ok {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -24,6 +24,7 @@ type ActiveIssueLister interface {
 type Poller struct {
 	tracker      ActiveIssueLister
 	orchestrator *Orchestrator
+	overflow     []tracker.Issue
 }
 
 // NewPoller returns a SPEC-aligned tracker poller backed by orchestrator-owned
@@ -46,16 +47,47 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	candidates := mergeOverflowCandidates(p.overflow, issues)
+	p.overflow = nil
 	var dispatchErr error
-	for _, issue := range issues {
+	for _, issue := range candidates {
 		if issue.ID == "" {
 			continue
 		}
-		if err := p.orchestrator.RequestDispatch(ctx, issue, nil); err != nil && !errors.Is(err, ErrNotDispatched) {
-			dispatchErr = errors.Join(dispatchErr, fmt.Errorf("dispatch %s: %w", issue.ID, err))
+		if err := p.orchestrator.RequestDispatch(ctx, issue, nil); err != nil {
+			switch {
+			case errors.Is(err, ErrNotDispatched):
+				continue
+			case errors.Is(err, ErrCapacityFull):
+				p.overflow = append(p.overflow, issue)
+			default:
+				dispatchErr = errors.Join(dispatchErr, fmt.Errorf("dispatch %s: %w", issue.ID, err))
+			}
 		}
 	}
 	return dispatchErr
+}
+
+func mergeOverflowCandidates(overflow, fresh []tracker.Issue) []tracker.Issue {
+	if len(overflow) == 0 {
+		return fresh
+	}
+	candidates := make([]tracker.Issue, 0, len(overflow)+len(fresh))
+	seen := make(map[string]struct{}, len(overflow)+len(fresh))
+	for _, issue := range overflow {
+		if issue.ID == "" {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		candidates = append(candidates, issue)
+	}
+	for _, issue := range fresh {
+		if _, ok := seen[issue.ID]; ok {
+			continue
+		}
+		candidates = append(candidates, issue)
+	}
+	return candidates
 }
 
 // TaskBuilder converts a tracker candidate into the task shape consumed by the

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -1,0 +1,156 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// ActiveIssueLister is the tracker reader required by the SPEC poll tick.
+type ActiveIssueLister interface {
+	ListActiveIssues(ctx context.Context) ([]tracker.Issue, error)
+}
+
+// Poller connects tracker polling to the orchestrator runtime state. It has no
+// durable queue dependency: candidates are read from the tracker and claimed by
+// the in-process Orchestrator actor.
+type Poller struct {
+	tracker      ActiveIssueLister
+	orchestrator *Orchestrator
+}
+
+// NewPoller returns a SPEC-aligned tracker poller backed by orchestrator-owned
+// runtime state instead of the legacy Postgres task queue.
+func NewPoller(tracker ActiveIssueLister, orchestrator *Orchestrator) *Poller {
+	return &Poller{tracker: tracker, orchestrator: orchestrator}
+}
+
+// PollOnce performs one tracker tick: fetch active issues and ask the
+// orchestrator actor to dispatch each candidate. Duplicate candidates are
+// ignored by the actor's runtime claim state.
+func (p *Poller) PollOnce(ctx context.Context) error {
+	if p == nil || p.tracker == nil {
+		return errors.New("orchestrator poller requires tracker")
+	}
+	if p.orchestrator == nil {
+		return errors.New("orchestrator poller requires orchestrator")
+	}
+	issues, err := p.tracker.ListActiveIssues(ctx)
+	if err != nil {
+		return err
+	}
+	var dispatchErr error
+	for _, issue := range issues {
+		if issue.ID == "" {
+			continue
+		}
+		if err := p.orchestrator.RequestDispatch(ctx, issue, nil); err != nil && !errors.Is(err, ErrNotDispatched) {
+			dispatchErr = errors.Join(dispatchErr, fmt.Errorf("dispatch %s: %w", issue.ID, err))
+		}
+	}
+	return dispatchErr
+}
+
+// TaskBuilder converts a tracker candidate into the task shape consumed by the
+// existing worker runner. This is an adapter between the SPEC poller/runtime
+// path and the legacy task execution API; it is intentionally in-memory only.
+type TaskBuilder func(issue tracker.Issue) (task.Task, error)
+
+// WorkerTaskDispatcher runs the existing worker task executor for issues
+// accepted by the orchestrator actor. It replaces the old Postgres claim loop:
+// the orchestrator owns scheduling/claim state, while worker.RunTask
+// continues to prepare workspaces and run the configured agent.
+type WorkerTaskDispatcher struct {
+	BuildTask TaskBuilder
+	Config    worker.Config
+	Emitter   worker.EventEmitter
+}
+
+// Spawn implements Dispatcher.
+func (d WorkerTaskDispatcher) Spawn(ctx context.Context, issue tracker.Issue, _ *int) <-chan WorkerResult {
+	out := make(chan WorkerResult, 1)
+	go func() {
+		defer close(out)
+		start := time.Now()
+		if d.BuildTask == nil {
+			out <- WorkerResult{Err: errors.New("worker task dispatcher requires task builder"), Elapsed: time.Since(start)}
+			return
+		}
+		tk, err := d.BuildTask(issue)
+		if err != nil {
+			out <- WorkerResult{Err: err, Elapsed: time.Since(start)}
+			return
+		}
+		if rterr := worker.RunTask(ctx, d.Emitter, tk, d.Config); rterr != nil {
+			out <- WorkerResult{Err: rterr.Err, Elapsed: time.Since(start)}
+			return
+		}
+		out <- WorkerResult{Elapsed: time.Since(start)}
+	}()
+	return out
+}
+
+// TaskFromIssue builds the in-memory task handed to worker execution for a
+// tracker candidate. Dedupe/claiming lives in OrchestratorState, not in this
+// task ID: the ID is only a stable per-run/workspace identifier.
+func TaskFromIssue(issue tracker.Issue, cfg workflow.Config) (task.Task, error) {
+	if cfg.Repo.CloneURL == "" {
+		return task.Task{}, fmt.Errorf("repo.clone_url missing in WORKFLOW.md")
+	}
+	sourceType := cfg.Tracker.Kind + "_issue"
+	if cfg.Tracker.Kind == "" {
+		sourceType = "tracker_issue"
+	}
+	sourceEventID := issue.ID
+	if sourceEventID == "" {
+		return task.Task{}, fmt.Errorf("tracker issue id is required")
+	}
+	if issue.Identifier != "" {
+		sourceEventID = issue.Identifier
+	}
+	return task.Task{
+		ID:            string(IssueID(issue.ID)),
+		SourceType:    sourceType,
+		SourceEventID: sourceEventID,
+		RepoOwner:     cfg.Repo.Owner,
+		RepoName:      cfg.Repo.Name,
+		CloneURL:      cfg.Repo.CloneURL,
+		BaseBranch:    cfg.Repo.DefaultBranch,
+		WorkBranch:    "ai/" + issue.ID,
+		Title:         fmt.Sprintf("%s %s", issue.Identifier, issue.Title),
+		Description:   issue.Description + "\n\nTracker: " + issue.URL,
+		Actor:         cfg.Tracker.Kind,
+		Model:         cfg.Agent.Default,
+		Priority:      50,
+	}, nil
+}
+
+// RunPollLoop repeatedly polls the tracker until ctx is canceled.
+func RunPollLoop(ctx context.Context, poller *Poller, interval time.Duration) error {
+	if poller == nil {
+		return errors.New("orchestrator poll loop requires poller")
+	}
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	for {
+		if err := poller.PollOnce(ctx); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			log.Printf("tracker poll error: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -80,12 +80,12 @@ func (d WorkerTaskDispatcher) Spawn(ctx context.Context, issue tracker.Issue, _ 
 		defer close(out)
 		start := time.Now()
 		if d.BuildTask == nil {
-			out <- WorkerResult{Err: errors.New("worker task dispatcher requires task builder"), Elapsed: time.Since(start)}
+			out <- WorkerResult{Err: errors.New("worker task dispatcher requires task builder"), NonRetryable: true, Elapsed: time.Since(start)}
 			return
 		}
 		tk, err := d.BuildTask(issue)
 		if err != nil {
-			out <- WorkerResult{Err: err, Elapsed: time.Since(start)}
+			out <- WorkerResult{Err: err, NonRetryable: true, Elapsed: time.Since(start)}
 			return
 		}
 		if rterr := worker.RunTask(ctx, d.Emitter, tk, d.Config); rterr != nil {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -270,7 +270,8 @@ func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
 		{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"},
 		{ID: "issue-2", Identifier: "LIN-2", State: "AI Ready"},
 	}}
-	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
+	firstRunBlocked := make(chan struct{})
+	dispatcher := &recordingDispatcher{releaseCh: firstRunBlocked}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
 		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
@@ -289,10 +290,13 @@ func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
 		t.Fatalf("first dispatched issue ID = %q, want issue-1", got)
 	}
 
-	close(dispatcher.releaseCh)
+	close(firstRunBlocked)
 	waitForCompleted(t, ctx, orch, "issue-1")
-	dispatcher.releaseCh = nil
 
+	secondRunBlocked := make(chan struct{})
+	dispatcher.mu.Lock()
+	dispatcher.releaseCh = secondRunBlocked
+	dispatcher.mu.Unlock()
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("second poll once after capacity freed: %v", err)
 	}
@@ -300,6 +304,7 @@ func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
 	if got := dispatcher.issueAt(1).ID; got != "issue-2" {
 		t.Fatalf("second dispatched issue ID = %q, want overflow issue-2", got)
 	}
+	close(secondRunBlocked)
 }
 
 func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -58,13 +58,25 @@ func (d *recordingDispatcher) issueAt(i int) tracker.Issue {
 	return d.issues[i]
 }
 
-type erroringTaskDispatcher struct{}
+type erroringTaskDispatcher struct {
+	mu    sync.Mutex
+	calls int
+}
 
-func (d erroringTaskDispatcher) Spawn(_ context.Context, _ tracker.Issue, _ *int) <-chan WorkerResult {
+func (d *erroringTaskDispatcher) Spawn(_ context.Context, _ tracker.Issue, _ *int) <-chan WorkerResult {
+	d.mu.Lock()
+	d.calls++
+	d.mu.Unlock()
 	ch := make(chan WorkerResult, 1)
 	ch <- WorkerResult{Err: errors.New("repo.clone_url missing in WORKFLOW.md"), NonRetryable: true, Elapsed: time.Millisecond}
 	close(ch)
 	return ch
+}
+
+func (d *erroringTaskDispatcher) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
 }
 
 type blockingDispatcher struct {
@@ -164,8 +176,9 @@ func TestPollOnceFailsFastAfterBuildTaskFailureWithoutRetryLoop(t *testing.T) {
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}}
+	dispatcher := &erroringTaskDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
-		Dispatcher: erroringTaskDispatcher{},
+		Dispatcher: dispatcher,
 		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
 	})
 	go orch.Run(ctx)
@@ -183,6 +196,9 @@ func TestPollOnceFailsFastAfterBuildTaskFailureWithoutRetryLoop(t *testing.T) {
 		t.Fatalf("second poll once: %v", err)
 	}
 	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
+	if got := dispatcher.count(); got != 1 {
+		t.Fatalf("deterministic build failure dispatched %d times, want 1", got)
+	}
 }
 
 func TestPollOnceDoesNotExceedMaxConcurrentAgents(t *testing.T) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -231,6 +231,46 @@ func TestPollOnceDoesNotExceedMaxConcurrentAgents(t *testing.T) {
 	}
 }
 
+func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"},
+		{ID: "issue-2", Identifier: "LIN-2", State: "AI Ready"},
+	}}
+	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPoller(trackerClient, orch)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("first poll once: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 1)
+	if got := dispatcher.issueAt(0).ID; got != "issue-1" {
+		t.Fatalf("first dispatched issue ID = %q, want issue-1", got)
+	}
+
+	close(dispatcher.releaseCh)
+	waitForCompleted(t, ctx, orch, "issue-1")
+	dispatcher.releaseCh = nil
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("second poll once after capacity freed: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 2)
+	if got := dispatcher.issueAt(1).ID; got != "issue-2" {
+		t.Fatalf("second dispatched issue ID = %q, want overflow issue-2", got)
+	}
+}
+
 func waitForDispatcherCount(t *testing.T, dispatcher *recordingDispatcher, want int) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -271,6 +271,44 @@ func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
 	}
 }
 
+func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"},
+		{ID: "issue-2", Identifier: "LIN-2", State: "AI Ready"},
+	}}
+	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPoller(trackerClient, orch)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("first poll once: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 1)
+
+	close(dispatcher.releaseCh)
+	waitForCompleted(t, ctx, orch, "issue-1")
+	dispatcher.releaseCh = nil
+	trackerClient.issues = []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("second poll once after issue-2 left active states: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 2)
+	if got := dispatcher.issueAt(1).ID; got != "issue-1" {
+		t.Fatalf("second dispatched issue ID = %q, want fresh active issue-1", got)
+	}
+}
+
 func waitForDispatcherCount(t *testing.T, dispatcher *recordingDispatcher, want int) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -48,6 +49,15 @@ func (d *recordingDispatcher) issueAt(i int) tracker.Issue {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.issues[i]
+}
+
+type erroringTaskDispatcher struct{}
+
+func (d erroringTaskDispatcher) Spawn(_ context.Context, _ tracker.Issue, _ *int) <-chan WorkerResult {
+	ch := make(chan WorkerResult, 1)
+	ch <- WorkerResult{Err: errors.New("repo.clone_url missing in WORKFLOW.md"), Elapsed: time.Millisecond}
+	close(ch)
+	return ch
 }
 
 func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *testing.T) {
@@ -116,6 +126,37 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	waitForDispatcherCount(t, dispatcher, 2)
 }
 
+func TestPollOnceRetriesAfterBuildTaskFailureWithoutLeakingRunningState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: erroringTaskDispatcher{},
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPoller(trackerClient, orch)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	waitForRetryQueued(t, ctx, orch, "issue-1")
+
+	view, err := orch.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	for _, running := range view.Running {
+		if running.IssueID == "issue-1" {
+			t.Fatalf("issue-1 still running after build-task failure")
+		}
+	}
+}
+
 func waitForDispatcherCount(t *testing.T, dispatcher *recordingDispatcher, want int) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
@@ -144,4 +185,22 @@ func waitForCompleted(t *testing.T, ctx context.Context, orch *Orchestrator, id 
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatalf("issue %s was not marked completed", id)
+}
+
+func waitForRetryQueued(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		view, err := orch.Snapshot(ctx)
+		if err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+		for _, retry := range view.Retrying {
+			if retry.IssueID == id {
+				return
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("issue %s was not retry queued", id)
 }

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -175,7 +175,7 @@ func TestPollOnceFailsFastAfterBuildTaskFailureWithoutRetryLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}}
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready", UpdatedAt: "2026-05-17T00:00:00Z"}}}
 	dispatcher := &erroringTaskDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
@@ -198,6 +198,37 @@ func TestPollOnceFailsFastAfterBuildTaskFailureWithoutRetryLoop(t *testing.T) {
 	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
 	if got := dispatcher.count(); got != 1 {
 		t.Fatalf("deterministic build failure dispatched %d times, want 1", got)
+	}
+}
+
+func TestPollOnceReleasesNonRetryableFailureAfterTrackerStateChanges(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready", UpdatedAt: "2026-05-17T00:00:00Z"}}}
+	dispatcher := &erroringTaskDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPoller(trackerClient, orch)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
+
+	trackerClient.issues = []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Rework", UpdatedAt: "2026-05-17T00:05:00Z"}}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once after tracker state changed: %v", err)
+	}
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
+	if got := dispatcher.count(); got != 2 {
+		t.Fatalf("changed tracker issue dispatched %d times, want retry after state change", got)
 	}
 }
 

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -62,7 +62,7 @@ type erroringTaskDispatcher struct{}
 
 func (d erroringTaskDispatcher) Spawn(_ context.Context, _ tracker.Issue, _ *int) <-chan WorkerResult {
 	ch := make(chan WorkerResult, 1)
-	ch <- WorkerResult{Err: errors.New("repo.clone_url missing in WORKFLOW.md"), Elapsed: time.Millisecond}
+	ch <- WorkerResult{Err: errors.New("repo.clone_url missing in WORKFLOW.md"), NonRetryable: true, Elapsed: time.Millisecond}
 	close(ch)
 	return ch
 }
@@ -159,7 +159,7 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	waitForDispatcherCount(t, dispatcher, 2)
 }
 
-func TestPollOnceRetriesAfterBuildTaskFailureWithoutLeakingRunningState(t *testing.T) {
+func TestPollOnceFailsFastAfterBuildTaskFailureWithoutRetryLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -177,17 +177,12 @@ func TestPollOnceRetriesAfterBuildTaskFailureWithoutLeakingRunningState(t *testi
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
-	waitForRetryQueued(t, ctx, orch, "issue-1")
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
 
-	view, err := orch.Snapshot(ctx)
-	if err != nil {
-		t.Fatalf("snapshot: %v", err)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("second poll once: %v", err)
 	}
-	for _, running := range view.Running {
-		if running.IssueID == "issue-1" {
-			t.Fatalf("issue-1 still running after build-task failure")
-		}
-	}
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
 }
 
 func TestPollOnceDoesNotExceedMaxConcurrentAgents(t *testing.T) {
@@ -262,7 +257,7 @@ func waitForCompleted(t *testing.T, ctx context.Context, orch *Orchestrator, id 
 	t.Fatalf("issue %s was not marked completed", id)
 }
 
-func waitForRetryQueued(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
+func waitForNoRunningOrRetrying(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
@@ -270,12 +265,29 @@ func waitForRetryQueued(t *testing.T, ctx context.Context, orch *Orchestrator, i
 		if err != nil {
 			t.Fatalf("snapshot: %v", err)
 		}
-		for _, retry := range view.Retrying {
-			if retry.IssueID == id {
-				return
-			}
+		if !hasRunningOrRetrying(view, id) {
+			return
 		}
 		time.Sleep(time.Millisecond)
 	}
-	t.Fatalf("issue %s was not retry queued", id)
+
+	view, err := orch.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	t.Fatalf("issue %s still running or retrying after deterministic build failure: running=%v retrying=%v", id, view.Running, view.Retrying)
+}
+
+func hasRunningOrRetrying(view StateView, id IssueID) bool {
+	for _, running := range view.Running {
+		if running.IssueID == id {
+			return true
+		}
+	}
+	for _, retry := range view.Retrying {
+		if retry.IssueID == id {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -60,6 +60,30 @@ func (d erroringTaskDispatcher) Spawn(_ context.Context, _ tracker.Issue, _ *int
 	return ch
 }
 
+type blockingDispatcher struct {
+	mu     sync.Mutex
+	issues []tracker.Issue
+}
+
+func (d *blockingDispatcher) Spawn(ctx context.Context, issue tracker.Issue, _ *int) <-chan WorkerResult {
+	d.mu.Lock()
+	d.issues = append(d.issues, issue)
+	d.mu.Unlock()
+	ch := make(chan WorkerResult, 1)
+	go func() {
+		<-ctx.Done()
+		ch <- WorkerResult{Err: ctx.Err(), Elapsed: time.Millisecond}
+		close(ch)
+	}()
+	return ch
+}
+
+func (d *blockingDispatcher) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.issues)
+}
+
 func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -157,7 +181,49 @@ func TestPollOnceRetriesAfterBuildTaskFailureWithoutLeakingRunningState(t *testi
 	}
 }
 
+func TestPollOnceDoesNotExceedMaxConcurrentAgents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"},
+		{ID: "issue-2", Identifier: "LIN-2", State: "AI Ready"},
+		{ID: "issue-3", Identifier: "LIN-3", State: "AI Ready"},
+	}}
+	dispatcher := &blockingDispatcher{}
+	orch := New(NewOrchestratorState(30000, 2), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPoller(trackerClient, orch)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	waitForBlockingDispatcherCount(t, dispatcher, 2)
+
+	if got := dispatcher.count(); got != 2 {
+		t.Fatalf("dispatcher issues = %d, want max_concurrent_agents limit 2", got)
+	}
+}
+
 func waitForDispatcherCount(t *testing.T, dispatcher *recordingDispatcher, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := dispatcher.count(); got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("dispatcher issues = %d, want %d", dispatcher.count(), want)
+}
+
+func waitForBlockingDispatcherCount(t *testing.T, dispatcher *blockingDispatcher, want int) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -25,17 +25,24 @@ func (f *fakeIssueTracker) ListActiveIssues(_ context.Context) ([]tracker.Issue,
 }
 
 type recordingDispatcher struct {
-	mu     sync.Mutex
-	issues []tracker.Issue
+	mu        sync.Mutex
+	issues    []tracker.Issue
+	releaseCh chan struct{}
 }
 
 func (d *recordingDispatcher) Spawn(_ context.Context, issue tracker.Issue, _ *int) <-chan WorkerResult {
 	d.mu.Lock()
 	d.issues = append(d.issues, issue)
+	releaseCh := d.releaseCh
 	d.mu.Unlock()
 	ch := make(chan WorkerResult, 1)
-	ch <- WorkerResult{Elapsed: time.Millisecond}
-	close(ch)
+	go func() {
+		if releaseCh != nil {
+			<-releaseCh
+		}
+		ch <- WorkerResult{Elapsed: time.Millisecond}
+		close(ch)
+	}()
 	return ch
 }
 
@@ -89,7 +96,8 @@ func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *t
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}}
-	dispatcher := &recordingDispatcher{}
+	releaseCh := make(chan struct{})
+	dispatcher := &recordingDispatcher{releaseCh: releaseCh}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
 		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
@@ -120,6 +128,7 @@ func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *t
 	if got := dispatcher.count(); got != 1 {
 		t.Fatalf("dispatcher issues after duplicate poll = %d, want 1", got)
 	}
+	close(releaseCh)
 }
 
 func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -1,0 +1,147 @@
+package orchestrator
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+type fakeIssueTracker struct {
+	issues []tracker.Issue
+	err    error
+	calls  int
+}
+
+func (f *fakeIssueTracker) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.issues, nil
+}
+
+type recordingDispatcher struct {
+	mu     sync.Mutex
+	issues []tracker.Issue
+}
+
+func (d *recordingDispatcher) Spawn(_ context.Context, issue tracker.Issue, _ *int) <-chan WorkerResult {
+	d.mu.Lock()
+	d.issues = append(d.issues, issue)
+	d.mu.Unlock()
+	ch := make(chan WorkerResult, 1)
+	ch <- WorkerResult{Elapsed: time.Millisecond}
+	close(ch)
+	return ch
+}
+
+func (d *recordingDispatcher) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.issues)
+}
+
+func (d *recordingDispatcher) issueAt(i int) tracker.Issue {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.issues[i]
+}
+
+func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}}
+	dispatcher := &recordingDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPoller(trackerClient, orch)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+
+	if trackerClient.calls != 1 {
+		t.Fatalf("ListActiveIssues calls = %d, want 1", trackerClient.calls)
+	}
+	if got := dispatcher.count(); got != 1 {
+		t.Fatalf("dispatcher issues = %d, want 1", got)
+	}
+	if got := dispatcher.issueAt(0).ID; got != "issue-1" {
+		t.Fatalf("dispatched issue ID = %q, want issue-1", got)
+	}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("second poll once: %v", err)
+	}
+	if got := dispatcher.count(); got != 1 {
+		t.Fatalf("dispatcher issues after duplicate poll = %d, want 1", got)
+	}
+}
+
+func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Rework"}}}
+	dispatcher := &recordingDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPoller(trackerClient, orch)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 1)
+	waitForCompleted(t, ctx, orch, "issue-1")
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("rework poll once: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 2)
+}
+
+func waitForDispatcherCount(t *testing.T, dispatcher *recordingDispatcher, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := dispatcher.count(); got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("dispatcher issues = %d, want %d", dispatcher.count(), want)
+}
+
+func waitForCompleted(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		view, err := orch.Snapshot(ctx)
+		if err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+		for _, completed := range view.Completed {
+			if completed == id {
+				return
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("issue %s was not marked completed", id)
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -116,6 +116,7 @@ type OrchestratorState struct {
 	Running       map[IssueID]*RunningEntry
 	Claimed       map[IssueID]struct{}
 	RetryAttempts map[IssueID]*RetryEntry
+	Failed        map[IssueID]struct{}
 	Completed     map[IssueID]struct{} // bookkeeping only per SPEC §4.1.8
 
 	CodexTotals     CodexTotals
@@ -140,6 +141,7 @@ func NewOrchestratorState(pollIntervalMs int64, maxConcurrentAgents int) *Orches
 		Running:             map[IssueID]*RunningEntry{},
 		Claimed:             map[IssueID]struct{}{},
 		RetryAttempts:       map[IssueID]*RetryEntry{},
+		Failed:              map[IssueID]struct{}{},
 		Completed:           map[IssueID]struct{}{},
 	}
 }
@@ -164,6 +166,9 @@ func (s *OrchestratorState) IsClaimed(id IssueID) bool {
 		return true
 	}
 	if _, ok := s.RetryAttempts[id]; ok {
+		return true
+	}
+	if _, ok := s.Failed[id]; ok {
 		return true
 	}
 	return false
@@ -204,6 +209,7 @@ func (s *OrchestratorState) BeginDispatch(id IssueID, entry *RunningEntry) {
 	s.Claimed[id] = struct{}{}
 	s.Running[id] = entry
 	delete(s.RetryAttempts, id)
+	delete(s.Failed, id)
 }
 
 // FinishRunSucceeded is the transition for a worker that exited cleanly
@@ -241,6 +247,18 @@ func (s *OrchestratorState) FinishRunFailed(id IssueID, run *RunningEntry, elaps
 	delete(s.Running, id)
 	delete(s.Claimed, id)
 	s.CodexTotals.AddSeconds(elapsed)
+	return true
+}
+
+// FinishRunNonRetryableFailed records a deterministic failure that should not
+// be re-dispatched while the issue remains active in the same process. This is
+// used for task-construction/configuration failures that would otherwise spin
+// on every tracker poll tick.
+func (s *OrchestratorState) FinishRunNonRetryableFailed(id IssueID, run *RunningEntry, elapsed time.Duration) bool {
+	if !s.FinishRunFailed(id, run, elapsed) {
+		return false
+	}
+	s.Failed[id] = struct{}{}
 	return true
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -116,11 +116,19 @@ type OrchestratorState struct {
 	Running       map[IssueID]*RunningEntry
 	Claimed       map[IssueID]struct{}
 	RetryAttempts map[IssueID]*RetryEntry
-	Failed        map[IssueID]struct{}
+	Failed        map[IssueID]FailedEntry
 	Completed     map[IssueID]struct{} // bookkeeping only per SPEC §4.1.8
 
 	CodexTotals     CodexTotals
 	CodexRateLimits *RateLimitSnapshot // nil until the runner populates it
+}
+
+// FailedEntry suppresses a deterministic non-retryable failure only while the
+// tracker issue is unchanged. A later tracker state/update change means a human
+// or agent may have fixed the configuration/input, so the poller may retry.
+type FailedEntry struct {
+	State     string
+	UpdatedAt string
 }
 
 // NewOrchestratorState mirrors the SPEC §16.1 reference initializer:
@@ -141,7 +149,7 @@ func NewOrchestratorState(pollIntervalMs int64, maxConcurrentAgents int) *Orches
 		Running:             map[IssueID]*RunningEntry{},
 		Claimed:             map[IssueID]struct{}{},
 		RetryAttempts:       map[IssueID]*RetryEntry{},
-		Failed:              map[IssueID]struct{}{},
+		Failed:              map[IssueID]FailedEntry{},
 		Completed:           map[IssueID]struct{}{},
 	}
 }
@@ -172,6 +180,21 @@ func (s *OrchestratorState) IsClaimed(id IssueID) bool {
 		return true
 	}
 	return false
+}
+
+// ReleaseFailedIfIssueChanged clears a non-retryable failure suppression when
+// the tracker issue has visibly changed since the failure was recorded.
+func (s *OrchestratorState) ReleaseFailedIfIssueChanged(issue tracker.Issue) bool {
+	id := IssueID(issue.ID)
+	failed, ok := s.Failed[id]
+	if !ok {
+		return false
+	}
+	if failed.State == issue.State && failed.UpdatedAt == issue.UpdatedAt {
+		return false
+	}
+	delete(s.Failed, id)
+	return true
 }
 
 // RunningCount reports in-flight work that consumes agent concurrency. Claimed
@@ -258,7 +281,7 @@ func (s *OrchestratorState) FinishRunNonRetryableFailed(id IssueID, run *Running
 	if !s.FinishRunFailed(id, run, elapsed) {
 		return false
 	}
-	s.Failed[id] = struct{}{}
+	s.Failed[id] = FailedEntry{State: run.Issue.State, UpdatedAt: run.Issue.UpdatedAt}
 	return true
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -169,6 +169,24 @@ func (s *OrchestratorState) IsClaimed(id IssueID) bool {
 	return false
 }
 
+// RunningCount reports in-flight work that consumes agent concurrency. Claimed
+// entries are included because dispatchOp reserves the slot before its followup
+// records Running; without counting those reservations, one poll tick can queue
+// more workers than max_concurrent_agents before any Running entry is visible.
+func (s *OrchestratorState) RunningCount() int {
+	counted := make(map[IssueID]struct{}, len(s.Running)+len(s.Claimed))
+	for id := range s.Running {
+		counted[id] = struct{}{}
+	}
+	for id := range s.Claimed {
+		counted[id] = struct{}{}
+	}
+	for id := range s.RetryAttempts {
+		delete(counted, id)
+	}
+	return len(counted)
+}
+
 // BeginDispatch records the SPEC §16.4 dispatch step: an eligible
 // candidate transitions from "fetched" to "claimed and running".
 //

--- a/internal/worker/export_test.go
+++ b/internal/worker/export_test.go
@@ -4,4 +4,4 @@ package worker
 // external worker_test package can exercise the worker lifecycle (workspace
 // prep, runner, verification, summary, and secret-scan gates) without
 // promoting runTask itself to a stable public API.
-var RunTaskForTest = runTask
+var RunTaskForTest = RunTask

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -30,6 +30,7 @@ type ReconcileConfig struct {
 	WorkspaceRoot   string
 	ActiveStates    []string
 	TerminalStates  []string
+	TrackerKind     string
 	Tracker         ReconcileTracker
 	Emitter         EventEmitter
 	ReconcileTaskID string
@@ -87,7 +88,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 		}
 	}
 
-	workspaces, err := listIssueWorkspaces(cfg.WorkspaceRoot)
+	workspaces, err := listIssueWorkspaces(cfg.WorkspaceRoot, cfg.TrackerKind)
 	if err != nil {
 		return err
 	}
@@ -164,7 +165,7 @@ type issueWorkspace struct {
 	Key  string
 }
 
-func listIssueWorkspaces(root string) ([]issueWorkspace, error) {
+func listIssueWorkspaces(root, trackerKind string) ([]issueWorkspace, error) {
 	ownerEntries, err := os.ReadDir(root)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -172,6 +173,7 @@ func listIssueWorkspaces(root string) ([]issueWorkspace, error) {
 		}
 		return nil, fmt.Errorf("read workspace root %s: %w", root, err)
 	}
+	sourceDirs := issueWorkspaceSourceDirs(trackerKind)
 	var workspaces []issueWorkspace
 	for _, ownerEntry := range ownerEntries {
 		if !ownerEntry.IsDir() {
@@ -187,7 +189,7 @@ func listIssueWorkspaces(root string) ([]issueWorkspace, error) {
 				continue
 			}
 			repoPath := filepath.Join(ownerPath, repoEntry.Name())
-			for _, sourceDir := range []string{"linear_issue", "linear-issue", "gitea_issue", "gitea-issue"} {
+			for _, sourceDir := range sourceDirs {
 				sourcePath := filepath.Join(repoPath, sourceDir)
 				workspaceEntries, err := os.ReadDir(sourcePath)
 				if err != nil {
@@ -207,6 +209,17 @@ func listIssueWorkspaces(root string) ([]issueWorkspace, error) {
 		}
 	}
 	return workspaces, nil
+}
+
+func issueWorkspaceSourceDirs(trackerKind string) []string {
+	switch strings.ToLower(strings.TrimSpace(trackerKind)) {
+	case "gitea":
+		return []string{"gitea_issue", "gitea-issue"}
+	case "", "linear":
+		return []string{"linear_issue", "linear-issue"}
+	default:
+		return nil
+	}
 }
 
 func removeWorkspace(ctx context.Context, cfg ReconcileConfig, taskID, path string, issue tracker.Issue, reason string) (bool, error) {

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -187,7 +187,7 @@ func listIssueWorkspaces(root string) ([]issueWorkspace, error) {
 				continue
 			}
 			repoPath := filepath.Join(ownerPath, repoEntry.Name())
-			for _, sourceDir := range []string{"linear_issue", "linear-issue"} {
+			for _, sourceDir := range []string{"linear_issue", "linear-issue", "gitea_issue", "gitea-issue"} {
 				sourcePath := filepath.Join(repoPath, sourceDir)
 				workspaceEntries, err := os.ReadDir(sourcePath)
 				if err != nil {

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -217,6 +217,7 @@ func TestReconcileStartupMatchesGiteaWorkspaceLayout(t *testing.T) {
 		WorkspaceRoot:  root,
 		ActiveStates:   []string{"AI Ready"},
 		TerminalStates: []string{"Done"},
+		TrackerKind:    "gitea",
 		Tracker: fakeReconcileTracker{issues: []tracker.Issue{
 			{ID: "issue-1", Identifier: "GIT-1", State: "AI Ready"},
 			{ID: "issue-2", Identifier: "GIT-2", State: "Done"},
@@ -232,6 +233,36 @@ func TestReconcileStartupMatchesGiteaWorkspaceLayout(t *testing.T) {
 	}
 	if _, err := os.Stat(terminalPath); !os.IsNotExist(err) {
 		t.Fatalf("terminal gitea workspace should be removed, stat err=%v", err)
+	}
+}
+
+func TestReconcileStartupSkipsOtherTrackerWorkspaceLayouts(t *testing.T) {
+	root := t.TempDir()
+	linearTerminalPath := filepath.Join(root, "acme", "repo", "linear-issue", "lin-2-done")
+	giteaOtherTrackerPath := filepath.Join(root, "acme", "repo", "gitea_issue", "issue-owned-by-gitea-worker")
+	for _, path := range []string{linearTerminalPath, giteaOtherTrackerPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:   root,
+		ActiveStates:    []string{"In Progress"},
+		TerminalStates:  []string{"Done"},
+		TrackerKind:     "linear",
+		Tracker:         fakeReconcileTracker{issues: []tracker.Issue{{ID: "issue-2", Identifier: "LIN 2 Done", State: "Done"}}},
+		Emitter:         &fakeEmitter{},
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup: %v", err)
+	}
+	if _, err := os.Stat(linearTerminalPath); !os.IsNotExist(err) {
+		t.Fatalf("linear terminal workspace should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(giteaOtherTrackerPath); err != nil {
+		t.Fatalf("gitea workspace should be ignored by linear reconciliation: %v", err)
 	}
 }
 

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -203,6 +203,38 @@ func TestReconcileStartupMatchesCurrentSanitizedWorkspaceLayout(t *testing.T) {
 	}
 }
 
+func TestReconcileStartupMatchesGiteaWorkspaceLayout(t *testing.T) {
+	root := t.TempDir()
+	activePath := filepath.Join(root, "acme", "repo", "gitea_issue", "issue-1")
+	terminalPath := filepath.Join(root, "acme", "repo", "gitea_issue", "issue-2")
+	for _, path := range []string{activePath, terminalPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:  root,
+		ActiveStates:   []string{"AI Ready"},
+		TerminalStates: []string{"Done"},
+		Tracker: fakeReconcileTracker{issues: []tracker.Issue{
+			{ID: "issue-1", Identifier: "GIT-1", State: "AI Ready"},
+			{ID: "issue-2", Identifier: "GIT-2", State: "Done"},
+		}},
+		Emitter:         &fakeEmitter{},
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup: %v", err)
+	}
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("active gitea workspace should remain: %v", err)
+	}
+	if _, err := os.Stat(terminalPath); !os.IsNotExist(err) {
+		t.Fatalf("terminal gitea workspace should be removed, stat err=%v", err)
+	}
+}
+
 func TestReconcileStartupKeepsReworkWorkspaceWhenUpdatedAtChanged(t *testing.T) {
 	root := t.TempDir()
 	reworkPath := filepath.Join(root, "acme", "repo", "linear-issue", "issue-3-rework-2026-05-16t10-00-00z")

--- a/internal/worker/run.go
+++ b/internal/worker/run.go
@@ -32,7 +32,6 @@ type runStore interface {
 // transitioner factories — those are provided to the agent via dynamic
 // tools (pending #64).
 type Config struct {
-	DSN             string
 	WorkspaceRoot   string
 	MirrorRoot      string
 	IdleSleep       time.Duration
@@ -43,7 +42,6 @@ type Config struct {
 // the same defaults the original cmd/worker/main.go used.
 func LoadConfigFromEnv() Config {
 	return Config{
-		DSN:             env("DATABASE_URL", "postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable"),
 		WorkspaceRoot:   env("WORKSPACE_ROOT", "/tmp/aiops-workspaces"),
 		MirrorRoot:      os.Getenv("AIOPS_MIRROR_ROOT"),
 		IdleSleep:       3 * time.Second,
@@ -77,7 +75,7 @@ func Run(ctx context.Context, store runStore, cfg Config) {
 			}
 			continue
 		}
-		if rterr := runTask(ctx, store, *t, cfg); rterr != nil {
+		if rterr := RunTask(ctx, store, *t, cfg); rterr != nil {
 			log.Printf("task %s failed: %v", t.ID, rterr.Err)
 			cleanupCtx, cancel := terminalUpdateContext(ctx)
 			handleTaskFailure(cleanupCtx, store, *t, rterr.Cfg, rterr.Err)

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -128,7 +128,10 @@ func handleTaskFailure(ctx context.Context, store failingStore, t task.Task, cfg
 // responsibility. The worker's role is: claim, prepare workspace, resolve
 // workflow, run agent session, enforce policy/secret-scan/RUN_SUMMARY gates,
 // emit events, and clean up.
-func runTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *RunTaskError {
+// RunTask executes a single in-memory task. The orchestrator-backed worker path
+// uses this directly after claiming a tracker issue in runtime state; the
+// legacy queue loop also calls it for remaining tests/compatibility.
+func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *RunTaskError {
 	mgr := workspace.New(cfg.WorkspaceRoot)
 	mgr.MirrorRoot = cfg.MirrorRoot
 	workdir, _, err := mgr.PrepareGitWorkspace(ctx, t)

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -15,6 +15,7 @@ type Workflow struct {
 	Path           string
 	Config         Config
 	PromptTemplate string
+	Source         Source
 }
 
 func Load(path string) (*Workflow, error) {
@@ -45,7 +46,11 @@ func Load(path string) (*Workflow, error) {
 			return nil, err
 		}
 	}
-	return &Workflow{Path: path, Config: cfg, PromptTemplate: strings.TrimSpace(body)}, nil
+	source := SourceFile
+	if !hasFrontMatter {
+		source = SourcePromptOnly
+	}
+	return &Workflow{Path: path, Config: cfg, PromptTemplate: strings.TrimSpace(body), Source: source}, nil
 }
 
 // supportedTrackerKinds enumerates the tracker integrations the platform

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -74,7 +74,7 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 	if found == "" {
 		cfg := DefaultConfig()
 		expandConfig(&cfg)
-		wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt()}
+		wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt(), Source: SourceDefault}
 		return wf, &Resolution{Source: SourceDefault}, nil
 	}
 	abs := filepath.Join(workdir, found)


### PR DESCRIPTION
## Summary
- Remove the worker's hard dependency on `DATABASE_URL`/Postgres queue claiming in the SPEC-aligned path.
- Add tracker-backed orchestrator polling that feeds runtime scheduling without queue rows.
- Update worker docs, examples, and Docker compose to describe tracker + filesystem recovery as the default path.

## Test Plan
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go build ./cmd/trigger-api ./cmd/worker ./cmd/linear-poller`

Closes #73
