### PR TITLE
[codex] reject invalid hook timeout config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ If the canonical file does not exist, the worker proceeds with built-in defaults
 | `policy.max_changed_loc` | `300` |
 | `verify.commands` | none |
 
+When present, `hooks.timeout_ms` must be a positive integer. Omit it to use the
+default `60000` ms timeout.
+
 The worker binds a private-loopback HTTP server at `127.0.0.1:<server.port>` and publishes the SPEC §13.7 state snapshot at `GET /api/v1/state`. Set `server.port: -1` to disable the endpoint in environments that provide their own state bridge. The endpoint accepts only `localhost` and `127.0.0.1` Host headers and assumes local host users and processes are trusted; on shared hosts, disable it or isolate the worker behind host-level access controls. If the configured listener cannot start, the worker logs the failure, continues without the HTTP state endpoint, and retries on later workflow reload checks until the bind succeeds or `server.port` changes.
 
 A `WORKFLOW.md` with no YAML front matter (just a prompt body) is supported: the body becomes the prompt template, all other settings fall through to the defaults above. The `workflow_resolved` event records this as `source: prompt_only` so an operator can tell apart "ran with full Symphony config" from "ran with body-only template".

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -259,11 +259,11 @@ func validateConfig(path string, cfg Config) error {
 		}
 		seenStateCaps[key] = state
 	}
-	if cfg.Hooks.TimeoutMs < 0 {
-		return fmt.Errorf("%s: hooks.timeout_ms must be non-negative", path)
+	if cfg.hookFields.TimeoutMs && cfg.Hooks.TimeoutMs <= 0 {
+		return fmt.Errorf("%s: hooks.timeout_ms must be a positive integer", path)
 	}
-	if cfg.Workspace.Hooks.TimeoutMs < 0 {
-		return fmt.Errorf("%s: workspace.hooks.timeout_ms must be non-negative", path)
+	if cfg.Workspace.hookFields.TimeoutMs && cfg.Workspace.Hooks.TimeoutMs <= 0 {
+		return fmt.Errorf("%s: workspace.hooks.timeout_ms must be a positive integer", path)
 	}
 	var invalid []string
 	if cfg.Codex.TurnTimeoutMs <= 0 {

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -58,3 +58,80 @@ Prompt body
 		}
 	}
 }
+
+func TestLoadRejectsNonPositiveHooksTimeoutMs(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "top-level negative",
+			body: `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  timeout_ms: -1
+---
+Prompt body
+`,
+		},
+		{
+			name: "top-level zero",
+			body: `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  timeout_ms: 0
+---
+Prompt body
+`,
+		},
+		{
+			name: "legacy negative",
+			body: `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+workspace:
+  hooks:
+    timeout_ms: -1
+---
+Prompt body
+`,
+		},
+		{
+			name: "legacy zero",
+			body: `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+workspace:
+  hooks:
+    timeout_ms: 0
+---
+Prompt body
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTempWorkflow(t, tt.body)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load succeeded with explicit non-positive hooks timeout, want validation error")
+			}
+			for _, want := range []string{path, "timeout_ms", "positive integer"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("Load error = %q, want substring %q", err, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #190

## Summary
- reject explicit non-positive `hooks.timeout_ms` values during workflow config validation
- apply the same positive-integer validation to legacy `workspace.hooks.timeout_ms` while omitted values keep the default
- document that `hooks.timeout_ms` must be positive when present

## Tests
- RED: `go test ./internal/workflow -run TestLoadRejectsNonPositiveHooksTimeoutMs -count=1` failed before the fix
- GREEN: `go test ./internal/workflow -run TestLoadRejectsNonPositiveHooksTimeoutMs -count=1`
- `go test ./internal/workflow -count=1`
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test -race -covermode=atomic ./internal/workflow ./internal/workspace`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- `docker run --rm -v "$PWD":/workspace -w /workspace golang:1.25 go test -race -covermode=atomic ./...`

Note: local macOS `go test -race -covermode=atomic ./...` was also run and failed in unrelated `internal/runner` tests that require Linux sandbox behavior plus two Codex app-server timing tests. The Linux container full gate passed.

## Local reviews
- Codex diff-only review: schema-valid `{"blocking_findings":[]}`
- Claude Code diff-only review: schema-valid `.structured_output` `{"blocking_findings":[]}`
