### PR TITLE
fix(worker): honor workflow workspace root at runtime

### DIFF
--- a/.hermes/kanban-throughput-migration-plan.md
+++ b/.hermes/kanban-throughput-migration-plan.md
@@ -1,0 +1,59 @@
+# Kanban Throughput Migration Plan
+
+Updated: 2026-05-20T09:27:00+08:00
+
+## Problem snapshot
+- The aiops-platform Kanban board was operating in a low-throughput legacy mode: tasks used `workspace_kind=dir` with shared checkout `/home/pi/work/aiops-platform`, and `kanban.max_spawn` was effectively a single-worker lane.
+- The shared checkout is currently dirty on branch `fix/issue-149-workspace-root-precedence` with issue #149 changes. This means generic dispatch of later issues can mutate the wrong branch.
+- The embedded gateway dispatcher auto-spawned issue #150 into the dirty #149 checkout. That worker was reclaimed immediately as a misdirected spawn before it made a useful handoff.
+- Ready tasks were temporarily blocked as migration holds so no further worker is spawned against the shared checkout while worktree migration is in progress.
+
+## Target operating model
+1. Issue implementation runs in dedicated git worktrees under `/home/pi/work/aiops-platform-worktrees/issue-<number>`.
+2. `kanban.max_spawn` is a live concurrency cap. Use `2` initially on this Raspberry Pi; consider `3` only after CPU/memory/API behavior is stable.
+3. The shared checkout `/home/pi/work/aiops-platform` is reserved for operator recovery, main fast-forward/sync, and serial PR merge/follow-through operations.
+4. PR follow-through and merge remain serialized behind `/tmp/aiops-platform-agent.lock`; implementation workers should not wait on CI/Codex for long periods while holding the implementation lane.
+5. Heartbeat/precheck must detect throughput/configuration defects, not merely the existence of a process. In particular, `max_spawn > 1` plus ready tasks on shared `dir` workspace is an actionable defect.
+6. Do not dispatch later issues while the shared checkout is dirty unless those issues have independent worktrees and the dirty checkout has an explicit owner/handoff.
+
+## Current safe-state actions already taken
+- Paused heartbeat cron job `75e947fdff1c`.
+- Set `kanban.dispatch_in_gateway=false` and restarted the gateway so embedded dispatch cannot race the migration.
+- Reclaimed the misdirected issue #150 worker from shared checkout.
+- Blocked ready tasks #150/#151/#159 with migration-hold reasons.
+
+## Implementation steps
+1. Finish/preserve issue #149 dirty checkout:
+   - Identify whether the diff is complete enough to test and PR, or needs a dedicated issue #149 worktree.
+   - Preserve before any destructive action: no reset/stash without diff backup.
+   - Run gofmt/focused tests/full `/home/pi/.local/go1.25.10/bin/go test ./...` and independent diff review before push.
+2. Add worktree bootstrap tooling:
+   - Create an operator script that maps Kanban task ids to issue numbers, creates/fixes `issue-<n>` branches from current `origin/main`, and updates `tasks.workspace_kind='worktree'`, `tasks.workspace_path=<absolute path>`.
+   - The script must refuse to overwrite dirty existing worktrees.
+3. Harden precheck:
+   - Include `kanban_config` (`dispatch_in_gateway`, `max_spawn`) in diagnostics.
+   - Detect ready/running tasks with `workspace_kind='dir'` and shared path `/home/pi/work/aiops-platform`.
+   - If `max_spawn > 1` and shared ready tasks exist, set `wakeAgent=true`, lane `shared_workspace_migration_required`.
+   - Distinguish dirty shared checkout from dirty per-issue worktree; dirty shared checkout blocks generic shared dispatch, but not independent worktree dispatch.
+4. Harden heartbeat cron prompt:
+   - Replace “dispatch exactly one worker” with “dispatch up to the configured live concurrency cap after dry-run, but only worktree-backed tasks are eligible for parallel implementation.”
+   - Keep PR follow-through/merge serial and lock-protected.
+   - Prohibit unblocking `dir:/home/pi/work/aiops-platform` implementation tasks when `max_spawn > 1`.
+5. Migrate board tasks:
+   - #149: resolve shared dirty work first, then move any remaining task state to `/home/pi/work/aiops-platform-worktrees/issue-149` or complete after PR merge.
+   - #150/#151/#159: create/update dedicated worktrees and unblock up to the concurrency target.
+   - #146/#147/#148: migrate before any future unblock; note #148 already has a worktree directory and should be reconciled before reuse.
+6. Enable controlled dispatch:
+   - Set `kanban.max_spawn=2`.
+   - Keep `dispatch_in_gateway=false` during validation; use manual `hermes kanban dispatch --dry-run --max 2 --json`, then dispatch.
+   - After verification, either resume heartbeat as the orchestrator or explicitly re-enable gateway dispatcher only if precheck/prompt are proven safe.
+7. Verify and resume:
+   - Dry-run shows at most two worktree-backed tasks.
+   - Live dispatch creates workers whose cwd/workspace is their per-issue worktree.
+   - No worker uses `/home/pi/work/aiops-platform` for implementation.
+   - Precheck reports coherent state: valid worktree workers active, clean PR follow-through, or explicit recovery lane.
+
+## Retrospective notes
+- Root cause: shared checkout + auto-dispatch made task ownership ambiguous; a later task could start on a previous issue branch.
+- Durable guardrail: never treat a live process as sufficient progress if queue/workspace configuration prevents throughput or risks wrong-branch mutation.
+- No credentials or secrets are recorded here.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ export GITEA_TOKEN=your-gitea-bot-token
 go run ./cmd/worker
 ```
 
+`WORKFLOW.md` front matter is the source of truth for runtime workspace placement: when `workspace.root` is set in the selected workflow, the worker creates and reconciles task workspaces under that path. `WORKSPACE_ROOT` is only the fallback for workflows that omit `workspace.root`.
+
 No `DATABASE_URL` or Postgres service is required for `cmd/worker`. Restart recovery follows SPEC §14.3: the worker starts with fresh runtime state, cleans terminal workspaces from tracker state, and re-dispatches eligible active issues on the next poll rather than restoring queue rows, retry timers, or running sessions from a database.
 
 The default Compose service now starts only `worker` unless a legacy profile is requested:

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -124,7 +124,7 @@ func validateWorkflowForRuntime(path string, source workflow.Source, cfg workflo
 func startupReconcileConfigForWorkflow(cfg workflow.Config, trackerClient worker.ReconcileTracker) worker.ReconcileConfig {
 	hooks := cfg.WorkspaceHooks()
 	return worker.ReconcileConfig{
-		WorkspaceRoot:       effectiveWorkspaceRoot(worker.LoadConfigFromEnv(), cfg),
+		WorkspaceRoot:       worker.EffectiveWorkspaceRoot(worker.LoadConfigFromEnv(), cfg),
 		ActiveStates:        cfg.Tracker.ActiveStates,
 		TerminalStates:      cfg.Tracker.TerminalStates,
 		TrackerKind:         cfg.Tracker.Kind,
@@ -154,7 +154,7 @@ func run(ctx context.Context, args []string) error {
 		return err
 	}
 	reconcileCfg := startupReconcileConfigForWorkflow(wf.Config, trackerClient)
-	reconcileCfg.WorkspaceRoot = effectiveWorkspaceRoot(cfg, wf.Config)
+	reconcileCfg.WorkspaceRoot = worker.EffectiveWorkspaceRoot(cfg, wf.Config)
 	if err := worker.ReconcileStartup(ctx, reconcileCfg); err != nil {
 		worker.LogReconcileError(err)
 		return err
@@ -198,22 +198,6 @@ func run(ctx context.Context, args []string) error {
 		}
 	}()
 	return orchestrator.RunPollLoopWithRuntime(ctx, poller, runtime, orchestrator.PollLoopRuntimeOptions{})
-}
-
-func effectiveWorkspaceRoot(cfg worker.Config, wcfg workflow.Config) string {
-	root := strings.TrimSpace(wcfg.Workspace.Root)
-	if root != "" && root != defaultWorkspaceRoot() {
-		return root
-	}
-	return cfg.WorkspaceRoot
-}
-
-func defaultWorkspaceRoot() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "~/aiops-workspaces"
-	}
-	return filepath.Join(home, "aiops-workspaces")
 }
 
 func reconciliationConfigForWorkflow(cfg workflow.Config) orchestrator.ReconciliationConfig {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -124,7 +124,7 @@ func validateWorkflowForRuntime(path string, source workflow.Source, cfg workflo
 func startupReconcileConfigForWorkflow(cfg workflow.Config, trackerClient worker.ReconcileTracker) worker.ReconcileConfig {
 	hooks := cfg.WorkspaceHooks()
 	return worker.ReconcileConfig{
-		WorkspaceRoot:       worker.LoadConfigFromEnv().WorkspaceRoot,
+		WorkspaceRoot:       effectiveWorkspaceRoot(worker.LoadConfigFromEnv(), cfg),
 		ActiveStates:        cfg.Tracker.ActiveStates,
 		TerminalStates:      cfg.Tracker.TerminalStates,
 		TrackerKind:         cfg.Tracker.Kind,
@@ -154,7 +154,7 @@ func run(ctx context.Context, args []string) error {
 		return err
 	}
 	reconcileCfg := startupReconcileConfigForWorkflow(wf.Config, trackerClient)
-	reconcileCfg.WorkspaceRoot = cfg.WorkspaceRoot
+	reconcileCfg.WorkspaceRoot = effectiveWorkspaceRoot(cfg, wf.Config)
 	if err := worker.ReconcileStartup(ctx, reconcileCfg); err != nil {
 		worker.LogReconcileError(err)
 		return err
@@ -198,6 +198,22 @@ func run(ctx context.Context, args []string) error {
 		}
 	}()
 	return orchestrator.RunPollLoopWithRuntime(ctx, poller, runtime, orchestrator.PollLoopRuntimeOptions{})
+}
+
+func effectiveWorkspaceRoot(cfg worker.Config, wcfg workflow.Config) string {
+	root := strings.TrimSpace(wcfg.Workspace.Root)
+	if root != "" && root != defaultWorkspaceRoot() {
+		return root
+	}
+	return cfg.WorkspaceRoot
+}
+
+func defaultWorkspaceRoot() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "~/aiops-workspaces"
+	}
+	return filepath.Join(home, "aiops-workspaces")
 }
 
 func reconciliationConfigForWorkflow(cfg workflow.Config) orchestrator.ReconciliationConfig {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -207,14 +208,68 @@ func TestStartupReconcileConfigUsesEffectiveWorkspaceHooks(t *testing.T) {
 }
 
 func TestStartupReconcileConfigHonorsWorkflowWorkspaceRoot(t *testing.T) {
-	cfg := workflow.DefaultConfig()
-	cfg.Workspace.Root = filepath.Join(t.TempDir(), "yaml-workspaces")
+	yamlRoot := filepath.Join(t.TempDir(), "yaml-workspaces")
+	workflowPath := writeWorkflowForStartupReconcileTest(t, fmt.Sprintf("workspace:\n  root: %s\n", yamlRoot))
+	wf, err := workflow.Load(workflowPath)
+	if err != nil {
+		t.Fatalf("Load workflow: %v", err)
+	}
 	t.Setenv("WORKSPACE_ROOT", filepath.Join(t.TempDir(), "env-workspaces"))
 
-	reconcile := startupReconcileConfigForWorkflow(cfg, nil)
-	if reconcile.WorkspaceRoot != cfg.Workspace.Root {
-		t.Fatalf("WorkspaceRoot = %q, want workflow workspace.root %q", reconcile.WorkspaceRoot, cfg.Workspace.Root)
+	reconcile := startupReconcileConfigForWorkflow(wf.Config, nil)
+	if reconcile.WorkspaceRoot != yamlRoot {
+		t.Fatalf("WorkspaceRoot = %q, want workflow workspace.root %q", reconcile.WorkspaceRoot, yamlRoot)
 	}
+}
+
+func TestStartupReconcileConfigFallsBackToEnvWorkspaceRoot(t *testing.T) {
+	workflowPath := writeWorkflowForStartupReconcileTest(t, "")
+	wf, err := workflow.Load(workflowPath)
+	if err != nil {
+		t.Fatalf("Load workflow: %v", err)
+	}
+	envRoot := filepath.Join(t.TempDir(), "env-workspaces")
+	t.Setenv("WORKSPACE_ROOT", envRoot)
+
+	reconcile := startupReconcileConfigForWorkflow(wf.Config, nil)
+	if reconcile.WorkspaceRoot != envRoot {
+		t.Fatalf("WorkspaceRoot = %q, want env workspace root %q", reconcile.WorkspaceRoot, envRoot)
+	}
+}
+
+func TestStartupReconcileConfigHonorsExplicitDefaultWorkflowWorkspaceRoot(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	yamlRoot := filepath.Join(home, "aiops-workspaces")
+	workflowPath := writeWorkflowForStartupReconcileTest(t, fmt.Sprintf("workspace:\n  root: %s\n", yamlRoot))
+	wf, err := workflow.Load(workflowPath)
+	if err != nil {
+		t.Fatalf("Load workflow: %v", err)
+	}
+	envRoot := filepath.Join(t.TempDir(), "env-workspaces")
+	t.Setenv("WORKSPACE_ROOT", envRoot)
+
+	reconcile := startupReconcileConfigForWorkflow(wf.Config, nil)
+	if reconcile.WorkspaceRoot != yamlRoot {
+		t.Fatalf("WorkspaceRoot = %q, want explicit workflow default root %q", reconcile.WorkspaceRoot, yamlRoot)
+	}
+}
+
+func writeWorkflowForStartupReconcileTest(t *testing.T, extraFrontMatter string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	body := "---\n" + extraFrontMatter + `repo:
+  owner: acme
+  name: demo
+  clone_url: https://example.invalid/acme/demo.git
+  default_branch: main
+` + "---\nPrompt body\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	return path
 }
 
 func TestStartupReconcileConfigPreservesServiceRoutedActiveWorkspaceKey(t *testing.T) {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -206,6 +206,17 @@ func TestStartupReconcileConfigUsesEffectiveWorkspaceHooks(t *testing.T) {
 	}
 }
 
+func TestStartupReconcileConfigHonorsWorkflowWorkspaceRoot(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Workspace.Root = filepath.Join(t.TempDir(), "yaml-workspaces")
+	t.Setenv("WORKSPACE_ROOT", filepath.Join(t.TempDir(), "env-workspaces"))
+
+	reconcile := startupReconcileConfigForWorkflow(cfg, nil)
+	if reconcile.WorkspaceRoot != cfg.Workspace.Root {
+		t.Fatalf("WorkspaceRoot = %q, want workflow workspace.root %q", reconcile.WorkspaceRoot, cfg.Workspace.Root)
+	}
+}
+
 func TestStartupReconcileConfigPreservesServiceRoutedActiveWorkspaceKey(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Tracker.Kind = "linear"

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -207,13 +207,14 @@ Run `go mod tidy`, then re-run the failing command. CI will reject changes that 
 
 After M2, the worker keeps a per-repo bare mirror under
 `AIOPS_MIRROR_ROOT` (default `os.UserCacheDir()/aiops-platform/mirrors`)
-and creates a per-task worktree under `WORKSPACE_ROOT` for every claimed
-task. This avoids re-cloning on every retry and lets two tasks run
-concurrently without sharing a working tree. See the dedicated
+and creates a per-task worktree under the selected workflow's `workspace.root`
+for every claimed task. If `workspace.root` is omitted from `WORKFLOW.md`, the
+worker falls back to `WORKSPACE_ROOT`. This avoids re-cloning on every retry and
+lets two tasks run concurrently without sharing a working tree. See the dedicated
 [workspace cache runbook](workspace-cache.md) for the on-disk layout,
 configuration knobs, and recommended cleanup cadence (the
-`(*workspace.Manager).Cleanup` API or `rm -rf $WORKSPACE_ROOT/*` once
-old tasks no longer matter).
+`(*workspace.Manager).Cleanup` API or removal of the effective workspace root
+once old tasks no longer matter).
 
 ## Running e2e tests locally
 

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -174,22 +174,6 @@ func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID,
 // RunTask executes a single in-memory task. The orchestrator-backed worker path
 // uses this directly after claiming a tracker issue in runtime state; the
 // legacy queue loop also calls it for remaining tests/compatibility.
-func effectiveWorkspaceRoot(cfg Config, wcfg workflow.Config) string {
-	root := strings.TrimSpace(wcfg.Workspace.Root)
-	if root != "" && root != defaultWorkspaceRoot() {
-		return root
-	}
-	return cfg.WorkspaceRoot
-}
-
-func defaultWorkspaceRoot() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "~/aiops-workspaces"
-	}
-	return filepath.Join(home, "aiops-workspaces")
-}
-
 func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret *RunTaskError) {
 	currentPhase := task.RunAttemptPhase("")
 	phaseTerminal := false
@@ -212,7 +196,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	wcfg := wf.Config
 	hooks := wcfg.WorkspaceHooks()
 
-	workspaceRoot := effectiveWorkspaceRoot(cfg, wcfg)
+	workspaceRoot := EffectiveWorkspaceRoot(cfg, wcfg)
 	mgr := workspace.New(workspaceRoot)
 	mgr.MirrorRoot = cfg.MirrorRoot
 	workdir, _, err := mgr.PrepareGitWorkspace(ctx, t)

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -174,6 +174,22 @@ func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID,
 // RunTask executes a single in-memory task. The orchestrator-backed worker path
 // uses this directly after claiming a tracker issue in runtime state; the
 // legacy queue loop also calls it for remaining tests/compatibility.
+func effectiveWorkspaceRoot(cfg Config, wcfg workflow.Config) string {
+	root := strings.TrimSpace(wcfg.Workspace.Root)
+	if root != "" && root != defaultWorkspaceRoot() {
+		return root
+	}
+	return cfg.WorkspaceRoot
+}
+
+func defaultWorkspaceRoot() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "~/aiops-workspaces"
+	}
+	return filepath.Join(home, "aiops-workspaces")
+}
+
 func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret *RunTaskError) {
 	currentPhase := task.RunAttemptPhase("")
 	phaseTerminal := false
@@ -196,7 +212,8 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	wcfg := wf.Config
 	hooks := wcfg.WorkspaceHooks()
 
-	mgr := workspace.New(cfg.WorkspaceRoot)
+	workspaceRoot := effectiveWorkspaceRoot(cfg, wcfg)
+	mgr := workspace.New(workspaceRoot)
 	mgr.MirrorRoot = cfg.MirrorRoot
 	workdir, _, err := mgr.PrepareGitWorkspace(ctx, t)
 	if err != nil {
@@ -280,7 +297,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
-	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: cfg.WorkspaceRoot, Prompt: prompt, PhaseTransitionSink: func(from, to task.RunAttemptPhase) {
+	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: workspaceRoot, Prompt: prompt, PhaseTransitionSink: func(from, to task.RunAttemptPhase) {
 		emitTaskPhase(from, to)
 	}}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
 		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs); err != nil {

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -100,7 +100,12 @@ do the work for {{task.title}}
 // workerCfgForIntegration assembles the Config the integration tests share.
 func workerCfgForIntegration(t *testing.T) worker.Config {
 	t.Helper()
-	wf, err := workflow.Load(writeServiceWorkflowForIntegration(t, linearWorkflowBody))
+	return workerCfgForIntegrationWithWorkflow(t, linearWorkflowBody)
+}
+
+func workerCfgForIntegrationWithWorkflow(t *testing.T, body string) worker.Config {
+	t.Helper()
+	wf, err := workflow.Load(writeServiceWorkflowForIntegration(t, body))
 	if err != nil {
 		t.Fatalf("load workflow: %v", err)
 	}
@@ -109,6 +114,67 @@ func workerCfgForIntegration(t *testing.T) worker.Config {
 		MirrorRoot:    t.TempDir(),
 		Workflow:      wf,
 	}
+}
+
+func TestRunTaskHonorsWorkspaceRootPrecedence(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+
+	t.Run("env only", func(t *testing.T) {
+		ev := &fakeEmitter{}
+		cfg := workerCfgForIntegration(t)
+		cfg.WorkspaceRoot = filepath.Join(t.TempDir(), "env-workspaces")
+
+		if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+			t.Fatalf("runTask: %v", rterr.Err)
+		}
+
+		assertTaskWorkdir(t, cfg.WorkspaceRoot, tk)
+	})
+
+	t.Run("yaml only", func(t *testing.T) {
+		ev := &fakeEmitter{}
+		yamlRoot := filepath.Join(t.TempDir(), "yaml-workspaces")
+		cfg := workerCfgForIntegrationWithWorkspaceRoot(t, yamlRoot)
+		cfg.WorkspaceRoot = ""
+
+		if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+			t.Fatalf("runTask: %v", rterr.Err)
+		}
+
+		assertTaskWorkdir(t, yamlRoot, tk)
+	})
+
+	t.Run("yaml wins over env", func(t *testing.T) {
+		ev := &fakeEmitter{}
+		envRoot := filepath.Join(t.TempDir(), "env-workspaces")
+		yamlRoot := filepath.Join(t.TempDir(), "yaml-workspaces")
+		cfg := workerCfgForIntegrationWithWorkspaceRoot(t, yamlRoot)
+		cfg.WorkspaceRoot = envRoot
+
+		if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+			t.Fatalf("runTask: %v", rterr.Err)
+		}
+
+		assertTaskWorkdir(t, yamlRoot, tk)
+		if _, err := os.Stat(filepath.Join(envRoot, "acme", "demo", "linear_issue", "issue-uuid")); !os.IsNotExist(err) {
+			t.Fatalf("env workspace root should not be used when workflow workspace.root is set; stat err=%v", err)
+		}
+	})
+}
+
+func assertTaskWorkdir(t *testing.T, root string, tk task.Task) {
+	t.Helper()
+	workdir := filepath.Join(root, tk.RepoOwner, tk.RepoName, "linear_issue", tk.SourceEventID)
+	if _, err := os.Stat(filepath.Join(workdir, ".aiops", "RUN_SUMMARY.md")); err != nil {
+		t.Fatalf("expected task workspace under %q; stat RUN_SUMMARY.md: %v", workdir, err)
+	}
+}
+
+func workerCfgForIntegrationWithWorkspaceRoot(t *testing.T, root string) worker.Config {
+	t.Helper()
+	body := strings.Replace(linearWorkflowBody, "agent:\n", fmt.Sprintf("workspace:\n  root: %s\nagent:\n", root), 1)
+	return workerCfgForIntegrationWithWorkflow(t, body)
 }
 
 func writeServiceWorkflowForIntegration(t *testing.T, body string) string {
@@ -169,7 +235,7 @@ func TestRunTaskExecutesWorkspaceHooksAroundRunner(t *testing.T) {
 		}
 	}
 
-	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
 	body, err := os.ReadFile(filepath.Join(workdir, "hook.log"))
 	if err != nil {
 		t.Fatalf("read hook log: %v", err)
@@ -194,7 +260,7 @@ func TestRunTaskRendersAttemptVariable(t *testing.T) {
 	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
 		t.Fatalf("runTask: %v", rterr.Err)
 	}
-	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
 	prompt, err := os.ReadFile(filepath.Join(workdir, ".aiops", "PROMPT.md"))
 	if err != nil {
 		t.Fatalf("read rendered prompt: %v", err)
@@ -215,7 +281,7 @@ func TestRunTaskRendersFirstAttemptAsEmptyForBareAttempt(t *testing.T) {
 	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
 		t.Fatalf("runTask: %v", rterr.Err)
 	}
-	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
 	prompt, err := os.ReadFile(filepath.Join(workdir, ".aiops", "PROMPT.md"))
 	if err != nil {
 		t.Fatalf("read rendered prompt: %v", err)
@@ -236,7 +302,7 @@ func TestRunTaskLeavesFirstAttemptAbsentForDefaultFilter(t *testing.T) {
 	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
 		t.Fatalf("runTask: %v", rterr.Err)
 	}
-	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
 	prompt, err := os.ReadFile(filepath.Join(workdir, ".aiops", "PROMPT.md"))
 	if err != nil {
 		t.Fatalf("read rendered prompt: %v", err)
@@ -258,7 +324,7 @@ func TestRunTaskExposesIssueObjectToPromptTemplate(t *testing.T) {
 	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
 		t.Fatalf("runTask: %v", rterr.Err)
 	}
-	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "lin-123")
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "lin-123")
 	prompt, err := os.ReadFile(filepath.Join(workdir, ".aiops", "PROMPT.md"))
 	if err != nil {
 		t.Fatalf("read rendered prompt: %v", err)
@@ -305,7 +371,7 @@ func TestRunTaskExecutesAfterCreateHookOnRecreatedWorkspace(t *testing.T) {
 	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
 		t.Fatalf("first runTask: %v", rterr.Err)
 	}
-	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
 	if err := os.WriteFile(filepath.Join(workdir, "stale.txt"), []byte("stale"), 0o644); err != nil {
 		t.Fatalf("write stale marker: %v", err)
 	}
@@ -343,7 +409,7 @@ func TestRunTaskDoesNotExecuteAfterRunHookWhenRunnerSetupFails(t *testing.T) {
 		t.Fatal("runTask succeeded, want runner setup failure")
 	}
 
-	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
 	if body, err := os.ReadFile(filepath.Join(workdir, "hook.log")); err == nil {
 		t.Fatalf("hook log = %q, want no before_run/after_run hooks when runner setup fails", body)
 	} else if !os.IsNotExist(err) {
@@ -380,7 +446,7 @@ func TestRunTaskRunsBeforeRemoveHookWhenAfterCreateFails(t *testing.T) {
 		t.Fatal("runTask succeeded, want after_create hook failure")
 	}
 
-	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear-issue", "issue-uuid")
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
 	if _, err := os.Stat(workdir); !os.IsNotExist(err) {
 		t.Fatalf("workdir stat err = %v, want removed after after_create failure", err)
 	}
@@ -419,7 +485,7 @@ func TestAnalysisOnlyRunAllowsPlanArtifactWithoutSourceChanges(t *testing.T) {
 		t.Fatalf("runTask: %v", rterr.Err)
 	}
 
-	workdir := filepath.Join(cfg.WorkspaceRoot, tk.RepoOwner, tk.RepoName, "linear-issue", tk.SourceEventID)
+	workdir := filepath.Join(cfg.WorkspaceRoot, tk.RepoOwner, tk.RepoName, "linear_issue", tk.SourceEventID)
 	if _, err := os.Stat(filepath.Join(workdir, ".aiops", "PLAN.md")); err != nil {
 		t.Fatalf("analysis-only run should write plan artifact: %v", err)
 	}

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -161,6 +161,23 @@ func TestRunTaskHonorsWorkspaceRootPrecedence(t *testing.T) {
 			t.Fatalf("env workspace root should not be used when workflow workspace.root is set; stat err=%v", err)
 		}
 	})
+
+	t.Run("explicit yaml default wins over env", func(t *testing.T) {
+		ev := &fakeEmitter{}
+		envRoot := filepath.Join(t.TempDir(), "env-workspaces")
+		yamlRoot := defaultWorkflowWorkspaceRootForTest(t)
+		cfg := workerCfgForIntegrationWithWorkspaceRoot(t, yamlRoot)
+		cfg.WorkspaceRoot = envRoot
+
+		if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+			t.Fatalf("runTask: %v", rterr.Err)
+		}
+
+		assertTaskWorkdir(t, yamlRoot, tk)
+		if _, err := os.Stat(filepath.Join(envRoot, "acme", "demo", "linear_issue", "issue-uuid")); !os.IsNotExist(err) {
+			t.Fatalf("env workspace root should not be used when explicit workflow workspace.root equals default; stat err=%v", err)
+		}
+	})
 }
 
 func assertTaskWorkdir(t *testing.T, root string, tk task.Task) {
@@ -174,7 +191,19 @@ func assertTaskWorkdir(t *testing.T, root string, tk task.Task) {
 func workerCfgForIntegrationWithWorkspaceRoot(t *testing.T, root string) worker.Config {
 	t.Helper()
 	body := strings.Replace(linearWorkflowBody, "agent:\n", fmt.Sprintf("workspace:\n  root: %s\nagent:\n", root), 1)
+	if body == linearWorkflowBody {
+		t.Fatal("test workflow fixture no longer contains agent block insertion point")
+	}
 	return workerCfgForIntegrationWithWorkflow(t, body)
+}
+
+func defaultWorkflowWorkspaceRootForTest(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("user home dir: %v", err)
+	}
+	return filepath.Join(home, "aiops-workspaces")
 }
 
 func writeServiceWorkflowForIntegration(t *testing.T, body string) string {

--- a/internal/worker/workspace_root.go
+++ b/internal/worker/workspace_root.go
@@ -1,0 +1,15 @@
+package worker
+
+import (
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func EffectiveWorkspaceRoot(cfg Config, wcfg workflow.Config) string {
+	root := strings.TrimSpace(wcfg.Workspace.Root)
+	if wcfg.Workspace.RootSet() && root != "" {
+		return root
+	}
+	return cfg.WorkspaceRoot
+}

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -90,6 +90,11 @@ type WorkspaceConfig struct {
 	Root       string         `yaml:"root" json:"root"`
 	Hooks      WorkspaceHooks `yaml:"hooks" json:"hooks"`
 	hookFields HookFieldPresence
+	rootSet    bool
+}
+
+func (w WorkspaceConfig) RootSet() bool {
+	return w.rootSet
 }
 
 type WorkspaceHooks struct {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -36,11 +36,13 @@ func Load(path string) (*Workflow, error) {
 		logUnknownTopLevelKeys(frontBytes)
 		hookFields := hookFieldPresence(frontBytes, "hooks")
 		legacyHookFields := hookFieldPresence(frontBytes, "workspace", "hooks")
+		workspaceRootSet := hasNestedKey(frontBytes, "workspace", "root")
 		if err := yaml.Unmarshal(frontBytes, &cfg); err != nil {
 			return nil, fmt.Errorf("parse workflow front matter: %w", err)
 		}
 		cfg.hookFields = hookFields
 		cfg.Workspace.hookFields = legacyHookFields
+		cfg.Workspace.rootSet = workspaceRootSet
 		if hookFields.TimeoutMs {
 			cfg.hooksTimeoutDefaulted = false
 		}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -167,9 +167,15 @@ func issueWorkspaceKey(t task.Task) string {
 	sourceType := strings.TrimSpace(t.SourceType)
 	sourceEventID := strings.TrimSpace(t.SourceEventID)
 	if sourceType != "" && sourceEventID != "" {
-		return filepath.Join(sourceType, SanitizeComponent(sourceEventID))
+		return filepath.Join(SanitizeSourceType(sourceType), SanitizeComponent(sourceEventID))
 	}
 	return SanitizeComponent(t.ID)
+}
+
+// SanitizeSourceType returns a filesystem-safe tracker source component while
+// preserving underscores used by SPEC source types such as linear_issue.
+func SanitizeSourceType(s string) string {
+	return sanitizeWithUnderscore(s)
 }
 
 // PrepareGitWorkspace materialises a per-issue workspace by adding a fresh
@@ -908,11 +914,19 @@ func SanitizeComponent(s string) string {
 }
 
 func sanitize(s string) string {
+	return sanitizeComponent(s, false)
+}
+
+func sanitizeWithUnderscore(s string) string {
+	return sanitizeComponent(s, true)
+}
+
+func sanitizeComponent(s string, preserveUnderscore bool) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	inSeparator := false
 	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || (preserveUnderscore && r == '_') {
 			b.WriteRune(r)
 			inSeparator = false
 			continue

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -164,8 +164,10 @@ func (m *Manager) PathFor(t task.Task) string {
 }
 
 func issueWorkspaceKey(t task.Task) string {
-	if strings.TrimSpace(t.SourceType) != "" && strings.TrimSpace(t.SourceEventID) != "" {
-		return filepath.Join(SanitizeComponent(t.SourceType), SanitizeComponent(t.SourceEventID))
+	sourceType := strings.TrimSpace(t.SourceType)
+	sourceEventID := strings.TrimSpace(t.SourceEventID)
+	if sourceType != "" && sourceEventID != "" {
+		return filepath.Join(sourceType, SanitizeComponent(sourceEventID))
 	}
 	return SanitizeComponent(t.ID)
 }

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -257,6 +257,12 @@ func TestPathForUsesStableSanitizedIssueIdentifier(t *testing.T) {
 	if got, want := mgr.PathFor(first), filepath.Join("/workspaces", "acme", "demo", "linear_issue", "issue-abc-123-needs-fix"); got != want {
 		t.Fatalf("PathFor() = %q, want %q", got, want)
 	}
+
+	unsafeSource := first
+	unsafeSource.SourceType = "../Linear Issue//Needs_Safety"
+	if got, want := mgr.PathFor(unsafeSource), filepath.Join("/workspaces", "acme", "demo", "linear-issue-needs_safety", "issue-abc-123-needs-fix"); got != want {
+		t.Fatalf("PathFor() unsafe source type = %q, want %q", got, want)
+	}
 	collidingOwner := first
 	collidingOwner.RepoOwner = "acme-demo"
 	collidingOwner.RepoName = ""

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -254,7 +254,7 @@ func TestPathForUsesStableSanitizedIssueIdentifier(t *testing.T) {
 	second.ID = "tsk-second"
 	second.WorkBranch = "ai/tsk-second"
 
-	if got, want := mgr.PathFor(first), filepath.Join("/workspaces", "acme", "demo", "linear-issue", "issue-abc-123-needs-fix"); got != want {
+	if got, want := mgr.PathFor(first), filepath.Join("/workspaces", "acme", "demo", "linear_issue", "issue-abc-123-needs-fix"); got != want {
 		t.Fatalf("PathFor() = %q, want %q", got, want)
 	}
 	collidingOwner := first


### PR DESCRIPTION
## Summary
- Honor explicit workflow `workspace.root` during startup reconciliation and task execution, using `WORKSPACE_ROOT` only as fallback.
- Preserve tracker source type directory names such as `linear_issue` in per-issue workspace paths while still sanitizing event IDs.
- Document runtime workspace precedence and record the Kanban throughput/worktree migration plan.

Closes #149

## Test Plan
- `/home/pi/.local/go1.25.10/bin/go test ./cmd/worker ./internal/worker ./internal/workspace -count=1`
- `/home/pi/.local/go1.25.10/bin/go test ./... -count=1`

## Automation safety notes
- Heartbeat remains paused until this PR passes CI/review and the shared checkout is restored clean.
- The local Hermes precheck currently reports `shared_workspace_blocked_reconciliation` for #149 rather than dispatching more implementation work.
