### PR TITLE
fix: add orchestrator continuation retry backoff

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -174,7 +174,7 @@ func run(ctx context.Context, args []string) error {
 	}
 	orch := orchestrator.New(state, orchestrator.Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  orchestrator.FixedDelayScheduler{Delay: 60 * time.Second},
+		Scheduler:  orchestrator.RetryScheduler{MaxBackoff: time.Duration(wf.Config.Agent.MaxRetryBackoffMs) * time.Millisecond},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -20,12 +20,9 @@ package orchestrator
 // mutation flowing through handle_call / handle_cast / handle_info
 // (orchestrator.ex:6,52,74-217); the Go actor here is the direct analog.
 //
-// PR 2 of the D21+D6 migration plan only ships this actor, the
-// Dispatcher seam, and the FixedDelayScheduler matching the legacy
-// queue's 60-second behavior. The poll-tick loop (PR 3) and the worker
-// rewire (PR 4) layer on top without further changes to the actor's
-// shape; D16 swaps FixedDelayScheduler for the SPEC §8.4 exponential
-// formula by replacing the Scheduler binding only.
+// PR 2 of the D21+D6 migration plan shipped this actor, the Dispatcher seam,
+// and a scheduler seam. D16 wires that seam to SPEC §8.4 exponential failure
+// backoff plus SPEC §16.6's short continuation retry.
 
 import (
 	"context"
@@ -61,26 +58,61 @@ type Dispatcher interface {
 	Spawn(ctx context.Context, issue tracker.Issue, attempt *int) <-chan WorkerResult
 }
 
-// Scheduler computes the delay before the next retry of a given
-// 1-based attempt counter. PR 2 ships FixedDelayScheduler matching the
-// legacy queue's 60-second retry so behavior is unchanged when the
-// worker migrates to the actor; D16 (#90) swaps in the SPEC §8.4
-// exponential-backoff formula by replacing the Scheduler binding only.
+// Scheduler computes the delay before the next retry request.
 type Scheduler interface {
-	NextDelay(attempt int) time.Duration
+	NextDelay(RetryRequest) time.Duration
 }
 
-// FixedDelayScheduler returns the same delay regardless of attempt.
-// Matches the existing internal/queue/postgres.go retry interval so the
-// PR 4 cutover is observably equivalent.
-type FixedDelayScheduler struct {
-	Delay time.Duration
+// RetryKind identifies whether the retry follows a failed worker run or a
+// clean continuation turn.
+type RetryKind string
+
+const (
+	RetryKindFailure      RetryKind = "failure"
+	RetryKindContinuation RetryKind = "continuation"
+)
+
+// RetryRequest describes the retry being scheduled. Attempt is the 1-based
+// failure retry attempt for RetryKindFailure. Continuation retries ignore it
+// and always use the short SPEC §16.6 delay.
+type RetryRequest struct {
+	Kind    RetryKind
+	Attempt int
+}
+
+// RetryScheduler implements the SPEC retry delays: clean continuation retries
+// use one second; failure retries use delay=min(10s*2^(attempt-1), MaxBackoff).
+type RetryScheduler struct {
+	MaxBackoff time.Duration
 }
 
 const retryCapacityRecheckDelay = 100 * time.Millisecond
+const continuationRetryDelay = time.Second
 
 // NextDelay implements Scheduler.
-func (f FixedDelayScheduler) NextDelay(int) time.Duration { return f.Delay }
+func (s RetryScheduler) NextDelay(req RetryRequest) time.Duration {
+	if req.Kind == RetryKindContinuation {
+		return continuationRetryDelay
+	}
+	if req.Attempt < 1 {
+		req.Attempt = 1
+	}
+	maxBackoff := s.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = 5 * time.Minute
+	}
+	delay := 10 * time.Second
+	for i := 1; i < req.Attempt; i++ {
+		if delay >= maxBackoff/2 {
+			return maxBackoff
+		}
+		delay *= 2
+	}
+	if delay > maxBackoff {
+		return maxBackoff
+	}
+	return delay
+}
 
 // Deps bundles construction-time dependencies so adding a new one
 // later doesn't ripple through every call site.
@@ -308,6 +340,20 @@ func (o *Orchestrator) RequestDispatch(ctx context.Context, issue tracker.Issue,
 	}
 }
 
+func (o *Orchestrator) RequestDispatchAfterTrackerRecheck(ctx context.Context, issue tracker.Issue, attempt *int) error {
+	reply := make(chan error, 1)
+	op := &dispatchOp{o: o, issue: issue, attempt: attempt, result: reply, trackerRechecked: true}
+	if err := o.submit(ctx, op); err != nil {
+		return err
+	}
+	select {
+	case err := <-reply:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // ReconcileInactiveTrackerIssuesAndWait cancels only issues explicitly observed
 // in a terminal or configured inactive tracker state. Missing issues are
 // treated as unknown instead of inactive because tracker adapters may return
@@ -336,7 +382,15 @@ func (o *Orchestrator) ReconcileInactiveTrackerIssuesAndWait(ctx context.Context
 // The 1-based attempt counter is the attempt number this retry will
 // run as (i.e. the prior run was attempt-1, or 0 for first-run).
 func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string) error {
-	delay := o.scheduler.NextDelay(attempt)
+	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindFailure, Attempt: attempt}, attempt, runErr)
+}
+
+func (o *Orchestrator) scheduleContinuationRetry(ctx context.Context, issue tracker.Issue, identifier string) error {
+	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindContinuation}, 0, "")
+}
+
+func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, req RetryRequest, attempt int, runErr string) error {
+	delay := o.scheduler.NextDelay(req)
 	op := &scheduleRetryOp{
 		o:          o,
 		issue:      issue,
@@ -344,6 +398,7 @@ func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, i
 		attempt:    attempt,
 		delay:      delay,
 		runErr:     runErr,
+		kind:       req.Kind,
 	}
 	return o.submit(ctx, op)
 }
