### PR TITLE
Add SPEC typed error categories

### DIFF
--- a/cmd/worker/errors_test.go
+++ b/cmd/worker/errors_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestTrackerClientForWorkflowSurfacesUnsupportedTrackerCategory(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "jira"
+	_, err := trackerClientForWorkflow(cfg)
+	if !errors.Is(err, tracker.ErrUnsupportedTrackerKind) {
+		t.Fatalf("trackerClientForWorkflow error = %T %[1]v, want ErrUnsupportedTrackerKind", err)
+	}
+}
+
+func TestStateHTTPHandlerUsesCategoryErrorEnvelope(t *testing.T) {
+	handler := stateHTTPHandler(func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, tracker.NewError(tracker.CategoryLinearUnknownPayload, "bad tracker payload", nil)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusInternalServerError, w.Body.String())
+	}
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode error envelope: %v; body=%s", err, w.Body.String())
+	}
+	if payload.Error.Code != string(tracker.CategoryLinearUnknownPayload) || payload.Error.Message == "" {
+		t.Fatalf("error envelope = %+v, want category code and message", payload.Error)
+	}
+}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -531,10 +531,10 @@ func stateHTTPHandler(snapshot stateSnapshotFunc) http.Handler {
 		view, err := snapshot(r.Context())
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				writeAPIError(w, http.StatusServiceUnavailable, "snapshot_unavailable", err.Error())
+				writeAPIError(w, http.StatusServiceUnavailable, "request_cancelled", err.Error())
 				return
 			}
-			writeAPIError(w, http.StatusInternalServerError, "snapshot_failed", err.Error())
+			writeAPIError(w, http.StatusInternalServerError, apiErrorCode(err), err.Error())
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -559,10 +559,10 @@ func issueHTTPHandler(snapshot stateSnapshotFunc) http.Handler {
 		view, err := snapshot(r.Context())
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				writeAPIError(w, http.StatusServiceUnavailable, "snapshot_unavailable", err.Error())
+				writeAPIError(w, http.StatusServiceUnavailable, "request_cancelled", err.Error())
 				return
 			}
-			writeAPIError(w, http.StatusInternalServerError, "snapshot_failed", err.Error())
+			writeAPIError(w, http.StatusInternalServerError, apiErrorCode(err), err.Error())
 			return
 		}
 		payload, ok := apiIssueFromView(view, identifier)
@@ -780,6 +780,16 @@ func stringPointerIfNotEmpty(value string) *string {
 	return &value
 }
 
+func apiErrorCode(err error) string {
+	if category, ok := workflow.ErrorCategory(err); ok {
+		return string(category)
+	}
+	if category, ok := tracker.ErrorCategory(err); ok {
+		return string(category)
+	}
+	return "internal_error"
+}
+
 func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 	generatedAt := view.GeneratedAt
 	if generatedAt.IsZero() {
@@ -941,7 +951,7 @@ func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error)
 		}
 		return tracker.NewGitHubClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name), nil
 	default:
-		return nil, fmt.Errorf("unsupported tracker.kind %q", cfg.Tracker.Kind)
+		return nil, tracker.NewError(tracker.CategoryUnsupportedTrackerKind, fmt.Sprintf("unsupported tracker.kind %q", cfg.Tracker.Kind), nil)
 	}
 }
 

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -89,9 +89,8 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 		return errors.New("orchestrator poller requires orchestrator")
 	}
 	issues, activeErr := p.tracker.ListActiveIssues(ctx)
-	if _, ok := tracker.ErrorCategory(activeErr); ok {
-		return activeErr
-	}
+	// Multi-tracker clients return (issues, errors.Join(...)) on partial success;
+	// keep the successful issues and join activeErr into pollErr below.
 	if activeErr != nil && len(issues) == 0 {
 		return activeErr
 	}

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -89,6 +89,9 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 		return errors.New("orchestrator poller requires orchestrator")
 	}
 	issues, activeErr := p.tracker.ListActiveIssues(ctx)
