### PR TITLE
fix(workflow/loader): line-aware closing --- fence (#231)

### DIFF
--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -526,20 +526,35 @@ func LoadOptional(path string) (*Workflow, error) {
 	return nil, err
 }
 
+// splitFrontMatter peels the SPEC §5.2 YAML front-matter block off
+// the start of a workflow file. The opening fence is `---` followed
+// by a newline; the closing fence is a line that is **exactly**
+// `---` (with an optional CR before the LF) and nothing else. The
+// earlier substring-based scan would mis-match `---` lines that
+// appear inside YAML block scalars or quoted strings — see #231,
+// where `description: |` blocks legitimately contained a `---` line
+// and silently truncated the parsed Config.
+//
+// Returns (front, body). When no opening fence is present or no
+// closing fence can be found, returns ("", s) so the caller treats
+// the whole file as the prompt body.
 func splitFrontMatter(s string) (string, string) {
 	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
 		return "", s
 	}
-	trimmed := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
-	idx := strings.Index(trimmed, "\n---")
-	if idx < 0 {
-		return "", s
+	rest := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
+	lines := strings.SplitAfter(rest, "\n")
+	var front strings.Builder
+	for i, line := range lines {
+		// Strip only the line-ending (CR/LF) for the fence comparison.
+		// Trailing spaces, indentation, or any other content disqualify
+		// the line from being the closing fence.
+		if strings.TrimRight(line, "\r\n") == "---" {
+			return front.String(), strings.Join(lines[i+1:], "")
+		}
+		front.WriteString(line)
 	}
-	front := trimmed[:idx]
-	body := trimmed[idx+len("\n---"):]
-	body = strings.TrimPrefix(body, "\r\n")
-	body = strings.TrimPrefix(body, "\n")
-	return front, body
+	return "", s
 }
 
 func expandConfig(cfg *Config) error {

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -333,3 +333,137 @@ Prompt body
 		t.Fatalf("tracker.base_url = %q, mixed-case env not resolved", got)
 	}
 }
