### PR TITLE
feat: add orchestrator runtime status snapshot

### DIFF
--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -1,0 +1,65 @@
+# Runtime status surface
+
+The runtime status surface is a lightweight observability view over the
+orchestrator's in-process state. It is intentionally not a scheduler database,
+not a queue replacement, and not an authority for ticket writes.
+
+## Source of truth
+
+The status payload is produced from `orchestrator.OrchestratorState`, the
+single in-memory authority described by Symphony SPEC sections 3.1, 4.1.8, and
+7.4. A process restart resets exact scheduler state; recovery comes from the
+tracker plus filesystem reconciliation, not from this status payload.
+
+The payload reports `source: "orchestrator_runtime"` so operators can tell it
+is not derived from the transitional Postgres queue.
+
+## Event vocabulary
+
+Recent runtime events use the SPEC-aligned operator vocabulary:
+
+- `candidate` — tracker issue was observed as an eligible candidate.
+- `running` — candidate was dispatched to an agent run.
+- `completed` — run exited successfully or reached workflow handoff.
+- `failed` — run failed and may retry or be suppressed by deterministic failure rules.
+- `blocked` — runtime observed an issue that cannot proceed because a dependency or policy gate is blocking it.
+
+These are observability events. They do not imply the worker changed tracker
+state, pushed a branch, opened a pull request, or posted a comment. Those writes
+belong to the agent/tool workflow boundary from Symphony SPEC section 1.
+
+## Branches and pull requests
+
+`branch` and `pr_url` fields are optional. The status surface may display them
+when they are discoverable from agent output or runtime events. Their presence
+means only that the runtime observed those links; it does not assume the worker
+created or owns them.
+
+## JSON shape
+
+The initial implementation exposes a reusable JSON writer used by CLI or
+read-only endpoint wrappers:
+
+```json
+{
+  "source": "orchestrator_runtime",
+  "summary": {
+    "candidate": 1,
+    "running": 1,
+    "completed": 0,
+    "failed": 0,
+    "blocked": 0,
+    "retrying": 0
+  },
+  "running": [],
+  "retrying": [],
+  "completed": [],
+  "recent_events": [],
+  "codex_totals": {
+    "InputTokens": 0,
+    "OutputTokens": 0,
+    "TotalTokens": 0,
+    "SecondsRunning": 0
+  }
+}
+```

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -256,6 +256,24 @@ func (o *Orchestrator) Snapshot(ctx context.Context) (StateView, error) {
 	}
 }
 
+// StatusSnapshot returns the queue-independent runtime status surface view.
+func (o *Orchestrator) StatusSnapshot(ctx context.Context, recentEventLimit int) (RuntimeStatus, error) {
+	reply := make(chan RuntimeStatus, 1)
+	op := opFunc(func(st *OrchestratorState) func() {
+		reply <- st.StatusSnapshot(recentEventLimit)
+		return nil
+	})
+	if err := o.submit(ctx, op); err != nil {
+		return RuntimeStatus{}, err
+	}
+	select {
+	case v := <-reply:
+		return v, nil
+	case <-ctx.Done():
+		return RuntimeStatus{}, ctx.Err()
+	}
+}
+
 // UpdateMaxConcurrentAgents applies a reloaded workflow capacity limit through
 // the actor so dispatch and retry capacity checks observe the new value without
 // restarting the process.
@@ -724,6 +742,7 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 			close(f.done)
 			return nil
 		}
+		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
 		st.Claimed[f.id] = struct{}{}
 		close(f.done)
 		// A clean continuation is a new normal turn. Keep its retry entry
@@ -743,6 +762,7 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 			close(f.done)
 			return nil
 		}
+		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: f.result.Err.Error()})
 		close(f.done)
 		return nil
 	}
@@ -758,6 +778,7 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		close(f.done)
 		return nil
 	}
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: f.result.Err.Error()})
 	// Hold the Claimed slot across the gap between this apply (which
 	// returns control to the actor's select loop) and the
 	// scheduleRetryOp that the followup enqueues. Without this re-set,
