### PR TITLE
fix(runner): validate agent workspace cwd

### DIFF
--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -65,10 +65,12 @@ Treat all of these inputs as potentially hostile unless you control them:
 - tool arguments passed to client-side tools such as tracker or PR APIs.
 
 The worker creates or reuses a per-issue workspace and runs the coding agent with
-that workspace as the current directory. Workspace path validation is a baseline
-control and must keep workspaces under the configured workspace root, but SPEC
-§15.1 is explicit that path validation is not a substitute for approval policy,
-credential scoping, or external sandboxing.
+that workspace as the current directory. Subprocess-backed runners validate that
+the launch cwd is the per-issue workspace path and that the workspace path stays
+under the configured workspace root before starting the coding agent, independent
+of whether the optional sandbox wrapper is enabled. SPEC §15.1 is explicit that
+path validation is not a substitute for approval policy, credential scoping, or
+external sandboxing.
 
 ## What is defended today
 
@@ -77,6 +79,8 @@ The current Go implementation provides these safety controls:
 - per-issue workspaces under a configured workspace root;
 - sanitized workspace identifiers;
 - coding-agent execution from the per-issue workspace directory;
+- runner-side `cwd` and workspace-root validation before agent subprocess
+  launch, even when `sandbox.enabled` is false;
 - workflow-configured policy limits such as `deny_paths`, `max_changed_files`,
   and `max_changed_loc`;
 - draft-PR mode for human review before merge;

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -41,6 +41,9 @@ func (CodexRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 		return Result{}, err
 	}
 	cmd.Dir = in.Workdir
+	if err := validateAgentCommandWorkdir(in, cmd); err != nil {
+		return Result{}, err
+	}
 	cmd, err = applySandbox(ctx, in, cmd)
 	if err != nil {
 		return Result{}, err

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -41,6 +41,9 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		return Result{}, err
 	}
 	cmd.Dir = in.Workdir