@@ -426,15 +481,25 @@ func isActiveTrackerState(state string, activeStates map[string]struct{}) bool {
 // dispatch decision atomic against concurrent claims while keeping I/O
 // off the actor goroutine.
 type dispatchOp struct {
-	o       *Orchestrator
-	issue   tracker.Issue
-	attempt *int
-	result  chan<- error
+	o                *Orchestrator
+	issue            tracker.Issue
+	attempt          *int
+	result           chan<- error
+	trackerRechecked bool
 }
 
 func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	id := IssueID(d.issue.ID)
 	st.ReleaseFailedIfIssueChanged(d.issue)
+	if d.trackerRechecked {
+		if entry, ok := st.RetryAttempts[id]; ok && entry.Kind == RetryKindContinuation {
+			if entry.Timer != nil {
+				entry.Timer.Stop()
+			}
+			delete(st.RetryAttempts, id)
+			delete(st.Claimed, id)
+		}
+	}
 	if st.IsClaimed(id) {
 		d.result <- ErrNotDispatched
 		return nil
@@ -468,6 +533,7 @@ type scheduleRetryOp struct {
 	attempt    int
 	delay      time.Duration
 	runErr     string
+	kind       RetryKind
 }
 
 func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
@@ -485,6 +551,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 		Attempt:    attempt,
 		DueAt:      time.Now().Add(s.delay),
 		Error:      s.runErr,
+		Kind:       s.kind,
 	}
 	entry.Timer = time.AfterFunc(s.delay, func() {
 		_ = o.submit(o.runCtx, &retryFireOp{
@@ -583,8 +650,14 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 			close(f.done)
 			return nil
 		}
+		st.Claimed[f.id] = struct{}{}
 		close(f.done)
-		return nil
+		o := f.o
+		issue := f.issue
+		identifier := f.identifier
+		return func() {
+			_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier)
+		}
 	}
 	if f.result.NonRetryable {
 		if !st.FinishRunNonRetryableFailed(f.id, f.entry, elapsed) {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -131,6 +131,7 @@ type Orchestrator struct {
 	state      *OrchestratorState
 	dispatcher Dispatcher
 	scheduler  Scheduler
+	retryWake  chan struct{}
 
 	// runCtx is captured by Run so followup goroutines can cancel
 	// their work when the actor stops. Set once at the top of Run
@@ -149,6 +150,7 @@ func New(state *OrchestratorState, deps Deps) *Orchestrator {
 		state:      state,
 		dispatcher: deps.Dispatcher,
 		scheduler:  deps.Scheduler,
+		retryWake:  make(chan struct{}, 1),
 		started:    make(chan struct{}),
 	}
 }
@@ -185,6 +187,23 @@ func (o *Orchestrator) WaitStarted(ctx context.Context) error {
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func (o *Orchestrator) retryWakeCh() <-chan struct{} {
+	if o == nil {
+		return nil
+	}
+	return o.retryWake
+}
+
+func (o *Orchestrator) wakeRetryPollLoop() {
+	if o == nil || o.retryWake == nil {
+		return
+	}
+	select {
+	case o.retryWake <- struct{}{}:
+	default:
 	}
 }
 
@@ -522,7 +541,7 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 				d.result <- ErrNotDispatched
 				return nil
 			}
-			if attempt == nil {
+			if attempt == nil && entry.Kind != RetryKindContinuation {
 				entryAttempt := entry.Attempt
 				attempt = &entryAttempt
 			}
@@ -631,12 +650,15 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 	}
 	if entry.Kind == RetryKindContinuation {
 		// Continuation retries are only a short wake-up signal after a clean
-		// worker exit. They must not spawn from the cached issue snapshot: the
-		// next poll tick has to observe the issue still active and call
-		// RequestDispatchAfterTrackerRecheck, which consumes this entry before
-		// spawning the next turn.
+		// worker exit. They must not spawn from the cached issue snapshot or
+		// carry failure retry accounting: a poll has to observe the issue still
+		// active and call RequestDispatchAfterTrackerRecheck, which consumes
+		// this entry before spawning the next normal turn. Wake the poll loop
+		// now so the one-second continuation delay is honored instead of
+		// waiting for the next regular tracker poll interval.
 		entry.Timer = nil
-		return nil
+		o := r.o
+		return func() { o.wakeRetryPollLoop() }
 	}
 	if st.RunningCount() >= st.MaxConcurrentAgents {
 		// Retry timers must obey the same capacity gate as fresh dispatch.

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -385,8 +385,8 @@ func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, i
 	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindFailure, Attempt: attempt}, attempt, runErr)
 }
 
-func (o *Orchestrator) scheduleContinuationRetry(ctx context.Context, issue tracker.Issue, identifier string) error {
-	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindContinuation}, 0, "")
+func (o *Orchestrator) scheduleContinuationRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int) error {
+	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindContinuation, Attempt: attempt}, attempt, "")
 }
 
 func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, req RetryRequest, attempt int, runErr string) error {
@@ -491,10 +491,15 @@ type dispatchOp struct {
 func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	id := IssueID(d.issue.ID)
 	st.ReleaseFailedIfIssueChanged(d.issue)
+	attempt := d.attempt
 	if d.trackerRechecked {
 		if entry, ok := st.RetryAttempts[id]; ok && entry.Kind == RetryKindContinuation {
 			if entry.Timer != nil {
 				entry.Timer.Stop()
+			}
+			if attempt == nil {
+				entryAttempt := entry.Attempt
+				attempt = &entryAttempt
 			}
 			delete(st.RetryAttempts, id)
 			delete(st.Claimed, id)
@@ -514,7 +519,6 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	st.Claimed[id] = struct{}{}
 	o := d.o
 	issue := d.issue
-	attempt := d.attempt
 	result := d.result
 	return func() {
 		o.spawn(id, issue, attempt)
@@ -661,11 +665,15 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		}
 		st.Claimed[f.id] = struct{}{}
 		close(f.done)
+		nextAttempt := 1
+		if f.attempt != nil {
+			nextAttempt = *f.attempt + 1
+		}
 		o := f.o
 		issue := f.issue
 		identifier := f.identifier
 		return func() {
-			_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier)
+			_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt)
 		}
 	}
 	if f.result.NonRetryable {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -261,6 +261,30 @@ func (o *Orchestrator) UpdateMaxConcurrentAgents(ctx context.Context, maxConcurr
 	}
 }
 
+// UpdateRetryScheduler applies reloaded retry timing through the actor so
+// subsequently scheduled retries observe workflow changes without a process
+// restart.
+func (o *Orchestrator) UpdateRetryScheduler(ctx context.Context, scheduler Scheduler) error {
+	if scheduler == nil {
+		return nil
+	}
+	done := make(chan struct{}, 1)
+	op := opFunc(func(*OrchestratorState) func() {
+		o.scheduler = scheduler
+		done <- struct{}{}
+		return nil
+	})
+	if err := o.submit(ctx, op); err != nil {
+		return err
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // ErrNotDispatched is returned by RequestDispatch when the issue was
 // already claimed (running, retry-queued, or otherwise reserved) and
 // dispatch was therefore deduped. It is not an error condition — SPEC

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -494,6 +494,10 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	attempt := d.attempt
 	if d.trackerRechecked {
 		if entry, ok := st.RetryAttempts[id]; ok && entry.Kind == RetryKindContinuation {
+			if !entry.IsDue(time.Now()) {
+				d.result <- ErrNotDispatched
+				return nil
+			}
 			if entry.Timer != nil {
 				entry.Timer.Stop()
 			}

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -516,30 +516,36 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	id := IssueID(d.issue.ID)
 	st.ReleaseFailedIfIssueChanged(d.issue)
 	attempt := d.attempt
+	var consumedContinuation *RetryEntry
 	if d.trackerRechecked {
 		if entry, ok := st.RetryAttempts[id]; ok && entry.Kind == RetryKindContinuation {
 			if !entry.IsDue(time.Now()) {
 				d.result <- ErrNotDispatched
 				return nil
 			}
-			if entry.Timer != nil {
-				entry.Timer.Stop()
-			}
 			if attempt == nil {
 				entryAttempt := entry.Attempt
 				attempt = &entryAttempt
 			}
-			delete(st.RetryAttempts, id)
-			delete(st.Claimed, id)
+			consumedContinuation = entry
+		} else if st.IsClaimed(id) {
+			d.result <- ErrNotDispatched
+			return nil
 		}
-	}
-	if st.IsClaimed(id) {
+	} else if st.IsClaimed(id) {
 		d.result <- ErrNotDispatched
 		return nil
 	}
 	if st.RunningCount() >= st.MaxConcurrentAgents {
 		d.result <- ErrCapacityFull
 		return nil
+	}
+	if consumedContinuation != nil {
+		if consumedContinuation.Timer != nil {
+			consumedContinuation.Timer.Stop()
+		}
+		delete(st.RetryAttempts, id)
+		delete(st.Claimed, id)
 	}
 	// Reserve the slot synchronously so a concurrent dispatchOp aborts
 	// on its IsClaimed check. The followup records Running once the
@@ -693,10 +699,11 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		}
 		st.Claimed[f.id] = struct{}{}
 		close(f.done)
+		// A clean continuation is a new normal turn. Keep its retry entry
+		// 1-based, but do not carry the prior run's attempt into future
+		// failure backoff; otherwise many successful turns inflate the next
+		// transient failure straight to the max backoff.
 		nextAttempt := 1
-		if f.attempt != nil {
-			nextAttempt = *f.attempt + 1
-		}
 		o := f.o
 		issue := f.issue
 		identifier := f.identifier

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -414,15 +414,14 @@ func (o *Orchestrator) scheduleContinuationRetry(ctx context.Context, issue trac
 }
 
 func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, req RetryRequest, attempt int, runErr string) error {
-	delay := o.scheduler.NextDelay(req)
 	op := &scheduleRetryOp{
 		o:          o,
 		issue:      issue,
 		identifier: identifier,
 		attempt:    attempt,
-		delay:      delay,
 		runErr:     runErr,
 		kind:       req.Kind,
+		req:        req,
 	}
 	return o.submit(ctx, op)
 }
@@ -569,9 +568,9 @@ type scheduleRetryOp struct {
 	issue      tracker.Issue
 	identifier string
 	attempt    int
-	delay      time.Duration
 	runErr     string
 	kind       RetryKind
+	req        RetryRequest
 }
 
 func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
@@ -579,6 +578,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 	o := s.o
 	issue := s.issue
 	attempt := s.attempt
+	delay := o.scheduler.NextDelay(s.req)
 	// time.AfterFunc schedules immediately and is cheap (no goroutine
 	// until fire), so we can safely create the timer on the actor
 	// without blocking. ScheduleRetry needs the Timer set on the entry
@@ -587,11 +587,11 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 		IssueID:    id,
 		Identifier: s.identifier,
 		Attempt:    attempt,
-		DueAt:      time.Now().Add(s.delay),
+		DueAt:      time.Now().Add(delay),
 		Error:      s.runErr,
 		Kind:       s.kind,
 	}
-	entry.Timer = time.AfterFunc(s.delay, func() {
+	entry.Timer = time.AfterFunc(delay, func() {
 		_ = o.submit(o.runCtx, &retryFireOp{
 			o:       o,
 			id:      id,

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -591,6 +591,15 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		// re-dispatch on its own timer.
 		return nil
 	}
+	if entry.Kind == RetryKindContinuation {
+		// Continuation retries are only a short wake-up signal after a clean
+		// worker exit. They must not spawn from the cached issue snapshot: the
+		// next poll tick has to observe the issue still active and call
+		// RequestDispatchAfterTrackerRecheck, which consumes this entry before
+		// spawning the next turn.
+		entry.Timer = nil
+		return nil
+	}
 	if st.RunningCount() >= st.MaxConcurrentAgents {
 		// Retry timers must obey the same capacity gate as fresh dispatch.
 		// Leave the retry queued and arm a short follow-up timer so the issue

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -227,6 +227,44 @@ func TestScheduleRetry_TimerFireProducesExactlyOneReDispatch(t *testing.T) {
 	}
 }
 
+func TestContinuationRetryTimerRequiresTrackerRecheckedDispatch(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-10", Identifier: "ENG-10", Title: "continuation"}
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("initial tracker-rechecked dispatch: %v", err)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("initial dispatch count = %d, want 1", got)
+	}
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	time.Sleep(20 * time.Millisecond)
+
+	if got := disp.count(); got != 1 {
+		t.Fatalf("continuation retry timer spawned without tracker recheck: got %d dispatches, want 1", got)
+	}
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 1 {
+		t.Fatalf("retrying view = %+v, want continuation retry retained until tracker recheck", view.Retrying)
+	}
+
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("tracker-rechecked continuation dispatch: %v", err)
+	}
+	if got := disp.count(); got != 2 {
+		t.Fatalf("dispatch count after tracker recheck = %d, want 2", got)
+	}
+}
+
 // TestRequestDispatch_DedupesAgainstRunning verifies that once a
 // dispatch is accepted and Running, a second RequestDispatch for the
 // same issue is denied — even though the Claimed window between

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -257,8 +257,8 @@ func TestContinuationRetryTimerRequiresTrackerRecheckedDispatch(t *testing.T) {
 	if len(view.Retrying) != 1 {
 		t.Fatalf("retrying view = %+v, want continuation retry retained until tracker recheck", view.Retrying)
 	}
-	if view.Retrying[0].Attempt != attempt+1 {
-		t.Fatalf("continuation retry attempt = %d, want %d", view.Retrying[0].Attempt, attempt+1)
+	if view.Retrying[0].Attempt != 1 {
+		t.Fatalf("continuation retry attempt = %d, want 1", view.Retrying[0].Attempt)
 	}
 
 	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
@@ -267,8 +267,38 @@ func TestContinuationRetryTimerRequiresTrackerRecheckedDispatch(t *testing.T) {
 	if got := disp.count(); got != 2 {
 		t.Fatalf("dispatch count after tracker recheck = %d, want 2", got)
 	}
-	if got := *disp.attempts[1]; got != attempt+1 {
-		t.Fatalf("tracker-rechecked continuation dispatch attempt = %d, want %d", got, attempt+1)
+	if got := *disp.attempts[1]; got != 1 {
+		t.Fatalf("tracker-rechecked continuation dispatch attempt = %d, want 1", got)
+	}
+}
+
+func TestFinalize_NormalExitResetsContinuationAttemptToOne(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-CONT-RESET", Identifier: "ENG-CONT-RESET", Title: "reset continuation"}
+	attempt := 7
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, &attempt); err != nil {
+		t.Fatalf("initial tracker-rechecked dispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1
+	}, time.Second)
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := view.Retrying[0].Attempt; got != 1 {
+		t.Fatalf("continuation retry attempt after clean exit = %d, want 1", got)
 	}
 }
 
@@ -311,6 +341,50 @@ func TestContinuationRetryRecheckedDispatchWaitsUntilDue(t *testing.T) {
 	}
 	if got := disp.count(); got != 2 {
 		t.Fatalf("dispatch count after due tracker recheck = %d, want 2", got)
+	}
+}
+
+func TestContinuationRetryRecheckedDispatchKeepsRetryWhenCapacityFull(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 1)
+	o := New(st, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	issueA := tracker.Issue{ID: "ENG-CONT-CAP", Identifier: "ENG-CONT-CAP", Title: "continuation waits"}
+	issueB := tracker.Issue{ID: "ENG-RUNNING", Identifier: "ENG-RUNNING", Title: "running"}
+	if err := o.RequestDispatch(context.Background(), issueB, nil); err != nil {
+		t.Fatalf("dispatch B: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	if err := o.scheduleContinuationRetry(context.Background(), issueA, issueA.Identifier, 1); err != nil {
+		t.Fatalf("schedule continuation retry: %v", err)
+	}
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && !view.Retrying[0].DueAt.After(time.Now())
+	}, time.Second)
+
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), issueA, nil); !errors.Is(err, ErrCapacityFull) {
+		t.Fatalf("tracker-rechecked continuation at capacity err = %v, want ErrCapacityFull", err)
+	}
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 1 || view.Retrying[0].IssueID != IssueID(issueA.ID) {
+		t.Fatalf("retrying after capacity rejection = %+v, want continuation retry preserved", view.Retrying)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("dispatch count after capacity rejection = %d, want only running issue B", got)
 	}
 }
 

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -72,6 +72,16 @@ func (f *fakeDispatcher) issueAt(i int) tracker.Issue {
 	return f.issues[i]
 }
 
+func (f *fakeDispatcher) attemptValueAt(i int) *int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.attempts[i] == nil {
+		return nil
+	}
+	attempt := *f.attempts[i]
+	return &attempt
+}
+
 // finishAt completes the i-th spawned worker with the given result.
 // Tests use this to drive the worker-exit path through the actor.
 func (f *fakeDispatcher) finishAt(i int, res WorkerResult) {
@@ -267,8 +277,8 @@ func TestContinuationRetryTimerRequiresTrackerRecheckedDispatch(t *testing.T) {
 	if got := disp.count(); got != 2 {
 		t.Fatalf("dispatch count after tracker recheck = %d, want 2", got)
 	}
-	if got := *disp.attempts[1]; got != 1 {
-		t.Fatalf("tracker-rechecked continuation dispatch attempt = %d, want 1", got)
+	if got := disp.attemptValueAt(1); got != nil {
+		t.Fatalf("tracker-rechecked continuation dispatch carried retry attempt = %d, want nil", *got)
 	}
 }
 
@@ -299,6 +309,49 @@ func TestFinalize_NormalExitResetsContinuationAttemptToOne(t *testing.T) {
 	}
 	if got := view.Retrying[0].Attempt; got != 1 {
 		t.Fatalf("continuation retry attempt after clean exit = %d, want 1", got)
+	}
+}
+
+func TestFinalize_FirstFailureAfterCleanContinuationUsesFirstFailureBackoff(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond, time.Hour}},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-CONT-FAIL", Identifier: "ENG-CONT-FAIL", Title: "fail after continuation"}
+	priorFailureAttempt := 7
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, &priorFailureAttempt); err != nil {
+		t.Fatalf("initial tracker-rechecked dispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1
+	}, time.Second)
+
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("tracker-rechecked continuation dispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+	if got := disp.attemptValueAt(1); got != nil {
+		t.Fatalf("clean continuation dispatch carried failure attempt = %d, want nil", *got)
+	}
+
+	disp.finishAt(1, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && view.Retrying[0].Error == "transient"
+	}, time.Second)
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := view.Retrying[0].Attempt; got != 1 {
+		t.Fatalf("failure after clean continuation scheduled retry attempt = %d, want 1", got)
 	}
 }
 

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -236,7 +236,8 @@ func TestContinuationRetryTimerRequiresTrackerRecheckedDispatch(t *testing.T) {
 	defer cancel()
 
 	iss := tracker.Issue{ID: "ENG-10", Identifier: "ENG-10", Title: "continuation"}
-	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+	attempt := 2
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, &attempt); err != nil {
 		t.Fatalf("initial tracker-rechecked dispatch: %v", err)
 	}
 	if got := disp.count(); got != 1 {
@@ -256,12 +257,18 @@ func TestContinuationRetryTimerRequiresTrackerRecheckedDispatch(t *testing.T) {
 	if len(view.Retrying) != 1 {
 		t.Fatalf("retrying view = %+v, want continuation retry retained until tracker recheck", view.Retrying)
 	}
+	if view.Retrying[0].Attempt != attempt+1 {
+		t.Fatalf("continuation retry attempt = %d, want %d", view.Retrying[0].Attempt, attempt+1)
+	}
 
 	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
 		t.Fatalf("tracker-rechecked continuation dispatch: %v", err)
 	}
 	if got := disp.count(); got != 2 {
 		t.Fatalf("dispatch count after tracker recheck = %d, want 2", got)
+	}
+	if got := *disp.attempts[1]; got != attempt+1 {
+		t.Fatalf("tracker-rechecked continuation dispatch attempt = %d, want %d", got, attempt+1)
 	}
 }
 

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -272,6 +272,48 @@ func TestContinuationRetryTimerRequiresTrackerRecheckedDispatch(t *testing.T) {
 	}
 }
 
