### PR TITLE
Add runtime issue and refresh endpoints

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -682,6 +682,7 @@ func apiIssueFromView(view orchestrator.StateView, identifier string) (apiIssueR
 		payload := base(row.IssueID, row.Identifier, "running")
 		payload.Workspace.Path = row.WorkspacePath
 		payload.Attempts.CurrentRetryAttempt = copyIntPointer(row.RetryAttempt)
+		payload.Attempts.RestartCount = restartCountFromRetryAttempt(row.RetryAttempt)
 		payload.Running = &running
 		return payload, true
 	}
@@ -692,11 +693,28 @@ func apiIssueFromView(view orchestrator.StateView, identifier string) (apiIssueR
 		retry := apiRetryFromView(row)
 		payload := base(row.IssueID, row.Identifier, "retrying")
 		payload.Attempts.CurrentRetryAttempt = &retry.Attempt
+		payload.Attempts.RestartCount = restartCountFromRetryAttempt(&retry.Attempt)
 		payload.Retry = &retry
 		payload.LastError = stringPointerIfNotEmpty(row.Error)
 		return payload, true
 	}
 	return apiIssueResponse{}, false
+}
+
+// restartCountFromRetryAttempt mirrors the Symphony Elixir reference
+// (lib/symphony_elixir_web/presenter.ex: `max(retry_attempt - 1, 0)`), and
+// matches the SPEC §13.7.2 example payload where restart_count=1 corresponds
+// to current_retry_attempt=2 (i.e. one prior restart triggered the second
+// attempt). nil retry attempt means the issue has not been retried, so the
+// restart count is zero.
+func restartCountFromRetryAttempt(retryAttempt *int) int {
+	if retryAttempt == nil {
+		return 0
+	}
+	if *retryAttempt <= 0 {
+		return 0
+	}
+	return *retryAttempt - 1
 }
 
 func matchesIssueLookup(issueID orchestrator.IssueID, identifier, normalizedWant string) bool {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -202,7 +204,7 @@ func run(ctx context.Context, args []string) error {
 		}
 	}()
 	go func() {
-		if err := runStateHTTPServerLoop(ctx, runtime, orch.Snapshot, stateHTTPServerLoopOptions{}); err != nil && ctx.Err() == nil {
+		if err := runStateHTTPServerLoop(ctx, runtime, orch.Snapshot, stateHTTPServerLoopOptions{Refresh: orch.RequestRefresh}); err != nil && ctx.Err() == nil {
 			log.Printf("state HTTP server loop exited: %v", err)
 		}
 	}()
@@ -211,6 +213,7 @@ func run(ctx context.Context, args []string) error {
 
 type stateHTTPServerController struct {
 	snapshot stateSnapshotFunc
+	refresh  stateRefreshFunc
 
 	desiredSet  bool
 	desiredPort int
@@ -219,8 +222,8 @@ type stateHTTPServerController struct {
 	serverDone  <-chan struct{}
 }
 
-func newStateHTTPServerController(snapshot stateSnapshotFunc) *stateHTTPServerController {
-	return &stateHTTPServerController{snapshot: snapshot}
+func newStateHTTPServerController(snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *stateHTTPServerController {
+	return &stateHTTPServerController{snapshot: snapshot, refresh: optionalStateRefreshFunc(refresh)}
 }
 
 func (c *stateHTTPServerController) apply(ctx context.Context, port int) error {
@@ -236,7 +239,7 @@ func (c *stateHTTPServerController) apply(ctx context.Context, port int) error {
 		return nil
 	}
 	serverCtx, cancel := context.WithCancel(ctx)
-	handle, err := startStateHTTPServer(serverCtx, port, c.snapshot)
+	handle, err := startStateHTTPServer(serverCtx, port, c.snapshot, c.refresh)
 	if err != nil {
 		cancel()
 		return err
@@ -292,13 +295,14 @@ func (c *stateHTTPServerController) clear() {
 type stateHTTPServerLoopOptions struct {
 	Sleep           func(context.Context, time.Duration) error
 	StopAfterChecks int
+	Refresh         stateRefreshFunc
 }
 
 func runStateHTTPServerLoop(ctx context.Context, runtime *orchestrator.WorkflowRuntime, snapshot stateSnapshotFunc, opts stateHTTPServerLoopOptions) error {
 	if runtime == nil {
 		return errors.New("state HTTP server loop requires workflow runtime")
 	}
-	controller := newStateHTTPServerController(snapshot)
+	controller := newStateHTTPServerController(snapshot, opts.Refresh)
 	defer controller.stop()
 	sleep := opts.Sleep
 	if sleep == nil {
@@ -343,12 +347,12 @@ type stateHTTPServerHandle struct {
 	Done <-chan struct{}
 }
 
-func startStateHTTPServer(ctx context.Context, port int, snapshot stateSnapshotFunc) (*stateHTTPServerHandle, error) {
+func startStateHTTPServer(ctx context.Context, port int, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) (*stateHTTPServerHandle, error) {
 	if port < 0 {
 		log.Printf("state HTTP server disabled by server.port=%d", port)
 		return nil, nil
 	}
-	server := newStateHTTPServer(port, snapshot)
+	server := newStateHTTPServer(port, snapshot, refresh...)
 	listener, err := net.Listen("tcp", server.Addr)
 	if err != nil {
 		log.Printf("state HTTP server disabled because listen on %s failed: %v", server.Addr, err)
@@ -379,9 +383,11 @@ func startStateHTTPServer(ctx context.Context, port int, snapshot stateSnapshotF
 	return &stateHTTPServerHandle{Addr: listener.Addr(), Done: done}, nil
 }
 
-func newStateHTTPServer(port int, snapshot stateSnapshotFunc) *http.Server {
+func newStateHTTPServer(port int, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle("/api/v1/state", stateHTTPHandler(snapshot))
+	mux.Handle("/api/v1/refresh", refreshHTTPHandler(optionalStateRefreshFunc(refresh)))
+	mux.Handle("/api/v1/", issueHTTPHandler(snapshot))
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			http.NotFound(w, r)
@@ -425,6 +431,19 @@ func isLoopbackHTTPHost(hostport string) bool {
 }
 
 type stateSnapshotFunc func(context.Context) (orchestrator.StateView, error)
+type stateRefreshFunc func(context.Context) (orchestrator.RefreshRequestResult, error)
+
+const (
+	refreshRequestHeader      = "X-AIOPS-Refresh"
+	refreshRequestHeaderValue = "true"
+)
+
+func optionalStateRefreshFunc(refresh []stateRefreshFunc) stateRefreshFunc {
+	if len(refresh) == 0 {
+		return nil
+	}
+	return refresh[0]
+}
 
 type apiStateResponse struct {
 	GeneratedAt                time.Time                       `json:"generated_at"`
@@ -471,20 +490,47 @@ type apiStateRetry struct {
 	Error      string               `json:"error,omitempty"`
 }
 
+type apiIssueResponse struct {
+	IssueIdentifier string               `json:"issue_identifier"`
+	IssueID         orchestrator.IssueID `json:"issue_id"`
+	Status          string               `json:"status"`
+	Workspace       struct {
+		Path string `json:"path,omitempty"`
+	} `json:"workspace"`
+	Attempts struct {
+		RestartCount        int  `json:"restart_count"`
+		CurrentRetryAttempt *int `json:"current_retry_attempt"`
+	} `json:"attempts"`
+	Running      *apiStateRunning `json:"running"`
+	Retry        *apiStateRetry   `json:"retry"`
+	RecentEvents []map[string]any `json:"recent_events"`
+	LastError    *string          `json:"last_error"`
+	Tracked      map[string]any   `json:"tracked"`
+}
+
+type apiErrorResponse struct {
+	Error apiError `json:"error"`
+}
+
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 func stateHTTPHandler(snapshot stateSnapshotFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", http.MethodGet)
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 			return
 		}
 		view, err := snapshot(r.Context())
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				writeAPIError(w, http.StatusServiceUnavailable, "snapshot_unavailable", err.Error())
 				return
 			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeAPIError(w, http.StatusInternalServerError, "snapshot_failed", err.Error())
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -494,6 +540,224 @@ func stateHTTPHandler(snapshot stateSnapshotFunc) http.Handler {
 	})
 }
 
+func issueHTTPHandler(snapshot stateSnapshotFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+			return
+		}
+		identifier, err := issueIdentifierFromPath(r.URL.Path)
+		if err != nil {
+			writeAPIError(w, http.StatusNotFound, "issue_not_found", err.Error())
+			return
+		}
+		view, err := snapshot(r.Context())
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				writeAPIError(w, http.StatusServiceUnavailable, "snapshot_unavailable", err.Error())
+				return
+			}
+			writeAPIError(w, http.StatusInternalServerError, "snapshot_failed", err.Error())
+			return
+		}
+		payload, ok := apiIssueFromView(view, identifier)
+		if !ok {
+			writeAPIError(w, http.StatusNotFound, "issue_not_found", fmt.Sprintf("issue %q was not found in the current runtime state", identifier))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			log.Printf("encode /api/v1/%s response: %v", identifier, err)
+		}
+	})
+}
+
+func refreshHTTPHandler(refresh stateRefreshFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+			return
+		}
+		if err := validateRefreshBody(r); err != nil {
+			writeAPIError(w, http.StatusBadRequest, "invalid_refresh_body", err.Error())
+			return
+		}
+		if !validRefreshHeader(r) {
+			writeAPIError(w, http.StatusForbidden, "refresh_header_required", fmt.Sprintf("%s: %s header is required", refreshRequestHeader, refreshRequestHeaderValue))
+			return
+		}
+		if refresh == nil {
+			writeAPIError(w, http.StatusServiceUnavailable, "refresh_unavailable", "refresh trigger is not configured")
+			return
+		}
+		result, err := refresh(r.Context())
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				writeAPIError(w, http.StatusServiceUnavailable, "refresh_unavailable", err.Error())
+				return
+			}
+			writeAPIError(w, http.StatusInternalServerError, "refresh_failed", err.Error())
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			log.Printf("encode /api/v1/refresh response: %v", err)
+		}
+	})
+}
+
+func validRefreshHeader(r *http.Request) bool {
+	return strings.EqualFold(strings.TrimSpace(r.Header.Get(refreshRequestHeader)), refreshRequestHeaderValue)
+}
+
+func issueIdentifierFromPath(path string) (string, error) {
+	raw := strings.TrimPrefix(path, "/api/v1/")
+	raw = strings.Trim(raw, "/")
+	if raw == "" {
+		return "", errors.New("missing issue identifier")
+	}
+	identifier, err := url.PathUnescape(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid issue identifier %q", raw)
+	}
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return "", errors.New("missing issue identifier")
+	}
+	return identifier, nil
+}
+
+func validateRefreshBody(r *http.Request) error {
+	if r.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	bodyText := strings.TrimSpace(string(body))
+	if bodyText == "" {
+		return nil
+	}
+	if bodyText[0] != '{' {
+		return fmt.Errorf("refresh request body must be empty or {}")
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(bodyText), &object); err != nil {
+		return fmt.Errorf("refresh request body must be empty or {}")
+	}
+	if len(object) != 0 {
+		return fmt.Errorf("refresh request body must be empty or {}")
+	}
+	return nil
+}
+
+func writeAPIError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(apiErrorResponse{Error: apiError{Code: code, Message: message}}); err != nil {
+		log.Printf("encode API error response: %v", err)
+	}
+}
+
+func apiIssueFromView(view orchestrator.StateView, identifier string) (apiIssueResponse, bool) {
+	want := normalizeIssueLookup(identifier)
+	base := func(issueID orchestrator.IssueID, identifier, status string) apiIssueResponse {
+		return apiIssueResponse{
+			IssueIdentifier: identifier,
+			IssueID:         issueID,
+			Status:          status,
+			RecentEvents:    []map[string]any{},
+			Tracked:         map[string]any{},
+		}
+	}
+	for _, row := range view.Running {
+		if !matchesIssueLookup(row.IssueID, row.Identifier, want) {
+			continue
+		}
+		running := apiRunningFromView(row)
+		payload := base(row.IssueID, row.Identifier, "running")
+		payload.Workspace.Path = row.WorkspacePath
+		payload.Attempts.CurrentRetryAttempt = copyIntPointer(row.RetryAttempt)
+		payload.Running = &running
+		return payload, true
+	}
+	for _, row := range view.Retrying {
+		if !matchesIssueLookup(row.IssueID, row.Identifier, want) {
+			continue
+		}
+		retry := apiRetryFromView(row)
+		payload := base(row.IssueID, row.Identifier, "retrying")
+		payload.Attempts.CurrentRetryAttempt = &retry.Attempt
+		payload.Retry = &retry
+		payload.LastError = stringPointerIfNotEmpty(row.Error)
+		return payload, true
+	}
+	return apiIssueResponse{}, false
+}
+
+func matchesIssueLookup(issueID orchestrator.IssueID, identifier, normalizedWant string) bool {
+	return normalizeIssueLookup(identifier) == normalizedWant || normalizeIssueLookup(string(issueID)) == normalizedWant
+}
+
+func normalizeIssueLookup(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
+	var startedAt *time.Time
+	if !row.StartedAt.IsZero() {
+		v := row.StartedAt
+		startedAt = &v
+	}
+	var lastCodexAt *time.Time
+	if !row.LastCodexAt.IsZero() {
+		v := row.LastCodexAt
+		lastCodexAt = &v
+	}
+	return apiStateRunning{
+		IssueID:       row.IssueID,
+		Identifier:    row.Identifier,
+		StartedAt:     startedAt,
+		RetryAttempt:  copyIntPointer(row.RetryAttempt),
+		WorkspacePath: row.WorkspacePath,
+		LastCodexAt:   lastCodexAt,
+	}
+}
+
+func apiRetryFromView(row orchestrator.RetryView) apiStateRetry {
+	var dueAt *time.Time
+	if !row.DueAt.IsZero() {
+		v := row.DueAt
+		dueAt = &v
+	}
+	return apiStateRetry{
+		IssueID:    row.IssueID,
+		Identifier: row.Identifier,
+		Attempt:    row.Attempt,
+		DueAt:      dueAt,
+		Error:      row.Error,
+	}
+}
+
+func copyIntPointer(in *int) *int {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func stringPointerIfNotEmpty(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
 func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 	generatedAt := view.GeneratedAt
 	if generatedAt.IsZero() {
@@ -501,47 +765,14 @@ func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 	}
 	running := make([]apiStateRunning, 0, len(view.Running))
 	for _, row := range view.Running {
-		var startedAt *time.Time
-		if !row.StartedAt.IsZero() {
-			v := row.StartedAt
-			startedAt = &v
-		}
-		var lastCodexAt *time.Time
-		if !row.LastCodexAt.IsZero() {
-			v := row.LastCodexAt
-			lastCodexAt = &v
-		}
-		var retryAttempt *int
-		if row.RetryAttempt != nil {
-			attempt := *row.RetryAttempt
-			retryAttempt = &attempt
-		}
-		running = append(running, apiStateRunning{
-			IssueID:       row.IssueID,
-			Identifier:    row.Identifier,
-			StartedAt:     startedAt,
-			RetryAttempt:  retryAttempt,
-			WorkspacePath: row.WorkspacePath,
-			LastCodexAt:   lastCodexAt,
-		})
+		running = append(running, apiRunningFromView(row))
 	}
 	sort.Slice(running, func(i, j int) bool {
 		return running[i].IssueID < running[j].IssueID
 	})
 	retrying := make([]apiStateRetry, 0, len(view.Retrying))
 	for _, row := range view.Retrying {
-		var dueAt *time.Time
-		if !row.DueAt.IsZero() {
-			v := row.DueAt
-			dueAt = &v
-		}
-		retrying = append(retrying, apiStateRetry{
-			IssueID:    row.IssueID,
-			Identifier: row.Identifier,
-			Attempt:    row.Attempt,
-			DueAt:      dueAt,
-			Error:      row.Error,
-		})
+		retrying = append(retrying, apiRetryFromView(row))
 	}
 	sort.Slice(retrying, func(i, j int) bool {
 		return retrying[i].IssueID < retrying[j].IssueID

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -229,6 +229,238 @@ func TestStateHTTPHandlerRejectsNonGET(t *testing.T) {
 	}
 }
 
+func TestIssueHTTPHandlerReturnsRunningIssueByIdentifier(t *testing.T) {
+	startedAt := time.Date(2026, 5, 21, 9, 0, 0, 0, time.UTC)
+	retryAttempt := 2
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{
+			Running: []orchestrator.RunningView{{
+				IssueID:       "issue-1",
+				Identifier:    "MT-649",
+				StartedAt:     startedAt,
+				RetryAttempt:  &retryAttempt,
+				WorkspacePath: "/tmp/symphony/MT-649",
+			}},
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/mt-649", nil)
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content type = %q, want application/json", got)
+	}
+	var payload struct {
+		IssueID         string `json:"issue_id"`
+		IssueIdentifier string `json:"issue_identifier"`
+		Status          string `json:"status"`
+		Workspace       struct {
+			Path string `json:"path"`
+		} `json:"workspace"`
+		Attempts struct {
+			CurrentRetryAttempt *int `json:"current_retry_attempt"`
+		} `json:"attempts"`
+		Running *struct {
+			StartedAt string `json:"started_at"`
+		} `json:"running"`
+		Retry *struct{} `json:"retry"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode issue response: %v; body=%s", err, w.Body.String())
+	}
+	if payload.IssueID != "issue-1" || payload.IssueIdentifier != "MT-649" || payload.Status != "running" {
+		t.Fatalf("issue payload identity/status = %+v, want running MT-649 issue-1", payload)
+	}
+	if payload.Workspace.Path != "/tmp/symphony/MT-649" {
+		t.Fatalf("workspace path = %q, want running workspace path", payload.Workspace.Path)
+	}
+	if payload.Attempts.CurrentRetryAttempt == nil || *payload.Attempts.CurrentRetryAttempt != retryAttempt {
+		t.Fatalf("current_retry_attempt = %v, want %d", payload.Attempts.CurrentRetryAttempt, retryAttempt)
+	}
+	if payload.Running == nil || payload.Running.StartedAt != startedAt.Format(time.RFC3339) {
+		t.Fatalf("running row = %+v, want started_at %s", payload.Running, startedAt.Format(time.RFC3339))
+	}
+	if payload.Retry != nil {
+		t.Fatalf("retry = %+v, want null for running issue", payload.Retry)
+	}
+}
+
+func TestIssueHTTPHandlerReturns404EnvelopeForUnknownIssue(t *testing.T) {
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/NOPE-1", nil)
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusNotFound, w.Body.String())
+	}
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode error response: %v; body=%s", err, w.Body.String())
+	}
+	if payload.Error.Code != "issue_not_found" || !strings.Contains(payload.Error.Message, "NOPE-1") {
+		t.Fatalf("error = %+v, want issue_not_found mentioning identifier", payload.Error)
+	}
+}
+
+func TestIssueHTTPHandlerRejectsNonGET(t *testing.T) {
+	called := false
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/MT-649", nil)
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusMethodNotAllowed, w.Body.String())
+	}
+	if called {
+		t.Fatal("snapshot function should not be called for non-GET issue request")
+	}
+	if got := w.Header().Get("Allow"); got != http.MethodGet {
+		t.Fatalf("Allow = %q, want GET", got)
+	}
+}
+
+func TestRefreshHTTPHandlerQueuesAndCoalescesImmediatePoll(t *testing.T) {
+	results := []orchestrator.RefreshRequestResult{
+		{Queued: true, Coalesced: false, RequestedAt: time.Date(2026, 5, 21, 9, 10, 0, 0, time.UTC), Operations: []string{"poll", "reconcile"}},
+		{Queued: true, Coalesced: true, RequestedAt: time.Date(2026, 5, 21, 9, 10, 1, 0, time.UTC), Operations: []string{"poll", "reconcile"}},
+	}
+	calls := 0
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		t.Fatal("snapshot function should not be called for refresh requests")
+		return orchestrator.StateView{}, nil
+	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
+		if calls >= len(results) {
+			t.Fatalf("refresh called %d times, want at most %d", calls+1, len(results))
+		}
+		result := results[calls]
+		calls++
+		return result, nil
+	})
+
+	first := httptest.NewRecorder()
+	firstReq := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", nil)
+	firstReq.Header.Set(refreshRequestHeader, refreshRequestHeaderValue)
+	server.Handler.ServeHTTP(first, firstReq)
+	second := httptest.NewRecorder()
+	secondReq := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", strings.NewReader("{}"))
+	secondReq.Header.Set(refreshRequestHeader, refreshRequestHeaderValue)
+	server.Handler.ServeHTTP(second, secondReq)
+
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first status code = %d, want %d; body=%s", first.Code, http.StatusAccepted, first.Body.String())
+	}
+	if second.Code != http.StatusAccepted {
+		t.Fatalf("second status code = %d, want %d; body=%s", second.Code, http.StatusAccepted, second.Body.String())
+	}
+	if calls != 2 {
+		t.Fatalf("refresh calls = %d, want 2", calls)
+	}
+	var firstPayload, secondPayload struct {
+		Queued      bool     `json:"queued"`
+		Coalesced   bool     `json:"coalesced"`
+		RequestedAt string   `json:"requested_at"`
+		Operations  []string `json:"operations"`
+	}
+	if err := json.Unmarshal(first.Body.Bytes(), &firstPayload); err != nil {
+		t.Fatalf("decode first refresh response: %v; body=%s", err, first.Body.String())
+	}
+	if err := json.Unmarshal(second.Body.Bytes(), &secondPayload); err != nil {
+		t.Fatalf("decode second refresh response: %v; body=%s", err, second.Body.String())
+	}
+	if !firstPayload.Queued || firstPayload.Coalesced {
+		t.Fatalf("first refresh payload = %+v, want queued and not coalesced", firstPayload)
+	}
+	if !secondPayload.Queued || !secondPayload.Coalesced {
+		t.Fatalf("second refresh payload = %+v, want queued and coalesced", secondPayload)
+	}
+	if !reflect.DeepEqual(firstPayload.Operations, []string{"poll", "reconcile"}) || !reflect.DeepEqual(secondPayload.Operations, []string{"poll", "reconcile"}) {
+		t.Fatalf("refresh operations = %+v / %+v, want poll+reconcile", firstPayload.Operations, secondPayload.Operations)
+	}
+}
+
+func TestRefreshHTTPHandlerRequiresRefreshHeader(t *testing.T) {
+	called := false
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, nil
+	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
+		called = true
+		return orchestrator.RefreshRequestResult{}, nil
+	})
+
+	resp := httptest.NewRecorder()
+	server.Handler.ServeHTTP(resp, httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", nil))
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status code = %d, want %d; body=%s", resp.Code, http.StatusForbidden, resp.Body.String())
+	}
+	if called {
+		t.Fatal("refresh function should not be called without refresh header")
+	}
+}
+
+func TestRefreshHTTPHandlerRejectsUnsupportedMethods(t *testing.T) {
+	called := false
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, nil
+	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
+		called = true
+		return orchestrator.RefreshRequestResult{}, nil
+	})
+
+	getResp := httptest.NewRecorder()
+	server.Handler.ServeHTTP(getResp, httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/refresh", nil))
+	if getResp.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET status code = %d, want %d; body=%s", getResp.Code, http.StatusMethodNotAllowed, getResp.Body.String())
+	}
+	if got := getResp.Header().Get("Allow"); got != http.MethodPost {
+		t.Fatalf("Allow = %q, want POST", got)
+	}
+	if called {
+		t.Fatal("refresh function should not be called for unsupported method")
+	}
+}
+
+func TestRefreshHTTPHandlerRejectsUnsupportedBodies(t *testing.T) {
+	called := false
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, nil
+	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
+		called = true
+		return orchestrator.RefreshRequestResult{}, nil
+	})
+
+	for _, body := range []string{`[]`, `null`, `"refresh"`, `{"force":true}`} {
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", strings.NewReader(body))
+		req.Header.Set(refreshRequestHeader, refreshRequestHeaderValue)
+		resp := httptest.NewRecorder()
+		server.Handler.ServeHTTP(resp, req)
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("body %s status code = %d, want %d; response=%s", body, resp.Code, http.StatusBadRequest, resp.Body.String())
+		}
+	}
+	if called {
+		t.Fatal("refresh function should not be called for unsupported bodies")
+	}
+}
+
 func TestStateHTTPServerRejectsNonLoopbackHost(t *testing.T) {
 	called := false
 	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -262,6 +262,7 @@ func TestIssueHTTPHandlerReturnsRunningIssueByIdentifier(t *testing.T) {
 			Path string `json:"path"`
 		} `json:"workspace"`
 		Attempts struct {
+			RestartCount        int  `json:"restart_count"`
 			CurrentRetryAttempt *int `json:"current_retry_attempt"`
 		} `json:"attempts"`
 		Running *struct {
@@ -281,11 +282,98 @@ func TestIssueHTTPHandlerReturnsRunningIssueByIdentifier(t *testing.T) {
 	if payload.Attempts.CurrentRetryAttempt == nil || *payload.Attempts.CurrentRetryAttempt != retryAttempt {
 		t.Fatalf("current_retry_attempt = %v, want %d", payload.Attempts.CurrentRetryAttempt, retryAttempt)
 	}
+	// SPEC §13.7.2 example: restart_count=1 corresponds to current_retry_attempt=2
+	// (matches Elixir reference: max(retry_attempt - 1, 0)).
+	if want := retryAttempt - 1; payload.Attempts.RestartCount != want {
+		t.Fatalf("restart_count = %d, want %d for current_retry_attempt %d", payload.Attempts.RestartCount, want, retryAttempt)
+	}
 	if payload.Running == nil || payload.Running.StartedAt != startedAt.Format(time.RFC3339) {
 		t.Fatalf("running row = %+v, want started_at %s", payload.Running, startedAt.Format(time.RFC3339))
 	}
 	if payload.Retry != nil {
 		t.Fatalf("retry = %+v, want null for running issue", payload.Retry)
+	}
+}
+
+func TestIssueHTTPHandlerReturnsRestartCountForRetryingIssue(t *testing.T) {
+	dueAt := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{
+			Retrying: []orchestrator.RetryView{{
+				IssueID:    "issue-2",
+				Identifier: "MT-650",
+				Attempt:    3,
+				DueAt:      dueAt,
+				Error:      "tracker temporarily unavailable",
+			}},
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/MT-650", nil)
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var payload struct {
+		Status   string `json:"status"`
+		Attempts struct {
+			RestartCount        int  `json:"restart_count"`
+			CurrentRetryAttempt *int `json:"current_retry_attempt"`
+		} `json:"attempts"`
+		LastError *string `json:"last_error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode issue response: %v; body=%s", err, w.Body.String())
+	}
+	if payload.Status != "retrying" {
+		t.Fatalf("status = %q, want retrying", payload.Status)
+	}
+	if payload.Attempts.CurrentRetryAttempt == nil || *payload.Attempts.CurrentRetryAttempt != 3 {
+		t.Fatalf("current_retry_attempt = %v, want 3", payload.Attempts.CurrentRetryAttempt)
+	}
+	if payload.Attempts.RestartCount != 2 {
+		t.Fatalf("restart_count = %d, want 2 for current_retry_attempt 3", payload.Attempts.RestartCount)
+	}
+	if payload.LastError == nil || *payload.LastError != "tracker temporarily unavailable" {
+		t.Fatalf("last_error = %v, want retry error", payload.LastError)
+	}
+}
+
+func TestIssueHTTPHandlerOmitsRestartCountForFirstRun(t *testing.T) {
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{
+			Running: []orchestrator.RunningView{{
+				IssueID:    "issue-3",
+				Identifier: "MT-651",
+				StartedAt:  time.Date(2026, 5, 21, 9, 30, 0, 0, time.UTC),
+				// RetryAttempt is nil: the issue has never been retried.
+			}},
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/MT-651", nil)
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d; body=%s", w.Code, w.Body.String())
+	}
+	var payload struct {
+		Attempts struct {
+			RestartCount        int  `json:"restart_count"`
+			CurrentRetryAttempt *int `json:"current_retry_attempt"`
+		} `json:"attempts"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode issue response: %v; body=%s", err, w.Body.String())
+	}
+	if payload.Attempts.CurrentRetryAttempt != nil {
+		t.Fatalf("current_retry_attempt = %v, want nil for first run", payload.Attempts.CurrentRetryAttempt)
+	}
+	if payload.Attempts.RestartCount != 0 {
+		t.Fatalf("restart_count = %d, want 0 for first run", payload.Attempts.RestartCount)
 	}
 }
 

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -35,10 +35,39 @@ when they are discoverable from agent output or runtime events. Their presence
 means only that the runtime observed those links; it does not assume the worker
 created or owns them.
 
+## HTTP endpoints
+
+When `server.port` is enabled, the worker binds the status API on
+`127.0.0.1:<port>` and accepts only `localhost` or `127.0.0.1` Host headers.
+
+- `GET /api/v1/state` returns the process-wide runtime snapshot: running rows,
+  retry rows, completed and failed issue IDs, aggregate token/runtime totals,
+  and the current poll/concurrency metadata.
+- `GET /api/v1/<issue_identifier>` returns one issue's current runtime row.
+  Lookup is case-insensitive and matches either the tracker issue identifier or
+  issue ID. Unknown issues return
+  `{"error":{"code":"issue_not_found","message":"..."}}` with HTTP 404.
+- `POST /api/v1/refresh` queues an immediate tracker poll and reconciliation
+  cycle. Send `X-AIOPS-Refresh: true`; the non-simple header prevents ordinary
+  cross-origin browser posts from triggering local refreshes. Empty bodies and
+  `{}` are accepted. The response is HTTP 202:
+
+```json
+{
+  "queued": true,
+  "coalesced": false,
+  "requested_at": "2026-05-21T09:10:00Z",
+  "operations": ["poll", "reconcile"]
+}
+```
+
+Repeated refresh requests before the poll loop consumes the wake signal are
+coalesced into one extra poll cycle. Unsupported methods on defined endpoints
+return HTTP 405 with a JSON error envelope.
+
 ## JSON shape
 
-The initial implementation exposes a reusable JSON writer used by CLI or
-read-only endpoint wrappers:
+The reusable runtime-status JSON writer uses the same queue-independent source:
 
 ```json
 {
@@ -56,10 +85,10 @@ read-only endpoint wrappers:
   "completed": [],
   "recent_events": [],
   "codex_totals": {
-    "InputTokens": 0,
-    "OutputTokens": 0,
-    "TotalTokens": 0,
-    "SecondsRunning": 0
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "total_tokens": 0,
+    "seconds_running": 0
   }
 }
 ```

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -199,13 +199,42 @@ func (o *Orchestrator) retryWakeCh() <-chan struct{} {
 }
 
 func (o *Orchestrator) wakeRetryPollLoop() {
+	_ = o.queuePollWake()
+}
+
+func (o *Orchestrator) queuePollWake() bool {
 	if o == nil || o.retryWake == nil {
-		return
+		return false
 	}
 	select {
 	case o.retryWake <- struct{}{}:
+		return false
 	default:
+		return true
 	}
+}
+
+// RefreshRequestResult is the SPEC §13.7.2 /api/v1/refresh response shape.
+type RefreshRequestResult struct {
+	Queued      bool      `json:"queued"`
+	Coalesced   bool      `json:"coalesced"`
+	RequestedAt time.Time `json:"requested_at"`
+	Operations  []string  `json:"operations"`
+}
+
+// RequestRefresh asks the poll loop to run one immediate poll/reconcile cycle.
+// The wake channel has one slot, so repeated requests before the loop consumes
+// the signal are coalesced into a single extra cycle.
+func (o *Orchestrator) RequestRefresh(ctx context.Context) (RefreshRequestResult, error) {
+	if err := ctx.Err(); err != nil {
+		return RefreshRequestResult{}, err
+	}
+	return RefreshRequestResult{
+		Queued:      true,
+		Coalesced:   o.queuePollWake(),
+		RequestedAt: time.Now().UTC(),
+		Operations:  []string{"poll", "reconcile"},
+	}, nil
 }
 
 // submit delivers op to the actor. It blocks until the actor reads the

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -137,6 +138,49 @@ func startActor(t *testing.T, deps Deps) (*Orchestrator, context.CancelFunc) {
 		t.Fatalf("WaitStarted: %v", err)
 	}
 	return o, cancel
+}
+
+func TestRequestRefreshQueuesOnePollWakeAndCoalescesRepeatedRequests(t *testing.T) {
+	o, cancel := startActor(t, Deps{Dispatcher: &fakeDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	first, err := o.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("first RequestRefresh: %v", err)
+	}
+	if !first.Queued || first.Coalesced {
+		t.Fatalf("first refresh = %+v, want queued and not coalesced", first)
+	}
+	if !reflect.DeepEqual(first.Operations, []string{"poll", "reconcile"}) {
+		t.Fatalf("first operations = %#v, want poll+reconcile", first.Operations)
+	}
+
+	second, err := o.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("second RequestRefresh: %v", err)
+	}
+	if !second.Queued || !second.Coalesced {
+		t.Fatalf("second refresh = %+v, want queued and coalesced", second)
+	}
+
+	select {
+	case <-o.retryWakeCh():
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not queue poll wake")
+	}
+	select {
+	case <-o.retryWakeCh():
+		t.Fatal("coalesced refresh queued a second poll wake")
+	default:
+	}
+
+	third, err := o.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("third RequestRefresh: %v", err)
+	}
+	if !third.Queued || third.Coalesced {
+		t.Fatalf("third refresh after draining wake = %+v, want new non-coalesced wake", third)
+	}
 }
 
 // TestRequestDispatch_ConcurrentSameIssueProducesOneRunning is the


### PR DESCRIPTION
Closes #186

## Summary
- Add `GET /api/v1/<issue_identifier>` runtime lookup over the worker state snapshot with case-insensitive matching and JSON error envelopes.
- Add `POST /api/v1/refresh` to request an immediate tracker poll/reconcile wake with coalescing, empty/`{}` body validation, and required `X-AIOPS-Refresh: true` header.
- Document the runtime status endpoints in `docs/runbooks/runtime-status.md`.

## Tests
- PASS: `gofmt -l $(git ls-files '*.go')`
- PASS: `go mod tidy` + `git diff --exit-code -- go.mod go.sum`
- PASS: `go test -race -covermode=atomic ./cmd/worker ./internal/orchestrator`
- PASS: `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- HOST-BLOCKED: `go test -race -covermode=atomic ./...` fails in pre-existing macOS-host-sensitive areas outside this PR scope:
  - `internal/runner` Codex app-server timing tests: `TestCodexAppServerRunnerReadTimeoutDoesNotPreemptStallBudget`, `TestCodexAppServerRunnerServerRequestsRefreshStallClock`, `TestCodexAppServerRunnerReturnsTurnTimeoutWithoutWaitingForOuterContext`
  - `internal/runner` sandbox tests expecting Linux `bubblewrap`/`firejail` behavior while current host is `darwin`

## Local review gates
- Codex local review: schema-valid `{"blocking_findings":[]}`
- Claude Code local review: `.structured_output` schema-valid `{"blocking_findings":[]}`
