### PR TITLE
fix(state-server): accept IPv6 loopback in Host validation (#235)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -431,8 +431,14 @@ func isLoopbackHTTPHost(hostport string) bool {
 		// "host:port" without IPv6 brackets that failed to split — malformed.
 		return false
 	}
-	// Strip IPv6 brackets when the host arrived bracketed without a port (e.g. "[::1]").
-	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	// Strip IPv6 brackets only when the host is properly bracketed (e.g. "[::1]").
+	// Reject unpaired brackets — "[::1" or "::1]" are malformed Host values.
+	if strings.HasPrefix(host, "[") || strings.HasSuffix(host, "]") {
+		if !strings.HasPrefix(host, "[") || !strings.HasSuffix(host, "]") {
+			return false
+		}
+		host = host[1 : len(host)-1]
+	}
 	if host == "localhost" {
 		return true
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -427,11 +427,19 @@ func isLoopbackHTTPHost(hostport string) bool {
 	host := hostport
 	if h, _, err := net.SplitHostPort(hostport); err == nil {
 		host = h
-	} else if strings.Contains(hostport, ":") {
+	} else if strings.Contains(hostport, ":") && !strings.HasPrefix(hostport, "[") {
+		// "host:port" without IPv6 brackets that failed to split — malformed.
 		return false
 	}
-	host = strings.Trim(host, "[]")
-	return host == "127.0.0.1" || host == "localhost"
+	// Strip IPv6 brackets when the host arrived bracketed without a port (e.g. "[::1]").
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return true
+	}
+	return false
 }
 
 type stateSnapshotFunc func(context.Context) (orchestrator.StateView, error)

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -662,6 +662,8 @@ func TestIsLoopbackHTTPHost(t *testing.T) {
 		{"[::1]:4000", true},
 		{"[::1]", true},
 		{"::1", false},
+		{"[::1", false},
+		{"::1]", false},
 		{"1.2.3.4:4000", false},
 		{"evil.example", false},
 		{"evil.example:4000", false},

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -630,6 +630,52 @@ func TestStateHTTPServerAllowsLoopbackHost(t *testing.T) {
 	}
 }
 
