### PR TITLE
Fix Codex app-server request handling

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -26,6 +26,7 @@ type CodexAppServerRunner struct{}
 
 const (
 	codexAppServerOutputPath = ".aiops/CODEX_APP_SERVER_OUTPUT.txt"
+	nonInteractiveInputReply = "This is a non-interactive session. Operator input is unavailable."
 )
 
 func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error) {
@@ -155,6 +156,7 @@ type appServerClient struct {
 	turnTimeoutMs       int
 	readTimeoutMs       int
 	stallTimeoutMs      int
+	approvalPolicy      any
 	lastTerminal        time.Time
 }
 
@@ -167,6 +169,7 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	c.turnTimeoutMs = in.Workflow.Config.Codex.TurnTimeoutMs
 	c.readTimeoutMs = in.Workflow.Config.Codex.ReadTimeoutMs
 	c.stallTimeoutMs = in.Workflow.Config.Codex.StallTimeoutMs
+	c.approvalPolicy = in.Workflow.Config.Codex.ApprovalPolicy
 	if _, err := c.request(ctx, "initialize", map[string]any{
 		"capabilities": map[string]any{"experimentalApi": true},
 		"clientInfo": map[string]any{
@@ -435,9 +438,10 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 				c.lastTerminal = time.Now()
 			default:
 				if _, ok := msg["id"]; ok {
-					if err := c.replyUnsupportedServerRequest(msg); err != nil {
+					if err := c.replyServerRequest(msg); err != nil {
 						return err
 					}
+					c.lastTerminal = time.Now()
 					continue
 				}
 				if c.stallTimeoutMs > 0 {
@@ -532,33 +536,97 @@ func toSnakeCase(s string) string {
 	return b.String()
 }
 
-func (c *appServerClient) replyUnsupportedServerRequest(msg map[string]any) error {
+func (c *appServerClient) replyServerRequest(msg map[string]any) error {
 	method, _ := msg["method"].(string)
-	if result, ok := protocolValidApprovalResult(method, msg); ok {
+	if result, ok := protocolServerRequestResult(method, msg, c.approvalPolicy); ok {
 		return c.send(map[string]any{"jsonrpc": "2.0", "id": msg["id"], "result": result})
 	}
-
-	result, err := dynamicToolResult(false, "unsupported server request: "+method)
-	if err != nil {
-		return err
-	}
-	var payload any
-	if err := json.Unmarshal([]byte(result), &payload); err != nil {
-		payload = map[string]any{"success": false, "output": result}
-	}
-	return c.send(map[string]any{"jsonrpc": "2.0", "id": msg["id"], "result": payload})
+	return c.sendJSONRPCError(msg["id"], -32601, "Method not found: "+method)
 }
 
-func protocolValidApprovalResult(method string, msg map[string]any) (map[string]any, bool) {
+func (c *appServerClient) sendJSONRPCError(id any, code int, message string) error {
+	return c.send(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	})
+}
+
+func protocolServerRequestResult(method string, msg map[string]any, approvalPolicy any) (map[string]any, bool) {
 	switch method {
 	case "item/commandExecution/requestApproval", "item/fileChange/requestApproval":
-		return map[string]any{"decision": "acceptForSession"}, true
+		if autoApproveRequest(method, approvalPolicy) {
+			return map[string]any{"decision": "acceptForSession"}, true
+		}
+		return map[string]any{"decision": "decline"}, true
 	case "item/permissions/requestApproval":
-		params, _ := msg["params"].(map[string]any)
-		return map[string]any{"permissions": params["permissions"]}, true
+		if autoApproveRequest(method, approvalPolicy) {
+			params, _ := msg["params"].(map[string]any)
+			return map[string]any{"permissions": params["permissions"]}, true
+		}
+		return map[string]any{"permissions": map[string]any{}}, true
+	case "execCommandApproval", "applyPatchApproval":
+		if autoApproveRequest(method, approvalPolicy) {
+			return map[string]any{"decision": "approved_for_session"}, true
+		}
+		return map[string]any{"decision": "denied"}, true
+	case "item/tool/requestUserInput":
+		return protocolUserInputResult(msg), true
+	case "mcpServer/elicitation/request":
+		return map[string]any{"action": "decline"}, true
 	default:
 		return nil, false
 	}
+}
+
+func autoApproveRequest(method string, approvalPolicy any) bool {
+	if policy, ok := approvalPolicy.(string); ok {
+		return strings.EqualFold(strings.TrimSpace(policy), "on-failure")
+	}
+	policy, ok := approvalPolicy.(map[string]any)
+	if !ok {
+		return false
+	}
+	if granular, ok := policy["granular"].(map[string]any); ok {
+		return !approvalRuleRequiresReview(granular, method)
+	}
+	if reject, ok := policy["reject"].(map[string]any); ok {
+		return !approvalRuleRequiresReview(reject, method)
+	}
+	return false
+}
+
+func approvalRuleRequiresReview(rules map[string]any, method string) bool {
+	if method == "item/permissions/requestApproval" {
+		return approvalRuleEnabled(rules, "request_permissions") ||
+			approvalRuleEnabled(rules, "sandbox_approval") ||
+			approvalRuleEnabled(rules, "rules")
+	}
+	return approvalRuleEnabled(rules, "sandbox_approval") || approvalRuleEnabled(rules, "rules")
+}
+
+func approvalRuleEnabled(rules map[string]any, key string) bool {
+	enabled, _ := rules[key].(bool)
+	return enabled
+}
+
+func protocolUserInputResult(msg map[string]any) map[string]any {
+	params, _ := msg["params"].(map[string]any)
+	questions, _ := params["questions"].([]any)
+	answers := make(map[string]any)
+	for _, question := range questions {
+		q, _ := question.(map[string]any)
+		id, _ := q["id"].(string)
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		answers[id] = map[string]any{"answers": []string{nonInteractiveInputReply}}
+	}
+	return map[string]any{"answers": answers}
 }
 
 func (c *appServerClient) handleNotification(msg map[string]any) {

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -414,7 +414,6 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 			}
 			return err
 		}
-		c.lastTerminal = time.Now()
 		if method, _ := msg["method"].(string); method != "" {
 			switch method {
 			case "turn/completed":
@@ -441,7 +440,6 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 					if err := c.replyServerRequest(msg); err != nil {
 						return err
 					}
-					c.lastTerminal = time.Now()
 					continue
 				}
 				if c.stallTimeoutMs > 0 {
@@ -576,7 +574,7 @@ func protocolServerRequestResult(method string, msg map[string]any, approvalPoli
 	case "item/tool/requestUserInput":
 		return protocolUserInputResult(msg), true
 	case "mcpServer/elicitation/request":
-		return map[string]any{"action": "decline"}, true
+		return map[string]any{"action": "decline", "content": nil}, true
 	default:
 		return nil, false
 	}

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -583,7 +583,12 @@ func protocolServerRequestResult(method string, msg map[string]any, approvalPoli
 
 func autoApproveRequest(method string, approvalPolicy any) bool {
 	if policy, ok := approvalPolicy.(string); ok {
-		return strings.EqualFold(strings.TrimSpace(policy), "on-failure")
+		switch strings.ToLower(strings.TrimSpace(policy)) {
+		case "never", "on-failure":
+			return true
+		default:
+			return false
+		}
 	}
 	policy, ok := approvalPolicy.(map[string]any)
 	if !ok {

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -591,7 +591,7 @@ func autoApproveRequest(method string, approvalPolicy any) bool {
 		return false
 	}
 	if granular, ok := policy["granular"].(map[string]any); ok {
-		return !approvalRuleRequiresReview(granular, method)
+		return approvalRuleAllowsRequest(granular, method)
 	}
 	if reject, ok := policy["reject"].(map[string]any); ok {
 		return !approvalRuleRequiresReview(reject, method)
@@ -604,6 +604,13 @@ func approvalRuleRequiresReview(rules map[string]any, method string) bool {
 		return approvalRuleEnabled(rules, "request_permissions") ||
 			approvalRuleEnabled(rules, "sandbox_approval") ||
 			approvalRuleEnabled(rules, "rules")
+	}
+	return approvalRuleEnabled(rules, "sandbox_approval") || approvalRuleEnabled(rules, "rules")
+}
+
+func approvalRuleAllowsRequest(rules map[string]any, method string) bool {
+	if method == "item/permissions/requestApproval" {
+		return approvalRuleEnabled(rules, "request_permissions")
 	}
 	return approvalRuleEnabled(rules, "sandbox_approval") || approvalRuleEnabled(rules, "rules")
 }

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -440,6 +440,7 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 					if err := c.replyServerRequest(msg); err != nil {
 						return err
 					}
+					c.lastTerminal = time.Now()
 					continue
 				}
 				if c.stallTimeoutMs > 0 {
@@ -568,9 +569,9 @@ func protocolServerRequestResult(method string, msg map[string]any, approvalPoli
 		return map[string]any{"permissions": map[string]any{}}, true
 	case "execCommandApproval", "applyPatchApproval":
 		if autoApproveRequest(method, approvalPolicy) {
-			return map[string]any{"decision": "approved_for_session"}, true
+			return map[string]any{"decision": "allow"}, true
 		}
-		return map[string]any{"decision": "denied"}, true
+		return map[string]any{"decision": "deny"}, true
 	case "item/tool/requestUserInput":
 		return protocolUserInputResult(msg), true
 	case "mcpServer/elicitation/request":

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -866,7 +867,7 @@ for line in sys.stdin:
 	}
 }
 
-func TestCodexAppServerRunnerServerRequestsDoNotMaskStallTimeout(t *testing.T) {
+func TestCodexAppServerRunnerServerRequestsRefreshStallClock(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json, time
 for line in sys.stdin:
@@ -891,9 +892,12 @@ for line in sys.stdin:
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	_, err := (CodexAppServerRunner{}).Run(ctx, in)
-	if !IsStall(err) {
-		t.Fatalf("Run error = %T %[1]v, want server request not to mask stall timeout", err)
+	res, err := (CodexAppServerRunner{}).Run(ctx, in)
+	if err != nil {
+		t.Fatalf("Run: %v, want server request activity to avoid stall timeout", err)
+	}
+	if res.Summary != "completed after server request" {
+		t.Fatalf("Summary = %q, want completion after server request", res.Summary)
 	}
 }
 
@@ -1057,6 +1061,27 @@ for line in sys.stdin:
 		if !strings.Contains(string(stdin), want) {
 			t.Fatalf("stdin missing %s in policy-limited approval responses: %s", want, stdin)
 		}
+	}
+}
+
+func TestProtocolServerRequestResultLegacyApprovalMethodsUseProtocolDecisions(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		method     string
+		policy     any
+		wantResult map[string]any
+	}{
+		{name: "exec allow", method: "execCommandApproval", policy: "on-failure", wantResult: map[string]any{"decision": "allow"}},
+		{name: "exec deny", method: "execCommandApproval", policy: "never", wantResult: map[string]any{"decision": "deny"}},
+		{name: "apply allow", method: "applyPatchApproval", policy: "on-failure", wantResult: map[string]any{"decision": "allow"}},
+		{name: "apply deny", method: "applyPatchApproval", policy: "never", wantResult: map[string]any{"decision": "deny"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := protocolServerRequestResult(tc.method, map[string]any{}, tc.policy)
+			if !ok || !reflect.DeepEqual(got, tc.wantResult) {
+				t.Fatalf("protocolServerRequestResult(%q) = %#v, %v; want %#v, true", tc.method, got, ok, tc.wantResult)
+			}
+		})
 	}
 }
 

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -866,7 +866,7 @@ for line in sys.stdin:
 	}
 }
 
-func TestCodexAppServerRunnerServerRequestsRefreshStallClock(t *testing.T) {
+func TestCodexAppServerRunnerServerRequestsDoNotMaskStallTimeout(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json, time
 for line in sys.stdin:
@@ -887,16 +887,13 @@ for line in sys.stdin:
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
-	in.Workflow.Config.Codex.StallTimeoutMs = 1000
+	in.Workflow.Config.Codex.StallTimeoutMs = 100
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	res, err := (CodexAppServerRunner{}).Run(ctx, in)
-	if err != nil {
-		t.Fatalf("Run: %v, want server request to count as activity", err)
-	}
-	if res.Summary != "completed after server request" {
-		t.Fatalf("Summary = %q, want completion after server request", res.Summary)
+	_, err := (CodexAppServerRunner{}).Run(ctx, in)
+	if !IsStall(err) {
+		t.Fatalf("Run error = %T %[1]v, want server request not to mask stall timeout", err)
 	}
 }
 
@@ -1114,6 +1111,9 @@ func TestProtocolServerRequestResultApprovalPolicyMatrix(t *testing.T) {
 	elicitationResult, ok := protocolServerRequestResult("mcpServer/elicitation/request", map[string]any{}, "never")
 	if !ok || elicitationResult["action"] != "decline" {
 		t.Fatalf("elicitation result = %#v, %v; want decline action", elicitationResult, ok)
+	}
+	if _, ok := elicitationResult["content"]; !ok || elicitationResult["content"] != nil {
+		t.Fatalf("elicitation content = %#v, present %v; want explicit null content", elicitationResult["content"], ok)
 	}
 }
 

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1072,9 +1072,9 @@ func TestProtocolServerRequestResultLegacyApprovalMethodsUseProtocolDecisions(t 
 		wantResult map[string]any
 	}{
 		{name: "exec allow", method: "execCommandApproval", policy: "on-failure", wantResult: map[string]any{"decision": "allow"}},
-		{name: "exec deny", method: "execCommandApproval", policy: "never", wantResult: map[string]any{"decision": "deny"}},
+		{name: "exec never auto-approves", method: "execCommandApproval", policy: "never", wantResult: map[string]any{"decision": "allow"}},
 		{name: "apply allow", method: "applyPatchApproval", policy: "on-failure", wantResult: map[string]any{"decision": "allow"}},
-		{name: "apply deny", method: "applyPatchApproval", policy: "never", wantResult: map[string]any{"decision": "deny"}},
+		{name: "apply never auto-approves", method: "applyPatchApproval", policy: "never", wantResult: map[string]any{"decision": "allow"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, ok := protocolServerRequestResult(tc.method, map[string]any{}, tc.policy)
@@ -1100,7 +1100,7 @@ func TestProtocolServerRequestResultApprovalPolicyMatrix(t *testing.T) {
 		wantModernDecision string
 		wantPermissions    bool
 	}{
-		{name: "never", policy: "never", wantModernDecision: "decline"},
+		{name: "never", policy: "never", wantModernDecision: "acceptForSession", wantPermissions: true},
 		{name: "on-request", policy: "on-request", wantModernDecision: "decline"},
 		{name: "untrusted", policy: "untrusted", wantModernDecision: "decline"},
 		{name: "on-failure", policy: "on-failure", wantModernDecision: "acceptForSession", wantPermissions: true},

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -26,9 +26,9 @@ func appServerInput(workdir string) RunInput {
 				TurnSandboxPolicy: map[string]any{
 					"mode": "workspace-write",
 				},
-				TurnTimeoutMs:  1000,
-				ReadTimeoutMs:  1000,
-				StallTimeoutMs: 1000,
+				TurnTimeoutMs:  3000,
+				ReadTimeoutMs:  3000,
+				StallTimeoutMs: 3000,
 			},
 		}},
 		Workdir: workdir,
@@ -620,7 +620,7 @@ for line in sys.stdin:
 `)
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
-	in.Workflow.Config.Codex.ReadTimeoutMs = 100
+	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
 	in.Workflow.Config.Codex.StallTimeoutMs = 250
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -815,8 +815,8 @@ for line in sys.stdin:
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
-	in.Workflow.Config.Codex.StallTimeoutMs = 50
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	in.Workflow.Config.Codex.StallTimeoutMs = 1000
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	res, err := (CodexAppServerRunner{}).Run(ctx, in)
@@ -841,20 +841,20 @@ for line in sys.stdin:
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
         print(json.dumps({'method': 'item/tool/call', 'params': {'call_id': 'call-1', 'name': 'gitea_issue_labels', 'arguments': {'owner': 'o', 'repo': 'r', 'number': 1}}}), flush=True)
     elif msg.get('method') == 'item/tool/call/output':
-        time.sleep(0.03)
+        time.sleep(0.08)
         print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'completed after tool'}}), flush=True)
         break
 `)
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
-	in.Workflow.Config.Codex.StallTimeoutMs = 50
+	in.Workflow.Config.Codex.StallTimeoutMs = 1000
 	in.Workflow.Config.Tracker.Kind = "gitea"
 	in.Workflow.Config.Tracker.APIKey = "token"
 	in.Workflow.Config.Tracker.ProjectSlug = "http://127.0.0.1:1"
 	in.Workflow.Config.Repo.Owner = "o"
 	in.Workflow.Config.Repo.Name = "r"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	res, err := (CodexAppServerRunner{}).Run(ctx, in)
@@ -877,18 +877,18 @@ for line in sys.stdin:
         print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
     elif msg.get('method') == 'turn/start':
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
-        time.sleep(0.03)
+        time.sleep(0.08)
         print(json.dumps({'jsonrpc': '2.0', 'id': 99, 'method': 'server/needs-help', 'params': {}}), flush=True)
     elif msg.get('id') == 99:
-        time.sleep(0.03)
+        time.sleep(0.08)
         print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'completed after server request'}}), flush=True)
         break
 `)
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
-	in.Workflow.Config.Codex.StallTimeoutMs = 50
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	in.Workflow.Config.Codex.StallTimeoutMs = 1000
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	res, err := (CodexAppServerRunner{}).Run(ctx, in)
@@ -974,8 +974,16 @@ for line in sys.stdin:
         pass
 `)
 	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.ApprovalPolicy = map[string]any{
+		"granular": map[string]any{
+			"sandbox_approval":    false,
+			"rules":               false,
+			"request_permissions": false,
+		},
+	}
 
-	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -993,7 +1001,128 @@ for line in sys.stdin:
 	}
 }
 
-func TestCodexAppServerRunnerRepliesToUnsupportedServerRequests(t *testing.T) {
+func TestCodexAppServerRunnerDeclinesApprovalsWhenPolicyRequiresReview(t *testing.T) {
+	binDir := codexAppServerStubScript(t, `
+import json
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+approval_methods = [
+    ('approval-command', 'item/commandExecution/requestApproval', {'command': 'go test ./...'}, {'decision': 'decline'}),
+    ('approval-file', 'item/fileChange/requestApproval', {'path': 'main.go'}, {'decision': 'decline'}),
+    (
+        'approval-permissions',
+        'item/permissions/requestApproval',
+        {'permissions': {'filesystem': {'write': True}, 'network': {'enabled': True}}},
+        {'permissions': {}},
+    ),
+]
+pending = list(approval_methods)
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        req_id, method, params, _expected = pending.pop(0)
+        print(json.dumps({'jsonrpc': '2.0', 'id': req_id, 'method': method, 'params': params}), flush=True)
+    elif msg.get('id', '').startswith('approval-'):
+        req_id = msg['id']
+        expected = next(item[3] for item in approval_methods if item[0] == req_id)
+        if msg.get('result') != expected:
+            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'unexpected approval response', 'got': msg.get('result'), 'want': expected}}), flush=True)
+            break
+        if pending:
+            req_id, method, params, _expected = pending.pop(0)
+            print(json.dumps({'jsonrpc': '2.0', 'id': req_id, 'method': method, 'params': params}), flush=True)
+        else:
+            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'review policy enforced'}}), flush=True)
+            break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.ApprovalPolicy = map[string]any{
+		"reject": map[string]any{
+			"sandbox_approval": true,
+			"rules":            true,
+		},
+	}
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "review policy enforced" {
+		t.Fatalf("Summary = %q, want review policy enforced", res.Summary)
+	}
+	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"decision":"decline"`, `"permissions":{}`} {
+		if !strings.Contains(string(stdin), want) {
+			t.Fatalf("stdin missing %s in policy-limited approval responses: %s", want, stdin)
+		}
+	}
+}
+
+func TestProtocolServerRequestResultApprovalPolicyMatrix(t *testing.T) {
+	request := map[string]any{
+		"params": map[string]any{
+			"permissions": map[string]any{
+				"filesystem": map[string]any{"write": true},
+				"network":    map[string]any{"enabled": true},
+			},
+		},
+	}
+	cases := []struct {
+		name               string
+		policy             any
+		wantModernDecision string
+		wantPermissions    bool
+	}{
+		{name: "never", policy: "never", wantModernDecision: "decline"},
+		{name: "on-request", policy: "on-request", wantModernDecision: "decline"},
+		{name: "untrusted", policy: "untrusted", wantModernDecision: "decline"},
+		{name: "on-failure", policy: "on-failure", wantModernDecision: "acceptForSession", wantPermissions: true},
+		{name: "reject legacy map", policy: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true}}, wantModernDecision: "decline"},
+		{name: "granular review disabled", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": false}}, wantModernDecision: "acceptForSession", wantPermissions: true},
+		{name: "granular permission review", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": true}}, wantModernDecision: "acceptForSession"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, method := range []string{"item/commandExecution/requestApproval", "item/fileChange/requestApproval"} {
+				result, ok := protocolServerRequestResult(method, request, tc.policy)
+				if !ok || result["decision"] != tc.wantModernDecision {
+					t.Fatalf("%s result = %#v, %v; want decision %q", method, result, ok, tc.wantModernDecision)
+				}
+			}
+			result, ok := protocolServerRequestResult("item/permissions/requestApproval", request, tc.policy)
+			if !ok {
+				t.Fatal("permissions approval was not handled")
+			}
+			permissions, _ := result["permissions"].(map[string]any)
+			if got := len(permissions) > 0; got != tc.wantPermissions {
+				t.Fatalf("permissions granted = %v with result %#v, want %v", got, result, tc.wantPermissions)
+			}
+		})
+	}
+	inputResult, ok := protocolServerRequestResult("item/tool/requestUserInput", map[string]any{
+		"params": map[string]any{"questions": []any{map[string]any{"id": "q1"}}},
+	}, "on-request")
+	if !ok || inputResult["answers"] == nil {
+		t.Fatalf("user input result = %#v, %v; want answers payload", inputResult, ok)
+	}
+	elicitationResult, ok := protocolServerRequestResult("mcpServer/elicitation/request", map[string]any{}, "never")
+	if !ok || elicitationResult["action"] != "decline" {
+		t.Fatalf("elicitation result = %#v, %v; want decline action", elicitationResult, ok)
+	}
+}
+
+func TestCodexAppServerRunnerRepliesToUnknownServerRequestsWithMethodNotFound(t *testing.T) {
 	binDir := codexAppServerStubScript(t, `
 import json
 log=open(os.environ['CODEX_STDIN_LOG'], 'w')
@@ -1006,13 +1135,13 @@ for line in sys.stdin:
         print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
     elif msg.get('method') == 'turn/start':
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
-        print(json.dumps({'jsonrpc': '2.0', 'id': 'approval-1', 'method': 'approval/request', 'params': {'reason': 'need approval'}}), flush=True)
-    elif msg.get('id') == 'approval-1':
-        result = msg.get('result', {})
-        if result.get('success') is not False or 'unsupported server request' not in result.get('output', ''):
-            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'unexpected unsupported request response', 'got': result}}), flush=True)
+        print(json.dumps({'jsonrpc': '2.0', 'id': 'unknown-1', 'method': 'server/needs-help', 'params': {'reason': 'need approval'}}), flush=True)
+    elif msg.get('id') == 'unknown-1':
+        err = msg.get('error', {})
+        if err.get('code') != -32601 or 'server/needs-help' not in err.get('message', ''):
+            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'unexpected unknown request response', 'got': msg}}), flush=True)
             break
-        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'request rejected'}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'unknown request rejected'}}), flush=True)
         break
     elif msg.get('method') == 'initialized':
         pass
@@ -1023,14 +1152,14 @@ for line in sys.stdin:
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if res.Summary != "request rejected" {
-		t.Fatalf("Summary = %q, want request rejected", res.Summary)
+	if res.Summary != "unknown request rejected" {
+		t.Fatalf("Summary = %q, want unknown request rejected", res.Summary)
 	}
 	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(stdin), `"id":"approval-1"`) || !strings.Contains(string(stdin), "unsupported server request") {
-		t.Fatalf("stdin did not include unsupported server request response: %s", stdin)
+	if !strings.Contains(string(stdin), `"code":-32601`) || strings.Contains(string(stdin), `"success":false`) {
+		t.Fatalf("stdin did not include JSON-RPC method-not-found error: %s", stdin)
 	}
 }

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -975,13 +975,7 @@ for line in sys.stdin:
 `)
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
-	in.Workflow.Config.Codex.ApprovalPolicy = map[string]any{
-		"granular": map[string]any{
-			"sandbox_approval":    false,
-			"rules":               false,
-			"request_permissions": false,
-		},
-	}
+	in.Workflow.Config.Codex.ApprovalPolicy = "on-failure"
 
 	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
 	if err != nil {
@@ -1089,8 +1083,9 @@ func TestProtocolServerRequestResultApprovalPolicyMatrix(t *testing.T) {
 		{name: "untrusted", policy: "untrusted", wantModernDecision: "decline"},
 		{name: "on-failure", policy: "on-failure", wantModernDecision: "acceptForSession", wantPermissions: true},
 		{name: "reject legacy map", policy: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true}}, wantModernDecision: "decline"},
-		{name: "granular review disabled", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": false}}, wantModernDecision: "acceptForSession", wantPermissions: true},
-		{name: "granular permission review", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": true}}, wantModernDecision: "acceptForSession"},
+		{name: "granular denies all disabled allowances", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": false}}, wantModernDecision: "decline"},
+		{name: "granular allows sandbox only", policy: map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "request_permissions": false}}, wantModernDecision: "acceptForSession"},
+		{name: "granular allows permissions only", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": true}}, wantModernDecision: "decline", wantPermissions: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #121

## Summary

- Pass `codex.approval_policy` into the Codex app-server server-request handler.
- Stop unconditional approval of command, file-change, and permission requests; review-required policies now decline or grant an empty permission set, while explicit non-review policies can still approve.
- Return app-server protocol-shaped payloads for known server-initiated requests (`requestApproval`, user input, MCP elicitation), and JSON-RPC `-32601` errors for truly unknown methods.
- Refresh the stall clock after replying to server-initiated requests.

## Tests

- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test ./internal/runner -run 'Test(CodexAppServerRunner(DeclinesApprovalsWhenPolicyRequiresReview|RepliesToUnknownServerRequestsWithMethodNotFound|RepliesToApprovalRequestsWithProtocolValidResults)|ProtocolServerRequestResultApprovalPolicyMatrix)' -count=1`
- `go test -race -covermode=atomic ./internal/runner -run 'TestCodexAppServerRunner(ReadTimeoutDoesNotPreemptStallBudget|ActivityWithinStallWindowKeepsTurnAlive|DynamicToolCallsRefreshStallClock|ServerRequestsRefreshStallClock|SendsInitializeThreadAndTurn)' -count=1`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- `git diff --check`

`go test -race -covermode=atomic ./...` was run on Darwin and still fails only in the existing Linux sandbox tests under `internal/runner/sandbox_test.go`, where bubblewrap/firejail tests expect Linux host behavior.

## Local Review Gates

- Codex JSON review: `{"blocking_findings":[]}`
- Claude Code JSON review: `{"blocking_findings":[]}`
