### PR TITLE
feat(worker): add --port CLI flag overriding server.port (#213, SPEC §13.7)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -70,7 +70,7 @@ func parseRunArgs(args []string) (string, *int, error) {
 	// and parse diagnostics reach the user. flag.ErrHelp is propagated
 	// to the caller, which treats it as a clean exit.
 	portFlag := fs.Int("port", 0, "override server.port from WORKFLOW.md: -1 disables the HTTP server, 0 binds an ephemeral port, 1..65535 binds explicitly. SPEC §13.7.")
-	if err := fs.Parse(args); err != nil {
+	if err := fs.Parse(reorderForFlagParse(args)); err != nil {
 		return "", nil, err
 	}
 	if fs.NArg() > 1 {
@@ -98,6 +98,40 @@ func parseRunArgs(args []string) (string, *int, error) {
 		override = &p
 	}
 	return path, override, nil
+}
+
+// reorderForFlagParse pulls flag tokens to the front of args so the
+// stdlib flag parser (which stops at the first non-flag argument)
+// accepts `worker /path/WORKFLOW.md --port=4001` and `worker
+// --port=4001 /path/WORKFLOW.md` interchangeably. Operators are not
+// expected to remember Go's flag-vs-positional ordering rule, and
+// SPEC §13.7 does not impose one.
+//
+// The reorder is flag-aware (knows --port takes a value) rather than
+// a naive "starts with -" split — that's only because --port can be
+// passed as two tokens (`--port 4001`). A `--` token preserves
+// everything that follows as positional, matching POSIX convention.
+func reorderForFlagParse(args []string) []string {
+	flags, positional := make([]string, 0, len(args)), make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--":
+			positional = append(positional, args[i+1:]...)
+			i = len(args)
+		case a == "--port" || a == "-port":
+			flags = append(flags, a)
+			if i+1 < len(args) {
+				flags = append(flags, args[i+1])
+				i++
+			}
+		case strings.HasPrefix(a, "-"):
+			flags = append(flags, a)
+		default:
+			positional = append(positional, a)
+		}
+	}
+	return append(flags, positional...)
 }
 
 // desiredPortForLoop selects the effective state-server port for one

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -47,6 +48,65 @@ func normalizeRunError(err error, runCtxErr error) error {
 	return err
 }
 
