### PR TITLE
feat: route Linear issues by service config

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -62,6 +62,7 @@ The 2026-05-15 gap audit (PR [#82](https://github.com/xrf9268-hue/aiops-platform
 | D22 | Run attempt phases (§7.2) and runtime events (§10.4) not modeled (depends on D1)                  | §7.2, §10.4                                               | Medium   | Open                    | [#96](https://github.com/xrf9268-hue/aiops-platform/issues/96)                                                                       |
 | D23 | `linear_graphql` client-side tool surface is partially implemented; #97 tracks remaining gaps     | §10.5                                                     | Medium   | Partial                 | [#97](https://github.com/xrf9268-hue/aiops-platform/issues/97) / PR [#116](https://github.com/xrf9268-hue/aiops-platform/pull/116) |
 | D24 | Workflow front-matter schema: aiops keys + missing core (`hooks`, `polling`, `workspace.root`)    | §5.3                                                      | Medium   | Open                    | [#98](https://github.com/xrf9268-hue/aiops-platform/issues/98)                                                                       |
+| D25 | Multi-service `WORKFLOW.md` routing schema is an implementation-defined extension requiring explicit documentation | §5.3 extension note, §8.2, §11.2                           | Low      | Partial                 | [#143](https://github.com/xrf9268-hue/aiops-platform/issues/143) / [#16](https://github.com/xrf9268-hue/aiops-platform/issues/16) |
 
 Severity reflects the risk and the gap to SPEC, not the implementation effort.
 

--- a/cmd/linear-poller/main.go
+++ b/cmd/linear-poller/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
 	"github.com/xrf9268-hue/aiops-platform/internal/queue"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
@@ -47,19 +49,66 @@ func main() {
 	}
 	defer pool.Close()
 	store := queue.New(pool)
-	client := tracker.NewLinearClient(wf.Config.Tracker)
+	listers := linearIssueListers(wf.Config)
 	interval := time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond
 
 	for {
-		issues, err := client.ListActiveIssues(ctx)
-		if err != nil {
+		if err := pollOnce(ctx, store, &wf.Config, listers); err != nil {
 			log.Printf("linear poll error: %v", err)
-			time.Sleep(interval)
-			continue
 		}
-		processIssues(ctx, store, &wf.Config, issues)
 		time.Sleep(interval)
 	}
+}
+
+type activeIssueLister interface {
+	ListActiveIssues(ctx context.Context) ([]tracker.Issue, error)
+}
+
+type linearIssueSource struct {
+	lister      activeIssueLister
+	projectSlug string
+}
+
+func linearIssueListers(cfg workflow.Config) []linearIssueSource {
+	projectConfigs := orchestrator.TrackerProjectConfigs(cfg)
+	listers := make([]linearIssueSource, 0, len(projectConfigs))
+	for _, projectCfg := range projectConfigs {
+		listers = append(listers, linearIssueSource{
+			lister:      tracker.NewLinearClient(projectCfg.Tracker),
+			projectSlug: strings.TrimSpace(projectCfg.Tracker.ProjectSlug),
+		})
+	}
+	return listers
+}
+
+func pollOnce(ctx context.Context, store enqueuer, cfg *workflow.Config, sources []linearIssueSource) error {
+	var pollErr error
+	for _, source := range sources {
+		issues, err := source.lister.ListActiveIssues(ctx)
+		if err != nil {
+			pollErr = errors.Join(pollErr, err)
+			continue
+		}
+		processIssues(ctx, store, cfg, filterIssuesForPollSource(*cfg, issues, source.projectSlug))
+	}
+	return pollErr
+}
+
+func filterIssuesForPollSource(cfg workflow.Config, issues []tracker.Issue, projectSlug string) []tracker.Issue {
+	rootProject := strings.TrimSpace(cfg.Tracker.ProjectSlug)
+	if rootProject != "" && strings.EqualFold(rootProject, strings.TrimSpace(projectSlug)) {
+		return issues
+	}
+	out := make([]tracker.Issue, 0, len(issues))
+	for _, issue := range issues {
+		for _, service := range cfg.Services {
+			if serviceMatchesIssue(service, cfg.Tracker, issue) {
+				out = append(out, issue)
+				break
+			}
+		}
+	}
+	return out
 }
 
 // processIssues enqueues each polled Linear issue once. It is split out from

--- a/cmd/linear-poller/main.go
+++ b/cmd/linear-poller/main.go
@@ -67,19 +67,27 @@ func main() {
 // without standing up Postgres or the Linear API.
 func processIssues(ctx context.Context, store enqueuer, cfg *workflow.Config, issues []tracker.Issue) {
 	for _, issue := range issues {
-		if cfg.Repo.CloneURL == "" {
+		repo, serviceName, ok := repoForIssue(*cfg, issue)
+		if !ok {
+			continue
+		}
+		if repo.CloneURL == "" {
 			log.Printf("skip %s: repo.clone_url missing in WORKFLOW.md", issue.Identifier)
 			continue
+		}
+		description := issue.Description + "\n\nLinear: " + issue.URL
+		if serviceName != "" {
+			description += "\n\nService: " + serviceName
 		}
 		out, deduped, err := store.Enqueue(ctx, task.Task{
 			SourceType:    "linear_issue",
 			SourceEventID: sourceEventID(issue),
-			RepoOwner:     cfg.Repo.Owner,
-			RepoName:      cfg.Repo.Name,
-			CloneURL:      cfg.Repo.CloneURL,
-			BaseBranch:    cfg.Repo.DefaultBranch,
+			RepoOwner:     repo.Owner,
+			RepoName:      repo.Name,
+			CloneURL:      repo.CloneURL,
+			BaseBranch:    repo.DefaultBranch,
 			Title:         fmt.Sprintf("%s %s", issue.Identifier, issue.Title),
-			Description:   issue.Description + "\n\nLinear: " + issue.URL,
+			Description:   description,
 			Actor:         "linear",
 			Model:         cfg.Agent.Default,
 			Priority:      50,
@@ -90,6 +98,77 @@ func processIssues(ctx context.Context, store enqueuer, cfg *workflow.Config, is
 		}
 		log.Printf("issue %s -> task %s deduped=%v", issue.Identifier, out.ID, deduped)
 	}
+}
+
+func repoForIssue(cfg workflow.Config, issue tracker.Issue) (workflow.RepoConfig, string, bool) {
+	if len(cfg.Services) == 0 {
+		return cfg.Repo, "", true
+	}
+	matches := make([]workflow.ServiceConfig, 0, len(cfg.Services))
+	for _, service := range cfg.Services {
+		if serviceMatchesIssue(service, cfg.Tracker, issue) {
+			matches = append(matches, service)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		if strings.TrimSpace(cfg.Repo.CloneURL) != "" {
+			return cfg.Repo, "", true
+		}
+		log.Printf("skip %s: no configured service matched Linear route", issue.Identifier)
+		return workflow.RepoConfig{}, "", false
+	case 1:
+		return matches[0].Repo, matches[0].Name, true
+	default:
+		names := make([]string, 0, len(matches))
+		for _, service := range matches {
+			names = append(names, service.Name)
+		}
+		log.Printf("skip %s: ambiguous Linear route matched services %s", issue.Identifier, strings.Join(names, ", "))
+		return workflow.RepoConfig{}, "", false
+	}
+}
+
+func serviceMatchesIssue(service workflow.ServiceConfig, defaults workflow.TrackerConfig, issue tracker.Issue) bool {
+	route := service.Tracker
+	if !hasExplicitServiceRoute(route) {
+		return false
+	}
+	projectSlug := strings.TrimSpace(route.ProjectSlug)
+	if projectSlug == "" {
+		projectSlug = strings.TrimSpace(defaults.ProjectSlug)
+	}
+	if projectSlug != "" && !strings.EqualFold(projectSlug, strings.TrimSpace(issue.ProjectSlug)) {
+		return false
+	}
+	if route.TeamKey != "" && !strings.EqualFold(strings.TrimSpace(route.TeamKey), strings.TrimSpace(issue.TeamKey)) {
+		return false
+	}
+	issueLabels := make(map[string]struct{}, len(issue.Labels))
+	for _, label := range issue.Labels {
+		if label = strings.ToLower(strings.TrimSpace(label)); label != "" {
+			issueLabels[label] = struct{}{}
+		}
+	}
+	for _, label := range route.Labels {
+		if _, ok := issueLabels[strings.ToLower(strings.TrimSpace(label))]; !ok {
+			return false
+		}
+	}
+	for key, want := range route.CustomFields {
+		got, ok := issue.CustomFields[key]
+		if !ok || strings.TrimSpace(got) != strings.TrimSpace(want) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasExplicitServiceRoute(route workflow.ServiceTrackerRouteConfig) bool {
+	return strings.TrimSpace(route.ProjectSlug) != "" ||
+		strings.TrimSpace(route.TeamKey) != "" ||
+		len(route.Labels) > 0 ||
+		len(route.CustomFields) > 0
 }
 
 // sourceEventID builds the dedupe key the poller hands to queue.Store.Enqueue.

--- a/cmd/linear-poller/main.go
+++ b/cmd/linear-poller/main.go
@@ -130,7 +130,7 @@ func processIssues(ctx context.Context, store enqueuer, cfg *workflow.Config, is
 		}
 		out, deduped, err := store.Enqueue(ctx, task.Task{
 			SourceType:    "linear_issue",
-			SourceEventID: sourceEventID(issue),
+			SourceEventID: sourceEventIDForService(issue, serviceName),
 			RepoOwner:     repo.Owner,
 			RepoName:      repo.Name,
 			CloneURL:      repo.CloneURL,
@@ -247,10 +247,18 @@ func hasExplicitServiceRoute(route workflow.ServiceTrackerRouteConfig) bool {
 // and updatedAt is sufficient because state changes are the dominant
 // trigger for re-polling a Rework issue.
 func sourceEventID(issue tracker.Issue) string {
-	if strings.EqualFold(issue.State, reworkStateName) && issue.UpdatedAt != "" {
-		return issue.ID + "|rework|" + issue.UpdatedAt
+	return sourceEventIDForService(issue, "")
+}
+
+func sourceEventIDForService(issue tracker.Issue, serviceName string) string {
+	key := issue.ID
+	if serviceName != "" {
+		key += "|service|" + serviceName
 	}
-	return issue.ID
+	if strings.EqualFold(issue.State, reworkStateName) && issue.UpdatedAt != "" {
+		return key + "|rework|" + issue.UpdatedAt
+	}
+	return key
 }
 
 func env(k, d string) string {

--- a/cmd/linear-poller/main_test.go
+++ b/cmd/linear-poller/main_test.go
@@ -207,6 +207,48 @@ func TestProcessIssuesRoutesServiceOnlyLinearWorkflow(t *testing.T) {
 	}
 }
 
+func TestProcessIssuesEnqueuesFreshTaskWhenIssueRouteChangesService(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Repo = workflow.RepoConfig{}
+	cfg.Tracker.ProjectSlug = "platform"
+	cfg.Services = []workflow.ServiceConfig{
+		{
+			Name:    "api",
+			Repo:    workflow.RepoConfig{Owner: "octo", Name: "api", CloneURL: "git@example.com:octo/api.git", DefaultBranch: "main"},
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"api"}},
+		},
+		{
+			Name:    "web",
+			Repo:    workflow.RepoConfig{Owner: "octo", Name: "web", CloneURL: "git@example.com:octo/web.git", DefaultBranch: "main"},
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"web"}},
+		},
+	}
+
+	issueForAPI := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "route me", State: "AI Ready",
+		ProjectSlug: "platform", Labels: []string{"api"}, UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+	issueForWeb := issueForAPI
+	issueForWeb.Labels = []string{"web"}
+
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issueForAPI})
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issueForWeb})
+
+	if store.inserts() != 2 {
+		t.Fatalf("inserts after route change = %d, want one task per matched service", store.inserts())
+	}
+	if got := store.calls[0].SourceEventID; got != "abc-123|service|api" {
+		t.Fatalf("first source_event_id = %q, want api service key", got)
+	}
+	if got := store.calls[1].SourceEventID; got != "abc-123|service|web" {
+		t.Fatalf("second source_event_id = %q, want web service key", got)
+	}
+	if store.calls[0].RepoName != "api" || store.calls[1].RepoName != "web" {
+		t.Fatalf("enqueued repos = %q then %q, want api then web", store.calls[0].RepoName, store.calls[1].RepoName)
+	}
+}
+
 func TestLinearIssueListersFanOutServiceOnlyLinearWorkflowProjects(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Repo = workflow.RepoConfig{}

--- a/cmd/linear-poller/main_test.go
+++ b/cmd/linear-poller/main_test.go
@@ -165,6 +165,125 @@ func TestProcessIssuesSkipsWhenCloneURLMissing(t *testing.T) {
 	}
 }
 
+func TestProcessIssuesRoutesServiceOnlyLinearWorkflow(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Repo = workflow.RepoConfig{}
+	cfg.Tracker.ProjectSlug = "platform"
+	cfg.Services = []workflow.ServiceConfig{
+		{
+			Name:    "api",
+			Repo:    workflow.RepoConfig{Owner: "octo", Name: "api", CloneURL: "git@example.com:octo/api.git", DefaultBranch: "main"},
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"api"}},
+		},
+	}
+
+	issue := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "route me", State: "AI Ready",
+		ProjectSlug: "platform", Labels: []string{"api"}, UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issue})
+
+	if len(store.calls) != 1 {
+		t.Fatalf("Enqueue calls = %d, want 1 for matched service route", len(store.calls))
+	}
+	got := store.calls[0]
+	if got.RepoOwner != "octo" || got.RepoName != "api" || got.CloneURL != "git@example.com:octo/api.git" {
+		t.Fatalf("task repo = %s/%s %s, want octo/api service repo", got.RepoOwner, got.RepoName, got.CloneURL)
+	}
+}
+
+func TestProcessIssuesSkipsUnmatchedServiceOnlyLinearWorkflow(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Repo = workflow.RepoConfig{}
+	cfg.Tracker.ProjectSlug = "platform"
+	cfg.Services = []workflow.ServiceConfig{
+		{
+			Name:    "api",
+			Repo:    workflow.RepoConfig{Owner: "octo", Name: "api", CloneURL: "git@example.com:octo/api.git", DefaultBranch: "main"},
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"api"}},
+		},
+	}
+
+	issue := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "skip me", State: "AI Ready",
+		ProjectSlug: "platform", Labels: []string{"docs"}, UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issue})
+
+	if len(store.calls) != 0 {
+		t.Fatalf("Enqueue called %d times, want 0 for unmatched service route", len(store.calls))
+	}
+}
+
+func TestProcessIssuesSkipsAmbiguousServiceOnlyLinearWorkflow(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Repo = workflow.RepoConfig{}
+	cfg.Tracker.ProjectSlug = "platform"
+	cfg.Services = []workflow.ServiceConfig{
+		{Name: "api", Repo: workflow.RepoConfig{Owner: "octo", Name: "api", CloneURL: "git@example.com:octo/api.git", DefaultBranch: "main"}, Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"backend"}}},
+		{Name: "worker", Repo: workflow.RepoConfig{Owner: "octo", Name: "worker", CloneURL: "git@example.com:octo/worker.git", DefaultBranch: "main"}, Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"backend"}}},
+	}
+
+	issue := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "ambiguous", State: "AI Ready",
+		ProjectSlug: "platform", Labels: []string{"backend"}, UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issue})
+
+	if len(store.calls) != 0 {
+		t.Fatalf("Enqueue called %d times, want 0 for ambiguous service route", len(store.calls))
+	}
+}
+
+func TestProcessIssuesIgnoresServiceWithoutLinearRoute(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Repo = workflow.RepoConfig{}
+	cfg.Tracker.ProjectSlug = "platform"
+	cfg.Services = []workflow.ServiceConfig{
+		{Name: "api", Repo: workflow.RepoConfig{Owner: "octo", Name: "api", CloneURL: "git@example.com:octo/api.git", DefaultBranch: "main"}, Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"api"}}},
+		{Name: "unrouted", Repo: workflow.RepoConfig{Owner: "octo", Name: "unrouted", CloneURL: "git@example.com:octo/unrouted.git", DefaultBranch: "main"}},
+	}
+
+	issue := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "route me", State: "AI Ready",
+		ProjectSlug: "platform", Labels: []string{"api"}, UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issue})
+
+	if len(store.calls) != 1 {
+		t.Fatalf("Enqueue calls = %d, want 1; unrouted service must not create ambiguity", len(store.calls))
+	}
+	if got := store.calls[0].RepoName; got != "api" {
+		t.Fatalf("enqueued repo name = %q, want api", got)
+	}
+}
+
+func TestProcessIssuesFallsBackToRootRepoWhenNoServiceRouteMatches(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Services = []workflow.ServiceConfig{
+		{Name: "api", Repo: workflow.RepoConfig{Owner: "octo", Name: "api", CloneURL: "git@example.com:octo/api.git", DefaultBranch: "main"}, Tracker: workflow.ServiceTrackerRouteConfig{Labels: []string{"api"}}},
+	}
+
+	issue := tracker.Issue{
+		ID: "abc-123", Identifier: "ENG-1", Title: "root repo", State: "AI Ready",
+		Labels: []string{"docs"}, UpdatedAt: "2026-05-08T10:00:00Z",
+	}
+	processIssues(context.Background(), store, cfg, []tracker.Issue{issue})
+
+	if len(store.calls) != 1 {
+		t.Fatalf("Enqueue calls = %d, want 1 for root repo fallback", len(store.calls))
+	}
+	got := store.calls[0]
+	if got.RepoOwner != "octo" || got.RepoName != "demo" || got.CloneURL != "git@example.com:octo/demo.git" {
+		t.Fatalf("task repo = %s/%s %s, want octo/demo root repo", got.RepoOwner, got.RepoName, got.CloneURL)
+	}
+}
+
 func mapKeys(m map[string]task.Task) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/cmd/linear-poller/main_test.go