+	if err := validateAgentCommandWorkdir(in, cmd); err != nil {
+		return Result{}, err
+	}
 	cmd, err = applySandbox(ctx, in, cmd)
 	if err != nil {
 		return Result{}, err

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -19,7 +19,8 @@ func appServerInput(workdir string) RunInput {
 	return RunInput{
 		Task: task.Task{ID: "AIOPS-64", Title: "Wire Codex app-server", Model: "codex-app-server"},
 		Workflow: workflow.Workflow{Config: workflow.Config{
-			Agent: workflow.AgentConfig{MaxTurns: 8},
+			Agent:     workflow.AgentConfig{MaxTurns: 8},
+			Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
 			Codex: workflow.CommandConfig{
 				Command:        "codex app-server",
 				ApprovalPolicy: "never",
@@ -63,6 +64,31 @@ func TestNewSupportsCodexAppServerRunner(t *testing.T) {
 	}
 	if _, ok := r.(CodexAppServerRunner); !ok {
 		t.Fatalf("New(codex-app-server) = %T, want CodexAppServerRunner", r)
+	}
+}
+
+func TestCodexAppServerRunnerRejectsOutsideWorkdirWhenSandboxDisabled(t *testing.T) {
+	binDir := codexAppServerStubScript(t, `
+with open(os.environ['CODEX_STARTED_LOG'], 'w') as f:
+    f.write('started')
+sys.exit(0)
+`)
+	t.Setenv("CODEX_STARTED_LOG", filepath.Join(binDir, "started.txt"))
+
+	root := t.TempDir()
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Workspace.Root = root
+
+	_, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected invalid workspace cwd error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid_workspace_cwd") {
+		t.Fatalf("error = %q, want invalid_workspace_cwd", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(binDir, "started.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("codex app-server was launched before workspace validation; stat err=%v", statErr)
 	}
 }
 

--- a/internal/runner/codex_test.go
+++ b/internal/runner/codex_test.go
@@ -55,7 +55,8 @@ func codexInput(workdir string) RunInput {
 	return RunInput{
 		Task: task.Task{ID: "tsk_codex_test", Model: "codex"},
 		Workflow: workflow.Workflow{Config: workflow.Config{
-			Codex: workflow.CommandConfig{Command: "codex exec", Profile: "safe"},
+			Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
+			Codex:     workflow.CommandConfig{Command: "codex exec", Profile: "safe"},
 		}},
 		Workdir: workdir,
 		Prompt:  "ignored — runner reads .aiops/PROMPT.md",
@@ -268,7 +269,8 @@ func TestCodexRunner_CustomProfileUsesShellWithStdin(t *testing.T) {
 	in := RunInput{
 		Task: task.Task{ID: "tsk_custom", Model: "codex"},
 		Workflow: workflow.Workflow{Config: workflow.Config{
-			Codex: workflow.CommandConfig{Command: "cat", Profile: "custom"},
+			Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(wd)},
+			Codex:     workflow.CommandConfig{Command: "cat", Profile: "custom"},
 		}},
 		Workdir: wd,
 	}
@@ -298,7 +300,8 @@ func TestCodexRunner_CustomProfileEmptyCommandRejected(t *testing.T) {
 	in := RunInput{
 		Task: task.Task{ID: "tsk_custom_empty", Model: "codex"},
 		Workflow: workflow.Workflow{Config: workflow.Config{
-			Codex: workflow.CommandConfig{Profile: "custom"},
+			Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(wd)},
+			Codex:     workflow.CommandConfig{Profile: "custom"},
 		}},
 		Workdir: wd,
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -15,8 +15,9 @@ type RunInput struct {
 	Workflow workflow.Workflow
 	Workdir  string
 	// WorkspaceRoot is the runtime root that created Workdir. When set,
-	// sandbox invariant checks must use this value instead of the workflow
-	// default so runner sandboxing matches the worker's actual checkout root.
+	// runner workspace-cwd invariant checks must use this value instead of
+	// the workflow default so launch validation matches the worker's actual
+	// checkout root.
 	WorkspaceRoot string
 	Prompt        string
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -97,8 +97,10 @@ func TestMockRunnerNoTimeoutWhenSleepShort(t *testing.T) {
 // regressed and we waited the full sleep budget.
 func TestShellRunnerKillsRunawayProcess(t *testing.T) {
 	t.Parallel()
+	workdir := shellTestWorkdir(t)
 	wf := workflow.Workflow{Config: workflow.Config{
-		Claude: workflow.CommandConfig{Command: "sleep 30"},
+		Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
+		Claude:    workflow.CommandConfig{Command: "sleep 30"},
 	}}
 	r := ShellRunner{Name: "claude"}
 
@@ -109,7 +111,7 @@ func TestShellRunnerKillsRunawayProcess(t *testing.T) {
 	_, err := r.Run(ctx, RunInput{
 		Task:     task.Task{ID: "tsk_shell"},
 		Workflow: wf,
-		Workdir:  shellTestWorkdir(t),
+		Workdir:  workdir,
 	})
 	elapsed := time.Since(start)
 
@@ -131,8 +133,10 @@ func TestShellRunnerKillsRunawayProcess(t *testing.T) {
 // TimeoutError — verify-vs-timeout retry routing depends on this.
 func TestShellRunnerNonTimeoutErrorNotMisclassified(t *testing.T) {
 	t.Parallel()
+	workdir := shellTestWorkdir(t)
 	wf := workflow.Workflow{Config: workflow.Config{
-		Claude: workflow.CommandConfig{Command: "exit 3"},
+		Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
+		Claude:    workflow.CommandConfig{Command: "exit 3"},
 	}}
 	r := ShellRunner{Name: "claude"}
 
@@ -142,7 +146,7 @@ func TestShellRunnerNonTimeoutErrorNotMisclassified(t *testing.T) {
 	_, err := r.Run(ctx, RunInput{
 		Task:     task.Task{ID: "tsk_nonzero"},
 		Workflow: wf,
-		Workdir:  shellTestWorkdir(t),
+		Workdir:  workdir,
 	})
 	if err == nil {
 		t.Fatal("expected non-zero exit error")

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -77,10 +77,13 @@ func ensurePathWithinRoot(path, root string) error {
 	if err != nil {
 		return fmt.Errorf("check workspace root invariant: %w", err)
 	}
-	if rel == "." || (rel != "" && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)) {
+	if rel == "." {
+		return fmt.Errorf("workspace path %q must be under workspace root %q, not the workspace root itself", path, root)
+	}
+	if rel != "" && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel) {
 		return nil
 	}
-	return fmt.Errorf("sandbox workdir %q is outside workspace root %q", path, root)
+	return fmt.Errorf("workspace path %q is outside workspace root %q", path, root)
 }
 
 func scopedEnv(allow []string) []string {

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -34,6 +34,9 @@ func (r ShellRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 	start := time.Now()
 	cmd := exec.CommandContext(ctx, "sh", "-lc", command+" < .aiops/PROMPT.md")
 	cmd.Dir = in.Workdir
+	if err := validateAgentCommandWorkdir(in, cmd); err != nil {
+		return Result{}, err
+	}
 	wrapped, err := applySandbox(ctx, in, cmd)
 	if err != nil {
 		return Result{}, err

--- a/internal/runner/workspace_cwd.go
+++ b/internal/runner/workspace_cwd.go
@@ -1,0 +1,54 @@
+package runner
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func validateAgentCommandWorkdir(in RunInput, cmd *exec.Cmd) error {
+	if cmd == nil {
+		return fmt.Errorf("invalid_workspace_cwd: command is required")
+	}
+	return validateAgentWorkdir(in, cmd.Dir)
+}
+
+func validateAgentWorkdir(in RunInput, cwd string) error {
+	workspacePath := strings.TrimSpace(in.Workdir)
+	if workspacePath == "" {
+		return fmt.Errorf("invalid_workspace_cwd: workspace_path is required")
+	}
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return fmt.Errorf("invalid_workspace_cwd: cwd is required")
+	}
+	workspaceAbs, err := filepath.Abs(workspacePath)
+	if err != nil {
+		return fmt.Errorf("invalid_workspace_cwd: resolve workspace_path: %w", err)
+	}
+	cwdAbs, err := filepath.Abs(cwd)
+	if err != nil {
+		return fmt.Errorf("invalid_workspace_cwd: resolve cwd: %w", err)
+	}
+	if cwdAbs != workspaceAbs {
+		return fmt.Errorf("invalid_workspace_cwd: cwd %q does not match workspace_path %q", cwdAbs, workspaceAbs)
+	}
+
+	root := strings.TrimSpace(in.WorkspaceRoot)
+	if root == "" {
+		root = strings.TrimSpace(in.Workflow.Config.Workspace.Root)
+	}
+	if root == "" {
+		return fmt.Errorf("invalid_workspace_cwd: workspace root is required")
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("invalid_workspace_cwd: resolve workspace root: %w", err)
+	}
+	// ensurePathWithinRoot canonicalizes symlinks before comparing paths.
+	if err := ensurePathWithinRoot(workspaceAbs, rootAbs); err != nil {
+		return fmt.Errorf("invalid_workspace_cwd: %w", err)
+	}
+	return nil
+}

--- a/internal/runner/workspace_cwd_test.go
+++ b/internal/runner/workspace_cwd_test.go
@@ -1,0 +1,59 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateAgentCommandWorkdirRejectsDirMismatch(t *testing.T) {
+	root := t.TempDir()
+	workdir := filepath.Join(root, "issue-185")
+	if err := os.Mkdir(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(root, "other")
+	if err := os.Mkdir(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "true")
+	cmd.Dir = other
+
+	err := validateAgentCommandWorkdir(RunInput{
+		Workdir:       workdir,
+		WorkspaceRoot: root,
+	}, cmd)
+	if err == nil {
+		t.Fatal("expected cwd mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid_workspace_cwd") || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("error = %q, want invalid_workspace_cwd cwd mismatch", err)
+	}
+}
+
+func TestValidateAgentCommandWorkdirRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "issue-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "true")
+	cmd.Dir = link
+
+	err := validateAgentCommandWorkdir(RunInput{
+		Workdir:       link,
+		WorkspaceRoot: root,
+	}, cmd)
+	if err == nil {
+		t.Fatal("expected symlink escape error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid_workspace_cwd") || !strings.Contains(err.Error(), "outside workspace root") {
+		t.Fatalf("error = %q, want invalid_workspace_cwd symlink escape", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #185.
- Adds runner-side `invalid_workspace_cwd` validation against the actual `exec.Cmd.Dir` before Codex, Codex app-server, and Claude subprocess launch.
- Enforces workspace-root containment independently of `sandbox.enabled`, including symlink escape rejection.
- Documents the sandbox-independent cwd/root invariant in `docs/security-posture.md`.

## Tests

- `go test ./internal/runner -run 'TestCodexAppServerRunnerRejectsOutsideWorkdirWhenSandboxDisabled|TestValidateAgentCommandWorkdir' -count=1`
- `gofmt -l $(git ls-files '*.go')`
- `git diff --check`
- `go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `go test -race -covermode=atomic ./...` on macOS: fails in existing `internal/runner` Darwin-host checks for Linux sandbox backends plus the existing 100 ms stall timing test.
- `docker run --rm -v "$PWD":/src -w /src golang:1.25-bookworm bash -c 'go version && go test -race -covermode=atomic ./...'`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- `docker run --rm -v "$PWD":/src -w /src golang:1.25-bookworm bash -c 'go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller'`

## Local Review Gates

- Codex JSON review: `{"blocking_findings":[]}`
- Claude Code JSON review: `{"blocking_findings":[]}`
