### PR TITLE
fix(worker): containment-check workspace deletes via workspace.SafeRemove (#196)

### DIFF
--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -76,6 +76,26 @@ the worker is deployed:
    worker's main loop (e.g. once per N completed tasks). Until that
    lands, treat cleanup as an out-of-band concern.
 
+## Cleanup containment invariant
+
+All cleanup paths that delete a per-task worktree go through
+`workspace.SafeRemove(root, path)`. The helper refuses to delete a path
+that is not strictly contained under the configured workspace root:
+empty/whitespace input, the root itself, a sibling of the root, a
+`..` traversal, and symlinks whose resolved target points outside the
+root all return `ErrSafeRemoveEscapesRoot` and the on-disk path is left
+untouched. This is a defense-in-depth guard against a future refactor or
+a malformed hook output that could otherwise pass an empty string or
+`/` into `os.RemoveAll` — see SPEC §9.5 Invariants 2 & 3, §15.2.
+
+The two production call sites today are
+`internal/worker/runtask.go::removeWorkdirAfterHookFailure` (rollback
+after `after_create` hook failure) and
+`internal/worker/reconcile.go::removeWorkspace` (reconcile-driven
+cleanup for closed/cancelled issues). Any new cleanup code that touches
+`$WORKSPACE_ROOT` should call `workspace.SafeRemove` rather than
+`os.RemoveAll` directly.
+
 ## Troubleshooting
 
 - `fatal: '<dir>' is not a working tree` printed during task setup is

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -236,7 +236,7 @@ func removeWorkspace(ctx context.Context, cfg ReconcileConfig, taskID, path stri
 	if err := runWorkspaceHook(ctx, cfg.Emitter, taskID, path, workspace.HookBeforeRemove, cfg.BeforeRemoveHook, cfg.HookTimeoutMillis); err != nil {
 		log.Printf("task %s: before_remove hook failed for %s workspace %s: %v", taskID, reason, path, err)
 	}
-	if err := os.RemoveAll(path); err != nil {
+	if err := workspace.SafeRemove(cfg.WorkspaceRoot, path); err != nil {
 		return false, fmt.Errorf("remove %s workspace %s: %w", reason, path, err)
 	}
 	Emit(ctx, cfg.Emitter, taskID, task.EventReconcileWorkspace, "removed workspace", map[string]any{

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -162,11 +162,11 @@ func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, workdir stri
 	return err
 }
 
-func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, reason string) {
+func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, reason string) {
 	if err := runWorkspaceHook(ctx, ev, taskID, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs); err != nil {
 		log.Printf("task %s: before_remove hook failed after %s hook failure: %v", taskID, reason, err)
 	}
-	if err := os.RemoveAll(workdir); err != nil {
+	if err := workspace.SafeRemove(workspaceRoot, workdir); err != nil {
 		log.Printf("task %s: remove workspace %s after %s hook failure: %v", taskID, workdir, reason, err)
 	}
 }
@@ -210,7 +210,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		}
 	}
 	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, hooks.AfterCreate, hooks.TimeoutMs); err != nil {
-		removeWorkdirAfterHookFailure(ctx, ev, t.ID, workdir, hooks.BeforeRemove, hooks.TimeoutMs, "after_create")
+		removeWorkdirAfterHookFailure(ctx, ev, t.ID, workspaceRoot, workdir, hooks.BeforeRemove, hooks.TimeoutMs, "after_create")
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 

--- a/internal/workspace/safe_remove.go
+++ b/internal/workspace/safe_remove.go
@@ -1,0 +1,95 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrSafeRemoveInvalidPath is returned when SafeRemove is called with an empty
+// or whitespace-only root/path.
+var ErrSafeRemoveInvalidPath = errors.New("safe remove: invalid path")
+
+// ErrSafeRemoveEscapesRoot is returned when SafeRemove is asked to delete a
+// path that is not strictly contained under the configured workspace root —
+// including the root itself, a sibling of the root, a `..` traversal, or a
+// symlink whose resolved target points outside the root.
+var ErrSafeRemoveEscapesRoot = errors.New("safe remove: path escapes workspace root")
+
+// SafeRemove deletes path with `os.RemoveAll` after confirming that path is a
+// non-empty subdirectory strictly contained under root.
+//
+// Defense-in-depth guard for the worker cleanup paths (per-task workdir
+// rollback after a hook failure, reconcile-driven workspace removal): if a
+// future refactor or malformed hook output ever feeds an empty string, the
+// process cwd, the workspace root itself, or a symlink that points outside the
+// root into these call sites, SafeRemove refuses rather than recursively
+// deleting whatever the path happens to point at. See SPEC §9.5 Invariants
+// 2 & 3, §15.2 (mandatory filesystem safety).
+//
+// A path that does not exist is treated as success — SafeRemove is meant to be
+// idempotent because both worker call sites can race with manual operator
+// cleanup. Containment is checked first so that a non-existent path under root
+// is allowed but a non-existent path outside root is still rejected.
+func SafeRemove(root, path string) error {
+	root = strings.TrimSpace(root)
+	path = strings.TrimSpace(path)
+	if root == "" || path == "" {
+		return ErrSafeRemoveInvalidPath
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("safe remove: abs root: %w", err)
+	}
+	absRoot = filepath.Clean(absRoot)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("safe remove: abs path: %w", err)
+	}
+	absPath = filepath.Clean(absPath)
+	if err := assertContained(absRoot, absPath); err != nil {
+		return err
+	}
+	// Re-validate after resolving symlinks on both root and path. A directory
+	// symlink under root that points outside (e.g. a stray operator-created
+	// link, or a malicious workspace file) must be rejected even though its
+	// raw `absPath` looks contained. Root is symlink-resolved too so platforms
+	// whose tempdir is itself a symlink (e.g. macOS `/var` → `/private/var`)
+	// don't trip the comparison.
+	resolvedRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			resolvedRoot = absRoot
+		} else {
+			return fmt.Errorf("safe remove: resolve root symlinks: %w", err)
+		}
+	}
+	resolvedRoot = filepath.Clean(resolvedRoot)
+	if resolved, err := filepath.EvalSymlinks(absPath); err == nil {
+		if err := assertContained(resolvedRoot, filepath.Clean(resolved)); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("safe remove: resolve symlinks: %w", err)
+	}
+	return os.RemoveAll(absPath)
+}
+
+func assertContained(absRoot, absPath string) error {
+	if absRoot == absPath {
+		return fmt.Errorf("%w: refuses to delete the workspace root itself (%s)", ErrSafeRemoveEscapesRoot, absRoot)
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil {
+		return fmt.Errorf("safe remove: relpath: %w", err)
+	}
+	if rel == "." || rel == "" {
+		return fmt.Errorf("%w: refuses to delete the workspace root itself (%s)", ErrSafeRemoveEscapesRoot, absRoot)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %s not under %s", ErrSafeRemoveEscapesRoot, absPath, absRoot)
+	}
+	return nil
+}

--- a/internal/workspace/safe_remove_test.go
+++ b/internal/workspace/safe_remove_test.go
@@ -1,0 +1,112 @@
+package workspace
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSafeRemoveRejectsEmptyRootOrPath(t *testing.T) {
+	root := t.TempDir()
+
+	if err := SafeRemove("", filepath.Join(root, "x")); !errors.Is(err, ErrSafeRemoveInvalidPath) {
+		t.Fatalf("empty root err = %v, want ErrSafeRemoveInvalidPath", err)
+	}
+	if err := SafeRemove(root, ""); !errors.Is(err, ErrSafeRemoveInvalidPath) {
+		t.Fatalf("empty path err = %v, want ErrSafeRemoveInvalidPath", err)
+	}
+	if err := SafeRemove(root, "   "); !errors.Is(err, ErrSafeRemoveInvalidPath) {
+		t.Fatalf("whitespace path err = %v, want ErrSafeRemoveInvalidPath", err)
+	}
+}
+
+func TestSafeRemoveRejectsRootItself(t *testing.T) {
+	root := t.TempDir()
+
+	if err := SafeRemove(root, root); !errors.Is(err, ErrSafeRemoveEscapesRoot) {
+		t.Fatalf("root == path err = %v, want ErrSafeRemoveEscapesRoot", err)
+	}
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("root must remain after rejection: %v", err)
+	}
+}
+
+func TestSafeRemoveRejectsPathOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	sibling := filepath.Join(outside, "victim")
+	if err := os.WriteFile(sibling, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("seed sibling: %v", err)
+	}
+
+	if err := SafeRemove(root, sibling); !errors.Is(err, ErrSafeRemoveEscapesRoot) {
+		t.Fatalf("outside path err = %v, want ErrSafeRemoveEscapesRoot", err)
+	}
+	if _, err := os.Stat(sibling); err != nil {
+		t.Fatalf("sibling must remain after rejection: %v", err)
+	}
+}
+
+func TestSafeRemoveRejectsParentTraversal(t *testing.T) {
+	root := t.TempDir()
+	traverse := filepath.Join(root, "..", filepath.Base(t.TempDir()))
+
+	if err := SafeRemove(root, traverse); !errors.Is(err, ErrSafeRemoveEscapesRoot) {
+		t.Fatalf("traversal err = %v, want ErrSafeRemoveEscapesRoot", err)
+	}
+}
+
+func TestSafeRemoveRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	root := t.TempDir()
+	external := t.TempDir()
+	externalChild := filepath.Join(external, "do-not-delete")
+	if err := os.WriteFile(externalChild, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("seed external: %v", err)
+	}
+	link := filepath.Join(root, "evil")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := SafeRemove(root, link); !errors.Is(err, ErrSafeRemoveEscapesRoot) {
+		t.Fatalf("symlinked-out err = %v, want ErrSafeRemoveEscapesRoot", err)
+	}
+	if _, err := os.Stat(externalChild); err != nil {
+		t.Fatalf("external child must remain: %v", err)
+	}
+}
+
+func TestSafeRemoveSucceedsForValidPath(t *testing.T) {
+	root := t.TempDir()
+	taskDir := filepath.Join(root, "tsk-1")
+	if err := os.MkdirAll(filepath.Join(taskDir, "nested"), 0o700); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "nested", "file"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := SafeRemove(root, taskDir); err != nil {
+		t.Fatalf("SafeRemove valid: %v", err)
+	}
+	if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
+		t.Fatalf("task dir still exists, err=%v", err)
+	}
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("root removed unexpectedly: %v", err)
+	}
+}
+
+func TestSafeRemoveIsIdempotentForMissingPath(t *testing.T) {
+	root := t.TempDir()
+	taskDir := filepath.Join(root, "tsk-missing")
+
+	if err := SafeRemove(root, taskDir); err != nil {
+		t.Fatalf("SafeRemove missing path = %v, want nil (idempotent)", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #196. Two cleanup paths called `os.RemoveAll(path)` against a path that came from upstream without re-validation:

- `internal/worker/runtask.go::removeWorkdirAfterHookFailure` (rollback after `after_create` hook failure)
- `internal/worker/reconcile.go::removeWorkspace` (reconcile-driven cleanup)

A future refactor or malformed hook output could feed an empty string, the process cwd, the workspace root, or a symlink that points outside the root, and the worker would recursively delete whatever the path pointed at. Defense-in-depth per SPEC §9.5 Invariants 2 & 3, §15.2.

## Changes

- New `workspace.SafeRemove(root, path)` helper:
  - rejects empty/whitespace root or path (`ErrSafeRemoveInvalidPath`);
  - absolutizes + cleans both, asserts containment via `filepath.Rel` (`ErrSafeRemoveEscapesRoot`);
  - re-validates after `filepath.EvalSymlinks` on **both** root and path (root resolution avoids tripping over platform-symlinked tempdirs like macOS `/var` → `/private/var`);
  - refuses to delete the workspace root itself;
  - idempotent for missing paths, matching existing `os.RemoveAll` semantics.
- `removeWorkdirAfterHookFailure` and `removeWorkspace` now call `workspace.SafeRemove`. The former gains a `workspaceRoot` parameter passed from `RunTask` (already resolved via `EffectiveWorkspaceRoot`).
- `docs/runbooks/workspace-cache.md` adds a \"Cleanup containment invariant\" section pointing future cleanup code at the helper.

## Tests

`internal/workspace/safe_remove_test.go` covers:

- empty / whitespace root or path
- root-equals-path
- sibling-of-root rejection (verifies the external file is untouched)
- `..` parent-traversal rejection
- symlink escape (creates a root-relative symlink to an external dir, verifies external child is untouched)
- valid path removal
- idempotent missing-path

`go test ./...` green.

## Test plan

- [x] `go test ./internal/workspace`
- [x] `go test ./internal/worker`
- [x] `go test ./...`