### PR TITLE
fix(pollers): honor SIGTERM in legacy linear+gitea poll loops (#238)

### DIFF
--- a/cmd/gitea-poller/main.go
+++ b/cmd/gitea-poller/main.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -26,7 +28,8 @@ func main() {
 	if len(os.Args) < 2 {
 		log.Fatal("usage: gitea-poller /path/to/WORKFLOW.md")
 	}
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	wf, err := workflow.Load(os.Args[1])
 	if err != nil {
 		log.Fatal(err)
@@ -49,15 +52,43 @@ func main() {
 	}
 	interval := time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond
 
+	runPollLoop(ctx, interval, func(ctx context.Context) {
+		pollOnce(ctx, store, &wf.Config, client)
+	})
+	log.Printf("gitea-poller: shutdown requested; exiting")
+}
+
+// pollOnce executes one tick of the gitea poll loop. Extracted from
+// main so the SIGTERM-aware runPollLoop can drive it.
+func pollOnce(ctx context.Context, store enqueuer, cfg *workflow.Config, client *gitea.TrackerClient) {
+	issues, err := client.ListActiveIssues(ctx)
+	if err != nil {
+		log.Printf("gitea poll error: %v", err)
+		return
+	}
+	processIssues(ctx, store, cfg, issues)
+}
+
+// runPollLoop runs poll on the given interval until ctx is cancelled
+// (typically by SIGTERM/SIGINT via signal.NotifyContext). The two
+// select statements gate both the start of each tick and the
+// inter-tick sleep: a cancel that arrives before the first poll never
+// invokes poll, and a cancel that arrives during a sleep wakes up
+// immediately instead of waiting for time.Sleep to return. Tests in
+// main_test.go pin both branches.
+func runPollLoop(ctx context.Context, interval time.Duration, poll func(context.Context)) {
 	for {
-		issues, err := client.ListActiveIssues(ctx)
-		if err != nil {
-			log.Printf("gitea poll error: %v", err)
-			time.Sleep(interval)
-			continue
+		select {
+		case <-ctx.Done():
+			return
+		default:
 		}
-		processIssues(ctx, store, &wf.Config, issues)
-		time.Sleep(interval)
+		poll(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+		}
 	}
 }
 

--- a/cmd/gitea-poller/main_test.go
+++ b/cmd/gitea-poller/main_test.go
@@ -113,6 +113,51 @@ func serverURL(r *http.Request) string {
 	return "http://" + r.Host
 }
 
+// TestRunPollLoop_CancelBeforeFirstTick — =0 boundary. ctx cancelled
+// before entry; poll must not be invoked (pre-poll select guard).
+func TestRunPollLoop_CancelBeforeFirstTick(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var calls int
+	runPollLoop(ctx, time.Millisecond, func(context.Context) { calls++ })
+	if calls != 0 {
+		t.Fatalf("poll calls = %d, want 0 when ctx is cancelled before entry", calls)
+	}
+}
+
+// TestRunPollLoop_CancelAfterFirstTick — =N+1 paired edge. First poll
+// runs; ctx is cancelled inside the closure so the sleep-select picks
+// up Done and returns. Exactly one invocation.
+func TestRunPollLoop_CancelAfterFirstTick(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int
+	runPollLoop(ctx, time.Hour, func(context.Context) {
+		calls++
+		cancel()
+	})
+	if calls != 1 {
+		t.Fatalf("poll calls = %d, want exactly 1 after cancel-during-sleep", calls)
+	}
+}
+
+// TestRunPollLoop_PollFunctionReceivesLoopCtx pins the contract that
+// the poll closure sees the loop's ctx (not a detached background
+// ctx), so in-flight HTTP/DB calls can themselves react to SIGTERM.
+func TestRunPollLoop_PollFunctionReceivesLoopCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var observed context.Context
+	runPollLoop(ctx, time.Hour, func(c context.Context) {
+		observed = c
+		cancel()
+	})
+	if observed == nil {
+		t.Fatalf("poll function did not receive a context")
+	}
+	if observed.Err() == nil {
+		t.Fatalf("inner ctx should be cancelled after outer cancel; err=%v", observed.Err())
+	}
+}
+
 func mustTime(value string) time.Time {
 	parsed, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {

--- a/cmd/linear-poller/main.go
+++ b/cmd/linear-poller/main.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -34,7 +36,8 @@ func main() {
 	if len(os.Args) < 2 {
 		log.Fatal("usage: linear-poller /path/to/WORKFLOW.md")
 	}
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	wf, err := workflow.Load(os.Args[1])
 	if err != nil {
 		log.Fatal(err)
@@ -52,11 +55,34 @@ func main() {
 	listers := linearIssueListers(wf.Config)
 	interval := time.Duration(wf.Config.Tracker.PollIntervalMs) * time.Millisecond
 
-	for {
+	runPollLoop(ctx, interval, func(ctx context.Context) {
 		if err := pollOnce(ctx, store, &wf.Config, listers); err != nil {
 			log.Printf("linear poll error: %v", err)
 		}
-		time.Sleep(interval)
+	})
+	log.Printf("linear-poller: shutdown requested; exiting")
+}
+
+// runPollLoop runs poll on the given interval until ctx is cancelled
+// (typically by SIGTERM/SIGINT via signal.NotifyContext). The two
+// select statements gate both the start of each tick and the
+// inter-tick sleep: a cancel that arrives before the first poll never
+// invokes poll, and a cancel that arrives during a sleep wakes up
+// immediately instead of waiting for time.Sleep to return. Tests in
+// main_test.go pin both branches.
+func runPollLoop(ctx context.Context, interval time.Duration, poll func(context.Context)) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		poll(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+		}
 	}
 }
 

--- a/cmd/linear-poller/main_test.go
+++ b/cmd/linear-poller/main_test.go
@@ -447,6 +447,55 @@ func TestProcessIssuesFallsBackToRootRepoWhenNoServiceRouteMatches(t *testing.T)
 	}
 }
 
+// TestRunPollLoop_CancelBeforeFirstTick covers the =0 boundary on the
+// poll-count cap: ctx is cancelled before runPollLoop is entered, so
+// the inner poll function must not run at all (the pre-poll select
+// guard catches it). Today's main loop would have invoked poll once
+// regardless — this pins the new contract.
+func TestRunPollLoop_CancelBeforeFirstTick(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var calls int
+	runPollLoop(ctx, time.Millisecond, func(context.Context) { calls++ })
+	if calls != 0 {
+		t.Fatalf("poll calls = %d, want 0 when ctx is cancelled before entry", calls)
+	}
+}
+
+// TestRunPollLoop_CancelAfterFirstTick covers the =N+1 boundary on the
+// same cap: the first poll runs, then ctx is cancelled during the
+// sleep select, so exactly one invocation happens. This is the paired
+// edge of CancelBeforeFirstTick — together they pin both select
+// statements in runPollLoop.
+func TestRunPollLoop_CancelAfterFirstTick(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int
+	runPollLoop(ctx, time.Hour, func(context.Context) {
+		calls++
+		cancel()
+	})
+	if calls != 1 {
+		t.Fatalf("poll calls = %d, want exactly 1 after cancel-during-sleep", calls)
+	}
+}
+
+// TestRunPollLoop_PollFunctionReceivesLoopCtx ensures the inner poll
+// function sees the same cancellable ctx, not a detached one.
+func TestRunPollLoop_PollFunctionReceivesLoopCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var observed context.Context
+	runPollLoop(ctx, time.Hour, func(c context.Context) {
+		observed = c
+		cancel()
+	})
+	if observed == nil {
+		t.Fatalf("poll function did not receive a context")
+	}
+	if observed.Err() == nil {
+		t.Fatalf("inner ctx should be cancelled after outer cancel; err=%v", observed.Err())
+	}
+}
+
 func mapKeys(m map[string]task.Task) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {


### PR DESCRIPTION
Closes #238 (option A — minimal SIGTERM handling; option B / D6 removal is its own issue).

## Summary
\`cmd/linear-poller\` and \`cmd/gitea-poller\` ran an unconditional \`for { ... time.Sleep ... }\` against \`context.Background()\`. SIGTERM from Compose shutdown, \`kubectl rollout restart\`, or any process manager bypassed all of it: the runtime ignored the signal, defers never fired, and any in-flight \`pgxpool\` operation was guillotined mid-INSERT, leaving \`tasks\` rows without their corresponding \`task_events\` rows.

These pollers are slated for removal once D6/D7 cleanup completes, but while they're still shipped under the \`legacy-queue\` Compose profile their shutdown story matters. This PR is the responsible bandage.

## Changes
- Both \`main()\`s build their root ctx via \`signal.NotifyContext(... os.Interrupt, syscall.SIGTERM)\`. The same ctx threads through \`pgxpool.New\`, \`pollOnce\`, and the tracker clients, so in-flight calls react to the signal rather than only the wrapper loop.
- New \`runPollLoop(ctx, interval, poll)\` helper duplicated in each command (these two are the only callers and #73 will delete them anyway). Two select statements: a pre-tick guard so a cancel before the first tick never invokes \`poll\`, and a post-tick sleep that wakes on \`time.After\` OR \`ctx.Done()\`.
- Gitea's previous inline poll body extracted as \`pollOnce\` to match linear's signature.

## Boundary coverage
- \`=N\` cap (poll-count=0): \`TestRunPollLoop_CancelBeforeFirstTick\` — cancel before entry, assert poll never invoked. Pins the pre-tick select.
- \`=N+1\` paired edge: \`TestRunPollLoop_CancelAfterFirstTick\` — closure cancels ctx, assert exactly one invocation. Pins the post-tick select.
- \`TestRunPollLoop_PollFunctionReceivesLoopCtx\` — closure sees the loop's ctx (so inner HTTP/DB calls can react to SIGTERM too).

Both poller packages get the same three tests.

CI: runs on the fork PR https://github.com/xrf-9527/aiops-platform/pull/17 (upstream is out of GHA quota).

## Test plan
- \`go test ./cmd/linear-poller/ ./cmd/gitea-poller/\` — green, 6 new tests across both.
- \`go vet ./...\` — clean.
- \`go build ./...\` — clean.

Refs: #238