### PR TITLE
fix(gitea): refresh issue states by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ For SPEC-aligned Gitea polling, encode issue state as exactly one `aiops/*` labe
 | `Done` | `aiops/done` |
 | `Canceled` | `aiops/canceled` |
 
+The worker-owned Gitea tracker path uses these labels for both active issue
+polling and per-tick reconciliation. If a running issue is moved to
+`aiops/done` or `aiops/canceled`, the next poll refreshes that issue by ID and
+stops the in-flight run.
+
 Then run the poller from source:
 
 ```bash

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -131,6 +131,11 @@ The Gitea poller treats Gitea as a tracker reader: issues are selected by `aiops
 | `Done` | `aiops/done` |
 | `Canceled` | `aiops/canceled` |
 
+The worker-owned `tracker.kind: gitea` path uses the same label mapping for
+per-tick reconciliation. After a run starts, moving the issue to `aiops/done`
+or `aiops/canceled` makes the next poll refresh that issue by ID and cancel the
+active worker.
+
 Option A: from source.
 
 ```bash

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -47,6 +48,8 @@ type TrackerClient struct {
 	Config  workflow.TrackerConfig
 	HTTP    *http.Client
 	Logf    func(format string, args ...any)
+
+	issueNumbers sync.Map
 
 	paginationCapHits atomic.Int64
 }
@@ -101,6 +104,53 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	return out, nil
 }
 
+func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+	if c.BaseURL == "" || c.Token == "" {
+		return nil, fmt.Errorf("GITEA_BASE_URL and Gitea tracker api_key are required")
+	}
+	if c.Owner == "" || c.Repo == "" {
+		return nil, fmt.Errorf("repo.owner and repo.name are required for Gitea tracker polling")
+	}
+	if len(issueIDs) == 0 {
+		return map[string]string{}, nil
+	}
+	states := make(map[string]string, len(issueIDs))
+	seen := map[string]struct{}{}
+	for _, issueID := range issueIDs {
+		issueID = strings.TrimSpace(issueID)
+		if issueID == "" {
+			continue
+		}
+		if _, ok := seen[issueID]; ok {
+			continue
+		}
+		seen[issueID] = struct{}{}
+		issueNumber, ok := c.cachedIssueNumber(issueID)
+		if !ok {
+			continue
+		}
+		issue, found, err := c.getIssueByNumber(ctx, issueNumber)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		if refreshedID := giteaIssueID(issue); refreshedID != issueID {
+			c.cacheIssueNumber(issue)
+			continue
+		}
+		c.cacheIssueNumber(issue)
+		state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
+		c.logDiagnostics(issue, diagnostics)
+		if state == "" {
+			continue
+		}
+		states[issueID] = state
+	}
+	return states, nil
+}
+
 func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, issueState string, wantedStates map[string]struct{}, seenIssues map[string]struct{}) ([]tracker.Issue, error) {
 	var out []tracker.Issue
 	for page := 1; page <= listIssuesMaxPages+1; page++ {
@@ -116,13 +166,11 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 			return out, nil
 		}
 		for _, issue := range batch {
-			issueKey := strconv.FormatInt(issue.ID, 10)
-			if issueKey == "0" {
-				issueKey = strconv.Itoa(issue.Number)
-			}
+			issueKey := giteaIssueID(issue)
 			if _, ok := seenIssues[issueKey]; ok {
 				continue
 			}
+			c.cacheIssueNumber(issue)
 			state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
 			c.logDiagnostics(issue, diagnostics)
 			if state == "" {
@@ -143,7 +191,7 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 			}
 			seenIssues[issueKey] = struct{}{}
 			out = append(out, tracker.Issue{
-				ID:          strconv.FormatInt(issue.ID, 10),
+				ID:          issueKey,
 				Identifier:  fmt.Sprintf("#%d", issue.Number),
 				Title:       issue.Title,
 				Description: issue.Body,
@@ -177,6 +225,52 @@ func parseGiteaIssueTime(field, value string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("parse Gitea issue %s %q: %w", field, value, err)
 	}
 	return parsed, nil
+}
+
+func (c *TrackerClient) getIssueByNumber(ctx context.Context, issueNumber int) (Issue, bool, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues/%d", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo), issueNumber)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Issue{}, false, err
+	}
+	req.Header.Set("Authorization", "token "+c.Token)
+	client := c.HTTP
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return Issue{}, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return Issue{}, false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Issue{}, false, fmt.Errorf("get Gitea issue #%d failed: %s", issueNumber, resp.Status)
+	}
+	var issue Issue
+	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
+		return Issue{}, false, err
+	}
+	return issue, true, nil
+}
+
+func (c *TrackerClient) cacheIssueNumber(issue Issue) {
+	issueID := giteaIssueID(issue)
+	if issueID == "" || issue.Number <= 0 {
+		return
+	}
+	c.issueNumbers.Store(issueID, issue.Number)
+}
+
+func (c *TrackerClient) cachedIssueNumber(issueID string) (int, bool) {
+	got, ok := c.issueNumbers.Load(issueID)
+	if !ok {
+		return 0, false
+	}
+	issueNumber, ok := got.(int)
+	return issueNumber, ok && issueNumber > 0
 }
 
 func (c *TrackerClient) listIssuesPage(ctx context.Context, labelName string, issueState string, page int) ([]Issue, bool, error) {
@@ -228,6 +322,16 @@ func hasNextPage(linkHeaders []string) bool {
 		}
 	}
 	return false
+}
+
+func giteaIssueID(issue Issue) string {
+	if issue.ID != 0 {
+		return strconv.FormatInt(issue.ID, 10)
+	}
+	if issue.Number != 0 {
+		return strconv.Itoa(issue.Number)
+	}
+	return ""
 }
 
 func giteaAPIStateForWorkflowStates(states, terminalStateNames []string) string {

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -12,8 +12,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+func TestTrackerClientSatisfiesIssueStateRefresher(t *testing.T) {
+	var _ tracker.IssueStateRefresher = (*TrackerClient)(nil)
+}
 
 func TestTrackerClientListIssuesByStatesReturnsNoIssuesWhenNoStatesRequested(t *testing.T) {
 	requests := 0
@@ -92,6 +97,56 @@ func TestTrackerClientListIssuesByStatesMapsAIOpsLabels(t *testing.T) {
 	}
 	if !issues[0].CreatedAt.Equal(mustTime("2026-05-16T23:59:00Z")) || !issues[1].CreatedAt.Equal(mustTime("2026-05-17T00:00:30Z")) {
 		t.Fatalf("issue created_at = %s, %s; want Gitea created_at metadata mapped", issues[0].CreatedAt, issues[1].CreatedAt)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) {
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		if r.Header.Get("Authorization") != "token secret" {
+			t.Fatalf("Authorization = %q, want token secret", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues":
+			if r.URL.Query().Get("labels") != "aiops/todo" {
+				t.Fatalf("labels query = %q, want aiops/todo", r.URL.Query().Get("labels"))
+			}
+			_ = json.NewEncoder(w).Encode([]Issue{
+				{ID: 101, Number: 1, Title: "running", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/todo"}}},
+				{ID: 202, Number: 2, Title: "missing later", HTMLURL: "https://gitea.local/o/r/issues/2", Labels: []Label{{Name: "aiops/todo"}}},
+			})
+		case "/api/v1/repos/owner/repo/issues/1":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 101, Number: 1, Title: "done", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/done"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/2":
+			http.NotFound(w, r)
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{
+		APIKey:       "secret",
+		ActiveStates: []string{"AI Ready"},
+	}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	if _, err := client.ListActiveIssues(context.Background()); err != nil {
+		t.Fatalf("ListActiveIssues: %v", err)
+	}
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"101", "202"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+	if got, want := states, map[string]string{"101": "Done"}; len(got) != len(want) || got["101"] != want["101"] {
+		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	if got, want := strings.Join(requestedPaths, ","), "/api/v1/repos/owner/repo/issues,/api/v1/repos/owner/repo/issues/1,/api/v1/repos/owner/repo/issues/2"; got != want {
+		t.Fatalf("requested paths = %s, want %s", got, want)
 	}
 }
 

--- a/test/e2e/gitea.go
+++ b/test/e2e/gitea.go
@@ -297,6 +297,22 @@ func (g *giteaEnv) addIssueLabels(ctx context.Context, owner, repo string, issue
 	return nil
 }
 
+func (g *giteaEnv) replaceIssueLabels(ctx context.Context, owner, repo string, issue int, labels []string) error {
+	type req struct {
+		Labels []string `json:"labels"`
+	}
+	resp, respBody, err := g.doJSON(ctx, "PUT",
+		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/labels", owner, repo, issue),
+		req{Labels: labels}, false)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("replaceIssueLabels: status %d body %s", resp.StatusCode, respBody)
+	}
+	return nil
+}
+
 type prSummary struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -68,6 +68,112 @@ func TestGiteaMockLoop_HappyPath(t *testing.T) {
 	}
 }
 
+func TestGiteaWorkerReconciliationStopsRunMovedToDone(t *testing.T) {
+	testStart := time.Now()
+	t.Cleanup(func() { bed.resetState(t, testStart) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	owner, repo := bed.gitea.botUser, "demo-gitea-reconcile"
+	if _, err := bed.gitea.createRepo(ctx, repo); err != nil {
+		t.Fatalf("createRepo: %v", err)
+	}
+	issueNum, err := bed.gitea.createIssue(ctx, owner, repo, "stop me", "move to done while running")
+	if err != nil {
+		t.Fatalf("createIssue: %v", err)
+	}
+	if err := bed.gitea.ensureLabels(ctx, owner, repo, []string{"aiops/todo", "aiops/done"}); err != nil {
+		t.Fatalf("ensure labels: %v", err)
+	}
+	if err := bed.gitea.addIssueLabels(ctx, owner, repo, issueNum, []string{"aiops/todo"}); err != nil {
+		t.Fatalf("add todo label: %v", err)
+	}
+
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.Owner = owner
+	cfg.Repo.Name = repo
+	cfg.Repo.DefaultBranch = "main"
+	cfg.Tracker.Kind = "gitea"
+	cfg.Tracker.APIKey = bed.gitea.botToken
+	cfg.Tracker.ActiveStates = []string{"AI Ready"}
+	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
+	client := gitea.NewTrackerClient(cfg.Tracker, bed.gitea.baseURL, owner, repo)
+	client.HTTP = httpClientForE2E()
+
+	dispatcher := &giteaReconcileBlockingDispatcher{
+		started:  make(chan tracker.Issue, 1),
+		canceled: make(chan error, 1),
+	}
+	orch := orchestrator.New(orchestrator.NewOrchestratorState(15000, 1), orchestrator.Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  orchestrator.RetryScheduler{MaxBackoff: time.Minute},
+	})
+	orchCtx, orchCancel := context.WithCancel(ctx)
+	t.Cleanup(orchCancel)
+	go orch.Run(orchCtx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("start orchestrator: %v", err)
+	}
+
+	poller := orchestrator.NewPollerWithReconciliation(client, orch, orchestrator.ReconciliationConfig{
+		ActiveStates:      cfg.Tracker.ActiveStates,
+		TerminalStates:    cfg.Tracker.TerminalStates,
+		WorkerExitTimeout: 10 * time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll: %v", err)
+	}
+	select {
+	case issue := <-dispatcher.started:
+		if issue.Identifier != fmt.Sprintf("#%d", issueNum) || issue.State != "AI Ready" {
+			t.Fatalf("started issue = %#v, want Gitea issue #%d in AI Ready", issue, issueNum)
+		}
+	case <-ctx.Done():
+		t.Fatalf("worker did not start: %v", ctx.Err())
+	}
+
+	if err := bed.gitea.replaceIssueLabels(ctx, owner, repo, issueNum, []string{"aiops/done"}); err != nil {
+		t.Fatalf("replace issue labels: %v", err)
+	}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("reconcile poll: %v", err)
+	}
+	select {
+	case <-dispatcher.canceled:
+	case <-ctx.Done():
+		t.Fatalf("worker was not canceled after moving issue to Done: %v", ctx.Err())
+	}
+	pollUntil(t, 10*time.Second, 100*time.Millisecond, func(ctx context.Context) (bool, error) {
+		view, err := orch.Snapshot(ctx)
+		if err != nil {
+			return false, err
+		}
+		return len(view.Running) == 0, nil
+	})
+}
+
+type giteaReconcileBlockingDispatcher struct {
+	started  chan tracker.Issue
+	canceled chan error
+}
+
+func (d *giteaReconcileBlockingDispatcher) Spawn(ctx context.Context, issue tracker.Issue, _ *int) <-chan orchestrator.WorkerResult {
+	select {
+	case d.started <- issue:
+	default:
+	}
+	ch := make(chan orchestrator.WorkerResult, 1)
+	go func() {
+		<-ctx.Done()
+		err := ctx.Err()
+		d.canceled <- err
+		ch <- orchestrator.WorkerResult{Err: err, Elapsed: time.Millisecond}
+		close(ch)
+	}()
+	return ch
+}
+
 func runGiteaPollerWorkerTask(t *testing.T, ctx context.Context, repo, title, body, fixture string) (taskID, owner, repoName string) {
 	t.Helper()
 


### PR DESCRIPTION
Closes #184

## Summary

- Adds Gitea `FetchIssueStatesByIDs` support for per-tick active-run reconciliation.
- Caches Gitea issue numbers from tracker listings so running Gitea issue IDs can be refreshed through the Gitea issue detail endpoint.
- Adds unit and e2e coverage for Gitea label-state refresh and cancellation after a running issue moves to `aiops/done`.
- Documents that Gitea reconciliation parity uses the same `aiops/*` labels as active polling.

## Verification

- Red check: applying the focused `internal/gitea` tests to `origin/main` fails because `TrackerClient` lacks `FetchIssueStatesByIDs` and does not satisfy `tracker.IssueStateRefresher`.
- `gofmt -l $(git ls-files '*.go')` passed with no output.
- `go mod tidy` plus `git diff --exit-code -- go.mod go.sum` passed.
- `go test -count=1 ./internal/gitea` passed.
- `go test -count=1 -tags e2e -race -timeout 15m ./test/e2e/... -run TestGiteaWorkerReconciliationStopsRunMovedToDone` passed.
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller` passed.
- `go test -race -covermode=atomic ./...` was run and failed only in pre-existing/local `internal/runner` Darwin-host cases: one 100 ms stall-clock timing assertion and Linux-only bubblewrap/firejail sandbox expectations.
- GitHub CI for this head is green: Go build and test, E2E Gitea mock loop, and Docker image build all passed. CI log warning scan found no `warning:` lines.

## Local reviews

- Codex JSON review: `{"blocking_findings":[]}`
- Claude Code JSON review `.structured_output`: `{"blocking_findings":[]}`
