### PR TITLE
feat(orchestrator): reconcile tracker state each poll tick

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -132,12 +133,49 @@ func run(ctx context.Context) error {
 	if err := orch.WaitStarted(ctx); err != nil {
 		return err
 	}
-	poller := orchestrator.NewPollerWithReconciliation(trackerClient, orch, orchestrator.ReconciliationConfig{
-		ActiveStates:      wf.Config.Tracker.ActiveStates,
-		TerminalStates:    wf.Config.Tracker.TerminalStates,
-		WorkerExitTimeout: 30 * time.Second,
-	})
+	poller := orchestrator.NewPollerWithReconciliation(trackerClient, orch, reconciliationConfigForWorkflow(wf.Config))
 	return orchestrator.RunPollLoop(ctx, poller, pollInterval)
+}
+
+func reconciliationConfigForWorkflow(cfg workflow.Config) orchestrator.ReconciliationConfig {
+	return orchestrator.ReconciliationConfig{
+		ActiveStates:      cfg.Tracker.ActiveStates,
+		TerminalStates:    cfg.Tracker.TerminalStates,
+		InactiveStates:    inferredInactiveStates(cfg.Tracker),
+		WorkerExitTimeout: 30 * time.Second,
+	}
+}
+
+func inferredInactiveStates(cfg workflow.TrackerConfig) []string {
+	candidates := []string{"Backlog", "Human Review"}
+	active := stateSet(cfg.ActiveStates)
+	terminal := stateSet(cfg.TerminalStates)
+	out := make([]string, 0, len(candidates))
+	for _, state := range candidates {
+		key := normalizeState(state)
+		if _, ok := active[key]; ok {
+			continue
+		}
+		if _, ok := terminal[key]; ok {
+			continue
+		}
+		out = append(out, state)
+	}
+	return out
+}
+
+func stateSet(states []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		if key := normalizeState(state); key != "" {
+			out[key] = struct{}{}
+		}
+	}
+	return out
+}
+
+func normalizeState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
 }
 
 type trackerRuntimeClient interface {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -147,21 +147,41 @@ func reconciliationConfigForWorkflow(cfg workflow.Config) orchestrator.Reconcili
 }
 
 func inferredInactiveStates(cfg workflow.TrackerConfig) []string {
-	candidates := []string{"Backlog", "Human Review"}
+	candidates := cfg.InactiveStates
+	if len(candidates) == 0 {
+		candidates = defaultInactiveStateCandidates(cfg.Kind)
+	}
 	active := stateSet(cfg.ActiveStates)
 	terminal := stateSet(cfg.TerminalStates)
 	out := make([]string, 0, len(candidates))
+	seen := map[string]struct{}{}
 	for _, state := range candidates {
 		key := normalizeState(state)
+		if key == "" {
+			continue
+		}
 		if _, ok := active[key]; ok {
 			continue
 		}
 		if _, ok := terminal[key]; ok {
 			continue
 		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
 		out = append(out, state)
 	}
 	return out
+}
+
+func defaultInactiveStateCandidates(kind string) []string {
+	switch normalizeState(kind) {
+	case "gitea":
+		return []string{"Human Review"}
+	default:
+		return []string{"Backlog", "Human Review"}
+	}
 }
 
 func stateSet(states []string) map[string]struct{} {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -132,7 +132,12 @@ func run(ctx context.Context) error {
 	if err := orch.WaitStarted(ctx); err != nil {
 		return err
 	}
-	return orchestrator.RunPollLoop(ctx, orchestrator.NewPoller(trackerClient, orch), pollInterval)
+	poller := orchestrator.NewPollerWithReconciliation(trackerClient, orch, orchestrator.ReconciliationConfig{
+		ActiveStates:      wf.Config.Tracker.ActiveStates,
+		TerminalStates:    wf.Config.Tracker.TerminalStates,
+		WorkerExitTimeout: 30 * time.Second,
+	})
+	return orchestrator.RunPollLoop(ctx, poller, pollInterval)
 }
 
 type trackerRuntimeClient interface {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -177,6 +177,36 @@ func TestValidateWorkflowForRuntimeAcceptsWorkflowWithRuntimeTaskFields(t *testi
 	}
 }
 
+func TestWorkerReconciliationConfigIncludesInactiveStates(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.CloneURL = "git@example.com:o/r.git"
+	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress", "Rework"}
+	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
+
+	reconcile := reconciliationConfigForWorkflow(cfg)
+	if len(reconcile.InactiveStates) == 0 {
+		t.Fatalf("inactive reconciliation states = %v, want non-empty states for explicit inactive tracker observations", reconcile.InactiveStates)
+	}
+	if containsState(reconcile.InactiveStates, "AI Ready") || containsState(reconcile.InactiveStates, "In Progress") || containsState(reconcile.InactiveStates, "Rework") {
+		t.Fatalf("inactive reconciliation states = %v, must not include configured active states", reconcile.InactiveStates)
+	}
+	if containsState(reconcile.InactiveStates, "Done") || containsState(reconcile.InactiveStates, "Canceled") {
+		t.Fatalf("inactive reconciliation states = %v, must not duplicate terminal states", reconcile.InactiveStates)
+	}
+	if !containsState(reconcile.InactiveStates, "Backlog") || !containsState(reconcile.InactiveStates, "Human Review") {
+		t.Fatalf("inactive reconciliation states = %v, want Backlog and Human Review", reconcile.InactiveStates)
+	}
+}
+
+func containsState(states []string, want string) bool {
+	for _, state := range states {
+		if state == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestValidateWorkflowForRuntimeRejectsFrontMatterWorkflowMissingTaskFields(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -180,6 +180,7 @@ func TestValidateWorkflowForRuntimeAcceptsWorkflowWithRuntimeTaskFields(t *testi
 func TestWorkerReconciliationConfigIncludesInactiveStates(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Repo.CloneURL = "git@example.com:o/r.git"
+	cfg.Tracker.Kind = "linear"
 	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress", "Rework"}
 	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
 
@@ -195,6 +196,38 @@ func TestWorkerReconciliationConfigIncludesInactiveStates(t *testing.T) {
 	}
 	if !containsState(reconcile.InactiveStates, "Backlog") || !containsState(reconcile.InactiveStates, "Human Review") {
 		t.Fatalf("inactive reconciliation states = %v, want Backlog and Human Review", reconcile.InactiveStates)
+	}
+}
+
+func TestWorkerReconciliationConfigDoesNotProbeUnmappedGiteaInactiveStates(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.CloneURL = "git@example.com:o/r.git"
+	cfg.Tracker.Kind = "gitea"
+	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress", "Rework"}
+	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
+
+	reconcile := reconciliationConfigForWorkflow(cfg)
+	if containsState(reconcile.InactiveStates, "Backlog") {
+		t.Fatalf("inactive reconciliation states = %v, must not include unmapped Gitea Backlog state", reconcile.InactiveStates)
+	}
+	if !containsState(reconcile.InactiveStates, "Human Review") {
+		t.Fatalf("inactive reconciliation states = %v, want mapped Gitea Human Review state", reconcile.InactiveStates)
+	}
+}
+
+func TestWorkerReconciliationConfigUsesWorkflowInactiveStates(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.CloneURL = "git@example.com:o/r.git"
+	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress"}
+	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
+	cfg.Tracker.InactiveStates = []string{"Paused", "Blocked", "Done", "AI Ready"}
+
+	reconcile := reconciliationConfigForWorkflow(cfg)
+	if !containsState(reconcile.InactiveStates, "Paused") || !containsState(reconcile.InactiveStates, "Blocked") {
+		t.Fatalf("inactive reconciliation states = %v, want workflow-configured inactive states", reconcile.InactiveStates)
+	}
+	if containsState(reconcile.InactiveStates, "Done") || containsState(reconcile.InactiveStates, "AI Ready") {
+		t.Fatalf("inactive reconciliation states = %v, must exclude configured active/terminal states", reconcile.InactiveStates)
 	}
 }
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -43,9 +43,9 @@ func TestWorkerEntrypointDoesNotRequirePostgresQueue(t *testing.T) {
 			t.Fatalf("cmd/worker/main.go contains %q; worker startup must use tracker + orchestrator runtime state, not the Postgres queue", forbidden)
 		}
 	}
-	for _, required := range []string{"orchestrator.NewOrchestratorState", "orchestrator.NewPoller", "orchestrator.RunPollLoop"} {
+	for _, required := range []string{"orchestrator.NewOrchestratorState", "orchestrator.NewPollerWithReconciliation", "orchestrator.RunPollLoop"} {
 		if !strings.Contains(string(src), required) {
-			t.Fatalf("cmd/worker/main.go missing %q; worker startup must poll tracker issues through orchestrator runtime state", required)
+			t.Fatalf("cmd/worker/main.go missing %q; worker startup must poll tracker issues through reconciled orchestrator runtime state", required)
 		}
 	}
 }

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -15,6 +15,9 @@ tracker:
   terminal_states:
     - Done
     - Canceled
+  inactive_states:
+    - Backlog
+    - Human Review
   poll_interval_ms: 30000
   # statuses names the Linear workflow states used for handoff updates
   # (for example claim -> in_progress, PR opened -> human_review, failure

--- a/examples/gitea-WORKFLOW.md
+++ b/examples/gitea-WORKFLOW.md
@@ -14,6 +14,8 @@ tracker:
   terminal_states:
     - Done
     - Canceled
+  inactive_states:
+    - Human Review
   poll_interval_ms: 30000
 
 workspace:

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -30,6 +30,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
@@ -217,6 +218,47 @@ var ErrNotDispatched = errors.New("orchestrator: issue already claimed")
 // tick rather than treating it as a duplicate dispatch.
 var ErrCapacityFull = errors.New("orchestrator: max_concurrent_agents reached")
 
+// ReconcileTrackerIssues cancels or releases in-process work that is no longer
+// tracker-eligible. It is the per-tick half of SPEC §2.1/#78: each tracker poll
+// revalidates active runs against the latest tracker state and cancels workers
+// whose issues moved out of active states.
+func (o *Orchestrator) ReconcileTrackerIssues(ctx context.Context, issuesByID map[string]tracker.Issue, activeStates map[string]struct{}) error {
+	return o.ReconcileTrackerIssuesAndWait(ctx, issuesByID, activeStates, 0)
+}
+
+// ReconcileTrackerIssuesAndWait performs the same reconciliation as
+// ReconcileTrackerIssues, then optionally waits for canceled workers to exit.
+// This lets poll ticks provide prompt cancellation semantics without making the
+// actor itself block on worker goroutines.
+func (o *Orchestrator) ReconcileTrackerIssuesAndWait(ctx context.Context, issuesByID map[string]tracker.Issue, activeStates map[string]struct{}, wait time.Duration) error {
+	reply := make(chan []*RunningEntry, 1)
+	if err := o.submit(ctx, &reconcileTrackerIssuesOp{issuesByID: issuesByID, activeStates: activeStates, result: reply}); err != nil {
+		return err
+	}
+	var canceled []*RunningEntry
+	select {
+	case canceled = <-reply:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if wait <= 0 {
+		return nil
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, wait)
+	defer cancel()
+	for _, entry := range canceled {
+		if entry.Done == nil {
+			continue
+		}
+		select {
+		case <-entry.Done:
+		case <-waitCtx.Done():
+			return waitCtx.Err()
+		}
+	}
+	return nil
+}
+
 // RequestDispatch is the public entry to dispatch issue if no other
 // claim exists. It returns nil on accepted dispatch (a worker is being
 // spawned) and ErrNotDispatched if the actor saw an existing claim.
@@ -257,6 +299,50 @@ func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, i
 		runErr:     runErr,
 	}
 	return o.submit(ctx, op)
+}
+
+type reconcileTrackerIssuesOp struct {
+	issuesByID   map[string]tracker.Issue
+	activeStates map[string]struct{}
+	result       chan<- []*RunningEntry
+}
+
+func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
+	var cancelEntries []*RunningEntry
+	for id, run := range st.Running {
+		issue, ok := r.issuesByID[string(id)]
+		if ok && isActiveTrackerState(issue.State, r.activeStates) {
+			continue
+		}
+		st.ReleaseClaim(id)
+		run.ReconcileCancel = true
+		cancelEntries = append(cancelEntries, run)
+	}
+	for id := range st.RetryAttempts {
+		issue, ok := r.issuesByID[string(id)]
+		if ok && isActiveTrackerState(issue.State, r.activeStates) {
+			continue
+		}
+		st.ReleaseClaim(id)
+	}
+	return func() {
+		for _, entry := range cancelEntries {
+			if entry.CancelWorker != nil {
+				entry.CancelWorker()
+			}
+		}
+		if r.result != nil {
+			r.result <- cancelEntries
+		}
+	}
+}
+
+func isActiveTrackerState(state string, activeStates map[string]struct{}) bool {
+	if len(activeStates) == 0 {
+		return false
+	}
+	_, ok := activeStates[strings.ToLower(strings.TrimSpace(state))]
+	return ok
 }
 
 // dispatchOp is the actor-side half of RequestDispatch: it checks
@@ -427,6 +513,14 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 	}
 	if f.result.NonRetryable {
 		if !st.FinishRunNonRetryableFailed(f.id, f.entry, elapsed) {
+			close(f.done)
+			return nil
+		}
+		close(f.done)
+		return nil
+	}
+	if f.entry.ReconcileCancel {
+		if !st.FinishRunReconciledCancelled(f.id, f.entry, elapsed) {
 			close(f.done)
 			return nil
 		}

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -241,6 +241,10 @@ func (o *Orchestrator) ReconcileTrackerIssuesAndWait(ctx context.Context, issues
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+	return waitForReconciledWorkers(ctx, canceled, wait)
+}
+
+func waitForReconciledWorkers(ctx context.Context, canceled []*RunningEntry, wait time.Duration) error {
 	if wait <= 0 {
 		return nil
 	}
@@ -278,6 +282,25 @@ func (o *Orchestrator) RequestDispatch(ctx context.Context, issue tracker.Issue,
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// ReconcileInactiveTrackerIssuesAndWait cancels only issues explicitly observed
+// in a terminal or configured inactive tracker state. Missing issues are
+// treated as unknown instead of inactive because tracker adapters may return
+// partial state listings under pagination caps.
+func (o *Orchestrator) ReconcileInactiveTrackerIssuesAndWait(ctx context.Context, issuesByID map[string]tracker.Issue, workerExitTimeout time.Duration) error {
+	reply := make(chan []*RunningEntry, 1)
+	op := &reconcileInactiveTrackerIssuesOp{issuesByID: issuesByID, result: reply}
+	if err := o.submit(ctx, op); err != nil {
+		return err
+	}
+	var canceled []*RunningEntry
+	select {
+	case canceled = <-reply:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return waitForReconciledWorkers(ctx, canceled, workerExitTimeout)
 }
 
 // ScheduleRetry enters the SPEC §7.1 retry-queued substate for issue.
@@ -325,14 +348,42 @@ func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
 		}
 		st.ReleaseClaim(id)
 	}
+	return reconcileCancelFollowup(cancelEntries, r.result)
+}
+
+type reconcileInactiveTrackerIssuesOp struct {
+	issuesByID map[string]tracker.Issue
+	result     chan<- []*RunningEntry
+}
+
+func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
+	var cancelEntries []*RunningEntry
+	for id, run := range st.Running {
+		if _, ok := r.issuesByID[string(id)]; !ok {
+			continue
+		}
+		st.ReleaseClaim(id)
+		run.ReconcileCancel = true
+		cancelEntries = append(cancelEntries, run)
+	}
+	for id := range st.RetryAttempts {
+		if _, ok := r.issuesByID[string(id)]; !ok {
+			continue
+		}
+		st.ReleaseClaim(id)
+	}
+	return reconcileCancelFollowup(cancelEntries, r.result)
+}
+
+func reconcileCancelFollowup(cancelEntries []*RunningEntry, result chan<- []*RunningEntry) func() {
 	return func() {
 		for _, entry := range cancelEntries {
 			if entry.CancelWorker != nil {
 				entry.CancelWorker()
 			}
 		}
-		if r.result != nil {
-			r.result <- cancelEntries
+		if result != nil {
+			result <- cancelEntries
 		}
 	}
 }

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
@@ -18,19 +19,54 @@ type ActiveIssueLister interface {
 	ListActiveIssues(ctx context.Context) ([]tracker.Issue, error)
 }
 
+// IssueStateLister is the tracker reader required for per-tick
+// reconciliation. Unlike ListActiveIssues, it can fetch explicit terminal and
+// inactive workflow states so a poll tick can cancel already-running work when
+// the tracker says the issue left the active set.
+type IssueStateLister interface {
+	ListIssuesByStates(ctx context.Context, states []string) ([]tracker.Issue, error)
+}
+
+// ReconciliationConfig names the workflow states the poller uses to decide
+// whether in-process work is still eligible to run. A running issue absent from
+// active states is canceled once it is observed in either terminal states or in
+// the known inactive states listed here.
+type ReconciliationConfig struct {
+	ActiveStates   []string
+	TerminalStates []string
+	InactiveStates []string
+
+	// WorkerExitTimeout bounds how long a poll tick waits after issuing a
+	// reconciliation cancel. Zero means the poll tick only requests cancellation;
+	// the worker watcher will clean up asynchronously.
+	WorkerExitTimeout time.Duration
+}
+
 // Poller connects tracker polling to the orchestrator runtime state. It has no
 // durable queue dependency: candidates are read from the tracker and claimed by
 // the in-process Orchestrator actor.
 type Poller struct {
-	tracker      ActiveIssueLister
-	orchestrator *Orchestrator
-	overflow     []tracker.Issue
+	tracker        ActiveIssueLister
+	stateTracker   IssueStateLister
+	orchestrator   *Orchestrator
+	overflow       []tracker.Issue
+	reconcile      ReconciliationConfig
+	reconcileKnown bool
 }
 
 // NewPoller returns a SPEC-aligned tracker poller backed by orchestrator-owned
 // runtime state instead of the legacy Postgres task queue.
 func NewPoller(tracker ActiveIssueLister, orchestrator *Orchestrator) *Poller {
 	return &Poller{tracker: tracker, orchestrator: orchestrator}
+}
+
+// NewPollerWithReconciliation returns a poller that reconciles the
+// orchestrator's in-memory running/retry state against tracker state on every
+// tick before considering new dispatches. It preserves the SPEC boundary: the
+// orchestrator reads tracker state and cancels workers, while tracker writes
+// remain agent-side.
+func NewPollerWithReconciliation(tracker IssueStateLister, orchestrator *Orchestrator, cfg ReconciliationConfig) *Poller {
+	return &Poller{tracker: activeIssueListerFromStates{tracker: tracker, states: cfg.ActiveStates}, stateTracker: tracker, orchestrator: orchestrator, reconcile: cfg, reconcileKnown: true}
 }
 
 // PollOnce performs one tracker tick: fetch active issues and ask the
@@ -46,6 +82,11 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 	issues, err := p.tracker.ListActiveIssues(ctx)
 	if err != nil {
 		return err
+	}
+	if p.reconcileKnown {
+		if err := p.reconcileTick(ctx, issues); err != nil {
+			return err
+		}
 	}
 	candidates := mergeOverflowCandidates(p.overflow, issues)
 	p.overflow = nil
@@ -66,6 +107,71 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 		}
 	}
 	return dispatchErr
+}
+
+type activeIssueListerFromStates struct {
+	tracker IssueStateLister
+	states  []string
+}
+
+func (l activeIssueListerFromStates) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	return l.tracker.ListIssuesByStates(ctx, l.states)
+}
+
+func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue) error {
+	if p.stateTracker == nil {
+		return errors.New("orchestrator poller reconciliation requires state tracker")
+	}
+	issuesByID := make(map[string]tracker.Issue, len(activeIssues))
+	for _, issue := range activeIssues {
+		if issue.ID != "" {
+			issuesByID[issue.ID] = issue
+		}
+	}
+	for _, states := range p.reconcileInactiveStateGroups() {
+		issues, err := p.stateTracker.ListIssuesByStates(ctx, states)
+		if err != nil {
+			return err
+		}
+		for _, issue := range issues {
+			if issue.ID != "" {
+				issuesByID[issue.ID] = issue
+			}
+		}
+	}
+	return p.orchestrator.ReconcileTrackerIssuesAndWait(ctx, issuesByID, normalizedStates(p.reconcile.ActiveStates), p.reconcile.WorkerExitTimeout)
+}
+
+func (p *Poller) reconcileInactiveStateGroups() [][]string {
+	groups := make([][]string, 0, 2)
+	if states := nonEmptyStateList(p.reconcile.TerminalStates); len(states) > 0 {
+		groups = append(groups, states)
+	}
+	if states := nonEmptyStateList(p.reconcile.InactiveStates); len(states) > 0 {
+		groups = append(groups, states)
+	}
+	return groups
+}
+
+func nonEmptyStateList(states []string) []string {
+	out := make([]string, 0, len(states))
+	for _, state := range states {
+		if strings.TrimSpace(state) != "" {
+			out = append(out, state)
+		}
+	}
+	return out
+}
+
+func normalizedStates(states []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		state = strings.ToLower(strings.TrimSpace(state))
+		if state != "" {
+			out[state] = struct{}{}
+		}
+	}
+	return out
 }
 
 func mergeOverflowCandidates(overflow, fresh []tracker.Issue) []tracker.Issue {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -130,10 +130,12 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 		}
 	}
 	inactiveByID := make(map[string]tracker.Issue)
