### PR TITLE
feat: add workspace lifecycle hooks

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -133,13 +133,15 @@ func run(ctx context.Context, args []string) error {
 		return err
 	}
 	if err := worker.ReconcileStartup(ctx, worker.ReconcileConfig{
-		WorkspaceRoot:   cfg.WorkspaceRoot,
-		ActiveStates:    wf.Config.Tracker.ActiveStates,
-		TerminalStates:  wf.Config.Tracker.TerminalStates,
-		TrackerKind:     wf.Config.Tracker.Kind,
-		Tracker:         trackerClient,
-		Emitter:         worker.LogEventEmitter{},
-		ReconcileTaskID: "reconcile-startup",
+		WorkspaceRoot:     cfg.WorkspaceRoot,
+		ActiveStates:      wf.Config.Tracker.ActiveStates,
+		TerminalStates:    wf.Config.Tracker.TerminalStates,
+		TrackerKind:       wf.Config.Tracker.Kind,
+		Tracker:           trackerClient,
+		Emitter:           worker.LogEventEmitter{},
+		ReconcileTaskID:   "reconcile-startup",
+		BeforeRemoveHook:  wf.Config.Workspace.Hooks.BeforeRemove,
+		HookTimeoutMillis: wf.Config.Workspace.Hooks.TimeoutMs,
 	}); err != nil {
 		worker.LogReconcileError(err)
 		return err

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -116,6 +116,21 @@ func validateWorkflowForRuntime(path string, source workflow.Source, cfg workflo
 	return nil
 }
 
+func startupReconcileConfigForWorkflow(cfg workflow.Config, trackerClient worker.ReconcileTracker) worker.ReconcileConfig {
+	hooks := cfg.WorkspaceHooks()
+	return worker.ReconcileConfig{
+		WorkspaceRoot:     worker.LoadConfigFromEnv().WorkspaceRoot,
+		ActiveStates:      cfg.Tracker.ActiveStates,
+		TerminalStates:    cfg.Tracker.TerminalStates,
+		TrackerKind:       cfg.Tracker.Kind,
+		Tracker:           trackerClient,
+		Emitter:           worker.LogEventEmitter{},
+		ReconcileTaskID:   "reconcile-startup",
+		BeforeRemoveHook:  hooks.BeforeRemove,
+		HookTimeoutMillis: hooks.TimeoutMs,
+	}
+}
+
 func run(ctx context.Context, args []string) error {
 	cfg := worker.LoadConfigFromEnv()
 	wf, resolution, err := resolveStartupWorkflow(args)
@@ -132,17 +147,9 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := worker.ReconcileStartup(ctx, worker.ReconcileConfig{
-		WorkspaceRoot:     cfg.WorkspaceRoot,
-		ActiveStates:      wf.Config.Tracker.ActiveStates,
-		TerminalStates:    wf.Config.Tracker.TerminalStates,
-		TrackerKind:       wf.Config.Tracker.Kind,
-		Tracker:           trackerClient,
-		Emitter:           worker.LogEventEmitter{},
-		ReconcileTaskID:   "reconcile-startup",
-		BeforeRemoveHook:  wf.Config.Workspace.Hooks.BeforeRemove,
-		HookTimeoutMillis: wf.Config.Workspace.Hooks.TimeoutMs,
-	}); err != nil {
+	reconcileCfg := startupReconcileConfigForWorkflow(wf.Config, trackerClient)
+	reconcileCfg.WorkspaceRoot = cfg.WorkspaceRoot
+	if err := worker.ReconcileStartup(ctx, reconcileCfg); err != nil {
 		worker.LogReconcileError(err)
 		return err
 	}

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -165,6 +166,22 @@ func TestLoadWorkflowForStartupReconcileLogsConfiguredGiteaWorkflow(t *testing.T
 	}
 	if strings.Contains(gotLog, "reconciliation will be skipped") {
 		t.Fatalf("startup reconciliation log = %q, did not expect skip diagnostic", gotLog)
+	}
+}
+
+func TestStartupReconcileConfigUsesEffectiveWorkspaceHooks(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Hooks = workflow.WorkspaceHooks{
+		BeforeRemove: workflow.WorkspaceHook{Commands: []string{"printf top-level"}},
+		TimeoutMs:    1234,
+	}
+
+	reconcile := startupReconcileConfigForWorkflow(cfg, nil)
+	if !reflect.DeepEqual(reconcile.BeforeRemoveHook.Commands, []string{"printf top-level"}) {
+		t.Fatalf("BeforeRemoveHook.Commands = %#v, want top-level effective hook", reconcile.BeforeRemoveHook.Commands)
+	}
+	if reconcile.HookTimeoutMillis != 1234 {
+		t.Fatalf("HookTimeoutMillis = %d, want top-level effective timeout", reconcile.HookTimeoutMillis)
 	}
 }
 

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -23,6 +23,8 @@ const (
 	EventEnqueued             = "enqueued"
 	EventClaimed              = "claimed"
 	EventWorkflowResolved     = "workflow_resolved"
+	EventWorkspaceHookStart   = "hook_start"
+	EventWorkspaceHookEnd     = "hook_end"
 	EventRunnerStart          = "runner_start"
 	EventRunnerEnd            = "runner_end"
 	EventRunnerTimeout        = "runner_timeout"

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
 )
 
@@ -27,13 +28,15 @@ type ReconcileTracker interface {
 // pass. The pass is idempotent: active issue workspaces are preserved, while
 // terminal and unknown/deleted issue workspaces are removed before dispatch.
 type ReconcileConfig struct {
-	WorkspaceRoot   string
-	ActiveStates    []string
-	TerminalStates  []string
-	TrackerKind     string
-	Tracker         ReconcileTracker
-	Emitter         EventEmitter
-	ReconcileTaskID string
+	WorkspaceRoot     string
+	ActiveStates      []string
+	TerminalStates    []string
+	TrackerKind       string
+	Tracker           ReconcileTracker
+	Emitter           EventEmitter
+	ReconcileTaskID   string
+	BeforeRemoveHook  workflow.WorkspaceHook
+	HookTimeoutMillis int
 }
 
 // ReconcileStartup reconciles existing per-issue workspaces with tracker state.
@@ -223,6 +226,9 @@ func issueWorkspaceSourceDirs(trackerKind string) []string {
 }
 
 func removeWorkspace(ctx context.Context, cfg ReconcileConfig, taskID, path string, issue tracker.Issue, reason string) (bool, error) {
+	if err := runWorkspaceHook(ctx, cfg.Emitter, taskID, path, workspace.HookBeforeRemove, cfg.BeforeRemoveHook, cfg.HookTimeoutMillis); err != nil {
+		log.Printf("task %s: before_remove hook failed for %s workspace %s: %v", taskID, reason, path, err)
+	}
 	if err := os.RemoveAll(path); err != nil {
 		return false, fmt.Errorf("remove %s workspace %s: %w", reason, path, err)
 	}

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 type fakeReconcileTracker struct {
@@ -304,6 +305,50 @@ func TestReconcileStartupReturnsTrackerError(t *testing.T) {
 	}); err == nil {
 		t.Fatal("ReconcileStartup error = nil, want tracker error")
 	}
+}
+
+func TestReconcileStartupRunsBeforeRemoveHookAndStillRemovesOnFailure(t *testing.T) {
+	root := t.TempDir()
+	terminalPath := filepath.Join(root, "acme", "repo", "linear-issue", "LIN-1")
+	if err := os.MkdirAll(terminalPath, 0o755); err != nil {
+		t.Fatalf("mkdir terminal workspace: %v", err)
+	}
+	marker := filepath.Join(root, "hook-ran")
+	emitter := &fakeEmitter{}
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:  root,
+		ActiveStates:   []string{"AI Ready"},
+		TerminalStates: []string{"Done"},
+		TrackerKind:    "linear",
+		Tracker:        fakeReconcileTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Done"}}},
+		Emitter:        emitter,
+		BeforeRemoveHook: workflow.WorkspaceHook{Commands: []string{
+			"printf before_remove > " + shellQuote(marker),
+			"exit 9",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup should ignore before_remove hook failure and remove workspace: %v", err)
+	}
+	if _, err := os.Stat(terminalPath); !os.IsNotExist(err) {
+		t.Fatalf("terminal workspace should be removed despite before_remove failure; stat err=%v", err)
+	}
+	if body, err := os.ReadFile(marker); err != nil || string(body) != "before_remove" {
+		t.Fatalf("before_remove hook marker = %q, %v; want hook to run before removal", body, err)
+	}
+	var hookEnds int
+	for _, e := range emitter.events {
+		if e.Kind == task.EventWorkspaceHookEnd {
+			hookEnds++
+		}
+	}
+	if hookEnds != 2 {
+		t.Fatalf("hook_end events = %d, want 2 for both before_remove commands; events=%#v", hookEnds, emitter.events)
+	}
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 func TestReconcileStartupRejectsEmptyActiveStatesBeforeCleanup(t *testing.T) {

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -124,22 +124,58 @@ func handleTaskFailure(ctx context.Context, store failingStore, t task.Task, cfg
 // responsibility. The worker's role is: claim, prepare workspace, resolve
 // workflow, run agent session, enforce policy/secret-scan/RUN_SUMMARY gates,
 // emit events, and clean up.
+
+func emitHookResults(ctx context.Context, ev EventEmitter, taskID string, results []workspace.HookResult) {
+	for _, res := range results {
+		Emit(ctx, ev, taskID, task.EventWorkspaceHookEnd, string(res.Name)+" hook completed", map[string]any{
+			"hook":        string(res.Name),
+			"command":     res.Command,
+			"exit_code":   res.ExitCode,
+			"output":      res.Output,
+			"truncated":   res.Truncated,
+			"duration_ms": res.Duration.Milliseconds(),
+			"error":       ErrSummary(res.Err),
+		})
+	}
+}
+
+func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, workdir string, name workspace.HookName, hook workflow.WorkspaceHook, timeoutMs int) error {
+	if len(hook.Commands) == 0 {
+		return nil
+	}
+	Emit(ctx, ev, taskID, task.EventWorkspaceHookStart, string(name)+" hook started", map[string]any{
+		"hook":       string(name),
+		"commands":   len(hook.Commands),
+		"timeout_ms": timeoutMs,
+	})
+	results, err := workspace.RunWorkspaceHook(ctx, workdir, name, hook, timeoutMs)
+	emitHookResults(ctx, ev, taskID, results)
+	return err
+}
+
 // RunTask executes a single in-memory task. The orchestrator-backed worker path
 // uses this directly after claiming a tracker issue in runtime state; the
 // legacy queue loop also calls it for remaining tests/compatibility.
 func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *RunTaskError {
-	mgr := workspace.New(cfg.WorkspaceRoot)
-	mgr.MirrorRoot = cfg.MirrorRoot
-	workdir, _, err := mgr.PrepareGitWorkspace(ctx, t)
-	if err != nil {
-		return &RunTaskError{Err: err}
-	}
-
 	wf, workflowSource, err := ResolveWorkflow(ctx, ev, t.ID, cfg.Workflow)
 	if err != nil {
 		return &RunTaskError{Err: err}
 	}
 	wcfg := wf.Config
+
+	mgr := workspace.New(cfg.WorkspaceRoot)
+	mgr.MirrorRoot = cfg.MirrorRoot
+	workdir, createdNow, err := mgr.PrepareGitWorkspace(ctx, t)
+	if err != nil {
+		return &RunTaskError{Cfg: wcfg, Err: err}
+	}
+	if createdNow {
+		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, wcfg.Workspace.Hooks.AfterCreate, wcfg.Workspace.Hooks.TimeoutMs); err != nil {
+			_ = os.RemoveAll(workdir)
+			return &RunTaskError{Cfg: wcfg, Err: err}
+		}
+	}
+
 	if t.Model == "" || t.Model == "mock" {
 		t.Model = wcfg.Agent.Default
 		if t.Model == "" {
@@ -176,9 +212,18 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 		return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("reset run summary: %w", err)}
 	}
 
+	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookBeforeRun, wcfg.Workspace.Hooks.BeforeRun, wcfg.Workspace.Hooks.TimeoutMs); err != nil {
+		WriteFailureArtifacts(ctx, workdir, nil, "before_run hook failed: "+ErrSummary(err))
+		return &RunTaskError{Cfg: wcfg, Err: err}
+	}
+
 	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: cfg.WorkspaceRoot, Prompt: prompt}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
 		WriteFailureArtifacts(ctx, workdir, nil, "runner failed: "+ErrSummary(runErr))
 		return &RunTaskError{Cfg: wcfg, Err: runErr}
+	}
+
+	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, wcfg.Workspace.Hooks.AfterRun, wcfg.Workspace.Hooks.TimeoutMs); err != nil {
+		log.Printf("task %s: after_run hook failed: %v", t.ID, err)
 	}
 
 	if err := workspace.EnforcePolicy(ctx, workdir, wcfg); err != nil {

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -162,6 +162,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 		return &RunTaskError{Err: err}
 	}
 	wcfg := wf.Config
+	hooks := wcfg.WorkspaceHooks()
 
 	mgr := workspace.New(cfg.WorkspaceRoot)
 	mgr.MirrorRoot = cfg.MirrorRoot
@@ -170,7 +171,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 	if createdNow {
-		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, wcfg.Workspace.Hooks.AfterCreate, wcfg.Workspace.Hooks.TimeoutMs); err != nil {
+		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, hooks.AfterCreate, hooks.TimeoutMs); err != nil {
 			_ = os.RemoveAll(workdir)
 			return &RunTaskError{Cfg: wcfg, Err: err}
 		}
@@ -199,6 +200,9 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 
 	r, err := runner.New(t.Model)
 	if err != nil {
+		if hookErr := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs); hookErr != nil {
+			log.Printf("task %s: after_run hook failed after runner setup error: %v", t.ID, hookErr)
+		}
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
@@ -212,17 +216,20 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 		return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("reset run summary: %w", err)}
 	}
 