+	if _, ok := tracker.ErrorCategory(activeErr); ok {
+		return activeErr
+	}
 	if activeErr != nil && len(issues) == 0 {
 		return activeErr
 	}

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -18,19 +20,24 @@ import (
 type fakeIssueTracker struct {
 	issues                []tracker.Issue
 	err                   error
+	partialSuccess        bool
 	calls                 int
 	preserveMissingFields bool
 }
 
 func (f *fakeIssueTracker) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
 	f.calls++
-	if f.err != nil {
+	if f.err != nil && !f.partialSuccess {
 		return nil, f.err
 	}
-	if f.preserveMissingFields {
-		return f.issues, nil
+	issues := f.issues
+	if !f.preserveMissingFields {
+		issues = defaultTrackerIssueTitles(f.issues)
 	}
-	return defaultTrackerIssueTitles(f.issues), nil
+	if f.err != nil {
+		return issues, f.err
+	}
+	return issues, nil
 }
 
 func defaultTrackerIssueTitles(issues []tracker.Issue) []tracker.Issue {
@@ -1889,4 +1896,52 @@ func mustTime(value string) time.Time {
 		panic(err)
 	}
 	return parsed
+}
+
+// TestPollOnceDispatchesPartialIssuesWhenTrackerReturnsCategorizedError covers
+// the multi-tracker partial-success case: ListActiveIssues may return
+// (issues, errors.Join(...)) where one tracker fails (a typed
+// tracker.ErrorCategory error) while another succeeds. PollOnce must keep
+// dispatching the successful issues; only fail-out early when no issues were
+// fetched at all.
+func TestPollOnceDispatchesPartialIssuesWhenTrackerReturnsCategorizedError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	categorizedErr := errors.Join(
+		errors.New("benign other"),
+		tracker.NewError(tracker.CategoryLinearGraphQLErrors, "linear partial outage", nil),
+	)
+	trackerClient := &fakeIssueTracker{
+		issues: []tracker.Issue{
+			{ID: "issue-1", Identifier: "GH-1", State: "AI Ready"},
+			{ID: "issue-2", Identifier: "GH-2", State: "AI Ready"},
+		},
+		err:            categorizedErr,
+		partialSuccess: true,
+	}
+	dispatcher := &recordingDispatcher{}
+	orch := New(NewOrchestratorState(30000, 4), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+	poller := NewPoller(trackerClient, orch)
+
+	pollErr := poller.PollOnce(ctx)
+	if pollErr == nil {
+		t.Fatal("PollOnce returned nil, want partial-success error reported")
+	}
+	if cat, ok := tracker.ErrorCategory(pollErr); !ok || cat != tracker.CategoryLinearGraphQLErrors {
+		t.Fatalf("PollOnce error category = %q ok=%v, want %q true", cat, ok, tracker.CategoryLinearGraphQLErrors)
+	}
+	waitForDispatcherCount(t, dispatcher, 2)
+	ids := dispatcher.issueIDs()
+	sort.Strings(ids)
+	if !reflect.DeepEqual(ids, []string{"issue-1", "issue-2"}) {
+		t.Fatalf("dispatched issue IDs = %v, want partial issues [issue-1 issue-2]", ids)
+	}
 }

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -681,6 +681,19 @@ func TestWorkflowRuntimeReloadFailureKeepsPreviousConfigAndEmitsFailureEvent(t *
 	}
 }
 
+func TestWorkflowFileFingerprintDoesNotMarkNonMissingReadErrorsAsMissing(t *testing.T) {
+	_, err := workflowFileFingerprint(t.TempDir())
+	if err == nil {
+		t.Fatalf("workflowFileFingerprint directory path error = nil, want read error")
+	}
+	if errors.Is(err, workflow.ErrMissingWorkflowFile) {
+		t.Fatalf("workflowFileFingerprint directory path error = %T %[1]v, must not match ErrMissingWorkflowFile", err)
+	}
+	if got, ok := workflow.ErrorCategory(err); ok {
+		t.Fatalf("ErrorCategory(directory fingerprint error) = %q, true; want uncategorized", got)
+	}
+}
+
 func TestRunWorkflowReloadLoopPollFallbackReloadsChangedWorkflow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -195,7 +195,10 @@ func normalizeStateConcurrencyLimits(in map[string]int) map[string]int {
 func workflowFileFingerprint(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", err
+		if errors.Is(err, os.ErrNotExist) {
+			return "", &workflow.Error{Category: workflow.CategoryMissingWorkflowFile, Path: path, Message: "read workflow file", Err: err}
+		}
+		return "", fmt.Errorf("%s: read workflow file: %w", path, err)
 	}
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:]), nil

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -30,6 +30,9 @@ const (
 )
 
 func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error) {
+	if err := validateAppServerWorkdir(in.Workdir); err != nil {
+		return Result{}, err
+	}
 	promptAbs := filepath.Join(in.Workdir, PromptPath)
 	prompt, err := os.ReadFile(promptAbs)
 	if err != nil {
@@ -114,15 +117,35 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: runErr}
 		}
+		if _, ok := ErrorCategory(runErr); ok {
+			return res, runErr
+		}
+		if waitErr != nil {
+			return res, NewError(CategoryPortExit, "codex app-server process exited", errors.Join(runErr, waitErr))
+		}
 		return res, runErr
 	}
 	if waitErr != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: waitErr}
 		}
-		return res, waitErr
+		return res, NewError(CategoryPortExit, "codex app-server process exited", waitErr)
 	}
 	return res, nil
+}
+
+func validateAppServerWorkdir(workdir string) error {
+	if strings.TrimSpace(workdir) == "" {
+		return NewError(CategoryInvalidWorkspaceCWD, "codex app-server workspace cwd is empty", nil)
+	}
+	info, err := os.Stat(workdir)
+	if err != nil {
+		return NewError(CategoryInvalidWorkspaceCWD, "codex app-server workspace cwd is invalid", err)
+	}
+	if !info.IsDir() {
+		return NewError(CategoryInvalidWorkspaceCWD, "codex app-server workspace cwd is not a directory", nil)
+	}
+	return nil
 }
 
 func buildCodexAppServerCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
@@ -136,7 +159,7 @@ func buildCodexAppServerCmd(ctx context.Context, in RunInput) (*exec.Cmd, error)
 	}
 	if fields[0] == "codex" {
 		if _, err := exec.LookPath("codex"); err != nil {
-			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
+			return nil, NewError(CategoryCodexNotFound, "codex binary not found in PATH; install codex CLI or set agent.default to claude/mock", err)
 		}
 		return exec.CommandContext(ctx, fields[0], fields[1:]...), nil
 	}