+	var fetchErr error
 	for _, states := range p.reconcileInactiveStateGroups() {
 		issues, err := p.stateTracker.ListIssuesByStates(ctx, states)
 		if err != nil {
-			return err
+			fetchErr = errors.Join(fetchErr, err)
+			continue
 		}
 		for _, issue := range issues {
 			if issue.ID == "" {
@@ -145,7 +147,8 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 			inactiveByID[issue.ID] = issue
 		}
 	}
-	return p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, inactiveByID, p.reconcile.WorkerExitTimeout)
+	reconcileErr := p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, inactiveByID, p.reconcile.WorkerExitTimeout)
+	return errors.Join(reconcileErr, fetchErr)
 }
 
 func (p *Poller) reconcileInactiveStateGroups() [][]string {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -83,9 +83,10 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	var pollErr error
 	if p.reconcileKnown {
 		if err := p.reconcileTick(ctx, issues); err != nil {
-			return err
+			pollErr = errors.Join(pollErr, err)
 		}
 	}
 	candidates := mergeOverflowCandidates(p.overflow, issues)
@@ -106,7 +107,7 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 			}
 		}
 	}
-	return dispatchErr
+	return errors.Join(pollErr, dispatchErr)
 }
 
 type activeIssueListerFromStates struct {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -139,7 +139,7 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 			}
 		}
 	}