@@ -808,6 +829,7 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int) {
 	}
 	_ = o.submit(o.runCtx, opFunc(func(st *OrchestratorState) func() {
 		st.Running[id] = entry
+		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventRunning, IssueID: id, Identifier: issue.Identifier, Message: "dispatched to agent", At: startedAt})
 		return nil
 	}))
 	go func() {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -587,6 +587,12 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 		delete(st.RetryAttempts, id)
 		delete(st.Claimed, id)
 	}
+	st.RecordEvent(RuntimeEvent{
+		Kind:       RuntimeEventCandidate,
+		IssueID:    id,
+		Identifier: d.issue.Identifier,
+		Message:    "candidate fetched from tracker",
+	})
 	// Reserve the slot synchronously so a concurrent dispatchOp aborts
 	// on its IsClaimed check. The followup records Running once the
 	// worker is spawned.

--- a/internal/orchestrator/actor_status_test.go
+++ b/internal/orchestrator/actor_status_test.go
@@ -1,0 +1,98 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+func TestActorStatusSnapshotRecordsDispatchAndCompletionEvents(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-42", Identifier: "ENG-42", Title: "status"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitForSpawn(t, disp, 1)
+	disp.finishAt(0, WorkerResult{Elapsed: 25 * time.Millisecond})
+
+	status := waitForStatus(t, o, func(status RuntimeStatus) bool {
+		return status.Summary.Completed == 1 && len(status.RecentEvents) >= 2
+	})
+
+	if status.Summary.Running != 0 || status.Summary.Completed != 1 {
+		t.Fatalf("summary = %+v, want completed runtime and no running", status.Summary)
+	}
+	kinds := map[RuntimeEventKind]bool{}
+	for _, ev := range status.RecentEvents {
+		kinds[ev.Kind] = true
+		if ev.IssueID == "ENG-42" && ev.Identifier != "ENG-42" {
+			t.Fatalf("event identifier = %q, want ENG-42", ev.Identifier)
+		}
+	}
+	if !kinds[RuntimeEventRunning] || !kinds[RuntimeEventCompleted] {
+		t.Fatalf("events = %+v, want running and completed", status.RecentEvents)
+	}
+}
+
+func TestActorStatusSnapshotRecordsRetryableFailureEvent(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-43", Identifier: "ENG-43", Title: "status failure"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitForSpawn(t, disp, 1)
+	disp.finishAt(0, WorkerResult{Err: context.DeadlineExceeded, Elapsed: 25 * time.Millisecond})
+
+	status := waitForStatus(t, o, func(status RuntimeStatus) bool {
+		return status.Summary.Failed == 1 && status.Summary.Retrying == 1
+	})
+
+	if status.Summary.Failed != 1 || status.Summary.Retrying != 1 {
+		t.Fatalf("summary = %+v, want one failed run waiting for retry", status.Summary)
+	}
+	for _, ev := range status.RecentEvents {
+		if ev.Kind == RuntimeEventFailed && ev.IssueID == "ENG-43" && ev.Identifier == "ENG-43" {
+			return
+		}
+	}
+	t.Fatalf("events = %+v, want failed event for ENG-43", status.RecentEvents)
+}
+
+func waitForStatus(t *testing.T, o *Orchestrator, ready func(RuntimeStatus) bool) RuntimeStatus {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var status RuntimeStatus
+	for time.Now().Before(deadline) {
+		var err error
+		status, err = o.StatusSnapshot(context.Background(), 10)
+		if err != nil {
+			t.Fatalf("StatusSnapshot: %v", err)
+		}
+		if ready(status) {
+			return status
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("status did not converge before deadline: %+v", status)
+	return RuntimeStatus{}
+}
+
+func waitForSpawn(t *testing.T, disp *fakeDispatcher, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if disp.count() >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("dispatcher spawn count = %d, want at least %d", disp.count(), want)
+}

--- a/internal/orchestrator/actor_status_test.go
+++ b/internal/orchestrator/actor_status_test.go
@@ -27,6 +27,9 @@ func TestActorStatusSnapshotRecordsDispatchAndCompletionEvents(t *testing.T) {
 	if status.Summary.Running != 0 || status.Summary.Completed != 1 {
 		t.Fatalf("summary = %+v, want completed runtime and no running", status.Summary)
 	}
+	if status.Summary.Candidate != 1 {
+		t.Fatalf("candidate summary = %d, want observed candidate before dispatch", status.Summary.Candidate)
+	}
 	kinds := map[RuntimeEventKind]bool{}
 	for _, ev := range status.RecentEvents {
 		kinds[ev.Kind] = true
@@ -34,8 +37,8 @@ func TestActorStatusSnapshotRecordsDispatchAndCompletionEvents(t *testing.T) {
 			t.Fatalf("event identifier = %q, want ENG-42", ev.Identifier)
 		}
 	}
-	if !kinds[RuntimeEventRunning] || !kinds[RuntimeEventCompleted] {
-		t.Fatalf("events = %+v, want running and completed", status.RecentEvents)
+	if !kinds[RuntimeEventCandidate] || !kinds[RuntimeEventRunning] || !kinds[RuntimeEventCompleted] {
+		t.Fatalf("events = %+v, want candidate, running, and completed", status.RecentEvents)
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -127,6 +127,8 @@ type OrchestratorState struct {
 
 	CodexTotals     CodexTotals
 	CodexRateLimits *RateLimitSnapshot // nil until the runner populates it
+
+	RecentEvents []RuntimeEvent
 }
 
 // FailedEntry suppresses a deterministic non-retryable failure only while the

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -366,6 +366,7 @@ type StateView struct {
 
 	Running         []RunningView
 	Retrying        []RetryView
+	Failed          []IssueID
 	Completed       []IssueID
 	CodexTotals     CodexTotals
 	CodexRateLimits *RateLimitSnapshot
@@ -403,6 +404,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 		MaxConcurrentAgents: s.MaxConcurrentAgents,
 		Running:             make([]RunningView, 0, len(s.Running)),
 		Retrying:            make([]RetryView, 0, len(s.RetryAttempts)),
+		Failed:              make([]IssueID, 0, len(s.Failed)),
 		Completed:           make([]IssueID, 0, len(s.Completed)),
 		CodexTotals:         s.CodexTotals,
 		CodexRateLimits:     s.CodexRateLimits,
@@ -434,6 +436,9 @@ func (s *OrchestratorState) Snapshot() StateView {
 			DueAt:      r.DueAt,
 			Error:      r.Error,
 		})
+	}
+	for id := range s.Failed {
+		view.Failed = append(view.Failed, id)
 	}
 	for id := range s.Completed {
 		view.Completed = append(view.Completed, id)

--- a/internal/orchestrator/status.go
+++ b/internal/orchestrator/status.go
@@ -1,0 +1,189 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"io"
+	"sort"
+	"time"
+)
+
+// RuntimeEventKind is the SPEC-aligned runtime event vocabulary used by the
+// lightweight status surface. It describes orchestrator runtime state, not rows
+// in the transitional queue.
+type RuntimeEventKind string
+
+const (
+	RuntimeEventCandidate RuntimeEventKind = "candidate"
+	RuntimeEventRunning   RuntimeEventKind = "running"
+	RuntimeEventCompleted RuntimeEventKind = "completed"
+	RuntimeEventFailed    RuntimeEventKind = "failed"
+	RuntimeEventBlocked   RuntimeEventKind = "blocked"
+)
+
+// RuntimeEvent is an operator-facing event observed by the orchestrator runtime.
+// Branch and PRURL are optional discoveries from agent output/events; their
+// presence does not imply the worker created or pushed anything itself.
+type RuntimeEvent struct {
+	Kind       RuntimeEventKind `json:"kind"`
+	IssueID    IssueID          `json:"issue_id,omitempty"`
+	Identifier string           `json:"identifier,omitempty"`
+	Message    string           `json:"message,omitempty"`
+	Branch     string           `json:"branch,omitempty"`
+	PRURL      string           `json:"pr_url,omitempty"`
+	At         time.Time        `json:"at"`
+}
+
+type RuntimeStatus struct {
+	Source       string             `json:"source"`
+	Summary      StatusSummary      `json:"summary"`
+	Running      []StatusRun        `json:"running"`
+	Retrying     []RetryView        `json:"retrying"`
+	Completed    []IssueID          `json:"completed"`
+	RecentEvents []RuntimeEvent     `json:"recent_events"`
+	CodexTotals  CodexTotals        `json:"codex_totals"`
+	RateLimits   *RateLimitSnapshot `json:"rate_limits,omitempty"`
+}
+
+type StatusSummary struct {
+	Candidate int `json:"candidate"`
+	Running   int `json:"running"`
+	Completed int `json:"completed"`
+	Failed    int `json:"failed"`
+	Blocked   int `json:"blocked"`
+	Retrying  int `json:"retrying"`
+}
+
+type StatusRun struct {
+	IssueID       IssueID   `json:"issue_id"`
+	Identifier    string    `json:"identifier,omitempty"`
+	StartedAt     time.Time `json:"started_at"`
+	RetryAttempt  *int      `json:"retry_attempt,omitempty"`
+	WorkspacePath string    `json:"workspace_path,omitempty"`
+	LastCodexAt   time.Time `json:"last_codex_at,omitempty"`
+	Branch        string    `json:"branch,omitempty"`
+	PRURL         string    `json:"pr_url,omitempty"`
+}
+
+// RecordEvent appends ev to the bounded in-memory event log.
+func (s *OrchestratorState) RecordEvent(ev RuntimeEvent) {
+	if s == nil {
+		return
+	}
+	if ev.At.IsZero() {
+		ev.At = time.Now().UTC()
+	}
+	s.RecentEvents = append(s.RecentEvents, ev)
+	const maxRuntimeEvents = 200
+	if len(s.RecentEvents) > maxRuntimeEvents {
+		copy(s.RecentEvents, s.RecentEvents[len(s.RecentEvents)-maxRuntimeEvents:])
+		s.RecentEvents = s.RecentEvents[:maxRuntimeEvents]
+	}
+}
+
+// StatusSnapshot returns a queue-independent operator status payload.
+func (s *OrchestratorState) StatusSnapshot(limit int) RuntimeStatus {
+	view := s.Snapshot()
+	events := boundedRuntimeEvents(s.RecentEvents, limit)
+	links := linksByIssue(events)
+
+	running := make([]StatusRun, 0, len(view.Running))
+	for _, r := range view.Running {
+		row := StatusRun{
+			IssueID:       r.IssueID,
+			Identifier:    r.Identifier,
+			StartedAt:     r.StartedAt,
+			RetryAttempt:  r.RetryAttempt,
+			WorkspacePath: r.WorkspacePath,
+			LastCodexAt:   r.LastCodexAt,
+		}
+		if link, ok := links[r.IssueID]; ok {
+			row.Branch = link.branch
+			row.PRURL = link.prURL
+		}
+		running = append(running, row)
+	}
+	sort.Slice(running, func(i, j int) bool { return running[i].IssueID < running[j].IssueID })
+	sort.Slice(view.Retrying, func(i, j int) bool { return view.Retrying[i].IssueID < view.Retrying[j].IssueID })
+	sort.Slice(view.Completed, func(i, j int) bool { return view.Completed[i] < view.Completed[j] })
+
+	summary := StatusSummary{Running: len(running), Completed: len(view.Completed), Retrying: len(view.Retrying)}
+	seenEventIssues := map[RuntimeEventKind]map[IssueID]struct{}{}
+	for _, ev := range events {
+		recordEventSummary(&summary, seenEventIssues, ev)
+	}
+	return RuntimeStatus{
+		Source:       "orchestrator_runtime",
+		Summary:      summary,
+		Running:      running,
+		Retrying:     view.Retrying,
+		Completed:    view.Completed,
+		RecentEvents: events,
+		CodexTotals:  view.CodexTotals,
+		RateLimits:   view.CodexRateLimits,
+	}
+}
+
+func recordEventSummary(summary *StatusSummary, seen map[RuntimeEventKind]map[IssueID]struct{}, ev RuntimeEvent) {
+	switch ev.Kind {
+	case RuntimeEventCandidate, RuntimeEventFailed, RuntimeEventBlocked:
+	default:
+		return
+	}
+	if ev.IssueID != "" {
+		byIssue := seen[ev.Kind]
+		if byIssue == nil {
+			byIssue = map[IssueID]struct{}{}
+			seen[ev.Kind] = byIssue
+		}
+		if _, ok := byIssue[ev.IssueID]; ok {
+			return
+		}
+		byIssue[ev.IssueID] = struct{}{}
+	}
+	switch ev.Kind {
+	case RuntimeEventCandidate:
+		summary.Candidate++
+	case RuntimeEventFailed:
+		summary.Failed++
+	case RuntimeEventBlocked:
+		summary.Blocked++
+	}
+}
+
+func boundedRuntimeEvents(src []RuntimeEvent, limit int) []RuntimeEvent {
+	if limit <= 0 || limit > len(src) {
+		limit = len(src)
+	}
+	out := make([]RuntimeEvent, limit)
+	copy(out, src[len(src)-limit:])
+	return out
+}
+
+type eventLinks struct {
+	branch string
+	prURL  string
+}
+
+func linksByIssue(events []RuntimeEvent) map[IssueID]eventLinks {
+	out := map[IssueID]eventLinks{}
+	for _, ev := range events {
+		if ev.IssueID == "" {
+			continue
+		}
+		link := out[ev.IssueID]
+		if ev.Branch != "" {
+			link.branch = ev.Branch
+		}
+		if ev.PRURL != "" {
+			link.prURL = ev.PRURL
+		}
+		out[ev.IssueID] = link
+	}
+	return out
+}
+
+func WriteStatusJSON(w io.Writer, status RuntimeStatus) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(status)
+}

--- a/internal/orchestrator/status.go
+++ b/internal/orchestrator/status.go
@@ -37,10 +37,10 @@ type RuntimeStatus struct {
 	Source       string             `json:"source"`
 	Summary      StatusSummary      `json:"summary"`
 	Running      []StatusRun        `json:"running"`
-	Retrying     []RetryView        `json:"retrying"`
+	Retrying     []StatusRetry      `json:"retrying"`
 	Completed    []IssueID          `json:"completed"`
 	RecentEvents []RuntimeEvent     `json:"recent_events"`
-	CodexTotals  CodexTotals        `json:"codex_totals"`
+	CodexTotals  StatusCodexTotals  `json:"codex_totals"`
 	RateLimits   *RateLimitSnapshot `json:"rate_limits,omitempty"`
 }
 
@@ -64,6 +64,21 @@ type StatusRun struct {
 	PRURL         string    `json:"pr_url,omitempty"`
 }
 
+type StatusRetry struct {
+	IssueID    IssueID   `json:"issue_id"`
+	Identifier string    `json:"identifier,omitempty"`
+	Attempt    int       `json:"attempt"`
+	DueAt      time.Time `json:"due_at"`
+	Error      string    `json:"error,omitempty"`
+}
+
+type StatusCodexTotals struct {
+	InputTokens    int64   `json:"input_tokens"`
+	OutputTokens   int64   `json:"output_tokens"`
+	TotalTokens    int64   `json:"total_tokens"`
+	SecondsRunning float64 `json:"seconds_running"`
+}
+
 // RecordEvent appends ev to the bounded in-memory event log.
 func (s *OrchestratorState) RecordEvent(ev RuntimeEvent) {
 	if s == nil {
@@ -83,8 +98,9 @@ func (s *OrchestratorState) RecordEvent(ev RuntimeEvent) {
 // StatusSnapshot returns a queue-independent operator status payload.
 func (s *OrchestratorState) StatusSnapshot(limit int) RuntimeStatus {
 	view := s.Snapshot()
+	allEvents := boundedRuntimeEvents(s.RecentEvents, 0)
 	events := boundedRuntimeEvents(s.RecentEvents, limit)
-	links := linksByIssue(events)
+	links := linksByIssue(allEvents)
 
 	running := make([]StatusRun, 0, len(view.Running))
 	for _, r := range view.Running {
@@ -103,23 +119,51 @@ func (s *OrchestratorState) StatusSnapshot(limit int) RuntimeStatus {
 		running = append(running, row)
 	}
 	sort.Slice(running, func(i, j int) bool { return running[i].IssueID < running[j].IssueID })
-	sort.Slice(view.Retrying, func(i, j int) bool { return view.Retrying[i].IssueID < view.Retrying[j].IssueID })
+	retrying := make([]StatusRetry, 0, len(view.Retrying))
+	for _, r := range view.Retrying {
+		retrying = append(retrying, StatusRetry{
+			IssueID:    r.IssueID,
+			Identifier: r.Identifier,
+			Attempt:    r.Attempt,
+			DueAt:      r.DueAt,
+			Error:      r.Error,
+		})
+	}
+	sort.Slice(retrying, func(i, j int) bool { return retrying[i].IssueID < retrying[j].IssueID })
+	sort.Slice(view.Failed, func(i, j int) bool { return view.Failed[i] < view.Failed[j] })
 	sort.Slice(view.Completed, func(i, j int) bool { return view.Completed[i] < view.Completed[j] })
 
-	summary := StatusSummary{Running: len(running), Completed: len(view.Completed), Retrying: len(view.Retrying)}
+	summary := StatusSummary{Running: len(running), Completed: len(view.Completed), Failed: len(view.Failed), Retrying: len(retrying)}
 	seenEventIssues := map[RuntimeEventKind]map[IssueID]struct{}{}
-	for _, ev := range events {
+	for _, id := range view.Failed {
+		seenFailed := seenEventIssues[RuntimeEventFailed]
+		if seenFailed == nil {
+			seenFailed = map[IssueID]struct{}{}
+			seenEventIssues[RuntimeEventFailed] = seenFailed
+		}
+		seenFailed[id] = struct{}{}
+	}
+	for _, ev := range allEvents {
 		recordEventSummary(&summary, seenEventIssues, ev)
 	}
 	return RuntimeStatus{
 		Source:       "orchestrator_runtime",
 		Summary:      summary,
 		Running:      running,
-		Retrying:     view.Retrying,
+		Retrying:     retrying,
 		Completed:    view.Completed,
 		RecentEvents: events,
-		CodexTotals:  view.CodexTotals,
+		CodexTotals:  statusCodexTotals(view.CodexTotals),
 		RateLimits:   view.CodexRateLimits,
+	}
+}
+
+func statusCodexTotals(t CodexTotals) StatusCodexTotals {
+	return StatusCodexTotals{
+		InputTokens:    t.InputTokens,
+		OutputTokens:   t.OutputTokens,
+		TotalTokens:    t.TotalTokens,
+		SecondsRunning: t.SecondsRunning,
 	}
 }
 

--- a/internal/orchestrator/status_test.go
+++ b/internal/orchestrator/status_test.go
@@ -93,8 +93,45 @@ func TestStatusSnapshotDeduplicatesEventSummaryByIssueAndKind(t *testing.T) {
 	}
 }
 
+func TestStatusSnapshotSummaryIgnoresRecentEventLimit(t *testing.T) {
+	st := NewOrchestratorState(30000, 2)
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: "issue-1", At: time.Unix(1, 0)})
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCandidate, IssueID: "issue-2", At: time.Unix(2, 0)})
+
+	status := st.StatusSnapshot(1)
+	if len(status.RecentEvents) != 1 {
+		t.Fatalf("recent events = %d, want display limit 1", len(status.RecentEvents))
+	}
+	if status.Summary.Failed != 1 || status.Summary.Candidate != 1 {
+		t.Fatalf("summary = %+v, want counters from full runtime event log", status.Summary)
+	}
+}
+
+func TestStatusSnapshotCountsCurrentNonRetryableFailuresAfterEventEviction(t *testing.T) {
+	st := NewOrchestratorState(30000, 2)
+	run := &RunningEntry{Issue: tracker.Issue{ID: "issue-1", Identifier: "ENG-1", State: "started", UpdatedAt: "2026-05-19T00:00:00Z"}}
+	st.BeginDispatch("issue-1", run)
+	st.FinishRunNonRetryableFailed("issue-1", run, time.Millisecond)
+	for i := range 201 {
+		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCandidate, IssueID: IssueID("issue-later"), At: time.Unix(int64(i), 0)})
+	}
+
+	status := st.StatusSnapshot(10)
+	if status.Summary.Failed != 1 {
+		t.Fatalf("failed summary = %d, want current non-retryable failure counted", status.Summary.Failed)
+	}
+}
+
 func TestWriteStatusJSONDocumentsQueueIndependentSource(t *testing.T) {
 	st := NewOrchestratorState(30000, 2)
+	st.RecordCodexTokens(10, 20)
+	st.ScheduleRetry(&RetryEntry{
+		IssueID:    "issue-2",
+		Identifier: "ENG-2",
+		Attempt:    2,
+		DueAt:      time.Unix(102, 0).UTC(),
+		Error:      "transient failure",
+	})
 	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventBlocked, IssueID: "issue-1", Identifier: "ENG-1", Message: "blocked by dependency", At: time.Unix(101, 0).UTC()})
 
 	var buf bytes.Buffer