+++ b/cmd/linear-poller/main_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+type fakeIssueLister struct {
+	issues []tracker.Issue
+	err    error
+	calls  int
+}
+
+func (l *fakeIssueLister) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	l.calls++
+	if l.err != nil {
+		return nil, l.err
+	}
+	return l.issues, nil
+}
+
 // fakeStore mimics queue.Store.Enqueue with the same dedupe semantics as the
 // Postgres ON CONFLICT (source_type, source_event_id) DO UPDATE clause: the
 // first call for a given key INSERTs and returns deduped=false, repeats
@@ -190,6 +204,103 @@ func TestProcessIssuesRoutesServiceOnlyLinearWorkflow(t *testing.T) {
 	got := store.calls[0]
 	if got.RepoOwner != "octo" || got.RepoName != "api" || got.CloneURL != "git@example.com:octo/api.git" {
 		t.Fatalf("task repo = %s/%s %s, want octo/api service repo", got.RepoOwner, got.RepoName, got.CloneURL)
+	}
+}
+
+func TestLinearIssueListersFanOutServiceOnlyLinearWorkflowProjects(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Repo = workflow.RepoConfig{}
+	cfg.Tracker.ProjectSlug = ""
+	cfg.Services = []workflow.ServiceConfig{
+		{
+			Name:    "api",
+			Repo:    workflow.RepoConfig{Owner: "octo", Name: "api", CloneURL: "git@example.com:octo/api.git", DefaultBranch: "main"},
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"},
+		},
+		{
+			Name:    "web",
+			Repo:    workflow.RepoConfig{Owner: "octo", Name: "web", CloneURL: "git@example.com:octo/web.git", DefaultBranch: "main"},
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"},
+		},
+	}
+
+	listers := linearIssueListers(*cfg)
+	if len(listers) != 2 {
+		t.Fatalf("linear issue listers = %d, want one per service project", len(listers))
+	}
+	projects := make([]string, 0, len(listers))
+	for _, source := range listers {
+		client, ok := source.lister.(*tracker.LinearClient)
+		if !ok {
+			t.Fatalf("lister type = %T, want *tracker.LinearClient", source.lister)
+		}
+		projects = append(projects, client.Config.ProjectSlug)
+	}
+	want := []string{"api-platform", "web-platform"}
+	for i := range want {
+		if projects[i] != want[i] {
+			t.Fatalf("lister projects = %v, want %v", projects, want)
+		}
+	}
+}
+
+func TestPollOnceFansOutProvidedLinearListers(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Tracker.ProjectSlug = "platform"
+	apiLister := &fakeIssueLister{issues: []tracker.Issue{{
+		ID: "api-1", Identifier: "API-1", Title: "api", State: "AI Ready", ProjectSlug: "platform",
+	}}}
+	webLister := &fakeIssueLister{issues: []tracker.Issue{{
+		ID: "web-1", Identifier: "WEB-1", Title: "web", State: "AI Ready", ProjectSlug: "platform",
+	}}}
+
+	err := pollOnce(context.Background(), store, cfg, []linearIssueSource{
+		{lister: apiLister, projectSlug: "platform"},
+		{lister: webLister, projectSlug: "platform"},
+	})
+	if err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if apiLister.calls != 1 || webLister.calls != 1 {
+		t.Fatalf("lister calls = api:%d web:%d, want both service project listers called once", apiLister.calls, webLister.calls)
+	}
+	if len(store.calls) != 2 {
+		t.Fatalf("Enqueue calls = %d, want one issue per lister", len(store.calls))
+	}
+}
+
+func TestPollOnceDoesNotFallbackServiceProjectIssuesToRootRepo(t *testing.T) {
+	store := newFakeStore()
+	cfg := baseConfig()
+	cfg.Tracker.ProjectSlug = "platform"
+	cfg.Services = []workflow.ServiceConfig{
+		{
+			Name:    "api",
+			Repo:    workflow.RepoConfig{Owner: "octo", Name: "api", CloneURL: "git@example.com:octo/api.git", DefaultBranch: "main"},
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform", Labels: []string{"api"}},
+		},
+	}
+	rootLister := &fakeIssueLister{issues: []tracker.Issue{{
+		ID: "root-1", Identifier: "ROOT-1", Title: "root", State: "AI Ready", ProjectSlug: "platform",
+	}}}
+	serviceLister := &fakeIssueLister{issues: []tracker.Issue{{
+		ID: "api-1", Identifier: "API-1", Title: "unmatched api project issue", State: "AI Ready", ProjectSlug: "api-platform",
+		Labels: []string{"docs"},
+	}}}
+
+	err := pollOnce(context.Background(), store, cfg, []linearIssueSource{
+		{lister: rootLister, projectSlug: "platform"},
+		{lister: serviceLister, projectSlug: "api-platform"},
+	})
+	if err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("Enqueue calls = %d, want only root project issue enqueued", len(store.calls))
+	}
+	if got := store.calls[0].SourceEventID; got != "root-1" {
+		t.Fatalf("enqueued source event = %q, want only root-1", got)
 	}
 }
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -124,15 +124,16 @@ func validateWorkflowForRuntime(path string, source workflow.Source, cfg workflo
 func startupReconcileConfigForWorkflow(cfg workflow.Config, trackerClient worker.ReconcileTracker) worker.ReconcileConfig {
 	hooks := cfg.WorkspaceHooks()
 	return worker.ReconcileConfig{
-		WorkspaceRoot:     worker.LoadConfigFromEnv().WorkspaceRoot,
-		ActiveStates:      cfg.Tracker.ActiveStates,
-		TerminalStates:    cfg.Tracker.TerminalStates,
-		TrackerKind:       cfg.Tracker.Kind,
-		Tracker:           trackerClient,
-		Emitter:           worker.LogEventEmitter{},
-		ReconcileTaskID:   "reconcile-startup",
-		BeforeRemoveHook:  hooks.BeforeRemove,
-		HookTimeoutMillis: hooks.TimeoutMs,
+		WorkspaceRoot:       worker.LoadConfigFromEnv().WorkspaceRoot,
+		ActiveStates:        cfg.Tracker.ActiveStates,
+		TerminalStates:      cfg.Tracker.TerminalStates,
+		TrackerKind:         cfg.Tracker.Kind,
+		Tracker:             trackerClient,
+		Emitter:             worker.LogEventEmitter{},
+		ReconcileTaskID:     "reconcile-startup",
+		BeforeRemoveHook:    hooks.BeforeRemove,
+		HookTimeoutMillis:   hooks.TimeoutMs,
+		ActiveWorkspaceKeys: worker.ActiveWorkspaceKeysForWorkflow(cfg),
 	}
 }
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -107,11 +107,16 @@ func logStartupReconcileWorkflow(resolution *workflow.Resolution, wf *workflow.W
 }
 
 func validateWorkflowForRuntime(path string, source workflow.Source, cfg workflow.Config) error {
-	if cfg.Repo.CloneURL == "" {
+	if cfg.Repo.CloneURL == "" && len(cfg.Services) == 0 {
 		if source == workflow.SourceDefault {
 			path = "built-in workflow defaults"
 		}
 		return fmt.Errorf("%s: repo.clone_url is required for poll-based worker runtime", path)
+	}
+	for i, service := range cfg.Services {
+		if service.Repo.CloneURL == "" {
+			return fmt.Errorf("%s: services[%d].repo.clone_url is required for poll-based worker runtime", path, i)
+		}
 	}
 	return nil
 }
@@ -263,7 +268,15 @@ type trackerRuntimeClient interface {
 func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error) {
 	switch cfg.Tracker.Kind {
 	case "linear":
-		return tracker.NewLinearClient(cfg.Tracker), nil
+		projectConfigs := orchestrator.TrackerProjectConfigs(cfg)
+		if len(projectConfigs) == 1 {
+			return tracker.NewLinearClient(projectConfigs[0].Tracker), nil
+		}
+		clients := make([]trackerRuntimeClient, 0, len(projectConfigs))
+		for _, projectCfg := range projectConfigs {
+			clients = append(clients, tracker.NewLinearClient(projectCfg.Tracker))
+		}
+		return multiTrackerRuntimeClient{trackers: clients}, nil
 	case "gitea":
 		baseURL := cfg.Tracker.ProjectSlug
 		if baseURL == "" {
@@ -273,6 +286,42 @@ func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error)
 	default:
 		return nil, fmt.Errorf("unsupported tracker.kind %q", cfg.Tracker.Kind)
 	}
+}
+
+type multiTrackerRuntimeClient struct {
+	trackers []trackerRuntimeClient
+}
+
+func (c multiTrackerRuntimeClient) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	var issues []tracker.Issue
+	var errOut error
+	for _, stateTracker := range c.trackers {
+		got, err := stateTracker.ListActiveIssues(ctx)
+		if err != nil {
+			errOut = errors.Join(errOut, err)
+			continue
+		}
+		issues = append(issues, got...)
+	}
+	return issues, errOut
+}
+
+func (c multiTrackerRuntimeClient) ListIssuesByStates(ctx context.Context, states []string) ([]tracker.Issue, error) {
+	var issues []tracker.Issue
+	var errOut error
+	for _, stateTracker := range c.trackers {
+		got, err := stateTracker.ListIssuesByStates(ctx, states)
+		if err != nil {
+			errOut = errors.Join(errOut, err)
+			continue
+		}
+		issues = append(issues, got...)
+	}
+	return issues, errOut
+}
+
+func (c multiTrackerRuntimeClient) Trackers() []trackerRuntimeClient {
+	return append([]trackerRuntimeClient(nil), c.trackers...)
 }
 
 func env(k, d string) string {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
@@ -185,6 +186,41 @@ func TestStartupReconcileConfigUsesEffectiveWorkspaceHooks(t *testing.T) {
 	}
 }
 
+func TestTrackerClientForWorkflowBuildsMultiProjectLinearClientForServiceRoutes(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "linear"
+	cfg.Tracker.ProjectSlug = ""
+	cfg.Services = []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
+		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}},
+	}
+
+	client, err := trackerClientForWorkflow(cfg)
+	if err != nil {
+		t.Fatalf("tracker client: %v", err)
+	}
+
+	multi, ok := client.(interface{ Trackers() []trackerRuntimeClient })
+	if !ok {
+		t.Fatalf("client type = %T, want multi-project tracker", client)
+	}
+	got := multi.Trackers()
+	if len(got) != 2 {
+		t.Fatalf("linear tracker count = %d, want 2 service projects", len(got))
+	}
+	projects := make([]string, 0, len(got))
+	for _, client := range got {
+		linearClient, ok := client.(*tracker.LinearClient)
+		if !ok {
+			t.Fatalf("linear tracker type = %T, want *tracker.LinearClient", client)
+		}
+		projects = append(projects, linearClient.Config.ProjectSlug)
+	}
+	if !reflect.DeepEqual(projects, []string{"api-platform", "web-platform"}) {
+		t.Fatalf("linear tracker projects = %#v, want service projects", projects)
+	}
+}
+
 func TestTrackerClientForWorkflowUsesGiteaProjectSlugBeforeEnvBaseURL(t *testing.T) {
 	t.Setenv("GITEA_BASE_URL", "https://gitea-env.example.test/")
 	cfg := workflow.DefaultConfig()
@@ -234,7 +270,7 @@ func TestValidateWorkflowForRuntimeRejectsDefaultWorkflowMissingTaskFields(t *te
 	}
 }
 