-	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookBeforeRun, wcfg.Workspace.Hooks.BeforeRun, wcfg.Workspace.Hooks.TimeoutMs); err != nil {
+	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookBeforeRun, hooks.BeforeRun, hooks.TimeoutMs); err != nil {
 		WriteFailureArtifacts(ctx, workdir, nil, "before_run hook failed: "+ErrSummary(err))
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
 	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: cfg.WorkspaceRoot, Prompt: prompt}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
+		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs); err != nil {
+			log.Printf("task %s: after_run hook failed after runner error: %v", t.ID, err)
+		}
 		WriteFailureArtifacts(ctx, workdir, nil, "runner failed: "+ErrSummary(runErr))
 		return &RunTaskError{Cfg: wcfg, Err: runErr}
 	}
 
-	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, wcfg.Workspace.Hooks.AfterRun, wcfg.Workspace.Hooks.TimeoutMs); err != nil {
+	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs); err != nil {
 		log.Printf("task %s: after_run hook failed: %v", t.ID, err)
 	}
 

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -166,15 +166,13 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) *Run
 
 	mgr := workspace.New(cfg.WorkspaceRoot)
 	mgr.MirrorRoot = cfg.MirrorRoot
-	workdir, createdNow, err := mgr.PrepareGitWorkspace(ctx, t)
+	workdir, _, err := mgr.PrepareGitWorkspace(ctx, t)
 	if err != nil {
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
-	if createdNow {
-		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, hooks.AfterCreate, hooks.TimeoutMs); err != nil {
-			_ = os.RemoveAll(workdir)
-			return &RunTaskError{Cfg: wcfg, Err: err}
-		}
+	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, hooks.AfterCreate, hooks.TimeoutMs); err != nil {
+		_ = os.RemoveAll(workdir)
+		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
 	if t.Model == "" || t.Model == "mock" {

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -180,6 +180,40 @@ func TestRunTaskExecutesWorkspaceHooksAroundRunner(t *testing.T) {
 	}
 }
 
+func TestRunTaskExecutesAfterCreateHookOnRecreatedWorkspace(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+
+	ev := &fakeEmitter{}
+	cfg := workerCfgForIntegration(t)
+	cfg.Workflow.Config.Hooks = workflow.WorkspaceHooks{
+		AfterCreate: workflow.WorkspaceHook{Commands: []string{"printf after_create >> hook.log"}},
+	}
+
+	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		t.Fatalf("first runTask: %v", rterr.Err)
+	}
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	if err := os.WriteFile(filepath.Join(workdir, "stale.txt"), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale marker: %v", err)
+	}
+
+	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		t.Fatalf("second runTask: %v", rterr.Err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(workdir, "hook.log"))
+	if err != nil {
+		t.Fatalf("read recreated hook log: %v", err)
+	}
+	if string(body) != "after_create" {
+		t.Fatalf("recreated hook log = %q, want after_create from the second fresh checkout", body)
+	}
+	if _, err := os.Stat(filepath.Join(workdir, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatalf("second run should recreate a clean workspace without stale marker; stat err=%v", err)
+	}
+}
+
 func TestRunTaskExecutesAfterRunHookWhenRunnerFails(t *testing.T) {
 	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
 	t.Setenv("REPO_URL", cloneURL)

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -2,6 +2,7 @@ package worker_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,6 +116,68 @@ func writeServiceWorkflowForIntegration(t *testing.T, body string) string {
 		t.Fatalf("write service workflow: %v", err)
 	}
 	return path
+}
+
+func TestRunTaskExecutesWorkspaceHooksAroundRunner(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+
+	ev := &fakeEmitter{}
+	cfg := workerCfgForIntegration(t)
+	cfg.Workflow.Config.Workspace.Hooks = workflow.WorkspaceHooks{
+		AfterCreate:  workflow.WorkspaceHook{Commands: []string{"printf after_create >> hook.log"}},
+		BeforeRun:    workflow.WorkspaceHook{Commands: []string{"printf before_run >> hook.log"}},
+		AfterRun:     workflow.WorkspaceHook{Commands: []string{"printf after_run >> hook.log"}},
+		BeforeRemove: workflow.WorkspaceHook{Commands: []string{"printf before_remove >> ../before_remove.log"}},
+	}
+
+	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		t.Fatalf("runTask: %v", rterr.Err)
+	}
+
+	type step struct {
+		kind string
+		hook string
+	}
+	wantSteps := []step{
+		{kind: task.EventWorkspaceHookStart, hook: "after_create"},
+		{kind: task.EventWorkspaceHookEnd, hook: "after_create"},
+		{kind: task.EventWorkspaceHookStart, hook: "before_run"},
+		{kind: task.EventWorkspaceHookEnd, hook: "before_run"},
+		{kind: task.EventRunnerStart},
+		{kind: task.EventRunnerEnd},
+		{kind: task.EventWorkspaceHookStart, hook: "after_run"},
+		{kind: task.EventWorkspaceHookEnd, hook: "after_run"},
+	}
+	var got []step
+	for _, e := range ev.events {
+		switch e.Kind {
+		case task.EventWorkspaceHookStart, task.EventWorkspaceHookEnd:
+			got = append(got, step{kind: e.Kind, hook: fmt.Sprint(e.Payload.(map[string]any)["hook"])})
+		case task.EventRunnerStart, task.EventRunnerEnd:
+			got = append(got, step{kind: e.Kind})
+		}
+	}
+	if len(got) < len(wantSteps) {
+		t.Fatalf("hook/runner event count = %d, want at least %d; events=%#v", len(got), len(wantSteps), ev.events)
+	}
+	for i, want := range wantSteps {
+		if got[i] != want {
+			t.Fatalf("event[%d] = %#v, want %#v; got sequence=%#v", i, got[i], want, got)
+		}
+	}
+
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	body, err := os.ReadFile(filepath.Join(workdir, "hook.log"))
+	if err != nil {
+		t.Fatalf("read hook log: %v", err)
+	}
+	if string(body) != "after_createbefore_runafter_run" {
+		t.Fatalf("hook log = %q, want hooks to run in order around runner", body)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(workdir), "before_remove.log")); !os.IsNotExist(err) {
+		t.Fatalf("before_remove hook should not run during normal RunTask completion; stat err=%v", err)
+	}
 }
 
 // TestRunTask_SuccessDoesNotPushCreatePROrWriteTracker pins the SPEC §1

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -180,6 +180,32 @@ func TestRunTaskExecutesWorkspaceHooksAroundRunner(t *testing.T) {
 	}
 }
 