-	return p.orchestrator.ReconcileTrackerIssuesAndWait(ctx, issuesByID, normalizedStates(p.reconcile.ActiveStates), p.reconcile.WorkerExitTimeout)
+	return p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, issuesByID, p.reconcile.WorkerExitTimeout)
 }
 
 func (p *Poller) reconcileInactiveStateGroups() [][]string {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -122,24 +122,29 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 	if p.stateTracker == nil {
 		return errors.New("orchestrator poller reconciliation requires state tracker")
 	}
-	issuesByID := make(map[string]tracker.Issue, len(activeIssues))
+	activeByID := make(map[string]struct{}, len(activeIssues))
 	for _, issue := range activeIssues {
 		if issue.ID != "" {
-			issuesByID[issue.ID] = issue
+			activeByID[issue.ID] = struct{}{}
 		}
 	}
+	inactiveByID := make(map[string]tracker.Issue)
 	for _, states := range p.reconcileInactiveStateGroups() {
 		issues, err := p.stateTracker.ListIssuesByStates(ctx, states)
 		if err != nil {
 			return err
 		}
 		for _, issue := range issues {
-			if issue.ID != "" {
-				issuesByID[issue.ID] = issue
+			if issue.ID == "" {
+				continue
 			}
+			if _, active := activeByID[issue.ID]; active {
+				continue
+			}
+			inactiveByID[issue.ID] = issue
 		}
 	}
-	return p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, issuesByID, p.reconcile.WorkerExitTimeout)
+	return p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, inactiveByID, p.reconcile.WorkerExitTimeout)
 }
 
 func (p *Poller) reconcileInactiveStateGroups() [][]string {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -160,6 +161,13 @@ type fakeIssueStateTracker struct {
 	err    error
 }
 
+type fakeIssueStateTrackerByCall struct {
+	mu        sync.Mutex
+	issues    [][]tracker.Issue
+	errByCall []error
+	calls     int
+}
+
 func (f *fakeIssueStateTracker) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
 	return f.ListIssuesByStates(ctx, nil)
 }
