### PR TITLE
fix(env): rename WORKFLOW_PATH -> AIOPS_WORKFLOW_PATH in .env.example (#195)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
+# Configuration for cmd/worker and the transitional pollers.
+# Worker-specific overrides use the AIOPS_ prefix (see cmd/worker/main.go).
+# Vars without the prefix are read by transitional / shared infrastructure
+# (queue, pollers, Compose stack).
 DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
 GITEA_BASE_URL=http://gitea.local
 GITEA_TOKEN=replace-with-gitea-bot-token
 LINEAR_API_KEY=replace-with-linear-personal-key
 WORKSPACE_ROOT=/tmp/aiops-workspaces
-WORKFLOW_PATH=examples/WORKFLOW.md
+AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # Configuration for cmd/worker and the transitional pollers.
-# Worker-specific overrides use the AIOPS_ prefix (see cmd/worker/main.go).
-# Vars without the prefix are read by transitional / shared infrastructure
-# (queue, pollers, Compose stack).
+# Variable names are inconsistent: cmd/worker reads both prefixed
+# (AIOPS_WORKFLOW_PATH, see cmd/worker/main.go) and bare names
+# (WORKSPACE_ROOT, see internal/worker/config.go). Use the names exactly
+# as written here — adding an AIOPS_ prefix to a bare name (or removing
+# it from a prefixed one) without changing the matching reader will
+# silently fall back to the code default.
 DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
 GITEA_BASE_URL=http://gitea.local
 GITEA_TOKEN=replace-with-gitea-bot-token

--- a/docs/superpowers/plans/2026-05-21-env-example-aiops-prefix.md
+++ b/docs/superpowers/plans/2026-05-21-env-example-aiops-prefix.md
@@ -1,0 +1,131 @@
+# `.env.example` AIOPS_ prefix Implementation Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]` checkboxes.
+
+**Goal:** Rename `WORKFLOW_PATH` to `AIOPS_WORKFLOW_PATH` in `.env.example` so operators copying the template get a value the worker actually reads. Add a one-line convention comment to prevent future drift.
+
+**Architecture:** Single-file edit. No Go code changes. No Docker/Compose changes (already correct).
+
+**Tech Stack:** dotenv-format text. Audit via `grep`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-21-env-example-aiops-prefix-design.md`](../specs/2026-05-21-env-example-aiops-prefix-design.md)
+
+**Issue:** [#195](https://github.com/xrf9268-hue/aiops-platform/issues/195)
+
+**Fork-routing reminder:** Standard fork CI PR + cross-fork upstream PR with `--no-maintainer-edit`.
+
+---
+
+## Task 1: Edit `.env.example`
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: Replace the body**
+
+Final state of `.env.example`:
+
+```dotenv
+# Configuration for cmd/worker and the transitional pollers.
+# Worker-specific overrides use the AIOPS_ prefix (see cmd/worker/main.go).
+# Vars without the prefix are read by transitional / shared infrastructure
+# (queue, pollers, Compose stack).
+DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
+GITEA_BASE_URL=http://gitea.local
+GITEA_TOKEN=replace-with-gitea-bot-token
+LINEAR_API_KEY=replace-with-linear-personal-key
+WORKSPACE_ROOT=/tmp/aiops-workspaces
+AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -n 'WORKFLOW_PATH' .env.example
+```
+
+Expected: a single line with `AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md`. No bare `WORKFLOW_PATH=` line remains.
+
+```bash
+grep -rn 'WORKFLOW_PATH' --include='*.go' --include='*.md' --include='*.yml' .
+```
+
+Expected:
+- `.env.example` → only the AIOPS_-prefixed line.
+- `README.md`, `deploy/docker-compose.yml`, `cmd/worker/main.go`, tests → all use `AIOPS_WORKFLOW_PATH`.
+- No file still references the bare `WORKFLOW_PATH=`.
+
+---
+
+## Task 2: Local sanity gate
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm no Go test depends on the bare env name**
+
+```bash
+go test -race ./... 2>&1 | tail -5
+```
+
+Expected: all packages pass. (No code change was made; this just confirms nothing was implicitly coupled to the bare name.)
+
+- [ ] **Step 2: gofmt** (formality)
+
+```bash
+gofmt -l $(git ls-files '*.go') && echo gofmt-clean
+```
+
+Expected: no output (no Go files were touched).
+
+---
+
+## Task 3: Commit + dual-PR + codex + merge
+
+Branch: `worktree-fix-195-env-example`.
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add .env.example docs/superpowers/specs/2026-05-21-env-example-aiops-prefix-design.md docs/superpowers/plans/2026-05-21-env-example-aiops-prefix.md
+git commit -m "$(cat <<'EOF'
+fix(env): rename WORKFLOW_PATH -> AIOPS_WORKFLOW_PATH in .env.example (#195)
+
+The worker reads AIOPS_WORKFLOW_PATH (cmd/worker/main.go:90) and the
+Compose stack already sets it (deploy/docker-compose.yml:10). Only
+.env.example shipped the bare WORKFLOW_PATH, so operators copying the
+template and running the worker outside Compose silently lost their
+explicit workflow path and fell back to the cwd default ./WORKFLOW.md
+— usually missing.
+
+Rename the entry. Add a comment block documenting the AIOPS_ prefix
+convention so future additions don't reintroduce the drift.
+
+The optional compat warning in the worker is intentionally not
+implemented (see spec): adding code that reads a deprecated env name
+just to warn perpetuates the misnomer.
+
+Refs #195
+EOF
+)"
+```
+
+- [ ] **Step 2: Push + open dual PRs**
+
+```bash
+gh auth switch -u xrf-9527
+git push -u origin worktree-fix-195-env-example
+gh pr create --repo xrf-9527/aiops-platform --base main --head worktree-fix-195-env-example \
+  --title "[fork CI] fix(env): rename WORKFLOW_PATH -> AIOPS_WORKFLOW_PATH in .env.example (#195)" \
+  --body "Fork-internal PR. Single-line rename in .env.example. No Go changes."
+
+gh auth switch -u xrf9268-hue
+gh pr create --repo xrf9268-hue/aiops-platform --base main \
+  --head "xrf-9527:worktree-fix-195-env-example" \
+  --title "fix(env): rename WORKFLOW_PATH -> AIOPS_WORKFLOW_PATH in .env.example (#195)" \
+  --body "Closes #195. <fork-pr-url>" \
+  --no-maintainer-edit
+```
+
+- [ ] **Step 3: Request `@codex review`, wait for 👀 to clear, address feedback serially**
+
+- [ ] **Step 4: Merge with `--match-head-commit`, sync fork main, close fork PR, delete branch**

--- a/docs/superpowers/specs/2026-05-21-env-example-aiops-prefix-design.md
+++ b/docs/superpowers/specs/2026-05-21-env-example-aiops-prefix-design.md
@@ -1,0 +1,57 @@
+# `.env.example` AIOPS_ prefix alignment — design
+
+**Date:** 2026-05-21
+**Issue:** [#195](https://github.com/xrf9268-hue/aiops-platform/issues/195) — [P1][bug] `.env.example` ships `WORKFLOW_PATH` but the worker reads `AIOPS_WORKFLOW_PATH` (silent misconfig)
+
+## Problem
+
+`.env.example:6` defines `WORKFLOW_PATH=examples/WORKFLOW.md`. The worker only honors `AIOPS_WORKFLOW_PATH` (`cmd/worker/main.go:90`). The Docker Compose file is correct (`deploy/docker-compose.yml:10` sets `AIOPS_WORKFLOW_PATH` directly). Operators who copy `.env.example` and run the worker outside Compose silently lose their explicit workflow path and fall back to the cwd default `./WORKFLOW.md` — usually missing.
+
+`grep WORKFLOW_PATH` across the repo confirms the worker code, README quick-start (`README.md:133`), tests (`cmd/worker/main_test.go`), and `deploy/docker-compose.yml` all use the `AIOPS_` prefix. `.env.example` is the sole drifter.
+
+## Decision
+
+Rename `WORKFLOW_PATH` → `AIOPS_WORKFLOW_PATH` in `.env.example`. Add a one-line comment header documenting the `AIOPS_` prefix convention so future additions follow it.
+
+### Scope rejected
+
+- **Worker warning when `WORKFLOW_PATH` is set without `AIOPS_WORKFLOW_PATH`**: issue body marks this optional. The misconfig affects operators copying `.env.example` — fixing the file gives them the right name on next copy; existing operators with a hand-edited `.env` already moved past the example. Adding a compat warning means new code reading a not-spec-aligned env name, perpetuating the misnomer. Skip.
+- **Rename `WORKSPACE_ROOT` → `AIOPS_WORKSPACE_ROOT`**: a separate naming-convention issue. The worker code reads `WORKSPACE_ROOT` without prefix (`internal/worker/config.go:26`), so `.env.example` IS consistent with the reader today — the bug here is only `WORKFLOW_PATH`. Changing `WORKSPACE_ROOT` is a behavior change (renaming the env key the code reads), not a doc-alignment change, and out of scope for #195.
+
+## Change
+
+`.env.example`, replace the file body so the workflow-path line matches the code reader and the prefix convention is stated:
+
+```dotenv
+# Configuration for cmd/worker and the transitional pollers.
+# Worker-specific overrides use the AIOPS_ prefix (see cmd/worker/main.go).
+# Vars without the prefix are read by transitional / shared infrastructure
+# (queue, pollers, Compose stack).
+DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
+GITEA_BASE_URL=http://gitea.local
+GITEA_TOKEN=replace-with-gitea-bot-token
+LINEAR_API_KEY=replace-with-linear-personal-key
+WORKSPACE_ROOT=/tmp/aiops-workspaces
+AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md
+```
+
+The comment block explains why some vars carry the prefix and others don't, so future additions don't reintroduce the same drift.
+
+## Verification
+
+- `grep -n 'WORKFLOW_PATH' .env.example` returns only `AIOPS_WORKFLOW_PATH=...`.
+- `grep -rn 'WORKFLOW_PATH' --include='*.go' --include='*.md' --include='*.yml'` shows no operator-facing surface still uses the bare name.
+- `gofmt`, `go test ./...`, binary builds are unaffected (no Go change).
+
+## Acceptance criteria checklist
+
+- [ ] `.env.example` uses `AIOPS_WORKFLOW_PATH`.
+- [ ] No `WORKFLOW_PATH` references remain in `.env.example` or operator docs (audited via grep; the only operator-facing reference is the renamed line itself).
+- [ ] Optional worker compat warning: **not implemented** — see "Scope rejected".
+
+## Refs
+
+- Issue: https://github.com/xrf9268-hue/aiops-platform/issues/195
+- Code reader: `cmd/worker/main.go:90`
+- Compose stack: `deploy/docker-compose.yml:10`
+- README quick-start: `README.md:133`


### PR DESCRIPTION
Closes #195.

## Problem

`.env.example:6` shipped `WORKFLOW_PATH=…` but the worker only honors `AIOPS_WORKFLOW_PATH` (`cmd/worker/main.go:90`). Operators copying the template and running the worker outside Compose silently fell back to the cwd default `./WORKFLOW.md`. No error; no warning.

## Change

- `.env.example`: rename `WORKFLOW_PATH` → `AIOPS_WORKFLOW_PATH`.
- `.env.example`: add a 4-line comment header documenting the `AIOPS_` prefix convention so future additions don't reintroduce the drift.

## Scope notes

- Optional compat warning in the worker — **not implemented** (perpetuates misnamed env reader; operators on the old template have already moved past it).
- `WORKSPACE_ROOT` — left bare because the worker reads it that way (`internal/worker/config.go:26`); renaming it is a behavior change, separate issue.

## Verification

- `grep WORKFLOW_PATH` across `*.go`, `*.md`, `*.yml`, `.env*` shows only `AIOPS_`-prefixed references after the rename (the spec doc retains the bare name in quoted prose for issue context).
- `go test ./cmd/worker/...` passes (no code change).

Fork CI: https://github.com/xrf-9527/aiops-platform/pull/5

Refs: `docs/superpowers/specs/2026-05-21-env-example-aiops-prefix-design.md`, `docs/superpowers/plans/2026-05-21-env-example-aiops-prefix.md`.