### PR TITLE
feat: expose Gitea pagination cap metric

### DIFF
--- a/cmd/gitea-poller/main.go
+++ b/cmd/gitea-poller/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -42,6 +43,9 @@ func main() {
 	baseURL := giteaBaseURL(wf.Config.Tracker)
 	client := gitea.NewTrackerClient(wf.Config.Tracker, baseURL, wf.Config.Repo.Owner, wf.Config.Repo.Name)
 	client.Logf = log.Printf
+	if metricsAddr := os.Getenv("GITEA_POLLER_METRICS_ADDR"); metricsAddr != "" {
+		startMetricsServer(metricsAddr, client)
+	}
 	interval := time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond
 
 	for {
@@ -88,6 +92,26 @@ func sourceEventID(issue tracker.Issue) string {
 		return issue.ID + "|rework|" + tracker.TimeString(issue.UpdatedAt)
 	}
 	return issue.ID
+}
+
+func startMetricsServer(addr string, client *gitea.TrackerClient) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		writeMetrics(w, r, client)
+	})
+	go func() {
+		if err := http.ListenAndServe(addr, mux); err != nil {
+			log.Printf("gitea poller metrics server stopped: %v", err)
+		}
+	}()
+	log.Printf("gitea poller metrics listening on %s", addr)
+}
+
+func writeMetrics(w http.ResponseWriter, _ *http.Request, client *gitea.TrackerClient) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	fmt.Fprintf(w, "# HELP aiops_gitea_issue_pagination_cap_hits_total Gitea issue listings capped after %d pages.\n", gitea.ListIssuesMaxPages())
+	fmt.Fprintln(w, "# TYPE aiops_gitea_issue_pagination_cap_hits_total counter")
+	fmt.Fprintf(w, "aiops_gitea_issue_pagination_cap_hits_total %d\n", client.PaginationCapHits())
 }
 
 func giteaBaseURL(cfg workflow.TrackerConfig) string {

--- a/cmd/gitea-poller/main.go
+++ b/cmd/gitea-poller/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -99,12 +100,23 @@ func startMetricsServer(addr string, client *gitea.TrackerClient) {
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		writeMetrics(w, r, client)
 	})
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Printf("gitea poller metrics listen error on %s: %v", addr, err)
+		return
+	}
 	go func() {
-		if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Printf("gitea poller metrics listening on %s", listener.Addr())
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Printf("gitea poller metrics server stopped: %v", err)
 		}
 	}()
