### PR TITLE
fix: guard retry fires by kind

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -718,6 +718,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 	o := s.o
 	issue := s.issue
 	attempt := s.attempt
+	kind := s.kind
 	delay := o.scheduler.NextDelay(s.req)
 	// time.AfterFunc schedules immediately and is cheap (no goroutine
 	// until fire), so we can safely create the timer on the actor
@@ -738,6 +739,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 			id:      id,
 			issue:   issue,
 			attempt: attempt,
+			kind:    kind,
 		})
 	})
 	st.ScheduleRetry(entry)
@@ -748,13 +750,14 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 // SPEC §16.6 retry path is "if the entry is still queued, re-dispatch;
 // otherwise drop the fire." Two timers may race here in pathological
 // cases (a ScheduleRetry replace where the prior timer's Stop missed
-// because the callback was already queued); the attempt-equality
+// because the callback was already queued); the attempt/kind equality
 // guard makes the stale fire a no-op.
 type retryFireOp struct {
 	o       *Orchestrator
 	id      IssueID
 	issue   tracker.Issue
 	attempt int
+	kind    RetryKind
 }
 
 func (r *retryFireOp) apply(st *OrchestratorState) func() {
@@ -764,7 +767,7 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		// earlier fire of the same retry. Either is correct.
 		return nil
 	}
-	if entry.Attempt != r.attempt {
+	if entry.Attempt != r.attempt || entry.Kind != r.kind {
 		// A newer ScheduleRetry replaced this entry; the older timer
 		// fired late. Drop the stale fire — the newer entry will
 		// re-dispatch on its own timer.
@@ -797,6 +800,7 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		o := r.o
 		id := r.id
 		attempt := r.attempt
+		kind := r.kind
 		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
 		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
 			_ = o.submit(o.runCtx, &retryFireOp{
@@ -804,6 +808,7 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 				id:      id,
 				issue:   issue,
 				attempt: attempt,
+				kind:    kind,
 			})
 		})
 		return nil
@@ -818,6 +823,7 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		o := r.o
 		id := r.id
 		attempt := r.attempt
+		kind := r.kind
 		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
 		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
 			_ = o.submit(o.runCtx, &retryFireOp{
@@ -825,6 +831,7 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 				id:      id,
 				issue:   issue,
 				attempt: attempt,
+				kind:    kind,
 			})
 		})
 		return nil

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -366,6 +366,7 @@ func TestFinalizeRunSchedulesRetryWithRefreshedIssueState(t *testing.T) {
 		id:      IssueID(moving.ID),
 		issue:   moving, // captured dispatch-time issue; entry.Issue should override
 		attempt: 1,
+		kind:    RetryKindFailure,
 	}); err != nil {
 		t.Fatalf("submit retry fire: %v", err)
 	}
@@ -426,6 +427,7 @@ func TestRetryFireUsesRefreshedIssueWhenReconciledMidQueue(t *testing.T) {
 		id:      IssueID(ip.ID),
 		issue:   ip, // dispatch-time In Progress; refreshed entry.Issue says Rework
 		attempt: 1,
+		kind:    RetryKindFailure,
 	}); err != nil {
 		t.Fatalf("submit retry fire: %v", err)
 	}
@@ -944,6 +946,99 @@ func TestUpdateMaxConcurrentAgentsByStateNormalizesStateKeys(t *testing.T) {
 	}
 }
 