-func TestValidateWorkflowForRuntimeAcceptsWorkflowWithRuntimeTaskFields(t *testing.T) {
+func TestValidateWorkflowForRuntimeAcceptsConfiguredRepo(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Repo.CloneURL = "git@example.com:o/r.git"
 
@@ -242,6 +278,17 @@ func TestValidateWorkflowForRuntimeAcceptsWorkflowWithRuntimeTaskFields(t *testi
 		if err := validateWorkflowForRuntime("WORKFLOW.md", source, cfg); err != nil {
 			t.Fatalf("validateWorkflowForRuntime(source=%s) = %v, want nil", source, err)
 		}
+	}
+}
+
+func TestValidateWorkflowForRuntimeAcceptsServiceOnlyRepos(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Services = []workflow.ServiceConfig{
+		{Name: "api", Repo: workflow.RepoConfig{CloneURL: "git@example.com:o/api.git"}},
+	}
+
+	if err := validateWorkflowForRuntime("WORKFLOW.md", workflow.SourceFile, cfg); err != nil {
+		t.Fatalf("validateWorkflowForRuntime(service-only repos) = %v, want nil", err)
 	}
 }
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -13,8 +13,27 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+type fakeReconcileTracker struct {
+	issues []tracker.Issue
+}
+
+func (f fakeReconcileTracker) ListIssuesByStates(_ context.Context, states []string) ([]tracker.Issue, error) {
+	want := map[string]struct{}{}
+	for _, state := range states {
+		want[state] = struct{}{}
+	}
+	var out []tracker.Issue
+	for _, issue := range f.issues {
+		if _, ok := want[issue.State]; ok {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
 
 func TestRunTreatsCanceledPollContextAsGracefulShutdown(t *testing.T) {
 	if err := normalizeRunError(context.Canceled, context.Canceled); err != nil {
@@ -184,6 +203,81 @@ func TestStartupReconcileConfigUsesEffectiveWorkspaceHooks(t *testing.T) {
 	if reconcile.HookTimeoutMillis != 1234 {
 		t.Fatalf("HookTimeoutMillis = %d, want top-level effective timeout", reconcile.HookTimeoutMillis)
 	}
+}
+
+func TestStartupReconcileConfigPreservesServiceRoutedActiveWorkspaceKey(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "linear"
+	cfg.Tracker.ProjectSlug = "platform"
+	cfg.Services = []workflow.ServiceConfig{
+		{
+			Name:    "api",
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"api"}},
+		},
+	}
+
+	reconcile := startupReconcileConfigForWorkflow(cfg, nil)
+	if reconcile.ActiveWorkspaceKeys == nil {
+		t.Fatal("ActiveWorkspaceKeys is nil; startup reconciliation will not recognize service-routed workspace keys")
+	}
+
+	keys := reconcile.ActiveWorkspaceKeys(tracker.Issue{
+		ID:          "abc-123",
+		Identifier:  "ENG-1",
+		State:       "Rework",
+		ProjectSlug: "platform",
+		Labels:      []string{"api"},
+		UpdatedAt:   "2026-05-19T03:00:00Z",
+	})
+	for _, want := range []string{"abc-123-service-api", "abc-123-service-api-rework-2026-05-19t03-00-00z"} {
+		if !containsString(keys, want) {
+			t.Fatalf("active workspace keys = %#v, want %s", keys, want)
+		}
+	}
+}
+
+func TestStartupReconcileKeepsServiceRoutedReworkWorkspaceAfterUpdatedAtChanges(t *testing.T) {
+	root := t.TempDir()
+	activePath := filepath.Join(root, "acme", "api", "linear_issue", "abc-123-service-api-rework-2026-05-18t03-00-00z")
+	terminalPath := filepath.Join(root, "acme", "api", "linear_issue", "done-1")
+	for _, path := range []string{activePath, terminalPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "linear"
+	cfg.Tracker.ActiveStates = []string{"Rework"}
+	cfg.Tracker.TerminalStates = []string{"Done"}
+	cfg.Tracker.ProjectSlug = "platform"
+	cfg.Services = []workflow.ServiceConfig{{
+		Name:    "api",
+		Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "platform", Labels: []string{"api"}},
+	}}
+	reconcile := startupReconcileConfigForWorkflow(cfg, fakeReconcileTracker{issues: []tracker.Issue{
+		{ID: "abc-123", Identifier: "ENG-1", State: "Rework", ProjectSlug: "platform", Labels: []string{"api"}, UpdatedAt: "2026-05-19T03:00:00Z"},
+		{ID: "done-1", Identifier: "DONE-1", State: "Done"},
+	}})
+	reconcile.WorkspaceRoot = root
+
+	if err := worker.ReconcileStartup(context.Background(), reconcile); err != nil {
+		t.Fatalf("ReconcileStartup: %v", err)
+	}
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("active service Rework workspace should remain after updatedAt changes: %v", err)
+	}
+	if _, err := os.Stat(terminalPath); !os.IsNotExist(err) {
+		t.Fatalf("terminal workspace should be removed, stat err=%v", err)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestTrackerClientForWorkflowBuildsMultiProjectLinearClientForServiceRoutes(t *testing.T) {

--- a/docs/symphony-integration.md
+++ b/docs/symphony-integration.md
@@ -81,6 +81,12 @@ accepted deliberate extensions. In particular, multi-path `WORKFLOW.md`
 discovery is not an accepted extension: it remains tracked as D4 and is being
 reverted under #72 as part of the service-level workflow-file work in D10 (#84).
 
+The multi-service `services` workflow key used for Linear tracker-to-service
+routing is tracked as D25 (#143) until its extension schema is fully documented.
+It is a read-only candidate-selection extension: the orchestrator may use Linear
+project/team/label/custom-field metadata to choose a configured service/repo,
+but ticket writes remain agent/tool-side per SPEC §1.
+
 ## Pointers
 
 - Symphony's Codex integration uses the long-running `codex app-server`

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -35,10 +35,13 @@ tracker:
   #   human_review: "Human Review"
   #   rework: "Rework"
 
-# Optional multi-service routing. Omit `services` for the default single-service
-# mode above. When present, Linear candidate selection matches project/team,
-# labels, and custom fields, then dispatches the issue with that service's repo.
-# Unmatched issues are skipped locally; ambiguous matches fail the poll tick.
+# Optional multi-service routing (tracked as D25/#143 until the extension schema
+# is fully documented). Omit `services` for the default single-service mode
+# above. When present for Linear workflows, candidate selection matches
+# project/team, labels, and custom fields, then dispatches the issue with that
+# service's repo. Unmatched issues are skipped locally; ambiguous matches fail
+# the poll tick. This is read-only routing: ticket writes remain agent/tool-side
+# per SPEC §1.
 # services:
 #   - name: api
 #     repo:

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -35,6 +35,24 @@ tracker:
   #   human_review: "Human Review"
   #   rework: "Rework"
 
+# Optional multi-service routing. Omit `services` for the default single-service
+# mode above. When present, Linear candidate selection matches project/team,
+# labels, and custom fields, then dispatches the issue with that service's repo.
+# Unmatched issues are skipped locally; ambiguous matches fail the poll tick.
+# services:
+#   - name: api
+#     repo:
+#       owner: your-gitea-user
+#       name: api
+#       clone_url: git@gitea.local:your-gitea-user/api.git
+#       default_branch: main
+#     tracker:
+#       project_slug: api-platform
+#       team_key: ENG
+#       labels: [backend]
+#       custom_fields:
+#         Runtime: go
+
 workspace:
   root: ~/aiops-workspaces/personal
 

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -455,21 +455,25 @@ func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	var cancelEntries []*RunningEntry
 	for id, run := range st.Running {
 		issue, ok := r.issuesByID[string(id)]
-		if ok && isActiveTrackerState(issue.State, r.activeStates) {
+		if ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(run.Issue, issue) {
 			continue
 		}
 		st.ReleaseClaim(id)
 		run.ReconcileCancel = true
 		cancelEntries = append(cancelEntries, run)
 	}
-	for id := range st.RetryAttempts {
+	for id, retry := range st.RetryAttempts {
 		issue, ok := r.issuesByID[string(id)]
-		if ok && isActiveTrackerState(issue.State, r.activeStates) {
+		if ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(retry.Issue, issue) {
 			continue
 		}
 		st.ReleaseClaim(id)
 	}
 	return reconcileCancelFollowup(cancelEntries, r.result)
+}
+
+func sameServiceRoute(previous, current tracker.Issue) bool {
+	return strings.TrimSpace(previous.ServiceName) == strings.TrimSpace(current.ServiceName)
 }
 
 type reconcileInactiveTrackerIssuesOp struct {
@@ -603,6 +607,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 	// without blocking. ScheduleRetry needs the Timer set on the entry
 	// before storing so a stale prior timer is stopped atomically.
 	entry := &RetryEntry{
+		Issue:      s.issue,
 		IssueID:    id,
 		Identifier: s.identifier,
 		Attempt:    attempt,

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -237,6 +237,88 @@ func TestScheduleRetry_TimerFireProducesExactlyOneReDispatch(t *testing.T) {
 	}
 }
 
+func TestReconcileTrackerIssuesCancelsRunWhenServiceRouteChanges(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "LIN-16", Identifier: "LIN-16", Title: "route", State: "AI Ready", ServiceName: "api"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	active := map[string]tracker.Issue{
+		"LIN-16": {ID: "LIN-16", Identifier: "LIN-16", Title: "route", State: "AI Ready", ServiceName: "web"},
+	}
+	if err := o.ReconcileTrackerIssues(context.Background(), active, normalizedStates([]string{"AI Ready"})); err != nil {
+		t.Fatalf("ReconcileTrackerIssues: %v", err)
+	}
+	select {
+	case <-disp.contexts[0].Done():
+	case <-time.After(time.Second):
+		t.Fatal("route-changed worker context was not canceled")
+	}
+
+	if err := o.RequestDispatch(context.Background(), active["LIN-16"], nil); err == nil {
+		t.Fatal("RequestDispatch while canceled worker is exiting returned nil error, want duplicate guard to keep old run claimed")
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("dispatch count while canceled worker is exiting = %d, want duplicate guard to suppress new worker", got)
+	}
+
+	disp.finishAt(0, WorkerResult{Err: context.Canceled})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		if err != nil {
+			t.Fatalf("Snapshot: %v", err)
+		}
+		return len(view.Running) == 0
+	}, time.Second)
+
+	if err := o.RequestDispatch(context.Background(), active["LIN-16"], nil); err != nil {
+		t.Fatalf("RequestDispatch after canceled worker exit: %v", err)
+	}
+	if got := disp.count(); got != 2 {
+		t.Fatalf("dispatch count after route change = %d, want new routed worker", got)
+	}
+	if got := disp.issueAt(1).ServiceName; got != "web" {
+		t.Fatalf("redispatched service = %q, want web", got)
+	}
+}
+
+func TestReconcileTrackerIssuesReleasesRetryWhenServiceRouteChanges(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "LIN-16", Identifier: "LIN-16", Title: "route", State: "AI Ready", ServiceName: "api"}
+	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 1 {
+		t.Fatalf("retrying entries = %d, want queued retry", len(view.Retrying))
+	}
+
+	active := map[string]tracker.Issue{
+		"LIN-16": {ID: "LIN-16", Identifier: "LIN-16", Title: "route", State: "AI Ready", ServiceName: "web"},
+	}
+	if err := o.ReconcileTrackerIssues(context.Background(), active, normalizedStates([]string{"AI Ready"})); err != nil {
+		t.Fatalf("ReconcileTrackerIssues: %v", err)
+	}
+	view, err = o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 0 {
+		t.Fatalf("retrying entries after route change = %+v, want released retry", view.Retrying)
+	}
+}
+
 func TestContinuationRetryTimerRequiresTrackerRecheckedDispatch(t *testing.T) {
 	disp := &fakeDispatcher{}
 	o, cancel := startActor(t, Deps{

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -376,6 +376,9 @@ func matchingServices(issue tracker.Issue, cfg workflow.Config) []workflow.Servi
 
 func serviceMatchesIssue(service workflow.ServiceConfig, defaults workflow.TrackerConfig, issue tracker.Issue) bool {
 	route := service.Tracker
+	if !hasExplicitServiceRoute(route) {
+		return false
+	}
 	projectSlug := strings.TrimSpace(route.ProjectSlug)
 	if projectSlug == "" {
 		projectSlug = strings.TrimSpace(defaults.ProjectSlug)
@@ -404,6 +407,13 @@ func serviceMatchesIssue(service workflow.ServiceConfig, defaults workflow.Track
 		}
 	}
 	return true
+}
+
+func hasExplicitServiceRoute(route workflow.ServiceTrackerRouteConfig) bool {
+	return strings.TrimSpace(route.ProjectSlug) != "" ||
+		strings.TrimSpace(route.TeamKey) != "" ||
+		len(route.Labels) > 0 ||
+		len(route.CustomFields) > 0
 }
 
 // TaskBuilder converts a tracker candidate into the task shape consumed by the

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -346,7 +346,7 @@ func selectRoutedCandidates(issues []tracker.Issue, cfg workflow.Config) ([]trac
 	out := make([]tracker.Issue, 0, len(issues))
 	var routeErr error
 	for _, issue := range issues {
-		matches := matchingServices(issue, cfg.Services)
+		matches := matchingServices(issue, cfg)
 		switch len(matches) {
 		case 0:
 			log.Printf("tracker route skipped issue %s: no configured service matched", issue.ID)
@@ -364,19 +364,23 @@ func selectRoutedCandidates(issues []tracker.Issue, cfg workflow.Config) ([]trac
 	return out, routeErr
 }
 
-func matchingServices(issue tracker.Issue, services []workflow.ServiceConfig) []workflow.ServiceConfig {
-	matches := make([]workflow.ServiceConfig, 0, len(services))
-	for _, service := range services {
-		if serviceMatchesIssue(service, issue) {
+func matchingServices(issue tracker.Issue, cfg workflow.Config) []workflow.ServiceConfig {
+	matches := make([]workflow.ServiceConfig, 0, len(cfg.Services))
+	for _, service := range cfg.Services {
+		if serviceMatchesIssue(service, cfg.Tracker, issue) {
 			matches = append(matches, service)
 		}
 	}
 	return matches
 }
 
-func serviceMatchesIssue(service workflow.ServiceConfig, issue tracker.Issue) bool {
+func serviceMatchesIssue(service workflow.ServiceConfig, defaults workflow.TrackerConfig, issue tracker.Issue) bool {
 	route := service.Tracker
-	if route.ProjectSlug != "" && !strings.EqualFold(strings.TrimSpace(route.ProjectSlug), strings.TrimSpace(issue.ProjectSlug)) {
+	projectSlug := strings.TrimSpace(route.ProjectSlug)
+	if projectSlug == "" {
+		projectSlug = strings.TrimSpace(defaults.ProjectSlug)
+	}
+	if projectSlug != "" && !strings.EqualFold(projectSlug, strings.TrimSpace(issue.ProjectSlug)) {
 		return false
 	}
 	if route.TeamKey != "" && !strings.EqualFold(strings.TrimSpace(route.TeamKey), strings.TrimSpace(issue.TeamKey)) {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -81,19 +81,23 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 	if p.orchestrator == nil {
 		return errors.New("orchestrator poller requires orchestrator")
 	}
-	issues, err := p.tracker.ListActiveIssues(ctx)
-	if err != nil {
-		return err
+	issues, activeErr := p.tracker.ListActiveIssues(ctx)
+	if activeErr != nil && len(issues) == 0 {
+		return activeErr
 	}
 	var pollErr error
+	if activeErr != nil {
+		pollErr = errors.Join(pollErr, activeErr)
+	}
 	routedIssues := issues
 	if p.routing != nil {
-		routedIssues, err = selectRoutedCandidates(issues, *p.routing)
-		if err != nil {
-			pollErr = errors.Join(pollErr, err)
+		var routeErr error
+		routedIssues, routeErr = selectRoutedCandidates(issues, *p.routing)
+		if routeErr != nil {
+			pollErr = errors.Join(pollErr, routeErr)
 		}
 	}
-	if p.reconcileKnown {
+	if p.reconcileKnown && activeErr == nil {
 		if err := p.reconcileTick(ctx, routedIssues); err != nil {
 			pollErr = errors.Join(pollErr, err)
 		}

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -90,7 +90,7 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 	if p.routing != nil {
 		routedIssues, err = selectRoutedCandidates(issues, *p.routing)
 		if err != nil {
-			return err
+			pollErr = errors.Join(pollErr, err)
 		}
 	}
 	if p.reconcileKnown {
@@ -349,7 +349,7 @@ func selectRoutedCandidates(issues []tracker.Issue, cfg workflow.Config) ([]trac
 		matches := matchingServices(issue, cfg)
 		switch len(matches) {
 		case 0:
-			if strings.TrimSpace(cfg.Repo.CloneURL) != "" {
+			if strings.TrimSpace(cfg.Repo.CloneURL) != "" && issueInRootTrackerProject(issue, cfg) {
 				out = append(out, issue)
 				continue
 			}
@@ -366,6 +366,14 @@ func selectRoutedCandidates(issues []tracker.Issue, cfg workflow.Config) ([]trac
 		}
 	}
 	return out, routeErr
+}
+
+func issueInRootTrackerProject(issue tracker.Issue, cfg workflow.Config) bool {
+	rootProject := strings.TrimSpace(cfg.Tracker.ProjectSlug)
+	if rootProject == "" {
+		return false
+	}
+	return strings.EqualFold(rootProject, strings.TrimSpace(issue.ProjectSlug))
 }
 
 func matchingServices(issue tracker.Issue, cfg workflow.Config) []workflow.ServiceConfig {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -531,7 +531,9 @@ func TaskFromIssue(issue tracker.Issue, cfg workflow.Config) (task.Task, error) 
 	if sourceEventID == "" {
 		return task.Task{}, fmt.Errorf("tracker issue id is required")
 	}
-	if issue.Identifier != "" {
+	if issue.ServiceName != "" {
+		sourceEventID += "|service|" + issue.ServiceName
+	} else if issue.Identifier != "" {
 		sourceEventID = issue.Identifier
 	}
 	return task.Task{

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -53,6 +53,7 @@ type Poller struct {
 	overflow       []tracker.Issue
 	reconcile      ReconciliationConfig
 	reconcileKnown bool
+	routing        *workflow.Config
 }
 
 // NewPoller returns a SPEC-aligned tracker poller backed by orchestrator-owned
@@ -85,12 +86,19 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 		return err
 	}
 	var pollErr error
+	routedIssues := issues
+	if p.routing != nil {
+		routedIssues, err = selectRoutedCandidates(issues, *p.routing)
+		if err != nil {
+			return err
+		}
+	}
 	if p.reconcileKnown {
-		if err := p.reconcileTick(ctx, issues); err != nil {
+		if err := p.reconcileTick(ctx, routedIssues); err != nil {
 			pollErr = errors.Join(pollErr, err)
 		}
 	}
-	candidates := filterEligibleCandidates(mergeOverflowCandidates(p.overflow, issues), p.reconcile.TerminalStates)
+	candidates := filterEligibleCandidates(mergeOverflowCandidates(p.overflow, routedIssues), p.reconcile.TerminalStates)
 	sortCandidates(candidates)
 	p.overflow = nil
 	var dispatchErr error
@@ -124,6 +132,11 @@ func (l activeIssueListerFromStates) ListActiveIssues(ctx context.Context) ([]tr
 func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue) error {
 	if p.stateTracker == nil {
 		return errors.New("orchestrator poller reconciliation requires state tracker")
+	}
+	if p.routing != nil {
+		if err := p.orchestrator.ReconcileTrackerIssuesAndWait(ctx, issueMap(activeIssues), normalizedStates(p.reconcile.ActiveStates), p.reconcile.WorkerExitTimeout); err != nil {
+			return err
+		}
 	}
 	activeByID := issueIDSet(activeIssues)
 	inactiveByID := make(map[string]tracker.Issue)
@@ -174,6 +187,16 @@ func issueIDSet(issues []tracker.Issue) map[string]struct{} {
 	for _, issue := range issues {
 		if issue.ID != "" {
 			out[issue.ID] = struct{}{}
+		}
+	}
+	return out
+}
+
+func issueMap(issues []tracker.Issue) map[string]tracker.Issue {
+	out := make(map[string]tracker.Issue, len(issues))
+	for _, issue := range issues {
+		if issue.ID != "" {
+			out[issue.ID] = issue
 		}
 	}
 	return out
@@ -316,6 +339,69 @@ func mergeOverflowCandidates(overflow, fresh []tracker.Issue) []tracker.Issue {
 	return candidates
 }
 
+func selectRoutedCandidates(issues []tracker.Issue, cfg workflow.Config) ([]tracker.Issue, error) {
+	if len(cfg.Services) == 0 {
+		return issues, nil
+	}
+	out := make([]tracker.Issue, 0, len(issues))
+	var routeErr error
+	for _, issue := range issues {
+		matches := matchingServices(issue, cfg.Services)
+		switch len(matches) {
+		case 0:
+			log.Printf("tracker route skipped issue %s: no configured service matched", issue.ID)
+		case 1:
+			issue.ServiceName = matches[0].Name
+			out = append(out, issue)
+		default:
+			names := make([]string, 0, len(matches))
+			for _, service := range matches {
+				names = append(names, service.Name)
+			}
+			routeErr = errors.Join(routeErr, fmt.Errorf("ambiguous route for issue %s: matched services %s", issue.ID, strings.Join(names, ", ")))
+		}
+	}
+	return out, routeErr
+}
+
+func matchingServices(issue tracker.Issue, services []workflow.ServiceConfig) []workflow.ServiceConfig {
+	matches := make([]workflow.ServiceConfig, 0, len(services))
+	for _, service := range services {
+		if serviceMatchesIssue(service, issue) {
+			matches = append(matches, service)
+		}
+	}
+	return matches
+}
+
+func serviceMatchesIssue(service workflow.ServiceConfig, issue tracker.Issue) bool {
+	route := service.Tracker
+	if route.ProjectSlug != "" && !strings.EqualFold(strings.TrimSpace(route.ProjectSlug), strings.TrimSpace(issue.ProjectSlug)) {
+		return false
+	}
+	if route.TeamKey != "" && !strings.EqualFold(strings.TrimSpace(route.TeamKey), strings.TrimSpace(issue.TeamKey)) {
+		return false
+	}
+	issueLabels := make(map[string]struct{}, len(issue.Labels))
+	for _, label := range issue.Labels {
+		if label = strings.ToLower(strings.TrimSpace(label)); label != "" {
+			issueLabels[label] = struct{}{}
+		}
+	}
+	for _, label := range route.Labels {
+		if _, ok := issueLabels[strings.ToLower(strings.TrimSpace(label))]; !ok {
+			return false
+		}
+	}
+	for key, want := range route.CustomFields {
+		got, ok := issue.CustomFields[key]
+		if !ok || strings.TrimSpace(got) != strings.TrimSpace(want) {
+			return false
+		}
+	}
+	return true
+}
+
 // TaskBuilder converts a tracker candidate into the task shape consumed by the
 // existing worker runner. This is an adapter between the SPEC poller/runtime
 // path and the legacy task execution API; it is intentionally in-memory only.
@@ -401,6 +487,13 @@ func completeRecordedTask(ctx context.Context, ev worker.EventEmitter, recordedT
 }
 
 func TaskFromIssue(issue tracker.Issue, cfg workflow.Config) (task.Task, error) {
+	if issue.ServiceName != "" {
+		serviceCfg, ok := serviceConfigByName(cfg, issue.ServiceName)
+		if !ok {
+			return task.Task{}, fmt.Errorf("service %q not found in WORKFLOW.md", issue.ServiceName)
+		}
+		cfg.Repo = serviceCfg.Repo
+	}
 	if cfg.Repo.CloneURL == "" {
 		return task.Task{}, fmt.Errorf("repo.clone_url missing in WORKFLOW.md")
 	}
@@ -430,6 +523,15 @@ func TaskFromIssue(issue tracker.Issue, cfg workflow.Config) (task.Task, error) 
 		Model:         cfg.Agent.Default,
 		Priority:      50,
 	}, nil
+}
+
+func serviceConfigByName(cfg workflow.Config, name string) (workflow.ServiceConfig, bool) {
+	for _, service := range cfg.Services {
+		if service.Name == name {
+			return service, true
+		}
+	}
+	return workflow.ServiceConfig{}, false
 }
 
 // RunPollLoop repeatedly polls the tracker until ctx is canceled.

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -349,6 +349,10 @@ func selectRoutedCandidates(issues []tracker.Issue, cfg workflow.Config) ([]trac
 		matches := matchingServices(issue, cfg)
 		switch len(matches) {
 		case 0:
+			if strings.TrimSpace(cfg.Repo.CloneURL) != "" {
+				out = append(out, issue)
+				continue
+			}
 			log.Printf("tracker route skipped issue %s: no configured service matched", issue.ID)
 		case 1:
 			issue.ServiceName = matches[0].Name

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -999,6 +999,38 @@ func TestTaskFromIssueUsesServiceRepoDefaultBranch(t *testing.T) {
 	}
 }
 
+func TestTaskFromIssueNamespacesServiceRoutedSourceEventID(t *testing.T) {
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "fallback", Name: "fallback", CloneURL: "git@example.com:fallback/fallback.git", DefaultBranch: "main"},
+		Services: []workflow.ServiceConfig{
+			{Name: "api", Repo: workflow.RepoConfig{Owner: "acme", Name: "mono", CloneURL: "git@example.com:acme/mono.git", DefaultBranch: "main"}},
+			{Name: "web", Repo: workflow.RepoConfig{Owner: "acme", Name: "mono", CloneURL: "git@example.com:acme/mono.git", DefaultBranch: "main"}},
+		},
+	}
+	apiIssue := tracker.Issue{ID: "issue-1", Identifier: "LIN-1", Title: "API work", ServiceName: "api"}
+	webIssue := apiIssue
+	webIssue.ServiceName = "web"
+
+	apiTask, err := TaskFromIssue(apiIssue, cfg)
+	if err != nil {
+		t.Fatalf("TaskFromIssue(api): %v", err)
+	}
+	webTask, err := TaskFromIssue(webIssue, cfg)
+	if err != nil {
+		t.Fatalf("TaskFromIssue(web): %v", err)
+	}
+
+	if apiTask.SourceEventID != "issue-1|service|api" {
+		t.Fatalf("api source event id = %q, want service-scoped issue id", apiTask.SourceEventID)
+	}
+	if webTask.SourceEventID != "issue-1|service|web" {
+		t.Fatalf("web source event id = %q, want service-scoped issue id", webTask.SourceEventID)
+	}
+	if apiTask.SourceEventID == webTask.SourceEventID {
+		t.Fatalf("service-routed tasks share source event id %q", apiTask.SourceEventID)
+	}
+}
+
 func TestTaskFromIssueRejectsUnknownService(t *testing.T) {
 	cfg := workflow.Config{
 		Repo: workflow.RepoConfig{Owner: "fallback", Name: "fallback", CloneURL: "git@example.com:fallback/fallback.git", DefaultBranch: "main"},

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/worker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 type fakeIssueTracker struct {
@@ -364,6 +365,42 @@ func TestPollOnceCancelsRunningIssueWhenTrackerMovesToBacklog(t *testing.T) {
 	trackerClient.setIssues([]tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Backlog"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("backlog poll once: %v", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
+}
+
+func TestPollOnceCancelsRunningIssueWhenActiveIssueNoLongerMatchesRoute(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", Title: "API work", State: "In Progress", ProjectSlug: "api-platform"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress", "Rework"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	})
+	poller.routing = &workflow.Config{Services: []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
+	}}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.setIssues([]tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", Title: "API work", State: "In Progress", ProjectSlug: "mobile-app"}})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("unrouted poll once: %v", err)
 	}
 	waitForContextCanceled(t, dispatcher.contextAt(0))
 	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
@@ -737,6 +774,106 @@ func TestPollOnceTreatsDefaultSpecTerminalBlockersAsUnblocked(t *testing.T) {
 		t.Fatalf("dispatched issue IDs = %v, want %v", got, want)
 	}
 	close(dispatcher.releaseCh)
+}
+
+func TestSelectRoutedCandidatesMatchesLinearProjectTeamLabelAndCustomField(t *testing.T) {
+	cfg := workflow.Config{Services: []workflow.ServiceConfig{
+		{
+			Name: "api",
+			Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git"},
+			Tracker: workflow.ServiceTrackerRouteConfig{
+				ProjectSlug:  "api-platform",
+				TeamKey:      "ENG",
+				Labels:       []string{"backend"},
+				CustomFields: map[string]string{"Runtime": "go"},
+			},
+		},
+	}}
+	issues := []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", Title: "API work", State: "AI Ready", ProjectSlug: "api-platform", TeamKey: "ENG", Labels: []string{"backend", "customer"}, CustomFields: map[string]string{"Runtime": "go"}},
+	}
+
+	got, err := selectRoutedCandidates(issues, cfg)
+	if err != nil {
+		t.Fatalf("selectRoutedCandidates: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("routed candidates = %d, want 1", len(got))
+	}
+	if got[0].ServiceName != "api" {
+		t.Fatalf("routed candidate service = %q, want api", got[0].ServiceName)
+	}
+}
+
+func TestSelectRoutedCandidatesSkipsUnmatchedLinearIssue(t *testing.T) {
+	cfg := workflow.Config{Services: []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
+	}}
+	issues := []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", Title: "Mobile work", State: "AI Ready", ProjectSlug: "mobile-app"},
+	}
+
+	got, err := selectRoutedCandidates(issues, cfg)
+	if err != nil {
+		t.Fatalf("selectRoutedCandidates: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("routed candidates = %#v, want unmatched issue skipped", got)
+	}
+}
+
+func TestSelectRoutedCandidatesRejectsAmbiguousLinearRoute(t *testing.T) {
+	cfg := workflow.Config{Services: []workflow.ServiceConfig{
+		{Name: "api-a", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
+		{Name: "api-b", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
+	}}
+	issues := []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", Title: "Ambiguous work", State: "AI Ready", ProjectSlug: "api-platform"},
+	}
+
+	_, err := selectRoutedCandidates(issues, cfg)
+	if err == nil {
+		t.Fatal("selectRoutedCandidates returned nil error, want ambiguous route error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), "issue-1") || !strings.Contains(err.Error(), "api-a") || !strings.Contains(err.Error(), "api-b") {
+		t.Fatalf("ambiguous route error = %q, want issue and matching services", err)
+	}
+}
+
+func TestTaskFromIssueUsesServiceRepoDefaultBranch(t *testing.T) {
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "fallback", Name: "fallback", CloneURL: "git@example.com:fallback/fallback.git", DefaultBranch: "main"},
+		Services: []workflow.ServiceConfig{
+			{Name: "api", Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
+		},
+	}
+	issue := tracker.Issue{ID: "issue-1", Identifier: "LIN-1", Title: "API work", ServiceName: "api"}
+
+	got, err := TaskFromIssue(issue, cfg)
+	if err != nil {
+		t.Fatalf("TaskFromIssue: %v", err)
+	}
+	if got.RepoOwner != "acme" || got.RepoName != "api" || got.CloneURL != "git@example.com:acme/api.git" {
+		t.Fatalf("task repo = %s/%s %s, want acme/api service repo", got.RepoOwner, got.RepoName, got.CloneURL)
+	}
+	if got.BaseBranch != "main" {
+		t.Fatalf("task base branch = %q, want main", got.BaseBranch)
+	}
+}
+
+func TestTaskFromIssueRejectsUnknownService(t *testing.T) {
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "fallback", Name: "fallback", CloneURL: "git@example.com:fallback/fallback.git", DefaultBranch: "main"},
+	}
+	issue := tracker.Issue{ID: "issue-1", Identifier: "LIN-1", Title: "API work", ServiceName: "missing"}
+
+	_, err := TaskFromIssue(issue, cfg)
+	if err == nil {
+		t.Fatal("TaskFromIssue returned nil error, want unknown service error")
+	}
+	if !strings.Contains(err.Error(), `service "missing" not found`) {
+		t.Fatalf("TaskFromIssue error = %q, want unknown service", err)
+	}
 }
 
 func TestPollOnceSortsCandidatesByTrackerPriorityCreatedAtIdentifier(t *testing.T) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -840,6 +840,34 @@ func TestSelectRoutedCandidatesRejectsAmbiguousLinearRoute(t *testing.T) {
 	}
 }
 
+func TestSelectRoutedCandidatesUsesTopLevelLinearProjectAsServiceDefault(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{ProjectSlug: "api-platform"},
+		Services: []workflow.ServiceConfig{
+			{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{TeamKey: "ENG"}},
+			{Name: "mobile", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "mobile-app", TeamKey: "ENG"}},
+		},
+	}
+	issues := []tracker.Issue{
+		{ID: "api-issue", Identifier: "LIN-1", Title: "API work", State: "AI Ready", ProjectSlug: "api-platform", TeamKey: "ENG"},
+		{ID: "mobile-issue", Identifier: "LIN-2", Title: "Mobile work", State: "AI Ready", ProjectSlug: "mobile-app", TeamKey: "ENG"},
+	}
+
+	got, err := selectRoutedCandidates(issues, cfg)
+	if err != nil {
+		t.Fatalf("selectRoutedCandidates: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("routed candidates = %d, want 2", len(got))
+	}
+	if got[0].ServiceName != "api" {
+		t.Fatalf("api issue service = %q, want api", got[0].ServiceName)
+	}
+	if got[1].ServiceName != "mobile" {
+		t.Fatalf("mobile issue service = %q, want mobile", got[1].ServiceName)
+	}
+}
+
 func TestTaskFromIssueUsesServiceRepoDefaultBranch(t *testing.T) {
 	cfg := workflow.Config{
 		Repo: workflow.RepoConfig{Owner: "fallback", Name: "fallback", CloneURL: "git@example.com:fallback/fallback.git", DefaultBranch: "main"},
@@ -1205,7 +1233,7 @@ func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
 	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
-		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Millisecond},
 	})
 	go orch.Run(ctx)
 	if err := orch.WaitStarted(ctx); err != nil {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -868,6 +868,30 @@ func TestSelectRoutedCandidatesUsesTopLevelLinearProjectAsServiceDefault(t *test
 	}
 }
 
+func TestSelectRoutedCandidatesIgnoresServiceWithoutExplicitRouteBeforeProjectDefault(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{ProjectSlug: "api-platform"},
+		Services: []workflow.ServiceConfig{
+			{Name: "catchall", Tracker: workflow.ServiceTrackerRouteConfig{}},
+			{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{TeamKey: "ENG"}},
+		},
+	}
+	issues := []tracker.Issue{
+		{ID: "api-issue", Identifier: "LIN-1", Title: "API work", State: "AI Ready", ProjectSlug: "api-platform", TeamKey: "ENG"},
+	}
+
+	got, err := selectRoutedCandidates(issues, cfg)
+	if err != nil {
+		t.Fatalf("selectRoutedCandidates: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("routed candidates = %d, want only explicitly routed service", len(got))
+	}
+	if got[0].ServiceName != "api" {
+		t.Fatalf("routed candidate service = %q, want api", got[0].ServiceName)
+	}
+}
+
 func TestTaskFromIssueUsesServiceRepoDefaultBranch(t *testing.T) {
 	cfg := workflow.Config{
 		Repo: workflow.RepoConfig{Owner: "fallback", Name: "fallback", CloneURL: "git@example.com:fallback/fallback.git", DefaultBranch: "main"},

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -406,6 +406,48 @@ func TestPollOnceCancelsRunningIssueWhenActiveIssueNoLongerMatchesRoute(t *testi
 	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
 }
 
+func TestPollOnceReconcilesRoutedIssuesWhenAnotherIssueHasAmbiguousRoute(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", Title: "API work", State: "In Progress", ProjectSlug: "api-platform"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress", "Rework"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	})
+	poller.routing = &workflow.Config{Services: []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
+		{Name: "docs-a", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "docs-platform"}},
+		{Name: "docs-b", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "docs-platform"}},
+	}}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.setIssues([]tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", Title: "API work", State: "In Progress", ProjectSlug: "mobile-app"},
+		{ID: "issue-2", Identifier: "LIN-2", Title: "Ambiguous docs", State: "In Progress", ProjectSlug: "docs-platform"},
+	})
+	err := poller.PollOnce(ctx)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("ambiguous poll error = %v, want ambiguity reported", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
+}
+
 func TestPollOnceTrackerErrorDoesNotCancelRunningIssue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -824,13 +866,14 @@ func TestSelectRoutedCandidatesSkipsUnmatchedLinearIssueWithoutFallbackRepo(t *t
 
 func TestSelectRoutedCandidatesKeepsUnmatchedLinearIssueForFallbackRepo(t *testing.T) {
 	cfg := workflow.Config{
-		Repo: workflow.RepoConfig{Owner: "acme", Name: "fallback", CloneURL: "git@example.com:acme/fallback.git"},
+		Tracker: workflow.TrackerConfig{ProjectSlug: "core-platform"},
+		Repo:    workflow.RepoConfig{Owner: "acme", Name: "fallback", CloneURL: "git@example.com:acme/fallback.git"},
 		Services: []workflow.ServiceConfig{
 			{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
 		},
 	}
 	issues := []tracker.Issue{
-		{ID: "issue-1", Identifier: "LIN-1", Title: "Mobile work", State: "AI Ready", ProjectSlug: "mobile-app"},
+		{ID: "issue-1", Identifier: "LIN-1", Title: "Core work", State: "AI Ready", ProjectSlug: "core-platform"},
 	}
 
 	got, err := selectRoutedCandidates(issues, cfg)
@@ -842,6 +885,26 @@ func TestSelectRoutedCandidatesKeepsUnmatchedLinearIssueForFallbackRepo(t *testi
 	}
 	if got[0].ServiceName != "" {
 		t.Fatalf("fallback candidate service = %q, want empty service", got[0].ServiceName)
+	}
+}
+
+func TestSelectRoutedCandidatesSkipsUnmatchedServiceProjectIssueWithFallbackRepo(t *testing.T) {
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "acme", Name: "fallback", CloneURL: "git@example.com:acme/fallback.git"},
+		Services: []workflow.ServiceConfig{
+			{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform", Labels: []string{"api"}}},
+		},
+	}
+	issues := []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", Title: "Unmatched service work", State: "AI Ready", ProjectSlug: "api-platform", Labels: []string{"docs"}},
+	}
+
+	got, err := selectRoutedCandidates(issues, cfg)
+	if err != nil {
+		t.Fatalf("selectRoutedCandidates: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("routed candidates = %#v, want unmatched service-project issue skipped instead of fallback repo", got)
 	}
 }
 

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -1385,7 +1385,7 @@ func waitForCompleted(t *testing.T, ctx context.Context, orch *Orchestrator, id 
 
 func waitForRetryDue(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		view, err := orch.Snapshot(ctx)
 		if err != nil {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -805,7 +805,7 @@ func TestSelectRoutedCandidatesMatchesLinearProjectTeamLabelAndCustomField(t *te
 	}
 }
 
-func TestSelectRoutedCandidatesSkipsUnmatchedLinearIssue(t *testing.T) {
+func TestSelectRoutedCandidatesSkipsUnmatchedLinearIssueWithoutFallbackRepo(t *testing.T) {
 	cfg := workflow.Config{Services: []workflow.ServiceConfig{
 		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
 	}}
@@ -819,6 +819,29 @@ func TestSelectRoutedCandidatesSkipsUnmatchedLinearIssue(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("routed candidates = %#v, want unmatched issue skipped", got)
+	}
+}
+
+func TestSelectRoutedCandidatesKeepsUnmatchedLinearIssueForFallbackRepo(t *testing.T) {
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "acme", Name: "fallback", CloneURL: "git@example.com:acme/fallback.git"},
+		Services: []workflow.ServiceConfig{
+			{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}},
+		},
+	}
+	issues := []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", Title: "Mobile work", State: "AI Ready", ProjectSlug: "mobile-app"},
+	}
+
+	got, err := selectRoutedCandidates(issues, cfg)
+	if err != nil {
+		t.Fatalf("selectRoutedCandidates: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("routed candidates = %d, want unmatched issue kept for fallback repo", len(got))
+	}
+	if got[0].ServiceName != "" {
+		t.Fatalf("fallback candidate service = %q, want empty service", got[0].ServiceName)
 	}
 }
 

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -1,6 +1,10 @@
 package orchestrator
 
-import "time"
+import (
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
 
 // RetryEntry is the SPEC §4.1.7 record stored under
 // OrchestratorState.RetryAttempts while an issue is in the retry-queued
@@ -22,6 +26,7 @@ import "time"
 //     through SPEC §13.3's retrying view so operators can see why an
 //     issue is in backoff.
 type RetryEntry struct {
+	Issue      tracker.Issue
 	IssueID    IssueID
 	Identifier string
 	Attempt    int

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -95,7 +95,9 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	p.trackers = trackerClients
 	p.lastSnapshotKey = key
 	poller := NewPollerWithReconciliation(multiIssueStateLister{trackers: trackerClients}, p.orchestrator, snap.Reconciliation)
-	poller.routing = &snap.Workflow.Config
+	if snap.Workflow.Config.Tracker.Kind == "linear" && len(snap.Workflow.Config.Services) > 0 {
+		poller.routing = &snap.Workflow.Config
+	}
 	return poller, nil
 }
 

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
@@ -14,6 +15,7 @@ import (
 type RuntimePoller struct {
 	trackerFactory func(workflow.Config) (IssueStateLister, error)
 	tracker        IssueStateLister
+	trackers       []IssueStateLister
 	orchestrator   *Orchestrator
 	runtime        *WorkflowRuntime
 	config         worker.Config
@@ -82,16 +84,101 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	if p.poller != nil && p.lastSnapshotKey == key {
 		return p.poller, nil
 	}
-	trackerClient, err := p.trackerFactory(snap.Workflow.Config)
+	trackerClients, err := p.trackerClientsForSnapshot(snap)
 	if err != nil {
 		return nil, err
 	}
-	if trackerClient == nil {
-		return nil, errors.New("runtime poller tracker factory returned nil tracker")
+	if len(trackerClients) == 0 {
+		return nil, errors.New("runtime poller tracker factory returned no trackers")
 	}
-	p.tracker = trackerClient
+	p.tracker = trackerClients[0]
+	p.trackers = trackerClients
 	p.lastSnapshotKey = key
-	return NewPollerWithReconciliation(trackerClient, p.orchestrator, snap.Reconciliation), nil
+	poller := NewPollerWithReconciliation(multiIssueStateLister{trackers: trackerClients}, p.orchestrator, snap.Reconciliation)
+	poller.routing = &snap.Workflow.Config
+	return poller, nil
+}
+
+func (p *RuntimePoller) trackerClientsForSnapshot(snap WorkflowSnapshot) ([]IssueStateLister, error) {
+	if snap.Workflow == nil {
+		trackerClient, err := p.trackerFactory(workflow.Config{})
+		if err != nil {
+			return nil, err
+		}
+		if trackerClient == nil {
+			return nil, errors.New("runtime poller tracker factory returned nil tracker")
+		}
+		return []IssueStateLister{trackerClient}, nil
+	}
+	cfg := snap.Workflow.Config
+	projectConfigs := trackerProjectConfigs(cfg)
+	clients := make([]IssueStateLister, 0, len(projectConfigs))
+	for _, projectCfg := range projectConfigs {
+		trackerClient, err := p.trackerFactory(projectCfg)
+		if err != nil {
+			return nil, err
+		}
+		if trackerClient == nil {
+			return nil, errors.New("runtime poller tracker factory returned nil tracker")
+		}
+		clients = append(clients, trackerClient)
+	}
+	return clients, nil
+}
+
+// TrackerProjectConfigs returns one workflow config per Linear project that a
+// poll/reconcile pass must query for a service-routed workflow.
+func TrackerProjectConfigs(cfg workflow.Config) []workflow.Config {
+	return trackerProjectConfigs(cfg)
+}
+
+func trackerProjectConfigs(cfg workflow.Config) []workflow.Config {
+	if cfg.Tracker.Kind != "linear" {
+		return []workflow.Config{cfg}
+	}
+	seen := map[string]struct{}{}
+	add := func(project string, out *[]workflow.Config) {
+		project = strings.TrimSpace(project)
+		if project == "" {
+			return
+		}
+		key := strings.ToLower(project)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		projectCfg := cfg
+		projectCfg.Tracker.ProjectSlug = project
+		projectCfg.Services = nil
+		*out = append(*out, projectCfg)
+	}
+	out := make([]workflow.Config, 0, len(cfg.Services)+1)
+	add(cfg.Tracker.ProjectSlug, &out)
+	for _, service := range cfg.Services {
+		add(service.Tracker.ProjectSlug, &out)
+	}
+	if len(out) == 0 {
+		out = append(out, cfg)
+	}
+	return out
+}
+
+type multiIssueStateLister struct {
+	trackers []IssueStateLister
+}
+
+func (l multiIssueStateLister) ListIssuesByStates(ctx context.Context, states []string) ([]tracker.Issue, error) {
+	var issues []tracker.Issue
+	var errOut error
+	for _, stateTracker := range l.trackers {
+		got, err := stateTracker.ListIssuesByStates(ctx, states)
+		if err != nil {
+			errOut = errors.Join(errOut, err)
+			continue
+		}
+		issues = append(issues, got...)
+	}
+	return issues, errOut
 }
 
 func snapshotWorkflowKey(snap WorkflowSnapshot) string {

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -310,6 +311,66 @@ func TestRuntimePollerRebuildsTrackerClientAfterTrackerConfigReload(t *testing.T
 	}
 }
 
+func TestRuntimePollerFetchesLinearIssuesFromEachServiceProject(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	initial.Config.Services = []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
+		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeProjectScopedIssueTracker{
+		issuesByProject: map[string][]tracker.Issue{
+			"api-platform": {{ID: "api-1", Identifier: "API-1", Title: "API work", State: "AI Ready", ProjectSlug: "api-platform"}},
+			"web-platform": {{ID: "web-1", Identifier: "WEB-1", Title: "Web work", State: "AI Ready", ProjectSlug: "web-platform"}},
+		},
+	}
+	dispatcher := &recordingDispatcher{}
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	poller, err := NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (IssueStateLister, error) {
+		return trackerClient.forProject(cfg.Tracker.ProjectSlug), nil
+	}, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	if got := dispatcher.count(); got != 2 {
+		t.Fatalf("dispatched issues = %d, want both service projects", got)
+	}
+	if got := strings.Join(trackerClient.projects(), ","); got != "api-platform,api-platform,web-platform,web-platform" {
+		t.Fatalf("queried projects = %q, want active and terminal reconciliation queries for api-platform,web-platform", got)
+	}
+}
+
+func TestRuntimePollerDoesNotFanOutServiceProjectsForGitea(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "gitea"
+	cfg.Tracker.ProjectSlug = "https://gitea.example.com"
+	cfg.Services = []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
+		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
+	}
+
+	got := TrackerProjectConfigs(cfg)
+	if len(got) != 1 {
+		t.Fatalf("tracker configs = %d, want one non-Linear tracker config", len(got))
+	}
+	if got[0].Tracker.ProjectSlug != "https://gitea.example.com" {
+		t.Fatalf("tracker project slug = %q, want original Gitea base URL", got[0].Tracker.ProjectSlug)
+	}
+}
+
 func TestWorkflowRuntimeReloadFailureKeepsPreviousConfigAndEmitsFailureEvent(t *testing.T) {
 	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
 	initial, err := workflow.Load(path)
@@ -464,6 +525,44 @@ func (s *recordingPollSleeper) sleep(_ context.Context, d time.Duration) error {
 type reloadLoopTestSleeper struct {
 	calls      int
 	afterFirst func()
+}
+
+type fakeProjectScopedIssueTracker struct {
+	mu              sync.Mutex
+	project         string
+	root            *fakeProjectScopedIssueTracker
+	issuesByProject map[string][]tracker.Issue
+	queriedProjects []string
+}
+
+func (f *fakeProjectScopedIssueTracker) forProject(project string) IssueStateLister {
+	return &fakeProjectScopedIssueTracker{project: project, root: f}
+}
+
+func (f *fakeProjectScopedIssueTracker) ListIssuesByStates(_ context.Context, states []string) ([]tracker.Issue, error) {
+	root := f.root
+	if root == nil {
+		root = f
+	}
+	root.mu.Lock()
+	defer root.mu.Unlock()
+	root.queriedProjects = append(root.queriedProjects, f.project)
+	wanted := normalizedStates(states)
+	out := make([]tracker.Issue, 0, len(root.issuesByProject[f.project]))
+	for _, issue := range root.issuesByProject[f.project] {
+		if isActiveTrackerState(issue.State, wanted) {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeProjectScopedIssueTracker) projects() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := append([]string(nil), f.queriedProjects...)
+	sort.Strings(out)
+	return out
 }
 
 func (s *reloadLoopTestSleeper) sleep(_ context.Context, _ time.Duration) error {

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -371,6 +371,68 @@ func TestRuntimePollerDoesNotFanOutServiceProjectsForGitea(t *testing.T) {
 	}
 }
 
+func TestRuntimePollerOnlyAppliesRoutingToLinearServiceWorkflows(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "gitea", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	initial.Config.Repo = workflow.RepoConfig{Owner: "acme", Name: "fallback", CloneURL: "git@example.com:acme/fallback.git", DefaultBranch: "main"}
+	initial.Config.Services = []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{
+		{ID: "gitea-ready", Identifier: "ISSUE-1", Title: "ready", State: "AI Ready"},
+	}}
+	dispatcher := &recordingDispatcher{}
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+	if poller.poller.routing != nil {
+		t.Fatal("gitea runtime poller enabled Linear service routing")
+	}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	waitFor(t, func() bool { return dispatcher.count() == 1 }, time.Second)
+	got := dispatcher.issueAt(0)
+	if got.ID != "gitea-ready" {
+		t.Fatalf("dispatched issue = %q, want gitea-ready", got.ID)
+	}
+	if got.ServiceName != "" {
+		t.Fatalf("gitea issue service = %q, want no Linear service routing", got.ServiceName)
+	}
+
+	linearPath := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
+	linearWorkflow, err := workflow.Load(linearPath)
+	if err != nil {
+		t.Fatalf("load linear workflow: %v", err)
+	}
+	linearWorkflow.Config.Services = []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
+	}
+	linearRuntime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: linearWorkflow, Path: linearPath, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new linear runtime: %v", err)
+	}
+	linearPoller, err := NewRuntimePoller(&fakeIssueStateTracker{}, orch, linearRuntime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new linear runtime poller: %v", err)
+	}
+	if linearPoller.poller.routing == nil {
+		t.Fatal("linear service runtime poller did not enable service routing")
+	}
+}
+
 func TestWorkflowRuntimeReloadFailureKeepsPreviousConfigAndEmitsFailureEvent(t *testing.T) {
 	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
 	initial, err := workflow.Load(path)

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -353,6 +353,168 @@ func TestRuntimePollerFetchesLinearIssuesFromEachServiceProject(t *testing.T) {
 	}
 }
 
+func TestRuntimePollerDispatchesHealthyServiceProjectWhenAnotherProjectPollFails(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	initial.Config.Services = []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
+		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeProjectScopedIssueTracker{
+		issuesByProject: map[string][]tracker.Issue{
+			"api-platform": {{ID: "api-1", Identifier: "API-1", Title: "API work", State: "AI Ready", ProjectSlug: "api-platform"}},
+		},
+		errsByProject: map[string]error{"web-platform": errors.New("web project unavailable")},
+	}
+	dispatcher := &recordingDispatcher{}
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	poller, err := NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (IssueStateLister, error) {
+		return trackerClient.forProject(cfg.Tracker.ProjectSlug), nil
+	}, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+
+	err = poller.PollOnce(ctx)
+	if err == nil || !strings.Contains(err.Error(), "web project unavailable") {
+		t.Fatalf("poll once error = %v, want failed project reported", err)
+	}
+	if got := dispatcher.count(); got != 1 {
+		t.Fatalf("dispatched issues = %d, want healthy project issue dispatched despite failed project", got)
+	}
+	if got := dispatcher.issueAt(0).ID; got != "api-1" {
+		t.Fatalf("dispatched issue = %q, want api-1", got)
+	}
+}
+
+func TestRuntimePollerKeepsRunningFailedProjectIssueWhenDispatchingHealthyPartialPoll(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	initial.Config.Services = []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
+		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeProjectScopedIssueTracker{
+		issuesByProject: map[string][]tracker.Issue{
+			"web-platform": {{ID: "web-1", Identifier: "WEB-1", Title: "Web work", State: "AI Ready", ProjectSlug: "web-platform"}},
+		},
+	}
+	dispatcher := &cancellationDispatcher{}
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	poller, err := NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (IssueStateLister, error) {
+		return trackerClient.forProject(cfg.Tracker.ProjectSlug), nil
+	}, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.mu.Lock()
+	trackerClient.issuesByProject = map[string][]tracker.Issue{
+		"api-platform": {{ID: "api-1", Identifier: "API-1", Title: "API work", State: "AI Ready", ProjectSlug: "api-platform"}},
+	}
+	trackerClient.errsByProject = map[string]error{"web-platform": errors.New("web project unavailable")}
+	trackerClient.mu.Unlock()
+
+	err = poller.PollOnce(ctx)
+	if err == nil || !strings.Contains(err.Error(), "web project unavailable") {
+		t.Fatalf("poll once error = %v, want failed project reported", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 2)
+	select {
+	case <-dispatcher.contextAt(0).Done():
+		t.Fatal("running issue from failed project was canceled after partial active poll")
+	default:
+	}
+}
+
+func TestRuntimePollerCancelsHealthyProjectIssueDuringPartialPoll(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	initial.Config.Services = []workflow.ServiceConfig{
+		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
+		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeProjectScopedIssueTracker{
+		issuesByProject: map[string][]tracker.Issue{
+			"api-platform": {{ID: "api-1", Identifier: "API-1", Title: "API work", State: "AI Ready", ProjectSlug: "api-platform"}},
+		},
+	}
+	dispatcher := &cancellationDispatcher{}
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	poller, err := NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (IssueStateLister, error) {
+		return trackerClient.forProject(cfg.Tracker.ProjectSlug), nil
+	}, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	trackerClient.mu.Lock()
+	trackerClient.issuesByProject = map[string][]tracker.Issue{
+		"web-platform": {{ID: "web-1", Identifier: "WEB-1", Title: "Web work", State: "AI Ready", ProjectSlug: "web-platform"}},
+	}
+	trackerClient.mu.Unlock()
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("web-only poll once: %v", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForCancellationDispatcherCount(t, dispatcher, 2)
+
+	trackerClient.mu.Lock()
+	trackerClient.issuesByProject = map[string][]tracker.Issue{
+		"api-platform": {{ID: "api-1", Identifier: "API-1", Title: "API work", State: "AI Ready", ProjectSlug: "api-platform"}},
+	}
+	trackerClient.errsByProject = map[string]error{"web-platform": errors.New("web project unavailable")}
+	trackerClient.mu.Unlock()
+
+	err = poller.PollOnce(ctx)
+	if err == nil || !strings.Contains(err.Error(), "web project unavailable") {
+		t.Fatalf("poll once error = %v, want failed project reported", err)
+	}
+	select {
+	case <-dispatcher.contextAt(1).Done():
+		t.Fatal("healthy project issue was canceled after partial active poll")
+	default:
+	}
+}
+
 func TestRuntimePollerDoesNotFanOutServiceProjectsForGitea(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Tracker.Kind = "gitea"
@@ -594,6 +756,7 @@ type fakeProjectScopedIssueTracker struct {
 	project         string
 	root            *fakeProjectScopedIssueTracker
 	issuesByProject map[string][]tracker.Issue
+	errsByProject   map[string]error
 	queriedProjects []string
 }
 
@@ -609,6 +772,9 @@ func (f *fakeProjectScopedIssueTracker) ListIssuesByStates(_ context.Context, st
 	root.mu.Lock()
 	defer root.mu.Unlock()
 	root.queriedProjects = append(root.queriedProjects, f.project)
+	if err := root.errsByProject[f.project]; err != nil {
+		return nil, err
+	}
 	wanted := normalizedStates(states)
 	out := make([]tracker.Issue, 0, len(root.issuesByProject[f.project]))
 	for _, issue := range root.issuesByProject[f.project] {

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -54,7 +54,7 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
       project { slugId }
       team { key }
       labels(first: 50) { nodes { name } }
-      customFields { name value }
+      customFieldValues(first: 50) { nodes { customField { name } value } }
       state { name }
     }
     pageInfo { hasNextPage endCursor }
@@ -86,10 +86,14 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 								Name string `json:"name"`
 							} `json:"nodes"`
 						} `json:"labels"`
-						CustomFields []struct {
-							Name  string          `json:"name"`
-							Value json.RawMessage `json:"value"`
-						} `json:"customFields"`
+						CustomFieldValues struct {
+							Nodes []struct {
+								CustomField struct {
+									Name string `json:"name"`
+								} `json:"customField"`
+								Value json.RawMessage `json:"value"`
+							} `json:"nodes"`
+						} `json:"customFieldValues"`
 						State struct {
 							Name string `json:"name"`
 						} `json:"state"`
@@ -123,12 +127,12 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 					labels = append(labels, strings.ToLower(strings.TrimSpace(label.Name)))
 				}
 			}
-			customFields := make(map[string]string, len(n.CustomFields))
-			for _, field := range n.CustomFields {
-				if strings.TrimSpace(field.Name) == "" {
+			customFields := make(map[string]string, len(n.CustomFieldValues.Nodes))
+			for _, field := range n.CustomFieldValues.Nodes {
+				if strings.TrimSpace(field.CustomField.Name) == "" {
 					continue
 				}
-				customFields[strings.TrimSpace(field.Name)] = stringifyLinearCustomFieldValue(field.Value)
+				customFields[strings.TrimSpace(field.CustomField.Name)] = stringifyLinearCustomFieldValue(field.Value)
 			}
 			issues = append(issues, Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, CreatedAt: n.CreatedAt, UpdatedAt: n.UpdatedAt, ProjectSlug: n.Project.SlugID, TeamKey: n.Team.Key, Labels: labels, CustomFields: customFields, State: n.State.Name, BlockedBy: blockers})
 		}

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -51,6 +51,10 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
       priority
       createdAt
       updatedAt
+      project { slugId }
+      team { key }
+      labels(first: 50) { nodes { name } }
+      customFields { name value }
       state { name }
     }
     pageInfo { hasNextPage endCursor }
@@ -71,7 +75,22 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 						Priority    int    `json:"priority"`
 						CreatedAt   string `json:"createdAt"`
 						UpdatedAt   string `json:"updatedAt"`
-						State       struct {
+						Project     struct {
+							SlugID string `json:"slugId"`
+						} `json:"project"`
+						Team struct {
+							Key string `json:"key"`
+						} `json:"team"`
+						Labels struct {
+							Nodes []struct {
+								Name string `json:"name"`
+							} `json:"nodes"`
+						} `json:"labels"`
+						CustomFields []struct {
+							Name  string          `json:"name"`
+							Value json.RawMessage `json:"value"`
+						} `json:"customFields"`
+						State struct {
 							Name string `json:"name"`
 						} `json:"state"`
 					} `json:"nodes"`
@@ -98,7 +117,20 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 					return nil, err
 				}
 			}
-			issues = append(issues, Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, CreatedAt: n.CreatedAt, UpdatedAt: n.UpdatedAt, State: n.State.Name, BlockedBy: blockers})
+			labels := make([]string, 0, len(n.Labels.Nodes))
+			for _, label := range n.Labels.Nodes {
+				if strings.TrimSpace(label.Name) != "" {
+					labels = append(labels, strings.ToLower(strings.TrimSpace(label.Name)))
+				}
+			}
+			customFields := make(map[string]string, len(n.CustomFields))
+			for _, field := range n.CustomFields {
+				if strings.TrimSpace(field.Name) == "" {
+					continue
+				}
+				customFields[strings.TrimSpace(field.Name)] = stringifyLinearCustomFieldValue(field.Value)
+			}
+			issues = append(issues, Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, CreatedAt: n.CreatedAt, UpdatedAt: n.UpdatedAt, ProjectSlug: n.Project.SlugID, TeamKey: n.Team.Key, Labels: labels, CustomFields: customFields, State: n.State.Name, BlockedBy: blockers})
 		}
 		if !out.Data.Issues.PageInfo.HasNextPage {
 			return issues, nil
@@ -109,6 +141,17 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 		after = out.Data.Issues.PageInfo.EndCursor
 	}
 	return nil, fmt.Errorf("linear pagination exceeded %d pages", maxLinearIssuePages)
+}
+
+func stringifyLinearCustomFieldValue(raw json.RawMessage) string {
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return strings.TrimSpace(s)
+	}
+	return strings.TrimSpace(string(raw))
 }
 
 func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -313,6 +313,64 @@ func TestListIssuesByStatesRequiresProjectSlugAndUsesProjectFilter(t *testing.T)
 	}
 }
 
+func TestListIssuesByStatesMapsRoutingFields(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		for _, fragment := range []string{"project { slugId }", "team { key }", "labels(first: 50)", "customFields { name value }"} {
+			if !strings.Contains(payload.Query, fragment) {
+				t.Fatalf("ListIssues query = %s, want fragment %q", payload.Query, fragment)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[{"name":"Backend"},{"name":"Customer"}]},"customFields":[{"name":"Runtime","value":"go"}],"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "api-platform"})
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"In Progress"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(issues))
+	}
+	issue := issues[0]
+	if issue.ProjectSlug != "api-platform" || issue.TeamKey != "ENG" {
+		t.Fatalf("issue route = project %q team %q, want api-platform/ENG", issue.ProjectSlug, issue.TeamKey)
+	}
+	if got := strings.Join(issue.Labels, ","); got != "backend,customer" {
+		t.Fatalf("labels = %q, want lower-cased backend,customer", got)
+	}
+	if issue.CustomFields["Runtime"] != "go" {
+		t.Fatalf("custom field Runtime = %q, want go", issue.CustomFields["Runtime"])
+	}
+}
+
+func TestListIssuesByStatesMapsNonStringCustomFieldValues(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[]},"customFields":[{"name":"Risk","value":3},{"name":"CustomerFacing","value":true},{"name":"Option","value":{"name":"gold"}}],"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "api-platform"})
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"In Progress"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(issues))
+	}
+	fields := issues[0].CustomFields
+	if fields["Risk"] != "3" || fields["CustomerFacing"] != "true" || fields["Option"] != `{"name":"gold"}` {
+		t.Fatalf("custom fields = %#v, want stringified non-string values", fields)
+	}
+}
+
 func TestListIssuesByStatesUsesDefaultPageSizeAndAggregatesMoreThanFiftyIssues(t *testing.T) {
 	var mu sync.Mutex
 	var requests []fakeLinearRequest

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -320,13 +320,13 @@ func TestListIssuesByStatesMapsRoutingFields(t *testing.T) {
 			Query string `json:"query"`
 		}
 		_ = json.Unmarshal(body, &payload)
-		for _, fragment := range []string{"project { slugId }", "team { key }", "labels(first: 50)", "customFields { name value }"} {
+		for _, fragment := range []string{"project { slugId }", "team { key }", "labels(first: 50)", "customFieldValues(first: 50)", "customField { name }"} {
 			if !strings.Contains(payload.Query, fragment) {
 				t.Fatalf("ListIssues query = %s, want fragment %q", payload.Query, fragment)
 			}
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[{"name":"Backend"},{"name":"Customer"}]},"customFields":[{"name":"Runtime","value":"go"}],"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[{"name":"Backend"},{"name":"Customer"}]},"customFieldValues":{"nodes":[{"customField":{"name":"Runtime"},"value":"go"}]},"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
 	}))
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "api-platform"})
@@ -353,7 +353,7 @@ func TestListIssuesByStatesMapsRoutingFields(t *testing.T) {
 func TestListIssuesByStatesMapsNonStringCustomFieldValues(t *testing.T) {
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[]},"customFields":[{"name":"Risk","value":3},{"name":"CustomerFacing","value":true},{"name":"Option","value":{"name":"gold"}}],"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[]},"customFieldValues":{"nodes":[{"customField":{"name":"Risk"},"value":3},{"customField":{"name":"CustomerFacing"},"value":true},{"customField":{"name":"Option"},"value":{"name":"gold"}}]},"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
 	}))
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "api-platform"})

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -3,16 +3,21 @@ package tracker
 import "context"
 
 type Issue struct {
-	ID          string
-	Identifier  string
-	Title       string
-	Description string
-	URL         string
-	State       string
-	Priority    int
-	CreatedAt   string
-	UpdatedAt   string
-	BlockedBy   []Blocker
+	ID           string
+	Identifier   string
+	Title        string
+	Description  string
+	URL          string
+	State        string
+	ProjectSlug  string
+	TeamKey      string
+	Labels       []string
+	CustomFields map[string]string
+	ServiceName  string
+	Priority     int
+	CreatedAt    string
+	UpdatedAt    string
+	BlockedBy    []Blocker
 }
 
 // Blocker is the minimal tracker dependency metadata the orchestrator needs to

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -28,15 +28,16 @@ type ReconcileTracker interface {
 // pass. The pass is idempotent: active issue workspaces are preserved, while
 // terminal and unknown/deleted issue workspaces are removed before dispatch.
 type ReconcileConfig struct {
-	WorkspaceRoot     string
-	ActiveStates      []string
-	TerminalStates    []string
-	TrackerKind       string
-	Tracker           ReconcileTracker
-	Emitter           EventEmitter
-	ReconcileTaskID   string
-	BeforeRemoveHook  workflow.WorkspaceHook
-	HookTimeoutMillis int
+	WorkspaceRoot       string
+	ActiveStates        []string
+	TerminalStates      []string
+	TrackerKind         string
+	Tracker             ReconcileTracker
+	Emitter             EventEmitter
+	ReconcileTaskID     string
+	BeforeRemoveHook    workflow.WorkspaceHook
+	HookTimeoutMillis   int
+	ActiveWorkspaceKeys func(tracker.Issue) []string
 }
 
 // ReconcileStartup reconciles existing per-issue workspaces with tracker state.
@@ -77,9 +78,13 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	if err != nil {
 		return fmt.Errorf("fetch terminal issues: %w", err)
 	}
+	activeKeysForIssue := cfg.ActiveWorkspaceKeys
+	if activeKeysForIssue == nil {
+		activeKeysForIssue = issueWorkspaceKeys
+	}
 	activeKeys := make(map[string]tracker.Issue, len(activeIssues))
 	for _, issue := range activeIssues {
-		for _, key := range issueWorkspaceKeys(issue) {
+		for _, key := range activeKeysForIssue(issue) {
 			activeKeys[key] = issue
 		}
 	}
@@ -113,7 +118,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 			})
 			continue
 		}
-		if activeIssue, ok := activeReworkIssueForWorkspace(workspace.Key, activeIssues); ok {
+		if activeIssue, ok := activeReworkIssueForWorkspace(workspace.Key, activeIssues, activeKeysForIssue); ok {
 			kept++
 			Emit(ctx, cfg.Emitter, taskID, task.EventReconcileWorkspace, "kept active workspace", map[string]any{
 				"path":       workspace.Path,
@@ -243,12 +248,12 @@ func removeWorkspace(ctx context.Context, cfg ReconcileConfig, taskID, path stri
 	return true, nil
 }
 
-func activeReworkIssueForWorkspace(workspaceKey string, issues []tracker.Issue) (tracker.Issue, bool) {
+func activeReworkIssueForWorkspace(workspaceKey string, issues []tracker.Issue, activeKeysForIssue func(tracker.Issue) []string) (tracker.Issue, bool) {
 	for _, issue := range issues {
 		if !strings.EqualFold(issue.State, "Rework") || strings.TrimSpace(issue.ID) == "" {
 			continue
 		}
-		for _, prefix := range reworkWorkspaceKeyPrefixes(issue.ID) {
+		for _, prefix := range reworkWorkspaceKeyPrefixes(issue, activeKeysForIssue) {
 			if strings.HasPrefix(workspaceKey, prefix) {
 				return issue, true
 			}
@@ -257,10 +262,19 @@ func activeReworkIssueForWorkspace(workspaceKey string, issues []tracker.Issue) 
 	return tracker.Issue{}, false
 }
 
-func reworkWorkspaceKeyPrefixes(issueID string) []string {
+func reworkWorkspaceKeyPrefixes(issue tracker.Issue, activeKeysForIssue func(tracker.Issue) []string) []string {
 	seen := map[string]struct{}{}
 	var prefixes []string
-	for _, key := range []string{workspace.SanitizeComponent(issueID), sanitizeLegacyWorkspaceKey(issueID)} {
+	baseKeys := []string{workspace.SanitizeComponent(issue.ID), sanitizeLegacyWorkspaceKey(issue.ID)}
+	for _, key := range activeKeysForIssue(issue) {
+		if base, ok := strings.CutSuffix(key, "-rework-"+workspace.SanitizeComponent(issue.UpdatedAt)); ok {
+			baseKeys = append(baseKeys, base)
+		}
+		if base, ok := strings.CutSuffix(key, "_rework_"+sanitizeLegacyWorkspaceKey(issue.UpdatedAt)); ok {
+			baseKeys = append(baseKeys, base)
+		}
+	}
+	for _, key := range baseKeys {
 		if key == "" {
 			continue
 		}
@@ -286,11 +300,38 @@ func nonEmptyStates(states []string) []string {
 }
 
 func issueWorkspaceKeys(issue tracker.Issue) []string {
+	return workspaceKeysForRawIssueKeys(issue, []string{issue.Identifier, issue.ID})
+}
+
+// ActiveWorkspaceKeysForWorkflow returns the active workspace key matcher used
+// by startup reconciliation. Service-routed Linear workflows enqueue tasks with
+// a service-specific source_event_id, so reconciliation must preserve those
+// active workspaces in addition to the legacy issue ID / identifier keys.
+func ActiveWorkspaceKeysForWorkflow(cfg workflow.Config) func(tracker.Issue) []string {
+	if len(cfg.Services) == 0 {
+		return nil
+	}
+	return func(issue tracker.Issue) []string {
+		rawKeys := []string{issue.Identifier, issue.ID}
+		for _, service := range cfg.Services {
+			if serviceMatchesIssueForReconcile(service, cfg.Tracker, issue) && strings.TrimSpace(service.Name) != "" {
+				rawKeys = append(rawKeys, issue.ID+"|service|"+service.Name)
+			}
+		}
+		return workspaceKeysForRawIssueKeys(issue, rawKeys)
+	}
+}
+
+func workspaceKeysForRawIssueKeys(issue tracker.Issue, rawKeys []string) []string {
 	seen := map[string]struct{}{}
 	var keys []string
-	rawKeys := []string{issue.Identifier, issue.ID}
 	if strings.EqualFold(issue.State, "Rework") && issue.ID != "" && issue.UpdatedAt != "" {
-		rawKeys = append(rawKeys, issue.ID+"|rework|"+issue.UpdatedAt)
+		baseKeys := append([]string(nil), rawKeys...)
+		for _, raw := range baseKeys {
+			if strings.TrimSpace(raw) != "" {
+				rawKeys = append(rawKeys, raw+"|rework|"+issue.UpdatedAt)
+			}
+		}
 	}
 	for _, raw := range rawKeys {
 		for _, key := range []string{workspace.SanitizeComponent(raw), sanitizeLegacyWorkspaceKey(raw)} {
@@ -305,6 +346,48 @@ func issueWorkspaceKeys(issue tracker.Issue) []string {
 		}
 	}
 	return keys
+}
+
+func serviceMatchesIssueForReconcile(service workflow.ServiceConfig, defaults workflow.TrackerConfig, issue tracker.Issue) bool {
+	route := service.Tracker
+	if !hasExplicitServiceRouteForReconcile(route) {
+		return false
+	}
+	projectSlug := strings.TrimSpace(route.ProjectSlug)
+	if projectSlug == "" {
+		projectSlug = strings.TrimSpace(defaults.ProjectSlug)
+	}
+	if projectSlug != "" && !strings.EqualFold(projectSlug, strings.TrimSpace(issue.ProjectSlug)) {
+		return false
+	}
+	if route.TeamKey != "" && !strings.EqualFold(strings.TrimSpace(route.TeamKey), strings.TrimSpace(issue.TeamKey)) {
+		return false
+	}
+	issueLabels := make(map[string]struct{}, len(issue.Labels))
+	for _, label := range issue.Labels {
+		if label = strings.ToLower(strings.TrimSpace(label)); label != "" {
+			issueLabels[label] = struct{}{}
+		}
+	}
+	for _, label := range route.Labels {
+		if _, ok := issueLabels[strings.ToLower(strings.TrimSpace(label))]; !ok {
+			return false
+		}
+	}
+	for key, want := range route.CustomFields {
+		got, ok := issue.CustomFields[key]
+		if !ok || strings.TrimSpace(got) != strings.TrimSpace(want) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasExplicitServiceRouteForReconcile(route workflow.ServiceTrackerRouteConfig) bool {
+	return strings.TrimSpace(route.ProjectSlug) != "" ||
+		strings.TrimSpace(route.TeamKey) != "" ||
+		len(route.Labels) > 0 ||
+		len(route.CustomFields) > 0
 }
 
 func sanitizeLegacyWorkspaceKey(s string) string {

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	Repo       RepoConfig      `yaml:"repo" json:"repo"`
 	Tracker    TrackerConfig   `yaml:"tracker" json:"tracker"`
+	Services   []ServiceConfig `yaml:"services" json:"services"`
 	Hooks      WorkspaceHooks  `yaml:"hooks" json:"hooks"`
 	Workspace  WorkspaceConfig `yaml:"workspace" json:"workspace"`
 	hookFields HookFieldPresence
@@ -34,6 +35,22 @@ type RepoConfig struct {
 	Name          string `yaml:"name" json:"name"`
 	CloneURL      string `yaml:"clone_url" json:"clone_url"`
 	DefaultBranch string `yaml:"default_branch" json:"default_branch"`
+}
+
+type ServiceConfig struct {
+	Name    string                    `yaml:"name" json:"name"`
+	Repo    RepoConfig                `yaml:"repo" json:"repo"`
+	Tracker ServiceTrackerRouteConfig `yaml:"tracker" json:"tracker"`
+}
+
+// ServiceTrackerRouteConfig describes the tracker-side predicates that route a
+// Linear issue to a configured service. The orchestrator only reads these
+// fields during candidate selection; tracker writes remain agent/tool-side.
+type ServiceTrackerRouteConfig struct {
+	ProjectSlug  string            `yaml:"project_slug" json:"project_slug"`
+	TeamKey      string            `yaml:"team_key" json:"team_key"`
+	Labels       []string          `yaml:"labels" json:"labels"`
+	CustomFields map[string]string `yaml:"custom_fields" json:"custom_fields"`
 }
 
 type TrackerConfig struct {

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -110,8 +110,10 @@ prompt body
 	}
 }
 
-func TestLoadAllowsServiceOnlyWorkflowWithoutFallbackRepo(t *testing.T) {
+func TestLoadAllowsLinearServiceOnlyWorkflowWithoutFallbackRepo(t *testing.T) {
 	body := `---
+tracker:
+  kind: linear
 services:
   - name: api
     repo:
@@ -130,6 +132,111 @@ prompt body
 	}
 	if wf.Config.Repo.CloneURL != "" {
 		t.Fatalf("fallback repo clone URL = %q, want empty service-only fallback", wf.Config.Repo.CloneURL)
+	}
+}
+
+func TestLoadAllowsLinearServiceOnlyWorkflowWithTopLevelProjectSlug(t *testing.T) {
+	body := `---
+tracker:
+  kind: linear
+  project_slug: platform
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+      clone_url: git@example.com:acme/api.git
+    tracker:
+      team_key: ENG
+---
+prompt body
+`
+
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if wf.Config.Tracker.ProjectSlug != "platform" {
+		t.Fatalf("top-level project slug = %q, want platform", wf.Config.Tracker.ProjectSlug)
+	}
+}
+
+func TestLoadRejectsLinearServiceOnlyWorkflowWithoutAnyProjectSlug(t *testing.T) {
+	body := `---
+tracker:
+  kind: linear
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+      clone_url: git@example.com:acme/api.git
+    tracker:
+      team_key: ENG
+---
+prompt body
+`
+
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load returned nil error, want project slug requirement for service-only Linear workflow")
+	}
+	if !strings.Contains(err.Error(), "tracker.project_slug") && !strings.Contains(err.Error(), "services[0].tracker.project_slug") {
+		t.Fatalf("Load error = %q, want project slug guidance", err)
+	}
+}
+
+func TestLoadRejectsLinearFallbackRepoWorkflowWithServiceMissingProjectSlug(t *testing.T) {
+	body := `---
+tracker:
+  kind: linear
+repo:
+  owner: acme
+  name: fallback
+  clone_url: git@example.com:acme/fallback.git
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+      clone_url: git@example.com:acme/api.git
+    tracker:
+      label: backend
+---
+prompt body
+`
+
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load returned nil error, want project slug requirement for routed Linear polling")
+	}
+	if !strings.Contains(err.Error(), "tracker.project_slug") && !strings.Contains(err.Error(), "services[0].tracker.project_slug") {
+		t.Fatalf("Load error = %q, want project slug guidance", err)
+	}
+}
+
+func TestLoadRejectsGiteaServiceOnlyWorkflowWithoutFallbackRepo(t *testing.T) {
+	body := `---
+tracker:
+  kind: gitea
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+      clone_url: git@example.com:acme/api.git
+    tracker:
+      project_slug: api-platform
+---
+prompt body
+`
+
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load returned nil error, want missing fallback repo clone_url error for non-Linear services")
+	}
+	if !strings.Contains(err.Error(), "repo.clone_url") || !strings.Contains(err.Error(), "linear") {
+		t.Fatalf("Load error = %q, want repo.clone_url and linear guidance", err)
 	}
 }
 

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -59,6 +59,166 @@ func TestDefaultConfig_PRDraftDefaultsFalse(t *testing.T) {
 	}
 }
 
+func TestLoadParsesServiceLinearRoutes(t *testing.T) {
+	t.Setenv("TEST_SERVICE_REPO_URL", "git@example.com:acme/api.git")
+	body := `---
+repo:
+  owner: fallback
+  name: fallback
+  clone_url: git@example.com:fallback/fallback.git
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+      clone_url: $TEST_SERVICE_REPO_URL
+    tracker:
+      project_slug: api-platform
+      team_key: ENG
+      labels:
+        - backend
+      custom_fields:
+        Runtime: go
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(wf.Config.Services); got != 1 {
+		t.Fatalf("services = %d, want 1", got)
+	}
+	service := wf.Config.Services[0]
+	if service.Name != "api" {
+		t.Fatalf("service name = %q, want api", service.Name)
+	}
+	if service.Repo.CloneURL != "git@example.com:acme/api.git" {
+		t.Fatalf("service repo clone URL = %q", service.Repo.CloneURL)
+	}
+	if service.Repo.DefaultBranch != "main" {
+		t.Fatalf("service repo default branch = %q, want main", service.Repo.DefaultBranch)
+	}
+	if service.Tracker.ProjectSlug != "api-platform" || service.Tracker.TeamKey != "ENG" {
+		t.Fatalf("service tracker route = %+v, want project api-platform team ENG", service.Tracker)
+	}
+	if !reflect.DeepEqual(service.Tracker.Labels, []string{"backend"}) {
+		t.Fatalf("service tracker labels = %#v, want backend", service.Tracker.Labels)
+	}
+	if !reflect.DeepEqual(service.Tracker.CustomFields, map[string]string{"Runtime": "go"}) {
+		t.Fatalf("service tracker custom fields = %#v, want Runtime=go", service.Tracker.CustomFields)
+	}
+}
+
+func TestLoadAllowsServiceOnlyWorkflowWithoutFallbackRepo(t *testing.T) {
+	body := `---
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+      clone_url: git@example.com:acme/api.git
+    tracker:
+      project_slug: api-platform
+---
+prompt body
+`
+
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if wf.Config.Repo.CloneURL != "" {
+		t.Fatalf("fallback repo clone URL = %q, want empty service-only fallback", wf.Config.Repo.CloneURL)
+	}
+}
+
+func TestLoadRejectsServiceRouteMissingRepoCloneURL(t *testing.T) {
+	body := `---
+repo:
+  owner: fallback
+  name: fallback
+  clone_url: git@example.com:fallback/fallback.git
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+    tracker:
+      project_slug: api-platform
+---
+prompt body
+`
+
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load returned nil error, want missing service repo clone_url error")
+	}
+	if !strings.Contains(err.Error(), "services[0].repo.clone_url") {
+		t.Fatalf("Load error = %q, want services[0].repo.clone_url", err)
+	}
+}
+
+func TestLoadRejectsEmptyServiceName(t *testing.T) {
+	body := `---
+repo:
+  owner: fallback
+  name: fallback
+  clone_url: git@example.com:fallback/fallback.git
+services:
+  - repo:
+      owner: acme
+      name: api
+      clone_url: git@example.com:acme/api.git
+    tracker:
+      project_slug: api-platform
+---
+prompt body
+`
+
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load returned nil error, want empty service name error")
+	}
+	if !strings.Contains(err.Error(), "services[0].name is required") {
+		t.Fatalf("Load error = %q, want services[0].name guidance", err)
+	}
+}
+
+func TestLoadRejectsDuplicateServiceNames(t *testing.T) {
+	body := `---
+repo:
+  owner: fallback
+  name: fallback
+  clone_url: git@example.com:fallback/fallback.git
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+      clone_url: git@example.com:acme/api.git
+    tracker:
+      project_slug: api-platform
+  - name: API
+    repo:
+      owner: acme
+      name: api-v2
+      clone_url: git@example.com:acme/api-v2.git
+    tracker:
+      project_slug: api-v2
+---
+prompt body
+`
+
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load returned nil error, want duplicate service name error")
+	}
+	if !strings.Contains(err.Error(), `services[1].name "API" duplicates services[0].name`) {
+		t.Fatalf("Load error = %q, want duplicate service name guidance", err)
+	}
+}
+
 func TestLoad_PRDraftDefaultsAndExplicitFalse(t *testing.T) {
 	cases := map[string]struct {
 		front string

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -201,7 +201,7 @@ services:
       name: api
       clone_url: git@example.com:acme/api.git
     tracker:
-      label: backend
+      labels: [backend]
 ---
 prompt body
 `
@@ -212,6 +212,30 @@ prompt body
 	}
 	if !strings.Contains(err.Error(), "tracker.project_slug") && !strings.Contains(err.Error(), "services[0].tracker.project_slug") {
 		t.Fatalf("Load error = %q, want project slug guidance", err)
+	}
+}
+
+func TestLoadRejectsLinearServiceWithoutExplicitRoute(t *testing.T) {
+	body := `---
+tracker:
+  kind: linear
+  project_slug: platform
+services:
+  - name: api
+    repo:
+      owner: acme
+      name: api
+      clone_url: git@example.com:acme/api.git
+---
+prompt body
+`
+
+	_, err := Load(writeTempWorkflow(t, body))
+	if err == nil {
+		t.Fatal("Load returned nil error, want explicit Linear route predicate requirement")
+	}
+	if !strings.Contains(err.Error(), "services[0].tracker") || !strings.Contains(err.Error(), "route predicate") {
+		t.Fatalf("Load error = %q, want explicit route predicate guidance", err)
 	}
 }
 

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -110,6 +110,13 @@ var supportedSandboxNetworks = map[string]struct{}{
 // are evaluated before non-empty checks. Errors include the workflow
 // file path and the offending field/value so operators can fix the
 // source rather than chasing runtime symptoms (issue #9).
+func hasExplicitServiceRoute(route ServiceTrackerRouteConfig) bool {
+	return strings.TrimSpace(route.ProjectSlug) != "" ||
+		strings.TrimSpace(route.TeamKey) != "" ||
+		len(route.Labels) > 0 ||
+		len(route.CustomFields) > 0
+}
+
 func validateConfig(path string, cfg Config) error {
 	if strings.TrimSpace(cfg.Repo.CloneURL) == "" {
 		if len(cfg.Services) == 0 {
@@ -126,6 +133,9 @@ func validateConfig(path string, cfg Config) error {
 	}
 	if cfg.Tracker.Kind == "linear" {
 		for i, service := range cfg.Services {
+			if !hasExplicitServiceRoute(service.Tracker) {
+				return fmt.Errorf("%s: services[%d].tracker must define at least one Linear route predicate (project_slug, team_key, labels, or custom_fields)", path, i)
+			}
 			if strings.TrimSpace(cfg.Tracker.ProjectSlug) == "" && strings.TrimSpace(service.Tracker.ProjectSlug) == "" {
 				return fmt.Errorf("%s: services[%d].tracker.project_slug or tracker.project_slug is required for Linear service routing", path, i)
 			}

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -111,8 +111,23 @@ var supportedSandboxNetworks = map[string]struct{}{
 // file path and the offending field/value so operators can fix the
 // source rather than chasing runtime symptoms (issue #9).
 func validateConfig(path string, cfg Config) error {
-	if strings.TrimSpace(cfg.Repo.CloneURL) == "" {
+	if strings.TrimSpace(cfg.Repo.CloneURL) == "" && len(cfg.Services) == 0 {
 		return fmt.Errorf("%s: repo.clone_url is required", path)
+	}
+	seenServiceNames := make(map[string]int, len(cfg.Services))
+	for i, service := range cfg.Services {
+		name := strings.TrimSpace(service.Name)
+		if name == "" {
+			return fmt.Errorf("%s: services[%d].name is required", path, i)
+		}
+		nameKey := strings.ToLower(name)
+		if first, ok := seenServiceNames[nameKey]; ok {
+			return fmt.Errorf("%s: services[%d].name %q duplicates services[%d].name", path, i, service.Name, first)
+		}
+		seenServiceNames[nameKey] = i
+		if strings.TrimSpace(service.Repo.CloneURL) == "" {
+			return fmt.Errorf("%s: services[%d].repo.clone_url is required", path, i)
+		}
 	}
 	if _, ok := supportedTrackerKinds[cfg.Tracker.Kind]; !ok {
 		return fmt.Errorf("%s: tracker.kind %q is not supported (allowed: gitea, linear)", path, cfg.Tracker.Kind)
@@ -271,15 +286,15 @@ func splitFrontMatter(s string) (string, string) {
 
 func expandConfig(cfg *Config) {
 	cfg.Tracker.APIKey = os.ExpandEnv(cfg.Tracker.APIKey)
-	cfg.Repo.CloneURL = os.ExpandEnv(cfg.Repo.CloneURL)
+	expandRepoConfig(&cfg.Repo)
+	for i := range cfg.Services {
+		expandRepoConfig(&cfg.Services[i].Repo)
+	}
 	cfg.Workspace.Root = expandPath(os.ExpandEnv(cfg.Workspace.Root))
 	cfg.Codex.Command = os.ExpandEnv(cfg.Codex.Command)
 	cfg.Claude.Command = os.ExpandEnv(cfg.Claude.Command)
 	for i := range cfg.Sandbox.CredentialFiles {
 		cfg.Sandbox.CredentialFiles[i] = expandPath(os.ExpandEnv(cfg.Sandbox.CredentialFiles[i]))
-	}
-	if cfg.Repo.DefaultBranch == "" {
-		cfg.Repo.DefaultBranch = "main"
 	}
 	if cfg.Agent.Default == "" {
 		cfg.Agent.Default = "mock"
@@ -325,6 +340,13 @@ func expandConfig(cfg *Config) {
 	}
 	if cfg.Codex.ApprovalPolicy == nil {
 		cfg.Codex.ApprovalPolicy = map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true, "mcp_elicitations": true}}
+	}
+}
+
+func expandRepoConfig(repo *RepoConfig) {
+	repo.CloneURL = os.ExpandEnv(repo.CloneURL)
+	if repo.DefaultBranch == "" {
+		repo.DefaultBranch = "main"
 	}
 }
 

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -111,8 +111,25 @@ var supportedSandboxNetworks = map[string]struct{}{
 // file path and the offending field/value so operators can fix the
 // source rather than chasing runtime symptoms (issue #9).
 func validateConfig(path string, cfg Config) error {
-	if strings.TrimSpace(cfg.Repo.CloneURL) == "" && len(cfg.Services) == 0 {
-		return fmt.Errorf("%s: repo.clone_url is required", path)
+	if strings.TrimSpace(cfg.Repo.CloneURL) == "" {
+		if len(cfg.Services) == 0 {
+			return fmt.Errorf("%s: repo.clone_url is required", path)
+		}
+		if cfg.Tracker.Kind != "linear" {
+			return fmt.Errorf("%s: repo.clone_url is required unless tracker.kind is linear and services provide routed repos", path)
+		}
+		for i, service := range cfg.Services {
+			if strings.TrimSpace(cfg.Tracker.ProjectSlug) == "" && strings.TrimSpace(service.Tracker.ProjectSlug) == "" {
+				return fmt.Errorf("%s: services[%d].tracker.project_slug or tracker.project_slug is required for service-only Linear workflows", path, i)
+			}
+		}
+	}
+	if cfg.Tracker.Kind == "linear" {
+		for i, service := range cfg.Services {
+			if strings.TrimSpace(cfg.Tracker.ProjectSlug) == "" && strings.TrimSpace(service.Tracker.ProjectSlug) == "" {
+				return fmt.Errorf("%s: services[%d].tracker.project_slug or tracker.project_slug is required for Linear service routing", path, i)
+			}
+		}
 	}
 	seenServiceNames := make(map[string]int, len(cfg.Services))
 	for i, service := range cfg.Services {


### PR DESCRIPTION
## Summary
- route Linear candidates to configured services by project/team/label/custom field while preserving single-repo default behavior
- map Linear `customFieldValues` for routing and keep Gitea/runtime pollers out of Linear-only routing
- cancel/release active or retrying runs when a Linear issue's matched service route changes
- track the `services` workflow extension as D25/#143 and document its read-only SPEC boundary

## Test Plan
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/workflow ./internal/tracker ./internal/orchestrator`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./...`
- [x] local Codex plugin review via `/codex:review --base origin/main` (no blocking findings)

Closes #16
Refs #143
