### PR TITLE
[codex] Emit missing codex app-server runtime events

### DIFF
--- a/docs/runbooks/task-api.md
+++ b/docs/runbooks/task-api.md
@@ -42,12 +42,11 @@ failed run can be reconstructed from the event timeline alone:
   `turn_cancelled`, `turn_ended_with_error`, `turn_input_required`,
   `approval_auto_approved`, `unsupported_tool_call`, `notification`,
   `other_message`, `malformed` — SPEC §10.4 app-server runtime vocabulary. The
-  `codex-app-server` runner currently captures session start, terminal turn
-  events, and generic protocol notifications, and the worker forwards those
+  `codex-app-server` runner captures the observed protocol branches for this
+  vocabulary, including auto-approved approvals, malformed protocol-like lines,
+  and known JSON payloads that do not match a handled method. The worker forwards
   captured runtime events into the task event stream with their structured
-  payloads. Event constants for the remaining SPEC runtime vocabulary are
-  exported so those protocol branches can be forwarded as the runner learns
-  them.
+  payloads.
 - `runner_start`, `runner_end`, `runner_timeout` — transitional worker runner
   timing and summary events retained for compatibility while the SPEC phase
   stream is adopted.

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -307,21 +307,32 @@ func (c *appServerClient) send(msg map[string]any) error {
 }
 
 func (c *appServerClient) readMessage(ctx context.Context) (map[string]any, error) {
+	msg, raw, err := c.readProtocolMessage(ctx)
+	if err != nil {
+		if raw != nil {
+			return nil, fmt.Errorf("decode codex app-server message: %w", err)
+		}
+		return nil, err
+	}
+	return msg, nil
+}
+
+func (c *appServerClient) readProtocolMessage(ctx context.Context) (map[string]any, []byte, error) {
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	default:
 	}
 	line, err := c.readLine(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	_, _ = c.out.Write(line)
 	var msg map[string]any
 	if err := json.Unmarshal(line, &msg); err != nil {
-		return nil, fmt.Errorf("decode codex app-server message: %w", err)
+		return nil, line, err
 	}
-	return msg, nil
+	return msg, line, nil
 }
 
 type readResult struct {
@@ -377,6 +388,14 @@ func isAppServerReadTimeout(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "codex app-server read timeout")
 }
 
+func protocolMessageCandidate(raw []byte) bool {
+	return strings.HasPrefix(strings.TrimLeft(string(raw), " \t\r\n"), "{")
+}
+
+func trimProtocolLine(raw []byte) string {
+	return strings.TrimRight(string(raw), "\r\n")
+}
+
 func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 	c.lastTerminal = time.Now()
 	for {
@@ -400,12 +419,20 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 			// stalled/runner_timeout retry path.
 			c.readTimeoutMs = 0
 		}
-		msg, err := c.readMessage(readCtx)
+		msg, raw, err := c.readProtocolMessage(readCtx)
 		c.readTimeoutMs = readTimeoutMs
 		if cancel != nil {
 			cancel()
 		}
 		if err != nil {
+			if raw != nil {
+				if !protocolMessageCandidate(raw) {
+					return fmt.Errorf("decode codex app-server message: %w", err)
+				}
+				c.recordMalformedRuntimeLine(raw, err)
+				c.lastTerminal = time.Now()
+				continue
+			}
 			elapsed := time.Since(c.lastTerminal)
 			if stallBudget > 0 && ctx.Err() == nil && elapsed >= stallBudget {
 				if errors.Is(err, context.DeadlineExceeded) || isAppServerReadTimeout(err) {
@@ -418,6 +445,7 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 			switch method {
 			case "turn/completed":
 				if err := completedTurnError(msg); err != nil {
+					c.recordRuntimeMessage(task.EventTurnEndedWithError, msg)
 					return err
 				}
 				c.handleNotification(msg)
@@ -453,6 +481,9 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 				c.handleNotification(msg)
 				c.recordRuntimeMessage(task.EventNotification, msg)
 			}
+		} else {
+			c.lastTerminal = time.Now()
+			c.recordOtherRuntimeMessage(msg, raw)
 		}
 	}
 }
@@ -463,13 +494,37 @@ func (c *appServerClient) recordRuntimeMessage(event string, msg map[string]any)
 	if payload == nil {
 		payload = map[string]any{}
 	}
