### PR TITLE
fix(worker): mask Sandbox.CredentialFiles + Repo.CloneURL userinfo in --print-config (#194)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-print-config-secret-masking-design.md
+++ b/docs/superpowers/specs/2026-05-22-print-config-secret-masking-design.md
@@ -1,0 +1,107 @@
+# `worker --print-config` secret masking — design
+
+Tracks issue #194.
+
+## Problem
+
+`internal/worker/print_config.go:124-131` (`maskSecrets`) only redacts `Tracker.APIKey`. Its own comment admits the gap. Since that comment was written, two additional secret-bearing surfaces have landed:
+
+- `workflow.SandboxConfig.CredentialFiles []string` — absolute paths to credential files. The path itself is sensitive ("where the attacker should look on disk if they get shell access").
+- `workflow.RepoConfig.CloneURL string` — may embed `https://user:token@host/…` basic-auth.
+
+Operators paste `--print-config` output into issues / chat / runbooks. Today, that paste leaks these values verbatim.
+
+A second, related problem: `configView` omits `Sandbox` entirely (`internal/worker/print_config.go:38-48`). Operators cannot use `--print-config` to verify the effective sandbox posture (`enabled`, `backend`, `network_mode`, etc.). That defeats the debugging purpose for the sandbox feature.
+
+## Goals
+
+1. `maskSecrets` covers every secret-bearing field on the current `workflow.Config`.
+2. `configView` includes the previously-omitted `Sandbox` block so it is observable from `--print-config` (after masking).
+3. New tests assert no plaintext secret reaches stdout for each secret-bearing field type.
+4. The policy is locally enumerated in a single function with a doc-comment contract — "every secret-bearing field is masked here; adding a new one without updating this function is a review-blocking change". The `aiops:"secret"` struct-tag walker mentioned in the issue is rejected (see below).
+
+## Non-goals
+
+- Building a reflection-based struct-tag walker. The current schema has three secret-bearing fields; a hand-written mask function is shorter, easier to audit, and produces specific diagnostics. A struct-tag walker would add a serializer-shaped subsystem to harden against a hypothetical future where someone adds a secret field without reading the very function they would have to touch anyway. Rejected as over-engineering. The doc-comment + tests around `maskSecrets` are the policy.
+- Masking `Codex` / `Claude` `CommandConfig` fields. Audit (see "Audit") shows none of its fields are secret-bearing today.
+- Changing the on-disk schema, default config, or any consumer of `workflow.Config`. This is a printer-only fix.
+
+## Audit of `workflow.Config`
+
+Walking each top-level field in `internal/workflow/config.go`:
+
+| Field | Secret-bearing? | Action |
+| --- | --- | --- |
+| `Server.Port` | no | keep |
+| `Repo.Owner` / `Name` / `DefaultBranch` | no | keep |
+| `Repo.CloneURL` | **yes** if userinfo present | strip userinfo |
+| `Tracker.APIKey` | **yes** | already masked |
+| `Tracker.Kind` / `ProjectSlug` / etc. | no | keep |
+| `Workspace.*` | no | keep |
+| `Agent.*` | no | keep |
+| `Codex.Command` / `Profile` / `ApprovalPolicy` / `ThreadSandbox` / `TurnSandboxPolicy` / `TurnTimeoutMs` / `ReadTimeoutMs` / `StallTimeoutMs` | no | keep |
+| `Claude.Command` / etc. | no | keep |
+| `Policy.*` | no | keep |
+| `Verify.*` | no | keep |
+| `PR.*` | no | keep |
+| `Sandbox.Enabled` / `Backend` / `NetworkMode` / `NetworkAllowlistCIDRs` / `NetworkInterface` / `EnvAllowlist` | no | **add to configView** |
+| `Sandbox.CredentialFiles` | **yes** (paths) | **add to configView + mask** |
+
+Three secret-bearing fields → three explicit mask branches. One newly-printed block.
+
+## `CloneURL` masking semantics
+
+`url.Parse` handles the `https://user:token@host/path` case cleanly: drop `Userinfo`. SSH-style URLs like `git@example.com:o/r.git` are not parseable as `net/url` URLs and do not embed secrets in their userinfo (the part before `@` is a username, not a token); they pass through unchanged.
+
+Behavior table:
+
+| Input | Output |
+| --- | --- |
+| `""` | `""` |
+| `git@example.com:o/r.git` | `git@example.com:o/r.git` |
+| `https://github.com/o/r.git` | `https://github.com/o/r.git` |
+| `https://user:token@github.com/o/r.git` | `https://github.com/o/r.git` |
+| `https://x-access-token:ghp_…@github.com/o/r.git` | `https://github.com/o/r.git` |
+| `https://user@github.com/o/r.git` (user, no password) | `https://github.com/o/r.git` (still strip — a "username" embedded in a clone URL is by convention a token alias, e.g. `oauth2`) |
+| malformed | input returned unchanged (no parse, no leak — but operators see the raw value, including any secret). The loader rejects malformed URLs upstream so this branch is defensive only. |
+
+The "drop userinfo whenever present" rule is the safe default. The cost of stripping a legitimate non-secret username is zero (it is a debug printer); the cost of leaving a token is high.
+
+## `CredentialFiles` masking semantics
+
+Each entry is replaced with `"***"`. The slice length and ordering are preserved so an operator can confirm "I configured three credential files; three are loaded." The actual paths never reach stdout. Empty slice / nil slice pass through unchanged.
+
+## Test plan (boundary-coverage)
+
+`internal/worker/print_config_test.go` adds tests using the `=N` / `=N+1` / paired-edges rule on each secret-bearing field:
+
+1. **`CloneURL` paired edges** — three sub-cases in one test, plus a negative assertion that the plaintext token never appears:
+   - userinfo present (user+password)
+   - userinfo present (user only — still stripped)
+   - plain HTTPS (no userinfo — round-trips unchanged)
+   - SSH-style git URL (no userinfo — round-trips unchanged)
+2. **`CredentialFiles` paired edges** — length 0 (omitted), length 1, length 2 to confirm slice-element masking applies to every element; assert no path substring leaks. The "exactly-N" boundary for credentials is "exactly empty vs. exactly non-empty" — empty slice must not produce `"***"`.
+3. **`Sandbox` visible in `configView`** — `enabled`, `backend`, `network`, `env_allowlist` round-trip into JSON (previously omitted entirely).
+4. **Existing `Tracker.APIKey` masking** — unchanged.
+5. **Schema-error path** — unchanged.
+
+No `bufio.Scanner.Buffer(_, N)`-style cap to test here; the boundary rule applies to "set vs. unset" rather than a numeric limit.
+
+## Implementation sequence
+
+1. In `internal/worker/print_config.go`:
+   - Add `Sandbox workflow.SandboxConfig` to `configView`.
+   - Populate it in `newConfigView`.
+   - Add `maskCloneURL(string) string` helper using `net/url`.
+   - Extend `maskSecrets` to clear `Repo.CloneURL`, walk `Sandbox.CredentialFiles`, and (existing) mask `Tracker.APIKey`. Update the doc-comment to read as the policy contract: "every secret-bearing field on `workflow.Config` is enumerated here; adding a new one without extending this function is a review-blocking gap. Tests in `print_config_test.go` enforce this for each known field."
+2. In `internal/worker/print_config_test.go`:
+   - Add `TestPrintConfig_MasksRepoCloneURLUserinfo` with the four URL forms from the table above.
+   - Add `TestPrintConfig_MasksSandboxCredentialFiles` covering length 0 / 1 / 2.
+   - Add `TestPrintConfig_SandboxVisibleInConfigView` asserting `enabled`/`backend`/`network` survive the round-trip.
+3. `go test ./internal/worker/...` green.
+4. `go vet ./...` green.
+
+## Risks
+
+- **External tooling** consuming `--print-config` JSON now sees a `sandbox` key it did not see before. The package comment on `printConfigOutput` already calls the shape "stable" but the change is additive (new key), not breaking (no key removed, no type changed). Consumers that decode into typed structs ignore unknown keys; consumers that whitelist keys will not see `sandbox` until they opt in. Acceptable.
+- **`url.Parse` performance**: `--print-config` is a one-shot debug command; parsing one URL per invocation is free.

--- a/internal/worker/print_config.go
+++ b/internal/worker/print_config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -45,6 +46,7 @@ type configView struct {
 	Policy    workflow.PolicyConfig    `json:"policy"`
 	Verify    workflow.VerifyConfig    `json:"verify"`
 	PR        workflow.PRConfig        `json:"pr"`
+	Sandbox   workflow.SandboxConfig   `json:"sandbox"`
 }
 
 // agentConfigView mirrors workflow.AgentConfig but renders Timeout as a
@@ -75,11 +77,12 @@ func newConfigView(cfg workflow.Config) configView {
 			Timeout:             cfg.Agent.Timeout.String(),
 			MaxTimeoutRetries:   cfg.Agent.MaxTimeoutRetries,
 		},
-		Codex:  cfg.Codex,
-		Claude: cfg.Claude,
-		Policy: cfg.Policy,
-		Verify: cfg.Verify,
-		PR:     cfg.PR,
+		Codex:   cfg.Codex,
+		Claude:  cfg.Claude,
+		Policy:  cfg.Policy,
+		Verify:  cfg.Verify,
+		PR:      cfg.PR,
+		Sandbox: cfg.Sandbox,
 	}
 }
 
