### PR TITLE
fix: avoid capture review search rate limit

### DIFF
--- a/.github/scripts/capture-unresolved-reviews.mjs
+++ b/.github/scripts/capture-unresolved-reviews.mjs
@@ -380,18 +380,57 @@ function uniqueIssues(issues) {
   return result;
 }
 
-function searchQuery({ repository, term }) {
-  return `${JSON.stringify(term)} repo:${repository.owner}/${repository.name} in:body type:issue`;
+export function buildTrackingIssueIndex(issues) {
+  const index = new Map();
+  for (const issue of issues ?? []) {
+    const body = issue.body ?? '';
+    const trackedIssue = {
+      number: issue.number,
+      state: issue.state,
+      url: issue.html_url ?? issue.url,
+    };
+    const terms = new Set(body.match(/discussion_r\d+/g) ?? []);
+    for (const discussion of [...terms]) {
+      const permalink = body.match(new RegExp(`https://github\\.com/[^\\s)]+#${discussion}`))?.[0];
+      if (permalink) {
+        terms.add(permalink);
+      }
+    }
+    for (const term of terms) {
+      index.set(term, uniqueIssues([...(index.get(term) ?? []), trackedIssue]));
+    }
+  }
+  return index;
+}
+
+export async function loadRepositoryIssuesForTracking({ repository, request = githubRequest }) {
+  const issues = [];
+  for (let page = 1; ; page += 1) {
+    const query = new URLSearchParams({
+      state: 'all',
+      per_page: '100',
+      page: String(page),
+    });
+    const payload = await request(`/repos/${repository.owner}/${repository.name}/issues?${query.toString()}`);
+    const pageIssues = (payload ?? []).filter((issue) => !issue.pull_request);
+    issues.push(...pageIssues);
+    if ((payload ?? []).length < 100) {
+      break;
+    }
+  }
+  return issues;
 }
 
 function createGitHubClient() {
+  let trackingIssueIndex;
   return {
     async searchIssuesByDiscussionPermalink({ repository, permalink }) {
+      if (!trackingIssueIndex) {
+        trackingIssueIndex = buildTrackingIssueIndex(await loadRepositoryIssuesForTracking({ repository }));
+      }
       const issues = [];
       for (const term of searchTermsForDiscussionPermalink(permalink)) {
-        const query = new URLSearchParams({ q: searchQuery({ repository, term }), per_page: '20' });
-        const payload = await githubRequest(`/search/issues?${query.toString()}`);
-        issues.push(...(payload.items ?? []).map((issue) => ({ number: issue.number, state: issue.state, url: issue.html_url })));
+        issues.push(...(trackingIssueIndex.get(term) ?? []));
       }
       return uniqueIssues(issues);
     },
@@ -400,6 +439,7 @@ function createGitHubClient() {
         method: 'POST',
         body: { title, body, labels },
       });
+      trackingIssueIndex = undefined;
       return { number: issue.number, url: issue.html_url };
     },
   };

--- a/.github/scripts/capture-unresolved-reviews.test.mjs
+++ b/.github/scripts/capture-unresolved-reviews.test.mjs
@@ -7,9 +7,11 @@ import {
   captureUnresolvedReviewThreads,
   extractPriorityLabel,
   loadRecentlyMergedPullNumbers,
+  loadRepositoryIssuesForTracking,
   normalizeDiscussionPermalink,
   parseArgs,
   searchTermsForDiscussionPermalink,
+  buildTrackingIssueIndex,
   verifyTrackingForActionableThreads,
 } from './capture-unresolved-reviews.mjs';
 
@@ -430,4 +432,72 @@ test('capture workflow has scheduled retroactive sweep and failure notification 
   assert.match(workflow, /^  schedule:\n    - cron: /m);
   assert.match(workflow, /--recent-merged-days/);
   assert.match(workflow, /Notify capture workflow failure/);
+});
+
+test('buildTrackingIssueIndex indexes full permalinks and discussion anchors from issue bodies without Search API calls', () => {
+  const index = buildTrackingIssueIndex([
+    {
+      number: 135,
+      state: 'open',
+      html_url: 'https://github.com/xrf9268-hue/aiops-platform/issues/135',
+      body: 'Discussion: https://github.com/xrf9268-hue/aiops-platform/pull/101#discussion_r3251385489',
+    },
+    {
+      number: 136,
+      state: 'closed',
+      html_url: 'https://github.com/xrf9268-hue/aiops-platform/issues/136',
+      body: 'Manual backfill for discussion_r3251492691 only.',
+    },
+    {
+      number: 137,
+      state: 'open',
+      html_url: 'https://github.com/xrf9268-hue/aiops-platform/issues/137',
+      body: 'Unrelated issue body.',
+    },
+  ]);
+
+  assert.deepEqual(index.get('https://github.com/xrf9268-hue/aiops-platform/pull/101#discussion_r3251385489'), [
+    { number: 135, state: 'open', url: 'https://github.com/xrf9268-hue/aiops-platform/issues/135' },
+  ]);
+  assert.deepEqual(index.get('discussion_r3251385489'), [
+    { number: 135, state: 'open', url: 'https://github.com/xrf9268-hue/aiops-platform/issues/135' },
+  ]);
+  assert.deepEqual(index.get('discussion_r3251492691'), [
+    { number: 136, state: 'closed', url: 'https://github.com/xrf9268-hue/aiops-platform/issues/136' },
+  ]);
+  assert.equal(index.has('discussion_rdoesnotexist'), false);
+});
+
+test('loadRepositoryIssuesForTracking paginates issue bodies through the regular issues API', async () => {
+  const requests = [];
+  const page1 = Array.from({ length: 100 }, (_, index) => ({
+    number: index + 1,
+    state: 'open',
+    html_url: `https://github.com/xrf9268-hue/aiops-platform/issues/${index + 1}`,
+    body: index === 0 ? 'Discussion: https://github.com/xrf9268-hue/aiops-platform/pull/101#discussion_r3251385489' : '',
+  }));
+  const page2 = [
+    {
+      number: 101,
+      state: 'closed',
+      html_url: 'https://github.com/xrf9268-hue/aiops-platform/issues/101',
+      body: 'Manual tracking issue for discussion_r3251492691.',
+    },
+  ];
+
+  const issues = await loadRepositoryIssuesForTracking({
+    repository,
+    async request(path) {
+      requests.push(path);
+      return requests.length === 1 ? page1 : page2;
+    },
+  });
+
+  assert.equal(requests.length, 2);
+  assert.match(requests[0], /\/repos\/xrf9268-hue\/aiops-platform\/issues\?/);
+  assert.match(requests[0], /state=all/);
+  assert.match(requests[0], /page=1/);
+  assert.match(requests[1], /page=2/);
+  assert.equal(issues.length, 101);
+  assert.equal(issues[100].number, 101);
 });


### PR DESCRIPTION
## Summary
- Fixes the capture-unresolved-reviews workflow failure from GitHub Search API rate limiting.
- Replaces per-thread issue searches with one paginated repository issues load plus an in-memory discussion permalink/anchor index.
- Adds regression coverage for the tracking issue index and paginated issue loading.

Fixes #139

## Test Plan
- `node --test .github/scripts/capture-unresolved-reviews.test.mjs`
- `REPO_OWNER=xrf9268-hue REPO_NAME=aiops-platform GITHUB_TOKEN=$(gh auth token) node .github/scripts/capture-unresolved-reviews.mjs --recent-merged-days 3 --dry-run`
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- Independent Codex diff-only review: LGTM
