### PR TITLE
fix(runner): allow GraphQL fragments in linear tool

### DIFF
--- a/.aiops/RUN_SUMMARY.md
+++ b/.aiops/RUN_SUMMARY.md
@@ -1,0 +1,29 @@
+# Run Summary
+
+Issue: #122, `linear_graphql` rejected valid single-operation GraphQL documents when they also defined fragments.
+
+## Changes
+
+- Added a focused regression test for `countGraphQLOperations` covering:
+  - named query plus fragment definition
+  - mutation plus fragment definition
+  - anonymous operation plus fragment definition
+  - fragment definition with directive input-object arguments
+  - multiple named operations still counting as multiple operations
+- Updated the operation counter so a top-level `fragment` definition is treated as a document definition header without incrementing the operation count. This prevents the fragment selection set from being misclassified as a second anonymous operation, including when fragment directives contain input-object braces before the selection set.
+
+## Why
+
+The Symphony `linear_graphql` tool contract requires exactly one GraphQL operation per tool call. GraphQL fragment definitions are reusable document definitions, not operations, so a document with one operation and one or more fragments should pass the local single-operation guard.
+
+## Verification
+
+- `go test ./internal/runner -run TestCountGraphQLOperationsIgnoresFragmentDefinitions -count=1` failed before the production change with counts of `2` for fragment-bearing single-operation documents.
+- `go test ./internal/runner -run TestCountGraphQLOperationsIgnoresFragmentDefinitions/fragment_directive_input_object -count=1` failed before the directive brace handling change with count `2`.
+- `go test ./internal/runner -run TestCountGraphQLOperationsIgnoresFragmentDefinitions -count=1` passed after the parser fix.
+- `gofmt -l $(git ls-files '*.go')` passed with no output.
+- `go mod tidy && git diff --exit-code -- go.mod go.sum` passed.
+- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller` passed.
+- `go test -race -covermode=atomic ./...` was run. It failed in `internal/runner` on this macOS host due existing environment-sensitive failures: Linux sandbox backend tests require `bubblewrap`/`firejail`, and `TestCodexAppServerRunnerServerRequestsRefreshStallClock` exceeded its 100 ms stall budget by about 2 ms.
+
+Local review gates are recorded in the PR body.

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -282,11 +282,13 @@ func countGraphQLOperations(query string) int {
 			}
 			continue
 		case '{':
-			if depth == 0 && !operationHeader {
-				count++
+			if depth == 0 && parenDepth == 0 {
+				if !operationHeader {
+					count++
+				}
+				operationHeader = false
 			}
 			depth++
-			operationHeader = false
 			i++
 			continue
 		case '}':
@@ -330,6 +332,8 @@ func countGraphQLOperations(query string) int {
 				switch name {
 				case "query", "mutation", "subscription":
 					count++
+					operationHeader = true
+				case "fragment":
 					operationHeader = true
 				}
 			}

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -244,6 +244,47 @@ func TestLinearGraphQLRejectsMultipleAnonymousOperationsWithoutHTTPRequest(t *te
 	}
 }
 
+func TestCountGraphQLOperationsIgnoresFragmentDefinitions(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{
+			name:  "named query with fragment",
+			query: `query Q { ...F } fragment F on Issue { id }`,
+			want:  1,
+		},
+		{
+			name:  "mutation with fragment",
+			query: `mutation M { issueUpdate(id: "1", input: {}) { success issue { ...IssueFields } } } fragment IssueFields on Issue { id title }`,
+			want:  1,
+		},
+		{
+			name: "anonymous query with fragment",
+			query: `{ viewer { id } }
+fragment ViewerFields on User { id name }`,
+			want: 1,
+		},
+		{
+			name:  "fragment directive input object",
+			query: `query Q { ...F } fragment F on Issue @cache(config: { ttl: 60 }) { id }`,
+			want:  1,
+		},
+		{
+			name:  "multiple operations",
+			query: `query A { viewer { id } } query B { organization { id } }`,
+			want:  2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countGraphQLOperations(tc.query); got != tc.want {
+				t.Fatalf("countGraphQLOperations() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLinearGraphQLAllowsSingleAnonymousOperation(t *testing.T) {
 	server := &fakeLinearGraphQLServer{}
 	httpServer := httptest.NewServer(server.handler())


### PR DESCRIPTION
## Summary

Closes #122.

- Treat top-level GraphQL `fragment` definitions as document definition headers, not operations, in the `linear_graphql` single-operation guard.
- Keep operation-header state scoped to top-level selection-set braces so fragment directives with input-object arguments do not corrupt the count.
- Add focused regression coverage for named operations, mutations, anonymous operations, fragment directive input objects, and multiple-operation rejection.

## Verification

- `go test ./internal/runner -run TestCountGraphQLOperationsIgnoresFragmentDefinitions -count=1` first failed before the production change, then passed after the fix.
- `go test ./internal/runner -run TestCountGraphQLOperationsIgnoresFragmentDefinitions/fragment_directive_input_object -count=1` first failed before the directive brace handling change, then passed after the fix.
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- `go test -race -covermode=atomic ./...` was run locally and failed in `internal/runner` on macOS due existing environment-sensitive failures: Linux sandbox backend tests require `bubblewrap`/`firejail`, and `TestCodexAppServerRunnerServerRequestsRefreshStallClock` exceeded its 100 ms stall budget by about 2 ms.

## Local review gates

- Codex complete-diff JSON review: `{"blocking_findings":[]}`
- Claude Code complete-diff JSON review: `structured_output={"blocking_findings":[]}`
- Note: an earlier Claude complete-diff attempt hit `max_turns`; it was rerun with the same required command shape and produced schema-valid empty findings.