@@ -190,6 +198,20 @@ func (f *fakeIssueStateTracker) setErr(err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.err = err
+}
+
+func (f *fakeIssueStateTrackerByCall) ListIssuesByStates(_ context.Context, _ []string) ([]tracker.Issue, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	call := f.calls
+	f.calls++
+	if call < len(f.errByCall) && f.errByCall[call] != nil {
+		return nil, f.errByCall[call]
+	}
+	if call < len(f.issues) {
+		return f.issues[call], nil
+	}
+	return nil, nil
 }
 
 type cancellationDispatcher struct {
@@ -351,6 +373,52 @@ func TestPollOnceTrackerErrorDoesNotCancelRunningIssue(t *testing.T) {
 		t.Fatalf("running issue context was canceled after tracker error")
 	default:
 	}
+}
+
+func TestPollOnceCancelsTerminalIssueBeforeReturningLaterInactiveFetchError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTrackerByCall{issues: [][]tracker.Issue{
+		{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}},
+		{},
+		{},
+		{},
+		{{ID: "issue-1", Identifier: "LIN-1", State: "Done"}},
+	}, errByCall: []error{
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		fmt.Errorf("inactive state fetch failed"),
+	}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress", "Rework"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		InactiveStates:    []string{"Backlog"},
+		WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	if err := poller.PollOnce(ctx); err == nil || !strings.Contains(err.Error(), "inactive state fetch failed") {
+		t.Fatalf("terminal poll once error = %v, want inactive fetch error", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
 }
 
 func TestPollOnceDoesNotCancelRunningIssueStillInActiveTrackerListing(t *testing.T) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -458,6 +458,42 @@ func TestPollOnceReturnsErrorWhenCanceledWorkerDoesNotExitBeforeTimeout(t *testi
 	waitForContextCanceled(t, dispatcher.contextAt(0))
 }
 
+func TestPollOnceDispatchesActiveCandidatesWhenCanceledWorkerDoesNotExitBeforeTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &stuckCancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 2), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		WorkerExitTimeout: time.Millisecond,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForStuckCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.setIssues([]tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", State: "Cancelled"},
+		{ID: "issue-2", Identifier: "LIN-2", State: "In Progress"},
+	})
+	if err := poller.PollOnce(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("cancel poll once error = %v, want context deadline exceeded", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForStuckCancellationDispatcherCount(t, dispatcher, 2)
+}
+
 func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -151,6 +152,236 @@ func (d *blockingDispatcher) count() int {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return len(d.issues)
+}
+
+type fakeIssueStateTracker struct {
+	mu     sync.Mutex
+	issues []tracker.Issue
+	err    error
+}
+
+func (f *fakeIssueStateTracker) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	return f.ListIssuesByStates(ctx, nil)
+}
+
+func (f *fakeIssueStateTracker) ListIssuesByStates(_ context.Context, states []string) ([]tracker.Issue, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return nil, f.err
+	}
+	wanted := normalizedStates(states)
+	out := make([]tracker.Issue, 0, len(f.issues))
+	for _, issue := range f.issues {
+		if isActiveTrackerState(issue.State, wanted) {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeIssueStateTracker) setIssues(issues []tracker.Issue) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.issues = issues
+}
+
+func (f *fakeIssueStateTracker) setErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+type cancellationDispatcher struct {
+	mu       sync.Mutex
+	issues   []tracker.Issue
+	contexts []context.Context
+}
+
+func (d *cancellationDispatcher) Spawn(ctx context.Context, issue tracker.Issue, _ *int) <-chan WorkerResult {
+	d.mu.Lock()
+	d.issues = append(d.issues, issue)
+	d.contexts = append(d.contexts, ctx)
+	d.mu.Unlock()
+	ch := make(chan WorkerResult, 1)
+	go func() {
+		<-ctx.Done()
+		ch <- WorkerResult{Err: ctx.Err(), Elapsed: time.Millisecond}
+		close(ch)
+	}()
+	return ch
+}
+
+func (d *cancellationDispatcher) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.issues)
+}
+
+func (d *cancellationDispatcher) contextAt(i int) context.Context {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.contexts[i]
+}
+
+type stuckCancellationDispatcher struct {
+	mu       sync.Mutex
+	issues   []tracker.Issue
+	contexts []context.Context
+}
+
+func (d *stuckCancellationDispatcher) Spawn(ctx context.Context, issue tracker.Issue, _ *int) <-chan WorkerResult {
+	d.mu.Lock()
+	d.issues = append(d.issues, issue)
+	d.contexts = append(d.contexts, ctx)
+	d.mu.Unlock()
+	return make(chan WorkerResult)
+}
+
+func (d *stuckCancellationDispatcher) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.issues)
+}
+
+func (d *stuckCancellationDispatcher) contextAt(i int) context.Context {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.contexts[i]
+}
+
+func TestPollOnceCancelsRunningIssueWhenTrackerMovesToCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress", "Rework"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.setIssues([]tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Cancelled"}})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("cancelled poll once: %v", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
+}
+
+func TestPollOnceCancelsRunningIssueWhenTrackerMovesToBacklog(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress", "Rework"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.setIssues([]tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Backlog"}})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("backlog poll once: %v", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
+}
+
+func TestPollOnceTrackerErrorDoesNotCancelRunningIssue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress", "Rework"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.setErr(fmt.Errorf("tracker 5xx"))
+	if err := poller.PollOnce(ctx); err == nil {
+		t.Fatalf("tracker-error poll once returned nil, want error")
+	}
+	select {
+	case <-dispatcher.contextAt(0).Done():
+		t.Fatalf("running issue context was canceled after tracker error")
+	default:
+	}
+}
+
+func TestPollOnceReturnsErrorWhenCanceledWorkerDoesNotExitBeforeTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &stuckCancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		WorkerExitTimeout: time.Millisecond,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForStuckCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.setIssues([]tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Cancelled"}})
+	if err := poller.PollOnce(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("cancel poll once error = %v, want context deadline exceeded", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
 }
 
 func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *testing.T) {
@@ -392,6 +623,39 @@ func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
 	waitForDispatcherCount(t, dispatcher, 2)
 	if got := dispatcher.issueAt(1).ID; got != "issue-1" {
 		t.Fatalf("second dispatched issue ID = %q, want fresh active issue-1", got)
+	}
+}
+
+func waitForCancellationDispatcherCount(t *testing.T, dispatcher *cancellationDispatcher, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := dispatcher.count(); got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("dispatcher issues = %d, want %d", dispatcher.count(), want)
+}
+
+func waitForStuckCancellationDispatcherCount(t *testing.T, dispatcher *stuckCancellationDispatcher, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := dispatcher.count(); got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("dispatcher issues = %d, want %d", dispatcher.count(), want)
+}
+
+func waitForContextCanceled(t *testing.T, ctx context.Context) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatalf("context was not canceled")
 	}
 }
 

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -353,6 +353,42 @@ func TestPollOnceTrackerErrorDoesNotCancelRunningIssue(t *testing.T) {
 	}
 }
 
