### PR TITLE
fix(runner): allow GraphQL fragments in Linear tool

### DIFF
--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -282,11 +282,13 @@ func countGraphQLOperations(query string) int {
 			}
 			continue
 		case '{':
-			if depth == 0 && !operationHeader {
-				count++
+			if depth == 0 && parenDepth == 0 {
+				if !operationHeader {
+					count++
+				}
+				operationHeader = false
 			}
 			depth++
-			operationHeader = false
 			i++
 			continue
 		case '}':

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -331,6 +331,8 @@ func countGraphQLOperations(query string) int {
 				case "query", "mutation", "subscription":
 					count++
 					operationHeader = true
+				case "fragment":
+					operationHeader = true
 				}
 			}
 			continue

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -244,6 +244,41 @@ func TestLinearGraphQLRejectsMultipleAnonymousOperationsWithoutHTTPRequest(t *te
 	}
 }
 
+func TestCountGraphQLOperationsIgnoresFragmentDefinitions(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{
+			name:  "named query with fragment",
+			query: `query Q { ...F } fragment F on T { id }`,
+			want:  1,
+		},
+		{
+			name:  "named mutation with fragment",
+			query: `mutation M { issueUpdate(id: "1", input: {}) { success } } fragment F on T { id title }`,
+			want:  1,
+		},
+		{
+			name:  "anonymous operation with fragment",
+			query: `{ viewer { ...F } } fragment F on T { id }`,
+			want:  1,
+		},
+		{
+			name:  "multiple operations still counted",
+			query: `query A { viewer { id } } query B { issue(id: "1") { id } }`,
+			want:  2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countGraphQLOperations(tc.query); got != tc.want {
+				t.Fatalf("countGraphQLOperations(%q) = %d, want %d", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLinearGraphQLAllowsSingleAnonymousOperation(t *testing.T) {
 	server := &fakeLinearGraphQLServer{}
 	httpServer := httptest.NewServer(server.handler())

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -266,6 +266,11 @@ func TestCountGraphQLOperationsIgnoresFragmentDefinitions(t *testing.T) {
 			want:  1,
 		},
 		{
+			name:  "fragment directive input object",
+			query: `query Q { ...F } fragment F on T @cache(config: { ttl: 60 }) { id }`,
+			want:  1,
+		},
+		{
 			name:  "multiple operations still counted",
 			query: `query A { viewer { id } } query B { issue(id: "1") { id } }`,
 			want:  2,

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -309,6 +309,54 @@ func TestLinearGraphQLAllowsSingleAnonymousOperation(t *testing.T) {
 	}
 }
 
+func TestLinearGraphQLAllowsSingleOperationWithFragments(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "named query",
+			query: `query Q { ...F } fragment F on Issue { id }`,
+		},
+		{
+			name:  "named mutation",
+			query: `mutation M { issueUpdate(id: "1", input: {}) { issue { ...F } } } fragment F on Issue { id }`,
+		},
+		{
+			name: "anonymous query",
+			query: `{ viewer { id } }
+fragment F on Issue { id }`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &fakeLinearGraphQLServer{}
+			httpServer := httptest.NewServer(server.handler())
+			defer httpServer.Close()
+
+			result, err := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client()}.
+				call(context.Background(), ToolCall{Query: tt.query})
+			if err != nil {
+				t.Fatalf("linear_graphql call: %v", err)
+			}
+			var payload struct {
+				Success bool `json:"success"`
+			}
+			if err := json.Unmarshal([]byte(result), &payload); err != nil {
+				t.Fatalf("result is not structured JSON: %v", err)
+			}
+			if !payload.Success {
+				t.Fatalf("success = false, want true; result=%s", result)
+			}
+			_, _, requests := server.recorded()
+			if requests != 1 {
+				t.Fatalf("server received %d requests, want 1", requests)
+			}
+		})
+	}
+}
+
 func TestLinearGraphQLAllowsOperationWordsInsideSingleOperationBody(t *testing.T) {
 	server := &fakeLinearGraphQLServer{}
 	httpServer := httptest.NewServer(server.handler())


### PR DESCRIPTION
## Summary

Closes #122.

- Treat top-level `fragment` as a GraphQL definition header in `countGraphQLOperations` without counting it as an executable operation.
- Preserve operation/fragment header state until the real top-level selection set begins, so directive argument input objects such as `@cache(config: { ttl: 60 })` do not consume the header state.
- Add regression coverage for parser counts and proxy-level `linear_graphql` calls with named query fragments, named mutation fragments, anonymous operation fragments, fragment directive input objects, and multiple-operation rejection.

## Tests

- RED on `origin/main` in `/tmp/aiops-122-red` with only the new tests applied: `go test ./internal/runner -run 'TestCountGraphQLOperationsIgnoresFragmentDefinitions|TestLinearGraphQLAllowsSingleOperationWithFragments'` failed as expected because fragment documents were counted as multiple operations and rejected before HTTP.
- GREEN on current branch: `go test ./internal/runner -run 'TestLinearGraphQLAllowsSingleOperationWithFragmentDefinitions|TestCountGraphQLOperations|TestLinearGraphQLAllowsOperationWordsInsideSingleOperationBody|TestLinearGraphQLRejectsMultipleOperationsWithoutHTTPRequest'` passed.
- `gofmt -l $(git ls-files '*.go')` passed with no output.
- `go mod tidy && git diff --exit-code -- go.mod go.sum` passed.
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller` passed.
- `go test -race -covermode=atomic ./...` was run locally on macOS and failed in existing unrelated `internal/runner` tests: the 100 ms stall-clock test exceeded budget, and Linux-only `bubblewrap` / `firejail` sandbox tests reject `darwin`.
- Existing GitHub Actions on current head are green: Go build/test, E2E Gitea mock loop, and Docker image build.

## Local Review Gates

- Codex structured local review on final diff: `{"blocking_findings":[]}`.
- Claude Code structured local review on final diff: `{"blocking_findings":[]}`. The Claude CLI wrapper used here exposed the schema payload as `structured_output`; it was valid JSON and validated locally.

## Bot Review

- Current head: `9692e32fe2389438374fd4c061c55aa47bb7e455`.
- Fresh `@codex review` after the PR update completed cleanly: https://github.com/xrf9268-hue/aiops-platform/pull/178#issuecomment-4503186594
- Thread-aware inspection shows no unresolved review threads.
