### PR TITLE
fix(workflow): require Linear project slug

### DIFF
--- a/.aiops/RUN_SUMMARY.md
+++ b/.aiops/RUN_SUMMARY.md
@@ -1,0 +1,26 @@
+# Run Summary
+
+## Issue
+
+Resolved GitHub issue #151: Linear workflows could omit `tracker.project_slug` and only fail later when the Linear client tried to poll candidate issues.
+
+## Changes
+
+- Added load-time validation for single-service Linear workflows: `tracker.kind: linear` now requires `tracker.project_slug` unless the workflow uses service-specific Linear routing.
+- Added a focused loader regression test covering the missing `tracker.project_slug` error and its operator-facing field/path guidance.
+- Updated valid Linear test fixtures to include `project_slug`.
+- Documented the Linear `tracker.project_slug` requirement in `README.md`, `docs/runbooks/local-dev.md`, and `examples/WORKFLOW.md`.
+
+## Verification
+
+- `go test ./internal/workflow -run TestLoadRejectsLinearWorkflowWithoutProjectSlug -count=1`
+- `go test ./internal/workflow ./cmd/worker -count=1`
+- `go test ./internal/orchestrator ./internal/worker ./internal/workflow ./cmd/worker -count=1`
+- `gofmt -l $(git ls-files '*.go')`
+- `go mod tidy && git diff --exit-code -- go.mod go.sum`
+- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
+- `go test -race -covermode=atomic $(go list ./... | grep -v '^github.com/xrf9268-hue/aiops-platform/internal/runner$')`
+- Codex JSON local review: `{"blocking_findings":[]}`
+- Claude Code JSON local review: `{"blocking_findings":[]}`
+
+`go test -race -covermode=atomic ./...` was run. It still fails in the unrelated `internal/runner` package on this macOS host due to the existing Darwin sandbox test expectations for bubblewrap/firejail. The packages touched by this change and the non-runner package set passed with the targeted commands above.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ If the canonical file does not exist, the worker proceeds with built-in defaults
 | `policy.max_changed_loc` | `300` |
 | `verify.commands` | none |
 
