### PR TITLE
fix(runner): cap codex app-server stdio reader at 10 MiB (#226)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-codex-line-cap-design.md
+++ b/docs/superpowers/specs/2026-05-22-codex-line-cap-design.md
@@ -1,0 +1,102 @@
+# Codex app-server stdio max-line cap — design
+
+**Date:** 2026-05-22
+**Issue:** [#226](https://github.com/xrf9268-hue/aiops-platform/issues/226)
+
+## Problem
+
+`internal/runner/codex_app_server.go:372` reads each JSON-RPC framed line via `c.reader.ReadBytes('\n')`. `bufio.Reader.ReadBytes` has no built-in line cap and grows its internal buffer until either a newline arrives or memory is exhausted. A misbehaving or malicious Codex app-server that emits a 4 GB line without a newline OOM-kills the worker (and any concurrent agents sharing the host).
+
+SPEC §10.1 RECOMMENDS "Max line size: 10 MB (for safe buffering)". Current code enforces no cap.
+
+## Decision
+
+Replace the `*bufio.Reader` field with a `*bufio.Scanner` configured via `Buffer(make([]byte, 0, 64<<10), maxAppServerLineBytes)` where `maxAppServerLineBytes = 10 * 1024 * 1024`. `bufio.Scanner.Scan` enforces the cap during the read — when a line exceeds the buffer, `Scan` returns `false` and `Err` returns `bufio.ErrTooLong`. Memory stays bounded at the cap.
+
+### Why Scanner and not a post-read length check on ReadBytes
+
+A post-read length check would still let `ReadBytes` allocate the entire (potentially gigabyte) line into the internal buffer before returning. The check rejects the result but the memory damage is already done. Scanner enforces the cap during the read itself.
+
+### Why not `io.LimitReader`-wrap stdout
+
+`io.LimitReader` exhausts after the cap. The Codex app-server session is long-running and emits many lines; a per-stream limit would break the second message. A per-line cap requires Scanner.
+
+### Why 10 MiB exactly (not configurable yet)
+
+SPEC says 10 MB. We adopt the recommendation as a constant. If operators report legitimate Codex responses above this (e.g. very long tool result payloads), exposing `codex.max_line_bytes` becomes a follow-up. The error path explicitly surfaces the cap value so the failure mode is diagnosable.
+
+## What changes
+
+| File | Change |
+| --- | --- |
+| `internal/runner/codex_app_server.go` | Replace `reader *bufio.Reader` field with `scanner *bufio.Scanner`. Construct via `bufio.NewScanner(stdout)` + `Buffer(make([]byte, 0, 64<<10), maxAppServerLineBytes)` at the same call site (currently line 84). |
+| `internal/runner/codex_app_server.go` (`readLine`) | Replace the `ReadBytes('\n')` goroutine with one that calls `scanner.Scan()`; on success, copy `scanner.Bytes()` (the slice is invalidated by the next `Scan`); on failure, surface `scanner.Err()` (or `io.EOF` if nil). |
+| `internal/runner/codex_app_server.go` (`readProtocolMessage`) | After `c.out.Write(line)`, also write `\n` to preserve transcript readability. Scanner strips the terminator from `Bytes()`. |
+| `internal/runner/codex_app_server.go` (constant) | Add `const maxAppServerLineBytes = 10 * 1024 * 1024`. |
+| `internal/runner/codex_app_server_test.go` | Add `TestAppServerClient_RejectsOversizedLine`: drive a fake stdin/stdout where the upstream emits a line longer than 10 MiB without `\n`; assert `readLine` (via a small wrapper) returns an error containing `"exceeded"` or `bufio.ErrTooLong` and does not OOM. |
+
+## Concrete change
+
+```go
+const (
+    appServerScannerInitialBuf = 64 << 10
+    maxAppServerLineBytes      = 10 * 1024 * 1024 // SPEC §10.1
+)
+
+type appServerClient struct {
+    stdin   io.Writer
+    scanner *bufio.Scanner
+    out     io.Writer
+    // ... rest unchanged
+}
+
+// at construction site:
+sc := bufio.NewScanner(stdout)
+sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes)
+client := &appServerClient{
+    stdin:   stdin,
+    scanner: sc,
+    out:     buf,
+}
+
+// readLine:
+go func() {
+    if c.scanner.Scan() {
+        line := append([]byte(nil), c.scanner.Bytes()...)
+        ch <- readResult{line: line, err: nil}
+        return
+    }
+    err := c.scanner.Err()
+    if err == nil {
+        err = io.EOF
+    }
+    if errors.Is(err, bufio.ErrTooLong) {
+        err = fmt.Errorf("codex app-server line exceeded %d bytes: %w", maxAppServerLineBytes, err)
+    }
+    ch <- readResult{err: err}
+}()
+
+// readProtocolMessage:
+_, _ = c.out.Write(line)
+_, _ = c.out.Write([]byte{'\n'})
+```
+
+## Non-goals
+
+- Don't make the cap configurable — SPEC value is the right default; revisit if operators report legitimate over-cap payloads.
+- Don't touch the mock runner — it emits internal Go data structures, not stdio bytes. The cap is a stdio-protocol property.
+- Don't add a `DEVIATIONS.md` row — this PR closes the deviation; SPEC §10.1 is now honored.
+
+## Acceptance criteria
+
+- [ ] Stdio reader bounded at 10 MiB.
+- [ ] Overflow surfaces as a wrapped error containing the cap value (and `bufio.ErrTooLong` per `errors.Is`).
+- [ ] Regression test simulates an oversized response and asserts graceful error (no OOM).
+- [ ] Existing app-server tests continue to pass; transcript output still includes line boundaries.
+
+## Refs
+
+- Issue: https://github.com/xrf9268-hue/aiops-platform/issues/226
+- Code: `internal/runner/codex_app_server.go:82-86, 169-175, 369-382, 346-362`
+- SPEC §10.1 ("Max line size: 10 MB"), §15.1 (harness hardening)
+- stdlib: `bufio.Scanner.Buffer`, `bufio.ErrTooLong`

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -18,6 +18,16 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+const (
+	// appServerScannerInitialBuf is the Scanner's starting buffer size; it grows
+	// as needed up to maxAppServerLineBytes.
+	appServerScannerInitialBuf = 64 << 10
+	// maxAppServerLineBytes caps each Codex app-server stdio line per SPEC §10.1
+	// ("Max line size: 10 MB"). Lines exceeding this surface as bufio.ErrTooLong
+	// instead of growing the buffer unbounded and OOMing the worker.
+	maxAppServerLineBytes = 10 * 1024 * 1024
+)
+
 // CodexAppServerRunner talks to `codex app-server` over JSON-RPC 2.0 stdio.
 // It is intentionally separate from CodexRunner so the existing one-shot
 // `codex exec` path remains backwards-compatible while the app-server transport
@@ -79,10 +89,12 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		return Result{}, err
 	}
 
+	sc := bufio.NewScanner(stdout)
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes)
 	client := &appServerClient{
-		stdin:  stdin,
-		reader: bufio.NewReader(stdout),
-		out:    buf,
+		stdin:   stdin,
+		scanner: sc,
+		out:     buf,
 	}
 	runErr := client.run(ctx, in, string(prompt))
 	if runErr != nil && ctx.Err() == nil {
@@ -168,7 +180,7 @@ func buildCodexAppServerCmd(ctx context.Context, in RunInput) (*exec.Cmd, error)
 
 type appServerClient struct {
 	stdin               io.Writer
-	reader              *bufio.Reader
+	scanner             *bufio.Scanner
 	out                 io.Writer
 	nextID              int
 	threadID            string
@@ -353,7 +365,10 @@ func (c *appServerClient) readProtocolMessage(ctx context.Context) (map[string]a
 	if err != nil {
 		return nil, nil, err
 	}
+	// Scanner strips the line terminator; restore one in the transcript so
+	// successive JSON-RPC messages remain visually separated.
 	_, _ = c.out.Write(line)
+	_, _ = c.out.Write([]byte{'\n'})
 	var msg map[string]any
 	if err := json.Unmarshal(line, &msg); err != nil {
 		return nil, line, NewError(CategoryResponseError, "decode codex app-server message", err)
@@ -369,8 +384,21 @@ type readResult struct {
 func (c *appServerClient) readLine(ctx context.Context) ([]byte, error) {
 	ch := make(chan readResult, 1)
 	go func() {
-		line, err := c.reader.ReadBytes('\n')
-		ch <- readResult{line: line, err: err}
+		if c.scanner.Scan() {
+			// scanner.Bytes() is invalidated by the next Scan; copy before
+			// crossing the goroutine boundary.
+			line := append([]byte(nil), c.scanner.Bytes()...)
+			ch <- readResult{line: line, err: nil}
+			return
+		}
+		err := c.scanner.Err()
+		if err == nil {
+			err = io.EOF
+		}
+		if errors.Is(err, bufio.ErrTooLong) {
+			err = fmt.Errorf("codex app-server line exceeded %d bytes: %w", maxAppServerLineBytes, err)
+		}
+		ch <- readResult{err: err}
 	}()
 
 	readTimeout := time.Duration(c.readTimeoutMs) * time.Millisecond

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -90,7 +90,10 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 	}
 
 	sc := bufio.NewScanner(stdout)
-	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes)
+	// Scanner returns ErrTooLong when the buffer fills with no token boundary,
+	// so passing maxAppServerLineBytes+1 as the cap allows tokens up to (and
+	// including) maxAppServerLineBytes and rejects anything strictly larger.
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
 	client := &appServerClient{
 		stdin:   stdin,
 		scanner: sc,

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1412,7 +1412,7 @@ func TestAppServerClient_ReadLineRejectsOversizedLine(t *testing.T) {
 	payload = append(payload, '\n')
 
 	sc := bufio.NewScanner(bytes.NewReader(payload))
-	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes)
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
 
 	c := &appServerClient{scanner: sc}
 	_, err := c.readLine(context.Background())
@@ -1427,23 +1427,21 @@ func TestAppServerClient_ReadLineRejectsOversizedLine(t *testing.T) {
 	}
 }
 
-func TestAppServerClient_ReadLineAcceptsLinesBelowCap(t *testing.T) {
-	// A line below the cap (use cap/2 for headroom; Scanner's max is the
-	// buffer ceiling, so lines at exactly cap are rejected by stdlib semantics)
-	// must come back intact.
-	size := maxAppServerLineBytes / 2
-	payload := bytes.Repeat([]byte{'x'}, size)
+func TestAppServerClient_ReadLineAcceptsLineAtCap(t *testing.T) {
+	// A line of exactly maxAppServerLineBytes — the documented limit — must
+	// pass; only strictly-larger lines should be rejected.
+	payload := bytes.Repeat([]byte{'x'}, maxAppServerLineBytes)
 	payload = append(payload, '\n')
 
 	sc := bufio.NewScanner(bytes.NewReader(payload))
-	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes)
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
 
 	c := &appServerClient{scanner: sc}
 	line, err := c.readLine(context.Background())
 	if err != nil {
-		t.Fatalf("readLine under cap err = %v, want nil", err)
+		t.Fatalf("readLine at cap err = %v, want nil (10 MiB is the documented inclusive limit)", err)
 	}
-	if got, want := len(line), size; got != want {
+	if got, want := len(line), maxAppServerLineBytes; got != want {
 		t.Fatalf("readLine line len = %d, want %d", got, want)
 	}
 }

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1,12 +1,16 @@
 package runner
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1396,5 +1400,50 @@ for line in sys.stdin:
 	}
 	if !strings.Contains(string(stdin), `"code":-32601`) || strings.Contains(string(stdin), `"success":false`) {
 		t.Fatalf("stdin did not include JSON-RPC method-not-found error: %s", stdin)
+	}
+}
+
+// TestAppServerClient_ReadLineRejectsOversizedLine drives readLine directly
+// with a synthesized stdout stream where a single line exceeds the 10 MiB
+// SPEC §10.1 ceiling. The Scanner-bounded reader must surface the cap as a
+// wrapped bufio.ErrTooLong instead of growing the buffer until OOM.
+func TestAppServerClient_ReadLineRejectsOversizedLine(t *testing.T) {
+	payload := bytes.Repeat([]byte{'x'}, maxAppServerLineBytes+1)
+	payload = append(payload, '\n')
+
+	sc := bufio.NewScanner(bytes.NewReader(payload))
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes)
+
+	c := &appServerClient{scanner: sc}
+	_, err := c.readLine(context.Background())
+	if err == nil {
+		t.Fatal("readLine err = nil, want over-cap error")
+	}
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Fatalf("readLine err = %v, want errors.Is(err, bufio.ErrTooLong)", err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(maxAppServerLineBytes)) {
+		t.Fatalf("readLine err = %q, want cap value %d to appear in message", err.Error(), maxAppServerLineBytes)
+	}
+}
+
+func TestAppServerClient_ReadLineAcceptsLinesBelowCap(t *testing.T) {
+	// A line below the cap (use cap/2 for headroom; Scanner's max is the
+	// buffer ceiling, so lines at exactly cap are rejected by stdlib semantics)
+	// must come back intact.
+	size := maxAppServerLineBytes / 2
+	payload := bytes.Repeat([]byte{'x'}, size)
+	payload = append(payload, '\n')
+
+	sc := bufio.NewScanner(bytes.NewReader(payload))
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes)
+
+	c := &appServerClient{scanner: sc}
+	line, err := c.readLine(context.Background())
+	if err != nil {
+		t.Fatalf("readLine under cap err = %v, want nil", err)
+	}
+	if got, want := len(line), size; got != want {
+		t.Fatalf("readLine line len = %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
Closes #226.

## Problem

`internal/runner/codex_app_server.go:readLine` used `bufio.Reader.ReadBytes('\n')` with no length cap. A misbehaving Codex app-server emitting a 4 GB line without newline grew the bufio buffer until OOM. SPEC §10.1 RECOMMENDS "Max line size: 10 MB".

## Change

Replace `*bufio.Reader` field with `*bufio.Scanner` configured via `Buffer(make([]byte, 0, 64<<10), maxAppServerLineBytes)` where `maxAppServerLineBytes = 10 * 1024 * 1024`. `bufio.Scanner.Scan()` enforces the cap during the read itself; over-cap lines surface as `bufio.ErrTooLong`. Memory stays bounded at the cap.

`readLine` wraps the error as `"codex app-server line exceeded 10485760 bytes: …"` preserving `errors.Is(err, bufio.ErrTooLong)`. Scanner strips the line terminator, so `readProtocolMessage` writes a trailing `\n` to `c.out` separately to keep transcript readability.

## Why not a post-read length check on ReadBytes

A post-read check still lets ReadBytes balloon the buffer to the malicious size first. Scanner is the only stdlib primitive that bounds memory **during** the read.

## Tests

- `TestAppServerClient_ReadLineRejectsOversizedLine`: synthesize `maxAppServerLineBytes+1` bytes of `'x'` + newline; assert wrapped `bufio.ErrTooLong` with cap value in message.
- `TestAppServerClient_ReadLineAcceptsLinesBelowCap`: `cap/2` line round-trips intact.

## Verification

- `go test -race -covermode=atomic ./...` — all packages pass.
- gofmt clean.

Fork CI: https://github.com/xrf-9527/aiops-platform/pull/11

Refs: `docs/superpowers/specs/2026-05-22-codex-line-cap-design.md`.