### PR TITLE
Implement per-state agent concurrency limits

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -298,6 +298,27 @@ func (o *Orchestrator) UpdateMaxConcurrentAgents(ctx context.Context, maxConcurr
 	}
 }
 
+// UpdateMaxConcurrentAgentsByState applies reloaded per-state capacity limits
+// through the actor so dispatch and retry capacity checks observe them without
+// restarting the process.
+func (o *Orchestrator) UpdateMaxConcurrentAgentsByState(ctx context.Context, limits map[string]int) error {
+	done := make(chan struct{}, 1)
+	op := opFunc(func(st *OrchestratorState) func() {
+		st.MaxConcurrentAgentsByState = normalizeStateConcurrencyLimits(limits)
+		done <- struct{}{}
+		return nil
+	})
+	if err := o.submit(ctx, op); err != nil {
+		return err
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // UpdateRetryScheduler applies reloaded retry timing through the actor so
 // subsequently scheduled retries observe workflow changes without a process
 // restart.
@@ -580,6 +601,14 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 		d.result <- ErrCapacityFull
 		return nil
 	}
+	capacityExcluded := IssueID("")
+	if consumedContinuation != nil {
+		capacityExcluded = id
+	}
+	if st.StateCapacityFullExcluding(d.issue.State, capacityExcluded) {
+		d.result <- ErrCapacityFull
+		return nil
+	}
 	if consumedContinuation != nil {
 		if consumedContinuation.Timer != nil {
 			consumedContinuation.Timer.Stop()
@@ -597,6 +626,7 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	// on its IsClaimed check. The followup records Running once the
 	// worker is spawned.
 	st.Claimed[id] = struct{}{}
+	st.ClaimedIssues[id] = d.issue
 	o := d.o
 	issue := d.issue
 	result := d.result
@@ -711,6 +741,28 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		})
 		return nil
 	}
+	if st.StateCapacityFull(entry.Issue.State) {
+		// Retry timers must also obey per-state capacity gates. Leave the retry
+		// queued and arm a short follow-up timer so noisy states cannot exceed
+		// max_concurrent_agents_by_state while other states are running.
+		if entry.Timer != nil {
+			entry.Timer.Stop()
+		}
+		o := r.o
+		id := r.id
+		issue := r.issue
+		attempt := r.attempt
+		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
+		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
+			_ = o.submit(o.runCtx, &retryFireOp{
+				o:       o,
+				id:      id,
+				issue:   issue,
+				attempt: attempt,
+			})
+		})
+		return nil
+	}
 	// Consume the retry entry but keep Claimed: the re-dispatch
 	// immediately re-adds Running, and dropping Claimed in between
 	// would let a concurrent tick race in.
@@ -750,6 +802,7 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		}
 		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
 		st.Claimed[f.id] = struct{}{}
+		st.ClaimedIssues[f.id] = f.issue
 		close(f.done)
 		// A clean continuation is a new normal turn. Keep its retry entry
 		// 1-based, but do not carry the prior run's attempt into future
@@ -795,6 +848,7 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 	// scheduleRetryOp's call to OrchestratorState.ScheduleRetry re-sets
 	// Claimed idempotently, so this is safe.
 	st.Claimed[f.id] = struct{}{}
+	st.ClaimedIssues[f.id] = f.issue
 	close(f.done)
 	// Schedule a retry with attempt+1. Per SPEC §4.1.5 the first run's
 	// RetryAttempt is nil; the first retry is attempt 1, the second 2,

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -687,6 +687,162 @@ func TestFinalize_AbnormalExitHoldsClaimAcrossScheduleRetryGap(t *testing.T) {
 	}
 }
 