@@ -112,5 +149,15 @@ func TestWriteStatusJSONDocumentsQueueIndependentSource(t *testing.T) {
 	}
 	if decoded.RecentEvents[0].Kind != RuntimeEventBlocked {
 		t.Fatalf("decoded event kind = %q, want %q", decoded.RecentEvents[0].Kind, RuntimeEventBlocked)
+	}
+	for _, internalName := range []string{"IssueID", "DueAt", "InputTokens"} {
+		if strings.Contains(body, internalName) {
+			t.Fatalf("status JSON leaked internal field name %q: %s", internalName, body)
+		}
+	}
+	for _, publicName := range []string{"issue_id", "due_at", "input_tokens"} {
+		if !strings.Contains(body, publicName) {
+			t.Fatalf("status JSON missing public field name %q: %s", publicName, body)
+		}
 	}
 }

--- a/internal/orchestrator/status_test.go
+++ b/internal/orchestrator/status_test.go
@@ -1,0 +1,116 @@
+package orchestrator
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+func TestStatusSnapshotIncludesRuntimeStateAndRecentEvents(t *testing.T) {
+	st := NewOrchestratorState(30000, 2)
+
+	run := &RunningEntry{
+		Issue:      tracker.Issue{ID: "issue-1", Identifier: "ENG-1", Title: "running issue", URL: "https://tracker.example/ENG-1"},
+		Identifier: "ENG-1",
+		StartedAt:  time.Unix(100, 0).UTC(),
+		Workspace:  Workspace{Path: "/tmp/symphony/ENG-1"},
+	}
+	st.BeginDispatch("issue-1", run)
+	st.RecordEvent(RuntimeEvent{
+		Kind:       RuntimeEventCandidate,
+		IssueID:    "issue-1",
+		Identifier: "ENG-1",
+		Message:    "candidate fetched from tracker",
+		At:         time.Unix(99, 0).UTC(),
+	})
+	st.RecordEvent(RuntimeEvent{
+		Kind:       RuntimeEventRunning,
+		IssueID:    "issue-1",
+		Identifier: "ENG-1",
+		Message:    "dispatched to agent",
+		Branch:     "agent/eng-1",
+		PRURL:      "https://github.example/pr/1",
+		At:         time.Unix(100, 0).UTC(),
+	})
+
+	status := st.StatusSnapshot(10)
+	if status.Source != "orchestrator_runtime" {
+		t.Fatalf("status source = %q, want orchestrator_runtime", status.Source)
+	}
+	if status.Summary.Candidate != 1 || status.Summary.Running != 1 {
+		t.Fatalf("summary = %+v, want one candidate and one running", status.Summary)
+	}
+	if len(status.Running) != 1 {
+		t.Fatalf("running rows = %d, want 1", len(status.Running))
+	}
+	if got := status.Running[0].Branch; got != "agent/eng-1" {
+		t.Fatalf("running branch = %q, want agent/eng-1", got)
+	}
+	if len(status.RecentEvents) != 2 {
+		t.Fatalf("events = %d, want 2", len(status.RecentEvents))
+	}
+	if status.RecentEvents[1].PRURL == "" {
+		t.Fatalf("expected PR link discovered from runtime event: %+v", status.RecentEvents[1])
+	}
+}
+
+func TestStatusSnapshotRecentEventsAreBoundedAndCopied(t *testing.T) {
+	st := NewOrchestratorState(30000, 2)
+	for i, kind := range []RuntimeEventKind{RuntimeEventCandidate, RuntimeEventRunning, RuntimeEventCompleted} {
+		st.RecordEvent(RuntimeEvent{Kind: kind, IssueID: IssueID("issue"), At: time.Unix(int64(i), 0)})
+	}
+
+	status := st.StatusSnapshot(2)
+	if len(status.RecentEvents) != 2 {
+		t.Fatalf("events = %d, want 2", len(status.RecentEvents))
+	}
+	if status.RecentEvents[0].Kind != RuntimeEventRunning || status.RecentEvents[1].Kind != RuntimeEventCompleted {
+		t.Fatalf("events = %+v, want last two in chronological order", status.RecentEvents)
+	}
+	status.RecentEvents[0].Kind = RuntimeEventFailed
+	again := st.StatusSnapshot(2)
+	if again.RecentEvents[0].Kind != RuntimeEventRunning {
+		t.Fatal("StatusSnapshot returned events aliased to orchestrator state")
+	}
+}
+
+func TestStatusSnapshotDeduplicatesEventSummaryByIssueAndKind(t *testing.T) {
+	st := NewOrchestratorState(30000, 2)
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCandidate, IssueID: "issue-1", At: time.Unix(1, 0)})
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCandidate, IssueID: "issue-1", At: time.Unix(2, 0)})
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventBlocked, IssueID: "issue-1", At: time.Unix(3, 0)})
+
+	status := st.StatusSnapshot(10)
+	if status.Summary.Candidate != 1 {
+		t.Fatalf("candidate summary = %d, want deduplicated count 1", status.Summary.Candidate)
+	}
+	if status.Summary.Blocked != 1 {
+		t.Fatalf("blocked summary = %d, want 1", status.Summary.Blocked)
+	}
+}
+
+func TestWriteStatusJSONDocumentsQueueIndependentSource(t *testing.T) {
+	st := NewOrchestratorState(30000, 2)
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventBlocked, IssueID: "issue-1", Identifier: "ENG-1", Message: "blocked by dependency", At: time.Unix(101, 0).UTC()})
+
+	var buf bytes.Buffer
+	if err := WriteStatusJSON(&buf, st.StatusSnapshot(20)); err != nil {
+		t.Fatalf("WriteStatusJSON: %v", err)
+	}
+
+	body := buf.String()
+	if strings.Contains(body, "postgres") || strings.Contains(body, "queue") {
+		t.Fatalf("status JSON should describe runtime source without legacy queue wording: %s", body)
+	}
+	var decoded RuntimeStatus
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("status JSON is invalid: %v", err)
+	}
+	if decoded.RecentEvents[0].Kind != RuntimeEventBlocked {
+		t.Fatalf("decoded event kind = %q, want %q", decoded.RecentEvents[0].Kind, RuntimeEventBlocked)
+	}
+}


### PR DESCRIPTION
## Summary
- add an in-memory orchestrator runtime status snapshot and JSON writer
- record running/completed/failed runtime events through the actor
- document the queue-independent runtime status surface and optional branch/PR links

## Test Plan
- `/home/pi/.local/go1.25.10/bin/go test ./internal/orchestrator -run TestActorStatusSnapshotRecordsRetryableFailureEvent -count=1`
- `/home/pi/.local/go1.25.10/bin/go test ./internal/orchestrator -count=1`
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- local Codex review fallback: `codex exec --full-auto 'Review this branch diff against origin/main ...'` → no blocking findings

Closes #26