+func TestStateHTTPServerAllowsIPv6LoopbackHost(t *testing.T) {
+	called := false
+	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://[::1]:4000/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !called {
+		t.Fatal("snapshot function was not called for IPv6 loopback Host")
+	}
+}
+
+func TestIsLoopbackHTTPHost(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"127.0.0.1:4000", true},
+		{"127.0.0.1", true},
+		{"127.1.2.3:8080", true},
+		{"localhost:4000", true},
+		{"localhost", true},
+		{"[::1]:4000", true},
+		{"[::1]", true},
+		{"::1", false},
+		{"1.2.3.4:4000", false},
+		{"evil.example", false},
+		{"evil.example:4000", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := isLoopbackHTTPHost(c.in); got != c.want {
+				t.Fatalf("isLoopbackHTTPHost(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 func TestStartStateHTTPServerSkipsDisabledPort(t *testing.T) {
 	handle, err := startStateHTTPServer(context.Background(), -1, func(context.Context) (orchestrator.StateView, error) {
 		t.Fatal("disabled state server must not evaluate snapshot")

--- a/docs/superpowers/specs/2026-05-22-loopback-ipv6-design.md
+++ b/docs/superpowers/specs/2026-05-22-loopback-ipv6-design.md
@@ -1,0 +1,83 @@
+# `isLoopbackHTTPHost` IPv6 support — design
+
+**Date:** 2026-05-22
+**Issue:** [#235](https://github.com/xrf9268-hue/aiops-platform/issues/235)
+
+## Problem
+
+`cmd/worker/main.go:423-435` validates the HTTP `Host` header against a literal allow-list of `"127.0.0.1"` and `"localhost"`. IPv6 loopback (`[::1]`) is rejected with **403 Forbidden**, even though it is the IPv6 host-equivalent of `127.0.0.1` per SPEC §13.7. The same rejection applies to `127.0.0.0/8` addresses other than `127.0.0.1` (e.g. `127.1.2.3`).
+
+## Decision
+
+Replace the literal allow-list with `net.ParseIP(host).IsLoopback()`. Keep the `"localhost"` special case because `net.ParseIP("localhost")` returns `nil` (it parses IPs, not names). Strip IPv6 brackets when the host arrived in bracket-without-port form (`"[::1]"`). Reject the `"::1"` (unbracketed) form — RFC 7230 requires IPv6 hosts in HTTP `Host` headers to be bracketed; an unbracketed `::1` is malformed.
+
+The `net.IP.IsLoopback()` primitive accepts `127.0.0.0/8` and `::1`, and rejects routable addresses, so the rule becomes complete with minimal logic.
+
+## What changes
+
+| File | Change |
+| --- | --- |
+| `cmd/worker/main.go:423-435` | Rewrite `isLoopbackHTTPHost` to use `net.ParseIP(host).IsLoopback()` plus the `"localhost"` special case. Preserve the existing malformed-input rejection for `"host:port"` strings without IPv6 brackets that fail `SplitHostPort`. |
+| `cmd/worker/main_test.go` | Add `TestIsLoopbackHTTPHost` table-driven cases covering IPv4, IPv4 loopback `127.0.0.0/8`, `localhost`, bracketed/unbracketed IPv6, non-loopback IP, and empty. Add `TestStateHTTPServerAllowsIPv6LoopbackHost` mirroring the existing IPv4 one. |
+
+## New implementation
+
+```go
+func isLoopbackHTTPHost(hostport string) bool {
+    if hostport == "" {
+        return false
+    }
+    host := hostport
+    if h, _, err := net.SplitHostPort(hostport); err == nil {
+        host = h
+    } else if strings.Contains(hostport, ":") && !strings.HasPrefix(hostport, "[") {
+        // "host:port" without IPv6 brackets that failed to split — malformed.
+        return false
+    }
+    // Trim IPv6 brackets when present without a port (e.g. "[::1]").
+    host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+    if host == "localhost" {
+        return true
+    }
+    if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+        return true
+    }
+    return false
+}
+```
+
+## Test matrix
+
+| Input | Expected |
+| --- | --- |
+| `"127.0.0.1:4000"` | true (IPv4 loopback + port) |
+| `"127.0.0.1"` | true (IPv4 loopback, no port) |
+| `"127.1.2.3:8080"` | true (other 127.0.0.0/8) |
+| `"localhost:4000"` | true (named, with port) |
+| `"localhost"` | true (named, no port) |
+| `"[::1]:4000"` | true (IPv6 loopback, bracketed + port) |
+| `"[::1]"` | true (IPv6 loopback, bracketed, no port) |
+| `"::1"` | false (IPv6 without brackets — malformed per RFC 7230) |
+| `"1.2.3.4:4000"` | false (routable IPv4) |
+| `"evil.example"` | false (non-loopback name) |
+| `""` | false |
+
+## Non-goals
+
+- Don't change the HTTP listener bind address — that's `cmd/worker/main.go` listener construction logic, not this validator.
+- Don't accept routable IPv6 addresses just because they're IPv6 — security boundary stays at "loopback" per SPEC §13.7.
+- Don't widen the special-case name list (e.g. `ip6-localhost`) — those don't appear in real HTTP `Host` headers, and adding them muddies the boundary.
+
+## Acceptance criteria
+
+- [ ] `[::1]` and `[::1]:<port>` Host headers pass.
+- [ ] `127.0.0.0/8` IPv4 loopback addresses pass.
+- [ ] Non-loopback IPs still rejected.
+- [ ] Table-driven test and IPv6 handler test added.
+
+## Refs
+
+- Issue: https://github.com/xrf9268-hue/aiops-platform/issues/235
+- Code: `cmd/worker/main.go:423-435`, existing tests at `main_test.go:595-631`
+- SPEC §13.7 loopback default
+- Stdlib: `net.IP.IsLoopback`


### PR DESCRIPTION
Closes #235.

## Problem

`isLoopbackHTTPHost` (`cmd/worker/main.go:423-435`) validated the HTTP `Host` header against a literal allow-list of `"127.0.0.1"` and `"localhost"`. IPv6 loopback (`[::1]`) was rejected with **403 Forbidden** even though it is the IPv6 host-equivalent per SPEC §13.7. Other `127.0.0.0/8` loopback addresses were also rejected.

## Change

- `cmd/worker/main.go`: replace the literal allow-list with `net.ParseIP(host).IsLoopback()` + a `"localhost"` special case (since `ParseIP` doesn't resolve names). Strip IPv6 brackets when the host arrived bracket-without-port (`"[::1]"`).
- `cmd/worker/main_test.go`:
  - `TestIsLoopbackHTTPHost` table-driven: 12 cases covering IPv4, IPv4 `127.0.0.0/8`, `localhost`, bracketed / unbracketed IPv6, non-loopback IP, empty.
  - `TestStateHTTPServerAllowsIPv6LoopbackHost` mirrors the existing IPv4 handler test.

## Scope notes

- `"::1"` unbracketed is **rejected** — RFC 7230 requires IPv6 hosts in HTTP `Host` headers to be bracketed; the unbracketed form is malformed.
- Listener bind address is unchanged; this PR is about Host-header validation only.

## Verification

- `go test -race -covermode=atomic ./...` — all packages pass.
- gofmt + `go mod tidy` clean.

Fork CI: https://github.com/xrf-9527/aiops-platform/pull/8

Refs: `docs/superpowers/specs/2026-05-22-loopback-ipv6-design.md`.