+func TestPollOnceDoesNotCancelRunningIssueStillInActiveTrackerListing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		InactiveStates:    []string{"Backlog"},
+		WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("active-listing poll once: %v", err)
+	}
+	select {
+	case <-dispatcher.contextAt(0).Done():
+		t.Fatalf("running issue context was canceled while still in active tracker listing")
+	default:
+	}
+}
+
 func TestPollOnceDoesNotCancelRunningIssueMissingFromPartialTrackerListing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -301,6 +301,7 @@ func TestPollOnceCancelsRunningIssueWhenTrackerMovesToBacklog(t *testing.T) {
 	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
 		ActiveStates:      []string{"In Progress", "Rework"},
 		TerminalStates:    []string{"Cancelled", "Done"},
+		InactiveStates:    []string{"Backlog"},
 		WorkerExitTimeout: time.Second,
 	})
 	if err := poller.PollOnce(ctx); err != nil {
@@ -348,6 +349,43 @@ func TestPollOnceTrackerErrorDoesNotCancelRunningIssue(t *testing.T) {
 	select {
 	case <-dispatcher.contextAt(0).Done():
 		t.Fatalf("running issue context was canceled after tracker error")
+	default:
+	}
+}
+
+func TestPollOnceDoesNotCancelRunningIssueMissingFromPartialTrackerListing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		InactiveStates:    []string{"Backlog"},
+		WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.setIssues(nil)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("partial-listing poll once: %v", err)
+	}
+	select {
+	case <-dispatcher.contextAt(0).Done():
+		t.Fatalf("running issue context was canceled after missing from partial tracker listing")
 	default:
 	}
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -98,6 +98,12 @@ type RunningEntry struct {
 
 	CancelWorker context.CancelFunc
 	Done         <-chan struct{}
+
+	// ReconcileCancel is set by per-tick reconciliation before it cancels a
+	// worker whose tracker issue left the active set. The worker still reports a
+	// context cancellation, but finalization must release the run without
+	// scheduling a retry because the tracker made the issue ineligible.
+	ReconcileCancel bool
 }
 
 // OrchestratorState is the single authoritative in-memory state owned