+
+// TestSplitFrontMatter_LineAwareClosingFence pins the #231 contract.
+// The closing fence is a line that is exactly "---" (with optional
+// CR before the LF). A bare substring match is wrong because YAML
+// block scalars and quoted strings can legally contain a "---" line.
+//
+// Boundary-coverage rule for "must be exactly the three-character
+// sequence on a line":
+//   - "---" \n → accept (=N cap, exact)
+//   - "---" \r\n → accept (paired line-ending edge)
+//   - "----" \n → reject (=N+1, one extra char on the line)
+//   - "--- " \n → reject (trailing whitespace is not the fence)
+//   - "  ---" \n → reject (indented; not at column 0)
+//   - missing fence → unchanged "(empty, s)" contract
+func TestSplitFrontMatter_LineAwareClosingFence(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantFront string
+		wantBody  string
+	}{
+		{
+			name:      "lf_exact_fence",
+			input:     "---\nfoo: bar\n---\nbody\n",
+			wantFront: "foo: bar\n",
+			wantBody:  "body\n",
+		},
+		{
+			name:      "crlf_exact_fence",
+			input:     "---\r\nfoo: bar\r\n---\r\nbody\r\n",
+			wantFront: "foo: bar\r\n",
+			wantBody:  "body\r\n",
+		},
+		{
+			name: "block_scalar_with_inner_dashes_does_not_close",
+			input: "---\n" +
+				"description: |\n" +
+				"  Reference: see below.\n" +
+				"  ---\n" +
+				"  More notes.\n" +
+				"agent:\n" +
+				"  default: codex\n" +
+				"---\n" +
+				"prompt body\n",
+			wantFront: "description: |\n" +
+				"  Reference: see below.\n" +
+				"  ---\n" +
+				"  More notes.\n" +
+				"agent:\n" +
+				"  default: codex\n",
+			wantBody: "prompt body\n",
+		},
+		{
+			name:      "four_dashes_is_not_fence",
+			input:     "---\nfoo: bar\n----\nstill front\n---\nbody\n",
+			wantFront: "foo: bar\n----\nstill front\n",
+			wantBody:  "body\n",
+		},
+		{
+			name:      "trailing_space_is_not_fence",
+			input:     "---\nfoo: bar\n--- \nstill front\n---\nbody\n",
+			wantFront: "foo: bar\n--- \nstill front\n",
+			wantBody:  "body\n",
+		},
+		{
+			name:      "indented_dashes_are_not_fence",
+			input:     "---\nfoo: bar\n  ---\nstill front\n---\nbody\n",
+			wantFront: "foo: bar\n  ---\nstill front\n",
+			wantBody:  "body\n",
+		},
+		{
+			name:      "missing_closing_fence_returns_empty_front",
+			input:     "---\nfoo: bar\nno fence here\n",
+			wantFront: "",
+			wantBody:  "---\nfoo: bar\nno fence here\n",
+		},
+		{
+			name:      "no_opening_fence_returns_empty_front",
+			input:     "no fence at all\n",
+			wantFront: "",
+			wantBody:  "no fence at all\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			front, body := splitFrontMatter(tc.input)
+			if front != tc.wantFront {
+				t.Fatalf("front =\n%q\nwant\n%q", front, tc.wantFront)
+			}
+			if body != tc.wantBody {
+				t.Fatalf("body =\n%q\nwant\n%q", body, tc.wantBody)
+			}
+		})
+	}
+}
+
+// TestLoadAcceptsBlockScalarContainingDashes is the user-visible
+// regression: a workflow file whose front-matter block scalar
+// contains a "---" line must Load() cleanly and surface the values
+// past that line, not get truncated to a partial Config.
+func TestLoadAcceptsBlockScalarContainingDashes(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+description: |
+  Reference: see SPEC §5.2 for delimiter handling.
+  ---
+  See above for the fence-rule note.
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  kind: linear
+  project_slug: example
+  api_key: $LINEAR_API_KEY_BLOCK_SCALAR_TEST
+agent:
+  default: codex
+---
+Prompt body across the inner --- line.
+`)
+	t.Setenv("LINEAR_API_KEY_BLOCK_SCALAR_TEST", "linear-secret")
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Agent.Default; got != "codex" {
+		t.Fatalf("agent.default = %q, want %q (front matter was truncated by inner --- line)", got, "codex")
+	}
+	if got := wf.Config.Tracker.APIKey; got != "linear-secret" {
+		t.Fatalf("tracker.api_key = %q, want %q", got, "linear-secret")
+	}
+	if !strings.Contains(wf.PromptTemplate, "Prompt body across the inner --- line.") {
+		t.Fatalf("prompt template missing expected body: %q", wf.PromptTemplate)
+	}
+}

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -429,6 +429,67 @@ func TestSplitFrontMatter_LineAwareClosingFence(t *testing.T) {
 	}
 }
 
+// TestSplitFrontMatter_EmptyFrontMatterIsPromptOnly covers the
+// Codex-flagged edge case from PR #264: an opening fence followed
+// immediately by a closing fence (`---\n---\n...`) returns an empty
+// front block. The loader treats empty fronts as prompt-only via
+// strings.TrimSpace(front) != "", so HasFrontMatterAt must report
+// the same — otherwise the workflow_resolved event labels the file
+// `source=file` while Load() boots with default Config.
+func TestSplitFrontMatter_EmptyFrontMatterIsPromptOnly(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantFront string
+		wantBody  string
+	}{
+		{
+			name:      "opening_then_immediate_closing",
+			input:     "---\n---\nbody\n",
+			wantFront: "",
+			wantBody:  "body\n",
+		},
+		{
+			name:      "opening_blank_line_closing",
+			input:     "---\n\n---\nbody\n",
+			wantFront: "\n",
+			wantBody:  "body\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			front, body := splitFrontMatter(tc.input)
+			if front != tc.wantFront {
+				t.Fatalf("front = %q, want %q", front, tc.wantFront)
+			}
+			if body != tc.wantBody {
+				t.Fatalf("body = %q, want %q", body, tc.wantBody)
+			}
+		})
+	}
+}
+
+// TestHasFrontMatterAt_EmptyFrontIsPromptOnly pins the
+// resolver-vs-loader agreement: an opening fence immediately followed
+// by a closing fence is reported as NOT having front matter, mirroring
+// the loader's `TrimSpace(front) != ""` check. Without this,
+// `workflow_resolved` would carry `source=file` while Load() produced
+// schema defaults.
+func TestHasFrontMatterAt_EmptyFrontIsPromptOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(path, []byte("---\n---\nprompt body\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := HasFrontMatterAt(path)
+	if err != nil {
+		t.Fatalf("HasFrontMatterAt: %v", err)
+	}
+	if got {
+		t.Fatalf("HasFrontMatterAt = true for empty front matter; loader treats this case as prompt_only, so the resolver must agree")
+	}
+}
+
 // TestLoadAcceptsBlockScalarContainingDashes is the user-visible
 // regression: a workflow file whose front-matter block scalar
 // contains a "---" line must Load() cleanly and surface the values

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -104,19 +104,14 @@ func HasFrontMatterAt(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	s := string(b)
-	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
-		return false, nil
-	}
-	rest := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
-	// Same line-aware scan as splitFrontMatter — see #231. A substring
-	// search would falsely match `---` that appears inside a YAML
-	// block scalar or quoted string, classifying a prompt-only file
-	// with such content as front-matter-bearing.
-	for _, line := range strings.SplitAfter(rest, "\n") {
-		if strings.TrimRight(line, "\r\n") == "---" {
-			return true, nil
-		}
-	}
-	return false, nil
+	// Delegate to splitFrontMatter so the two functions cannot diverge
+	// on edge cases: a file that begins `---\n---\n...` has an opening
+	// and closing fence but no content between them, and the loader
+	// treats that case as prompt-only via
+	// `hasFrontMatter := strings.TrimSpace(front) != ""`. HasFrontMatterAt
+	// must report the same classification or the workflow_resolved
+	// event's `source` field disagrees with the actual Config that
+	// Load() produced.
+	front, _ := splitFrontMatter(string(b))
+	return strings.TrimSpace(front) != "", nil
 }

--- a/internal/workflow/resolver.go
+++ b/internal/workflow/resolver.go
@@ -108,6 +108,15 @@ func HasFrontMatterAt(path string) (bool, error) {
 	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
 		return false, nil
 	}
-	trimmed := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
-	return strings.Contains(trimmed, "\n---"), nil
+	rest := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
+	// Same line-aware scan as splitFrontMatter — see #231. A substring
+	// search would falsely match `---` that appears inside a YAML
+	// block scalar or quoted string, classifying a prompt-only file
+	// with such content as front-matter-bearing.
+	for _, line := range strings.SplitAfter(rest, "\n") {
+		if strings.TrimRight(line, "\r\n") == "---" {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
Closes #231.

## Summary
\`splitFrontMatter\` used \`strings.Index(trimmed, \"\\\\n---\")\` to find the closing front-matter fence — a naive substring search that matches anywhere the four-byte sequence \`\\\\n---\` appears. YAML block scalars and quoted strings can legally carry a \`---\` line, so a workflow file with a \`description: |\` block that mentions \`---\` would terminate at the indented inner line instead of the operator-authored closing fence. Either YAML parse fails with a confusing \"did not find expected key\" pointing into the user's prose, or — worse — the truncated front matter parses to a partial Config that boots with default agent/tracker values.

## Changes
- Rewrite \`splitFrontMatter\` (\`internal/workflow/loader.go\`) and \`HasFrontMatterAt\` (\`internal/workflow/resolver.go\`) to scan line-by-line and accept the closing fence only when a line, after stripping CR/LF, equals exactly \`---\`. Trailing whitespace, indentation, additional dashes (\`----\`), or any other content disqualify the line.
- The two functions still share the same opening-fence detection; both stay in sync per the comment policy.

## Boundary coverage
Exact-line cap on \`---\`:
- \`---\\\\n\` (LF) → accept (=N, exact)
- \`---\\\\r\\\\n\` → accept (paired line-ending edge)
- \`----\\\\n\` → reject (=N+1, one extra char)
- \`--- \\\\n\` → reject (trailing space)
- \`  ---\\\\n\` → reject (indented; not at column 0)
- block-scalar inner \`---\` → reject (the user-visible regression fixture)
- no closing fence / no opening fence → unchanged \`(\"\", s)\` contract

Plus \`TestLoadAcceptsBlockScalarContainingDashes\` covers the end-to-end \`Load()\` happy path with a block scalar carrying \`---\`.

CI: runs on the fork PR https://github.com/xrf-9527/aiops-platform/pull/19 (upstream is out of GHA quota).

## Test plan
- \`go test ./...\` — green, 9 new sub-tests on \`splitFrontMatter\` + 1 end-to-end Load test.
- \`go vet ./...\` — clean.

Refs: #231