-	log.Printf("gitea poller metrics listening on %s", addr)
 }
 
 func writeMetrics(w http.ResponseWriter, _ *http.Request, client *gitea.TrackerClient) {

--- a/cmd/gitea-poller/main_test.go
+++ b/cmd/gitea-poller/main_test.go
@@ -2,9 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -60,6 +67,50 @@ func TestSourceEventIDReworkUsesUpdatedAt(t *testing.T) {
 	if got != "101|rework|2026-05-17T00:00:00Z" {
 		t.Fatalf("sourceEventID = %q", got)
 	}
+}
+
+func TestGiteaMetricsHandlerExposesPaginationCapHits(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil {
+			t.Fatalf("page query = %q: %v", r.URL.Query().Get("page"), err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Add("Link", fmt.Sprintf(`<%s%s?page=%d>; rel="next"`, serverURL(r), r.URL.Path, page+1))
+		issues := make([]gitea.Issue, 50)
+		for i := range issues {
+			number := (page-1)*50 + i + 1
+			issues[i] = gitea.Issue{ID: int64(number), Number: number, Title: "todo", HTMLURL: fmt.Sprintf("https://gitea.local/o/r/issues/%d", number), Labels: []gitea.Label{{Name: "aiops/todo"}}}
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := gitea.NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	client.Logf = func(string, ...any) {}
+	if _, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"}); err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	writeMetrics(w, req, client)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("metrics status = %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/plain") {
+		t.Fatalf("Content-Type = %q, want text/plain", got)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "aiops_gitea_issue_pagination_cap_hits_total 1") {
+		t.Fatalf("metrics body = %q, want pagination cap counter", body)
+	}
+}
+
+func serverURL(r *http.Request) string {
+	return "http://" + r.Host
 }
 
 func mustTime(value string) time.Time {

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -138,6 +138,16 @@ go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md
 
 The poller exits immediately with `tracker.kind must be gitea` if its workflow is not configured for Gitea. It logs `skip <issue>: repo.clone_url missing in WORKFLOW.md` if `repo.clone_url` is empty.
 
+Gitea issue listing is capped at 20 pages of 50 issues per state label (1000 issues). When the `+1` probe page proves more issues exist, the poller keeps running with the capped result set and increments `aiops_gitea_issue_pagination_cap_hits_total`. Expose that counter by setting `GITEA_POLLER_METRICS_ADDR` before starting the poller:
+
+```bash
+export GITEA_POLLER_METRICS_ADDR=:9091
+go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md
+curl http://localhost:9091/metrics | grep aiops_gitea_issue_pagination_cap_hits_total
+```
+
+A non-zero counter means at least one active state label has more than 1000 matching Gitea issues, so operators should reduce the active backlog or split labels before relying on the poller for exhaustive dispatch.
+
 ## 5. Smoke test
 
 The fastest way to verify local configuration without a real Gitea or Linear is

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -146,7 +146,7 @@ go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md
 curl http://localhost:9091/metrics | grep aiops_gitea_issue_pagination_cap_hits_total
 ```
 
-A non-zero counter means at least one active state label has more than 1000 matching Gitea issues, so operators should reduce the active backlog or split labels before relying on the poller for exhaustive dispatch.
+The metric is cumulative for the poller process. A non-zero value means at least one poll since startup observed an active state label with more than 1000 matching Gitea issues; alert on recent increases, not just the absolute value. When it increases, operators should reduce the active backlog or split labels before relying on the poller for exhaustive dispatch.
 
 ## 5. Smoke test
 

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -72,13 +72,6 @@ func (c *TrackerClient) PaginationCapHits() int64 {
 	return c.paginationCapHits.Load()
 }
 
-// RecordPaginationCapHit records a manually observed pagination cap condition.
-// It exists for callers that expose TrackerClient diagnostics through their own
-// operator surfaces; normal issue listings call it automatically.
-func (c *TrackerClient) RecordPaginationCapHit(labelName string) {
-	c.recordPaginationCapHit(labelName)
-}
-
 func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string) ([]tracker.Issue, error) {
 	if c.BaseURL == "" || c.Token == "" {
 		return nil, fmt.Errorf("GITEA_BASE_URL and Gitea tracker api_key are required")

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
@@ -18,6 +19,10 @@ const (
 	listIssuesPageSize = 50
 	listIssuesMaxPages = 20
 )
+
+func ListIssuesMaxPages() int {
+	return listIssuesMaxPages
+}
 
 // Issue is the subset of Gitea's issue JSON used by the tracker reader.
 type Issue struct {
@@ -42,6 +47,8 @@ type TrackerClient struct {
 	Config  workflow.TrackerConfig
 	HTTP    *http.Client
 	Logf    func(format string, args ...any)
+
+	paginationCapHits atomic.Int64
 }
 
 func NewTrackerClient(cfg workflow.TrackerConfig, baseURL, owner, repo string) *TrackerClient {
@@ -57,6 +64,19 @@ func NewTrackerClient(cfg workflow.TrackerConfig, baseURL, owner, repo string) *
 
 func (c *TrackerClient) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
 	return c.ListIssuesByStates(ctx, c.Config.ActiveStates)
+}
+
+// PaginationCapHits returns how often this client observed more than
+// listIssuesMaxPages of Gitea issue results for a label-scoped listing.
+func (c *TrackerClient) PaginationCapHits() int64 {
+	return c.paginationCapHits.Load()
+}
+
+// RecordPaginationCapHit records a manually observed pagination cap condition.
+// It exists for callers that expose TrackerClient diagnostics through their own
+// operator surfaces; normal issue listings call it automatically.
+func (c *TrackerClient) RecordPaginationCapHit(labelName string) {
+	c.recordPaginationCapHit(labelName)
 }
 
 func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string) ([]tracker.Issue, error) {
@@ -99,9 +119,7 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 			if len(batch) == 0 {
 				return out, nil
 			}
-			if c.Logf != nil {
-				c.Logf("gitea issue pagination exceeded %d pages for label %q; returning capped result set", listIssuesMaxPages, labelName)
-			}
+			c.recordPaginationCapHit(labelName)
 			return out, nil
 		}
 		for _, issue := range batch {
@@ -147,6 +165,13 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 		}
 	}
 	return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
+}
+
+func (c *TrackerClient) recordPaginationCapHit(labelName string) {
+	c.paginationCapHits.Add(1)
+	if c.Logf != nil {
+		c.Logf("gitea issue pagination exceeded %d pages for label %q; returning capped result set", listIssuesMaxPages, labelName)
+	}
 }
 
 func parseGiteaIssueTime(field, value string) (time.Time, error) {

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -289,6 +289,9 @@ func TestTrackerClientListIssuesByStatesReturnsCappedResultsInsteadOfFailingWhen
 	client.Logf = func(format string, args ...any) {
 		logs = append(logs, fmt.Sprintf(format, args...))
 	}
+	if got := client.PaginationCapHits(); got != 0 {
+		t.Fatalf("initial PaginationCapHits = %d, want 0", got)
+	}
 	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates must return capped results instead of failing the poll cycle: %v", err)
@@ -298,6 +301,9 @@ func TestTrackerClientListIssuesByStatesReturnsCappedResultsInsteadOfFailingWhen
 	}
 	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "gitea issue pagination exceeded") {
 		t.Fatalf("logs = %#v, want pagination cap diagnostic", logs)
+	}
+	if got := client.PaginationCapHits(); got != 1 {
+		t.Fatalf("PaginationCapHits = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an atomic Gitea pagination-cap counter on TrackerClient
- expose the counter through an opt-in gitea-poller Prometheus-style /metrics endpoint
- document the 1000-issue-per-label cap and monitoring command in the local dev runbook

Closes #129

## Test Plan
- [x] go test ./internal/gitea -run TestTrackerClientListIssuesByStatesReturnsCappedResultsInsteadOfFailingWhenPageLimitExceeded -count=1
- [x] go test ./cmd/gitea-poller -run TestGiteaMetricsHandlerExposesPaginationCapHits -count=1
- [x] go test ./cmd/gitea-poller ./internal/gitea -count=1
- [x] go test ./...
- [x] gofmt -l $(git ls-files '*.go')
- [x] go mod tidy && git diff --exit-code -- go.mod go.sum
- [x] go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller
- [ ] go test -race -covermode=atomic ./... (blocked locally: ThreadSanitizer unsupported VMA range on this Raspberry Pi host: "FATAL: Found 47 - Supported 48")
