### PR TITLE
docs(runbooks/local-dev): align with D6/D7/D8 + AIOPS_WORKFLOW_PATH (#224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ The default Compose service now starts only `worker` unless a legacy profile is 
 docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
 ```
 
+For an operator-side walkthrough — workflow file layout, the `/api/v1/state` and `--print-config` smoke checks, and the legacy queue-driven pollers — see the [local development runbook](docs/runbooks/local-dev.md). If the runbook and this README ever diverge, **this README is canonical**.
+
 ## Legacy Linear queue polling path
 
 `cmd/linear-poller` is retained only as transitional queue-ingress code until D7 cleanup. The SPEC-aligned `worker` no longer drains Postgres queue rows, so do not start `linear-poller worker` as a working legacy stack. For active Linear issue execution, configure `tracker.kind: linear` in `WORKFLOW.md` and run the worker-owned tracker polling path above.

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -51,9 +51,11 @@ are intentionally running the legacy queue path.
 
 ## 1. Configure the workflow and environment
 
-Copy the example workflow and example env into place:
+Copy the example workflow and example env into place. The `.aiops/`
+directory does not exist in a fresh clone; create it first:
 
 ```bash
+mkdir -p .aiops
 cp examples/WORKFLOW.md .aiops/WORKFLOW.md   # or wherever you point AIOPS_WORKFLOW_PATH
 cp .env.example .env
 ```
@@ -107,11 +109,20 @@ profile is explicitly requested (see
 ## 3. Smoke test
 
 The fastest way to verify local configuration is to print the
-effective worker config:
+effective worker config. `--print-config <workdir>` resolves
+`<workdir>/WORKFLOW.md` directly and does **not** consult
+`AIOPS_WORKFLOW_PATH`, so pass the directory that holds the workflow
+you want to inspect — not just `$PWD`:
 
 ```bash
-go run ./cmd/worker --print-config $PWD
+go run ./cmd/worker --print-config "$(dirname "$AIOPS_WORKFLOW_PATH")"
 ```
+
+If you keep your `WORKFLOW.md` at the repo root, `--print-config $PWD`
+works the same way. Passing the wrong directory silently reports
+default config (with `source: default`) instead of failing, so always
+check the `resolution.source` and `resolution.path` fields against the
+file you expected.
 
 Secret-bearing fields (`tracker.api_key`, `repo.clone_url` userinfo,
 `sandbox.credential_files`) are masked with `***` so the output is

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -122,6 +122,16 @@ Option B: in Docker.
 docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
 ```
 
+The Compose service hardcodes `AIOPS_WORKFLOW_PATH=/app/examples/WORKFLOW.md`
+and mounts `../examples:/app/examples:ro`, so this command always runs
+against the bundled Linear example workflow — edits to your local
+`.aiops/WORKFLOW.md` are **not** picked up by the container. To run
+the container against your own workflow, either bind-mount your file
+over the example path (e.g.
+`-v $PWD/.aiops/WORKFLOW.md:/app/examples/WORKFLOW.md:ro`) or override
+`AIOPS_WORKFLOW_PATH` in `.env` to a path that resolves inside the
+container.
+
 The default Compose service starts only `worker` unless a legacy
 profile is explicitly requested (see
 [Section 4](#4-legacy-queue-driven-pollers-d6d7d8)).
@@ -305,11 +315,17 @@ in `WORKFLOW.md`:
   `${VAR}`) and the env var is unset or empty, workflow loading fails
   at startup with `missing_tracker_api_key` before the first poll.
   This is the loud, fail-fast path — fix the env var and retry.
-- If `tracker.api_key` is empty or a non-env literal, startup succeeds
-  with no warning and the first tracker poll fails (e.g. the Gitea
-  client errors with `GITEA_BASE_URL and Gitea tracker api_key are
-  required`). Check the worker log for the first poll cycle, not just
-  the startup line.
+- If `tracker.api_key` is empty (or missing entirely), startup
+  succeeds with no warning and the first tracker poll fails (e.g. the
+  Gitea client errors with `GITEA_BASE_URL and Gitea tracker api_key
+  are required`). Check the worker log for the first poll cycle, not
+  just the startup line.
+- A non-empty literal value (e.g. `tracker.api_key: ghp_…`) is passed
+  through unchanged and used as the token — that is a valid
+  configuration, just not the recommended one because the secret then
+  sits in `WORKFLOW.md` rather than the environment. Operators who
+  paste a raw token here are not hitting a loader bug; they are
+  bypassing the env-expansion path.
 
 ### `/api/v1/state` returns nothing or refuses to bind
 

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -240,10 +240,15 @@ workflow: AIOPS_WORKFLOW_PATH refers to /…/WORKFLOW.md which does not exist
 ```
 
 - `AIOPS_WORKFLOW_PATH` must point at the file, not the directory.
-- The file must contain a YAML front-matter block followed by a prompt
-  body. Run
+- A YAML front-matter block is optional. Files with no `---` fence
+  load as `source: prompt_only` and pick up schema defaults for every
+  config field; files with a front-matter block use those values
+  instead. Either form is valid — front matter is only required when
+  you need to override a default (e.g. a non-default
+  `repo.clone_url`, `tracker.kind`, or `agent.default`).
+- Run
   `go run ./cmd/worker --print-config $(dirname "$AIOPS_WORKFLOW_PATH")`
-  to see how the loader resolves it.
+  to see how the loader resolves it and which `source` is reported.
 
 ### Missing tracker credentials at startup
 

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -123,14 +123,26 @@ docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
 ```
 
 The Compose service hardcodes `AIOPS_WORKFLOW_PATH=/app/examples/WORKFLOW.md`
-and mounts `../examples:/app/examples:ro`, so this command always runs
-against the bundled Linear example workflow — edits to your local
-`.aiops/WORKFLOW.md` are **not** picked up by the container. To run
-the container against your own workflow, either bind-mount your file
-over the example path (e.g.
-`-v $PWD/.aiops/WORKFLOW.md:/app/examples/WORKFLOW.md:ro`) or override
-`AIOPS_WORKFLOW_PATH` in `.env` to a path that resolves inside the
-container.
+as a fixed literal (not `${AIOPS_WORKFLOW_PATH}`) and mounts
+`../examples:/app/examples:ro`, so this command always runs against
+the bundled Linear example workflow — edits to your local
+`.aiops/WORKFLOW.md` are **not** picked up by the container, and
+setting `AIOPS_WORKFLOW_PATH` in `.env` has no effect. To run the
+container against your own workflow:
+
+- Bind-mount your file over the example path (simplest):
+
+  ```bash
+  docker compose --env-file .env -f deploy/docker-compose.yml run \
+    -v "$PWD/.aiops/WORKFLOW.md:/app/examples/WORKFLOW.md:ro" worker
+  ```
+
+- Or override `AIOPS_WORKFLOW_PATH` per invocation with
+  `docker compose run -e AIOPS_WORKFLOW_PATH=/app/your/path worker`
+  (combined with whatever mount makes that path readable).
+
+- Or maintain a `deploy/docker-compose.override.yml` that re-declares
+  `environment.AIOPS_WORKFLOW_PATH` for the `worker` service.
 
 The default Compose service starts only `worker` unless a legacy
 profile is explicitly requested (see

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -78,7 +78,7 @@ without calling any external model.
 Option A: from source.
 
 ```bash
-export AIOPS_WORKFLOW_PATH=$PWD/examples/WORKFLOW.md
+export AIOPS_WORKFLOW_PATH=$PWD/.aiops/WORKFLOW.md
 export WORKSPACE_ROOT=$PWD/.aiops/workspaces
 
 # For tracker.kind: linear

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -75,20 +75,40 @@ without calling any external model.
 
 ## 2. Run the worker
 
+The worker does **not** read `LINEAR_API_KEY` / `GITEA_TOKEN` /
+`GITHUB_TOKEN` directly — those env vars only affect the worker when
+`tracker.api_key` in your selected `WORKFLOW.md` references them via
+`$VAR` syntax. Before running the worker, make sure the workflow file
+has the right `tracker.api_key` mapping for your `tracker.kind`:
+
+| `tracker.kind` | `tracker.api_key` line in `WORKFLOW.md` |
+| --- | --- |
+| `linear` | `api_key: $LINEAR_API_KEY` |
+| `gitea`  | `api_key: $GITEA_TOKEN` |
+| `github` | `api_key: $GITHUB_TOKEN` |
+
+The shipped `examples/WORKFLOW.md` and
+`examples/github-local-WORKFLOW.md` already use this pattern;
+`examples/gitea-WORKFLOW.md` omits it and must be edited before the
+worker can poll Gitea.
+
 Option A: from source.
 
 ```bash
 export AIOPS_WORKFLOW_PATH=$PWD/.aiops/WORKFLOW.md
 export WORKSPACE_ROOT=$PWD/.aiops/workspaces
 
-# For tracker.kind: linear
+# For tracker.kind: linear  (consumed by WORKFLOW.md "api_key: $LINEAR_API_KEY")
 export LINEAR_API_KEY=your-linear-personal-key
 
 # For tracker.kind: gitea
+# GITEA_BASE_URL is consumed at runtime as a base-URL fallback when
+# tracker.project_slug is empty; GITEA_TOKEN must be wired through
+# "api_key: $GITEA_TOKEN" in WORKFLOW.md to actually authenticate.
 export GITEA_BASE_URL=https://gitea.example.com
 export GITEA_TOKEN=your-gitea-bot-token
 
-# For tracker.kind: github
+# For tracker.kind: github  (consumed via WORKFLOW.md "api_key: $GITHUB_TOKEN")
 export GITHUB_TOKEN=$(gh auth token -h github.com)
 
 go run ./cmd/worker

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -261,17 +261,29 @@ workflow: AIOPS_WORKFLOW_PATH refers to /…/WORKFLOW.md which does not exist
   `go run ./cmd/worker --print-config $(dirname "$AIOPS_WORKFLOW_PATH")`
   to see how the loader resolves it and which `source` is reported.
 
-### Missing tracker credentials at startup
+### Missing tracker credentials
 
-The worker fails workflow loading before the first poll when the
-applicable tracker credentials are absent. Confirm the credential env
-var matches the configured `tracker.kind`:
+Confirm the credential env var matches the configured `tracker.kind`:
 
 | `tracker.kind` | Required env vars |
 | --- | --- |
 | `linear` | `LINEAR_API_KEY` (or whatever `$VAR` `tracker.api_key` references in `WORKFLOW.md`) |
 | `gitea` | `GITEA_BASE_URL`, `GITEA_TOKEN` |
 | `github` | `GITHUB_TOKEN` |
+
+When the failure surfaces depends on how the value is encoded:
+
+- If `tracker.api_key` in `WORKFLOW.md` is an explicit env reference
+  (`$VAR` or `${VAR}`) and the env var is unset or empty, workflow
+  loading fails at startup with `missing_tracker_api_key` before the
+  first poll. This is the loud, fail-fast path — fix the env var and
+  retry.
+- If `tracker.api_key` is empty or a non-env literal (and for the
+  gitea/github clients which read `GITEA_TOKEN`/`GITHUB_TOKEN` at poll
+  time rather than at load time), startup succeeds with no warning
+  and the first tracker poll fails (`ListIssuesByStates` returns a
+  401/403 / "credentials missing" style error). Check the worker log
+  for the first poll cycle, not just the startup line.
 
 ### `/api/v1/state` returns nothing or refuses to bind
 

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -263,27 +263,33 @@ workflow: AIOPS_WORKFLOW_PATH refers to /…/WORKFLOW.md which does not exist
 
 ### Missing tracker credentials
 
-Confirm the credential env var matches the configured `tracker.kind`:
+All tracker tokens flow through `tracker.api_key` in `WORKFLOW.md`,
+regardless of `tracker.kind`. The worker does **not** read
+`LINEAR_API_KEY` / `GITEA_TOKEN` / `GITHUB_TOKEN` directly at poll
+time — the canonical pattern is to set `tracker.api_key: $VAR` in
+the workflow and let the loader expand `$VAR` at startup. Only the
+tracker's base URL has any direct env fallback (`GITEA_BASE_URL` /
+`GITHUB_API_BASE_URL`, applied at runtime when the corresponding
+config field is empty).
 
-| `tracker.kind` | Required env vars |
-| --- | --- |
-| `linear` | `LINEAR_API_KEY` (or whatever `$VAR` `tracker.api_key` references in `WORKFLOW.md`) |
-| `gitea` | `GITEA_BASE_URL`, `GITEA_TOKEN` |
-| `github` | `GITHUB_TOKEN` |
+| `tracker.kind` | `WORKFLOW.md` token reference | Base-URL env fallback |
+| --- | --- | --- |
+| `linear` | `tracker.api_key: $LINEAR_API_KEY` (or any `$VAR`) | n/a |
+| `gitea`  | `tracker.api_key: $GITEA_TOKEN`  (or any `$VAR`) | `GITEA_BASE_URL` when `tracker.project_slug` is empty |
+| `github` | `tracker.api_key: $GITHUB_TOKEN` (or any `$VAR`) | `GITHUB_API_BASE_URL` when `tracker.base_url` is empty |
 
-When the failure surfaces depends on how the value is encoded:
+When the failure surfaces depends on how `tracker.api_key` is encoded
+in `WORKFLOW.md`:
 
-- If `tracker.api_key` in `WORKFLOW.md` is an explicit env reference
-  (`$VAR` or `${VAR}`) and the env var is unset or empty, workflow
-  loading fails at startup with `missing_tracker_api_key` before the
-  first poll. This is the loud, fail-fast path — fix the env var and
-  retry.
-- If `tracker.api_key` is empty or a non-env literal (and for the
-  gitea/github clients which read `GITEA_TOKEN`/`GITHUB_TOKEN` at poll
-  time rather than at load time), startup succeeds with no warning
-  and the first tracker poll fails (`ListIssuesByStates` returns a
-  401/403 / "credentials missing" style error). Check the worker log
-  for the first poll cycle, not just the startup line.
+- If `tracker.api_key` is an explicit env reference (`$VAR` or
+  `${VAR}`) and the env var is unset or empty, workflow loading fails
+  at startup with `missing_tracker_api_key` before the first poll.
+  This is the loud, fail-fast path — fix the env var and retry.
+- If `tracker.api_key` is empty or a non-env literal, startup succeeds
+  with no warning and the first tracker poll fails (e.g. the Gitea
+  client errors with `GITEA_BASE_URL and Gitea tracker api_key are
+  required`). Check the worker log for the first poll cycle, not just
+  the startup line.
 
 ### `/api/v1/state` returns nothing or refuses to bind
 

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -1,109 +1,182 @@
 # Local development runbook
 
-This is the first document to open after cloning. It walks through bootstrapping the local loop: the worker, optional transitional pollers, and smoke checks for tracker polling.
+This is the first document to open after cloning. It walks through
+bootstrapping the local loop: the SPEC-aligned `cmd/worker` against a
+real or mock tracker, optional legacy queue-driven pollers (kept only
+for D6/D7 transitional reasons), and smoke checks for the tracker poll.
 
-The repository ships with a `deploy/docker-compose.yml` that runs the same components in containers. This runbook documents both the all-in-one Docker path and the run-from-source path that is more convenient when iterating on Go code.
+> This runbook is the operator companion to README's "Quick start:
+> worker-owned tracker polling path". If this runbook and the README
+> ever diverge, **the README is canonical** — the runbook is meant to
+> elaborate on the same flow, not contradict it.
+
+## What `cmd/worker` does (and doesn't)
+
+The worker is the SPEC-aligned entry point. Per D6 (#73), D7 (#74), and
+D8 (#76), it has stopped owning behaviors that earlier prototypes
+included:
+
+- **No Postgres / queue.** `cmd/worker` does not read `DATABASE_URL`
+  and does not enqueue or drain queue rows. Restart recovery follows
+  SPEC §14.3: the worker starts with fresh runtime state, cleans
+  terminal workspaces from tracker state, and re-dispatches eligible
+  active issues on the next poll.
+- **No PR creation, no tracker writes.** The worker prepares a
+  deterministic Git workspace, runs the configured agent (`mock`,
+  `codex`, or `claude`), enforces policy, and stops. Push, draft-PR
+  creation, and tracker label transitions happen agent-side via the
+  configured tool surface (`linear_graphql`, the workflow prompt's
+  push step, etc.), not in `cmd/worker`.
+
+If a doc, log line, or env var hints that the worker creates PRs or
+needs Postgres, it is stale — file an issue.
 
 ## Prerequisites
 
 - Go 1.25 or newer (matches `go.mod`).
-- Docker and Docker Compose v2.
 - `git` and `curl`.
-- Optional: a Gitea instance and bot token if you want to exercise the Gitea poller path.
-- Optional: a Linear personal API key if you want to exercise the Linear poller path.
+- Tracker credentials matching the workflow you're running:
+  - `tracker.kind: linear` → a Linear personal API key.
+  - `tracker.kind: gitea` → a Gitea base URL and bot token.
+  - `tracker.kind: github` → a GitHub token (`gh auth token` works).
+- A scratch workspace root. `workspace.root` in `WORKFLOW.md` is the
+  source of truth; `WORKSPACE_ROOT` is the fallback when omitted.
+- Optional: Docker and Docker Compose v2, only if you want the
+  containerized worker or the legacy compose path.
+- Optional: the Codex CLI installed and on `PATH`, only if you set
+  `agent.default: codex` and want a real model loop.
 
-## 1. Configure environment
+`cmd/worker` does **not** need Postgres. Skip step 2 below unless you
+are intentionally running the legacy queue path.
 
-Copy the example file and adjust values as needed:
+## 1. Configure the workflow and environment
+
+Copy the example workflow and example env into place:
 
 ```bash
+cp examples/WORKFLOW.md .aiops/WORKFLOW.md   # or wherever you point AIOPS_WORKFLOW_PATH
 cp .env.example .env
 ```
 
-The defaults assume Postgres listens on `localhost:5432` with user `aiops`, password `aiops`, database `aiops`. You only need to change the Gitea and Linear values when you actually use those integrations. Never commit a real `.env`.
+Edit `.env` to fill in only the variables the worker actually reads for
+your tracker kind (see [Prerequisites](#prerequisites)). Never commit
+a real `.env`.
 
-## 2. Start Postgres and apply migrations
+The worker resolves its workflow source from `AIOPS_WORKFLOW_PATH`
+(prefixed) and its fallback workspace root from `WORKSPACE_ROOT`
+(unprefixed). The `.env.example` file documents this naming
+inconsistency; use the names as written there.
 
-The compose file mounts `migrations/` into Postgres's `/docker-entrypoint-initdb.d` directory, so the schema is applied automatically on first startup.
+For first-time local testing keep `agent.default: mock` in the
+selected `WORKFLOW.md`. The mock runner produces a deterministic change
+without calling any external model.
 
-Start Postgres only:
+## 2. Run the worker
+
+Option A: from source.
+
+```bash
+export AIOPS_WORKFLOW_PATH=$PWD/examples/WORKFLOW.md
+export WORKSPACE_ROOT=$PWD/.aiops/workspaces
+
+# For tracker.kind: linear
+export LINEAR_API_KEY=your-linear-personal-key
+
+# For tracker.kind: gitea
+export GITEA_BASE_URL=https://gitea.example.com
+export GITEA_TOKEN=your-gitea-bot-token
+
+# For tracker.kind: github
+export GITHUB_TOKEN=$(gh auth token -h github.com)
+
+go run ./cmd/worker
+```
+
+Set only the credential block matching your selected `tracker.kind`.
+
+Option B: in Docker.
+
+```bash
+docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
+```
+
+The default Compose service starts only `worker` unless a legacy
+profile is explicitly requested (see
+[Section 4](#4-legacy-queue-driven-pollers-d6d7d8)).
+
+## 3. Smoke test
+
+The fastest way to verify local configuration is to print the
+effective worker config:
+
+```bash
+go run ./cmd/worker --print-config $PWD
+```
+
+Secret-bearing fields (`tracker.api_key`, `repo.clone_url` userinfo,
+`sandbox.credential_files`) are masked with `***` so the output is
+safe to paste into chat or issues.
+
+Once the worker is running, inspect live runtime state via the
+loopback-only HTTP server:
+
+```bash
+# Aggregate state
+curl http://127.0.0.1:4000/api/v1/state
+
+# Per-issue detail
+curl http://127.0.0.1:4000/api/v1/MT-649
+
+# Force an immediate poll + reconcile (instead of waiting for the next tick)
+curl -X POST -H 'X-AIOPS-Refresh: true' http://127.0.0.1:4000/api/v1/refresh
+```
+
+To exercise dispatch end-to-end, configure your `WORKFLOW.md` for a
+real Linear, Gitea, or GitHub tracker, keep `agent.default: mock`,
+move one issue into an active state, and start the worker. The worker
+discovers the active tracker issue and dispatches it; there is no
+webhook or manual enqueue endpoint in the normal loop.
+
+## 4. Legacy queue-driven pollers (D6/D7/D8)
+
+`cmd/linear-poller` and `cmd/gitea-poller` write to a Postgres queue
+that `cmd/worker` no longer reads. The SPEC-aligned loop runs entirely
+inside the worker against the tracker — see Section 2.
+
+Treat anything below as legacy. It is kept only as transitional
+ingress code until D7 cleanup completes. **Do not start
+`linear-poller` (or `gitea-poller`) and `worker` together expecting a
+working stack** — `worker` does not drain the queue, so the rows the
+poller produces are never claimed.
+
+### 4.1 Postgres for the legacy pollers
 
 ```bash
 docker compose --env-file .env -f deploy/docker-compose.yml up -d postgres
-```
-
-Verify the schema:
-
-```bash
 docker compose --env-file .env -f deploy/docker-compose.yml \
   exec postgres psql -U aiops -d aiops -c '\dt'
 ```
 
-You should see `tasks` and `task_events`.
+You should see `tasks` and `task_events`. The compose file mounts
+`migrations/` into Postgres's `/docker-entrypoint-initdb.d`, so the
+schema is applied automatically on first startup.
 
-If you need to reapply `migrations/001_init.sql` against an existing database, the SQL is written with `CREATE TABLE IF NOT EXISTS`, so it is safe to run again:
+If you need to reapply `migrations/001_init.sql` against an existing
+database, the SQL uses `CREATE TABLE IF NOT EXISTS` and is safe to run
+again:
 
 ```bash
 docker compose --env-file .env -f deploy/docker-compose.yml \
   exec -T postgres psql -U aiops -d aiops < migrations/001_init.sql
 ```
 
-To wipe state during development:
+To wipe state:
 
 ```bash
 docker compose --env-file .env -f deploy/docker-compose.yml down -v
 ```
 
-## 3. Run the worker
-
-The worker claims queued tasks, prepares a deterministic Git workspace, runs the configured runner (`mock`, `codex`, or `claude`), enforces policy, and opens a draft PR through the Gitea client.
-
-Option A: from source.
-
-```bash
-export DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
-export WORKSPACE_ROOT=/tmp/aiops-workspaces
-# Required: cmd/worker always calls the Gitea client at the end of every task.
-# Both values must be non-empty or every task fails after the agent run with
-# "GITEA_BASE_URL and GITEA_TOKEN are required". For local-only smoke testing
-# without a real Gitea, any non-empty placeholder is enough to get past the
-# precondition (the HTTP call will then fail, but that happens after the
-# verification step you usually care about in a smoke test).
-export GITEA_BASE_URL=http://gitea.local
-export GITEA_TOKEN=replace-with-gitea-bot-token
-go run ./cmd/worker
-```
-
-A minimal `.env` snippet that satisfies the worker's required vars:
-
-```bash
-DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
-WORKSPACE_ROOT=/tmp/aiops-workspaces
-GITEA_BASE_URL=http://gitea.local
-GITEA_TOKEN=placeholder-not-used-for-mock-only-smoke-test
-```
-
-Option B: in Docker.
-
-```bash
-docker compose --env-file .env -f deploy/docker-compose.yml up -d worker
-```
-
-For first-time local testing, keep `agent.default: mock` in `examples/WORKFLOW.md`. The mock runner produces a deterministic change without calling any external model.
-
-## 4. Run a tracker poller (optional)
-
-The Linear and Gitea pollers read `examples/WORKFLOW.md` for the repo, tracker, and poll interval, then enqueue a task per active issue.
-
-### Linear
-
-The Linear poller enqueues issues in configured active Linear workflow states.
-For Linear workflows, `tracker.project_slug` in the selected `WORKFLOW.md` maps
-to Linear's project `slugId` and is required unless `services[]` routes define
-per-service `tracker.project_slug` values. The worker fails workflow loading
-before the first poll when the applicable project slug is missing.
-
-Option A: from source.
+### 4.2 Linear legacy poller
 
 ```bash
 export DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
@@ -111,17 +184,25 @@ export LINEAR_API_KEY=your-linear-personal-key
 go run ./cmd/linear-poller examples/WORKFLOW.md
 ```
 
-Option B: in Docker.
+The poller exits immediately with `tracker.kind must be linear` if the
+workflow is not configured for Linear, and logs `skip <issue>:
+repo.clone_url missing in WORKFLOW.md` if `repo.clone_url` is empty.
+
+For Linear workflows, `tracker.project_slug` in the selected
+`WORKFLOW.md` maps to Linear's project `slugId` and is required unless
+`services[]` routes define per-service `tracker.project_slug` values.
+
+### 4.3 Gitea legacy poller
 
 ```bash
-docker compose --env-file .env -f deploy/docker-compose.yml --profile linear up -d linear-poller
+export DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
+export GITEA_BASE_URL=http://localhost:3000
+export GITEA_TOKEN=your-gitea-bot-token
+go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md
 ```
 
-The poller exits immediately with `tracker.kind must be linear` if `examples/WORKFLOW.md` is not configured for Linear, and logs `skip <issue>: repo.clone_url missing in WORKFLOW.md` if `repo.clone_url` is empty.
-
-### Gitea
-
-The Gitea poller treats Gitea as a tracker reader: issues are selected by `aiops/*` state labels, and label writes happen through the agent tool surface rather than the poller. The default state labels are:
+The poller treats Gitea as a tracker reader; label writes go through
+the agent tool surface, not the poller. Default state labels:
 
 | Workflow state | Gitea label |
 | --- | --- |
@@ -131,23 +212,11 @@ The Gitea poller treats Gitea as a tracker reader: issues are selected by `aiops
 | `Done` | `aiops/done` |
 | `Canceled` | `aiops/canceled` |
 
-The worker-owned `tracker.kind: gitea` path uses the same label mapping for
-per-tick reconciliation. After a run starts, moving the issue to `aiops/done`
-or `aiops/canceled` makes the next poll refresh that issue by ID and cancel the
-active worker.
-
-Option A: from source.
-
-```bash
-export DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
-export GITEA_BASE_URL=http://localhost:3000
-export GITEA_TOKEN=your-gitea-bot-token
-go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md
-```
-
-The poller exits immediately with `tracker.kind must be gitea` if its workflow is not configured for Gitea. It logs `skip <issue>: repo.clone_url missing in WORKFLOW.md` if `repo.clone_url` is empty.
-
-Gitea issue listing is capped at 20 pages of 50 issues per state label (1000 issues). When the `+1` probe page proves more issues exist, the poller keeps running with the capped result set and increments `aiops_gitea_issue_pagination_cap_hits_total`. Expose that counter by setting `GITEA_POLLER_METRICS_ADDR` before starting the poller:
+Gitea issue listing is capped at 20 pages of 50 issues per state label
+(1000 issues). When the `+1` probe page proves more issues exist, the
+poller keeps running with the capped result set and increments
+`aiops_gitea_issue_pagination_cap_hits_total`. Expose the counter via
+`GITEA_POLLER_METRICS_ADDR`:
 
 ```bash
 export GITEA_POLLER_METRICS_ADDR=:9091
@@ -155,55 +224,78 @@ go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md
 curl http://localhost:9091/metrics | grep aiops_gitea_issue_pagination_cap_hits_total
 ```
 
-The metric is cumulative for the poller process. A non-zero value means at least one poll since startup observed an active state label with more than 1000 matching Gitea issues; alert on recent increases, not just the absolute value. When it increases, operators should reduce the active backlog or split labels before relying on the poller for exhaustive dispatch.
-
-## 5. Smoke test
-
-The fastest way to verify local configuration without a real Gitea or Linear is
-to load the workflow and print the effective worker config:
-
-```bash
-go run ./cmd/worker --print-config .
-```
-
-To exercise dispatch, configure `examples/WORKFLOW.md` for a real Linear or
-Gitea tracker, keep `agent.default: mock`, move one issue into an active state,
-and run the worker plus the matching poller. The poller discovers the active
-tracker issue; there is no webhook or manual enqueue endpoint in the normal
-loop.
-
-You can also inspect the queue directly:
-
-```bash
-docker compose --env-file .env -f deploy/docker-compose.yml exec postgres \
-  psql -U aiops -d aiops -c \
-  "select id,status,repo_owner,repo_name,work_branch,updated_at from tasks order by created_at desc limit 5;"
-```
+The same label mapping is also used by the **SPEC-aligned**
+`tracker.kind: gitea` path in `cmd/worker` for per-tick reconciliation:
+after a run starts, moving the issue to `aiops/done` or
+`aiops/canceled` makes the next worker poll refresh that issue by ID
+and cancel the active run. That part is current; only the
+queue-writing poller is legacy.
 
 ## Common failure modes
 
-### `connection refused` against Postgres
+### Worker fails to read the workflow
 
-A transitional poller logs `dial tcp 127.0.0.1:5432: connect: connection refused`.
+```
+workflow: AIOPS_WORKFLOW_PATH refers to /…/WORKFLOW.md which does not exist
+```
 
-- Check `docker compose ps` and ensure the `postgres` service is healthy.
-- Confirm `DATABASE_URL` matches the host you are running from. Inside compose use `postgres:5432`, from your host use `localhost:5432`.
+- `AIOPS_WORKFLOW_PATH` must point at the file, not the directory.
+- The file must contain a YAML front-matter block followed by a prompt
+  body. Run
+  `go run ./cmd/worker --print-config $(dirname "$AIOPS_WORKFLOW_PATH")`
+  to see how the loader resolves it.
 
-### `tasks` table does not exist
+### Missing tracker credentials at startup
 
-A transitional poller logs `relation "tasks" does not exist`.
+The worker fails workflow loading before the first poll when the
+applicable tracker credentials are absent. Confirm the credential env
+var matches the configured `tracker.kind`:
 
-- This means the init script in `migrations/001_init.sql` did not run. It only runs on the very first start of the Postgres volume. Run `docker compose down -v` to drop the volume and start again, or apply the SQL manually as shown in step 2.
+| `tracker.kind` | Required env vars |
+| --- | --- |
+| `linear` | `LINEAR_API_KEY` (or whatever `$VAR` `tracker.api_key` references in `WORKFLOW.md`) |
+| `gitea` | `GITEA_BASE_URL`, `GITEA_TOKEN` |
+| `github` | `GITHUB_TOKEN` |
 
-### Linear poller exits with `tracker.kind must be linear`
+### `/api/v1/state` returns nothing or refuses to bind
 
-`examples/WORKFLOW.md` is not configured for Linear. Set `tracker.kind: linear`, provide an `api_key` (the value can reference `$LINEAR_API_KEY`), and set `tracker.project_slug` to the Linear project slug used for SPEC §11.2 candidate filtering.
+- The HTTP server is loopback-only (`127.0.0.1:server.port`). From
+  inside a container, expose it explicitly or run the worker on the
+  host.
+- The server is disabled when `server.port: -1` is set in
+  `WORKFLOW.md`. Use `--print-config` to confirm the effective port.
 
-### Worker fails to push or open PRs
+### `connection refused` against Postgres (legacy pollers only)
 
-- `GITEA_BASE_URL` and `GITEA_TOKEN` must be set and the bot user must have write access to the target repository.
-- The worker container mounts a **dedicated** SSH keypair at
-  `/root/.ssh/id_ed25519` — not your entire `~/.ssh`. Set it up once:
+`cmd/worker` does **not** need Postgres — if you see this error from
+the worker, you are running an out-of-date binary or an old shell with
+stale env vars. For the legacy pollers:
+
+- Check `docker compose ps` and ensure the `postgres` service is
+  healthy.
+- Confirm `DATABASE_URL` matches the host you are running from.
+  Inside compose use `postgres:5432`, from your host use
+  `localhost:5432`.
+
+### `tasks` table does not exist (legacy pollers only)
+
+The init script in `migrations/001_init.sql` only runs on the very
+first start of the Postgres volume. Run `docker compose down -v` to
+drop the volume and start again, or apply the SQL manually as shown
+in [Section 4.1](#41-postgres-for-the-legacy-pollers).
+
+### Agent fails to push or open PRs
+
+PR creation lives **agent-side**, not in the worker. The worker no
+longer holds Gitea credentials. If the agent (Codex, Claude, etc.)
+needs to push:
+
+- The agent invocation environment must carry credentials matching
+  the configured remote (SSH key, deploy key, or
+  `GITEA_TOKEN`/`GITHUB_TOKEN` exported to the agent process).
+- For Docker Compose, the worker container mounts a **dedicated** SSH
+  keypair at `/root/.ssh/id_ed25519` — not your entire `~/.ssh`. Set
+  it up once:
 
   ```bash
   cd deploy
@@ -211,43 +303,48 @@ A transitional poller logs `relation "tasks" does not exist`.
   ssh-keyscan -H <your-gitea-host> >> ssh/known_hosts
   ```
 
-  Then register `deploy/ssh/id_ed25519.pub` as a Gitea / GitHub deploy key on
-  the target repository. The keypair lives outside version control thanks to
-  the root `.gitignore`. Override the path with `AIOPS_SSH_KEY_PATH` /
-  `AIOPS_SSH_KNOWN_HOSTS_PATH` in `.env` if you keep the key elsewhere. See
-  `docs/security-posture.md` ("Docker Compose SSH key isolation") for the
-  rationale — this scoping closed the broad credential exposure described
-  in issue #221.
+  Then register `deploy/ssh/id_ed25519.pub` as a Gitea / GitHub deploy
+  key on the target repository. The keypair lives outside version
+  control thanks to the root `.gitignore`. Override the path with
+  `AIOPS_SSH_KEY_PATH` / `AIOPS_SSH_KNOWN_HOSTS_PATH` in `.env` if
+  you keep the key elsewhere. See `docs/security-posture.md` ("Docker
+  Compose SSH key isolation") for the rationale — this scoping closed
+  the broad credential exposure described in issue #221.
 
-### Port `5432` already in use
+### Port `5432` already in use (legacy pollers only)
 
-Stop the conflicting local service or change the published port in `deploy/docker-compose.yml` and `DATABASE_URL` accordingly.
+Stop the conflicting local service or change the published port in
+`deploy/docker-compose.yml` and `DATABASE_URL` accordingly.
 
 ### `go: module lookup disabled` or `go.sum` mismatch
 
-Run `go mod tidy`, then re-run the failing command. CI will reject changes that leave `go.mod` or `go.sum` dirty; see [CI/CD runbook](ci.md) for the local pre-push check list.
+Run `go mod tidy`, then re-run the failing command. CI rejects changes
+that leave `go.mod` or `go.sum` dirty; see [CI/CD runbook](ci.md) for
+the local pre-push check list.
 
 ## Workspace cache and cleanup
 
-After M2, the worker keeps a per-repo bare mirror under
-`AIOPS_MIRROR_ROOT` (default `os.UserCacheDir()/aiops-platform/mirrors`)
-and creates a per-task worktree under the selected workflow's `workspace.root`
-for every claimed task. If `workspace.root` is omitted from `WORKFLOW.md`, the
-worker falls back to `WORKSPACE_ROOT`. This avoids re-cloning on every retry and
-lets two tasks run concurrently without sharing a working tree. See the dedicated
+The worker keeps a per-repo bare mirror under `AIOPS_MIRROR_ROOT`
+(default `os.UserCacheDir()/aiops-platform/mirrors`) and creates a
+per-task worktree under the selected workflow's `workspace.root` for
+every claimed task. If `workspace.root` is omitted from `WORKFLOW.md`,
+the worker falls back to `WORKSPACE_ROOT`. This avoids re-cloning on
+every retry and lets two tasks run concurrently without sharing a
+working tree. See the dedicated
 [workspace cache runbook](workspace-cache.md) for the on-disk layout,
 configuration knobs, and recommended cleanup cadence (the
-`(*workspace.Manager).Cleanup` API or removal of the effective workspace root
-once old tasks no longer matter).
+`(*workspace.Manager).Cleanup` API or removal of the effective
+workspace root once old tasks no longer matter).
 
 ## Running e2e tests locally
 
-The e2e suite under `test/e2e/` validates the Gitea poller loop against real
-Postgres and Gitea containers. It is gated by the `e2e` build tag and does not
-run as part of `go test ./...`.
+The e2e suite under `test/e2e/` validates the Gitea poller loop
+against real Postgres and Gitea containers. It is gated by the `e2e`
+build tag and does not run as part of `go test ./...`.
 
 Requirements: a working Docker daemon. Cold first run pulls ~600MB of
-images and takes 2–3 minutes. Warm runs take ~10 seconds for all four tests.
+images and takes 2–3 minutes. Warm runs take ~10 seconds for all four
+tests.
 
 ```bash
 go test -tags e2e -race -timeout 15m ./test/e2e/...
@@ -255,6 +352,7 @@ go test -tags e2e -race -timeout 15m ./test/e2e/...
 
 Common failure modes:
 
-- `Cannot connect to the Docker daemon` — start Docker Desktop or `colima`.
-- `go test` reports `build constraints exclude all Go files` — the `-tags
-  e2e` flag is missing.
+- `Cannot connect to the Docker daemon` — start Docker Desktop or
+  `colima`.
+- `go test` reports `build constraints exclude all Go files` — the
+  `-tags e2e` flag is missing.


### PR DESCRIPTION
Closes #224.

## Summary
\`docs/runbooks/local-dev.md\` had drifted from current behavior since D6 (#73), D7 (#74), and D8 (#76):
- mandated Postgres for \`cmd/worker\` (D6 removed the queue read path);
- told operators the worker "opens a draft PR through the Gitea client" (D8 moved PR creation agent-side);
- listed \`DATABASE_URL\` and \`GITEA_TOKEN\` as worker-required;
- still referenced the legacy \`WORKFLOW_PATH\` env var instead of the current \`AIOPS_WORKFLOW_PATH\`.

Rewrite to reflect current behavior:

- New "What \`cmd/worker\` does (and doesn't)" preface naming the three closed deviations and the resulting boundary (no Postgres / no queue / no PR creation / no tracker writes).
- Tracker-credential table: \`tracker.kind\` → required env vars.
- "Run the worker" uses only \`AIOPS_WORKFLOW_PATH\` + \`WORKSPACE_ROOT\` + the tracker-specific credential block.
- New "Smoke test" section centred on \`--print-config\` + the \`/api/v1/state\` loopback HTTP API; notes the print-config secret-masking contract from #194.
- "Legacy queue-driven pollers (D6/D7/D8)" — Postgres setup, \`linear-poller\` and \`gitea-poller\` invocations, \`DATABASE_URL\` — all collapsed into one clearly-labeled section with a "do not start poller + worker together" warning.
- "Common failure modes" gets new entries (workflow load failures, missing tracker creds, \`/api/v1/state\` not binding) and the Postgres-specific failures are scoped to the legacy pollers. PR-push failure modes acknowledge creation lives agent-side now.
- README quick-start gets a one-line pointer at the runbook with the "README is canonical" note so the next drift fails review.

## Acceptance criteria
- [x] Section 1: Postgres no longer described as required for \`cmd/worker\`.
- [x] Section 3 (now §2): "opens a draft PR through the Gitea client" removed; replaced with the agent-side handoff model.
- [x] All \`WORKFLOW_PATH\` references changed to \`AIOPS_WORKFLOW_PATH\`.
- [x] Legacy queue path moved to a clearly-labeled "Legacy / D6/D7/D8" section.
- [x] Troubleshooting section updated to reference \`/api/v1/state\` and \`--print-config\`, not Postgres.
- [x] README contains a brief pointer at this runbook with a "if they diverge, README is canonical" note.

## Test plan
- Doc-only change. Verified by reading.

CI: runs on the fork PR https://github.com/xrf-9527/aiops-platform/pull/16 (upstream is out of GHA quota).

Refs: #224