+func TestRequestDispatch_RespectsPerStateCapacityAndFallback(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 3)
+	st.MaxConcurrentAgentsByState = map[string]int{"rework": 1}
+	o := New(st, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(ctx); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	if err := o.RequestDispatch(context.Background(), tracker.Issue{ID: "rw-1", Identifier: "RW-1", State: "Rework"}, nil); err != nil {
+		t.Fatalf("dispatch first rework: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	if err := o.RequestDispatch(context.Background(), tracker.Issue{ID: "rw-2", Identifier: "RW-2", State: "rework"}, nil); !errors.Is(err, ErrCapacityFull) {
+		t.Fatalf("dispatch second rework err = %v, want ErrCapacityFull", err)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("dispatcher count after capped rework = %d, want 1", got)
+	}
+
+	if err := o.RequestDispatch(context.Background(), tracker.Issue{ID: "ip-1", Identifier: "IP-1", State: "In Progress"}, nil); err != nil {
+		t.Fatalf("dispatch fallback state: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+}
+
+func TestRequestDispatch_PerStateCapacityNormalizesStateKey(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	st.MaxConcurrentAgentsByState = map[string]int{"in_progress": 1}
+	o := New(st, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(ctx); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	if err := o.RequestDispatch(context.Background(), tracker.Issue{ID: "ip-1", Identifier: "IP-1", State: "In Progress"}, nil); err != nil {
+		t.Fatalf("dispatch first in-progress: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	if err := o.RequestDispatch(context.Background(), tracker.Issue{ID: "ip-2", Identifier: "IP-2", State: "in_progress"}, nil); !errors.Is(err, ErrCapacityFull) {
+		t.Fatalf("dispatch normalized in-progress err = %v, want ErrCapacityFull", err)
+	}
+}
+
+func TestContinuationRetryRecheckedDispatchIgnoresOwnPerStateClaim(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	st.MaxConcurrentAgentsByState = map[string]int{"rework": 1}
+	o := New(st, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	iss := tracker.Issue{ID: "ENG-CONT-CAP", Identifier: "ENG-CONT-CAP", State: "Rework", Title: "continue under cap"}
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("initial tracker-rechecked dispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, err := o.Snapshot(context.Background())
+		return err == nil && len(v.Retrying) == 1
+	}, time.Second)
+
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("tracker-rechecked continuation dispatch under own per-state cap: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+}
+
+func TestUpdateMaxConcurrentAgentsByStateNormalizesStateKeys(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp})
+	defer cancel()
+
+	if err := o.UpdateMaxConcurrentAgentsByState(context.Background(), map[string]int{"In Progress": 1}); err != nil {
+		t.Fatalf("UpdateMaxConcurrentAgentsByState: %v", err)
+	}
+	if err := o.RequestDispatch(context.Background(), tracker.Issue{ID: "ip-1", Identifier: "IP-1", State: "in_progress"}, nil); err != nil {
+		t.Fatalf("dispatch first in-progress: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	if err := o.RequestDispatch(context.Background(), tracker.Issue{ID: "ip-2", Identifier: "IP-2", State: "In Progress"}, nil); !errors.Is(err, ErrCapacityFull) {
+		t.Fatalf("dispatch second normalized in-progress err = %v, want ErrCapacityFull", err)
+	}
+}
+
+func TestRetryFire_RespectsPerStateCapacityBeforeSpawning(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	st.MaxConcurrentAgentsByState = map[string]int{"rework": 1}
+	o := New(st, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Hour}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	issueA := tracker.Issue{ID: "ENG-A", Identifier: "ENG-A", State: "Rework", Title: "retry later"}
+	issueB := tracker.Issue{ID: "ENG-B", Identifier: "ENG-B", State: "Rework", Title: "running now"}
+	if err := o.RequestDispatch(context.Background(), issueA, nil); err != nil {
+		t.Fatalf("dispatch A: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.Retrying) == 1
+	}, time.Second)
+
+	if err := o.RequestDispatch(context.Background(), issueB, nil); err != nil {
+		t.Fatalf("dispatch B while A is retrying: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(issueA.ID),
+		issue:   issueA,
+		attempt: 1,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := disp.count(); got != 2 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 2; retry must not spawn while per-state capacity is full", got)
+	}
+	if len(v.Running) != 1 || len(v.Retrying) != 1 {
+		t.Fatalf("state after retry fire at per-state capacity: running=%+v retrying=%+v, want B running and A still retrying", v.Running, v.Retrying)
+	}
+}
+
 // TestRetryFire_RespectsCapacityBeforeSpawning is a regression for retry
 // timers bypassing the max_concurrent_agents gate. A failed issue may sit in
 // RetryAttempts while another issue starts; when the retry timer fires, it must

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -73,6 +73,9 @@ func (p *RuntimePoller) PollOnce(ctx context.Context) error {
 	if err := p.orchestrator.UpdateMaxConcurrentAgents(ctx, snap.MaxConcurrentAgents); err != nil {
 		return err
 	}
+	if err := p.orchestrator.UpdateMaxConcurrentAgentsByState(ctx, snap.MaxConcurrentAgentsByState); err != nil {
+		return err
+	}
 	if err := p.orchestrator.UpdateRetryScheduler(ctx, RetryScheduler{MaxBackoff: snap.MaxRetryBackoff}); err != nil {
 		return err
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -15,6 +15,7 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
@@ -116,11 +117,13 @@ type RunningEntry struct {
 // next migration step. Tests in this package construct it directly
 // because they exercise the transitions, not the discipline.
 type OrchestratorState struct {
-	PollIntervalMs      int64
-	MaxConcurrentAgents int
+	PollIntervalMs             int64
+	MaxConcurrentAgents        int
+	MaxConcurrentAgentsByState map[string]int
 
 	Running       map[IssueID]*RunningEntry
 	Claimed       map[IssueID]struct{}
+	ClaimedIssues map[IssueID]tracker.Issue
 	RetryAttempts map[IssueID]*RetryEntry
 	Failed        map[IssueID]FailedEntry
 	Completed     map[IssueID]struct{} // bookkeeping only per SPEC §4.1.8
@@ -152,13 +155,15 @@ type FailedEntry struct {
 // on a nil-map write.
 func NewOrchestratorState(pollIntervalMs int64, maxConcurrentAgents int) *OrchestratorState {
 	return &OrchestratorState{
-		PollIntervalMs:      pollIntervalMs,
-		MaxConcurrentAgents: maxConcurrentAgents,
-		Running:             map[IssueID]*RunningEntry{},
-		Claimed:             map[IssueID]struct{}{},
-		RetryAttempts:       map[IssueID]*RetryEntry{},
-		Failed:              map[IssueID]FailedEntry{},
-		Completed:           map[IssueID]struct{}{},
+		PollIntervalMs:             pollIntervalMs,
+		MaxConcurrentAgents:        maxConcurrentAgents,
+		MaxConcurrentAgentsByState: map[string]int{},
+		Running:                    map[IssueID]*RunningEntry{},
+		Claimed:                    map[IssueID]struct{}{},
+		ClaimedIssues:              map[IssueID]tracker.Issue{},
+		RetryAttempts:              map[IssueID]*RetryEntry{},
+		Failed:                     map[IssueID]FailedEntry{},
+		Completed:                  map[IssueID]struct{}{},
 	}
 }
 
@@ -210,6 +215,54 @@ func (s *OrchestratorState) ReleaseFailedIfIssueChanged(issue tracker.Issue) boo
 // records Running; without counting those reservations, one poll tick can queue
 // more workers than max_concurrent_agents before any Running entry is visible.
 func (s *OrchestratorState) RunningCount() int {
+	counted := s.runningIssueIDs()
+	return len(counted)
+}
+
+func (s *OrchestratorState) RunningCountByState(state string) int {
+	return s.RunningCountByStateExcluding(state, "")
+}
+
+func (s *OrchestratorState) StateCapacityFull(state string) bool {
+	return s.StateCapacityFullExcluding(state, "")
+}
+
+func (s *OrchestratorState) StateCapacityFullExcluding(state string, excluded IssueID) bool {
+	if len(s.MaxConcurrentAgentsByState) == 0 {
+		return false
+	}
+	limit, ok := s.MaxConcurrentAgentsByState[normalizeStateConcurrencyKey(state)]
+	if !ok || limit <= 0 {
+		return false
+	}
+	return s.RunningCountByStateExcluding(state, excluded) >= limit
+}
+
+func (s *OrchestratorState) RunningCountByStateExcluding(state string, excluded IssueID) int {
+	stateKey := normalizeStateConcurrencyKey(state)
+	if stateKey == "" {
+		return 0
+	}
+	counted := s.runningIssueIDs()
+	if excluded != "" {
+		delete(counted, excluded)
+	}
+	count := 0
+	for id := range counted {
+		if run, ok := s.Running[id]; ok {
+			if normalizeStateConcurrencyKey(run.Issue.State) == stateKey {
+				count++
+			}
+			continue
+		}
+		if claimed, ok := s.ClaimedIssues[id]; ok && normalizeStateConcurrencyKey(claimed.State) == stateKey {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *OrchestratorState) runningIssueIDs() map[IssueID]struct{} {
 	counted := make(map[IssueID]struct{}, len(s.Running)+len(s.Claimed))
 	for id := range s.Running {
 		counted[id] = struct{}{}
@@ -220,7 +273,11 @@ func (s *OrchestratorState) RunningCount() int {
 	for id := range s.RetryAttempts {
 		delete(counted, id)
 	}
-	return len(counted)
+	return counted
+}
+
+func normalizeStateConcurrencyKey(state string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(state)), " ", "_")
 }
 
 // BeginDispatch records the SPEC §16.4 dispatch step: an eligible
@@ -238,6 +295,7 @@ func (s *OrchestratorState) RunningCount() int {
 // state mutation.
 func (s *OrchestratorState) BeginDispatch(id IssueID, entry *RunningEntry) {
 	s.Claimed[id] = struct{}{}
+	s.ClaimedIssues[id] = entry.Issue
 	s.Running[id] = entry
 	delete(s.RetryAttempts, id)
 	delete(s.Failed, id)
@@ -260,6 +318,7 @@ func (s *OrchestratorState) FinishRunSucceeded(id IssueID, run *RunningEntry, el
 	}
 	delete(s.Running, id)
 	delete(s.Claimed, id)
+	delete(s.ClaimedIssues, id)
 	s.Completed[id] = struct{}{}
 	s.CodexTotals.AddSeconds(elapsed)
 	return true
@@ -289,6 +348,7 @@ func (s *OrchestratorState) finishRunAborted(id IssueID, run *RunningEntry, elap
 	}
 	delete(s.Running, id)
 	delete(s.Claimed, id)
+	delete(s.ClaimedIssues, id)
 	s.CodexTotals.AddSeconds(elapsed)
 	return true
 }
@@ -320,6 +380,7 @@ func (s *OrchestratorState) ScheduleRetry(entry *RetryEntry) {
 	}
 	s.RetryAttempts[entry.IssueID] = entry
 	s.Claimed[entry.IssueID] = struct{}{}
+	s.ClaimedIssues[entry.IssueID] = entry.Issue
 }
 
 // ReleaseClaim removes id from Claimed and tears down any pending
@@ -332,6 +393,7 @@ func (s *OrchestratorState) ScheduleRetry(entry *RetryEntry) {
 //     (row 6 in the design's state-transition table).
 func (s *OrchestratorState) ReleaseClaim(id IssueID) {
 	delete(s.Claimed, id)
+	delete(s.ClaimedIssues, id)
 	if entry, ok := s.RetryAttempts[id]; ok {
 		if entry.Timer != nil {
 			entry.Timer.Stop()
@@ -361,8 +423,9 @@ func (s *OrchestratorState) RecordRateLimits(snap *RateLimitSnapshot) {
 // design doc's "HTTP surface" section) but Snapshot() ships now so
 // tests have a stable read API.
 type StateView struct {
-	PollIntervalMs      int64
-	MaxConcurrentAgents int
+	PollIntervalMs             int64
+	MaxConcurrentAgents        int
+	MaxConcurrentAgentsByState map[string]int
 
 	Running         []RunningView
 	Retrying        []RetryView
@@ -400,14 +463,15 @@ type RetryView struct {
 // handler, CLI status) sort by IssueID before display.
 func (s *OrchestratorState) Snapshot() StateView {
 	view := StateView{
-		PollIntervalMs:      s.PollIntervalMs,
-		MaxConcurrentAgents: s.MaxConcurrentAgents,
-		Running:             make([]RunningView, 0, len(s.Running)),
-		Retrying:            make([]RetryView, 0, len(s.RetryAttempts)),
-		Failed:              make([]IssueID, 0, len(s.Failed)),
-		Completed:           make([]IssueID, 0, len(s.Completed)),
-		CodexTotals:         s.CodexTotals,
-		CodexRateLimits:     s.CodexRateLimits,
+		PollIntervalMs:             s.PollIntervalMs,
+		MaxConcurrentAgents:        s.MaxConcurrentAgents,
+		MaxConcurrentAgentsByState: copyStateConcurrencyLimits(s.MaxConcurrentAgentsByState),
+		Running:                    make([]RunningView, 0, len(s.Running)),
+		Retrying:                   make([]RetryView, 0, len(s.RetryAttempts)),
+		Failed:                     make([]IssueID, 0, len(s.Failed)),
+		Completed:                  make([]IssueID, 0, len(s.Completed)),
+		CodexTotals:                s.CodexTotals,
+		CodexRateLimits:            s.CodexRateLimits,
 	}
 	for id, r := range s.Running {
 		// Deep-copy RetryAttempt so a snapshot consumer mutating the

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -305,6 +305,71 @@ func TestFinishRunIgnoresStaleRunIdentity(t *testing.T) {
 	}
 }
 
+func TestClaimedIssuesClearedOnTerminalTransitions(t *testing.T) {
+	tests := []struct {
+		name string
+		act  func(st *OrchestratorState, id IssueID, entry *RunningEntry)
+	}{
+		{
+			name: "success",
+			act: func(st *OrchestratorState, id IssueID, entry *RunningEntry) {
+				if !st.FinishRunSucceeded(id, entry, time.Second) {
+					t.Fatalf("FinishRunSucceeded returned false")
+				}
+			},
+		},
+		{
+			name: "failed",
+			act: func(st *OrchestratorState, id IssueID, entry *RunningEntry) {
+				if !st.FinishRunFailed(id, entry, time.Second) {
+					t.Fatalf("FinishRunFailed returned false")
+				}
+			},
+		},
+		{
+			name: "non_retryable_failed",
+			act: func(st *OrchestratorState, id IssueID, entry *RunningEntry) {
+				if !st.FinishRunNonRetryableFailed(id, entry, time.Second) {
+					t.Fatalf("FinishRunNonRetryableFailed returned false")
+				}
+			},
+		},
+		{
+			name: "reconciled_cancelled",
+			act: func(st *OrchestratorState, id IssueID, entry *RunningEntry) {
+				if !st.FinishRunReconciledCancelled(id, entry, time.Second) {
+					t.Fatalf("FinishRunReconciledCancelled returned false")
+				}
+			},
+		},
+		{
+			name: "release_claim",
+			act: func(st *OrchestratorState, id IssueID, entry *RunningEntry) {
+				st.ReleaseClaim(id)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := NewOrchestratorState(15000, 4)
+			iss := issue("ENG-CLAIMED-ISSUES")
+			id := IssueID(iss.ID)
+			entry := runningEntry(t, iss)
+			st.BeginDispatch(id, entry)
+
+			tt.act(st, id, entry)
+
+			if _, ok := st.Claimed[id]; ok {
+				t.Fatalf("Claimed[%s] still present", id)
+			}
+			if _, ok := st.ClaimedIssues[id]; ok {
+				t.Fatalf("ClaimedIssues[%s] still present", id)
+			}
+		})
+	}
+}
+
 func TestCodexTotals_AddTokensAndSeconds(t *testing.T) {
 	var c CodexTotals
 	c.AddTokens(100, 250)

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -210,6 +210,51 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsToDispatchCapacity(t *te
 	waitForBlockingDispatcherCount(t, dispatcher, 2)
 }
 
+func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsByStateToDispatchCapacity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready", withReloadTestMaxConcurrentAgents(10), withReloadTestMaxConcurrentAgentsByState(map[string]int{"AI Ready": 1}))
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load initial workflow: %v", err)
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{
+		{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "AI Ready"},
+		{ID: "issue-2", Identifier: "ISSUE-2", Title: "two", State: "AI Ready"},
+	}}
+	dispatcher := &blockingDispatcher{}
+	st := NewOrchestratorState(30000, initial.Config.Agent.MaxConcurrentAgents)
+	st.MaxConcurrentAgentsByState = initial.Config.Agent.MaxConcurrentAgentsByState
+	orch := New(st, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("first poll: %v", err)
+	}
+	waitForBlockingDispatcherCount(t, dispatcher, 1)
+
+	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "AI Ready", withReloadTestMaxConcurrentAgents(10), withReloadTestMaxConcurrentAgentsByState(map[string]int{"ai_ready": 2}))
+	if err := runtime.ReloadOnce(ctx); err != nil {
+		t.Fatalf("reload workflow: %v", err)
+	}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("second poll: %v", err)
+	}
+	waitForBlockingDispatcherCount(t, dispatcher, 2)
+}
+
 func TestRuntimePollerAppliesReloadedMaxRetryBackoffToFailureRetries(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -828,6 +873,7 @@ func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIn
 		"  default: mock\n" +
 		"  max_concurrent_agents: " + itoaForReloadTest(cfg.maxConcurrentAgents) + "\n" +
 		"  max_retry_backoff_ms: " + itoaForReloadTest(cfg.maxRetryBackoffMs) + "\n" +
+		reloadTestMaxConcurrentAgentsByStateYAML(cfg.maxConcurrentAgentsByState) +
 		"---\n" +
 		"Prompt body\n"
 	if err := osWriteFileForReloadTest(path, []byte(content)); err != nil {
@@ -836,8 +882,9 @@ func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIn
 }
 
 type reloadWorkflowTestConfig struct {
-	maxConcurrentAgents int
-	maxRetryBackoffMs   int
+	maxConcurrentAgents        int
+	maxRetryBackoffMs          int
+	maxConcurrentAgentsByState map[string]int
 }
 
 type reloadWorkflowTestOption func(*reloadWorkflowTestConfig)
@@ -852,6 +899,23 @@ func withReloadTestMaxRetryBackoffMs(n int) reloadWorkflowTestOption {
 	return func(cfg *reloadWorkflowTestConfig) {
 		cfg.maxRetryBackoffMs = n
 	}
+}
+
+func withReloadTestMaxConcurrentAgentsByState(caps map[string]int) reloadWorkflowTestOption {
+	return func(cfg *reloadWorkflowTestConfig) {
+		cfg.maxConcurrentAgentsByState = caps
+	}
+}
+
+func reloadTestMaxConcurrentAgentsByStateYAML(caps map[string]int) string {
+	if len(caps) == 0 {
+		return ""
+	}
+	out := "  max_concurrent_agents_by_state:\n"
+	for state, cap := range caps {
+		out += "    " + state + ": " + itoaForReloadTest(cap) + "\n"
+	}
+	return out
 }
 
 var osWriteFileForReloadTest = func(path string, data []byte) error {

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -39,12 +39,13 @@ type WorkflowRuntime struct {
 }
 
 type WorkflowSnapshot struct {
-	Workflow            *workflow.Workflow
-	PollInterval        time.Duration
-	MaxConcurrentAgents int
-	MaxRetryBackoff     time.Duration
-	Reconciliation      ReconciliationConfig
-	Fingerprint         string
+	Workflow                   *workflow.Workflow
+	PollInterval               time.Duration
+	MaxConcurrentAgents        int
+	MaxConcurrentAgentsByState map[string]int
+	MaxRetryBackoff            time.Duration
+	Reconciliation             ReconciliationConfig
+	Fingerprint                string
 }
 
 func NewWorkflowRuntime(cfg WorkflowRuntimeConfig) (*WorkflowRuntime, error) {
@@ -151,13 +152,40 @@ func (r *WorkflowRuntime) snapshotFromWorkflow(wf *workflow.Workflow, fingerprin
 		reconcile = r.reconciliationConfig(wf.Config)
 	}
 	return &WorkflowSnapshot{
-		Workflow:            wf,
-		PollInterval:        time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond,
-		MaxConcurrentAgents: wf.Config.Agent.MaxConcurrentAgents,
-		MaxRetryBackoff:     time.Duration(wf.Config.Agent.MaxRetryBackoffMs) * time.Millisecond,
-		Reconciliation:      reconcile,
-		Fingerprint:         fingerprint,
+		Workflow:                   wf,
+		PollInterval:               time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond,
+		MaxConcurrentAgents:        wf.Config.Agent.MaxConcurrentAgents,
+		MaxConcurrentAgentsByState: copyStateConcurrencyLimits(wf.Config.Agent.MaxConcurrentAgentsByState),
+		MaxRetryBackoff:            time.Duration(wf.Config.Agent.MaxRetryBackoffMs) * time.Millisecond,
+		Reconciliation:             reconcile,
+		Fingerprint:                fingerprint,
 	}
+}
+
+func copyStateConcurrencyLimits(in map[string]int) map[string]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(in))
+	for state, limit := range in {
+		out[state] = limit
+	}
+	return out
+}
+
+func normalizeStateConcurrencyLimits(in map[string]int) map[string]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(in))
+	for state, limit := range in {
+		key := normalizeStateConcurrencyKey(state)
+		if key == "" || limit <= 0 {
+			continue
+		}
+		out[key] = limit
+	}
+	return out
 }
 
 func workflowFileFingerprint(path string) (string, error) {

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -171,10 +171,11 @@ func (c Config) WorkspaceHooks() WorkspaceHooks {
 }
 
 type AgentConfig struct {
-	Default             string `yaml:"default" json:"default"`
-	MaxConcurrentAgents int    `yaml:"max_concurrent_agents" json:"max_concurrent_agents"`
-	MaxTurns            int    `yaml:"max_turns" json:"max_turns"`
-	MaxRetryBackoffMs   int    `yaml:"max_retry_backoff_ms" json:"max_retry_backoff_ms"`
+	Default                    string         `yaml:"default" json:"default"`
+	MaxConcurrentAgents        int            `yaml:"max_concurrent_agents" json:"max_concurrent_agents"`
+	MaxConcurrentAgentsByState map[string]int `yaml:"max_concurrent_agents_by_state" json:"max_concurrent_agents_by_state"`
+	MaxTurns                   int            `yaml:"max_turns" json:"max_turns"`
+	MaxRetryBackoffMs          int            `yaml:"max_retry_backoff_ms" json:"max_retry_backoff_ms"`
 	// Timeout caps a single runner invocation. When exceeded, the runner
 	// subprocess is killed and the task records a `runner_timeout` event.
 	// Configured via YAML as `agent.timeout: 10m`. Zero means use the

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -53,6 +53,115 @@ prompt body
 // `pr.draft` got ready-for-review PRs. Keeping the default at false
 // preserves that behavior; profiles like `company-cautious-WORKFLOW.md`
 // must opt in explicitly with `pr.draft: true`.
+
+func TestLoadParsesAgentMaxConcurrentAgentsByStateWithNormalizedKeys(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: xrf9268-hue
+  name: aiops-platform
+  clone_url: https://github.com/xrf9268-hue/aiops-platform.git
+agent:
+  default: mock
+  max_concurrent_agents: 4
+  max_concurrent_agents_by_state:
+    In Progress: 2
+    rework: 1
+---
+Prompt body
+`)
+
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := wf.Config.Agent.MaxConcurrentAgentsByState
+	if got["in_progress"] != 2 {
+		t.Fatalf("normalized In Progress cap = %d, want 2 (map=%v)", got["in_progress"], got)
+	}
+	if got["rework"] != 1 {
+		t.Fatalf("rework cap = %d, want 1 (map=%v)", got["rework"], got)
+	}
+	if _, ok := got["In Progress"]; ok {
+		t.Fatalf("map kept unnormalized state key: %v", got)
+	}
+}
+
+func TestLoadRejectsDuplicateNormalizedAgentMaxConcurrentAgentsByState(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: xrf9268-hue
+  name: aiops-platform
+  clone_url: https://github.com/xrf9268-hue/aiops-platform.git
+agent:
+  default: mock
+  max_concurrent_agents_by_state:
+    In Progress: 2
+    in_progress: 5
+---
+Prompt body
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("Load succeeded with duplicate normalized state caps")
+	}
+	if !strings.Contains(err.Error(), "duplicates") || !strings.Contains(err.Error(), "in_progress") {
+		t.Fatalf("Load error = %v, want duplicate normalized key guidance", err)
+	}
+}
+
+func TestLoadRejectsInvalidAgentMaxConcurrentAgentsByState(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "empty state key",
+			body: `---
+repo:
+  owner: xrf9268-hue
+  name: aiops-platform
+  clone_url: https://github.com/xrf9268-hue/aiops-platform.git
+agent:
+  default: mock
+  max_concurrent_agents_by_state:
+    "": 1
+---
+Prompt body
+`,
+			want: "empty state key",
+		},
+		{
+			name: "non-positive limit",
+			body: `---
+repo:
+  owner: xrf9268-hue
+  name: aiops-platform
+  clone_url: https://github.com/xrf9268-hue/aiops-platform.git
+agent:
+  default: mock
+  max_concurrent_agents_by_state:
+    rework: 0
+---
+Prompt body
+`,
+			want: "must be positive",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Load(writeTempWorkflow(t, tt.body))
+			if err == nil {
+				t.Fatalf("Load succeeded, want validation error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestDefaultConfig_PRDraftDefaultsFalse(t *testing.T) {
 	if got := DefaultConfig().PR.Draft; got != false {
 		t.Fatalf("DefaultConfig().PR.Draft: got %v want false (would regress non-draft default)", got)

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -42,7 +42,17 @@ func Load(path string) (*Workflow, error) {
 			cfg.hooksTimeoutDefaulted = false
 		}
 	}
+	var rawStateCaps map[string]int
+	if hasFrontMatter && len(cfg.Agent.MaxConcurrentAgentsByState) > 0 {
+		rawStateCaps = make(map[string]int, len(cfg.Agent.MaxConcurrentAgentsByState))
+		for state, limit := range cfg.Agent.MaxConcurrentAgentsByState {
+			rawStateCaps[state] = limit
+		}
+	}
 	expandConfig(&cfg)
+	if rawStateCaps != nil {
+		cfg.Agent.MaxConcurrentAgentsByState = rawStateCaps
+	}
 	// Only validate when the file actually carries a front-matter block.
 	// Prompt-only WORKFLOW.md files are a supported pattern for repos that
 	// rely on the worker's built-in defaults (same semantic as
@@ -54,6 +64,7 @@ func Load(path string) (*Workflow, error) {
 			return nil, err
 		}
 	}
+	cfg.Agent.MaxConcurrentAgentsByState = normalizeStateConcurrencyLimits(cfg.Agent.MaxConcurrentAgentsByState)
 	source := SourceFile
 	if !hasFrontMatter {
 		source = SourcePromptOnly
@@ -202,6 +213,20 @@ func validateConfig(path string, cfg Config) error {
 	}
 	if cfg.Agent.MaxRetryBackoffMs <= 0 {
 		return fmt.Errorf("%s: agent.max_retry_backoff_ms must be positive", path)
+	}
+	seenStateCaps := make(map[string]string, len(cfg.Agent.MaxConcurrentAgentsByState))
+	for state, limit := range cfg.Agent.MaxConcurrentAgentsByState {
+		if strings.TrimSpace(state) == "" {
+			return fmt.Errorf("%s: agent.max_concurrent_agents_by_state contains an empty state key", path)
+		}
+		if limit <= 0 {
+			return fmt.Errorf("%s: agent.max_concurrent_agents_by_state[%q] must be positive", path, state)
+		}
+		key := normalizeTrackerStateKey(state)
+		if first, ok := seenStateCaps[key]; ok {
+			return fmt.Errorf("%s: agent.max_concurrent_agents_by_state[%q] duplicates %q after normalization to %q", path, state, first, key)
+		}
+		seenStateCaps[key] = state
 	}
 	if cfg.Hooks.TimeoutMs < 0 {
 		return fmt.Errorf("%s: hooks.timeout_ms must be non-negative", path)
@@ -388,4 +413,24 @@ func expandPath(p string) string {
 		}
 	}
 	return p
+}
+
+func normalizeStateConcurrencyLimits(limits map[string]int) map[string]int {
+	if len(limits) == 0 {
+		return nil
+	}
+	normalized := make(map[string]int, len(limits))
+	for state, limit := range limits {
+		key := normalizeTrackerStateKey(state)
+		if key == "" {
+			normalized[state] = limit
+			continue
+		}
+		normalized[key] = limit
+	}
+	return normalized
+}
+
+func normalizeTrackerStateKey(state string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(state)), " ", "_")
 }


### PR DESCRIPTION
## Summary
- Add workflow config support for `agent.max_concurrent_agents_by_state`, including validation and normalized state keys.
- Apply per-state concurrency limits through the orchestrator actor, retry fire path, and runtime workflow reloads.
- Track claimed issue metadata so claimed-but-not-yet-running work counts toward state capacity, with continuation/retry regressions covered.

## Validation
- `/home/pi/.local/go1.25.10/bin/go test ./internal/orchestrator ./internal/workflow`
- `/home/pi/.local/go1.25.10/bin/go test ./...`
- Independent diff-only review via `claude -p ... --allowedTools '' --max-turns 1`: LGTM

Closes #89.
