### PR TITLE
[codex] fix workflow env reference resolution

### DIFF
--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -278,7 +278,9 @@ Prompt body
 func TestExpandConfigLeavesRelativeWorkspaceRootWithoutWorkflowPath(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Workspace.Root = "relative-workspaces"
-	expandConfig(&cfg)
+	if err := expandConfig(&cfg); err != nil {
+		t.Fatalf("expandConfig: %v", err)
+	}
 	if cfg.Workspace.Root != "relative-workspaces" {
 		t.Fatalf("workspace.root = %q, want unchanged relative root without workflow path", cfg.Workspace.Root)
 	}

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -580,11 +580,14 @@ func isExplicitEnvName(name string) bool {
 	if name == "" {
 		return false
 	}
+	isLetter := func(r rune) bool {
+		return (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z')
+	}
 	for i, r := range name {
 		switch {
-		case i == 0 && (r == '_' || (r >= 'A' && r <= 'Z')):
+		case i == 0 && (r == '_' || isLetter(r)):
 			continue
-		case i > 0 && (r == '_' || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')):
+		case i > 0 && (r == '_' || isLetter(r) || (r >= '0' && r <= '9')):
 			continue
 		default:
 			return false

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -422,6 +422,9 @@ func expandConfigForWorkflowPath(workflowPath string, cfg *Config) error {
 	if cfg.Tracker.APIKey, err = resolveExplicitEnv("tracker.api_key", cfg.Tracker.APIKey); err != nil {
 		return err
 	}
+	if cfg.Tracker.BaseURL, err = resolveExplicitEnv("tracker.base_url", cfg.Tracker.BaseURL); err != nil {
+		return err
+	}
 	if err := expandRepoConfig("repo.clone_url", &cfg.Repo); err != nil {
 		return err
 	}

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -55,7 +55,9 @@ func Load(path string) (*Workflow, error) {
 			rawStateCaps[state] = limit
 		}
 	}
-	expandConfigForWorkflowPath(path, &cfg)
+	if err := expandConfigForWorkflowPath(path, &cfg); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
 	if rawStateCaps != nil {
 		cfg.Agent.MaxConcurrentAgentsByState = rawStateCaps
 	}
@@ -387,7 +389,9 @@ func LoadOptional(path string) (*Workflow, error) {
 	}
 	if os.IsNotExist(err) {
 		cfg := DefaultConfig()
-		expandConfig(&cfg)
+		if err := expandConfig(&cfg); err != nil {
+			return nil, err
+		}
 		return &Workflow{Path: path, Config: cfg, PromptTemplate: DefaultPrompt()}, nil
 	}
 	return nil, err
@@ -409,22 +413,39 @@ func splitFrontMatter(s string) (string, string) {
 	return front, body
 }
 
-func expandConfig(cfg *Config) {
-	expandConfigForWorkflowPath("", cfg)
+func expandConfig(cfg *Config) error {
+	return expandConfigForWorkflowPath("", cfg)
 }
 
-func expandConfigForWorkflowPath(workflowPath string, cfg *Config) {
-	cfg.Tracker.APIKey = os.ExpandEnv(cfg.Tracker.APIKey)
-	cfg.Tracker.BaseURL = os.ExpandEnv(cfg.Tracker.BaseURL)
-	expandRepoConfig(&cfg.Repo)
-	for i := range cfg.Services {
-		expandRepoConfig(&cfg.Services[i].Repo)
+func expandConfigForWorkflowPath(workflowPath string, cfg *Config) error {
+	var err error
+	if cfg.Tracker.APIKey, err = resolveExplicitEnv("tracker.api_key", cfg.Tracker.APIKey); err != nil {
+		return err
 	}
-	cfg.Workspace.Root = normalizeWorkflowPath(workflowPath, cfg.Workspace.Root)
-	cfg.Codex.Command = os.ExpandEnv(cfg.Codex.Command)
-	cfg.Claude.Command = os.ExpandEnv(cfg.Claude.Command)
+	if err := expandRepoConfig("repo.clone_url", &cfg.Repo); err != nil {
+		return err
+	}
+	for i := range cfg.Services {
+		if err := expandRepoConfig(fmt.Sprintf("services[%d].repo.clone_url", i), &cfg.Services[i].Repo); err != nil {
+			return err
+		}
+	}
+	if cfg.Workspace.Root, err = normalizeWorkflowPath(workflowPath, cfg.Workspace.Root); err != nil {
+		return err
+	}
+	if cfg.Codex.Command, err = resolveExplicitEnv("codex.command", cfg.Codex.Command); err != nil {
+		return err
+	}
+	if cfg.Claude.Command, err = resolveExplicitEnv("claude.command", cfg.Claude.Command); err != nil {
+		return err
+	}
 	for i := range cfg.Sandbox.CredentialFiles {
-		cfg.Sandbox.CredentialFiles[i] = expandPath(os.ExpandEnv(cfg.Sandbox.CredentialFiles[i]))
+		field := fmt.Sprintf("sandbox.credential_files[%d]", i)
+		resolved, err := resolveExplicitEnv(field, cfg.Sandbox.CredentialFiles[i])
+		if err != nil {
+			return err
+		}
+		cfg.Sandbox.CredentialFiles[i] = expandPath(resolved)
 	}
 	if cfg.Agent.Default == "" {
 		cfg.Agent.Default = "mock"
@@ -475,22 +496,31 @@ func expandConfigForWorkflowPath(workflowPath string, cfg *Config) {
 	if cfg.Codex.ApprovalPolicy == nil {
 		cfg.Codex.ApprovalPolicy = map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true, "mcp_elicitations": true}}
 	}
+	return nil
 }
 
-func expandRepoConfig(repo *RepoConfig) {
-	repo.CloneURL = os.ExpandEnv(repo.CloneURL)
+func expandRepoConfig(field string, repo *RepoConfig) error {
+	var err error
+	if repo.CloneURL, err = resolveExplicitEnv(field, repo.CloneURL); err != nil {
+		return err
+	}
 	if repo.DefaultBranch == "" {
 		repo.DefaultBranch = "main"
 	}
+	return nil
 }
 
-func normalizeWorkflowPath(workflowPath, p string) string {
-	expanded := expandPath(os.ExpandEnv(p))
+func normalizeWorkflowPath(workflowPath, p string) (string, error) {
+	resolved, err := resolveExplicitEnv("workspace.root", p)
+	if err != nil {
+		return "", err
+	}
+	expanded := expandPath(resolved)
 	if expanded == "" || filepath.IsAbs(expanded) || workflowPath == "" {
-		return expanded
+		return expanded, nil
 	}
 	log.Printf("workflow: relative workspace.root %s resolved relative to workflow file %s", expanded, workflowPath)
-	return filepath.Join(filepath.Dir(workflowPath), expanded)
+	return filepath.Join(filepath.Dir(workflowPath), expanded), nil
 }
 
 func expandPath(p string) string {
@@ -504,6 +534,60 @@ func expandPath(p string) string {
 		}
 	}
 	return p
+}
+
+type MissingEnvValueError struct {
+	Field  string
+	EnvVar string
+}
+
+func (e *MissingEnvValueError) Error() string {
+	category := "workflow_config_missing_value"
+	if e.Field == "tracker.api_key" {
+		category = "missing_tracker_api_key"
+	}
+	return fmt.Sprintf("%s: %s references $%s but the environment variable is unset or empty", category, e.Field, e.EnvVar)
+}
+
+func resolveExplicitEnv(field, value string) (string, error) {
+	envName, ok := explicitEnvReferenceName(value)
+	if !ok {
+		return value, nil
+	}
+	resolved, ok := os.LookupEnv(envName)
+	if !ok || resolved == "" {
+		return "", &MissingEnvValueError{Field: field, EnvVar: envName}
+	}
+	return resolved, nil
+}
+
+func explicitEnvReferenceName(value string) (string, bool) {
+	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
+		name := strings.TrimSuffix(strings.TrimPrefix(value, "${"), "}")
+		return name, isExplicitEnvName(name)
+	}
+	if strings.HasPrefix(value, "$") {
+		name := strings.TrimPrefix(value, "$")
+		return name, isExplicitEnvName(name)
+	}
+	return "", false
+}
+
+func isExplicitEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case i == 0 && (r == '_' || (r >= 'A' && r <= 'Z')):
+			continue
+		case i > 0 && (r == '_' || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')):
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeStateConcurrencyLimits(limits map[string]int) map[string]int {

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -133,5 +135,130 @@ Prompt body
 				}
 			}
 		})
+	}
+}
+
+func TestLoadResolvesExactEnvironmentReferences(t *testing.T) {
+	workspaceRoot := filepath.Join(t.TempDir(), "workspaces")
+	credentialPath := filepath.Join(t.TempDir(), "token")
+	t.Setenv("AIOPS_TEST_REPO_URL", "git@example.com:o/r.git")
+	t.Setenv("AIOPS_TEST_TRACKER_KEY", "tracker-secret")
+	t.Setenv("AIOPS_TEST_WORKSPACE_ROOT", workspaceRoot)
+	t.Setenv("AIOPS_TEST_CODEX_COMMAND", "codex app-server")
+	t.Setenv("AIOPS_TEST_CLAUDE_COMMAND", "claude --print")
+	t.Setenv("AIOPS_TEST_CREDENTIAL_PATH", credentialPath)
+
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: $AIOPS_TEST_REPO_URL
+tracker:
+  api_key: ${AIOPS_TEST_TRACKER_KEY}
+workspace:
+  root: $AIOPS_TEST_WORKSPACE_ROOT
+codex:
+  command: $AIOPS_TEST_CODEX_COMMAND
+claude:
+  command: ${AIOPS_TEST_CLAUDE_COMMAND}
+sandbox:
+  credential_files:
+    - ${AIOPS_TEST_CREDENTIAL_PATH}
+---
+Prompt body
+`)
+
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Repo.CloneURL; got != "git@example.com:o/r.git" {
+		t.Fatalf("repo.clone_url = %q", got)
+	}
+	if got := wf.Config.Tracker.APIKey; got != "tracker-secret" {
+		t.Fatalf("tracker.api_key = %q", got)
+	}
+	if got := wf.Config.Workspace.Root; got != workspaceRoot {
+		t.Fatalf("workspace.root = %q, want %q", got, workspaceRoot)
+	}
+	if got := wf.Config.Codex.Command; got != "codex app-server" {
+		t.Fatalf("codex.command = %q", got)
+	}
+	if got := wf.Config.Claude.Command; got != "claude --print" {
+		t.Fatalf("claude.command = %q", got)
+	}
+	if len(wf.Config.Sandbox.CredentialFiles) != 1 || wf.Config.Sandbox.CredentialFiles[0] != credentialPath {
+		t.Fatalf("sandbox.credential_files = %#v, want [%q]", wf.Config.Sandbox.CredentialFiles, credentialPath)
+	}
+}
+
+func TestLoadPreservesLiteralDollarSubstrings(t *testing.T) {
+	t.Setenv("USER", "expanded-user")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: https://gitea.example/$USER/aiops
+workspace:
+  root: .aiops-$USER
+codex:
+  command: bash -lc 'echo $RUNTIME_VAR'
+claude:
+  command: claude --append-system-prompt '$LITERAL'
+sandbox:
+  credential_files:
+    - /secrets/$TOKEN/path
+---
+Prompt body
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Repo.CloneURL; got != "https://gitea.example/$USER/aiops" {
+		t.Fatalf("repo.clone_url = %q", got)
+	}
+	wantRoot := filepath.Join(dir, ".aiops-$USER")
+	if got := wf.Config.Workspace.Root; got != wantRoot {
+		t.Fatalf("workspace.root = %q, want %q", got, wantRoot)
+	}
+	if got := wf.Config.Codex.Command; got != "bash -lc 'echo $RUNTIME_VAR'" {
+		t.Fatalf("codex.command = %q", got)
+	}
+	if got := wf.Config.Claude.Command; got != "claude --append-system-prompt '$LITERAL'" {
+		t.Fatalf("claude.command = %q", got)
+	}
+	if len(wf.Config.Sandbox.CredentialFiles) != 1 || wf.Config.Sandbox.CredentialFiles[0] != "/secrets/$TOKEN/path" {
+		t.Fatalf("sandbox.credential_files = %#v, want literal dollar path", wf.Config.Sandbox.CredentialFiles)
+	}
+}
+
+func TestLoadRejectsMissingExplicitEnvironmentReference(t *testing.T) {
+	t.Setenv("AIOPS_TEST_EMPTY_TRACKER_KEY", "")
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  api_key: $AIOPS_TEST_EMPTY_TRACKER_KEY
+---
+Prompt body
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load = nil, want missing env reference error")
+	}
+	for _, want := range []string{path, "missing_tracker_api_key", "tracker.api_key", "$AIOPS_TEST_EMPTY_TRACKER_KEY"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Load error = %q, want substring %q", err, want)
+		}
 	}
 }

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -301,3 +301,35 @@ Prompt body
 		}
 	}
 }
+
+func TestLoadResolvesLowercaseEnvironmentReferences(t *testing.T) {
+	t.Setenv("aiops_test_repo_url", "git@example.com:o/lower.git")
+	t.Setenv("linear_token", "linear-secret")
+	t.Setenv("Mixed_Case_Url", "https://tracker.example/mixed")
+
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: $aiops_test_repo_url
+tracker:
+  api_key: ${linear_token}
+  base_url: $Mixed_Case_Url
+---
+Prompt body
+`)
+
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Repo.CloneURL; got != "git@example.com:o/lower.git" {
+		t.Fatalf("repo.clone_url = %q, lowercase env not resolved", got)
+	}
+	if got := wf.Config.Tracker.APIKey; got != "linear-secret" {
+		t.Fatalf("tracker.api_key = %q, lowercase ${} env not resolved", got)
+	}
+	if got := wf.Config.Tracker.BaseURL; got != "https://tracker.example/mixed" {
+		t.Fatalf("tracker.base_url = %q, mixed-case env not resolved", got)
+	}
+}

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -143,6 +143,7 @@ func TestLoadResolvesExactEnvironmentReferences(t *testing.T) {
 	credentialPath := filepath.Join(t.TempDir(), "token")
 	t.Setenv("AIOPS_TEST_REPO_URL", "git@example.com:o/r.git")
 	t.Setenv("AIOPS_TEST_TRACKER_KEY", "tracker-secret")
+	t.Setenv("AIOPS_TEST_TRACKER_BASE_URL", "https://tracker.example/api")
 	t.Setenv("AIOPS_TEST_WORKSPACE_ROOT", workspaceRoot)
 	t.Setenv("AIOPS_TEST_CODEX_COMMAND", "codex app-server")
 	t.Setenv("AIOPS_TEST_CLAUDE_COMMAND", "claude --print")
@@ -155,6 +156,7 @@ repo:
   clone_url: $AIOPS_TEST_REPO_URL
 tracker:
   api_key: ${AIOPS_TEST_TRACKER_KEY}
+  base_url: $AIOPS_TEST_TRACKER_BASE_URL
 workspace:
   root: $AIOPS_TEST_WORKSPACE_ROOT
 codex:
@@ -177,6 +179,9 @@ Prompt body
 	}
 	if got := wf.Config.Tracker.APIKey; got != "tracker-secret" {
 		t.Fatalf("tracker.api_key = %q", got)
+	}
+	if got := wf.Config.Tracker.BaseURL; got != "https://tracker.example/api" {
+		t.Fatalf("tracker.base_url = %q", got)
 	}
 	if got := wf.Config.Workspace.Root; got != workspaceRoot {
 		t.Fatalf("workspace.root = %q, want %q", got, workspaceRoot)
@@ -201,6 +206,8 @@ repo:
   owner: o
   name: r
   clone_url: https://gitea.example/$USER/aiops
+tracker:
+  base_url: https://tracker.example/$USER/api
 workspace:
   root: .aiops-$USER
 codex:
@@ -223,6 +230,9 @@ Prompt body
 	}
 	if got := wf.Config.Repo.CloneURL; got != "https://gitea.example/$USER/aiops" {
 		t.Fatalf("repo.clone_url = %q", got)
+	}
+	if got := wf.Config.Tracker.BaseURL; got != "https://tracker.example/$USER/api" {
+		t.Fatalf("tracker.base_url = %q", got)
 	}
 	wantRoot := filepath.Join(dir, ".aiops-$USER")
 	if got := wf.Config.Workspace.Root; got != wantRoot {
@@ -257,6 +267,35 @@ Prompt body
 		t.Fatal("Load = nil, want missing env reference error")
 	}
 	for _, want := range []string{path, "missing_tracker_api_key", "tracker.api_key", "$AIOPS_TEST_EMPTY_TRACKER_KEY"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Load error = %q, want substring %q", err, want)
+		}
+	}
+}
+
+func TestLoadRejectsMissingExplicitEnvironmentReferenceNonTrackerField(t *testing.T) {
+	os.Unsetenv("AIOPS_TEST_UNSET_CODEX_COMMAND")
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  api_key: literal-key
+codex:
+  command: $AIOPS_TEST_UNSET_CODEX_COMMAND
+---
+Prompt body
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load = nil, want missing env reference error for codex.command")
+	}
+	if strings.Contains(err.Error(), "missing_tracker_api_key") {
+		t.Fatalf("Load error = %q, codex.command must not use tracker.api_key category", err)
+	}
+	for _, want := range []string{path, "workflow_config_missing_value", "codex.command", "$AIOPS_TEST_UNSET_CODEX_COMMAND"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("Load error = %q, want substring %q", err, want)
 		}

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -56,13 +56,17 @@ func Resolve(workdir string) (*Workflow, *Resolution, error) {
 			return nil, nil, err
 		}
 		cfg := DefaultConfig()
-		expandConfig(&cfg)
+		if err := expandConfig(&cfg); err != nil {
+			return nil, nil, err
+		}
 		wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt(), Source: SourceDefault}
 		return wf, &Resolution{Source: SourceDefault}, nil
 	}
 	if info.IsDir() {
 		cfg := DefaultConfig()
-		expandConfig(&cfg)
+		if err := expandConfig(&cfg); err != nil {
+			return nil, nil, err
+		}
 		wf := &Workflow{Config: cfg, PromptTemplate: DefaultPrompt(), Source: SourceDefault}
 		return wf, &Resolution{Source: SourceDefault}, nil
 	}