+func TestRunTaskExecutesAfterRunHookWhenRunnerFails(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+	tk.Model = "does-not-exist"
+
+	ev := &fakeEmitter{}
+	cfg := workerCfgForIntegration(t)
+	cfg.Workflow.Config.Hooks = workflow.WorkspaceHooks{
+		AfterRun: workflow.WorkspaceHook{Commands: []string{"printf after_run >> hook.log"}},
+	}
+
+	rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg)
+	if rterr == nil {
+		t.Fatal("runTask succeeded, want runner setup failure")
+	}
+
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	body, err := os.ReadFile(filepath.Join(workdir, "hook.log"))
+	if err != nil {
+		t.Fatalf("read hook log: %v", err)
+	}
+	if string(body) != "after_run" {
+		t.Fatalf("hook log = %q, want after_run hook to execute on failed attempt", body)
+	}
+}
+
 // TestRunTask_SuccessDoesNotPushCreatePROrWriteTracker pins the SPEC §1
 // boundary: a successful worker run prepares the workspace, executes the
 // agent, and enforces gates, but it does not push branches, create PRs, or

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -12,14 +12,20 @@ type Config struct {
 	Tracker   TrackerConfig   `yaml:"tracker" json:"tracker"`
 	Hooks     WorkspaceHooks  `yaml:"hooks" json:"hooks"`
 	Workspace WorkspaceConfig `yaml:"workspace" json:"workspace"`
-	Agent     AgentConfig     `yaml:"agent" json:"agent"`
-	Codex     CommandConfig   `yaml:"codex" json:"codex"`
-	Claude    CommandConfig   `yaml:"claude" json:"claude"`
-	Policy    PolicyConfig    `yaml:"policy" json:"policy"`
-	Safety    SafetyConfig    `yaml:"safety" json:"safety"`
-	Sandbox   SandboxConfig   `yaml:"sandbox" json:"sandbox"`
-	Verify    VerifyConfig    `yaml:"verify" json:"verify"`
-	PR        PRConfig        `yaml:"pr" json:"pr"`
+
+	// hooksTimeoutDefaulted is true when Hooks.TimeoutMs came from DefaultConfig
+	// rather than WORKFLOW.md. It lets WorkspaceHooks keep the SPEC default while
+	// still honoring the legacy workspace.hooks.timeout_ms override during the
+	// one-release migration window.
+	hooksTimeoutDefaulted bool
+	Agent                 AgentConfig   `yaml:"agent" json:"agent"`
+	Codex                 CommandConfig `yaml:"codex" json:"codex"`
+	Claude                CommandConfig `yaml:"claude" json:"claude"`
+	Policy                PolicyConfig  `yaml:"policy" json:"policy"`
+	Safety                SafetyConfig  `yaml:"safety" json:"safety"`
+	Sandbox               SandboxConfig `yaml:"sandbox" json:"sandbox"`
+	Verify                VerifyConfig  `yaml:"verify" json:"verify"`
+	PR                    PRConfig      `yaml:"pr" json:"pr"`
 }
 
 type RepoConfig struct {
@@ -128,11 +134,11 @@ func (c Config) WorkspaceHooks() WorkspaceHooks {
 	if !hooks.BeforeRemove.HasCommands() && legacy.BeforeRemove.HasCommands() {
 		hooks.BeforeRemove = legacy.BeforeRemove
 	}
-	if hooks.TimeoutMs <= 0 {
+	if legacy.TimeoutMs > 0 && (hooks.TimeoutMs <= 0 || c.hooksTimeoutDefaulted) {
 		hooks.TimeoutMs = legacy.TimeoutMs
 	}
 	if hooks.TimeoutMs <= 0 {
-		hooks.TimeoutMs = c.Hooks.TimeoutMs
+		hooks.TimeoutMs = 60000
 	}
 	return hooks
 }
@@ -310,8 +316,9 @@ func DefaultConfig() Config {
 				Rework:      "Rework",
 			},
 		},
-		Hooks:     WorkspaceHooks{TimeoutMs: 60000},
-		Workspace: WorkspaceConfig{Root: "~/aiops-workspaces"},
+		Hooks:                 WorkspaceHooks{TimeoutMs: 60000},
+		hooksTimeoutDefaulted: true,
+		Workspace:             WorkspaceConfig{Root: "~/aiops-workspaces"},
 		// Agent.MaxTimeoutRetries is intentionally left nil here so the
 		// "absent" signal survives a YAML unmarshal that overlays this
 		// default. The effective default of 1 retry is supplied by

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -257,7 +257,7 @@ func DefaultConfig() Config {
 				Rework:      "Rework",
 			},
 		},
