### PR TITLE
fix(workflow-runtime): dedupe EventWorkflowReloadFailed per fingerprint (#239)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-reload-dedupe-design.md
+++ b/docs/superpowers/specs/2026-05-22-reload-dedupe-design.md
@@ -1,0 +1,110 @@
+# WorkflowReloadFailed fingerprint dedupe — design
+
+**Date:** 2026-05-22
+**Issue:** [#239](https://github.com/xrf9268-hue/aiops-platform/issues/239)
+
+## Problem
+
+`WorkflowRuntime.ReloadOnce` emits `EventWorkflowReloadFailed` on every tick whenever the workflow file is present but invalid. Default tick = 1 s; an hour of bad config = 3600 identical emissions. The 200-entry runtime event ring (`internal/orchestrator/status.go`) evicts everything useful, structured-log sinks alert thousands of times, and the reload-loop wastes CPU re-running `Load + validate` for content that hasn't changed.
+
+The fingerprint check at `workflow_runtime.go:108` only suppresses re-emission of `EventWorkflowReloaded` — it short-circuits when the **last successful** fingerprint matches the current file. When the file is invalid, no successful snapshot is stored, so the comparison never matches and the load+validate runs every tick.
+
+## Decision
+
+Track the most recent **failed** fingerprint separately. Suppress `EventWorkflowReloadFailed` and the load/validate work when the fingerprint hasn't changed since the last emission. Clear the failed-fingerprint state on the next successful load.
+
+Treat fingerprint-extraction failures (file missing, EISDIR, permission denied) with a sentinel string so they dedupe the same way as load/validate failures.
+
+### Why fingerprint-keyed and not time-rate-limited
+
+Rate limiting (e.g. once per minute) would still emit many duplicates per day and gives no signal about whether the underlying file actually changed. Fingerprint-keying means **operators see exactly one event per distinct broken configuration** — the cardinality reflects real operator activity, not wall-clock time.
+
+### Concurrency
+
+`ReloadOnce` has exactly one production caller (`RunWorkflowReloadLoop` in `cmd/worker/main.go:206`), sequential. The new field is still guarded by a `sync.Mutex` for safety in tests (which call `ReloadOnce` directly from the test goroutine and may run with `-race`).
+
+### Sentinel for read-error case
+
+`workflowFileFingerprint` returns an error before any hex digest is computed when the file is missing/unreadable. We use the literal `"<workflow-read-error>"` as the fingerprint marker for this case. SHA-256 hex is `[0-9a-f]{64}`, so the angle-bracket sentinel cannot collide with a real fingerprint.
+
+## What changes
+
+| File | Change |
+| --- | --- |
+| `internal/orchestrator/workflow_runtime.go` | Add `mu sync.Mutex` + `lastFailedFingerprint string` fields on `WorkflowRuntime`. |
+| `internal/orchestrator/workflow_runtime.go` (`ReloadOnce`) | After fingerprint read: if read fails, compare against sentinel and skip re-emit if matched; otherwise compare current file fingerprint against `lastFailedFingerprint` and skip both `workflow.Load` and re-emit when matched. On any successful path (snap match or new snap stored), clear `lastFailedFingerprint`. |
+| `internal/orchestrator/workflow_reloader_test.go` | Add `TestWorkflowRuntimeReloadOnceDedupesIdenticalFailures`: write invalid workflow, call `ReloadOnce` six times, assert `count(EventWorkflowReloadFailed) == 1`; then restore validity and assert one `EventWorkflowReloaded`. Add a second test for missing-file dedupe. |
+
+## Implementation sketch
+
+```go
+const workflowReloadReadErrorSentinel = "<workflow-read-error>"
+
+type WorkflowRuntime struct {
+    // ... existing fields ...
+    mu                    sync.Mutex
+    lastFailedFingerprint string
+}
+
+func (r *WorkflowRuntime) ReloadOnce(ctx context.Context) error {
+    // (existing nil / SourceDefault checks unchanged)
+    fingerprint, err := workflowFileFingerprint(r.path)
+    if err != nil {
+        r.mu.Lock()
+        suppress := r.lastFailedFingerprint == workflowReloadReadErrorSentinel
+        r.lastFailedFingerprint = workflowReloadReadErrorSentinel
+        r.mu.Unlock()
+        if !suppress {
+            r.emit(ctx, task.EventWorkflowReloadFailed, ...)
+        }
+        return err
+    }
+    if snap := r.Current(); snap.Fingerprint != "" && snap.Fingerprint == fingerprint {
+        r.clearLastFailedFingerprint()
+        return nil
+    }
+    r.mu.Lock()
+    if r.lastFailedFingerprint == fingerprint {
+        r.mu.Unlock()
+        return errWorkflowReloadDeduped
+    }
+    r.mu.Unlock()
+    wf, err := workflow.Load(r.path)
+    if err == nil && r.validate != nil {
+        err = r.validate(wf.Path, wf.Source, wf.Config)
+    }
+    if err != nil {
+        r.mu.Lock()
+        r.lastFailedFingerprint = fingerprint
+        r.mu.Unlock()
+        r.emit(ctx, task.EventWorkflowReloadFailed, ...)
+        return err
+    }
+    r.clearLastFailedFingerprint()
+    r.current.Store(r.snapshotFromWorkflow(wf, fingerprint))
+    r.emit(ctx, task.EventWorkflowReloaded, ...)
+    return nil
+}
+```
+
+`errWorkflowReloadDeduped` is a sentinel `errors.New("workflow reload deduped: identical to last-failed fingerprint")`. The single existing caller (`RunWorkflowReloadLoop`) does not switch on the error type, so the sentinel is purely diagnostic for tests.
+
+## Non-goals
+
+- Don't introduce a time-based rate-limiter — fingerprint dedupe gives exactly-one-per-distinct-failure cardinality, which is what operators want.
+- Don't change `RunWorkflowReloadLoop` backoff behavior — the loop's interval is unchanged; the cost saving is per-tick (no `Load`/`validate` re-run on identical fingerprints).
+- Don't expose `lastFailedFingerprint` on `WorkflowSnapshot` — it's internal state, not a snapshot property.
+
+## Acceptance criteria
+
+- [ ] Persistent invalid workflow emits exactly one `EventWorkflowReloadFailed` per distinct broken fingerprint.
+- [ ] When the file is fixed, exactly one `EventWorkflowReloaded` fires and dedupe state clears.
+- [ ] Missing-file failure also dedupes.
+- [ ] Test simulates ≥6 ticks against an invalid file and asserts the count remains 1.
+
+## Refs
+
+- Issue: https://github.com/xrf9268-hue/aiops-platform/issues/239
+- Code: `internal/orchestrator/workflow_runtime.go:96-122, 195-205`
+- Existing test patterns: `internal/orchestrator/workflow_reloader_test.go:655-682` (single-failure emission), `:93-122` (success dedupe by fingerprint)
+- SPEC §6.2 ("Invalid reloads MUST NOT crash the service; … emit an operator-visible error")

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -952,3 +952,91 @@ var osWriteFileForReloadTest = func(path string, data []byte) error {
 func itoaForReloadTest(v int) string {
 	return strconv.Itoa(v)
 }
+
+func TestWorkflowRuntimeReloadOnceDedupesIdenticalFailures(t *testing.T) {
+	emitter := &recordingWorkflowReloadEmitter{}
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load initial workflow: %v", err)
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{
+		Initial:     initial,
+		Path:        path,
+		Source:      workflow.SourceFile,
+		Emitter:     emitter,
+		EventTaskID: "workflow-runtime",
+	})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	// Make the file invalid (unsupported tracker.kind). First ReloadOnce must
+	// emit one EventWorkflowReloadFailed; the next five must dedupe.
+	writeWorkflowForReloadTestAt(t, path, "unsupported", 30000, "Rework")
+	if err := runtime.ReloadOnce(context.Background()); err == nil {
+		t.Fatal("first reload of invalid file must return an error")
+	}
+	if got := emitter.count(task.EventWorkflowReloadFailed); got != 1 {
+		t.Fatalf("after first failure, reload_failed count = %d, want 1", got)
+	}
+	for i := 0; i < 5; i++ {
+		if err := runtime.ReloadOnce(context.Background()); err == nil {
+			t.Fatalf("reload %d of identical invalid file must still return an error", i+2)
+		}
+	}
+	if got := emitter.count(task.EventWorkflowReloadFailed); got != 1 {
+		t.Fatalf("after 6 calls with identical invalid fingerprint, reload_failed count = %d, want 1 (deduped)", got)
+	}
+
+	// Fix the file → exactly one EventWorkflowReloaded; the dedupe state clears.
+	writeWorkflowForReloadTestAt(t, path, "linear", 42000, "Rework")
+	if err := runtime.ReloadOnce(context.Background()); err != nil {
+		t.Fatalf("reload after fix: %v", err)
+	}
+	if got := emitter.count(task.EventWorkflowReloaded); got != 1 {
+		t.Fatalf("after recovery, reloaded count = %d, want 1", got)
+	}
+
+	// Break it again with a *different* invalid fingerprint — must emit a new
+	// reload_failed (fingerprint changed, so the dedupe cache misses).
+	writeWorkflowForReloadTestAt(t, path, "unsupported", 42000, "Rework")
+	if err := runtime.ReloadOnce(context.Background()); err == nil {
+		t.Fatal("reload of newly-invalid file must return an error")
+	}
+	if got := emitter.count(task.EventWorkflowReloadFailed); got != 2 {
+		t.Fatalf("after second distinct failure, reload_failed count = %d, want 2", got)
+	}
+}
+
+func TestWorkflowRuntimeReloadOnceDedupesMissingFile(t *testing.T) {
+	emitter := &recordingWorkflowReloadEmitter{}
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load initial workflow: %v", err)
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{
+		Initial:     initial,
+		Path:        path,
+		Source:      workflow.SourceFile,
+		Emitter:     emitter,
+		EventTaskID: "workflow-runtime",
+	})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove workflow file: %v", err)
+	}
+
+	for i := 0; i < 6; i++ {
+		if err := runtime.ReloadOnce(context.Background()); err == nil {
+			t.Fatalf("reload %d with missing file must return an error", i+1)
+		}
+	}
+	if got := emitter.count(task.EventWorkflowReloadFailed); got != 1 {
+		t.Fatalf("after 6 missing-file reloads, reload_failed count = %d, want 1 (deduped via read-error sentinel)", got)
+	}
+}

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +16,19 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+// workflowReloadReadErrorSentinel marks the lastFailedFingerprint when the
+// workflow file cannot be read (missing / EISDIR / permission denied). SHA-256
+// fingerprints are 64 lowercase hex chars, so the angle-bracketed string
+// cannot collide with a real fingerprint.
+const workflowReloadReadErrorSentinel = "<workflow-read-error>"
+
+// errWorkflowReloadDeduped is returned by ReloadOnce when the current workflow
+// file fingerprint matches a previous failed reload — the caller already
+// received an EventWorkflowReloadFailed for this fingerprint, so we skip
+// re-emitting and re-running Load/validate. Diagnostic only; the single
+// production caller (RunWorkflowReloadLoop) does not branch on the type.
+var errWorkflowReloadDeduped = errors.New("workflow reload deduped: identical to last-failed fingerprint")
 
 type WorkflowRuntimeConfig struct {
 	Initial              *workflow.Workflow
@@ -36,6 +50,13 @@ type WorkflowRuntime struct {
 	validate             func(path string, source workflow.Source, cfg workflow.Config) error
 	reconciliationConfig func(workflow.Config) ReconciliationConfig
 	current              atomic.Pointer[WorkflowSnapshot]
+
+	// failureMu guards lastFailedFingerprint. ReloadOnce has one production
+	// caller (RunWorkflowReloadLoop) that runs sequentially, but the mutex
+	// keeps -race tests honest if a future caller (e.g. a refresh endpoint)
+	// races with the loop.
+	failureMu             sync.Mutex
+	lastFailedFingerprint string
 }
 
 type WorkflowSnapshot struct {
@@ -102,23 +123,46 @@ func (r *WorkflowRuntime) ReloadOnce(ctx context.Context) error {
 	}
 	fingerprint, err := workflowFileFingerprint(r.path)
 	if err != nil {
-		r.emit(ctx, task.EventWorkflowReloadFailed, fmt.Sprintf("workflow reload failed: %v", err), map[string]any{"path": r.path, "error": err.Error()})
+		r.failureMu.Lock()
+		suppress := r.lastFailedFingerprint == workflowReloadReadErrorSentinel
+		r.lastFailedFingerprint = workflowReloadReadErrorSentinel
+		r.failureMu.Unlock()
+		if !suppress {
+			r.emit(ctx, task.EventWorkflowReloadFailed, fmt.Sprintf("workflow reload failed: %v", err), map[string]any{"path": r.path, "error": err.Error()})
+		}
 		return err
 	}
 	if snap := r.Current(); snap.Fingerprint != "" && snap.Fingerprint == fingerprint {
+		r.clearLastFailedFingerprint()
 		return nil
 	}
+	r.failureMu.Lock()
+	if r.lastFailedFingerprint == fingerprint {
+		r.failureMu.Unlock()
+		return errWorkflowReloadDeduped
+	}
+	r.failureMu.Unlock()
 	wf, err := workflow.Load(r.path)
 	if err == nil && r.validate != nil {
 		err = r.validate(wf.Path, wf.Source, wf.Config)
 	}
 	if err != nil {
+		r.failureMu.Lock()
+		r.lastFailedFingerprint = fingerprint
+		r.failureMu.Unlock()
 		r.emit(ctx, task.EventWorkflowReloadFailed, fmt.Sprintf("workflow reload failed: %v", err), map[string]any{"path": r.path, "error": err.Error()})
 		return err
 	}
+	r.clearLastFailedFingerprint()
 	r.current.Store(r.snapshotFromWorkflow(wf, fingerprint))
 	r.emit(ctx, task.EventWorkflowReloaded, "workflow reloaded", map[string]any{"path": r.path, "poll_interval_ms": wf.Config.Tracker.PollIntervalMs})
 	return nil
+}
+
+func (r *WorkflowRuntime) clearLastFailedFingerprint() {
+	r.failureMu.Lock()
+	r.lastFailedFingerprint = ""
+	r.failureMu.Unlock()
 }
 
 func (r *WorkflowRuntime) emit(ctx context.Context, kind, msg string, payload any) {


### PR DESCRIPTION
Closes #239.

## Problem

`WorkflowRuntime.ReloadOnce` emitted `EventWorkflowReloadFailed` every tick (default 1s) when the workflow file was present but invalid — 3,600 identical emissions per hour. The 200-entry runtime event ring evicted everything else, structured-log sinks alerted thousands of times, and the loop re-ran `workflow.Load` + `validate` on identical content every tick.

The existing fingerprint check (`workflow_runtime.go:108`) only short-circuits re-emission of `EventWorkflowReloaded` — it compares against the last *successful* fingerprint, which is empty when no good load has ever happened, so the check never matched for an invalid file.

## Change

- `internal/orchestrator/workflow_runtime.go`: add `failureMu sync.Mutex` + `lastFailedFingerprint string` on `WorkflowRuntime`. ReloadOnce now:
  - Read fails → sentinel `"<workflow-read-error>"`; subsequent identical read-error skips emit.
  - Snap fingerprint matches file → clear lastFailed; return nil (unchanged).
  - Fingerprint matches lastFailed → return `errWorkflowReloadDeduped` *without* re-running `Load`/`validate` and *without* re-emit.
  - Load/validate fails → set lastFailed = fingerprint, emit, return err.
  - Load/validate succeeds → clear lastFailed, store snap, emit reloaded.

## Tests

- `TestWorkflowRuntimeReloadOnceDedupesIdenticalFailures`: invalid → 6 identical ticks (1 emission) → fix → 1 reloaded → different invalid (1 new emission). Asserts exact counts.
- `TestWorkflowRuntimeReloadOnceDedupesMissingFile`: delete file, 6 ticks, exactly 1 emission via read-error sentinel.

## Verification

- `go test -race -covermode=atomic ./...` — all packages pass.
- gofmt clean.

Fork CI: https://github.com/xrf-9527/aiops-platform/pull/12

Refs: `docs/superpowers/specs/2026-05-22-reload-dedupe-design.md`.