+	c.recordRuntimeEvent(event, c.withRuntimeContext(payload))
+}
+
+func (c *appServerClient) recordOtherRuntimeMessage(msg map[string]any, raw []byte) {
+	payload := normalizeRuntimePayload(msg)
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	payload["raw"] = trimProtocolLine(raw)
+	c.recordRuntimeEvent(task.EventOtherMessage, c.withRuntimeContext(payload))
+}
+
+func (c *appServerClient) recordMalformedRuntimeLine(raw []byte, err error) {
+	if !protocolMessageCandidate(raw) {
+		return
+	}
+	payload := map[string]any{
+		"raw":   trimProtocolLine(raw),
+		"error": err.Error(),
+	}
+	c.recordRuntimeEvent(task.EventMalformed, c.withRuntimeContext(payload))
+}
+
+func (c *appServerClient) withRuntimeContext(payload map[string]any) map[string]any {
 	if _, ok := payload["thread_id"]; !ok && c.threadID != "" {
 		payload["thread_id"] = c.threadID
 	}
 	if _, ok := payload["turn_id"]; !ok && c.turnID != "" {
 		payload["turn_id"] = c.turnID
 	}
-	c.recordRuntimeEvent(event, payload)
+	return payload
 }
 
 func (c *appServerClient) recordRuntimeEvent(event string, payload map[string]any) {
@@ -538,9 +593,26 @@ func toSnakeCase(s string) string {
 func (c *appServerClient) replyServerRequest(msg map[string]any) error {
 	method, _ := msg["method"].(string)
 	if result, ok := protocolServerRequestResult(method, msg, c.approvalPolicy); ok {
-		return c.send(map[string]any{"jsonrpc": "2.0", "id": msg["id"], "result": result})
+		if err := c.send(map[string]any{"jsonrpc": "2.0", "id": msg["id"], "result": result}); err != nil {
+			return err
+		}
+		if protocolServerRequestAutoApproved(method, c.approvalPolicy) {
+			c.recordApprovalAutoApproved(method, msg, result)
+		}
+		return nil
 	}
 	return c.sendJSONRPCError(msg["id"], -32601, "Method not found: "+method)
+}
+
+func (c *appServerClient) recordApprovalAutoApproved(method string, msg map[string]any, result map[string]any) {
+	params, _ := msg["params"].(map[string]any)
+	payload := normalizeRuntimePayload(params)
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	payload["method"] = method
+	payload["result"] = normalizeRuntimeValue(result)
+	c.recordRuntimeEvent(task.EventApprovalAutoApproved, c.withRuntimeContext(payload))
 }
 
 func (c *appServerClient) sendJSONRPCError(id any, code int, message string) error {
@@ -578,6 +650,15 @@ func protocolServerRequestResult(method string, msg map[string]any, approvalPoli
 		return map[string]any{"action": "decline", "content": nil}, true
 	default:
 		return nil, false
+	}
+}
+
+func protocolServerRequestAutoApproved(method string, approvalPolicy any) bool {
+	switch method {
+	case "item/commandExecution/requestApproval", "item/fileChange/requestApproval", "item/permissions/requestApproval", "execCommandApproval", "applyPatchApproval":
+		return autoApproveRequest(method, approvalPolicy)
+	default:
+		return false
 	}
 }
 

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -194,6 +194,95 @@ for line in sys.stdin:
 	}
 }
 