+func TestRetryFire_DropsStaleContinuationFireAfterFailureReplacement(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	o := New(st, Deps{Dispatcher: disp})
+
+	issueID := IssueID("ENG-KIND")
+	continuationIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "AI Ready", Title: "old continuation"}
+	failureIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "Needs Fix", Title: "new failure"}
+	st.ScheduleRetry(&RetryEntry{
+		Issue:      failureIssue,
+		IssueID:    issueID,
+		Identifier: failureIssue.Identifier,
+		Attempt:    1,
+		Kind:       RetryKindFailure,
+	})
+
+	followup := (&retryFireOp{
+		o:       o,
+		id:      issueID,
+		issue:   continuationIssue,
+		attempt: 1,
+		kind:    RetryKindContinuation,
+	}).apply(st)
+	if followup != nil {
+		t.Fatal("stale continuation fire returned a followup, want it dropped before side effects")
+	}
+
+	if got := disp.count(); got != 0 {
+		t.Fatalf("stale continuation fire spawned %d workers, want 0", got)
+	}
+	if len(st.Running) != 0 {
+		t.Fatalf("running after stale continuation fire = %+v, want none", st.Running)
+	}
+	entry, ok := st.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("stale continuation fire consumed the replacement failure retry")
+	}
+	if entry.Kind != RetryKindFailure || entry.Issue.Title != failureIssue.Title {
+		t.Fatalf("replacement retry = kind %q issue %+v, want failure issue preserved", entry.Kind, entry.Issue)
+	}
+	if !st.IsClaimed(issueID) {
+		t.Fatal("stale continuation fire released claim for replacement failure retry")
+	}
+}
+
+func TestRetryFire_DropsStaleFailureFireAfterContinuationReplacement(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	o := New(st, Deps{Dispatcher: disp})
+
+	issueID := IssueID("ENG-KIND")
+	failureIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "Needs Fix", Title: "old failure"}
+	continuationIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "AI Ready", Title: "new continuation"}
+	timer := time.AfterFunc(time.Hour, func() {})
+	defer timer.Stop()
+	st.ScheduleRetry(&RetryEntry{
+		Issue:      continuationIssue,
+		IssueID:    issueID,
+		Identifier: continuationIssue.Identifier,
+		Attempt:    1,
+		Timer:      timer,
+		Kind:       RetryKindContinuation,
+	})
+
+	followup := (&retryFireOp{
+		o:       o,
+		id:      issueID,
+		issue:   failureIssue,
+		attempt: 1,
+		kind:    RetryKindFailure,
+	}).apply(st)
+	if followup != nil {
+		t.Fatal("stale failure fire returned a followup, want it dropped before side effects")
+	}
+
+	if got := disp.count(); got != 0 {
+		t.Fatalf("stale failure fire spawned %d workers, want 0", got)
+	}
+	if len(st.Running) != 0 {
+		t.Fatalf("running after stale failure fire = %+v, want none", st.Running)
+	}
+	entry, ok := st.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("stale failure fire consumed the replacement continuation retry")
+	}
+	if entry.Kind != RetryKindContinuation || entry.Timer == nil {
+		t.Fatalf("replacement retry = kind %q timer %v, want continuation timer preserved", entry.Kind, entry.Timer)
+	}
+	if !st.IsClaimed(issueID) {
+		t.Fatal("stale failure fire released claim for replacement continuation retry")
+	}
+}
+
 func TestRetryFire_RespectsPerStateCapacityBeforeSpawning(t *testing.T) {
 	disp := &fakeDispatcher{}
 	st := NewOrchestratorState(15000, 10)
@@ -982,6 +1077,7 @@ func TestRetryFire_RespectsPerStateCapacityBeforeSpawning(t *testing.T) {
 		id:      IssueID(issueA.ID),
 		issue:   issueA,
 		attempt: 1,
+		kind:    RetryKindFailure,
 	}); err != nil {
 		t.Fatalf("submit retry fire: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Capture `RetryKind` in retry timer fire operations and include it in the stale-fire equality guard.
- Preserve the captured kind when retry fires are re-armed after global or per-state capacity deferral.
- Add regression coverage for Continuation(Attempt=1) -> Failure(Attempt=1) and Failure(Attempt=1) -> Continuation(Attempt=1) stale timer races.

Closes #145

## Test Plan
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/orchestrator -run 'TestRetryFire_DropsStale(Continuation|Failure)FireAfter.*Replacement' -count=1`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/orchestrator -count=1`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./...`
- [x] `git diff --check`
- [x] `/home/pi/.local/go1.25.10/bin/go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `/home/pi/.local/go1.25.10/bin/go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`

## Notes
- `go test -race -covermode=atomic ./...` was attempted but this Raspberry Pi host cannot run Go ThreadSanitizer: `FATAL: ThreadSanitizer: unsupported VMA range; Found 47 - Supported 48`.
- SPEC context checked: SPEC §16.6 retry semantics and the Elixir orchestrator GenServer single-authority retry/timer model.