-		Hooks:     WorkspaceHooks{TimeoutMs: 500},
+		Hooks:     WorkspaceHooks{TimeoutMs: 60000},
 		Workspace: WorkspaceConfig{Root: "~/aiops-workspaces"},
 		// Agent.MaxTimeoutRetries is intentionally left nil here so the
 		// "absent" signal survives a YAML unmarshal that overlays this

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -52,7 +52,20 @@ type TrackerStatusConfig struct {
 }
 
 type WorkspaceConfig struct {
-	Root string `yaml:"root" json:"root"`
+	Root  string         `yaml:"root" json:"root"`
+	Hooks WorkspaceHooks `yaml:"hooks" json:"hooks"`
+}
+
+type WorkspaceHooks struct {
+	AfterCreate  WorkspaceHook `yaml:"after_create" json:"after_create"`
+	BeforeRun    WorkspaceHook `yaml:"before_run" json:"before_run"`
+	AfterRun     WorkspaceHook `yaml:"after_run" json:"after_run"`
+	BeforeRemove WorkspaceHook `yaml:"before_remove" json:"before_remove"`
+	TimeoutMs    int           `yaml:"timeout_ms" json:"timeout_ms"`
+}
+
+type WorkspaceHook struct {
+	Commands []string `yaml:"commands" json:"commands"`
 }
 
 type AgentConfig struct {

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -5,6 +5,7 @@ import "time"
 type Config struct {
 	Repo      RepoConfig      `yaml:"repo" json:"repo"`
 	Tracker   TrackerConfig   `yaml:"tracker" json:"tracker"`
+	Hooks     WorkspaceHooks  `yaml:"hooks" json:"hooks"`
 	Workspace WorkspaceConfig `yaml:"workspace" json:"workspace"`
 	Agent     AgentConfig     `yaml:"agent" json:"agent"`
 	Codex     CommandConfig   `yaml:"codex" json:"codex"`
@@ -66,6 +67,21 @@ type WorkspaceHooks struct {
 
 type WorkspaceHook struct {
 	Commands []string `yaml:"commands" json:"commands"`
+}
+
+func (h WorkspaceHooks) HasCommands() bool {
+	return len(h.AfterCreate.Commands) > 0 || len(h.BeforeRun.Commands) > 0 || len(h.AfterRun.Commands) > 0 || len(h.BeforeRemove.Commands) > 0
+}
+
+func (c Config) WorkspaceHooks() WorkspaceHooks {
+	hooks := c.Hooks
+	if !hooks.HasCommands() && c.Workspace.Hooks.HasCommands() {
+		hooks = c.Workspace.Hooks
+	}
+	if hooks.TimeoutMs <= 0 {
+		hooks.TimeoutMs = c.Hooks.TimeoutMs
+	}
+	return hooks
 }
 
 type AgentConfig struct {
@@ -241,6 +257,7 @@ func DefaultConfig() Config {
 				Rework:      "Rework",
 			},
 		},
+		Hooks:     WorkspaceHooks{TimeoutMs: 500},
 		Workspace: WorkspaceConfig{Root: "~/aiops-workspaces"},
 		// Agent.MaxTimeoutRetries is intentionally left nil here so the
 		// "absent" signal survives a YAML unmarshal that overlays this

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -1,6 +1,11 @@
 package workflow
 
-import "time"
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
 
 type Config struct {
 	Repo      RepoConfig      `yaml:"repo" json:"repo"`
@@ -69,14 +74,62 @@ type WorkspaceHook struct {
 	Commands []string `yaml:"commands" json:"commands"`
 }
 
+func (h *WorkspaceHook) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		var command string
+		if err := value.Decode(&command); err != nil {
+			return err
+		}
+		if command != "" {
+			h.Commands = []string{command}
+		}
+		return nil
+	case yaml.SequenceNode:
+		var commands []string
+		if err := value.Decode(&commands); err != nil {
+			return err
+		}
+		h.Commands = commands
+		return nil
+	case yaml.MappingNode:
+		type workspaceHook WorkspaceHook
+		var decoded workspaceHook
+		if err := value.Decode(&decoded); err != nil {
+			return err
+		}
+		*h = WorkspaceHook(decoded)
+		return nil
+	default:
+		return fmt.Errorf("workspace hook must be a shell script string, command list, or commands object")
+	}
+}
+
+func (h WorkspaceHook) HasCommands() bool {
+	return len(h.Commands) > 0
+}
+
 func (h WorkspaceHooks) HasCommands() bool {
-	return len(h.AfterCreate.Commands) > 0 || len(h.BeforeRun.Commands) > 0 || len(h.AfterRun.Commands) > 0 || len(h.BeforeRemove.Commands) > 0
+	return h.AfterCreate.HasCommands() || h.BeforeRun.HasCommands() || h.AfterRun.HasCommands() || h.BeforeRemove.HasCommands()
 }
 
 func (c Config) WorkspaceHooks() WorkspaceHooks {
 	hooks := c.Hooks
-	if !hooks.HasCommands() && c.Workspace.Hooks.HasCommands() {
-		hooks = c.Workspace.Hooks
+	legacy := c.Workspace.Hooks
+	if !hooks.AfterCreate.HasCommands() && legacy.AfterCreate.HasCommands() {
+		hooks.AfterCreate = legacy.AfterCreate
+	}
+	if !hooks.BeforeRun.HasCommands() && legacy.BeforeRun.HasCommands() {
+		hooks.BeforeRun = legacy.BeforeRun
+	}
+	if !hooks.AfterRun.HasCommands() && legacy.AfterRun.HasCommands() {
+		hooks.AfterRun = legacy.AfterRun
+	}
+	if !hooks.BeforeRemove.HasCommands() && legacy.BeforeRemove.HasCommands() {
+		hooks.BeforeRemove = legacy.BeforeRemove
+	}
+	if hooks.TimeoutMs <= 0 {
+		hooks.TimeoutMs = legacy.TimeoutMs
 	}
 	if hooks.TimeoutMs <= 0 {
 		hooks.TimeoutMs = c.Hooks.TimeoutMs

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Config struct {
-	Repo      RepoConfig      `yaml:"repo" json:"repo"`
-	Tracker   TrackerConfig   `yaml:"tracker" json:"tracker"`
-	Hooks     WorkspaceHooks  `yaml:"hooks" json:"hooks"`
-	Workspace WorkspaceConfig `yaml:"workspace" json:"workspace"`
+	Repo       RepoConfig      `yaml:"repo" json:"repo"`
+	Tracker    TrackerConfig   `yaml:"tracker" json:"tracker"`
+	Hooks      WorkspaceHooks  `yaml:"hooks" json:"hooks"`
+	Workspace  WorkspaceConfig `yaml:"workspace" json:"workspace"`
+	hookFields HookFieldPresence
 
 	// hooksTimeoutDefaulted is true when Hooks.TimeoutMs came from DefaultConfig
 	// rather than WORKFLOW.md. It lets WorkspaceHooks keep the SPEC default while
@@ -64,8 +65,9 @@ type TrackerStatusConfig struct {
 }
 
 type WorkspaceConfig struct {
-	Root  string         `yaml:"root" json:"root"`
-	Hooks WorkspaceHooks `yaml:"hooks" json:"hooks"`
+	Root       string         `yaml:"root" json:"root"`
+	Hooks      WorkspaceHooks `yaml:"hooks" json:"hooks"`
+	hookFields HookFieldPresence
 }
 
 type WorkspaceHooks struct {
@@ -74,6 +76,14 @@ type WorkspaceHooks struct {
 	AfterRun     WorkspaceHook `yaml:"after_run" json:"after_run"`
 	BeforeRemove WorkspaceHook `yaml:"before_remove" json:"before_remove"`
 	TimeoutMs    int           `yaml:"timeout_ms" json:"timeout_ms"`
+}
+
+type HookFieldPresence struct {
+	AfterCreate  bool
+	BeforeRun    bool
+	AfterRun     bool
+	BeforeRemove bool
+	TimeoutMs    bool
 }
 
 type WorkspaceHook struct {
@@ -122,19 +132,19 @@ func (h WorkspaceHooks) HasCommands() bool {
 func (c Config) WorkspaceHooks() WorkspaceHooks {
 	hooks := c.Hooks
 	legacy := c.Workspace.Hooks
-	if !hooks.AfterCreate.HasCommands() && legacy.AfterCreate.HasCommands() {
+	if !c.hookFields.AfterCreate && legacy.AfterCreate.HasCommands() {
 		hooks.AfterCreate = legacy.AfterCreate
 	}
-	if !hooks.BeforeRun.HasCommands() && legacy.BeforeRun.HasCommands() {
+	if !c.hookFields.BeforeRun && legacy.BeforeRun.HasCommands() {
 		hooks.BeforeRun = legacy.BeforeRun
 	}
-	if !hooks.AfterRun.HasCommands() && legacy.AfterRun.HasCommands() {
+	if !c.hookFields.AfterRun && legacy.AfterRun.HasCommands() {
 		hooks.AfterRun = legacy.AfterRun
 	}
-	if !hooks.BeforeRemove.HasCommands() && legacy.BeforeRemove.HasCommands() {
+	if !c.hookFields.BeforeRemove && legacy.BeforeRemove.HasCommands() {
 		hooks.BeforeRemove = legacy.BeforeRemove
 	}
-	if legacy.TimeoutMs > 0 && (hooks.TimeoutMs <= 0 || c.hooksTimeoutDefaulted) {
+	if legacy.TimeoutMs > 0 && !c.hookFields.TimeoutMs {
 		hooks.TimeoutMs = legacy.TimeoutMs
 	}
 	if hooks.TimeoutMs <= 0 {

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -205,13 +205,11 @@ prompt body
 func TestWorkspaceHooksMergesTopLevelAndLegacyPerHook(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Hooks = WorkspaceHooks{
-		AfterRun:  WorkspaceHook{Commands: []string{"printf top-after-run"}},
-		TimeoutMs: 0,
+		AfterRun: WorkspaceHook{Commands: []string{"printf top-after-run"}},
 	}
 	cfg.Workspace.Hooks = WorkspaceHooks{
 		AfterCreate:  WorkspaceHook{Commands: []string{"printf legacy-after-create"}},
 		BeforeRemove: WorkspaceHook{Commands: []string{"printf legacy-before-remove"}},
-		TimeoutMs:    4321,
 	}
 
 	hooks := cfg.WorkspaceHooks()
@@ -224,8 +222,51 @@ func TestWorkspaceHooksMergesTopLevelAndLegacyPerHook(t *testing.T) {
 	if !reflect.DeepEqual(hooks.BeforeRemove.Commands, []string{"printf legacy-before-remove"}) {
 		t.Fatalf("BeforeRemove.Commands = %#v", hooks.BeforeRemove.Commands)
 	}
-	if hooks.TimeoutMs != 4321 {
-		t.Fatalf("TimeoutMs = %d, want legacy timeout fallback 4321", hooks.TimeoutMs)
+}
+
+func TestWorkspaceHooksHonorsLegacyTimeoutOverride(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+workspace:
+  hooks:
+    timeout_ms: 4321
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := wf.Config.WorkspaceHooks().TimeoutMs; got != 4321 {
+		t.Fatalf("WorkspaceHooks().TimeoutMs = %d, want legacy timeout override 4321", got)
+	}
+}
+
+func TestWorkspaceHooksPrefersExplicitTopLevelTimeout(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  timeout_ms: 1234
+workspace:
+  hooks:
+    timeout_ms: 4321
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := wf.Config.WorkspaceHooks().TimeoutMs; got != 1234 {
+		t.Fatalf("WorkspaceHooks().TimeoutMs = %d, want explicit top-level timeout 1234", got)
 	}
 }
 

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -168,8 +168,8 @@ prompt body
 }
 
 func TestDefaultConfigWorkspaceHooksTimeout(t *testing.T) {
-	if got := DefaultConfig().Hooks.TimeoutMs; got <= 0 {
-		t.Fatalf("DefaultConfig().Hooks.TimeoutMs = %d, want safe nonzero default", got)
+	if got, want := DefaultConfig().Hooks.TimeoutMs, 60000; got != want {
+		t.Fatalf("DefaultConfig().Hooks.TimeoutMs = %d, want SPEC default %d", got, want)
 	}
 }
 

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -270,6 +270,31 @@ prompt body
 	}
 }
 
+func TestWorkspaceHooksPreservesExplicitEmptyTopLevelOverride(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  before_run: []
+workspace:
+  hooks:
+    before_run:
+      - printf legacy-before-run
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := wf.Config.WorkspaceHooks().BeforeRun.Commands; len(got) != 0 {
+		t.Fatalf("WorkspaceHooks().BeforeRun.Commands = %#v, want explicit empty top-level hook to suppress legacy hook", got)
+	}
+}
+
 func TestDefaultConfigWorkspaceHooksTimeout(t *testing.T) {
 	if got, want := DefaultConfig().Hooks.TimeoutMs, 60000; got != want {
 		t.Fatalf("DefaultConfig().Hooks.TimeoutMs = %d, want SPEC default %d", got, want)

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -167,6 +167,68 @@ prompt body
 	}
 }
 
+func TestLoadParsesSpecWorkspaceHookScriptStrings(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  after_create: |
+    printf after_create
+  before_run: printf before_run
+  after_run: |
+    printf after_run
+  before_remove: printf before_remove
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	hooks := wf.Config.Hooks
+	if !reflect.DeepEqual(hooks.AfterCreate.Commands, []string{"printf after_create\n"}) {
+		t.Fatalf("Hooks.AfterCreate.Commands = %#v", hooks.AfterCreate.Commands)
+	}
+	if !reflect.DeepEqual(hooks.BeforeRun.Commands, []string{"printf before_run"}) {
+		t.Fatalf("Hooks.BeforeRun.Commands = %#v", hooks.BeforeRun.Commands)
+	}
+	if !reflect.DeepEqual(hooks.AfterRun.Commands, []string{"printf after_run\n"}) {
+		t.Fatalf("Hooks.AfterRun.Commands = %#v", hooks.AfterRun.Commands)
+	}
+	if !reflect.DeepEqual(hooks.BeforeRemove.Commands, []string{"printf before_remove"}) {
+		t.Fatalf("Hooks.BeforeRemove.Commands = %#v", hooks.BeforeRemove.Commands)
+	}
+}
+
+func TestWorkspaceHooksMergesTopLevelAndLegacyPerHook(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Hooks = WorkspaceHooks{
+		AfterRun:  WorkspaceHook{Commands: []string{"printf top-after-run"}},
+		TimeoutMs: 0,
+	}
+	cfg.Workspace.Hooks = WorkspaceHooks{
+		AfterCreate:  WorkspaceHook{Commands: []string{"printf legacy-after-create"}},
+		BeforeRemove: WorkspaceHook{Commands: []string{"printf legacy-before-remove"}},
+		TimeoutMs:    4321,
+	}
+
+	hooks := cfg.WorkspaceHooks()
+	if !reflect.DeepEqual(hooks.AfterCreate.Commands, []string{"printf legacy-after-create"}) {
+		t.Fatalf("AfterCreate.Commands = %#v", hooks.AfterCreate.Commands)
+	}
+	if !reflect.DeepEqual(hooks.AfterRun.Commands, []string{"printf top-after-run"}) {
+		t.Fatalf("AfterRun.Commands = %#v", hooks.AfterRun.Commands)
+	}
+	if !reflect.DeepEqual(hooks.BeforeRemove.Commands, []string{"printf legacy-before-remove"}) {
+		t.Fatalf("BeforeRemove.Commands = %#v", hooks.BeforeRemove.Commands)
+	}
+	if hooks.TimeoutMs != 4321 {
+		t.Fatalf("TimeoutMs = %d, want legacy timeout fallback 4321", hooks.TimeoutMs)
+	}
+}
+
 func TestDefaultConfigWorkspaceHooksTimeout(t *testing.T) {
 	if got, want := DefaultConfig().Hooks.TimeoutMs, 60000; got != want {
 		t.Fatalf("DefaultConfig().Hooks.TimeoutMs = %d, want SPEC default %d", got, want)

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -122,6 +122,77 @@ func TestDefaultConfigAgentTimeout(t *testing.T) {
 	}
 }
 
+func TestLoadParsesTopLevelWorkspaceHooks(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  after_create:
+    commands:
+      - printf after_create
+  before_run:
+    commands:
+      - printf before_run
+  after_run:
+    commands:
+      - printf after_run
+  before_remove:
+    commands:
+      - printf before_remove
+  timeout_ms: 1234
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	hooks := wf.Config.Hooks
+	if !reflect.DeepEqual(hooks.AfterCreate.Commands, []string{"printf after_create"}) {
+		t.Fatalf("Hooks.AfterCreate.Commands = %#v", hooks.AfterCreate.Commands)
+	}
+	if !reflect.DeepEqual(hooks.BeforeRun.Commands, []string{"printf before_run"}) {
+		t.Fatalf("Hooks.BeforeRun.Commands = %#v", hooks.BeforeRun.Commands)
+	}
+	if !reflect.DeepEqual(hooks.AfterRun.Commands, []string{"printf after_run"}) {
+		t.Fatalf("Hooks.AfterRun.Commands = %#v", hooks.AfterRun.Commands)
+	}
+	if !reflect.DeepEqual(hooks.BeforeRemove.Commands, []string{"printf before_remove"}) {
+		t.Fatalf("Hooks.BeforeRemove.Commands = %#v", hooks.BeforeRemove.Commands)
+	}
+	if hooks.TimeoutMs != 1234 {
+		t.Fatalf("Hooks.TimeoutMs = %d, want 1234", hooks.TimeoutMs)
+	}
+}
+
+func TestDefaultConfigWorkspaceHooksTimeout(t *testing.T) {
+	if got := DefaultConfig().Hooks.TimeoutMs; got <= 0 {
+		t.Fatalf("DefaultConfig().Hooks.TimeoutMs = %d, want safe nonzero default", got)
+	}
+}
+
+func TestLoadRejectsNegativeWorkspaceHooksTimeout(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  timeout_ms: -1
+---
+prompt body
+`
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load succeeded, want negative hooks.timeout_ms validation error")
+	}
+	if !strings.Contains(err.Error(), "hooks.timeout_ms") {
+		t.Fatalf("Load error = %v, want hooks.timeout_ms", err)
+	}
+}
+
 func TestDefaultConfigSandboxDisabled(t *testing.T) {
 	cfg := DefaultConfig()
 	if cfg.Sandbox.Enabled {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -31,11 +31,14 @@ func Load(path string) (*Workflow, error) {
 		if err := rejectRemovedFields(frontBytes); err != nil {
 			return nil, err
 		}
-		hasTopLevelHookTimeout := hasNestedKey(frontBytes, "hooks", "timeout_ms")
+		hookFields := hookFieldPresence(frontBytes, "hooks")
+		legacyHookFields := hookFieldPresence(frontBytes, "workspace", "hooks")
 		if err := yaml.Unmarshal(frontBytes, &cfg); err != nil {
 			return nil, fmt.Errorf("parse workflow front matter: %w", err)
 		}
-		if hasTopLevelHookTimeout {
+		cfg.hookFields = hookFields
+		cfg.Workspace.hookFields = legacyHookFields
+		if hookFields.TimeoutMs {
 			cfg.hooksTimeoutDefaulted = false
 		}
 	}
@@ -199,6 +202,16 @@ func hasNestedKey(front []byte, path ...string) bool {
 		}
 	}
 	return true
+}
+
+func hookFieldPresence(front []byte, path ...string) HookFieldPresence {
+	return HookFieldPresence{
+		AfterCreate:  hasNestedKey(front, append(path, "after_create")...),
+		BeforeRun:    hasNestedKey(front, append(path, "before_run")...),
+		AfterRun:     hasNestedKey(front, append(path, "after_run")...),
+		BeforeRemove: hasNestedKey(front, append(path, "before_remove")...),
+		TimeoutMs:    hasNestedKey(front, append(path, "timeout_ms")...),
+	}
 }
 
 func rejectRemovedFields(front []byte) error {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -27,11 +27,16 @@ func Load(path string) (*Workflow, error) {
 	cfg := DefaultConfig()
 	hasFrontMatter := strings.TrimSpace(front) != ""
 	if hasFrontMatter {
-		if err := rejectRemovedFields([]byte(front)); err != nil {
+		frontBytes := []byte(front)
+		if err := rejectRemovedFields(frontBytes); err != nil {
 			return nil, err
 		}
-		if err := yaml.Unmarshal([]byte(front), &cfg); err != nil {
+		hasTopLevelHookTimeout := hasNestedKey(frontBytes, "hooks", "timeout_ms")
+		if err := yaml.Unmarshal(frontBytes, &cfg); err != nil {
 			return nil, fmt.Errorf("parse workflow front matter: %w", err)
+		}
+		if hasTopLevelHookTimeout {
+			cfg.hooksTimeoutDefaulted = false
 		}
 	}
 	expandConfig(&cfg)
@@ -177,6 +182,25 @@ func validateConfig(path string, cfg Config) error {
 // drops unknown fields, which would let workflow authors keep believing
 // the key still controls behavior. Targeted detection keeps existing
 // benign extras working while flagging known footguns.
+func hasNestedKey(front []byte, path ...string) bool {
+	var raw map[string]any
+	if err := yaml.Unmarshal(front, &raw); err != nil {
+		return false
+	}
+	var current any = raw
+	for _, key := range path {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current, ok = m[key]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func rejectRemovedFields(front []byte) error {
 	var raw map[string]any
 	if err := yaml.Unmarshal(front, &raw); err != nil {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -150,6 +150,12 @@ func validateConfig(path string, cfg Config) error {
 	if strings.TrimSpace(cfg.Claude.Profile) != "" {
 		return fmt.Errorf("%s: claude.profile is not supported (only codex has profiles)", path)
 	}
+	if cfg.Hooks.TimeoutMs < 0 {
+		return fmt.Errorf("%s: hooks.timeout_ms must be non-negative", path)
+	}
+	if cfg.Workspace.Hooks.TimeoutMs < 0 {
+		return fmt.Errorf("%s: workspace.hooks.timeout_ms must be non-negative", path)
+	}
 	var invalid []string
 	if cfg.Codex.TurnTimeoutMs <= 0 {
 		invalid = append(invalid, "codex.turn_timeout_ms")

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -227,6 +228,20 @@ func EffectiveWorkspaceHookTimeoutMs(timeoutMs int) int {
 	return workflow.DefaultConfig().Hooks.TimeoutMs
 }
 
+func workspaceHookWaitDelay(timeoutMs int) time.Duration {
+	if timeoutMs <= 0 {
+		return 100 * time.Millisecond
+	}
+	grace := time.Duration(math.Ceil(float64(timeoutMs)/10)) * time.Millisecond
+	if grace < 100*time.Millisecond {
+		return 100 * time.Millisecond
+	}
+	if grace > time.Second {
+		return time.Second
+	}
+	return grace
+}
+
 func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName, command string, timeoutMs int) HookResult {
 	start := time.Now()
 	runCtx := ctx
@@ -235,6 +250,7 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 		runCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutMs)*time.Millisecond)
 	}
 	defer cancel()
+	waitDelay := workspaceHookWaitDelay(timeoutMs)
 
 	cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
 	cmd.Dir = workdir
@@ -245,7 +261,7 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 		}
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 	}
-	cmd.WaitDelay = 100 * time.Millisecond
+	cmd.WaitDelay = waitDelay
 	var out cappedBuffer
 	out.Cap = VerifyOutputCap
 	cmd.Stdout = &out
@@ -263,7 +279,11 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 	case err = <-done:
 	case <-runCtx.Done():
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		err = <-done
+		select {
+		case err = <-done:
+		case <-time.After(waitDelay):
+			err = fmt.Errorf("hook wait exceeded cleanup grace after timeout: %w", runCtx.Err())
+		}
 	}
 	res := HookResult{Name: name, Command: command, ExitCode: exitCode(err), Output: out.String(), Truncated: out.Truncated(), Duration: time.Since(start), Err: err}
 	if runCtx.Err() == context.DeadlineExceeded {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -236,9 +236,16 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 	}
 	defer cancel()
 
-	cmd := exec.Command("sh", "-lc", command)
+	cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
 	cmd.Dir = workdir
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 100 * time.Millisecond
 	var out cappedBuffer
 	out.Cap = VerifyOutputCap
 	cmd.Stdout = &out

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -204,6 +204,7 @@ func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string,
 // RunWorkspaceHook executes the configured shell commands for a lifecycle hook
 // in workdir, in order, using the shared workspace hook timeout.
 func RunWorkspaceHook(ctx context.Context, workdir string, name HookName, hook workflow.WorkspaceHook, timeoutMs int) ([]HookResult, error) {
+	timeoutMs = EffectiveWorkspaceHookTimeoutMs(timeoutMs)
 	results := make([]HookResult, 0, len(hook.Commands))
 	for _, raw := range hook.Commands {
 		command := strings.TrimSpace(raw)
@@ -217,6 +218,13 @@ func RunWorkspaceHook(ctx context.Context, workdir string, name HookName, hook w
 		}
 	}
 	return results, nil
+}
+
+func EffectiveWorkspaceHookTimeoutMs(timeoutMs int) int {
+	if timeoutMs > 0 {
+		return timeoutMs
+	}
+	return workflow.DefaultConfig().Hooks.TimeoutMs
 }
 
 func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName, command string, timeoutMs int) HookResult {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unicode"
@@ -92,11 +93,15 @@ type VerifyResult struct {
 // holding the entire output of a verbose verify command in memory.
 type cappedBuffer struct {
 	Cap     int
+	mu      sync.Mutex
 	buf     bytes.Buffer
 	dropped int64
 }
 
 func (c *cappedBuffer) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	remaining := c.Cap - c.buf.Len()
 	if remaining > 0 {
 		take := len(p)
@@ -115,9 +120,26 @@ func (c *cappedBuffer) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (c *cappedBuffer) String() string  { return c.buf.String() }
-func (c *cappedBuffer) Truncated() bool { return c.dropped > 0 }
-func (c *cappedBuffer) Dropped() int64  { return c.dropped }
+func (c *cappedBuffer) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.buf.String()
+}
+
+func (c *cappedBuffer) Truncated() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.dropped > 0
+}
+
+func (c *cappedBuffer) Dropped() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.dropped
+}
 
 // Compile-time check that cappedBuffer satisfies io.Writer.
 var _ io.Writer = (*cappedBuffer)(nil)

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -228,25 +228,28 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 	}
 	defer cancel()
 
-	cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
+	cmd := exec.Command("sh", "-lc", command)
 	cmd.Dir = workdir
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	var out cappedBuffer
 	out.Cap = VerifyOutputCap
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	done := make(chan struct{})
+	if err := cmd.Start(); err != nil {
+		return HookResult{Name: name, Command: command, ExitCode: exitCode(err), Output: out.String(), Truncated: out.Truncated(), Duration: time.Since(start), Err: err}
+	}
+	done := make(chan error, 1)
 	go func() {
-		select {
-		case <-runCtx.Done():
-			if cmd.Process != nil {
-				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-			}
-		case <-done:
-		}
+		done <- cmd.Wait()
 	}()
-	err := cmd.Run()
-	close(done)
+
+	var err error
+	select {
+	case err = <-done:
+	case <-runCtx.Done():
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		err = <-done
+	}
 	res := HookResult{Name: name, Command: command, ExitCode: exitCode(err), Output: out.String(), Truncated: out.Truncated(), Duration: time.Since(start), Err: err}
 	if runCtx.Err() == context.DeadlineExceeded {
 		res.Err = fmt.Errorf("hook timed out after %dms: %w", timeoutMs, runCtx.Err())

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,50 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+// HookName identifies one of the SPEC-defined workspace lifecycle hooks.
+type HookName string
+
+const (
+	HookAfterCreate  HookName = "after_create"
+	HookBeforeRun    HookName = "before_run"
+	HookAfterRun     HookName = "after_run"
+	HookBeforeRemove HookName = "before_remove"
+)
+
+// HookResult captures one workspace hook command execution for task events and
+// caller-side failure policy decisions.
+type HookResult struct {
+	Name      HookName
+	Command   string
+	ExitCode  int
+	Output    string
+	Truncated bool
+	Duration  time.Duration
+	Err       error
+}
+
+// HookError reports a failed workspace hook while preserving every command
+// result captured before the failure.
+type HookError struct {
+	Name    HookName
+	Results []HookResult
+	Err     error
+}
+
+func (e *HookError) Error() string {
+	if e == nil || e.Err == nil {
+		return "workspace hook failed"
+	}
+	return fmt.Sprintf("workspace hook %s failed: %v", e.Name, e.Err)
+}
+
+func (e *HookError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
 
 // VerifyOutputCap bounds how many bytes of combined stdout+stderr we keep in
 // memory per verify command. Verbose verify steps (e.g. `go test -v ./...`)
@@ -154,6 +199,60 @@ func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string,
 	// downstream tooling inspects `git remote -v` from within the worktree.
 	_ = run(ctx, workdir, "git", "remote", "set-url", "origin", t.CloneURL)
 	return workdir, createdNow, nil
+}
+
+// RunWorkspaceHook executes the configured shell commands for a lifecycle hook
+// in workdir, in order, using the shared workspace hook timeout.
+func RunWorkspaceHook(ctx context.Context, workdir string, name HookName, hook workflow.WorkspaceHook, timeoutMs int) ([]HookResult, error) {
+	results := make([]HookResult, 0, len(hook.Commands))
+	for _, raw := range hook.Commands {
+		command := strings.TrimSpace(raw)
+		if command == "" {
+			continue
+		}
+		res := runWorkspaceHookCommand(ctx, workdir, name, command, timeoutMs)
+		results = append(results, res)
+		if res.Err != nil {
+			return results, &HookError{Name: name, Results: results, Err: res.Err}
+		}
+	}
+	return results, nil
+}
+
+func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName, command string, timeoutMs int) HookResult {
+	start := time.Now()
+	runCtx := ctx
+	cancel := func() {}
+	if timeoutMs > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutMs)*time.Millisecond)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
+	cmd.Dir = workdir
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var out cappedBuffer
+	out.Cap = VerifyOutputCap
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-runCtx.Done():
+			if cmd.Process != nil {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
+		case <-done:
+		}
+	}()
+	err := cmd.Run()
+	close(done)
+	res := HookResult{Name: name, Command: command, ExitCode: exitCode(err), Output: out.String(), Truncated: out.Truncated(), Duration: time.Since(start), Err: err}
+	if runCtx.Err() == context.DeadlineExceeded {
+		res.Err = fmt.Errorf("hook timed out after %dms: %w", timeoutMs, runCtx.Err())
+		res.ExitCode = -1
+	}
+	return res
 }
 
 func WritePrompt(workdir string, prompt string) error {
@@ -633,6 +732,17 @@ func remoteBranchExists(ctx context.Context, workdir, branch string) (bool, erro
 		return false, err
 	}
 	return strings.TrimSpace(stdout.String()) != "", nil
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }
 
 func run(ctx context.Context, dir string, name string, args ...string) error {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -478,6 +478,30 @@ func TestEffectiveWorkspaceHookTimeoutUsesSpecDefaultWhenUnset(t *testing.T) {
 	}
 }
 
+func TestRunWorkspaceHookTimeoutDoesNotWaitForeverOnEscapedDescendantOutput(t *testing.T) {
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{"setsid sh -c 'while true; do printf x; sleep 1; done' & sleep 2"}}
+
+	start := time.Now()
+	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("RunWorkspaceHook should fail on timeout")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("hook timeout waited %v for escaped descendant output, want under 1s", elapsed)
+	}
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("results len = %d, want %d", got, want)
+	}
+	if results[0].ExitCode != -1 || results[0].Err == nil {
+		t.Fatalf("timeout result = %#v, want exit -1 with error", results[0])
+	}
+	if !strings.Contains(results[0].Err.Error(), "timed out") {
+		t.Fatalf("timeout error = %v, want timed out", results[0].Err)
+	}
+}
+
 // TestRunVerifyCollectsAllFailures pins the post-#18 contract: RunVerify
 // runs every non-empty command and records a result for each, even after
 // a non-zero exit. The aggregate error is non-nil iff at least one

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -472,6 +472,27 @@ func TestRunWorkspaceHookTimeoutStopsCommand(t *testing.T) {
 	}
 }
 
+func TestRunWorkspaceHookUsesDefaultTimeoutWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{"sleep 2"}}
+
+	start := time.Now()
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("RunWorkspaceHook succeeded, want default timeout failure")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("default hook timeout took %v, want under 1s", elapsed)
+	}
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("results len = %d, want %d", got, want)
+	}
+	if results[0].Err == nil || !strings.Contains(results[0].Err.Error(), "timed out") {
+		t.Fatalf("timeout error = %v, want timed out", results[0].Err)
+	}
+}
+
 // TestRunVerifyCollectsAllFailures pins the post-#18 contract: RunVerify
 // runs every non-empty command and records a result for each, even after
 // a non-zero exit. The aggregate error is non-nil iff at least one

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -472,24 +472,9 @@ func TestRunWorkspaceHookTimeoutStopsCommand(t *testing.T) {
 	}
 }
 
-func TestRunWorkspaceHookUsesDefaultTimeoutWhenUnset(t *testing.T) {
-	dir := t.TempDir()
-	hook := workflow.WorkspaceHook{Commands: []string{"sleep 2"}}
-
-	start := time.Now()
-	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0)
-	elapsed := time.Since(start)
-	if err == nil {
-		t.Fatal("RunWorkspaceHook succeeded, want default timeout failure")
-	}
-	if elapsed > time.Second {
-		t.Fatalf("default hook timeout took %v, want under 1s", elapsed)
-	}
-	if got, want := len(results), 1; got != want {
-		t.Fatalf("results len = %d, want %d", got, want)
-	}
-	if results[0].Err == nil || !strings.Contains(results[0].Err.Error(), "timed out") {
-		t.Fatalf("timeout error = %v, want timed out", results[0].Err)
+func TestEffectiveWorkspaceHookTimeoutUsesSpecDefaultWhenUnset(t *testing.T) {
+	if got, want := EffectiveWorkspaceHookTimeoutMs(0), 60000; got != want {
+		t.Fatalf("EffectiveWorkspaceHookTimeoutMs(0) = %d, want SPEC default %d", got, want)
 	}
 }
 

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -415,6 +415,63 @@ func TestWriteAndReadSummaryRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRunWorkspaceHookStopsOnNonZeroAndCapturesOutput(t *testing.T) {
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{
+		"printf first",
+		"printf boom && exit 7",
+		"printf never > should-not-exist",
+	}}
+
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0)
+	if err == nil {
+		t.Fatalf("RunWorkspaceHook should fail on non-zero exit")
+	}
+	var hookErr *HookError
+	if !errors.As(err, &hookErr) {
+		t.Fatalf("error type = %T, want *HookError", err)
+	}
+	if hookErr.Name != HookBeforeRun {
+		t.Fatalf("hook error name = %q, want %q", hookErr.Name, HookBeforeRun)
+	}
+	if got, want := len(results), 2; got != want {
+		t.Fatalf("results len = %d, want %d", got, want)
+	}
+	if results[0].Output != "first" || results[0].ExitCode != 0 || results[0].Err != nil {
+		t.Fatalf("first result = %#v, want successful captured output", results[0])
+	}
+	if results[1].Output != "boom" || results[1].ExitCode != 7 || results[1].Err == nil {
+		t.Fatalf("second result = %#v, want failing captured output with exit 7", results[1])
+	}
+	if _, err := os.Stat(filepath.Join(dir, "should-not-exist")); !os.IsNotExist(err) {
+		t.Fatalf("commands after failed hook should not run; stat err=%v", err)
+	}
+}
+
+func TestRunWorkspaceHookTimeoutStopsCommand(t *testing.T) {
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{"sleep 2"}}
+
+	start := time.Now()
+	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("RunWorkspaceHook should fail on timeout")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("hook timeout took %v, want under 1s", elapsed)
+	}
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("results len = %d, want %d", got, want)
+	}
+	if results[0].ExitCode != -1 || results[0].Err == nil {
+		t.Fatalf("timeout result = %#v, want exit -1 with error", results[0])
+	}
+	if !strings.Contains(results[0].Err.Error(), "timed out") {
+		t.Fatalf("timeout error = %v, want timed out", results[0].Err)
+	}
+}
+
 // TestRunVerifyCollectsAllFailures pins the post-#18 contract: RunVerify
 // runs every non-empty command and records a result for each, even after
 // a non-zero exit. The aggregate error is non-nil iff at least one


### PR DESCRIPTION
## Summary
- Adds SPEC D12 workspace lifecycle hook config for `after_create`, `before_run`, `after_run`, and `before_remove`.
- Runs hooks around workspace creation/task attempts, emits hook task events with output/exit metadata, and treats `after_run`/`before_remove` as best-effort cleanup hooks.
- Ensures hook timeouts terminate the shell process group so child commands cannot survive the timeout.

## Test Plan
- [x] `/home/pi/.local/go1.25.10/bin/go test ./...`

Closes #86