+func TestCodexAppServerRunnerEmitsOtherMessageForMethodlessRuntimePayload(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'wrapper': 'unexpected', 'payload': {'message': 'known JSON without method'}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'done'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "other message")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	events := runtimeEventsNamed(res.RuntimeEvents, task.EventOtherMessage)
+	if len(events) != 1 {
+		t.Fatalf("other_message events = %d, want 1; events=%#v", len(events), res.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, events[0], "wrapper"); got != "unexpected" {
+		t.Fatalf("other_message wrapper = %#v, want unexpected; payload=%#v", got, events[0].Payload)
+	}
+}
+
+func TestCodexAppServerRunnerEmitsMalformedAndContinuesForProtocolLikeInvalidJSON(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print('{"method": "item/updated", "params": ', flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'done after malformed'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "malformed message")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v, want malformed protocol line to be reported then ignored", err)
+	}
+	events := runtimeEventsNamed(res.RuntimeEvents, task.EventMalformed)
+	if len(events) != 1 {
+		t.Fatalf("malformed events = %d, want 1; events=%#v", len(events), res.RuntimeEvents)
+	}
+	if raw, _ := runtimeEventField(t, events[0], "raw").(string); !strings.Contains(raw, `"item/updated"`) {
+		t.Fatalf("malformed raw = %#v, want original invalid JSON line", raw)
+	}
+}
+
+func TestCodexAppServerRunnerRejectsPlainMalformedStdout(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print('plain diagnostic on stdout', flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'should not complete'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "plain malformed stdout")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err == nil || !strings.Contains(err.Error(), "decode codex app-server message") {
+		t.Fatalf("Run error = %v, want plain stdout garbage to remain a protocol decode failure", err)
+	}
+	if events := runtimeEventsNamed(res.RuntimeEvents, task.EventMalformed); len(events) != 0 {
+		t.Fatalf("malformed events = %d, want non-protocol stdout to fail without malformed event; events=%#v", len(events), res.RuntimeEvents)
+	}
+}
+
 func TestCodexAppServerRunnerEmitsSpecPhaseTransitions(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json
@@ -337,6 +426,16 @@ func runtimeEventField(t *testing.T, event task.RuntimeEvent, key string) any {
 		t.Fatalf("runtime event payload is %T, want map[string]any: %#v", event.Payload, event.Payload)
 	}
 	return payload[key]
+}
+
+func runtimeEventsNamed(events []task.RuntimeEvent, name string) []task.RuntimeEvent {
+	var matches []task.RuntimeEvent
+	for _, event := range events {
+		if event.Event == name {
+			matches = append(matches, event)
+		}
+	}
+	return matches
 }
 
 func TestCodexAppServerRunnerDoesNotPutLinearTokenOnWire(t *testing.T) {
@@ -546,9 +645,16 @@ for line in sys.stdin:
 `)
 	wd := codexWorkdir(t, "x")
 
-	_, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
 	if err == nil || !strings.Contains(err.Error(), "turn/completed failed") || !strings.Contains(err.Error(), "tool crashed") {
 		t.Fatalf("Run error = %v, want failed turn/completed error with reason", err)
+	}
+	events := runtimeEventsNamed(res.RuntimeEvents, task.EventTurnEndedWithError)
+	if len(events) != 1 {
+		t.Fatalf("turn_ended_with_error events = %d, want 1; events=%#v", len(events), res.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, events[0], "reason"); got != "tool crashed" {
+		t.Fatalf("turn_ended_with_error reason = %#v, want tool crashed; payload=%#v", got, events[0].Payload)
 	}
 }
 
@@ -984,6 +1090,10 @@ for line in sys.stdin:
 	}
 	if res.Summary != "approvals handled" {
 		t.Fatalf("Summary = %q, want approvals handled", res.Summary)
+	}
+	events := runtimeEventsNamed(res.RuntimeEvents, task.EventApprovalAutoApproved)
+	if len(events) != 3 {
+		t.Fatalf("approval_auto_approved events = %d, want 3; events=%#v", len(events), res.RuntimeEvents)
 	}
 	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
 	if err != nil {


### PR DESCRIPTION
Closes #189

## Summary

Decision: Option A. Keep the SPEC §10.4 runtime event vocabulary and emit the four previously declared-but-unemitted Codex app-server events.

- Emit `turn_ended_with_error` when `turn/completed` reports an error status.
- Emit `approval_auto_approved` after auto-approved app-server approval requests are answered.
- Emit `other_message` for valid JSON runtime payloads that do not carry a handled method.
- Emit `malformed` for protocol-like malformed JSON lines while keeping plain stdout garbage as a transport decode failure.
- Update the task API runbook now that these protocol branches are captured.

## Verification

- `go test ./internal/runner -run 'TestCodexAppServerRunner(EmitsOtherMessage|EmitsMalformed|RejectsPlainMalformedStdout|TreatsFailedTurnCompleted|RepliesToApprovalRequests)' -count=1` passed before the review fix.
- `go test -race -covermode=atomic ./internal/runner -run 'TestCodexAppServerRunner(EmitsOtherMessage|EmitsMalformed|RejectsPlainMalformedStdout|TreatsFailedTurnCompleted|RepliesToApprovalRequests)' -count=1` passed after the review fix.
- `gofmt -l $(git ls-files '*.go')` produced no output.
- `go mod tidy` left `go.mod` and `go.sum` unchanged (`git diff --exit-code -- go.mod go.sum`).
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller` passed.
- `go test -race -covermode=atomic ./...` was run and failed in `internal/runner` on this macOS host for pre-existing baseline failures: `TestCodexAppServerRunnerServerRequestsRefreshStallClock` with a 100ms stall budget, plus Linux `bubblewrap`/`firejail` sandbox tests reporting `current host OS is darwin`. I verified `TestCodexAppServerRunnerServerRequestsRefreshStallClock` also fails on a detached worktree at current `HEAD` before this change.

## Local review gates

- Codex JSON review: `{"blocking_findings":[]}`.
- Claude Code JSON review: `{"blocking_findings":[]}` from `.structured_output`.


- GitHub CI on PR #208 passed: `Go build and test`, `E2E Gitea mock loop`, and `Docker image build`.