@@ -264,6 +270,18 @@ func (s *OrchestratorState) FinishRunSucceeded(id IssueID, run *RunningEntry, el
 // folds elapsed time so the caller can decide whether to enqueue a
 // retry via ScheduleRetry.
 func (s *OrchestratorState) FinishRunFailed(id IssueID, run *RunningEntry, elapsed time.Duration) bool {
+	return s.finishRunAborted(id, run, elapsed)
+}
+
+// FinishRunReconciledCancelled releases a run that was stopped because the
+// tracker made it ineligible. It is intentionally separate from
+// FinishRunFailed so reconciliation cancellations are not counted as worker
+// failures and cannot consume retry budget.
+func (s *OrchestratorState) FinishRunReconciledCancelled(id IssueID, run *RunningEntry, elapsed time.Duration) bool {
+	return s.finishRunAborted(id, run, elapsed)
+}
+
+func (s *OrchestratorState) finishRunAborted(id IssueID, run *RunningEntry, elapsed time.Duration) bool {
 	if current, ok := s.Running[id]; !ok || current != run {
 		return false
 	}

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -24,12 +24,17 @@ type RepoConfig struct {
 }
 
 type TrackerConfig struct {
-	Kind           string              `yaml:"kind" json:"kind"`
-	APIKey         string              `yaml:"api_key" json:"api_key"`
-	TeamKey        string              `yaml:"team_key" json:"team_key"`
-	ProjectSlug    string              `yaml:"project_slug" json:"project_slug"`
-	ActiveStates   []string            `yaml:"active_states" json:"active_states"`
-	TerminalStates []string            `yaml:"terminal_states" json:"terminal_states"`
+	Kind           string   `yaml:"kind" json:"kind"`
+	APIKey         string   `yaml:"api_key" json:"api_key"`
+	TeamKey        string   `yaml:"team_key" json:"team_key"`
+	ProjectSlug    string   `yaml:"project_slug" json:"project_slug"`
+	ActiveStates   []string `yaml:"active_states" json:"active_states"`
+	TerminalStates []string `yaml:"terminal_states" json:"terminal_states"`
+	// InactiveStates names non-terminal tracker states that make an already
+	// running issue ineligible. Poll-tick reconciliation probes these states so
+	// operator pauses such as Backlog/Human Review cancel in-flight workers
+	// without treating issues missing from partial tracker listings as inactive.
+	InactiveStates []string            `yaml:"inactive_states" json:"inactive_states"`
 	PollIntervalMs int                 `yaml:"poll_interval_ms" json:"poll_interval_ms"`
 	Statuses       TrackerStatusConfig `yaml:"statuses" json:"statuses"`
 }


### PR DESCRIPTION
## Summary
- add poller reconciliation before dispatch so active runs are revalidated against tracker state on every tick
- propagate tracker-ineligible state changes to running worker context cancellation without consuming retry budget
- wire cmd/worker to use the reconciled poller and add regression coverage for Cancelled, Backlog, tracker-error, and stuck-worker timeout cases

Closes #78

## Test Plan
- [x] /home/pi/.local/go1.25.10/bin/go test ./internal/orchestrator -run 'TestPollOnce' -count=1 -v
- [x] /home/pi/.local/go1.25.10/bin/go test ./cmd/worker -run 'TestWorkerEntrypoint' -count=1 -v
- [x] /home/pi/.local/go1.25.10/bin/go test ./...

## Notes
- Read upstream Symphony SPEC §2.1 and the Elixir orchestrator reconciliation flow before making the change.
- Independent local diff-only review was run with Claude; concrete findings about reconcile-cancel classification and stuck-worker timeout coverage were addressed before opening this PR.