@@ -283,7 +306,7 @@ func (c *appServerClient) request(ctx context.Context, method string, params map
 		}
 		if gotID, ok := numberID(msg["id"]); ok && gotID == id {
 			if e, ok := msg["error"]; ok {
-				return nil, fmt.Errorf("rpc error: %v", e)
+				return nil, NewError(CategoryResponseError, fmt.Sprintf("rpc error: %v", e), nil)
 			}
 			result, _ := msg["result"].(map[string]any)
 			if result == nil {
@@ -333,7 +356,7 @@ func (c *appServerClient) readProtocolMessage(ctx context.Context) (map[string]a
 	_, _ = c.out.Write(line)
 	var msg map[string]any
 	if err := json.Unmarshal(line, &msg); err != nil {
-		return nil, line, err
+		return nil, line, NewError(CategoryResponseError, "decode codex app-server message", err)
 	}
 	return msg, line, nil
 }
@@ -457,10 +480,11 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 			case "turn/failed", "turn/cancelled":
 				if method == "turn/failed" {
 					c.recordRuntimeMessage(task.EventTurnFailed, msg)
+					return NewError(CategoryTurnFailed, fmt.Sprintf("%s: %v", method, msg["params"]), nil)
 				} else {
 					c.recordRuntimeMessage(task.EventTurnCancelled, msg)
+					return NewError(CategoryTurnCancelled, fmt.Sprintf("%s: %v", method, msg["params"]), nil)
 				}
-				return fmt.Errorf("%s: %v", method, msg["params"])
 			case "item/tool/call":
 				if err := c.handleDynamicToolCall(ctx, msg); err != nil {
 					return err
@@ -775,7 +799,7 @@ func completedTurnError(msg map[string]any) error {
 	if reason == "" {
 		reason = fmt.Sprint(params)
 	}
-	return fmt.Errorf("turn/completed failed with status %q: %s", status, reason)
+	return NewError(CategoryTurnFailed, fmt.Sprintf("turn/completed failed with status %q: %s", status, reason), nil)
 }
 
 func (c *appServerClient) handleDynamicToolCall(ctx context.Context, msg map[string]any) error {
@@ -880,11 +904,11 @@ func appServerContinuationPrompt(in RunInput, turn int) string {
 func extractString(m map[string]any, outer, inner string) (string, error) {
 	o, _ := m[outer].(map[string]any)
 	if o == nil {
-		return "", fmt.Errorf("missing %s", outer)
+		return "", NewError(CategoryResponseError, "missing "+outer, nil)
 	}
 	v, _ := o[inner].(string)
 	if v == "" {
-		return "", fmt.Errorf("missing %s.%s", outer, inner)
+		return "", NewError(CategoryResponseError, fmt.Sprintf("missing %s.%s", outer, inner), nil)
 	}
 	return v, nil
 }

--- a/internal/runner/errors_test.go
+++ b/internal/runner/errors_test.go
@@ -1,0 +1,84 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunnerSentinelsCoverSpecCategories(t *testing.T) {
+	cases := []struct {
+		category RunnerErrorCategory
+		sentinel error
+	}{
+		{CategoryCodexNotFound, ErrCodexNotFound},
+		{CategoryInvalidWorkspaceCWD, ErrInvalidWorkspaceCWD},
+		{CategoryResponseTimeout, ErrResponseTimeout},
+		{CategoryTurnTimeout, ErrTurnTimeout},
+		{CategoryPortExit, ErrPortExit},
+		{CategoryResponseError, ErrResponseError},
+		{CategoryTurnFailed, ErrTurnFailed},
+		{CategoryTurnCancelled, ErrTurnCancelled},
+		{CategoryTurnInputRequired, ErrTurnInputRequired},
+	}
+	for _, tc := range cases {
+		err := NewError(tc.category, "runner category", nil)
+		if !errors.Is(err, tc.sentinel) {
+			t.Fatalf("NewError(%q) = %T %[2]v, want errors.Is sentinel", tc.category, err)
+		}
+		if got, ok := ErrorCategory(err); !ok || got != tc.category {
+			t.Fatalf("ErrorCategory(%q) = %q, %v", tc.category, got, ok)
+		}
+	}
+}
+
+func TestCodexAppServerRunnerSurfacesRunnerErrorCategories(t *testing.T) {
+	t.Run("codex not found", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		_, err := buildCodexAppServerCmd(context.Background(), appServerInput(t.TempDir()))
+		if !errors.Is(err, ErrCodexNotFound) {
+			t.Fatalf("buildCodexAppServerCmd error = %T %[1]v, want ErrCodexNotFound", err)
+		}
+	})
+
+	t.Run("invalid workspace cwd", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing")
+		_, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(missing))
+		if !errors.Is(err, ErrInvalidWorkspaceCWD) {
+			t.Fatalf("Run missing workdir error = %T %[1]v, want ErrInvalidWorkspaceCWD", err)
+		}
+	})
+}
+
+func TestTimeoutTypesExposeRunnerCategories(t *testing.T) {
+	read := &ReadTimeoutError{Timeout: time.Millisecond, Cause: errors.New("read")}
+	if !errors.Is(read, ErrResponseTimeout) {
+		t.Fatalf("ReadTimeoutError does not match ErrResponseTimeout")
+	}
+	turn := &TurnTimeoutError{Timeout: time.Millisecond, Elapsed: time.Millisecond, Cause: context.DeadlineExceeded}
+	if !errors.Is(turn, ErrTurnTimeout) {
+		t.Fatalf("TurnTimeoutError does not match ErrTurnTimeout")
+	}
+	if got, ok := ErrorCategory(turn); !ok || got != CategoryTurnTimeout {
+		t.Fatalf("ErrorCategory(turn) = %q, %v; want %q, true", got, ok, CategoryTurnTimeout)
+	}
+}
+
+func TestCodexAppServerRunnerStillReadsPromptForValidWorkspace(t *testing.T) {
+	wd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wd, ".aiops"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, PromptPath), []byte("prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	_, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err == nil || !strings.Contains(err.Error(), "codex binary not found") {
+		t.Fatalf("Run valid workdir error = %T %[1]v, want codex lookup after prompt read", err)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -65,6 +65,95 @@ func New(name string) (Runner, error) {
 	}
 }
 
+type RunnerErrorCategory string
+
+const (
+	CategoryCodexNotFound       RunnerErrorCategory = "codex_not_found"
+	CategoryInvalidWorkspaceCWD RunnerErrorCategory = "invalid_workspace_cwd"
+	CategoryResponseTimeout     RunnerErrorCategory = "response_timeout"
+	CategoryTurnTimeout         RunnerErrorCategory = "turn_timeout"
+	CategoryPortExit            RunnerErrorCategory = "port_exit"
+	CategoryResponseError       RunnerErrorCategory = "response_error"
+	CategoryTurnFailed          RunnerErrorCategory = "turn_failed"
+	CategoryTurnCancelled       RunnerErrorCategory = "turn_cancelled"
+	CategoryTurnInputRequired   RunnerErrorCategory = "turn_input_required"
+)
+
+var (
+	ErrCodexNotFound       = &Error{Category: CategoryCodexNotFound}
+	ErrInvalidWorkspaceCWD = &Error{Category: CategoryInvalidWorkspaceCWD}
+	ErrResponseTimeout     = &Error{Category: CategoryResponseTimeout}
+	ErrTurnTimeout         = &Error{Category: CategoryTurnTimeout}
+	ErrPortExit            = &Error{Category: CategoryPortExit}
+	ErrResponseError       = &Error{Category: CategoryResponseError}
+	ErrTurnFailed          = &Error{Category: CategoryTurnFailed}
+	ErrTurnCancelled       = &Error{Category: CategoryTurnCancelled}
+	ErrTurnInputRequired   = &Error{Category: CategoryTurnInputRequired}
+)
+
+type Error struct {
+	Category RunnerErrorCategory
+	Message  string
+	Err      error
+}
+
+func NewError(category RunnerErrorCategory, message string, err error) *Error {
+	return &Error{Category: category, Message: message, Err: err}
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	msg := e.Message
+	if msg == "" {
+		msg = string(e.Category)
+	}
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	return msg
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *Error) Is(target error) bool {
+	return runnerCategoryMatches(e.category(), target)
+}
+
+func (e *Error) category() RunnerErrorCategory {
+	if e == nil {
+		return ""
+	}
+	return e.Category
+}
+
+type runnerCategorized interface {
+	category() RunnerErrorCategory
+}
+
+func ErrorCategory(err error) (RunnerErrorCategory, bool) {
+	var categorizedErr runnerCategorized
+	if errors.As(err, &categorizedErr) {
+		category := categorizedErr.category()
+		return category, category != ""
+	}
+	return "", false
+}
+
+func runnerCategoryMatches(category RunnerErrorCategory, target error) bool {
+	if category == "" || target == nil {
+		return false
+	}
+	var targetCategory runnerCategorized
+	return errors.As(target, &targetCategory) && targetCategory.category() == category
+}
+
 // TimeoutError is returned by Runner implementations when the parent
 // context's deadline elapsed before the runner subprocess finished.
 // Callers should treat this distinctly from a generic non-zero exit so
@@ -134,6 +223,14 @@ func (e *TurnTimeoutError) Error() string {
 
 func (e *TurnTimeoutError) Unwrap() error { return e.Cause }
 
+func (e *TurnTimeoutError) Is(target error) bool {
+	return runnerCategoryMatches(e.category(), target)
+}
+
+func (e *TurnTimeoutError) category() RunnerErrorCategory {
+	return CategoryTurnTimeout
+}
+
 // IsTurnTimeout reports whether err is (or wraps) a *TurnTimeoutError.
 func IsTurnTimeout(err error) bool {
 	var te *TurnTimeoutError
@@ -155,6 +252,14 @@ func (e *ReadTimeoutError) Error() string {
 }
 
 func (e *ReadTimeoutError) Unwrap() error { return e.Cause }
+
+func (e *ReadTimeoutError) Is(target error) bool {
+	return runnerCategoryMatches(e.category(), target)
+}
+
+func (e *ReadTimeoutError) category() RunnerErrorCategory {
+	return CategoryResponseTimeout
+}
 
 // IsReadTimeout reports whether err is (or wraps) a *ReadTimeoutError.
 func IsReadTimeout(err error) bool {

--- a/internal/tracker/errors_test.go
+++ b/internal/tracker/errors_test.go
@@ -1,0 +1,92 @@
+package tracker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestLinearClientSurfacesTrackerErrorCategories(t *testing.T) {
+	t.Run("missing api key", func(t *testing.T) {
+		_, err := NewLinearClient(workflow.TrackerConfig{ProjectSlug: "aiops"}).ListIssuesByStates(context.Background(), []string{"Todo"})
+		if !errors.Is(err, ErrMissingTrackerAPIKey) {
+			t.Fatalf("ListIssuesByStates missing key error = %T %[1]v, want ErrMissingTrackerAPIKey", err)
+		}
+	})
+
+	t.Run("missing project slug", func(t *testing.T) {
+		_, err := NewLinearClient(workflow.TrackerConfig{APIKey: "key"}).ListIssuesByStates(context.Background(), []string{"Todo"})
+		if !errors.Is(err, ErrMissingTrackerProjectSlug) {
+			t.Fatalf("ListIssuesByStates missing slug error = %T %[1]v, want ErrMissingTrackerProjectSlug", err)
+		}
+	})
+
+	t.Run("graphql errors", func(t *testing.T) {
+		client := linearTestClientForCategory(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{"errors":[{"message":"bad token"}]}`)
+		}))
+		_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+		if !errors.Is(err, ErrLinearGraphQLErrors) {
+			t.Fatalf("ListIssuesByStates GraphQL error = %T %[1]v, want ErrLinearGraphQLErrors", err)
+		}
+	})
+
+	t.Run("non-200 status", func(t *testing.T) {
+		client := linearTestClientForCategory(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "nope", http.StatusBadGateway)
+		}))
+		_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+		if !errors.Is(err, ErrLinearAPIStatus) {
+			t.Fatalf("ListIssuesByStates status error = %T %[1]v, want ErrLinearAPIStatus", err)
+		}
+	})
+
+	t.Run("unknown payload", func(t *testing.T) {
+		client := linearTestClientForCategory(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{`)
+		}))
+		_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+		if !errors.Is(err, ErrLinearUnknownPayload) {
+			t.Fatalf("ListIssuesByStates payload error = %T %[1]v, want ErrLinearUnknownPayload", err)
+		}
+	})
+
+	t.Run("missing end cursor", func(t *testing.T) {
+		client := linearTestClientForCategory(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":""}}}}`)
+		}))
+		_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+		if !errors.Is(err, ErrLinearMissingEndCursor) {
+			t.Fatalf("ListIssuesByStates cursor error = %T %[1]v, want ErrLinearMissingEndCursor", err)
+		}
+		if got, ok := ErrorCategory(err); !ok || got != CategoryLinearMissingEndCursor {
+			t.Fatalf("ErrorCategory = %q, %v; want %q, true", got, ok, CategoryLinearMissingEndCursor)
+		}
+	})
+}
+
+func TestTrackerSentinelsCoverSpecCategories(t *testing.T) {
+	err := NewError(CategoryUnsupportedTrackerKind, "unsupported tracker.kind jira", nil)
+	if !errors.Is(err, ErrUnsupportedTrackerKind) {
+		t.Fatalf("unsupported tracker error = %T %[1]v, want ErrUnsupportedTrackerKind", err)
+	}
+	err = NewError(CategoryLinearAPIRequest, "request failed", context.Canceled)
+	if !errors.Is(err, ErrLinearAPIRequest) {
+		t.Fatalf("request error = %T %[1]v, want ErrLinearAPIRequest", err)
+	}
+}
+
+func linearTestClientForCategory(t *testing.T, handler http.Handler) *LinearClient {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	client := NewLinearClient(workflow.TrackerConfig{APIKey: "key", ProjectSlug: "aiops"})
+	client.BaseURL = srv.URL
+	client.HTTP = srv.Client()
+	return client
+}

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -16,6 +17,77 @@ const (
 	linearIssuePageSize = 50
 	maxLinearIssuePages = 200
 )