@@ -123,13 +126,47 @@ const maskedSecret = "***"
 // maskSecrets rewrites secret-bearing fields on a Config to a fixed
 // placeholder before serialization. The function takes its argument by
 // value; the workflow.Config used by the running worker is never
-// touched. Currently only Tracker.APIKey is masked — extend this list
-// when new secret-bearing fields are added to the schema.
+// touched.
+//
+// Policy contract: this function is the single point that enumerates
+// every secret-bearing field on workflow.Config. Adding a new
+// secret-bearing field to the schema without extending this function is
+// a review-blocking gap — tests in print_config_test.go pin each known
+// field against plaintext leaks. Current coverage:
+//   - Tracker.APIKey            (token)
+//   - Repo.CloneURL             (may embed https://user:token@... userinfo)
+//   - Sandbox.CredentialFiles   (each path is itself an attacker pointer)
 func maskSecrets(cfg workflow.Config) workflow.Config {
 	if cfg.Tracker.APIKey != "" {
 		cfg.Tracker.APIKey = maskedSecret
 	}
+	cfg.Repo.CloneURL = maskCloneURL(cfg.Repo.CloneURL)
+	if n := len(cfg.Sandbox.CredentialFiles); n > 0 {
+		masked := make([]string, n)
+		for i := range masked {
+			masked[i] = maskedSecret
+		}
+		cfg.Sandbox.CredentialFiles = masked
+	}
 	return cfg
+}
+
+// maskCloneURL strips embedded basic-auth from a clone URL. URLs that
+// do not parse as net/url (notably the SSH-style git@host:path form)
+// return unchanged, since that form does not carry userinfo. A bare
+// username with no password is also stripped: by convention an embedded
+// user in an HTTPS clone URL is a token alias (e.g. "oauth2",
+// "x-access-token", or the token itself), not a real account name.
+func maskCloneURL(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
 }
 
 // printConfig writes the effective workflow for workdir as JSON to

