### PR TITLE
fix(linear): enforce 30s per-request network timeout (#212)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-linear-timeout-design.md
+++ b/docs/superpowers/specs/2026-05-22-linear-timeout-design.md
@@ -1,0 +1,88 @@
+# Linear client 30s network timeout — design
+
+**Date:** 2026-05-22
+**Issue:** [#212](https://github.com/xrf9268-hue/aiops-platform/issues/212)
+
+## Problem
+
+`internal/tracker/linear.go:101` constructs the Linear client with `HTTP: http.DefaultClient`. `http.DefaultClient.Timeout == 0`. The GraphQL request site at `linear.go:530` uses the caller's context as-is. The orchestrator's poll-tick path passes a long-lived context with no deadline, so a wedged Linear endpoint (CDN hiccup, network partition) hangs the poll loop indefinitely instead of failing fast per SPEC §14.2 "skip this tick, try again on next tick".
+
+SPEC §11.2 specifies a 30 000 ms network timeout for Linear queries.
+
+## Decision
+
+**Option A** from the issue body: wrap each request's context in `context.WithTimeout` at the call site. Expose the timeout as a `RequestTimeout time.Duration` field on `LinearClient`, default 30 s in `NewLinearClient`, overridable for tests.
+
+### Why Option A (per-call) over Option B (client.Timeout)
+
+- Option B sets `http.Client.Timeout`. That works but applies uniformly to anything done through that client; future code that introduces streaming or long-poll endpoints would inherit a 30 s ceiling silently.
+- Option A makes the contract explicit at every GraphQL call site and survives swapping `c.HTTP` for any other `*http.Client`.
+- Tests inject `client.HTTP = srv.Client()` — a per-call timeout still fires there.
+
+### Why a struct field (not a package-level var or hardcoded constant)
+
+- Hardcoded `30 * time.Second` forces the test to actually wait 30 s on a wedged endpoint. Unacceptable for CI.
+- Package-level mutable var races between parallel tests.
+- A `RequestTimeout` field defaults to 30 s in the constructor and is set per-client in tests. No global state.
+
+## What changes
+
+| File | Change |
+| --- | --- |
+| `internal/tracker/linear.go` (struct) | Add `RequestTimeout time.Duration`. |
+| `internal/tracker/linear.go` (`NewLinearClient`) | Default-initialize `RequestTimeout = 30 * time.Second`. |
+| `internal/tracker/linear.go` (request method around line 530) | Resolve effective timeout (fall back to 30 s if zero), wrap `ctx` with `context.WithTimeout`, build the request with the wrapped context, defer the cancel. |
+| `internal/tracker/linear_test.go` | Add `TestLinearClient_EnforcesRequestTimeout`: blocking handler, `RequestTimeout = 50 * time.Millisecond`, asserts the error unwraps to `context.DeadlineExceeded`. |
+
+## Concrete change
+
+```go
+type LinearClient struct {
+    APIKey         string
+    BaseURL        string
+    Config         workflow.TrackerConfig
+    HTTP           *http.Client
+    RequestTimeout time.Duration // SPEC §11.2 — defaults to 30s when zero
+}
+
+func NewLinearClient(cfg workflow.TrackerConfig) *LinearClient {
+    base := "https://api.linear.app/graphql"
+    return &LinearClient{
+        APIKey:         cfg.APIKey,
+        BaseURL:        base,
+        Config:         cfg,
+        HTTP:           http.DefaultClient,
+        RequestTimeout: 30 * time.Second,
+    }
+}
+
+// In the request method (around line 530):
+timeout := c.RequestTimeout
+if timeout <= 0 {
+    timeout = 30 * time.Second
+}
+reqCtx, cancel := context.WithTimeout(ctx, timeout)
+defer cancel()
+req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.BaseURL, bytes.NewReader(b))
+```
+
+Existing `*tracker.Error.Unwrap()` (linear.go:69) preserves `context.DeadlineExceeded`, so `errors.Is(err, context.DeadlineExceeded)` works through the wrapper.
+
+## Non-goals
+
+- Don't introduce a separate exposed constant for the 30 s value — the struct default is the canonical source.
+- Don't change `c.HTTP` from `http.DefaultClient` to a `&http.Client{Timeout: 30 * time.Second}` — Option B explicitly rejected above.
+- Don't add per-method timeout overrides (e.g. shorter for `ListActiveIssues`, longer for mutations) — outside SPEC scope.
+
+## Acceptance criteria
+
+- [ ] Linear API calls enforce a 30 s timeout (default), overridable per-client.
+- [ ] `TestLinearClient_EnforcesRequestTimeout` proves the ceiling via a blocking server + small `RequestTimeout`.
+- [ ] No regression in existing Linear tests.
+
+## Refs
+
+- Issue: https://github.com/xrf9268-hue/aiops-platform/issues/212
+- Code: `internal/tracker/linear.go:92-101, 525-540`
+- Error wrapping: `internal/tracker/linear.go:69-74` (Unwrap), 76-82 (Is)
+- SPEC §11.2 (30 000 ms), §14.2 (per-tick failure behavior)

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -94,11 +94,22 @@ type LinearClient struct {
 	BaseURL string
 	Config  workflow.TrackerConfig
 	HTTP    *http.Client
+	// RequestTimeout caps each Linear GraphQL request per SPEC §11.2.
+	// Defaults to 30s when zero.
+	RequestTimeout time.Duration
 }
+
+const defaultLinearRequestTimeout = 30 * time.Second
 
 func NewLinearClient(cfg workflow.TrackerConfig) *LinearClient {
 	base := "https://api.linear.app/graphql"
-	return &LinearClient{APIKey: cfg.APIKey, BaseURL: base, Config: cfg, HTTP: http.DefaultClient}
+	return &LinearClient{
+		APIKey:         cfg.APIKey,
+		BaseURL:        base,
+		Config:         cfg,
+		HTTP:           http.DefaultClient,
+		RequestTimeout: defaultLinearRequestTimeout,
+	}
 }
 
 func (c *LinearClient) ListActiveIssues(ctx context.Context) ([]Issue, error) {
@@ -527,7 +538,13 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 	if err != nil {
 		return NewError(CategoryLinearAPIRequest, "build Linear GraphQL request", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL, bytes.NewReader(b))
+	timeout := c.RequestTimeout
+	if timeout <= 0 {
+		timeout = defaultLinearRequestTimeout
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.BaseURL, bytes.NewReader(b))
 	if err != nil {
 		return NewError(CategoryLinearAPIRequest, "build Linear GraphQL request", err)
 	}

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -740,4 +741,36 @@ func TestListIssuesByStatesErrorsWhenInverseRelationMaxPagesExceeded(t *testing.
 
 func TestLinearClient_SatisfiesStateIssueLister(t *testing.T) {
 	var _ StateIssueLister = (*LinearClient)(nil)
+}
+
+func TestLinearClient_EnforcesRequestTimeout(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-block:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(block)
+		srv.Close()
+	})
+
+	client := newTestClient(t, srv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+	client.RequestTimeout = 50 * time.Millisecond
+
+	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want wrapping context.DeadlineExceeded", err)
+	}
+}
+
+func TestNewLinearClient_DefaultsRequestTimeoutTo30s(t *testing.T) {
+	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k"})
+	if client.RequestTimeout != 30*time.Second {
+		t.Fatalf("default RequestTimeout = %v, want 30s", client.RequestTimeout)
+	}
 }


### PR DESCRIPTION
Closes #212.

## Problem

`LinearClient.HTTP = http.DefaultClient` has no timeout, and the GraphQL request site at `internal/tracker/linear.go:530` used the caller's context as-is. The poll-tick path passes a long-lived context with no deadline, so a wedged Linear endpoint hung the poll loop indefinitely instead of failing per SPEC §14.2 ("skip this tick, try again next tick"). SPEC §11.2 specifies a 30 000 ms ceiling.

## Change

- `internal/tracker/linear.go`: add `RequestTimeout time.Duration` field on `LinearClient`; constant `defaultLinearRequestTimeout = 30 * time.Second`; `NewLinearClient` initialises the field.
- `internal/tracker/linear.go` GraphQL request method: resolve effective timeout (fall back to default if zero), `context.WithTimeout(ctx, timeout)`, build the request with the wrapped context, defer cancel.

Per-request `WithTimeout` (not `http.Client.Timeout`) keeps the ceiling explicit at the call site and survives any future code that swaps `c.HTTP` for a custom client. Existing tests inject `client.HTTP = srv.Client()` and continue to pass — the per-call timeout still fires there.

## Tests

- `TestNewLinearClient_DefaultsRequestTimeoutTo30s` pins the default value.
- `TestLinearClient_EnforcesRequestTimeout` blocks the server handler indefinitely and sets `RequestTimeout = 50ms`; asserts `errors.Is(err, context.DeadlineExceeded)`. The existing `*tracker.Error.Unwrap()` (linear.go:69) preserves the sentinel.

## Verification

- `go test -race -covermode=atomic ./...` — all packages pass.
- gofmt clean.

Fork CI: https://github.com/xrf-9527/aiops-platform/pull/9

Refs: `docs/superpowers/specs/2026-05-22-linear-timeout-design.md`.