+// parseRunArgs parses the run-mode CLI args (everything after
+// os.Args[0]; the --print-config subcommand is handled separately
+// before this is called). It returns the positional workflow path and
+// an optional --port override.
+//
+// SPEC §13.7 declares --port as the canonical override for
+// server.port in WORKFLOW.md. The value range is -1 (disable), 0
+// (ephemeral), or 1..65535. Note that the workflow loader itself
+// rejects 0 in WORKFLOW.md (see internal/workflow/loader.go), so CLI
+// is the legitimate path for an ephemeral port — tests and operator
+// scratch sessions are the motivating callers.
+func parseRunArgs(args []string) (string, *int, error) {
+	fs := flag.NewFlagSet("worker", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // tests assert on the returned error; don't dump usage to stderr
+	portFlag := fs.Int("port", 0, "override server.port from WORKFLOW.md: -1 disables the HTTP server, 0 binds an ephemeral port, 1..65535 binds explicitly. SPEC §13.7.")
+	if err := fs.Parse(args); err != nil {
+		return "", nil, err
+	}
+	if fs.NArg() > 1 {
+		return "", nil, fmt.Errorf("usage: worker [--port=N] [path-to-WORKFLOW.md]")
+	}
+	var path string
+	if fs.NArg() == 1 {
+		path = fs.Arg(0)
+	}
+	// Use fs.Visit to distinguish "flag explicitly provided" from "flag
+	// at its default value". A naked sentinel int has no safe pick: any
+	// reserved value would conflict with a real --port=N for that N.
+	var portSet bool
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "port" {
+			portSet = true
+		}
+	})
+	var override *int
+	if portSet {
+		p := *portFlag
+		if p < -1 || p > 65535 {
+			return "", nil, fmt.Errorf("--port %d out of range: pass -1 to disable the HTTP server, 0 for an ephemeral port, or 1..65535", p)
+		}
+		override = &p
+	}
+	return path, override, nil
+}
+
+// desiredPortForLoop selects the effective state-server port for one
+// tick of runStateHTTPServerLoop. CLI override wins per SPEC §13.7;
+// otherwise the workflow snapshot's `server.port` is used; absent a
+// snapshot, the loop stays disabled (-1).
+func desiredPortForLoop(opts stateHTTPServerLoopOptions, wf *workflow.Workflow) int {
+	if opts.PortOverride != nil {
+		return *opts.PortOverride
+	}
+	if wf != nil {
+		return wf.Config.Server.Port
+	}
+	return -1
+}
+
 func loadWorkflowForStartupReconcile() (*workflow.Workflow, error) {
 	wf, resolution, err := resolveStartupWorkflow(nil)
 	if err != nil {
@@ -82,7 +142,7 @@ func resolveStartupWorkflow(args []string) (*workflow.Workflow, *workflow.Resolu
 
 func startupWorkflowPath(args []string) (string, error) {
 	if len(args) > 1 {
-		return "", fmt.Errorf("usage: worker [path-to-WORKFLOW.md]")
+		return "", fmt.Errorf("usage: worker [--port=N] [path-to-WORKFLOW.md]")
 	}
 	if len(args) == 1 {
 		return args[0], nil
@@ -144,8 +204,16 @@ func startupReconcileConfigForWorkflow(cfg workflow.Config, trackerClient worker
 }
 
 func run(ctx context.Context, args []string) error {
+	workflowPath, portOverride, err := parseRunArgs(args)
+	if err != nil {
+		return err
+	}
+	var resolveArgs []string
+	if workflowPath != "" {
+		resolveArgs = []string{workflowPath}
+	}
 	cfg := worker.LoadConfigFromEnv()
-	wf, resolution, err := resolveStartupWorkflow(args)
+	wf, resolution, err := resolveStartupWorkflow(resolveArgs)
 	if err != nil {
 		return err
 	}
@@ -208,7 +276,7 @@ func run(ctx context.Context, args []string) error {
 		}
 	}()
 	go func() {
-		if err := runStateHTTPServerLoop(ctx, runtime, orch.Snapshot, stateHTTPServerLoopOptions{Refresh: orch.RequestRefresh}); err != nil && ctx.Err() == nil {
+		if err := runStateHTTPServerLoop(ctx, runtime, orch.Snapshot, stateHTTPServerLoopOptions{Refresh: orch.RequestRefresh, PortOverride: portOverride}); err != nil && ctx.Err() == nil {
 			log.Printf("state HTTP server loop exited: %v", err)
 		}
 	}()
@@ -300,6 +368,11 @@ type stateHTTPServerLoopOptions struct {
 	Sleep           func(context.Context, time.Duration) error
 	StopAfterChecks int
 	Refresh         stateRefreshFunc
+	// PortOverride, when non-nil, replaces the workflow snapshot's
+	// `server.port` for every tick of the loop. SPEC §13.7 defines this
+	// as the CLI `--port` precedence rule. -1 disables the HTTP server,
+	// 0 binds an ephemeral port, 1..65535 binds explicitly.
+	PortOverride *int
 }
 
 func runStateHTTPServerLoop(ctx context.Context, runtime *orchestrator.WorkflowRuntime, snapshot stateSnapshotFunc, opts stateHTTPServerLoopOptions) error {
@@ -318,10 +391,11 @@ func runStateHTTPServerLoop(ctx context.Context, runtime *orchestrator.WorkflowR
 	}
 	checks := 0
 	for {
-		port := -1
+		var wf *workflow.Workflow
 		if snap := runtime.Current(); snap.Workflow != nil {
-			port = snap.Workflow.Config.Server.Port
+			wf = snap.Workflow
 		}
+		port := desiredPortForLoop(opts, wf)
 		if err := controller.apply(ctx, port); err != nil {
 			return err
 		}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -45,6 +45,11 @@ func normalizeRunError(err error, runCtxErr error) error {
 	if runCtxErr != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return nil
 	}
+	if errors.Is(err, flag.ErrHelp) {
+		// flag.Parse already wrote usage to stderr when -h/--help was
+		// requested; treat that as a clean exit, not a fatal error.
+		return nil
+	}
 	return err
 }
 
@@ -61,7 +66,9 @@ func normalizeRunError(err error, runCtxErr error) error {
 // scratch sessions are the motivating callers.
 func parseRunArgs(args []string) (string, *int, error) {
 	fs := flag.NewFlagSet("worker", flag.ContinueOnError)
-	fs.SetOutput(io.Discard) // tests assert on the returned error; don't dump usage to stderr
+	// Leave fs.Output() at its default (os.Stderr) so `worker --help`
+	// and parse diagnostics reach the user. flag.ErrHelp is propagated
+	// to the caller, which treats it as a clean exit.
 	portFlag := fs.Int("port", 0, "override server.port from WORKFLOW.md: -1 disables the HTTP server, 0 binds an ephemeral port, 1..65535 binds explicitly. SPEC §13.7.")
 	if err := fs.Parse(args); err != nil {
 		return "", nil, err

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -117,7 +117,12 @@ func reorderForFlagParse(args []string) []string {
 		a := args[i]
 		switch {
 		case a == "--":
-			positional = append(positional, args[i+1:]...)
+			// POSIX end-of-options: everything after is positional,
+			// even if it begins with "-". Preserve the "--" itself so
+			// the stdlib flag parser still recognizes the boundary
+			// when it scans the reordered slice.
+			tail := append([]string{"--"}, args[i+1:]...)
+			positional = append(positional, tail...)
 			i = len(args)
 		case a == "--port" || a == "-port":
 			flags = append(flags, a)

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -1702,6 +1703,20 @@ func TestParseRunArgs_PortFlagBoundaries(t *testing.T) {
 				t.Fatalf("port = %d, want %d", *port, *tc.wantPort)
 			}
 		})
+	}
+}
+
+// TestParseRunArgs_HelpReturnsFlagErrHelp confirms `--help` propagates
+// the stdlib sentinel up to main, where normalizeRunError treats it as
+// a clean exit. Without this, `worker --help` would be logged as a
+// fatal error.
+func TestParseRunArgs_HelpReturnsFlagErrHelp(t *testing.T) {
+	_, _, err := parseRunArgs([]string{"--help"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("err = %v, want flag.ErrHelp", err)
+	}
+	if normalized := normalizeRunError(err, nil); normalized != nil {
+		t.Fatalf("normalizeRunError(flag.ErrHelp) = %v, want nil", normalized)
 	}
 }
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1651,6 +1651,134 @@ func TestRefreshHTTPHandler_DoesNotLeakErrorTextInBody(t *testing.T) {
 	}
 }
 
+// TestParseRunArgs_PortFlagBoundaries covers SPEC §13.7 --port range.
+// The acceptable values are {-1 (disable), 0 (ephemeral), 1..65535}.
+// Boundary rule (=N + =N+1) is applied at each cap edge:
+//   - lower cap: -1 accepted, -2 rejected
+//   - upper cap: 65535 accepted, 65536 rejected
+// The interior values 0, 1, 4000 confirm the band; 0 is the SPEC-
+// blessed "ephemeral" sentinel that the workflow loader rejects (port
+// 0 is not allowed in WORKFLOW.md) — CLI is the legitimate path for
+// ephemeral. The error message must name the flag so test harnesses
+// can distinguish CLI parsing failures from workflow-load failures.
+func TestParseRunArgs_PortFlagBoundaries(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantPort  *int
+		wantErr   string // substring, "" = no error
+	}{
+		{name: "unset_no_override", args: []string{}, wantPort: nil},
+		{name: "below_lower_cap_minus_two", args: []string{"--port=-2"}, wantErr: "--port"},
+		{name: "lower_cap_minus_one_disables", args: []string{"--port=-1"}, wantPort: intPtr(-1)},
+		{name: "zero_ephemeral", args: []string{"--port=0"}, wantPort: intPtr(0)},
+		{name: "one", args: []string{"--port=1"}, wantPort: intPtr(1)},
+		{name: "interior_4001", args: []string{"--port=4001"}, wantPort: intPtr(4001)},
+		{name: "upper_cap_65535", args: []string{"--port=65535"}, wantPort: intPtr(65535)},
+		{name: "above_upper_cap_65536", args: []string{"--port=65536"}, wantErr: "--port"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, port, err := parseRunArgs(tc.args)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("err = nil, want substring %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			switch {
+			case tc.wantPort == nil && port != nil:
+				t.Fatalf("port = %d, want nil", *port)
+			case tc.wantPort != nil && port == nil:
+				t.Fatalf("port = nil, want %d", *tc.wantPort)
+			case tc.wantPort != nil && *port != *tc.wantPort:
+				t.Fatalf("port = %d, want %d", *port, *tc.wantPort)
+			}
+		})
+	}
+}
+
+// TestParseRunArgs_WorkflowPathStillSupported confirms the existing
+// positional contract (worker [path-to-WORKFLOW.md]) is preserved when
+// --port is also present, in either order.
+func TestParseRunArgs_WorkflowPathStillSupported(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "positional_only", args: []string{"/path/to/WORKFLOW.md"}, want: "/path/to/WORKFLOW.md"},
+		{name: "flag_then_path", args: []string{"--port=4001", "/path/to/WORKFLOW.md"}, want: "/path/to/WORKFLOW.md"},
+		{name: "no_args", args: []string{}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, _, err := parseRunArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseRunArgs(%v): %v", tc.args, err)
+			}
+			if path != tc.want {
+				t.Fatalf("path = %q, want %q", path, tc.want)
+			}
+		})
+	}
+}
+
+// TestDesiredPortForLoop_OverrideWinsOverWorkflow pins SPEC §13.7's
+// "CLI --port overrides server.port when both are present" against the
+// runStateHTTPServerLoop port-selection step.
+func TestDesiredPortForLoop_OverrideWinsOverWorkflow(t *testing.T) {
+	override := 4001
+	got := desiredPortForLoop(stateHTTPServerLoopOptions{PortOverride: &override}, &workflow.Workflow{
+		Config: workflow.Config{Server: workflow.ServerConfig{Port: 4000}},
+	})
+	if got != 4001 {
+		t.Fatalf("desiredPortForLoop = %d, want 4001 (CLI override wins)", got)
+	}
+}
+
+// TestDesiredPortForLoop_FallsBackToWorkflowWhenNoOverride covers the
+// no-override path: workflow value is used verbatim.
+func TestDesiredPortForLoop_FallsBackToWorkflowWhenNoOverride(t *testing.T) {
+	got := desiredPortForLoop(stateHTTPServerLoopOptions{}, &workflow.Workflow{
+		Config: workflow.Config{Server: workflow.ServerConfig{Port: 4000}},
+	})
+	if got != 4000 {
+		t.Fatalf("desiredPortForLoop = %d, want 4000", got)
+	}
+}
+
+// TestDesiredPortForLoop_OverrideMinusOneDisables — paired edge with
+// OverrideWinsOverWorkflow: --port -1 must shut the server down even
+// when workflow says enable.
+func TestDesiredPortForLoop_OverrideMinusOneDisables(t *testing.T) {
+	override := -1
+	got := desiredPortForLoop(stateHTTPServerLoopOptions{PortOverride: &override}, &workflow.Workflow{
+		Config: workflow.Config{Server: workflow.ServerConfig{Port: 4000}},
+	})
+	if got != -1 {
+		t.Fatalf("desiredPortForLoop = %d, want -1 (CLI disable wins)", got)
+	}
+}
+
+// TestDesiredPortForLoop_NoWorkflowYieldsDisable mirrors the existing
+// runtime-level guard: when runtime.Current() has no workflow snapshot
+// yet, the server should stay disabled.
+func TestDesiredPortForLoop_NoWorkflowYieldsDisable(t *testing.T) {
+	got := desiredPortForLoop(stateHTTPServerLoopOptions{}, nil)
+	if got != -1 {
+		t.Fatalf("desiredPortForLoop(nil workflow) = %d, want -1", got)
+	}
+}
+
+func intPtr(v int) *int { return &v }
+
 func mustTime(value string) time.Time {
 	parsed, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1656,6 +1656,7 @@ func TestRefreshHTTPHandler_DoesNotLeakErrorTextInBody(t *testing.T) {
 // Boundary rule (=N + =N+1) is applied at each cap edge:
 //   - lower cap: -1 accepted, -2 rejected
 //   - upper cap: 65535 accepted, 65536 rejected
+//
 // The interior values 0, 1, 4000 confirm the band; 0 is the SPEC-
 // blessed "ephemeral" sentinel that the workflow loader rejects (port
 // 0 is not allowed in WORKFLOW.md) — CLI is the legitimate path for
@@ -1663,10 +1664,10 @@ func TestRefreshHTTPHandler_DoesNotLeakErrorTextInBody(t *testing.T) {
 // can distinguish CLI parsing failures from workflow-load failures.
 func TestParseRunArgs_PortFlagBoundaries(t *testing.T) {
 	cases := []struct {
-		name      string
-		args      []string
-		wantPort  *int
-		wantErr   string // substring, "" = no error
+		name     string
+		args     []string
+		wantPort *int
+		wantErr  string // substring, "" = no error
 	}{
 		{name: "unset_no_override", args: []string{}, wantPort: nil},
 		{name: "below_lower_cap_minus_two", args: []string{"--port=-2"}, wantErr: "--port"},

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1767,6 +1767,9 @@ func TestParseRunArgs_WorkflowPathStillSupported(t *testing.T) {
 		{name: "path_then_flag_split", args: []string{"/path/to/WORKFLOW.md", "--port", "4001"}, want: "/path/to/WORKFLOW.md"},
 		{name: "flag_split_then_path", args: []string{"--port", "4001", "/path/to/WORKFLOW.md"}, want: "/path/to/WORKFLOW.md"},
 		{name: "dash_dash_terminates_flags", args: []string{"--", "/path/to/WORKFLOW.md"}, want: "/path/to/WORKFLOW.md"},
+		{name: "dash_dash_protects_dash_prefixed_path", args: []string{"--", "-workflow.md"}, want: "-workflow.md"},
+		{name: "dash_dash_protects_help_as_path", args: []string{"--", "--help"}, want: "--help"},
+		{name: "dash_dash_after_flag", args: []string{"--port=4001", "--", "-foo.md"}, want: "-foo.md"},
 		{name: "no_args", args: []string{}, want: ""},
 	}
 	for _, tc := range cases {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1706,6 +1706,38 @@ func TestParseRunArgs_PortFlagBoundaries(t *testing.T) {
 	}
 }
 
+// TestParseRunArgs_PortAfterPositionalPathStillParses pins the
+// Codex-flagged regression: `worker /path/WORKFLOW.md --port=4001`
+// used to fail because stdlib flag.Parse stops at the first non-flag
+// arg. The reorder helper now pulls flag tokens to the front.
+// Boundary form: paired-edges on token ordering with the same value
+// (=4001) shows up in both positions.
+func TestParseRunArgs_PortAfterPositionalPathStillParses(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "path_then_port_equals", args: []string{"/wf.md", "--port=4001"}},
+		{name: "path_then_port_split", args: []string{"/wf.md", "--port", "4001"}},
+		{name: "port_equals_then_path", args: []string{"--port=4001", "/wf.md"}},
+		{name: "port_split_then_path", args: []string{"--port", "4001", "/wf.md"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, port, err := parseRunArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseRunArgs(%v): %v", tc.args, err)
+			}
+			if path != "/wf.md" {
+				t.Fatalf("path = %q, want /wf.md", path)
+			}
+			if port == nil || *port != 4001 {
+				t.Fatalf("port = %v, want &4001", port)
+			}
+		})
+	}
+}
+
 // TestParseRunArgs_HelpReturnsFlagErrHelp confirms `--help` propagates
 // the stdlib sentinel up to main, where normalizeRunError treats it as
 // a clean exit. Without this, `worker --help` would be logged as a
@@ -1731,6 +1763,10 @@ func TestParseRunArgs_WorkflowPathStillSupported(t *testing.T) {
 	}{
 		{name: "positional_only", args: []string{"/path/to/WORKFLOW.md"}, want: "/path/to/WORKFLOW.md"},
 		{name: "flag_then_path", args: []string{"--port=4001", "/path/to/WORKFLOW.md"}, want: "/path/to/WORKFLOW.md"},
+		{name: "path_then_flag_equals", args: []string{"/path/to/WORKFLOW.md", "--port=4001"}, want: "/path/to/WORKFLOW.md"},
+		{name: "path_then_flag_split", args: []string{"/path/to/WORKFLOW.md", "--port", "4001"}, want: "/path/to/WORKFLOW.md"},
+		{name: "flag_split_then_path", args: []string{"--port", "4001", "/path/to/WORKFLOW.md"}, want: "/path/to/WORKFLOW.md"},
+		{name: "dash_dash_terminates_flags", args: []string{"--", "/path/to/WORKFLOW.md"}, want: "/path/to/WORKFLOW.md"},
 		{name: "no_args", args: []string{}, want: ""},
 	}
 	for _, tc := range cases {

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -50,6 +50,20 @@ created or owns them.
 When `server.port` is enabled, the worker binds the status API on
 `127.0.0.1:<port>` and accepts only `localhost` or `127.0.0.1` Host headers.
 
+The effective port is resolved in this order, per SPEC §13.7:
+
+1. The CLI flag `--port` if provided. `--port -1` disables the server,
+   `--port 0` requests an ephemeral port (useful for tests and scratch
+   sessions; the actual bound port is logged at startup), `--port N`
+   (1..65535) binds explicitly. The CLI override applies for the
+   process lifetime — even across workflow reloads — so an operator
+   can pin the listen address without editing the version-controlled
+   `WORKFLOW.md`.
+2. Otherwise the `server.port` value from the loaded `WORKFLOW.md`.
+   The loader rejects `server.port: 0` in a workflow file; if you
+   need an ephemeral bind, use `--port 0` instead.
+3. Otherwise the schema default of `4000`.
+
 - `GET /api/v1/state` returns the process-wide runtime snapshot: running rows,
   retry rows, completed and failed issue IDs, aggregate token/runtime totals,
   and the current poll/concurrency metadata.


### PR DESCRIPTION
Closes #213.

## Summary
SPEC §13.7 declares that \"CLI --port overrides server.port when both are present\", with the value range -1 (disable), 0 (ephemeral), or 1..65535. The Go worker shipped without the flag — the listener address was readable only from \`WORKFLOW.md\` server.port. This PR adds the flag and threads it through to the state HTTP server loop.

## Changes
- New \`parseRunArgs\` helper parses \`--port=N\` and the existing positional \`[path-to-WORKFLOW.md]\` via \`flag.NewFlagSet\`. The \`--print-config <workdir>\` subcommand is preserved as a separate dispatch in main(). \`fs.Visit\` distinguishes \"flag explicitly provided\" from \"flag at default\" — no sentinel int is safe (every reserved value would conflict with a legitimate \`--port=N\`).
- New \`PortOverride *int\` on \`stateHTTPServerLoopOptions\` threads the override from \`run\` into \`runStateHTTPServerLoop\`. \`desiredPortForLoop\` makes the precedence explicit: CLI override > workflow snapshot > -1 (disabled when no snapshot).
- Note that the workflow loader rejects \`server.port: 0\` in WORKFLOW.md (see \`internal/workflow/loader.go\`), so \`--port 0\` is the only path to an ephemeral bind today. Documented in \`docs/runbooks/runtime-status.md\`.

## Boundary coverage
Range cap at \`-1 ≤ port ≤ 65535\`:
- \`below_lower_cap_minus_two\` (\`-2\`) → rejected (\`=N+1\` below)
- \`lower_cap_minus_one_disables\` (\`-1\`) → accepted (paired edge, disable)
- \`zero_ephemeral\` (\`0\`) / \`one\` / \`interior_4001\` → interior pass
- \`upper_cap_65535\` → accepted (\`=N\`)
- \`above_upper_cap_65536\` → rejected (\`=N+1\`)
- \`unset_no_override\` → nil override (no implicit value)

Plus \`desiredPortForLoop\` paired-edge tests: override-wins-over-workflow, no-override-uses-workflow, override-minus-one-disables, no-workflow-yields-disable.

## Acceptance criteria
- [x] \`--port\` flag parsed by \`cmd/worker/main.go\`.
- [x] Resolution order: CLI > workflow > default.
- [x] \`--port -1\` disables the listener.
- [x] Help text describes the override (via flag.Int description).
- [x] Tests cover the override matrix (8 boundary cases + 4 precedence cases).
- [x] Runbook updated (\`docs/runbooks/runtime-status.md\`).

CI: runs on the fork PR https://github.com/xrf-9527/aiops-platform/pull/18 (upstream is out of GHA quota).

## Test plan
- \`go test ./cmd/worker/...\` — green, 12 new test cases.
- \`go vet ./...\` — clean.
- \`go build ./...\` — clean.

Refs: #213