+func TestContinuationRetryRecheckedDispatchWaitsUntilDue(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{50 * time.Millisecond}},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-11", Identifier: "ENG-11", Title: "continuation not due"}
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("initial tracker-rechecked dispatch: %v", err)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("initial dispatch count = %d, want 1", got)
+	}
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1
+	}, time.Second)
+
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); !errors.Is(err, ErrNotDispatched) {
+		t.Fatalf("early tracker-rechecked dispatch err = %v, want ErrNotDispatched", err)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("early tracker recheck spawned before continuation due time: got %d dispatches, want 1", got)
+	}
+
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && !view.Retrying[0].DueAt.After(time.Now())
+	}, time.Second)
+
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("due tracker-rechecked continuation dispatch: %v", err)
+	}
+	if got := disp.count(); got != 2 {
+		t.Fatalf("dispatch count after due tracker recheck = %d, want 2", got)
+	}
+}
+
 // TestRequestDispatch_DedupesAgainstRunning verifies that once a
 // dispatch is accepted and Running, a second RequestDispatch for the
 // same issue is denied — even though the Claimed window between

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -34,7 +34,7 @@ type sequenceScheduler struct {
 	delays []time.Duration
 }
 
-func (s *sequenceScheduler) NextDelay(int) time.Duration {
+func (s *sequenceScheduler) NextDelay(RetryRequest) time.Duration {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.delays) == 0 {
@@ -103,7 +103,7 @@ func startActor(t *testing.T, deps Deps) (*Orchestrator, context.CancelFunc) {
 // the mechanism that delivers it.
 func TestRequestDispatch_ConcurrentSameIssueProducesOneRunning(t *testing.T) {
 	disp := &fakeDispatcher{}
-	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 
 	iss := tracker.Issue{ID: "ENG-1", Identifier: "ENG-1", Title: "race"}
@@ -168,7 +168,7 @@ func TestScheduleRetry_TimerFireProducesExactlyOneReDispatch(t *testing.T) {
 	disp := &fakeDispatcher{}
 	o, cancel := startActor(t, Deps{
 		Dispatcher: disp,
-		Scheduler:  FixedDelayScheduler{Delay: 5 * time.Millisecond},
+		Scheduler:  RetryScheduler{MaxBackoff: 5 * time.Millisecond},
 	})
 	defer cancel()
 
@@ -236,7 +236,7 @@ func TestScheduleRetry_TimerFireProducesExactlyOneReDispatch(t *testing.T) {
 // silently regress it.
 func TestRequestDispatch_DedupesAgainstRunning(t *testing.T) {
 	disp := &fakeDispatcher{}
-	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 
 	iss := tracker.Issue{ID: "ENG-2", Identifier: "ENG-2", Title: "dedupe"}
@@ -255,13 +255,13 @@ func TestRequestDispatch_DedupesAgainstRunning(t *testing.T) {
 	}
 }
 
-// TestFinalize_NormalExitMarksCompletedNoRetry covers the §7.3 normal
-// exit branch end-to-end through the actor: dispatch, the dispatcher
-// returns a successful WorkerResult, the finalize op moves the entry
-// into Completed and does not schedule a retry.
-func TestFinalize_NormalExitMarksCompletedNoRetry(t *testing.T) {
+// TestFinalize_NormalExitMarksCompletedAndSchedulesContinuationRetry covers
+// the §7.3 normal exit branch end-to-end through the actor: dispatch, the
+// dispatcher returns a successful WorkerResult, the finalize op records
+// Completed and schedules a short continuation retry.
+func TestFinalize_NormalExitMarksCompletedAndSchedulesContinuationRetry(t *testing.T) {
 	disp := &fakeDispatcher{}
-	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 
 	iss := tracker.Issue{ID: "ENG-3", Identifier: "ENG-3", Title: "ok"}
@@ -275,7 +275,7 @@ func TestFinalize_NormalExitMarksCompletedNoRetry(t *testing.T) {
 
 	waitFor(t, func() bool {
 		v, _ := o.Snapshot(context.Background())
-		return len(v.Running) == 0 && len(v.Completed) == 1 && len(v.Retrying) == 0
+		return len(v.Running) == 0 && len(v.Completed) == 1 && len(v.Retrying) == 1
 	}, time.Second)
 }
 
@@ -287,7 +287,7 @@ func TestFinalize_AbnormalExitSchedulesRetry(t *testing.T) {
 	disp := &fakeDispatcher{}
 	o, cancel := startActor(t, Deps{
 		Dispatcher: disp,
-		Scheduler:  FixedDelayScheduler{Delay: 250 * time.Millisecond},
+		Scheduler:  RetryScheduler{MaxBackoff: 250 * time.Millisecond},
 	})
 	defer cancel()
 
@@ -335,7 +335,7 @@ func TestFinalize_AbnormalExitHoldsClaimAcrossScheduleRetryGap(t *testing.T) {
 	// we're testing the gap, not the eventual re-dispatch.
 	o, cancel := startActor(t, Deps{
 		Dispatcher: disp,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	defer cancel()
 
@@ -400,7 +400,7 @@ func TestRetryFire_RespectsCapacityBeforeSpawning(t *testing.T) {
 	st := NewOrchestratorState(15000, 1)
 	o := New(st, Deps{
 		Dispatcher: disp,
-		Scheduler:  FixedDelayScheduler{Delay: 20 * time.Millisecond},
+		Scheduler:  RetryScheduler{MaxBackoff: 20 * time.Millisecond},
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -503,7 +503,7 @@ func TestRetryFire_CapacityDeferralUsesShortRecheckDelay(t *testing.T) {
 // would deadlock and time out.
 func TestApply_FollowupRunsOffActorAndCanResubmit(t *testing.T) {
 	disp := &fakeDispatcher{}
-	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 
 	resubmitted := make(chan struct{})
@@ -538,7 +538,7 @@ func TestApply_FollowupRunsOffActorAndCanResubmit(t *testing.T) {
 func TestRun_ContextCancelStopsActor(t *testing.T) {
 	disp := &fakeDispatcher{}
 	st := NewOrchestratorState(15000, 4)
-	o := New(st, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	o := New(st, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -564,7 +564,7 @@ func TestRun_ContextCancelStopsActor(t *testing.T) {
 // followup submitted, so the Running entry is always visible.
 func TestSnapshot_SerializedThroughActor(t *testing.T) {
 	disp := &fakeDispatcher{}
-	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 
 	for i := 0; i < 10; i++ {
@@ -582,13 +582,20 @@ func TestSnapshot_SerializedThroughActor(t *testing.T) {
 	}
 }
 
-// TestFixedDelayScheduler_NextDelay is a one-line guard so the legacy
-// 60-second behavior the PR 4 cutover preserves cannot drift silently.
-func TestFixedDelayScheduler_NextDelay(t *testing.T) {
-	s := FixedDelayScheduler{Delay: 60 * time.Second}
-	for attempt := 1; attempt <= 5; attempt++ {
-		if got := s.NextDelay(attempt); got != 60*time.Second {
-			t.Errorf("NextDelay(%d) = %v, want 60s", attempt, got)
+func TestRetryScheduler_FailureBackoffDoublesUntilCap(t *testing.T) {
+	s := RetryScheduler{MaxBackoff: 25 * time.Second}
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{attempt: 1, want: 10 * time.Second},
+		{attempt: 2, want: 20 * time.Second},
+		{attempt: 3, want: 25 * time.Second},
+		{attempt: 4, want: 25 * time.Second},
+	}
+	for _, tt := range tests {
+		if got := s.NextDelay(RetryRequest{Attempt: tt.attempt}); got != tt.want {
+			t.Errorf("failure retry delay attempt %d = %v, want %v", tt.attempt, got, tt.want)
 		}
 	}
 }

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -656,6 +656,25 @@ func TestRetryFire_CapacityDeferralUsesShortRecheckDelay(t *testing.T) {
 	}
 }
 
+func TestScheduleRetryUsesReloadedSchedulerWithoutRacing(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Hour}},
+	})
+	defer cancel()
+
+	if err := o.UpdateRetryScheduler(context.Background(), &sequenceScheduler{delays: []time.Duration{time.Millisecond}}); err != nil {
+		t.Fatalf("UpdateRetryScheduler: %v", err)
+	}
+	iss := tracker.Issue{ID: "ENG-SCHED", Identifier: "ENG-SCHED", Title: "scheduler reload"}
+	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "boom"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+}
+
 // TestApply_FollowupRunsOffActorAndCanResubmit pins the design's
 // "apply must not block on the ops channel" invariant: a followup
 // returned by apply runs on a fresh goroutine, so it can submit

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -342,6 +342,11 @@ func RunPollLoop(ctx context.Context, poller *Poller, interval time.Duration) er
 	if interval <= 0 {
 		interval = 30 * time.Second
 	}
+	intervalTimer := time.NewTimer(interval)
+	if !intervalTimer.Stop() {
+		<-intervalTimer.C
+	}
+	defer intervalTimer.Stop()
 	for {
 		if err := poller.PollOnce(ctx); err != nil {
 			if ctx.Err() != nil {
@@ -349,11 +354,15 @@ func RunPollLoop(ctx context.Context, poller *Poller, interval time.Duration) er
 			}
 			log.Printf("tracker poll error: %v", err)
 		}
+		intervalTimer.Reset(interval)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-poller.orchestrator.retryWakeCh():
-		case <-time.After(interval):
+			if !intervalTimer.Stop() {
+				<-intervalTimer.C
+			}
+		case <-intervalTimer.C:
 		}
 	}
 }

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -96,7 +96,7 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 		if issue.ID == "" {
 			continue
 		}
-		if err := p.orchestrator.RequestDispatch(ctx, issue, nil); err != nil {
+		if err := p.orchestrator.RequestDispatchAfterTrackerRecheck(ctx, issue, nil); err != nil {
 			switch {
 			case errors.Is(err, ErrNotDispatched):
 				continue

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -123,12 +123,7 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 	if p.stateTracker == nil {
 		return errors.New("orchestrator poller reconciliation requires state tracker")
 	}
-	activeByID := make(map[string]struct{}, len(activeIssues))
-	for _, issue := range activeIssues {
-		if issue.ID != "" {
-			activeByID[issue.ID] = struct{}{}
-		}
-	}
+	activeByID := issueIDSet(activeIssues)
 	inactiveByID := make(map[string]tracker.Issue)
 	var fetchErr error
 	for _, states := range p.reconcileInactiveStateGroups() {
@@ -167,6 +162,16 @@ func nonEmptyStateList(states []string) []string {
 	for _, state := range states {
 		if strings.TrimSpace(state) != "" {
 			out = append(out, state)
+		}
+	}
+	return out
+}
+
+func issueIDSet(issues []tracker.Issue) map[string]struct{} {
+	out := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		if issue.ID != "" {
+			out[issue.ID] = struct{}{}
 		}
 	}
 	return out
@@ -347,6 +352,7 @@ func RunPollLoop(ctx context.Context, poller *Poller, interval time.Duration) er
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-poller.orchestrator.retryWakeCh():
 		case <-time.After(interval):
 		}
 	}

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -30,12 +30,14 @@ func (f *fakeIssueTracker) ListActiveIssues(_ context.Context) ([]tracker.Issue,
 type recordingDispatcher struct {
 	mu        sync.Mutex
 	issues    []tracker.Issue
+	attempts  []*int
 	releaseCh chan struct{}
 }
 
-func (d *recordingDispatcher) Spawn(_ context.Context, issue tracker.Issue, _ *int) <-chan WorkerResult {
+func (d *recordingDispatcher) Spawn(_ context.Context, issue tracker.Issue, attempt *int) <-chan WorkerResult {
 	d.mu.Lock()
 	d.issues = append(d.issues, issue)
+	d.attempts = append(d.attempts, attempt)
 	releaseCh := d.releaseCh
 	d.mu.Unlock()
 	ch := make(chan WorkerResult, 1)
@@ -628,6 +630,12 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 		t.Fatalf("rework poll once: %v", err)
 	}
 	waitForDispatcherCount(t, dispatcher, 2)
+	dispatcher.mu.Lock()
+	secondAttempt := dispatcher.attempts[1]
+	dispatcher.mu.Unlock()
+	if secondAttempt == nil || *secondAttempt != 1 {
+		t.Fatalf("continuation dispatch attempt = %v, want 1", secondAttempt)
+	}
 }
 
 func TestPollOnceFailsFastAfterBuildTaskFailureWithoutRetryLoop(t *testing.T) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -280,7 +280,7 @@ func TestPollOnceCancelsRunningIssueWhenTrackerMovesToCancelled(t *testing.T) {
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -313,7 +313,7 @@ func TestPollOnceCancelsRunningIssueWhenTrackerMovesToBacklog(t *testing.T) {
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -347,7 +347,7 @@ func TestPollOnceTrackerErrorDoesNotCancelRunningIssue(t *testing.T) {
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -396,7 +396,7 @@ func TestPollOnceCancelsTerminalIssueBeforeReturningLaterInactiveFetchError(t *t
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -429,7 +429,7 @@ func TestPollOnceDoesNotCancelRunningIssueStillInActiveTrackerListing(t *testing
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -465,7 +465,7 @@ func TestPollOnceDoesNotCancelRunningIssueMissingFromPartialTrackerListing(t *te
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -502,7 +502,7 @@ func TestPollOnceReturnsErrorWhenCanceledWorkerDoesNotExitBeforeTimeout(t *testi
 	dispatcher := &stuckCancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -534,7 +534,7 @@ func TestPollOnceDispatchesActiveCandidatesWhenCanceledWorkerDoesNotExitBeforeTi
 	dispatcher := &stuckCancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 2), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -571,7 +571,7 @@ func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *t
 	dispatcher := &recordingDispatcher{releaseCh: releaseCh}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -610,7 +610,7 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	dispatcher := &recordingDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -638,7 +638,7 @@ func TestPollOnceFailsFastAfterBuildTaskFailureWithoutRetryLoop(t *testing.T) {
 	dispatcher := &erroringTaskDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -668,7 +668,7 @@ func TestPollOnceReleasesNonRetryableFailureAfterTrackerStateChanges(t *testing.
 	dispatcher := &erroringTaskDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -703,7 +703,7 @@ func TestPollOnceDoesNotExceedMaxConcurrentAgents(t *testing.T) {
 	dispatcher := &blockingDispatcher{}
 	orch := New(NewOrchestratorState(30000, 2), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -733,7 +733,7 @@ func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
 	dispatcher := &recordingDispatcher{releaseCh: firstRunBlocked}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
@@ -777,7 +777,7 @@ func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
 	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  FixedDelayScheduler{Delay: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -608,7 +608,6 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Rework"}}}
 	dispatcher := &recordingDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
@@ -616,12 +615,12 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
-		t.Fatalf("wait for orchestrator: %v", err)
+		t.Fatalf("WaitStarted: %v", err)
 	}
+	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1"}}}, orch)
 
-	poller := NewPoller(trackerClient, orch)
 	if err := poller.PollOnce(ctx); err != nil {
-		t.Fatalf("poll once: %v", err)
+		t.Fatalf("initial poll once: %v", err)
 	}
 	waitForDispatcherCount(t, dispatcher, 1)
 	waitForCompleted(t, ctx, orch, "issue-1")
@@ -634,8 +633,79 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	dispatcher.mu.Lock()
 	secondAttempt := dispatcher.attempts[1]
 	dispatcher.mu.Unlock()
-	if secondAttempt == nil || *secondAttempt != 1 {
-		t.Fatalf("continuation dispatch attempt = %v, want 1", secondAttempt)
+	if secondAttempt != nil {
+		t.Fatalf("continuation dispatch carried retry attempt = %d, want nil", *secondAttempt)
+	}
+}
+
+func TestPollOnceKeepsDueContinuationRetryMissingFromActiveListing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dispatcher := &recordingDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+	issue := tracker.Issue{ID: "issue-missing", Identifier: "ISSUE-MISSING", Title: "Issue missing from capped active listing"}
+	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{issue}}, orch)
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 1)
+	waitForCompleted(t, ctx, orch, IssueID(issue.ID))
+	waitForRetryDue(t, ctx, orch, IssueID(issue.ID))
+
+	poller.tracker = &fakeIssueTracker{}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("missing poll once: %v", err)
+	}
+	view, err := orch.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 1 || view.Retrying[0].IssueID != IssueID(issue.ID) {
+		t.Fatalf("retrying after issue missing from active listing = %+v, want continuation retained", view.Retrying)
+	}
+	if got := dispatcher.count(); got != 1 {
+		t.Fatalf("missing continuation poll spawned %d workers, want no new dispatch", got-1)
+	}
+}
+
+func TestRunPollLoopWakesWhenContinuationRetryTimerFires(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dispatcher := &recordingDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+	issue := tracker.Issue{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1"}
+	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{issue}}, orch)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- RunPollLoop(ctx, poller, time.Hour)
+	}()
+	waitForDispatcherCount(t, dispatcher, 2)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunPollLoop error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunPollLoop did not exit after context cancel")
 	}
 }
 

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -612,7 +612,7 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	dispatcher := &recordingDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -626,6 +626,7 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	waitForDispatcherCount(t, dispatcher, 1)
 	waitForCompleted(t, ctx, orch, "issue-1")
 
+	waitForRetryDue(t, ctx, orch, "issue-1")
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("rework poll once: %v", err)
 	}
@@ -802,6 +803,7 @@ func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
 	waitForCompleted(t, ctx, orch, "issue-1")
 	dispatcher.releaseCh = nil
 	trackerClient.issues = []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}
+	waitForRetryDue(t, ctx, orch, "issue-1")
 
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("second poll once after issue-2 left active states: %v", err)
@@ -885,6 +887,29 @@ func waitForCompleted(t *testing.T, ctx context.Context, orch *Orchestrator, id 
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatalf("issue %s was not marked completed", id)
+}
+
+func waitForRetryDue(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		view, err := orch.Snapshot(ctx)
+		if err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+		for _, retry := range view.Retrying {
+			if retry.IssueID == id && !retry.DueAt.After(time.Now()) {
+				return
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	view, err := orch.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	t.Fatalf("issue %s retry did not become due: retrying=%v", id, view.Retrying)
 }
 
 func waitForNoRunningOrRetrying(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -28,6 +28,7 @@ type RetryEntry struct {
 	DueAt      time.Time
 	Timer      *time.Timer
 	Error      string
+	Kind       RetryKind
 }
 
 // IsDue reports whether the retry's DueAt has passed relative to now.

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -71,6 +71,9 @@ func (p *RuntimePoller) PollOnce(ctx context.Context) error {
 	if err := p.orchestrator.UpdateMaxConcurrentAgents(ctx, snap.MaxConcurrentAgents); err != nil {
 		return err
 	}
+	if err := p.orchestrator.UpdateRetryScheduler(ctx, RetryScheduler{MaxBackoff: snap.MaxRetryBackoff}); err != nil {
+		return err
+	}
 	return poller.PollOnce(ctx)
 }
 

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -405,6 +405,40 @@ func TestRunPollLoopWithRuntimeUsesReloadedPollingCadence(t *testing.T) {
 	}
 }
 
+func TestRunPollLoopWithRuntimePollerHonorsInjectedSleep(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	path := writeWorkflowForReloadTest(t, "linear", 60000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load initial workflow: %v", err)
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	disp := &recordingDispatcher{releaseCh: make(chan struct{})}
+	orch, orchCancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Second}})
+	defer orchCancel()
+	poller, err := NewRuntimePoller(&fakeIssueStateTracker{}, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+	sleeper := &recordingPollSleeper{}
+
+	start := time.Now()
+	err = RunPollLoopWithRuntime(ctx, poller, runtime, PollLoopRuntimeOptions{Sleep: sleeper.sleep, StopAfterPolls: 1})
+	if err != nil {
+		t.Fatalf("run poll loop: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("runtime poll loop ignored injected sleep and waited %v", elapsed)
+	}
+	if got, want := sleeper.durations, []time.Duration{60 * time.Second}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("sleep durations = %v, want %v", got, want)
+	}
+}
+
 type countingPollOnce struct {
 	calls      int
 	afterFirst func()

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
@@ -208,6 +209,55 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsToDispatchCapacity(t *te
 	waitForBlockingDispatcherCount(t, dispatcher, 2)
 }
 
+func TestRuntimePollerAppliesReloadedMaxRetryBackoffToFailureRetries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready", withReloadTestMaxRetryBackoffMs(1000))
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load initial workflow: %v", err)
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "AI Ready"}}}
+	dispatcher := &fakeDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Second}})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+
+	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "AI Ready", withReloadTestMaxRetryBackoffMs(50))
+	if err := runtime.ReloadOnce(ctx); err != nil {
+		t.Fatalf("reload workflow: %v", err)
+	}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll after retry backoff reload: %v", err)
+	}
+	waitFor(t, func() bool { return dispatcher.count() == 1 }, time.Second)
+	dispatcher.finishAt(0, WorkerResult{Err: errors.New("boom"), Elapsed: time.Millisecond})
+
+	waitFor(t, func() bool {
+		view, err := orch.Snapshot(ctx)
+		if err != nil {
+			return false
+		}
+		for _, retry := range view.Retrying {
+			if retry.IssueID == "issue-1" && retry.DueAt.Sub(time.Now()) <= 200*time.Millisecond {
+				return true
+			}
+		}
+		return false
+	}, time.Second)
+}
+
 func TestRuntimePollerRebuildsTrackerClientAfterTrackerConfigReload(t *testing.T) {
 	ctx := context.Background()
 	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
@@ -390,16 +440,16 @@ func (s *reloadLoopTestSleeper) sleep(_ context.Context, _ time.Duration) error 
 	return nil
 }
 
-func writeWorkflowForReloadTest(t *testing.T, trackerKind string, pollIntervalMs int, activeState string) string {
+func writeWorkflowForReloadTest(t *testing.T, trackerKind string, pollIntervalMs int, activeState string, opts ...reloadWorkflowTestOption) string {
 	t.Helper()
 	path := t.TempDir() + "/WORKFLOW.md"
-	writeWorkflowForReloadTestAt(t, path, trackerKind, pollIntervalMs, activeState)
+	writeWorkflowForReloadTestAt(t, path, trackerKind, pollIntervalMs, activeState, opts...)
 	return path
 }
 
 func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIntervalMs int, activeState string, opts ...reloadWorkflowTestOption) {
 	t.Helper()
-	cfg := reloadWorkflowTestConfig{maxConcurrentAgents: 100}
+	cfg := reloadWorkflowTestConfig{maxConcurrentAgents: 100, maxRetryBackoffMs: 300000}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -416,6 +466,7 @@ func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIn
 		"agent:\n" +
 		"  default: mock\n" +
 		"  max_concurrent_agents: " + itoaForReloadTest(cfg.maxConcurrentAgents) + "\n" +
+		"  max_retry_backoff_ms: " + itoaForReloadTest(cfg.maxRetryBackoffMs) + "\n" +
 		"---\n" +
 		"Prompt body\n"
 	if err := osWriteFileForReloadTest(path, []byte(content)); err != nil {
@@ -425,6 +476,7 @@ func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIn
 
 type reloadWorkflowTestConfig struct {
 	maxConcurrentAgents int
+	maxRetryBackoffMs   int
 }
 
 type reloadWorkflowTestOption func(*reloadWorkflowTestConfig)
@@ -432,6 +484,12 @@ type reloadWorkflowTestOption func(*reloadWorkflowTestConfig)
 func withReloadTestMaxConcurrentAgents(n int) reloadWorkflowTestOption {
 	return func(cfg *reloadWorkflowTestConfig) {
 		cfg.maxConcurrentAgents = n
+	}
+}
+
+func withReloadTestMaxRetryBackoffMs(n int) reloadWorkflowTestOption {
+	return func(cfg *reloadWorkflowTestConfig) {
+		cfg.maxRetryBackoffMs = n
 	}
 }
 

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -135,7 +135,7 @@ func TestRuntimePollerUsesReloadedTrackerStatesFromSameWorkflowPath(t *testing.T
 		{ID: "issue-rework", Identifier: "ISSUE-2", Title: "rework", State: "Rework"},
 	}}
 	dispatcher := &fakeDispatcher{}
-	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
 	if err != nil {
@@ -183,7 +183,7 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsToDispatchCapacity(t *te
 		{ID: "issue-2", Identifier: "ISSUE-2", Title: "two", State: "AI Ready"},
 	}}
 	dispatcher := &blockingDispatcher{}
-	orch := New(NewOrchestratorState(30000, initial.Config.Agent.MaxConcurrentAgents), Deps{Dispatcher: dispatcher, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	orch := New(NewOrchestratorState(30000, initial.Config.Agent.MaxConcurrentAgents), Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("wait for orchestrator: %v", err)
@@ -225,7 +225,7 @@ func TestRuntimePollerRebuildsTrackerClientAfterTrackerConfigReload(t *testing.T
 	}
 	factoryCalls := 0
 	dispatcher := &fakeDispatcher{}
-	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: FixedDelayScheduler{Delay: time.Minute}})
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 	poller, err := NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (IssueStateLister, error) {
 		factoryCalls++

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -42,6 +42,7 @@ type WorkflowSnapshot struct {
 	Workflow            *workflow.Workflow
 	PollInterval        time.Duration
 	MaxConcurrentAgents int
+	MaxRetryBackoff     time.Duration
 	Reconciliation      ReconciliationConfig
 	Fingerprint         string
 }
@@ -153,6 +154,7 @@ func (r *WorkflowRuntime) snapshotFromWorkflow(wf *workflow.Workflow, fingerprin
 		Workflow:            wf,
 		PollInterval:        time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond,
 		MaxConcurrentAgents: wf.Config.Agent.MaxConcurrentAgents,
+		MaxRetryBackoff:     time.Duration(wf.Config.Agent.MaxRetryBackoffMs) * time.Millisecond,
 		Reconciliation:      reconcile,
 		Fingerprint:         fingerprint,
 	}

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -201,12 +201,36 @@ func RunPollLoopWithRuntime(ctx context.Context, poller pollOnce, runtime *Workf
 			log.Printf("tracker poll error: %v", err)
 		}
 		polls++
-		if err := sleep(ctx, interval); err != nil {
+		if runtimePoller, ok := poller.(*RuntimePoller); ok {
+			if err := sleepOrRetryWake(ctx, sleep, interval, runtimePoller.orchestrator.retryWakeCh()); err != nil {
+				return err
+			}
+		} else if err := sleep(ctx, interval); err != nil {
 			return err
 		}
 		if opts.StopAfterPolls > 0 && polls >= opts.StopAfterPolls {
 			return nil
 		}
+	}
+}
+
+func sleepOrRetryWake(ctx context.Context, sleep func(context.Context, time.Duration) error, interval time.Duration, wake <-chan struct{}) error {
+	if wake == nil {
+		return sleep(ctx, interval)
+	}
+	sleepCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	sleepErr := make(chan error, 1)
+	go func() {
+		sleepErr <- sleep(sleepCtx, interval)
+	}()
+	select {
+	case err := <-sleepErr:
+		return err
+	case <-wake:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/internal/worker/print_config.go
+++ b/internal/worker/print_config.go
@@ -55,6 +55,7 @@ type agentConfigView struct {
 	Default             string `json:"default"`
 	MaxConcurrentAgents int    `json:"max_concurrent_agents"`
 	MaxTurns            int    `json:"max_turns"`
+	MaxRetryBackoffMs   int    `json:"max_retry_backoff_ms"`
 	Timeout             string `json:"timeout"`
 	MaxTimeoutRetries   *int   `json:"max_timeout_retries"`
 }
@@ -68,6 +69,7 @@ func newConfigView(cfg workflow.Config) configView {
 			Default:             cfg.Agent.Default,
 			MaxConcurrentAgents: cfg.Agent.MaxConcurrentAgents,
 			MaxTurns:            cfg.Agent.MaxTurns,
+			MaxRetryBackoffMs:   cfg.Agent.MaxRetryBackoffMs,
 			Timeout:             cfg.Agent.Timeout.String(),
 			MaxTimeoutRetries:   cfg.Agent.MaxTimeoutRetries,
 		},

--- a/internal/worker/print_config_test.go
+++ b/internal/worker/print_config_test.go
@@ -169,6 +169,35 @@ func TestPrintConfig_AgentTimeoutFromYAMLOverride(t *testing.T) {
 	}
 }
 
+// TestPrintConfig_ExposesMaxRetryBackoffMs verifies the effective-config
+// inspection path includes the retry backoff cap that controls orchestrator
+// retry timing. Operators rely on --print-config to confirm workflow reloads
+// and overrides took effect.
+func TestPrintConfig_ExposesMaxRetryBackoffMs(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  max_retry_backoff_ms: 45000\ntracker:\n  kind: linear\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	var out struct {
+		Config struct {
+			Agent struct {
+				MaxRetryBackoffMs int `json:"max_retry_backoff_ms"`
+			} `json:"agent"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout: %s", err, stdout.String())
+	}
+	if got, want := out.Config.Agent.MaxRetryBackoffMs, 45000; got != want {
+		t.Fatalf("agent.max_retry_backoff_ms = %d, want %d\nstdout:\n%s", got, want, stdout.String())
+	}
+}
+
 // TestPrintConfig_TopLevelSourceAndShadowedBy pins the contract from
 // issue #69: the JSON output surfaces `source` and `shadowed_by` at the
 // top level (not only under `resolution`) so operators answering "which

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -157,6 +157,7 @@ type AgentConfig struct {
 	Default             string `yaml:"default" json:"default"`
 	MaxConcurrentAgents int    `yaml:"max_concurrent_agents" json:"max_concurrent_agents"`
 	MaxTurns            int    `yaml:"max_turns" json:"max_turns"`
+	MaxRetryBackoffMs   int    `yaml:"max_retry_backoff_ms" json:"max_retry_backoff_ms"`
 	// Timeout caps a single runner invocation. When exceeded, the runner
 	// subprocess is killed and the task records a `runner_timeout` event.
 	// Configured via YAML as `agent.timeout: 10m`. Zero means use the
@@ -337,6 +338,7 @@ func DefaultConfig() Config {
 			Default:             "mock",
 			MaxConcurrentAgents: 1,
 			MaxTurns:            20,
+			MaxRetryBackoffMs:   300000,
 			Timeout:             30 * time.Minute,
 		},
 		Codex: CommandConfig{

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -120,6 +120,49 @@ func TestDefaultConfigAgentTimeout(t *testing.T) {
 	if got := cfg.Agent.MaxTimeoutRetriesValue(); got != 1 {
 		t.Fatalf("default Agent.MaxTimeoutRetriesValue: got %d want 1", got)
 	}
+	if cfg.Agent.MaxRetryBackoffMs != 300000 {
+		t.Fatalf("default Agent.MaxRetryBackoffMs: got %d want 300000", cfg.Agent.MaxRetryBackoffMs)
+	}
+}
+
+func TestLoadParsesAgentMaxRetryBackoffMs(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+agent:
+  max_retry_backoff_ms: 45000
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if wf.Config.Agent.MaxRetryBackoffMs != 45000 {
+		t.Fatalf("Agent.MaxRetryBackoffMs = %d, want 45000", wf.Config.Agent.MaxRetryBackoffMs)
+	}
+}
+
+func TestLoadRejectsNonPositiveAgentMaxRetryBackoffMs(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+agent:
+  max_retry_backoff_ms: 0
+---
+prompt body
+`
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load succeeded with agent.max_retry_backoff_ms=0, want validation error")
+	}
+	if !strings.Contains(err.Error(), "agent.max_retry_backoff_ms must be positive") {
+		t.Fatalf("Load error = %v, want agent.max_retry_backoff_ms positivity guidance", err)
+	}
 }
 
 func TestLoadParsesTopLevelWorkspaceHooks(t *testing.T) {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -158,6 +158,9 @@ func validateConfig(path string, cfg Config) error {
 	if strings.TrimSpace(cfg.Claude.Profile) != "" {
 		return fmt.Errorf("%s: claude.profile is not supported (only codex has profiles)", path)
 	}
+	if cfg.Agent.MaxRetryBackoffMs <= 0 {
+		return fmt.Errorf("%s: agent.max_retry_backoff_ms must be positive", path)
+	}
 	if cfg.Hooks.TimeoutMs < 0 {
 		return fmt.Errorf("%s: hooks.timeout_ms must be non-negative", path)
 	}

--- a/test/e2e/gitea_poller_test.go
+++ b/test/e2e/gitea_poller_test.go
@@ -45,7 +45,7 @@ func TestGiteaPollerDispatchesLabeledIssueAndDedupesRepeatedPolls(t *testing.T) 
 	disp := &fakeE2EDispatcher{}
 	orch := orchestrator.New(orchestrator.NewOrchestratorState(15000, 1), orchestrator.Deps{
 		Dispatcher: disp,
-		Scheduler:  orchestrator.FixedDelayScheduler{Delay: time.Minute},
+		Scheduler:  orchestrator.RetryScheduler{MaxBackoff: time.Minute},
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -112,7 +112,7 @@ func TestGiteaPollerIgnoresBacklogAndTerminalIssues(t *testing.T) {
 	disp := &fakeE2EDispatcher{}
 	orch := orchestrator.New(orchestrator.NewOrchestratorState(15000, 1), orchestrator.Deps{
 		Dispatcher: disp,
-		Scheduler:  orchestrator.FixedDelayScheduler{Delay: time.Minute},
+		Scheduler:  orchestrator.RetryScheduler{MaxBackoff: time.Minute},
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -128,7 +128,7 @@ func runGiteaPollerWorkerTask(t *testing.T, ctx context.Context, repo, title, bo
 	}
 	orch := orchestrator.New(orchestrator.NewOrchestratorState(15000, 1), orchestrator.Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  orchestrator.FixedDelayScheduler{Delay: time.Minute},
+		Scheduler:  orchestrator.RetryScheduler{MaxBackoff: time.Minute},
 	})
 	orchCtx, orchCancel := context.WithCancel(ctx)
 	t.Cleanup(orchCancel)


### PR DESCRIPTION
## Summary
- add `agent.max_retry_backoff_ms` workflow config validation/defaults
- replace fixed retry delay with SPEC-style continuation retry and exponential failure backoff
- preserve poll-tick redispatch after tracker recheck while holding continuation retry claims between clean exits

## Test Plan
- `/home/pi/.local/go1.25.10/bin/go test ./internal/workflow ./internal/orchestrator ./cmd/worker`
- `/home/pi/.local/go1.25.10/bin/go test ./...`

Closes #90