+Linear workflows must set `tracker.project_slug` in `WORKFLOW.md`; it maps to
+Linear's `project.slugId` and is required for candidate issue polling. Example:
+
+```yaml
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: your-linear-project-slug
+```
+
 The worker binds a private-loopback HTTP server at `127.0.0.1:<server.port>` and publishes the SPEC §13.7 state snapshot at `GET /api/v1/state`. Set `server.port: -1` to disable the endpoint in environments that provide their own state bridge. The endpoint accepts only `localhost` and `127.0.0.1` Host headers and assumes local host users and processes are trusted; on shared hosts, disable it or isolate the worker behind host-level access controls. If the configured listener cannot start, the worker logs the failure, continues without the HTTP state endpoint, and retries on later workflow reload checks until the bind succeeds or `server.port` changes.
 
 A `WORKFLOW.md` with no YAML front matter (just a prompt body) is supported: the body becomes the prompt template, all other settings fall through to the defaults above. The `workflow_resolved` event records this as `source: prompt_only` so an operator can tell apart "ran with full Symphony config" from "ran with body-only template".

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -485,7 +485,7 @@ func TestWorkerEntrypointDoesNotRequirePostgresQueue(t *testing.T) {
 func TestLoadWorkflowForStartupReconcileUsesConfiguredWorkflowPath(t *testing.T) {
 	dir := t.TempDir()
 	workflowPath := filepath.Join(dir, "linear-workflow.md")
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  active_states: [\"AI Ready\"]\n  terminal_states: [\"Done\"]\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n  active_states: [\"AI Ready\"]\n  terminal_states: [\"Done\"]\n---\nprompt\n"
 	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write workflow: %v", err)
 	}
@@ -520,7 +520,7 @@ func TestLoadWorkflowForStartupReconcileUsesConfiguredWorkflowPath(t *testing.T)
 func TestResolveStartupWorkflowUsesPositionalPath(t *testing.T) {
 	dir := t.TempDir()
 	workflowPath := filepath.Join(dir, "service-WORKFLOW.md")
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n---\nservice prompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n---\nservice prompt\n"
 	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write workflow: %v", err)
 	}
@@ -976,7 +976,7 @@ func TestLoadWorkflowForStartupReconcileClassifiesConfiguredPromptOnlyWorkflow(t
 func TestLoadWorkflowForStartupReconcileResolvesCWDWorkflowAndLogsSource(t *testing.T) {
 	dir := t.TempDir()
 	workflowPath := filepath.Join(dir, "WORKFLOW.md")
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n---\nprompt\n"
 	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write workflow: %v", err)
 	}

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -98,6 +98,9 @@ The Linear and Gitea pollers read `examples/WORKFLOW.md` for the repo, tracker, 
 ### Linear
 
 The Linear poller enqueues issues in configured active Linear workflow states.
+Linear workflows must set `tracker.project_slug` in `examples/WORKFLOW.md`;
+the value maps to Linear's `project.slugId` and scopes candidate issue polling
+to that project.
 
 Option A: from source.
 
@@ -113,7 +116,7 @@ Option B: in Docker.
 docker compose --env-file .env -f deploy/docker-compose.yml --profile linear up -d linear-poller
 ```
 
-The poller exits immediately with `tracker.kind must be linear` if `examples/WORKFLOW.md` is not configured for Linear, and logs `skip <issue>: repo.clone_url missing in WORKFLOW.md` if `repo.clone_url` is empty.
+The poller exits immediately with `tracker.kind must be linear` if `examples/WORKFLOW.md` is not configured for Linear. The workflow loader rejects Linear configs that omit `tracker.project_slug` before polling starts, and the poller logs `skip <issue>: repo.clone_url missing in WORKFLOW.md` if `repo.clone_url` is empty.
 
 ### Gitea
 
@@ -188,7 +191,7 @@ A transitional poller logs `relation "tasks" does not exist`.
 
 ### Linear poller exits with `tracker.kind must be linear`
 
-`examples/WORKFLOW.md` is not configured for Linear. Set `tracker.kind: linear` and provide an `api_key` (the value can reference `$LINEAR_API_KEY`).
+`examples/WORKFLOW.md` is not configured for Linear. Set `tracker.kind: linear`, provide an `api_key` (the value can reference `$LINEAR_API_KEY`), and set `tracker.project_slug` to the Linear project slug ID you want to poll.
 
 ### Worker fails to push or open PRs
 

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -13,6 +13,9 @@ repo:
 tracker:
   kind: linear
   api_key: $LINEAR_API_KEY
+  # Required for Linear: maps to Linear project.slugId and scopes candidate
+  # issue polling to one project.
+  project_slug: your-linear-project-slug
   active_states:
     - AI Ready
     - In Progress

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -363,6 +363,7 @@ func TestRuntimePollerFetchesLinearIssuesFromEachServiceProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load workflow: %v", err)
 	}
+	initial.Config.Tracker.ProjectSlug = ""
 	initial.Config.Services = []workflow.ServiceConfig{
 		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
 		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
@@ -405,6 +406,7 @@ func TestRuntimePollerDispatchesHealthyServiceProjectWhenAnotherProjectPollFails
 	if err != nil {
 		t.Fatalf("load workflow: %v", err)
 	}
+	initial.Config.Tracker.ProjectSlug = ""
 	initial.Config.Services = []workflow.ServiceConfig{
 		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
 		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
@@ -448,6 +450,7 @@ func TestRuntimePollerKeepsRunningFailedProjectIssueWhenDispatchingHealthyPartia
 	if err != nil {
 		t.Fatalf("load workflow: %v", err)
 	}
+	initial.Config.Tracker.ProjectSlug = ""
 	initial.Config.Services = []workflow.ServiceConfig{
 		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
 		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
@@ -502,6 +505,7 @@ func TestRuntimePollerCancelsHealthyProjectIssueDuringPartialPoll(t *testing.T) 
 	if err != nil {
 		t.Fatalf("load workflow: %v", err)
 	}
+	initial.Config.Tracker.ProjectSlug = ""
 	initial.Config.Services = []workflow.ServiceConfig{
 		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
 		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
@@ -624,6 +628,7 @@ func TestRuntimePollerOnlyAppliesRoutingToLinearServiceWorkflows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load linear workflow: %v", err)
 	}
+	linearWorkflow.Config.Tracker.ProjectSlug = ""
 	linearWorkflow.Config.Services = []workflow.ServiceConfig{
 		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
 	}
@@ -859,6 +864,10 @@ func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIn
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	projectSlug := ""
+	if trackerKind == "linear" {
+		projectSlug = "  project_slug: platform\n"
+	}
 	content := "---\n" +
 		"repo:\n" +
 		"  owner: xrf9268-hue\n" +
@@ -866,6 +875,7 @@ func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIn
 		"  clone_url: https://github.com/xrf9268-hue/aiops-platform.git\n" +
 		"tracker:\n" +
 		"  kind: " + trackerKind + "\n" +
+		projectSlug +
 		"  active_states: [\"" + activeState + "\"]\n" +
 		"  terminal_states: [\"Done\"]\n" +
 		"polling:\n" +

--- a/internal/worker/print_config_test.go
+++ b/internal/worker/print_config_test.go
@@ -18,7 +18,7 @@ import (
 func TestPrintConfig_MasksTrackerAPIKey(t *testing.T) {
 	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin_super_secret_value")
 	dir := t.TempDir()
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  api_key: $AIOPS_TEST_LINEAR_KEY\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  api_key: $AIOPS_TEST_LINEAR_KEY\n  project_slug: platform\n---\nprompt\n"
 	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestPrintConfig_DefaultSource(t *testing.T) {
 func TestPrintConfig_FileSourceWithPromptCanary(t *testing.T) {
 	dir := t.TempDir()
 	canary := "SHOULD_NOT_LEAK_xyz"
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  default: codex\ntracker:\n  kind: linear\n---\nFirst line of prompt template.\nSecond line includes canary " + canary + " in the middle.\nMore body...\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  default: codex\ntracker:\n  kind: linear\n  project_slug: platform\n---\nFirst line of prompt template.\nSecond line includes canary " + canary + " in the middle.\nMore body...\n"
 	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestPrintConfig_RendersAgentTimeoutAsDurationString(t *testing.T) {
 // to the same duration.
 func TestPrintConfig_AgentTimeoutFromYAMLOverride(t *testing.T) {
 	dir := t.TempDir()
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  timeout: 10m\ntracker:\n  kind: linear\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  timeout: 10m\ntracker:\n  kind: linear\n  project_slug: platform\n---\nprompt\n"
 	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestPrintConfig_AgentTimeoutFromYAMLOverride(t *testing.T) {
 // and overrides took effect.
 func TestPrintConfig_ExposesMaxRetryBackoffMs(t *testing.T) {
 	dir := t.TempDir()
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  max_retry_backoff_ms: 45000\ntracker:\n  kind: linear\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  max_retry_backoff_ms: 45000\ntracker:\n  kind: linear\n  project_slug: platform\n---\nprompt\n"
 	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestPrintConfig_ExposesMaxRetryBackoffMs(t *testing.T) {
 // reported as normal shadow workflow sources.
 func TestPrintConfig_TopLevelSourceOmitsLegacyShadowedBy(t *testing.T) {
 	dir := t.TempDir()
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n---\nprompt\n"
 	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
 		t.Fatalf("write root: %v", err)
 	}

--- a/internal/worker/run_test.go
+++ b/internal/worker/run_test.go
@@ -136,6 +136,7 @@ repo:
   clone_url: $REPO_URL
 tracker:
   kind: linear
+  project_slug: platform
 agent:
   default: definitely-not-a-runner
 ---
@@ -845,7 +846,7 @@ func TestRunRunnerWithTimeoutZeroBudgetUsesDefault(t *testing.T) {
 // post-hoc inspection contract.
 func TestResolveWorkflow_EmitsResolvedEvent(t *testing.T) {
 	dir := t.TempDir()
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  default: codex\npolicy:\n  mode: draft_pr\ntracker:\n  kind: linear\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\nagent:\n  default: codex\npolicy:\n  mode: draft_pr\ntracker:\n  kind: linear\n  project_slug: platform\n---\nprompt\n"
 	workflowPath := filepath.Join(dir, "WORKFLOW.md")
 	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
@@ -898,7 +899,7 @@ func TestResolveWorkflow_EmitsResolvedEvent(t *testing.T) {
 // so the common case stays terse.
 func TestResolveWorkflow_LogsResolutionLine(t *testing.T) {
 	dir := t.TempDir()
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n---\nprompt\n"
 	workflowPath := filepath.Join(dir, "WORKFLOW.md")
 	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write root: %v", err)
@@ -949,7 +950,7 @@ func TestResolveWorkflow_LogsResolutionLine(t *testing.T) {
 // the line carries `source=` and `path=` but no `shadowed=` segment.
 func TestResolveWorkflow_LogsResolutionLineOmitsEmptyShadowed(t *testing.T) {
 	dir := t.TempDir()
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n---\nprompt\n"
 	workflowPath := filepath.Join(dir, "WORKFLOW.md")
 	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -91,6 +91,7 @@ repo:
   clone_url: $REPO_URL
 tracker:
   kind: linear
+  project_slug: platform
 agent:
   default: mock
 ---

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -1715,6 +1715,7 @@ repo:
   clone_url: git@example.com:o/r.git
 tracker:
   kind: linear
+  project_slug: platform
   statuses:
     in_progress: "Doing"
 ---
@@ -1752,6 +1753,7 @@ repo:
   clone_url: git@example.com:o/r.git
 tracker:
   kind: linear
+  project_slug: platform
   statuses:
     in_progress: "Coding"
     human_review: "Review"
@@ -1818,6 +1820,7 @@ repo:
   clone_url: file:///tmp/repo
 tracker:
   kind: linear
+  project_slug: platform
 agent:
   default: codex
 codex:
@@ -1844,6 +1847,7 @@ repo:
   clone_url: file:///tmp/repo
 tracker:
   kind: linear
+  project_slug: platform
 agent:
   default: codex
 codex:
@@ -1868,6 +1872,7 @@ repo:
   clone_url: file:///tmp/repo
 tracker:
   kind: linear
+  project_slug: platform
 agent:
   default: codex
 codex:
@@ -1891,6 +1896,7 @@ repo:
   clone_url: file:///tmp/repo
 tracker:
   kind: linear
+  project_slug: platform
 agent:
   default: claude
 claude:
@@ -1915,6 +1921,7 @@ repo:
   clone_url: file:///tmp/repo
 tracker:
   kind: linear
+  project_slug: platform
 safety:
   allowed_networks:
     - git remote for this repository
@@ -1952,6 +1959,7 @@ repo:
   clone_url: file:///tmp/repo
 tracker:
   kind: linear
+  project_slug: platform
 agent:
   default: codex-app-server
 codex:
@@ -2014,6 +2022,7 @@ repo:
   clone_url: file:///tmp/repo
 tracker:
   kind: linear
+  project_slug: platform
 agent:
   default: codex-app-server
 codex:

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -166,6 +166,9 @@ func validateConfig(path string, cfg Config) error {
 		}
 	}
 	if cfg.Tracker.Kind == "linear" {
+		if strings.TrimSpace(cfg.Tracker.ProjectSlug) == "" && len(cfg.Services) == 0 {
+			return fmt.Errorf("%s: tracker.project_slug is required when tracker.kind=linear", path)
+		}
 		for i, service := range cfg.Services {
 			if !hasExplicitServiceRoute(service.Tracker) {
 				return fmt.Errorf("%s: services[%d].tracker must define at least one Linear route predicate (project_slug, team_key, labels, or custom_fields)", path, i)

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -1,0 +1,39 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadRejectsLinearWorkflowWithoutProjectSlug(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+---
+prompt
+`
+	t.Setenv("LINEAR_API_KEY", "test-key")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("Load: expected error for missing tracker.project_slug, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"tracker.project_slug", "tracker.kind=linear", path} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("Load error %q: want substring %q", msg, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #151.

## Summary

- fail Linear WORKFLOW.md loading early when single-service configs omit `tracker.project_slug`
- add a focused loader regression test for the missing project slug error
- document the Linear project slug requirement in README, local-dev runbook, and the example workflow

## Tests

- PASS: `go test ./internal/workflow -run TestLoadRejectsLinearWorkflowWithoutProjectSlug -count=1`
- PASS: `go test ./internal/workflow ./cmd/worker -count=1`
- PASS: `go test -race -covermode=atomic $(go list ./... | grep -v '^github.com/xrf9268-hue/aiops-platform/internal/runner$')`
- PASS: `gofmt -l $(git ls-files '*.go')`
- PASS: `go mod tidy && git diff --exit-code -- go.mod go.sum`
- PASS: `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- RAN / HOST-BLOCKED: `go test -race -covermode=atomic ./...` fails locally only in unrelated `internal/runner` sandbox tests because this host is Darwin while the tests expect Linux bubblewrap/firejail behavior.

## Local Reviews

- Codex JSON review: `{"blocking_findings":[]}`
- Claude Code JSON review: `{"blocking_findings":[]}`
