### PR TITLE
fix(runner): Codex turn title carries issue identifier per SPEC §10.2 (#252)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -975,14 +975,26 @@ func appServerDynamicToolSpecs(cfg workflow.Config) []map[string]any {
 	return specs
 }
 
+// appServerTurnTitle builds the Codex turn title following SPEC §10.2:
+// "<issue.identifier>: <issue.title>". Task.SourceEventID is the
+// tracker identifier (e.g. "AIOPS-64", "MT-649"); Task.ID is an
+// internal queue nonce that means nothing to operators reading a
+// Codex session log. Prefer the identifier; fall back to title alone
+// if the identifier is unset; fall back to the task nonce only as a
+// last resort so prompt-only tests still get something to dispatch.
 func appServerTurnTitle(in RunInput) string {
-	if in.Task.ID != "" && in.Task.Title != "" {
-		return in.Task.ID + ": " + in.Task.Title
+	identifier := strings.TrimSpace(in.Task.SourceEventID)
+	title := strings.TrimSpace(in.Task.Title)
+	switch {
+	case identifier != "" && title != "":
+		return identifier + ": " + title
+	case identifier != "":
+		return identifier
+	case title != "":
+		return title
+	default:
+		return in.Task.ID
 	}
-	if in.Task.Title != "" {
-		return in.Task.Title
-	}
-	return in.Task.ID
 }
 
 func appServerContinuationPrompt(in RunInput, turn int) string {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -21,7 +21,7 @@ import (
 
 func appServerInput(workdir string) RunInput {
 	return RunInput{
-		Task: task.Task{ID: "AIOPS-64", Title: "Wire Codex app-server", Model: "codex-app-server"},
+		Task: task.Task{ID: "tsk-001", SourceEventID: "AIOPS-64", Title: "Wire Codex app-server", Model: "codex-app-server"},
 		Workflow: workflow.Workflow{Config: workflow.Config{
 			Agent:     workflow.AgentConfig{MaxTurns: 8},
 			Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
@@ -1443,5 +1443,75 @@ func TestAppServerClient_ReadLineAcceptsLineAtCap(t *testing.T) {
 	}
 	if got, want := len(line), maxAppServerLineBytes; got != want {
 		t.Fatalf("readLine line len = %d, want %d", got, want)
+	}
+}
+
+// TestAppServerTurnTitle_PrefersIssueIdentifier pins SPEC §10.2's
+// "<issue.identifier>: <issue.title>" pattern. Task.SourceEventID
+// carries the tracker identifier ("AIOPS-64", "MT-649"); Task.ID is
+// an internal queue nonce. The title must surface the identifier so
+// operators can cross-reference a Codex session log to a Linear /
+// Gitea ticket without translating through queue storage.
+//
+// Paired-edges across (identifier set, title set) × (identifier set,
+// title set):
+//   - both set → "<id>: <title>"
+//   - identifier only → "<id>"
+//   - title only → "<title>"
+//   - neither (only Task.ID) → Task.ID as last-resort
+func TestAppServerTurnTitle_PrefersIssueIdentifier(t *testing.T) {
+	cases := []struct {
+		name string
+		in   RunInput
+		want string
+	}{
+		{
+			name: "identifier_and_title_set",
+			in:   RunInput{Task: task.Task{ID: "tsk-001", SourceEventID: "AIOPS-64", Title: "Wire Codex app-server"}},
+			want: "AIOPS-64: Wire Codex app-server",
+		},
+		{
+			name: "identifier_only_set",
+			in:   RunInput{Task: task.Task{ID: "tsk-002", SourceEventID: "AIOPS-65"}},
+			want: "AIOPS-65",
+		},
+		{
+			name: "title_only_set",
+			in:   RunInput{Task: task.Task{ID: "tsk-003", Title: "Untracked title"}},
+			want: "Untracked title",
+		},
+		{
+			name: "neither_set_falls_back_to_task_id",
+			in:   RunInput{Task: task.Task{ID: "tsk-004"}},
+			want: "tsk-004",
+		},
+		{
+			name: "whitespace_only_identifier_treated_as_unset",
+			in:   RunInput{Task: task.Task{ID: "tsk-005", SourceEventID: "  ", Title: "Fallback title"}},
+			want: "Fallback title",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := appServerTurnTitle(tc.in); got != tc.want {
+				t.Fatalf("appServerTurnTitle = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAppServerContinuationPrompt_InheritsIdentifierSubject confirms
+// the continuation-turn prompt subject also resolves through the
+// identifier-first rule (since appServerContinuationPrompt delegates
+// to appServerTurnTitle). The prompt template stays operator-readable
+// when the identifier is the visible breadcrumb.
+func TestAppServerContinuationPrompt_InheritsIdentifierSubject(t *testing.T) {
+	in := RunInput{Task: task.Task{ID: "tsk-099", SourceEventID: "ENG-42", Title: "Mid-run continuation"}}
+	got := appServerContinuationPrompt(in, 2)
+	if !strings.Contains(got, "ENG-42: Mid-run continuation") {
+		t.Fatalf("continuation prompt should carry identifier subject, got: %q", got)
+	}
+	if strings.Contains(got, "tsk-099") {
+		t.Fatalf("continuation prompt should NOT include the internal task nonce; got: %q", got)
 	}
 }


### PR DESCRIPTION
Closes #252.

## Summary
SPEC §10.2: \"Include issue-identifying metadata, such as \`<issue.identifier>: <issue.title>\`, when the targeted protocol supports turn or session titles.\"

\`appServerTurnTitle\` had been building the title from \`Task.ID\` — the internal queue nonce (e.g. \`tsk-1716293045-abc123\`) — instead of \`Task.SourceEventID\`, the tracker identifier (\`AIOPS-64\`, \`MT-649\`, etc.). The Codex session log's turn title was therefore opaque to operators: a session entry showed the nonce, not the ticket. \`appServerContinuationPrompt\` consumes the same title, so continuation-turn prompts inherited the bug.

## Changes
- \`appServerTurnTitle\` resolution order: trimmed \`Task.SourceEventID\` → trimmed \`Task.Title\` → \`Task.ID\` (last-resort fallback for prompt-only/unrouted dispatches).
- Whitespace-only identifiers treated as unset.
- The existing app-server integration test fixture (\`appServerInput\`) updated: \`Task{ID: \"tsk-001\", SourceEventID: \"AIOPS-64\"}\` is the realistic split. Before the fix the identifier sat in \`Task.ID\`, which happened to render the right title but for the wrong reason.

## Boundary coverage
Paired-edges across (identifier set, title set):
- both set → \`AIOPS-64: Wire Codex app-server\`
- identifier only → \`AIOPS-65\`
- title only → \`Untracked title\`
- both unset → \`tsk-004\` (Task.ID fallback)
- whitespace-only identifier → falls through to title (\`Fallback title\`)

Plus \`TestAppServerContinuationPrompt_InheritsIdentifierSubject\`: the continuation prompt carries \`ENG-42: Mid-run continuation\` and does NOT expose the internal nonce.

CI: runs on the fork PR https://github.com/xrf-9527/aiops-platform/pull/21 (upstream is out of GHA quota).

## Test plan
- \`go test ./...\` — green; 2 new test functions covering the paired-edges matrix + continuation prompt.
- \`go vet ./...\` — clean.

Refs: #252