### PR TITLE
chore(runner): remove unused gitea label replacement helper

### DIFF
--- a/.aiops/RUN_SUMMARY.md
+++ b/.aiops/RUN_SUMMARY.md
@@ -1,0 +1,28 @@
+# RUN_SUMMARY for Issue #127
+
+## What changed
+- Removed dead code `replaceAIOpsLabels` from `internal/runner/gitea_tools.go`.
+- Kept the active label update path intact (`giteaIssueLabelsProxy.call` continues to use incremental add/delete semantics via `addIssueLabels`, `currentIssueLabels`, `deleteIssueLabel`, and helper checks).
+
+## Why
+- Issue #127 identified `replaceAIOpsLabels` as an unreachable leftover from an earlier full-replacement label strategy and requested either deletion or explicit reintegration.
+- No call sites reference it anywhere in the tree, so keeping it added unnecessary, security-adjacent audit surface for a token-bearing path without behavior.
+
+## Verification
+### Focused checks
+- `go test ./internal/runner -run 'TestGiteaIssueLabels' -count=1`
+  - Passed.
+
+### Required project commands
+- `gofmt -l $(git ls-files '*.go')`
+  - No output.
+- `go mod tidy && git diff --exit-code -- go.mod go.sum`
+  - Passed.
+- `go test -race -covermode=atomic ./...`
+  - Failed in this environment due existing unrelated baseline issues (e.g., `internal/runner` sandbox/timeout tests, plus a pre-existing `cmd/worker` path-resolution expectation mismatch).
+- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
+  - Passed.
+
+### Local review gates
+- Codex review (`codex exec --ephemeral ...`) returned: `{"blocking_findings":[]}`.
+- Claude review (`claude -p ...`) returned JSON with `.structured_output.blocking_findings = []`.

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -243,36 +243,6 @@ func validGiteaStateLabels() map[string]struct{} {
 	}
 }
 
-func replaceAIOpsLabels(currentLabels, desiredStateLabels []string) []string {
-	labels := make([]string, 0, len(currentLabels)+len(desiredStateLabels))
-	seen := make(map[string]struct{}, len(currentLabels)+len(desiredStateLabels))
-	for _, label := range currentLabels {
-		trimmed := strings.TrimSpace(label)
-		if trimmed == "" || strings.HasPrefix(strings.ToLower(trimmed), "aiops/") {
-			continue
-		}
-		key := strings.ToLower(trimmed)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		labels = append(labels, trimmed)
-	}
-	for _, label := range desiredStateLabels {
-		trimmed := strings.TrimSpace(label)
-		key := strings.ToLower(trimmed)
-		if trimmed == "" {
-			continue
-		}
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		labels = append(labels, trimmed)
-	}
-	return labels
-}
-
 func containsLabelFold(labels []string, label string) bool {
 	want := strings.ToLower(strings.TrimSpace(label))
 	for _, candidate := range labels {


### PR DESCRIPTION
### Issue
- Fixes #127

### Summary
- Removed dead helper `replaceAIOpsLabels` from `internal/runner/gitea_tools.go` in the Gitea label proxy path.
- No functional behavior was changed; the active label-update flow still uses incremental add/delete operations.
- Added `.aiops/RUN_SUMMARY.md` per repository issue workflow requirement.

### Verification
- `go test ./internal/runner -run 'TestGiteaIssueLabels' -count=1` (pass)
- `gofmt -l $(git ls-files '*.go')` (pass)
- `go mod tidy && git diff --exit-code -- go.mod go.sum` (pass)
- `go test -race -covermode=atomic ./...` (fails in this environment on pre-existing tests: `internal/runner` sandbox/timeouts + `cmd/worker` startup path expectation mismatch)
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller` (pass)

### Local review gates
- Codex review: `{"blocking_findings":[]}`
- Claude review: `.structured_output.blocking_findings = []`