+
+type Category string
+
+const (
+	CategoryUnsupportedTrackerKind    Category = "unsupported_tracker_kind"
+	CategoryMissingTrackerAPIKey      Category = "missing_tracker_api_key"
+	CategoryMissingTrackerProjectSlug Category = "missing_tracker_project_slug"
+	CategoryLinearAPIRequest          Category = "linear_api_request"
+	CategoryLinearAPIStatus           Category = "linear_api_status"
+	CategoryLinearGraphQLErrors       Category = "linear_graphql_errors"
+	CategoryLinearUnknownPayload      Category = "linear_unknown_payload"
+	CategoryLinearMissingEndCursor    Category = "linear_missing_end_cursor"
+)
+
+var (
+	ErrUnsupportedTrackerKind    = &Error{Category: CategoryUnsupportedTrackerKind}
+	ErrMissingTrackerAPIKey      = &Error{Category: CategoryMissingTrackerAPIKey}
+	ErrMissingTrackerProjectSlug = &Error{Category: CategoryMissingTrackerProjectSlug}
+	ErrLinearAPIRequest          = &Error{Category: CategoryLinearAPIRequest}
+	ErrLinearAPIStatus           = &Error{Category: CategoryLinearAPIStatus}
+	ErrLinearGraphQLErrors       = &Error{Category: CategoryLinearGraphQLErrors}
+	ErrLinearUnknownPayload      = &Error{Category: CategoryLinearUnknownPayload}
+	ErrLinearMissingEndCursor    = &Error{Category: CategoryLinearMissingEndCursor}
+)
+
+type Error struct {
+	Category Category
+	Message  string
+	Err      error
+}
+
+func NewError(category Category, message string, err error) *Error {
+	return &Error{Category: category, Message: message, Err: err}
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	msg := e.Message
+	if msg == "" {
+		msg = string(e.Category)
+	}
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	return msg
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *Error) Is(target error) bool {
+	if e == nil || e.Category == "" || target == nil {
+		return false
+	}
+	var targetErr *Error
+	return errors.As(target, &targetErr) && targetErr.Category == e.Category
+}
+
+func ErrorCategory(err error) (Category, bool) {
+	var trackerErr *Error
+	if errors.As(err, &trackerErr) {
+		return trackerErr.Category, trackerErr.Category != ""
+	}
+	return "", false
+}
 
 type LinearClient struct {
 	APIKey  string
@@ -35,11 +107,11 @@ func (c *LinearClient) ListActiveIssues(ctx context.Context) ([]Issue, error) {
 
 func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) ([]Issue, error) {
 	if c.APIKey == "" {
-		return nil, fmt.Errorf("Linear API key is required")
+		return nil, NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
 	}
 	projectSlug := strings.TrimSpace(c.Config.ProjectSlug)
 	if projectSlug == "" {
-		return nil, fmt.Errorf("Linear project slug is required")
+		return nil, NewError(CategoryMissingTrackerProjectSlug, "Linear project slug is required", nil)
 	}
 	query := `query ListIssues($projectSlug: String!, $states: [String!], $first: Int!, $after: String) {
   issues(filter: { project: { slugId: { eq: $projectSlug } }, state: { name: { in: $states } } }, first: $first, after: $after) {
@@ -113,7 +185,7 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 			return nil, err
 		}
 		if len(out.Errors) > 0 {
-			return nil, fmt.Errorf("linear errors: %v", out.Errors)
+			return nil, linearGraphQLErrors(out.Errors)
 		}
 		for _, n := range out.Data.Issues.Nodes {
 			createdAt, err := parseLinearIssueTime("createdAt", n.CreatedAt)
@@ -151,7 +223,7 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 			return issues, nil
 		}
 		if out.Data.Issues.PageInfo.EndCursor == "" {
-			return nil, fmt.Errorf("linear pagination missing endCursor")
+			return nil, NewError(CategoryLinearMissingEndCursor, "linear pagination missing endCursor", nil)
 		}
 		after = out.Data.Issues.PageInfo.EndCursor
 	}
@@ -183,7 +255,7 @@ func stringifyLinearCustomFieldValue(raw json.RawMessage) string {
 
 func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
 	if c.APIKey == "" {
-		return nil, fmt.Errorf("Linear API key is required")
+		return nil, NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
 	}
 	if len(issueIDs) == 0 {
 		return map[string]string{}, nil
@@ -220,7 +292,7 @@ func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []str
 			return nil, err
 		}
 		if len(out.Errors) > 0 {
-			return nil, fmt.Errorf("linear errors: %v", out.Errors)
+			return nil, linearGraphQLErrors(out.Errors)
 		}
 		for _, n := range out.Data.Issues.Nodes {
 			states[n.ID] = n.State.Name
@@ -268,7 +340,7 @@ func (c *LinearClient) linearBlockersForIssue(ctx context.Context, issueID strin
 		return nil, err
 	}
 	if len(out.Errors) > 0 {
-		return nil, fmt.Errorf("linear errors: %v", out.Errors)
+		return nil, linearGraphQLErrors(out.Errors)
 	}
 	return c.linearBlockersFromInverseRelations(ctx, issueID, out.Data.Issue.InverseRelations.Nodes, out.Data.Issue.InverseRelations.PageInfo.HasNextPage, out.Data.Issue.InverseRelations.PageInfo.EndCursor)
 }
@@ -286,7 +358,7 @@ func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, i
 	appendBlockers(nodes)
 	for page := 0; hasNextPage && page < maxLinearIssuePages; page++ {
 		if endCursor == "" {
-			return nil, fmt.Errorf("linear inverse relation pagination missing endCursor for issue %s", issueID)
+			return nil, NewError(CategoryLinearMissingEndCursor, fmt.Sprintf("linear inverse relation pagination missing endCursor for issue %s", issueID), nil)
 		}
 		var out struct {
 			Data struct {
@@ -311,7 +383,7 @@ func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, i
 			return nil, err
 		}
 		if len(out.Errors) > 0 {
-			return nil, fmt.Errorf("linear errors: %v", out.Errors)
+			return nil, linearGraphQLErrors(out.Errors)
 		}
 		appendBlockers(out.Data.Issue.InverseRelations.Nodes)
 		hasNextPage = out.Data.Issue.InverseRelations.PageInfo.HasNextPage
@@ -332,7 +404,7 @@ func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, i
 // aborts the underlying task.
 func (c *LinearClient) MoveIssueToState(ctx context.Context, issueID, stateName string) error {
 	if c.APIKey == "" {
-		return fmt.Errorf("Linear API key is required")
+		return NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
 	}
 	if issueID == "" {
 		return fmt.Errorf("issue id is required")
@@ -359,7 +431,7 @@ func (c *LinearClient) MoveIssueToState(ctx context.Context, issueID, stateName 
 		return err
 	}
 	if len(out.Errors) > 0 {
-		return fmt.Errorf("linear errors: %v", out.Errors)
+		return linearGraphQLErrors(out.Errors)
 	}
 	if !out.Data.IssueUpdate.Success {
 		return fmt.Errorf("linear: issueUpdate did not report success")
@@ -372,7 +444,7 @@ func (c *LinearClient) MoveIssueToState(ctx context.Context, issueID, stateName 
 // visible on the issue even if the workflow state could not be moved.
 func (c *LinearClient) AddComment(ctx context.Context, issueID, body string) error {
 	if c.APIKey == "" {
-		return fmt.Errorf("Linear API key is required")
+		return NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
 	}
 	if issueID == "" {
 		return fmt.Errorf("issue id is required")
@@ -392,7 +464,7 @@ func (c *LinearClient) AddComment(ctx context.Context, issueID, body string) err
 		return err
 	}
 	if len(out.Errors) > 0 {
-		return fmt.Errorf("linear errors: %v", out.Errors)
+		return linearGraphQLErrors(out.Errors)
 	}
 	if !out.Data.CommentCreate.Success {
 		return fmt.Errorf("linear: commentCreate did not report success")
@@ -437,7 +509,7 @@ func (c *LinearClient) lookupStateID(ctx context.Context, stateName string) (str
 		return "", err
 	}
 	if len(out.Errors) > 0 {
-		return "", fmt.Errorf("linear errors: %v", out.Errors)
+		return "", linearGraphQLErrors(out.Errors)
 	}
 	if len(out.Data.WorkflowStates.Nodes) == 0 {
 		return "", fmt.Errorf("no workflow state matches %q", stateName)
@@ -453,11 +525,11 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 	payload := map[string]any{"query": query, "variables": variables}
 	b, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return NewError(CategoryLinearAPIRequest, "build Linear GraphQL request", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL, bytes.NewReader(b))
 	if err != nil {
-		return err
+		return NewError(CategoryLinearAPIRequest, "build Linear GraphQL request", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", c.APIKey)
@@ -467,14 +539,21 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return err
+		return NewError(CategoryLinearAPIRequest, "send Linear GraphQL request", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("linear request failed: %s", resp.Status)
+		return NewError(CategoryLinearAPIStatus, fmt.Sprintf("linear request failed: %s", resp.Status), nil)
 	}
 	if out == nil {
 		return nil
 	}
-	return json.NewDecoder(resp.Body).Decode(out)
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return NewError(CategoryLinearUnknownPayload, "decode Linear GraphQL response", err)
+	}
+	return nil
+}
+
+func linearGraphQLErrors(errs []map[string]any) error {
+	return NewError(CategoryLinearGraphQLErrors, fmt.Sprintf("linear errors: %v", errs), nil)
 }

--- a/internal/workflow/errors_test.go
+++ b/internal/workflow/errors_test.go
@@ -1,0 +1,78 @@
+package workflow
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSurfacesWorkflowErrorCategories(t *testing.T) {
+	t.Run("missing workflow file", func(t *testing.T) {
+		_, err := Load(filepath.Join(t.TempDir(), "WORKFLOW.md"))
+		if !errors.Is(err, ErrMissingWorkflowFile) {
+			t.Fatalf("Load missing file error = %T %[1]v, want ErrMissingWorkflowFile", err)
+		}
+		if got, ok := ErrorCategory(err); !ok || got != CategoryMissingWorkflowFile {
+			t.Fatalf("ErrorCategory = %q, %v; want %q, true", got, ok, CategoryMissingWorkflowFile)
+		}
+	})
+
+	t.Run("non-missing read error", func(t *testing.T) {
+		_, err := Load(t.TempDir())
+		if err == nil {
+			t.Fatalf("Load directory path error = nil, want read error")
+		}
+		if errors.Is(err, ErrMissingWorkflowFile) {
+			t.Fatalf("Load directory path error = %T %[1]v, must not match ErrMissingWorkflowFile", err)
+		}
+		if got, ok := ErrorCategory(err); ok {
+			t.Fatalf("ErrorCategory(directory read error) = %q, true; want uncategorized", got)
+		}
+	})
+
+	t.Run("front matter parse error", func(t *testing.T) {
+		path := writeTempWorkflow(t, "---\nrepo: [\n---\nbody\n")
+		_, err := Load(path)
+		if !errors.Is(err, ErrWorkflowParse) {
+			t.Fatalf("Load malformed YAML error = %T %[1]v, want ErrWorkflowParse", err)
+		}
+	})
+
+	t.Run("front matter root is not map", func(t *testing.T) {
+		path := writeTempWorkflow(t, "---\n- repo\n---\nbody\n")
+		_, err := Load(path)
+		if !errors.Is(err, ErrWorkflowFrontMatterNotMap) {
+			t.Fatalf("Load non-map YAML error = %T %[1]v, want ErrWorkflowFrontMatterNotMap", err)
+		}
+	})
+}
+
+func TestRenderSurfacesTemplateErrorCategories(t *testing.T) {
+	_, err := Render("{% definitely_not_supported %}", map[string]any{})
+	if !errors.Is(err, ErrTemplateParse) {
+		t.Fatalf("Render syntax error = %T %[1]v, want ErrTemplateParse", err)
+	}
+
+	_, err = Render("work on {{ missing }}", map[string]any{})
+	if !errors.Is(err, ErrTemplateRender) {
+		t.Fatalf("Render missing variable error = %T %[1]v, want ErrTemplateRender", err)
+	}
+	if got, ok := ErrorCategory(err); !ok || got != CategoryTemplateRenderError {
+		t.Fatalf("ErrorCategory = %q, %v; want %q, true", got, ok, CategoryTemplateRenderError)
+	}
+}
+
+func TestLoadOptionalStillTreatsMissingWorkflowAsDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	wf, err := LoadOptional(path)
+	if err != nil {
+		t.Fatalf("LoadOptional missing file: %v", err)
+	}
+	if wf.Path != path || wf.PromptTemplate == "" {
+		t.Fatalf("LoadOptional missing file = %+v, want default workflow at requested path", wf)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("test expected workflow file to stay absent, stat error = %v", err)
+	}
+}

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -20,16 +21,133 @@ type Workflow struct {
 	Source         Source
 }
 
+type Category string
+
+const (
+	CategoryMissingWorkflowFile       Category = "missing_workflow_file"
+	CategoryWorkflowParseError        Category = "workflow_parse_error"
+	CategoryWorkflowFrontMatterNotMap Category = "workflow_front_matter_not_a_map"
+	CategoryTemplateParseError        Category = "template_parse_error"
+	CategoryTemplateRenderError       Category = "template_render_error"
+)
+
+var (
+	ErrMissingWorkflowFile       = &Error{Category: CategoryMissingWorkflowFile}
+	ErrWorkflowParse             = &Error{Category: CategoryWorkflowParseError}
+	ErrWorkflowFrontMatterNotMap = &Error{Category: CategoryWorkflowFrontMatterNotMap}
+	ErrTemplateParse             = &TemplateParseError{}
+	ErrTemplateRender            = &TemplateRenderError{}
+)
+
+type Error struct {
+	Category Category
+	Path     string
+	Message  string
+	Err      error
+}
+
+func NewError(category Category, message string, err error) *Error {
+	return &Error{Category: category, Message: message, Err: err}
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	msg := e.Message
+	if msg == "" {
+		msg = string(e.Category)
+	}
+	if e.Path != "" {
+		msg = e.Path + ": " + msg
+	}
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	return msg
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *Error) Is(target error) bool {
+	return categoryMatches(e.category(), target)
+}
+
+func (e *Error) category() Category {
+	if e == nil {
+		return ""
+	}
+	return e.Category
+}
+
+type TemplateParseError struct {
+	Err error
+}
+
+func (e *TemplateParseError) Error() string {
+	if e == nil || e.Err == nil {
+		return string(CategoryTemplateParseError)
+	}
+	return fmt.Sprintf("%s: %v", CategoryTemplateParseError, e.Err)
+}
+
+func (e *TemplateParseError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *TemplateParseError) Is(target error) bool {
+	return categoryMatches(e.category(), target)
+}
+
+func (e *TemplateParseError) category() Category {
+	return CategoryTemplateParseError
+}
+
+type categorized interface {
+	category() Category
+}
+
+func ErrorCategory(err error) (Category, bool) {
+	var categorizedErr categorized
+	if errors.As(err, &categorizedErr) {
+		category := categorizedErr.category()
+		return category, category != ""
+	}
+	return "", false
+}
+
+func categoryMatches(category Category, target error) bool {
+	if category == "" || target == nil {
+		return false
+	}
+	var targetCategory categorized
+	return errors.As(target, &targetCategory) && targetCategory.category() == category
+}
+
 func Load(path string) (*Workflow, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, &Error{Category: CategoryMissingWorkflowFile, Path: path, Message: "read workflow file", Err: err}
+		}
+		return nil, fmt.Errorf("%s: read workflow file: %w", path, err)
 	}
 	front, body := splitFrontMatter(string(b))
 	cfg := DefaultConfig()
 	hasFrontMatter := strings.TrimSpace(front) != ""
 	if hasFrontMatter {
 		frontBytes := []byte(front)
+		if err := validateFrontMatterRoot(path, frontBytes); err != nil {
+			return nil, err
+		}
 		if err := rejectRemovedFields(frontBytes); err != nil {
 			return nil, err
 		}
@@ -38,7 +156,7 @@ func Load(path string) (*Workflow, error) {
 		legacyHookFields := hookFieldPresence(frontBytes, "workspace", "hooks")
 		workspaceRootSet := hasNestedKey(frontBytes, "workspace", "root")
 		if err := yaml.Unmarshal(frontBytes, &cfg); err != nil {
-			return nil, fmt.Errorf("parse workflow front matter: %w", err)
+			return nil, &Error{Category: CategoryWorkflowParseError, Path: path, Message: "parse workflow front matter", Err: err}
 		}
 		cfg.hookFields = hookFields
 		cfg.Workspace.hookFields = legacyHookFields
@@ -78,6 +196,17 @@ func Load(path string) (*Workflow, error) {
 		source = SourcePromptOnly
 	}
 	return &Workflow{Path: path, Config: cfg, PromptTemplate: strings.TrimSpace(body), Source: source}, nil
+}
+
+func validateFrontMatterRoot(path string, frontBytes []byte) error {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(frontBytes, &doc); err != nil {
+		return &Error{Category: CategoryWorkflowParseError, Path: path, Message: "parse workflow front matter", Err: err}
+	}
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return &Error{Category: CategoryWorkflowFrontMatterNotMap, Path: path, Message: "workflow front matter must decode to a map"}
+	}
+	return nil
 }
 
 func migratePollingInterval(frontBytes []byte, cfg *Config) {
@@ -387,7 +516,7 @@ func LoadOptional(path string) (*Workflow, error) {
 	if err == nil {
 		return wf, nil
 	}
-	if os.IsNotExist(err) {
+	if errors.Is(err, ErrMissingWorkflowFile) || os.IsNotExist(err) {
 		cfg := DefaultConfig()
 		if err := expandConfig(&cfg); err != nil {
 			return nil, err

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -32,18 +32,23 @@ Rules:
 }
 
 type TemplateRenderError struct {
-	Name string
-	Err  error
+	Category Category
+	Name     string
+	Err      error
 }
 
 func (e *TemplateRenderError) Error() string {
-	if e == nil {
-		return "template_render_error"
+	category := CategoryTemplateRenderError
+	if e != nil && e.Category != "" {
+		category = e.Category
+	}
+	if e == nil || e.Err == nil {
+		return string(category)
 	}
 	if e.Name == "" {
-		return "template_render_error: " + e.Err.Error()
+		return string(category) + ": " + e.Err.Error()
 	}
-	return fmt.Sprintf("template_render_error: %s: %v", e.Name, e.Err)
+	return fmt.Sprintf("%s: %s: %v", category, e.Name, e.Err)
 }
 
 func (e *TemplateRenderError) Unwrap() error {
@@ -53,6 +58,17 @@ func (e *TemplateRenderError) Unwrap() error {
 	return e.Err
 }
 
+func (e *TemplateRenderError) Is(target error) bool {
+	return categoryMatches(e.category(), target)
+}
+
+func (e *TemplateRenderError) category() Category {
+	if e != nil && e.Category != "" {
+		return e.Category
+	}
+	return CategoryTemplateRenderError
+}
+
 func Render(template string, vars map[string]any) (string, error) {
 	if strings.TrimSpace(template) == "" {
 		template = DefaultPrompt()
@@ -60,6 +76,10 @@ func Render(template string, vars map[string]any) (string, error) {
 	var err error
 	template, err = renderLiquidIfTags(template, vars)
 	if err != nil {
+		var parseErr *TemplateParseError
+		if errors.As(err, &parseErr) {
+			return "", err
+		}
 		return "", &TemplateRenderError{Err: err}
 	}
 
@@ -100,10 +120,10 @@ func renderLiquidIfTags(template string, vars map[string]any) (string, error) {
 		}
 		tag := strings.TrimSpace(template[match[2]:match[3]])
 		if tag == "endif" {
-			return "", fmt.Errorf("unexpected endif tag")
+			return "", &TemplateParseError{Err: fmt.Errorf("unexpected endif tag")}
 		}
 		if !strings.HasPrefix(tag, "if ") {
-			return "", fmt.Errorf("unsupported tag %q", tag)
+			return "", &TemplateParseError{Err: fmt.Errorf("unsupported tag %q", tag)}
 		}
 		closeStart, closeEnd, err := findLiquidEndif(template[match[1]:])
 		if err != nil {
@@ -183,7 +203,7 @@ func findLiquidEndif(template string) (start int, end int, err error) {
 			}
 		}
 	}
-	return 0, 0, fmt.Errorf("unterminated if tag")
+	return 0, 0, &TemplateParseError{Err: fmt.Errorf("unterminated if tag")}
 }
 
 func evalLiquidCondition(cond string, vars map[string]any) (bool, error) {


### PR DESCRIPTION
## Issue

Closes #188

## Summary

- Added shared typed error categories and sentinels for SPEC workflow, runner, and tracker failure categories.
- Migrated relevant workflow loading/rendering, Codex app-server runner, Linear tracker, orchestrator dispatch gating, and worker state API error-envelope call sites to use the shared categories.
- Added unit coverage for category detection, HTTP error envelope codes, and non-missing workflow read errors.

Policy note: this crosses the default size limits because the assigned issue explicitly spans workflow, runner, tracker, orchestrator gating, and the worker HTTP envelope. I kept the patch limited to those issue paths.

## Verification

- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test ./internal/workflow ./internal/orchestrator ./internal/tracker ./cmd/worker`
- `go test ./internal/runner -run 'TestRunnerSentinelsCoverSpecCategories|TestCodexAppServerRunnerSurfacesRunnerErrorCategories|TestTimeoutTypesExposeRunnerCategories|TestCodexAppServerRunnerStillReadsPromptForValidWorkspace|TestCodexAppServerRunnerTreatsFailedTurnCompletedAsError|TestCodexAppServerRunnerUsesReadTimeout|TestCodexAppServerRunnerUsesTurnTimeout|TestCodexAppServerRunnerTreatsNestedFailedTurnCompletedAsError'`
- `go test -race -covermode=atomic ./internal/workflow ./internal/tracker ./internal/orchestrator ./cmd/worker`
- `go test -race -covermode=atomic ./internal/runner -run 'TestRunnerSentinelsCoverSpecCategories|TestCodexAppServerRunnerSurfacesRunnerErrorCategories|TestTimeoutTypesExposeRunnerCategories|TestCodexAppServerRunnerStillReadsPromptForValidWorkspace|TestCodexAppServerRunnerTreatsFailedTurnCompletedAsError|TestCodexAppServerRunnerUsesReadTimeout|TestCodexAppServerRunnerTreatsNestedFailedTurnCompletedAsError'`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`

Configured full-suite note: `go test -race -covermode=atomic ./...` was run and failed only in `internal/runner` on existing local Darwin sandbox tests that require Linux sandbox backends plus the existing timing-sensitive `TestCodexAppServerRunnerServerRequestsRefreshStallClock` 100 ms budget. The touched packages passed in that run.

## Local Review Gates

- Codex structured review: `{"blocking_findings":[]}`
- Claude Code structured review: `{"blocking_findings":[]}`