--- a/internal/worker/print_config_test.go
+++ b/internal/worker/print_config_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -289,6 +290,194 @@ func TestPrintConfig_TopLevelOmitsEmptyShadowedBy(t *testing.T) {
 	}
 	if out.Source != "default" {
 		t.Fatalf("top-level source = %q, want %q", out.Source, "default")
+	}
+}
+
+// TestPrintConfig_MasksRepoCloneURLUserinfo pins the secret-masking
+// contract for `repo.clone_url`: when the URL embeds basic-auth
+// userinfo (the conventional way GitHub-style tokens are passed via
+// HTTPS clones), the userinfo segment is stripped before serialization
+// so `--print-config` paste-into-chat does not leak the token. Non-auth
+// URL forms (plain HTTPS, SSH-style git URLs) must round-trip
+// unchanged.
+//
+// Boundary-coverage rule: paired edges on the userinfo bracket — both
+// halves (user+password), opening-only (user, no password), neither
+// (plain), and a structurally distinct form (SSH) all in one test so a
+// future regression on any branch is loud.
+func TestPrintConfig_MasksRepoCloneURLUserinfo(t *testing.T) {
+	cases := []struct {
+		name     string
+		clone    string
+		wantOut  string
+		mustHide []string
+	}{
+		{
+			name:     "user_and_token_password",
+			clone:    "https://oauth2:ghp_super_secret_token@github.com/o/r.git",
+			wantOut:  "https://github.com/o/r.git",
+			mustHide: []string{"ghp_super_secret_token", "oauth2:ghp_super_secret_token"},
+		},
+		{
+			name:     "user_only_treated_as_token_alias",
+			clone:    "https://ghp_super_secret_token@github.com/o/r.git",
+			wantOut:  "https://github.com/o/r.git",
+			mustHide: []string{"ghp_super_secret_token"},
+		},
+		{
+			name:    "plain_https_round_trips",
+			clone:   "https://github.com/o/r.git",
+			wantOut: "https://github.com/o/r.git",
+		},
+		{
+			name:    "ssh_git_url_round_trips",
+			clone:   "git@example.com:o/r.git",
+			wantOut: "git@example.com:o/r.git",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: " + tc.clone + "\ntracker:\n  kind: linear\n  project_slug: platform\n---\nprompt\n"
+			if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			var stdout, stderr bytes.Buffer
+			if code := printConfig(dir, &stdout, &stderr); code != 0 {
+				t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+			}
+			got := stdout.String()
+			for _, secret := range tc.mustHide {
+				if strings.Contains(got, secret) {
+					t.Fatalf("secret %q leaked into stdout:\n%s", secret, got)
+				}
+			}
+			wantLine := `"clone_url": "` + tc.wantOut + `"`
+			if !strings.Contains(got, wantLine) {
+				t.Fatalf("clone_url not rendered as %q in stdout:\n%s", tc.wantOut, got)
+			}
+		})
+	}
+}
+
+// TestPrintConfig_MasksSandboxCredentialFiles pins the secret-masking
+// contract for `sandbox.credential_files`: the path itself is sensitive
+// (a precise on-disk pointer for any attacker with shell access) and
+// each entry must be replaced with the standard `***` placeholder.
+//
+// Boundary-coverage rule applied to slice length: 0 (must not produce a
+// placeholder — empty means empty), 1 (one entry masked), and 2 (every
+// element masked, not just the first). The masked entries appear in
+// stdout; the original paths must not.
+func TestPrintConfig_MasksSandboxCredentialFiles(t *testing.T) {
+	cases := []struct {
+		name      string
+		yamlList  string
+		wantCount int
+		mustHide  []string
+	}{
+		{
+			name:      "empty_slice_no_placeholder",
+			yamlList:  "",
+			wantCount: 0,
+			mustHide:  nil,
+		},
+		{
+			name:      "single_entry_masked",
+			yamlList:  "    - /etc/aiops/creds/lone-token\n",
+			wantCount: 1,
+			mustHide:  []string{"/etc/aiops/creds/lone-token", "lone-token"},
+		},
+		{
+			name:      "two_entries_each_masked",
+			yamlList:  "    - /etc/aiops/creds/alpha\n    - /etc/aiops/creds/bravo\n",
+			wantCount: 2,
+			mustHide:  []string{"/etc/aiops/creds/alpha", "/etc/aiops/creds/bravo", "alpha", "bravo"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sandbox := "sandbox:\n"
+			if tc.yamlList != "" {
+				sandbox += "  credential_files:\n" + tc.yamlList
+			} else {
+				sandbox = ""
+			}
+			body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n" + sandbox + "---\nprompt\n"
+			if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			var stdout, stderr bytes.Buffer
+			if code := printConfig(dir, &stdout, &stderr); code != 0 {
+				t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+			}
+			got := stdout.String()
+			for _, secret := range tc.mustHide {
+				if strings.Contains(got, secret) {
+					t.Fatalf("secret substring %q leaked into stdout:\n%s", secret, got)
+				}
+			}
+			var out struct {
+				Config struct {
+					Sandbox struct {
+						CredentialFiles []string `json:"credential_files"`
+					} `json:"sandbox"`
+				} `json:"config"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+				t.Fatalf("decode: %v\nstdout: %s", err, stdout.String())
+			}
+			if got, want := len(out.Config.Sandbox.CredentialFiles), tc.wantCount; got != want {
+				t.Fatalf("credential_files length = %d, want %d\nstdout:\n%s", got, want, stdout.String())
+			}
+			for i, entry := range out.Config.Sandbox.CredentialFiles {
+				if entry != "***" {
+					t.Fatalf("credential_files[%d] = %q, want %q\nstdout:\n%s", i, entry, "***", stdout.String())
+				}
+			}
+		})
+	}
+}
+
+// TestPrintConfig_SandboxVisibleInConfigView covers the observability
+// half of #194: the `sandbox` block must round-trip through
+// --print-config (after masking) so operators can verify the effective
+// sandbox posture, not just stare at silence.
+func TestPrintConfig_SandboxVisibleInConfigView(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\nsandbox:\n  enabled: true\n  backend: bubblewrap\n  network: none\n  env_allowlist:\n    - HOME\n    - PATH\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	var out struct {
+		Config struct {
+			Sandbox struct {
+				Enabled      bool     `json:"enabled"`
+				Backend      string   `json:"backend"`
+				NetworkMode  string   `json:"network"`
+				EnvAllowlist []string `json:"env_allowlist"`
+			} `json:"sandbox"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout: %s", err, stdout.String())
+	}
+	if !out.Config.Sandbox.Enabled {
+		t.Fatalf("sandbox.enabled = false, want true\nstdout:\n%s", stdout.String())
+	}
+	if got, want := out.Config.Sandbox.Backend, "bubblewrap"; got != want {
+		t.Fatalf("sandbox.backend = %q, want %q", got, want)
+	}
+	if got, want := out.Config.Sandbox.NetworkMode, "none"; got != want {
+		t.Fatalf("sandbox.network = %q, want %q", got, want)
+	}
+	if got, want := out.Config.Sandbox.EnvAllowlist, []string{"HOME", "PATH"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("sandbox.env_allowlist = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #194.

## Summary
- Extend `maskSecrets` so `worker --print-config` redacts `Repo.CloneURL` userinfo (via `net/url`) and replaces each `Sandbox.CredentialFiles` entry with `***` while preserving slice length, so operators can still confirm "I configured N credential files, N are loaded". The function's doc-comment is upgraded into an explicit policy contract: adding a new secret-bearing field without extending this function is a review-blocking gap, enforced by per-field tests.
- Add the missing `Sandbox` block to `configView` so `--print-config` actually surfaces the effective `enabled`/`backend`/`network`/`env_allowlist` posture instead of silently dropping it (the observability half of #194).
- Per-field boundary tests: paired URL userinfo edges (user+password / user-only / plain HTTPS / SSH-style); credential_files at slice length 0/1/2; sandbox visible in output.
- Spec doc: `docs/superpowers/specs/2026-05-22-print-config-secret-masking-design.md`.

The struct-tag walker suggested in the issue was deliberately not built — three known secret-bearing fields don't warrant a reflection subsystem, and the enumerated mask with per-field tests is shorter and easier to audit. The audit table in the spec explains every top-level `workflow.Config` field's classification.

CI: runs on the fork PR https://github.com/xrf-9527/aiops-platform/pull/14 (this upstream repo is out of GHA quota).

## Test plan
- `go test ./internal/worker/...` — green, including 3 new test functions covering the new contracts.
- `go vet ./...` — clean.
- `go build ./...` — clean.

Refs: #194