### PR TITLE
fix(orchestrator): refresh run state during reconciliation

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -728,6 +728,11 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		o := r.o
 		return func() { o.wakeRetryPollLoop() }
 	}
+	// Use entry.Issue rather than the timer-captured r.issue: reconciliation
+	// may have refreshed the tracker state while the retry was queued, and
+	// both the per-state capacity gate and the spawned worker must see the
+	// live state.
+	issue := entry.Issue
 	if st.RunningCount() >= st.MaxConcurrentAgents {
 		// Retry timers must obey the same capacity gate as fresh dispatch.
 		// Leave the retry queued and arm a short follow-up timer so the issue
@@ -737,7 +742,6 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		}
 		o := r.o
 		id := r.id
-		issue := r.issue
 		attempt := r.attempt
 		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
 		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
@@ -750,7 +754,7 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		})
 		return nil
 	}
-	if st.StateCapacityFull(entry.Issue.State) {
+	if st.StateCapacityFull(issue.State) {
 		// Retry timers must also obey per-state capacity gates. Leave the retry
 		// queued and arm a short follow-up timer so noisy states cannot exceed
 		// max_concurrent_agents_by_state while other states are running.
@@ -759,7 +763,6 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		}
 		o := r.o
 		id := r.id
-		issue := r.issue
 		attempt := r.attempt
 		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
 		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
@@ -777,7 +780,6 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 	// would let a concurrent tick race in.
 	delete(st.RetryAttempts, r.id)
 	o := r.o
-	issue := r.issue
 	attempt := r.attempt
 	return func() {
 		o.spawn(r.id, issue, &attempt)
@@ -810,8 +812,12 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 			return nil
 		}
 		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
+		// Use f.entry.Issue, not f.issue: reconciliation may have refreshed
+		// the tracker state mid-run, and per-state capacity gates must see
+		// the live state, not the dispatch-time snapshot.
+		issue := f.entry.Issue
 		st.Claimed[f.id] = struct{}{}
-		st.ClaimedIssues[f.id] = f.issue
+		st.ClaimedIssues[f.id] = issue
 		close(f.done)
 		// A clean continuation is a new normal turn. Keep its retry entry
 		// 1-based, but do not carry the prior run's attempt into future
@@ -819,7 +825,6 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		// transient failure straight to the max backoff.
 		nextAttempt := 1
 		o := f.o
-		issue := f.issue
 		identifier := f.identifier
 		return func() {
 			_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt)
@@ -856,8 +861,11 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 	// backoff and racing a phantom retry timer against a live worker.
 	// scheduleRetryOp's call to OrchestratorState.ScheduleRetry re-sets
 	// Claimed idempotently, so this is safe.
+	// Use f.entry.Issue, not f.issue: reconciliation may have refreshed
+	// the tracker state mid-run, and the retry must carry the live state.
+	issue := f.entry.Issue
 	st.Claimed[f.id] = struct{}{}
-	st.ClaimedIssues[f.id] = f.issue
+	st.ClaimedIssues[f.id] = issue
 	close(f.done)
 	// Schedule a retry with attempt+1. Per SPEC §4.1.5 the first run's
 	// RetryAttempt is nil; the first retry is attempt 1, the second 2,
@@ -867,7 +875,6 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		nextAttempt = *f.attempt + 1
 	}
 	o := f.o
