### PR TITLE
chore: deduplicate Gitea label HTTP requests

### DIFF
--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -113,77 +113,24 @@ func (p giteaIssueLabelsProxy) addIssueLabels(ctx context.Context, client *http.
 		})
 		return "", failure
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
-	if err != nil {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label request could not be built", "reason": err.Error()},
-		})
+	_, respBody, failure := p.doGiteaRequest(ctx, client, http.MethodPost, endpoint, body)
+	if failure != "" {
 		return "", failure
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "token "+strings.TrimSpace(p.token))
-	resp, err := client.Do(req)
-	if err != nil {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label request failed during transport", "reason": err.Error()},
-		})
-		return "", failure
-	}
-	defer resp.Body.Close()
-	var respBody bytes.Buffer
-	_, readErr := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
-	if readErr != nil {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label response body could not be read", "reason": readErr.Error()},
-		})
-		return "", failure
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label request failed", "status": resp.Status, "body": respBody.String()},
-		})
-		return "", failure
-	}
-	result, _ := dynamicToolResult(true, respBody.String())
+	result, _ := dynamicToolResult(true, string(respBody))
 	return result, ""
 }
 
 func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *http.Client, endpoint string) ([]giteaIssueLabel, string) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label read request could not be built", "reason": err.Error()},
-		})
-		return nil, failure
-	}
-	req.Header.Set("Authorization", "token "+strings.TrimSpace(p.token))
-	resp, err := client.Do(req)
-	if err != nil {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label read request failed during transport", "reason": err.Error()},
-		})
-		return nil, failure
-	}
-	defer resp.Body.Close()
-	var respBody bytes.Buffer
-	_, readErr := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
-	if readErr != nil {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label read response body could not be read", "reason": readErr.Error()},
-		})
-		return nil, failure
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label read request failed", "status": resp.Status, "body": respBody.String()},
-		})
+	_, respBody, failure := p.doGiteaRequest(ctx, client, http.MethodGet, endpoint, nil)
+	if failure != "" {
 		return nil, failure
 	}
 	var labels []struct {
 		ID   int64  `json:"id"`
 		Name string `json:"name"`
 	}
-	if err := json.Unmarshal(respBody.Bytes(), &labels); err != nil {
+	if err := json.Unmarshal(respBody, &labels); err != nil {
 		failure, _ := dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "Gitea label read response body could not be decoded", "reason": err.Error()},
 		})
@@ -199,40 +146,52 @@ func (p giteaIssueLabelsProxy) currentIssueLabels(ctx context.Context, client *h
 }
 
 func (p giteaIssueLabelsProxy) deleteIssueLabel(ctx context.Context, client *http.Client, endpoint string, labelID int64) string {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf("%s/%d", endpoint, labelID), nil)
+	status, _, failure := p.doGiteaRequest(ctx, client, http.MethodDelete, fmt.Sprintf("%s/%d", endpoint, labelID), nil)
+	if status == http.StatusNotFound {
+		return ""
+	}
+	return failure
+}
+
+func (p giteaIssueLabelsProxy) doGiteaRequest(ctx context.Context, client *http.Client, method, endpoint string, body []byte) (int, []byte, string) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
 	if err != nil {
 		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label delete request could not be built", "reason": err.Error()},
+			"error": map[string]any{"message": "Gitea label request could not be built", "reason": err.Error()},
 		})
-		return failure
+		return 0, nil, failure
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Authorization", "token "+strings.TrimSpace(p.token))
 	resp, err := client.Do(req)
 	if err != nil {
 		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label delete request failed during transport", "reason": err.Error()},
+			"error": map[string]any{"message": "Gitea label request failed during transport", "reason": err.Error()},
 		})
-		return failure
+		return 0, nil, failure
 	}
 	defer resp.Body.Close()
 	var respBody bytes.Buffer
 	_, readErr := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
 	if readErr != nil {
 		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label delete response body could not be read", "reason": readErr.Error()},
+			"error": map[string]any{"message": "Gitea label response body could not be read", "reason": readErr.Error()},
 		})
-		return failure
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		return ""
+		return resp.StatusCode, respBody.Bytes(), failure
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label delete request failed", "status": resp.Status, "body": respBody.String()},
+			"error": map[string]any{"message": "Gitea label request failed", "status": resp.Status, "body": respBody.String()},
 		})
-		return failure
+		return resp.StatusCode, respBody.Bytes(), failure
 	}
-	return ""
+	return resp.StatusCode, respBody.Bytes(), ""
 }
 
 func (p giteaIssueLabelsProxy) decodeIssueLabelsFromToolResult(result, source string) ([]giteaIssueLabel, string) {

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -352,6 +352,30 @@ func TestGiteaIssueLabelsAcceptsGiteaAddLabelArrayResponse(t *testing.T) {
 	}
 }
 
+func TestGiteaIssueLabelsRequestHelperReturnsStructuredFailureForHTTPStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "token trimmed-token" {
+			t.Fatalf("Authorization = %q, want trimmed token auth", got)
+		}
+		http.Error(w, `{"message":"temporary failure"}`, http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	status, body, failure := giteaIssueLabelsProxy{token: "  trimmed-token  "}.
+		doGiteaRequest(context.Background(), server.Client(), http.MethodGet, server.URL, nil)
+
+	if status != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", status, http.StatusBadGateway)
+	}
+	if !strings.Contains(string(body), "temporary failure") {
+		t.Fatalf("body = %q, want upstream failure body", body)
+	}
+	assertStructuredFailure(t, failure, nil, "Gitea label request failed")
+	if !strings.Contains(failure, "502 Bad Gateway") || !strings.Contains(failure, "temporary failure") {
+		t.Fatalf("failure = %s, want status and bounded response body", failure)
+	}
+}
+
 func TestGiteaIssueLabelsTreatsMissingStaleStateAsSuccess(t *testing.T) {
 	var mu sync.Mutex
 	var methods []string


### PR DESCRIPTION
## Summary
- Refactors Gitea issue-label HTTP calls through a single `doGiteaRequest` helper for auth, transport, bounded response reads, and structured failure envelopes.
- Leaves add/read/delete methods focused on payload/decode/delete-404 behavior.
- Adds a focused helper failure-envelope regression test.

## Test Plan
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/runner -run TestGiteaIssueLabelsRequestHelperReturnsStructuredFailureForHTTPStatus -count=1`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/runner -run 'TestGiteaIssueLabels(RequestHelperReturnsStructuredFailureForHTTPStatus|TreatsMissingStaleStateAsSuccess|PreservesNonAIOpsLabelsWhenReplacingState|DoesNotDeleteExistingStateWhenAddingDesiredStateFails)' -count=1`
- [x] `/home/pi/.local/go1.25.10/bin/gofmt -l $(git ls-files '*.go')`
- [x] `/home/pi/.local/go1.25.10/bin/go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./internal/runner -count=1`
- [x] `/home/pi/.local/go1.25.10/bin/go test ./... -count=1`
- [x] `/home/pi/.local/go1.25.10/bin/go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- [x] `git diff --check`

Note: local race gate could not run on this Raspberry Pi host because ThreadSanitizer reports `unsupported VMA range` / `Found 47 - Supported 48`, matching the known ARM/RPi environment limitation.

Closes #128