### PR DESCRIPTION
Closes #187

## Summary

- Replace broad `os.ExpandEnv` workflow loading with exact whole-token env reference resolution.
- Preserve literal `$` substrings inside clone URLs, command strings, workspace paths, and sandbox credential paths unless the entire value is `$VAR` or `${VAR}`.
- Surface empty or unset explicit env references as typed workflow config errors, including `missing_tracker_api_key` for `tracker.api_key`.
- Add focused loader tests for exact env resolution, literal dollar preservation, and missing explicit env references.

## Verification

- `go test ./internal/workflow -run 'TestLoad(ResolvesExactEnvironmentReferences|PreservesLiteralDollarSubstrings|RejectsMissingExplicitEnvironmentReference)'` first failed against the old `os.ExpandEnv` behavior, then passed after the fix.
- `go test ./internal/workflow`
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test -race -covermode=atomic ./internal/workflow`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- Attempted `go test -race -covermode=atomic ./...`; this host-wide check still fails in pre-existing `internal/runner` cases on Darwin: app-server timeout timing assertions under race and Linux sandbox expectation tests for bubblewrap/firejail. The changed `internal/workflow` package passes with race coverage.

## Local Review Gates

- Codex review: `{"blocking_findings":[]}`
- Claude Code review: `{"blocking_findings":[]}`