-	issue := f.issue
 	identifier := f.identifier
 	runErr := f.result.Err.Error()
 	return func() {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -364,6 +364,24 @@ func (o *Orchestrator) ReconcileTrackerIssues(ctx context.Context, issuesByID ma
 	return o.ReconcileTrackerIssuesAndWait(ctx, issuesByID, activeStates, 0)
 }
 
+// RefreshActiveTrackerIssues updates stored issue metadata for in-process runs
+// and queued retries whose issues are still observed in the active set, without
+// canceling any work. Use this when the active listing may be partial (so
+// absence from issuesByID must not imply inactivity) but per-state capacity
+// gates still need the latest tracker state.
+func (o *Orchestrator) RefreshActiveTrackerIssues(ctx context.Context, issuesByID map[string]tracker.Issue, activeStates map[string]struct{}) error {
+	done := make(chan struct{}, 1)
+	if err := o.submit(ctx, &refreshActiveTrackerIssuesOp{issuesByID: issuesByID, activeStates: activeStates, done: done}); err != nil {
+		return err
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // ReconcileTrackerIssuesAndWait performs the same reconciliation as
 // ReconcileTrackerIssues, then optionally waits for canceled workers to exit.
 // This lets poll ticks provide prompt cancellation semantics without making the
@@ -482,6 +500,42 @@ func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, i
 		req:        req,
 	}
 	return o.submit(ctx, op)
+}
+
+// refreshActiveTrackerIssuesOp refreshes RunningEntry.Issue and the matching
+// ClaimedIssues snapshot for every in-process issue observed in the active set,
+// without canceling anything. It is safe to call when the active listing may be
+// partial, because absence from issuesByID is treated as "no information," not
+// "now inactive."
+type refreshActiveTrackerIssuesOp struct {
+	issuesByID   map[string]tracker.Issue
+	activeStates map[string]struct{}
+	done         chan<- struct{}
+}
+
+func (r *refreshActiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
+	for id, run := range st.Running {
+		issue, ok := r.issuesByID[string(id)]
+		if !ok || !isActiveTrackerState(issue.State, r.activeStates) || !sameServiceRoute(run.Issue, issue) {
+			continue
+		}
+		run.Issue = issue
+		st.ClaimedIssues[id] = issue
+	}
+	for id, retry := range st.RetryAttempts {
+		issue, ok := r.issuesByID[string(id)]
+		if !ok || !isActiveTrackerState(issue.State, r.activeStates) || !sameServiceRoute(retry.Issue, issue) {
+			continue
+		}
+		retry.Issue = issue
+		st.ClaimedIssues[id] = issue
+	}
+	done := r.done
+	return func() {
+		if done != nil {
+			close(done)
+		}
+	}
 }
 
 type reconcileTrackerIssuesOp struct {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -495,6 +495,13 @@ func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	for id, run := range st.Running {
 		issue, ok := r.issuesByID[string(id)]
 		if ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(run.Issue, issue) {
+			// Refresh stored issue metadata so per-state capacity gates
+			// (RunningCountByState, StateCapacityFull) see the latest tracker
+			// state. Without this, an issue that moved between active states
+			// keeps counting toward its dispatch-time bucket and a later poll
+			// can exceed max_concurrent_agents_by_state for the new state.
+			run.Issue = issue
+			st.ClaimedIssues[id] = issue
 			continue
 		}
 		st.ReleaseClaim(id)
@@ -504,6 +511,8 @@ func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	for id, retry := range st.RetryAttempts {
 		issue, ok := r.issuesByID[string(id)]
 		if ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(retry.Issue, issue) {
+			retry.Issue = issue
+			st.ClaimedIssues[id] = issue
 			continue
 		}
 		st.ReleaseClaim(id)

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -321,6 +321,126 @@ func TestReconcileTrackerIssuesRefreshesIssueStateForCapacityCounting(t *testing
 	}
 }
 
+func TestFinalizeRunSchedulesRetryWithRefreshedIssueState(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	st.MaxConcurrentAgentsByState = map[string]int{"rework": 1}
+	o := New(st, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Hour}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	moving := tracker.Issue{ID: "ENG-MOVE", Identifier: "ENG-MOVE", Title: "moves and fails", State: "In Progress"}
+	if err := o.RequestDispatch(context.Background(), moving, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	moved := moving
+	moved.State = "Rework"
+	active := map[string]tracker.Issue{moved.ID: moved}
+	if err := o.ReconcileTrackerIssues(context.Background(), active, normalizedStates([]string{"In Progress", "Rework"})); err != nil {
+		t.Fatalf("ReconcileTrackerIssues: %v", err)
+	}
+
+	disp.finishAt(0, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.Retrying) == 1
+	}, time.Second)
+
+	other := tracker.Issue{ID: "ENG-OTHER", Identifier: "ENG-OTHER", Title: "second rework", State: "Rework"}
+	if err := o.RequestDispatch(context.Background(), other, nil); err != nil {
+		t.Fatalf("dispatch other rework while moved retry is queued: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(moving.ID),
+		issue:   moving, // captured dispatch-time issue; entry.Issue should override
+		attempt: 1,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := disp.count(); got != 2 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 2; retry must see refreshed Rework state and respect per-state cap", got)
+	}
+	if len(v.Retrying) != 1 {
+		t.Fatalf("retry queue after fire = %+v, want refreshed retry still queued", v.Retrying)
+	}
+}
+
+func TestRetryFireUsesRefreshedIssueWhenReconciledMidQueue(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	st.MaxConcurrentAgentsByState = map[string]int{"rework": 1}
+	o := New(st, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Hour}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	ip := tracker.Issue{ID: "ENG-IP", Identifier: "ENG-IP", Title: "queued ip retry", State: "In Progress"}
+	if err := o.RequestDispatch(context.Background(), ip, nil); err != nil {
+		t.Fatalf("dispatch ip: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.Retrying) == 1
+	}, time.Second)
+
+	rw := tracker.Issue{ID: "ENG-RW", Identifier: "ENG-RW", Title: "rework filler", State: "Rework"}
+	if err := o.RequestDispatch(context.Background(), rw, nil); err != nil {
+		t.Fatalf("dispatch rework filler: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+
+	moved := ip
+	moved.State = "Rework"
+	active := map[string]tracker.Issue{moved.ID: moved, rw.ID: rw}
+	if err := o.ReconcileTrackerIssues(context.Background(), active, normalizedStates([]string{"In Progress", "Rework"})); err != nil {
+		t.Fatalf("ReconcileTrackerIssues: %v", err)
+	}
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(ip.ID),
+		issue:   ip, // dispatch-time In Progress; refreshed entry.Issue says Rework
+		attempt: 1,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := disp.count(); got != 2 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 2; queued retry must see refreshed Rework state", got)
+	}
+	if len(v.Retrying) != 1 {
+		t.Fatalf("retry queue after refresh-aware fire = %+v, want still queued behind Rework cap", v.Retrying)
+	}
+}
+
 func TestReconcileTrackerIssuesReleasesRetryWhenServiceRouteChanges(t *testing.T) {
 	disp := &fakeDispatcher{}
 	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -287,6 +287,40 @@ func TestReconcileTrackerIssuesCancelsRunWhenServiceRouteChanges(t *testing.T) {
 	}
 }
 
+func TestReconcileTrackerIssuesRefreshesIssueStateForCapacityCounting(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	st.MaxConcurrentAgentsByState = map[string]int{"rework": 1}
+	o := New(st, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	iss := tracker.Issue{ID: "ENG-MOVE", Identifier: "ENG-MOVE", Title: "moves state", State: "In Progress"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	moved := iss
+	moved.State = "Rework"
+	active := map[string]tracker.Issue{moved.ID: moved}
+	if err := o.ReconcileTrackerIssues(context.Background(), active, normalizedStates([]string{"In Progress", "Rework"})); err != nil {
+		t.Fatalf("ReconcileTrackerIssues: %v", err)
+	}
+
+	other := tracker.Issue{ID: "ENG-OTHER", Identifier: "ENG-OTHER", Title: "second rework", State: "Rework"}
+	if err := o.RequestDispatch(context.Background(), other, nil); !errors.Is(err, ErrCapacityFull) {
+		t.Fatalf("dispatch second rework after reconciliation moved first into Rework err = %v, want ErrCapacityFull", err)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("dispatcher count after reconciliation = %d, want 1 (per-state cap must see refreshed state)", got)
+	}
+}
+
 func TestReconcileTrackerIssuesReleasesRetryWhenServiceRouteChanges(t *testing.T) {
 	disp := &fakeDispatcher{}
 	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -137,8 +137,19 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 	if p.stateTracker == nil {
 		return errors.New("orchestrator poller reconciliation requires state tracker")
 	}
+	activeIssuesByID := issueMap(activeIssues)
+	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
 	if p.routing != nil {
-		if err := p.orchestrator.ReconcileTrackerIssuesAndWait(ctx, issueMap(activeIssues), normalizedStates(p.reconcile.ActiveStates), p.reconcile.WorkerExitTimeout); err != nil {
+		// Routing-aware listings are complete for their scope, so absence from
+		// the active set is real evidence of inactivity and may cancel runs.
+		if err := p.orchestrator.ReconcileTrackerIssuesAndWait(ctx, activeIssuesByID, activeStateKeys, p.reconcile.WorkerExitTimeout); err != nil {
+			return err
+		}
+	} else {
+		// Without routing the active listing may be partial; still refresh
+		// stored issue metadata for runs we DO see so per-state capacity gates
+		// observe the latest tracker state without treating absence as inactive.
+		if err := p.orchestrator.RefreshActiveTrackerIssues(ctx, activeIssuesByID, activeStateKeys); err != nil {
 			return err
 		}
 	}

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -566,6 +566,54 @@ func TestPollOnceDoesNotCancelRunningIssueStillInActiveTrackerListing(t *testing
 	}
 }
 
+func TestPollOnceRefreshesRunningIssueStateWithoutRouting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	first := tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{first}}
+	dispatcher := &cancellationDispatcher{}
+	st := NewOrchestratorState(30000, 10)
+	st.MaxConcurrentAgentsByState = map[string]int{"rework": 1}
+	orch := New(st, Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress", "Rework"},
+		TerminalStates:    []string{"Cancelled"},
+		InactiveStates:    []string{"Backlog"},
+		WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	moved := first
+	moved.State = "Rework"
+	trackerClient.setIssues([]tracker.Issue{moved})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("refresh poll: %v", err)
+	}
+
+	select {
+	case <-dispatcher.contextAt(0).Done():
+		t.Fatalf("running issue was canceled by non-routed refresh path")
+	default:
+	}
+
+	other := tracker.Issue{ID: "issue-2", Identifier: "LIN-2", State: "Rework"}
+	if err := orch.RequestDispatch(ctx, other, nil); !errors.Is(err, ErrCapacityFull) {
+		t.Fatalf("dispatch second Rework after refresh err = %v, want ErrCapacityFull", err)
+	}
+}
+
 func TestPollOnceDoesNotCancelRunningIssueMissingFromPartialTrackerListing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Reconciliation kept active runs alive but never updated RunningEntry.Issue
or ClaimedIssues, so per-state capacity counts continued to use the
dispatch-time state. An issue moved from In Progress to Rework was still
counted as In Progress, letting a later poll exceed
max_concurrent_agents_by_state.rework.

Refresh the stored Issue (and retry entry) when reconciliation observes
an active issue, and cover the regression with an actor test.

Addresses Codex review on #158.