### PR TITLE
fix(runner): redact raw Codex turn-failure params from errors + events (#193)

### DIFF
--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -127,6 +127,14 @@ The current Go implementation provides these safety controls:
 - operator-visible blocked state for Codex input-required and MCP elicitation
   requests, so non-interactive runs stop and remain claimed instead of burning
   retries silently;
+- allow-listed redaction of Codex `turn/failed`, `turn/cancelled`, and failed
+  `turn/completed` protocol payloads: returned error strings and
+  `runtime_events` JSON payloads carry only the documented
+  `status`/`reason`/`error`/`message`/`error_code` fields (plus the same keys
+  under nested `turn`), with `"reason unavailable"` as fallback. Arbitrary
+  protocol fields — including any tool-call output, elicitation echoes, or
+  future Codex additions — are never embedded in worker error strings,
+  `RecordEvent.Message`, or `/api/v1/state` payloads;
 - branch protection and review gates when configured on the remote repository.
 
 These controls reduce accidental damage and make changes reviewable. They do not

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -886,13 +886,39 @@ func safeTurnReason(params map[string]any) string {
 		sources = append(sources, turn)
 	}
 	for _, source := range sources {
-		for _, key := range []string{"reason", "error", "message", "error_code"} {
-			if v, _ := source[key].(string); strings.TrimSpace(v) != "" {
-				return strings.TrimSpace(v)
-			}
+		if v := extractReasonFields(source); v != "" {
+			return v
 		}
 	}
 	return fallback
+}
+
+// extractReasonFields walks the allow-listed reason keys in a single map and
+// returns the first non-empty string. `error` is special: Codex may serialize
+// it as a string or as a nested object like
+// `{"message": "...", "code": "...", "error_code": "..."}`. Both shapes are
+// supported; nested object lookup only allows the same allow-listed scalar
+// fields.
+func extractReasonFields(source map[string]any) string {
+	for _, key := range []string{"reason", "error", "message", "error_code"} {
+		raw, ok := source[key]
+		if !ok {
+			continue
+		}
+		switch v := raw.(type) {
+		case string:
+			if s := strings.TrimSpace(v); s != "" {
+				return s
+			}
+		case map[string]any:
+			for _, nestedKey := range []string{"message", "reason", "error_code", "code"} {
+				if s, _ := v[nestedKey].(string); strings.TrimSpace(s) != "" {
+					return strings.TrimSpace(s)
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // safeTurnFailurePayload returns a runtime-event payload built from only the
@@ -908,21 +934,13 @@ func safeTurnFailurePayload(params map[string]any) map[string]any {
 	if v, _ := params["status"].(string); strings.TrimSpace(v) != "" {
 		out["status"] = strings.TrimSpace(v)
 	}
-	for _, key := range []string{"reason", "error", "message", "error_code"} {
-		if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
-			out[key] = strings.TrimSpace(v)
-		}
-	}
+	copyAllowlistedReasonFields(params, out)
 	if turn, _ := params["turn"].(map[string]any); turn != nil {
 		nested := map[string]any{}
 		if v, _ := turn["status"].(string); strings.TrimSpace(v) != "" {
 			nested["status"] = strings.TrimSpace(v)
 		}
-		for _, key := range []string{"reason", "error", "message", "error_code"} {
-			if v, _ := turn[key].(string); strings.TrimSpace(v) != "" {
-				nested[key] = strings.TrimSpace(v)
-			}
-		}
+		copyAllowlistedReasonFields(turn, nested)
 		if len(nested) > 0 {
 			out["turn"] = nested
 		}
@@ -931,6 +949,34 @@ func safeTurnFailurePayload(params map[string]any) map[string]any {
 		out["reason"] = safeTurnReason(params)
 	}
 	return out
+}
+
+// copyAllowlistedReasonFields copies allow-listed reason fields from src to
+// dst. String values are trimmed; structured `error` objects are flattened to a
+// fresh allow-listed sub-map so non-allow-listed siblings are never persisted.
+func copyAllowlistedReasonFields(src, dst map[string]any) {
+	for _, key := range []string{"reason", "error", "message", "error_code"} {
+		raw, ok := src[key]
+		if !ok {
+			continue
+		}
+		switch v := raw.(type) {
+		case string:
+			if s := strings.TrimSpace(v); s != "" {
+				dst[key] = s
+			}
+		case map[string]any:
+			scrubbed := map[string]any{}
+			for _, nestedKey := range []string{"message", "reason", "error_code", "code"} {
+				if s, _ := v[nestedKey].(string); strings.TrimSpace(s) != "" {
+					scrubbed[nestedKey] = strings.TrimSpace(s)
+				}
+			}
+			if len(scrubbed) > 0 {
+				dst[key] = scrubbed
+			}
+		}
+	}
 }
 
 func (c *appServerClient) recordSafeTurnFailure(event string, params map[string]any) {

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -502,20 +502,22 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 			switch method {
 			case "turn/completed":
 				if err := completedTurnError(msg); err != nil {
-					c.recordRuntimeMessage(task.EventTurnEndedWithError, msg)
+					params, _ := msg["params"].(map[string]any)
+					c.recordSafeTurnFailure(task.EventTurnEndedWithError, params)
 					return err
 				}
 				c.handleNotification(msg)
 				c.recordRuntimeMessage(task.EventTurnCompleted, msg)
 				return nil
 			case "turn/failed", "turn/cancelled":
+				params, _ := msg["params"].(map[string]any)
+				reason := safeTurnReason(params)
 				if method == "turn/failed" {
-					c.recordRuntimeMessage(task.EventTurnFailed, msg)
-					return NewError(CategoryTurnFailed, fmt.Sprintf("%s: %v", method, msg["params"]), nil)
-				} else {
-					c.recordRuntimeMessage(task.EventTurnCancelled, msg)
-					return NewError(CategoryTurnCancelled, fmt.Sprintf("%s: %v", method, msg["params"]), nil)
+					c.recordSafeTurnFailure(task.EventTurnFailed, params)
+					return NewError(CategoryTurnFailed, fmt.Sprintf("%s: %s", method, reason), nil)
 				}
+				c.recordSafeTurnFailure(task.EventTurnCancelled, params)
+				return NewError(CategoryTurnCancelled, fmt.Sprintf("%s: %s", method, reason), nil)
 			case "item/tool/call":
 				if err := c.handleDynamicToolCall(ctx, msg); err != nil {
 					return err
@@ -864,34 +866,75 @@ func completedTurnError(msg map[string]any) error {
 	if status == "" || status == "completed" || status == "succeeded" || status == "success" || status == "interrupted" {
 		return nil
 	}
-	reason := ""
-	reasonSources := []map[string]any{params}
+	return NewError(CategoryTurnFailed, fmt.Sprintf("turn/completed failed with status %q: %s", status, safeTurnReason(params)), nil)
+}
+
+// safeTurnReason extracts a human-readable reason string from a Codex
+// `turn/failed`, `turn/cancelled`, or failed `turn/completed` params payload,
+// pulling only from an explicit allow-list of fields. Returns
+// `"reason unavailable"` when none are populated. This is a defense-in-depth
+// guard so that arbitrary protocol fields (which may carry tool output,
+// elicitation snippets, or secrets) never end up in returned error strings or
+// the structured log/event surface. See docs/security-posture.md.
+func safeTurnReason(params map[string]any) string {
+	const fallback = "reason unavailable"
+	if params == nil {
+		return fallback
+	}
+	sources := []map[string]any{params}
 	if turn, _ := params["turn"].(map[string]any); turn != nil {
-		reasonSources = append(reasonSources, turn)
+		sources = append(sources, turn)
 	}
-	for _, source := range reasonSources {
-		for _, key := range []string{"reason", "error", "message"} {
+	for _, source := range sources {
+		for _, key := range []string{"reason", "error", "message", "error_code"} {
 			if v, _ := source[key].(string); strings.TrimSpace(v) != "" {
-				reason = strings.TrimSpace(v)
-				break
-			}
-		}
-		if reason != "" {
-			break
-		}
-	}
-	if reason == "" {
-		for _, key := range []string{"reason", "error", "message"} {
-			if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
-				reason = strings.TrimSpace(v)
-				break
+				return strings.TrimSpace(v)
 			}
 		}
 	}
-	if reason == "" {
-		reason = fmt.Sprint(params)
+	return fallback
+}
+
+// safeTurnFailurePayload returns a runtime-event payload built from only the
+// allow-listed status/reason fields of a Codex failure params map. Mirrors the
+// redaction discipline of safeTurnReason so the JSON event surface
+// (`/api/v1/state`, runtime event log) never persists the raw protocol payload.
+func safeTurnFailurePayload(params map[string]any) map[string]any {
+	out := map[string]any{}
+	if params == nil {
+		out["reason"] = "reason unavailable"
+		return out
 	}
-	return NewError(CategoryTurnFailed, fmt.Sprintf("turn/completed failed with status %q: %s", status, reason), nil)
+	if v, _ := params["status"].(string); strings.TrimSpace(v) != "" {
+		out["status"] = strings.TrimSpace(v)
+	}
+	for _, key := range []string{"reason", "error", "message", "error_code"} {
+		if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
+			out[key] = strings.TrimSpace(v)
+		}
+	}
+	if turn, _ := params["turn"].(map[string]any); turn != nil {
+		nested := map[string]any{}
+		if v, _ := turn["status"].(string); strings.TrimSpace(v) != "" {
+			nested["status"] = strings.TrimSpace(v)
+		}
+		for _, key := range []string{"reason", "error", "message", "error_code"} {
+			if v, _ := turn[key].(string); strings.TrimSpace(v) != "" {
+				nested[key] = strings.TrimSpace(v)
+			}
+		}
+		if len(nested) > 0 {
+			out["turn"] = nested
+		}
+	}
+	if _, ok := out["reason"]; !ok {
+		out["reason"] = safeTurnReason(params)
+	}
+	return out
+}
+
+func (c *appServerClient) recordSafeTurnFailure(event string, params map[string]any) {
+	c.recordRuntimeEvent(event, c.withRuntimeContext(safeTurnFailurePayload(params)))
 }
 
 func (c *appServerClient) handleDynamicToolCall(ctx context.Context, msg map[string]any) error {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -874,6 +874,110 @@ for line in sys.stdin:
 	}
 }
 
+func TestCodexAppServerRunnerRedactsTurnFailureParams(t *testing.T) {
+	const secret = "sk-secret-must-not-leak-9f7c1e"
+	cases := []struct {
+		name      string
+		stubBody  string
+		event     string
+		errSubstr string
+		reason    string
+	}{
+		{
+			name: "turn_failed",
+			stubBody: `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'planner exploded', 'leak': '` + secret + `', 'got': {'inner': '` + secret + `'}}}), flush=True)
+        break
+`,
+			event:     task.EventTurnFailed,
+			errSubstr: "planner exploded",
+			reason:    "planner exploded",
+		},
+		{
+			name: "turn_cancelled",
+			stubBody: `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/cancelled', 'params': {'message': 'user aborted', 'leak': '` + secret + `'}}), flush=True)
+        break
+`,
+			event:     task.EventTurnCancelled,
+			errSubstr: "user aborted",
+			reason:    "user aborted",
+		},
+		{
+			name: "turn_completed_unknown_status_fallback",
+			stubBody: `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'status': 'broken', 'leak': '` + secret + `'}}), flush=True)
+        break
+`,
+			event:     task.EventTurnEndedWithError,
+			errSubstr: "reason unavailable",
+			reason:    "reason unavailable",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			codexAppServerStubScript(t, tc.stubBody)
+			wd := codexWorkdir(t, "x")
+
+			res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+			if err == nil {
+				t.Fatalf("Run err = nil, want failure")
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Fatalf("err leaked secret: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Fatalf("err = %v, want substring %q", err, tc.errSubstr)
+			}
+			events := runtimeEventsNamed(res.RuntimeEvents, tc.event)
+			if len(events) != 1 {
+				t.Fatalf("%s events = %d, want 1; events=%#v", tc.event, len(events), res.RuntimeEvents)
+			}
+			payloadJSON, marshalErr := json.Marshal(events[0].Payload)
+			if marshalErr != nil {
+				t.Fatalf("marshal payload: %v", marshalErr)
+			}
+			if bytes.Contains(payloadJSON, []byte(secret)) {
+				t.Fatalf("payload leaked secret: %s", payloadJSON)
+			}
+			if got := runtimeEventField(t, events[0], "reason"); got != tc.reason {
+				t.Fatalf("reason = %#v, want %q; payload=%s", got, tc.reason, payloadJSON)
+			}
+			if _, ok := events[0].Payload.(map[string]any)["leak"]; ok {
+				t.Fatalf("payload should not retain non-allowlisted field 'leak': %s", payloadJSON)
+			}
+		})
+	}
+}
+
 func TestCodexAppServerRunnerSendsContinuationInputAfterContinueRequest(t *testing.T) {
 	binDir := codexAppServerStubScript(t, `
 import json

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -922,6 +922,44 @@ for line in sys.stdin:
 			reason:    "user aborted",
 		},
 		{
+			name: "turn_completed_structured_turn_error",
+			stubBody: `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'turn': {'status': 'failed', 'error': {'message': 'sandbox denied write', 'code': 'sandbox_violation', 'leak_inside_error': '` + secret + `'}}, 'leak': '` + secret + `'}}), flush=True)
+        break
+`,
+			event:     task.EventTurnEndedWithError,
+			errSubstr: "sandbox denied write",
+			reason:    "sandbox denied write",
+		},
+		{
+			name: "turn_failed_structured_error",
+			stubBody: `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/failed', 'params': {'error': {'message': 'planner crashed', 'leak': '` + secret + `'}}}), flush=True)
+        break
+`,
+			event:     task.EventTurnFailed,
+			errSubstr: "planner crashed",
+			reason:    "planner crashed",
+		},
+		{
 			name: "turn_completed_unknown_status_fallback",
 			stubBody: `
 import json


### PR DESCRIPTION
## Summary

Closes #193.

Two paths in `internal/runner/codex_app_server.go` formatted the raw `msg["params"]` / `params` map directly into returned `error` strings via `%v` / `fmt.Sprint`:

- `turn/failed` and `turn/cancelled` (`fmt.Sprintf(\"%s: %v\", method, msg[\"params\"])`)
- `completedTurnError` fallback when no `reason`/`error`/`message` field was populated (`reason = fmt.Sprint(params)`)

The error string flowed through `RunTaskError`, `RecordEvent.Message` (`/api/v1/state` per #150), and the worker's structured log stream. The corresponding `recordRuntimeMessage` calls additionally normalized the entire `params` map into the runtime-event JSON payload. Codex protocol payloads can carry arbitrary tool output, elicitation snippets, or future fields — `%v`-ing them is exactly what `docs/security-posture.md` should not permit. Defense-in-depth, not a known active leak.

## Changes

- New `safeTurnReason(params)` extracts only allow-listed string fields (`reason`, `error`, `message`, `error_code`) from `params` and any nested `turn` map; falls back to the stable string `\"reason unavailable\"` (no map stringification).
- New `safeTurnFailurePayload(params)` + `recordSafeTurnFailure` helper emit runtime-event payloads built from the same allow-list. `turn_failed`, `turn_cancelled`, and `turn_ended_with_error` payloads now persist only allow-listed fields. `turn/completed` success and unrelated notification paths are unchanged.
- `docs/security-posture.md` \"What is defended today\" lists the redaction discipline so operators know which fields persist vs. drop.

## Tests

- New `TestCodexAppServerRunnerRedactsTurnFailureParams` covers `turn/failed`, `turn/cancelled`, and the `completedTurnError` fallback. Each sub-test injects a synthetic secret under non-allow-listed `params` keys and asserts:
  - `err.Error()` does not contain the secret;
  - `event.Payload` JSON does not contain the secret;
  - allow-listed `reason` (or `\"reason unavailable\"` fallback) still surfaces;
  - the non-allow-listed `leak` field is dropped from the event payload.
- Existing `TestCodexAppServerRunnerTreatsFailedTurnCompletedAsError`, `TestCodexAppServerRunnerTreatsNestedFailedTurnCompletedAsError`, and `TestCodexAppServerRunnerTreatsInterruptedTurnCompletedAsSuccess` continue to pass — reason extraction for documented fields is preserved.
- Full `go test ./...` green.

## Test plan

- [x] `go test ./internal/runner/...`
- [x] `go test ./...`
- [x] `go vet ./...`