### PR TITLE
fix(workspace): allow-list env for hook & verify subprocesses (#227)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -245,6 +245,7 @@ func startupReconcileConfigForWorkflow(cfg workflow.Config, trackerClient worker
 		ReconcileTaskID:     "reconcile-startup",
 		BeforeRemoveHook:    hooks.BeforeRemove,
 		HookTimeoutMillis:   hooks.TimeoutMs,
+		HookEnvPassthrough:  hooks.EnvPassthrough,
 		ActiveWorkspaceKeys: worker.ActiveWorkspaceKeysForWorkflow(cfg),
 	}
 }

--- a/docs/design/hook-verify-env-allowlist.md
+++ b/docs/design/hook-verify-env-allowlist.md
@@ -1,0 +1,109 @@
+# Hook & verify subprocess env allowlist (#227)
+
+## Problem
+
+`workspace.runWorkspaceHookCommand` and `workspace.RunVerify` construct
+`exec.CommandContext("sh", "-lc", script)` without setting `cmd.Env`.
+Go's stdlib `exec.Cmd` inherits the parent's environment when `Env` is
+nil, so every hook script and every verify command runs with full
+access to the worker process's environment — `LINEAR_API_KEY`,
+`GITHUB_TOKEN`, `GITEA_TOKEN`, `SSH_AUTH_SOCK`, and any other secret in
+the operator's `.env`.
+
+SPEC §15.4 frames hooks as "fully trusted configuration", but §15.5
+recommends narrowing client-side credentials to the minimum the
+workflow needs. Inheriting the agent's tracker API key into an
+`after_create` hook violates that recommendation: a hook does not need
+the tracker token to do its job, and a malicious or buggy WORKFLOW.md
+could `env > /tmp/dump` and exfiltrate.
+
+## Decision
+
+Hooks and verify commands build their subprocess environment from an
+explicit allowlist rather than inheriting. Operators can opt specific
+additional vars in via two new schema fields:
+
+```yaml
+hooks:
+  env_passthrough: [CARGO_HOME, GIT_AUTHOR_NAME]
+verify:
+  env_passthrough: [CARGO_HOME, NPM_CONFIG_USERCONFIG]
+```
+
+### Baseline allowlist
+
+Both hook and verify subprocesses always inherit, when set:
+
+- `PATH`
+- `HOME`
+- `USER`
+- `LANG`
+- `LC_ALL`
+- `LC_CTYPE`
+- `TZ`
+- `TERM`
+
+These are the minimum needed to run a POSIX shell + locate common
+tooling. Tracker tokens, SSH credentials, and any `*_TOKEN` / `*_KEY`
+secrets are excluded by default.
+
+### Per-config passthrough
+
+`hooks.env_passthrough` and `verify.env_passthrough` are separate
+fields, not a shared one. Hooks and verify run at different lifecycle
+points and typically need different env: hooks may want
+git-identity vars, verify may want build-tool caches (`CARGO_HOME`,
+`GOMODCACHE`). Operators set each list explicitly to the union of vars
+those scripts actually consume.
+
+A name in `env_passthrough` that is not set in the worker's env is
+silently dropped (no error, no empty `NAME=` entry) so passthrough
+lists can include "may or may not be present" vars without spurious
+config-validation noise.
+
+### Why allow-list rather than deny-list
+
+A deny-list (e.g. "drop `*_TOKEN` and `*_KEY`") would let new secrets
+named differently leak through — the model is fail-closed for unknown
+names. The allowlist matches the precedent set by `sandbox.env_allowlist`
+in `WorkspaceConfig` (config.go:307).
+
+## Migration
+
+Existing workflows that depended on a specific env var being inherited
+must add it to `hooks.env_passthrough` or `verify.env_passthrough`.
+Concretely: any hook that read `$LINEAR_API_KEY`, `$GITHUB_TOKEN`,
+`$GITEA_TOKEN`, etc. directly will now see an empty string. The
+workflow loader does not flag this — it's a runtime behavior change
+visible in hook output.
+
+The release note (`docs/security-posture.md`, "What is defended today")
+spells out the new behavior so operators reviewing security can audit
+it.
+
+## Out of scope
+
+- Schema validation for env-var name shape: stdlib does the right thing
+  for malformed names already; the loader does not need a regex.
+- Setting `cmd.Env` for the agent subprocess itself: SPEC §15.3 already
+  treats the agent as a trusted-config-driven actor, and the existing
+  `sandbox.env_allowlist` covers the supported reduction.
+- Allowing per-hook (rather than per-WorkspaceHooks) passthrough:
+  per-hook overrides could come later if real workflows need them;
+  YAGNI for now.
+
+## Implementation
+
+1. Add `EnvPassthrough []string` field to `WorkspaceHooks` and
+   `VerifyConfig` (workflow/config.go).
+2. New `workspace.subprocessEnv(passthrough []string)` helper builds
+   `[]string{"K=V", ...}` from baseline allowlist + passthrough.
+3. `RunWorkspaceHook` grows an `envPassthrough []string` parameter;
+   passes it to `runWorkspaceHookCommand` which sets `cmd.Env`.
+4. `RunVerify` reads `wf.Verify.EnvPassthrough` and sets `cmd.Env` on
+   each verify command.
+5. `internal/worker/runtask.go` plumbs `wcfg.Hooks.EnvPassthrough`
+   into the `RunWorkspaceHook` call.
+6. Tests: hook subprocess env does not contain `LINEAR_API_KEY` by
+   default; verify subprocess env does not contain `LINEAR_API_KEY` by
+   default; explicit passthrough surfaces a named var.

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -127,6 +127,17 @@ The current Go implementation provides these safety controls:
 - operator-visible blocked state for Codex input-required and MCP elicitation
   requests, so non-interactive runs stop and remain claimed instead of burning
   retries silently;
+- allow-listed environment for hook and verify subprocesses: by default
+  hook scripts (`after_create`, `before_run`, `after_run`,
+  `before_remove`) and verify commands run with only a small POSIX
+  baseline env (`PATH`, `HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`,
+  `TZ`, `TERM`). Tracker tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`,
+  `GITEA_TOKEN`), `SSH_AUTH_SOCK`, and any other secret in the worker's
+  `.env` are excluded — a malicious or buggy WORKFLOW.md cannot `env >
+  /tmp/dump` and exfiltrate. Operators opt specific extra vars back in
+  per workflow with `hooks.env_passthrough: [VAR_NAME, ...]` and
+  `verify.env_passthrough: [VAR_NAME, ...]`. See
+  [`docs/design/hook-verify-env-allowlist.md`](design/hook-verify-env-allowlist.md);
 - allow-listed redaction of Codex `turn/failed`, `turn/cancelled`, and failed
   `turn/completed` protocol payloads: returned error strings and
   `runtime_events` JSON payloads carry only the documented

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -37,6 +37,7 @@ type ReconcileConfig struct {
 	ReconcileTaskID     string
 	BeforeRemoveHook    workflow.WorkspaceHook
 	HookTimeoutMillis   int
+	HookEnvPassthrough  []string
 	ActiveWorkspaceKeys func(tracker.Issue) []string
 }
 
@@ -233,7 +234,7 @@ func issueWorkspaceSourceDirs(trackerKind string) []string {
 }
 
 func removeWorkspace(ctx context.Context, cfg ReconcileConfig, taskID, path string, issue tracker.Issue, reason string) (bool, error) {
-	if err := runWorkspaceHook(ctx, cfg.Emitter, taskID, path, workspace.HookBeforeRemove, cfg.BeforeRemoveHook, cfg.HookTimeoutMillis); err != nil {
+	if err := runWorkspaceHook(ctx, cfg.Emitter, taskID, path, workspace.HookBeforeRemove, cfg.BeforeRemoveHook, cfg.HookTimeoutMillis, cfg.HookEnvPassthrough); err != nil {
 		log.Printf("task %s: before_remove hook failed for %s workspace %s: %v", taskID, reason, path, err)
 	}
 	if err := workspace.SafeRemove(cfg.WorkspaceRoot, path); err != nil {

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -148,7 +148,7 @@ func emitHookResults(ctx context.Context, ev EventEmitter, taskID string, result
 	}
 }
 
-func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, workdir string, name workspace.HookName, hook workflow.WorkspaceHook, timeoutMs int) error {
+func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, workdir string, name workspace.HookName, hook workflow.WorkspaceHook, timeoutMs int, envPassthrough []string) error {
 	if len(hook.Commands) == 0 {
 		return nil
 	}
@@ -157,13 +157,13 @@ func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, workdir stri
 		"commands":   len(hook.Commands),
 		"timeout_ms": timeoutMs,
 	})
-	results, err := workspace.RunWorkspaceHook(ctx, workdir, name, hook, timeoutMs)
+	results, err := workspace.RunWorkspaceHook(ctx, workdir, name, hook, timeoutMs, envPassthrough)
 	emitHookResults(ctx, ev, taskID, results)
 	return err
 }
 
-func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, reason string) {
-	if err := runWorkspaceHook(ctx, ev, taskID, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs); err != nil {
+func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, reason string) {
+	if err := runWorkspaceHook(ctx, ev, taskID, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs, envPassthrough); err != nil {
 		log.Printf("task %s: before_remove hook failed after %s hook failure: %v", taskID, reason, err)
 	}
 	if err := workspace.SafeRemove(workspaceRoot, workdir); err != nil {
@@ -209,8 +209,8 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 			return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("resolve workspace base: %w", err)}
 		}
 	}
-	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, hooks.AfterCreate, hooks.TimeoutMs); err != nil {
-		removeWorkdirAfterHookFailure(ctx, ev, t.ID, workspaceRoot, workdir, hooks.BeforeRemove, hooks.TimeoutMs, "after_create")
+	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, hooks.AfterCreate, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
+		removeWorkdirAfterHookFailure(ctx, ev, t.ID, workspaceRoot, workdir, hooks.BeforeRemove, hooks.TimeoutMs, hooks.EnvPassthrough, "after_create")
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
@@ -295,7 +295,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		}
 	}
 
-	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookBeforeRun, hooks.BeforeRun, hooks.TimeoutMs); err != nil {
+	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookBeforeRun, hooks.BeforeRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
 		WriteFailureArtifacts(ctx, workdir, nil, "before_run hook failed: "+ErrSummary(err))
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
@@ -303,14 +303,14 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: workspaceRoot, Prompt: prompt, PhaseTransitionSink: func(from, to task.RunAttemptPhase) {
 		emitTaskPhase(from, to)
 	}}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
-		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs); err != nil {
+		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
 			log.Printf("task %s: after_run hook failed after runner error: %v", t.ID, err)
 		}
 		WriteFailureArtifacts(ctx, workdir, nil, "runner failed: "+ErrSummary(runErr))
 		return &RunTaskError{Cfg: wcfg, Err: runErr}
 	}
 
-	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs); err != nil {
+	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
 		log.Printf("task %s: after_run hook failed: %v", t.ID, err)
 	}
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -119,11 +119,12 @@ type WorkspaceHooks struct {
 }
 
 type HookFieldPresence struct {
-	AfterCreate  bool
-	BeforeRun    bool
-	AfterRun     bool
-	BeforeRemove bool
-	TimeoutMs    bool
+	AfterCreate    bool
+	BeforeRun      bool
+	AfterRun       bool
+	BeforeRemove   bool
+	TimeoutMs      bool
+	EnvPassthrough bool
 }
 
 type WorkspaceHook struct {
@@ -186,6 +187,9 @@ func (c Config) WorkspaceHooks() WorkspaceHooks {
 	}
 	if legacy.TimeoutMs > 0 && !c.hookFields.TimeoutMs {
 		hooks.TimeoutMs = legacy.TimeoutMs
+	}
+	if !c.hookFields.EnvPassthrough && len(legacy.EnvPassthrough) > 0 {
+		hooks.EnvPassthrough = legacy.EnvPassthrough
 	}
 	if hooks.TimeoutMs <= 0 {
 		hooks.TimeoutMs = 60000

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -109,6 +109,13 @@ type WorkspaceHooks struct {
 	AfterRun     WorkspaceHook `yaml:"after_run" json:"after_run"`
 	BeforeRemove WorkspaceHook `yaml:"before_remove" json:"before_remove"`
 	TimeoutMs    int           `yaml:"timeout_ms" json:"timeout_ms"`
+	// EnvPassthrough names environment variables that hook subprocesses
+	// inherit from the worker process. By default hooks see only a small
+	// POSIX-shell baseline (PATH/HOME/USER/LANG/LC_*/TZ/TERM) — tracker
+	// tokens, SSH credentials, and any other secret in the worker's env
+	// are excluded. List names here to opt specific vars back in. See
+	// docs/design/hook-verify-env-allowlist.md (#227).
+	EnvPassthrough []string `yaml:"env_passthrough" json:"env_passthrough"`
 }
 
 type HookFieldPresence struct {
@@ -324,6 +331,12 @@ type VerifyConfig struct {
 	// annotated with a "verification failed (investigation mode)"
 	// banner. Default false: failed verification blocks PR creation.
 	AllowFailure bool `yaml:"allow_failure" json:"allow_failure"`
+	// EnvPassthrough names environment variables that verify subprocesses
+	// inherit from the worker process. Same allowlist semantics as
+	// `hooks.env_passthrough` — typically holds build-tool env like
+	// CARGO_HOME or GOMODCACHE. See
+	// docs/design/hook-verify-env-allowlist.md (#227).
+	EnvPassthrough []string `yaml:"env_passthrough" json:"env_passthrough"`
 }
 
 // SecretScanConfig describes an optional pre-push secret scanner that runs

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -1111,6 +1111,82 @@ prompt body
 	}
 }
 
+func TestWorkspaceHooksHonorsLegacyEnvPassthrough(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+workspace:
+  hooks:
+    env_passthrough:
+      - LEGACY_VAR
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	got := wf.Config.WorkspaceHooks().EnvPassthrough
+	if !reflect.DeepEqual(got, []string{"LEGACY_VAR"}) {
+		t.Fatalf("WorkspaceHooks().EnvPassthrough = %#v, want legacy env_passthrough to surface", got)
+	}
+}
+
+func TestWorkspaceHooksPrefersExplicitTopLevelEnvPassthrough(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  env_passthrough:
+    - TOP_VAR
+workspace:
+  hooks:
+    env_passthrough:
+      - LEGACY_VAR
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	got := wf.Config.WorkspaceHooks().EnvPassthrough
+	if !reflect.DeepEqual(got, []string{"TOP_VAR"}) {
+		t.Fatalf("WorkspaceHooks().EnvPassthrough = %#v, want explicit top-level to win over legacy", got)
+	}
+}
+
+func TestWorkspaceHooksPreservesExplicitEmptyTopLevelEnvPassthrough(t *testing.T) {
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+hooks:
+  env_passthrough: []
+workspace:
+  hooks:
+    env_passthrough:
+      - LEGACY_VAR
+---
+prompt body
+`
+	wf, err := Load(writeTempWorkflow(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := wf.Config.WorkspaceHooks().EnvPassthrough; len(got) != 0 {
+		t.Fatalf("WorkspaceHooks().EnvPassthrough = %#v, want explicit empty top-level to suppress legacy passthrough", got)
+	}
+}
+
 func TestDefaultConfigWorkspaceHooksTimeout(t *testing.T) {
 	if got, want := DefaultConfig().Hooks.TimeoutMs, 60000; got != want {
 		t.Fatalf("DefaultConfig().Hooks.TimeoutMs = %d, want SPEC default %d", got, want)

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -445,11 +445,12 @@ func hasNestedKey(front []byte, path ...string) bool {
 
 func hookFieldPresence(front []byte, path ...string) HookFieldPresence {
 	return HookFieldPresence{
-		AfterCreate:  hasNestedKey(front, append(path, "after_create")...),
-		BeforeRun:    hasNestedKey(front, append(path, "before_run")...),
-		AfterRun:     hasNestedKey(front, append(path, "after_run")...),
-		BeforeRemove: hasNestedKey(front, append(path, "before_remove")...),
-		TimeoutMs:    hasNestedKey(front, append(path, "timeout_ms")...),
+		AfterCreate:    hasNestedKey(front, append(path, "after_create")...),
+		BeforeRun:      hasNestedKey(front, append(path, "before_run")...),
+		AfterRun:       hasNestedKey(front, append(path, "after_run")...),
+		BeforeRemove:   hasNestedKey(front, append(path, "before_remove")...),
+		TimeoutMs:      hasNestedKey(front, append(path, "timeout_ms")...),
+		EnvPassthrough: hasNestedKey(front, append(path, "env_passthrough")...),
 	}
 }
 

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -237,16 +237,21 @@ func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string,
 }
 
 // RunWorkspaceHook executes the configured shell commands for a lifecycle hook
-// in workdir, in order, using the shared workspace hook timeout.
-func RunWorkspaceHook(ctx context.Context, workdir string, name HookName, hook workflow.WorkspaceHook, timeoutMs int) ([]HookResult, error) {
+// in workdir, in order, using the shared workspace hook timeout. Hook
+// subprocesses receive an explicit env built from the workspace baseline
+// allowlist plus envPassthrough — secrets in the worker's environment that
+// are not in either list are dropped. See
+// docs/design/hook-verify-env-allowlist.md (#227).
+func RunWorkspaceHook(ctx context.Context, workdir string, name HookName, hook workflow.WorkspaceHook, timeoutMs int, envPassthrough []string) ([]HookResult, error) {
 	timeoutMs = EffectiveWorkspaceHookTimeoutMs(timeoutMs)
+	env := subprocessEnv(envPassthrough)
 	results := make([]HookResult, 0, len(hook.Commands))
 	for _, raw := range hook.Commands {
 		command := strings.TrimSpace(raw)
 		if command == "" {
 			continue
 		}
-		res := runWorkspaceHookCommand(ctx, workdir, name, command, timeoutMs)
+		res := runWorkspaceHookCommand(ctx, workdir, name, command, timeoutMs, env)
 		results = append(results, res)
 		if res.Err != nil {
 			return results, &HookError{Name: name, Results: results, Err: res.Err}
@@ -276,7 +281,7 @@ func workspaceHookWaitDelay(timeoutMs int) time.Duration {
 	return grace
 }
 
-func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName, command string, timeoutMs int) HookResult {
+func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName, command string, timeoutMs int, env []string) HookResult {
 	start := time.Now()
 	runCtx := ctx
 	cancel := func() {}
@@ -288,6 +293,7 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 
 	cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
 	cmd.Dir = workdir
+	cmd.Env = env
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
@@ -356,6 +362,7 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		runCtx, cancel = context.WithTimeout(ctx, wf.Verify.Timeout)
 		defer cancel()
 	}
+	env := subprocessEnv(wf.Verify.EnvPassthrough)
 
 	var (
 		results  []VerifyResult
@@ -376,6 +383,7 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		buf := &cappedBuffer{Cap: VerifyOutputCap}
 		cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
 		cmd.Dir = workdir
+		cmd.Env = env
 		cmd.Stdout = buf
 		cmd.Stderr = buf
 		// Run each verify command in its own process group so a

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -423,7 +423,7 @@ func TestRunWorkspaceHookStopsOnNonZeroAndCapturesOutput(t *testing.T) {
 		"printf never > should-not-exist",
 	}}
 
-	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0)
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil)
 	if err == nil {
 		t.Fatalf("RunWorkspaceHook should fail on non-zero exit")
 	}
@@ -453,7 +453,7 @@ func TestRunWorkspaceHookTimeoutStopsCommand(t *testing.T) {
 	hook := workflow.WorkspaceHook{Commands: []string{"sleep 2"}}
 
 	start := time.Now()
-	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50)
+	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50, nil)
 	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatalf("RunWorkspaceHook should fail on timeout")
@@ -483,7 +483,7 @@ func TestRunWorkspaceHookTimeoutDoesNotWaitForeverOnEscapedDescendantOutput(t *t
 	hook := workflow.WorkspaceHook{Commands: []string{"setsid sh -c 'while true; do printf x; sleep 1; done' & sleep 2"}}
 
 	start := time.Now()
-	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50)
+	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50, nil)
 	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatalf("RunWorkspaceHook should fail on timeout")
@@ -744,5 +744,120 @@ func mustGit(t *testing.T, dir string, args ...string) {
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func TestRunWorkspaceHookEnvDropsNonAllowlistedSecretsByDefault(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_secret_must_not_leak_xx")
+	t.Setenv("GITHUB_TOKEN", "ghp_secret_must_not_leak_xx")
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{
+		`printf '<%s><%s><%s>' "$LINEAR_API_KEY" "$GITHUB_TOKEN" "$PATH"`,
+	}}
+
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil)
+	if err != nil {
+		t.Fatalf("RunWorkspaceHook: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	out := results[0].Output
+	if strings.Contains(out, "lin_secret_must_not_leak_xx") {
+		t.Fatalf("LINEAR_API_KEY leaked into hook env: %q", out)
+	}
+	if strings.Contains(out, "ghp_secret_must_not_leak_xx") {
+		t.Fatalf("GITHUB_TOKEN leaked into hook env: %q", out)
+	}
+	if !strings.Contains(out, "<><>") {
+		t.Fatalf("hook output = %q, want empty secret slots <><>", out)
+	}
+	// PATH should still flow through the baseline allowlist so the shell
+	// can resolve `sh`, `printf`, etc.
+	if strings.Contains(out, "<><><>") {
+		t.Fatalf("PATH unexpectedly empty in hook env: %q", out)
+	}
+}
+
+func TestRunWorkspaceHookEnvPassthroughLetsNamedVarThrough(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_secret_must_not_leak_yy")
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{
+		`printf '<%s><%s>' "$LINEAR_API_KEY" "$EXTRA_BUILD_VAR"`,
+	}}
+
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, []string{"EXTRA_BUILD_VAR"})
+	if err != nil {
+		t.Fatalf("RunWorkspaceHook: %v", err)
+	}
+	out := results[0].Output
+	if strings.Contains(out, "lin_secret_must_not_leak_yy") {
+		t.Fatalf("LINEAR_API_KEY leaked despite not being in passthrough: %q", out)
+	}
+	if !strings.Contains(out, "let-me-in") {
+		t.Fatalf("EXTRA_BUILD_VAR did not pass through: %q", out)
+	}
+}
+
+func TestRunVerifyEnvDropsNonAllowlistedSecretsByDefault(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_secret_must_not_leak_zz")
+	dir := t.TempDir()
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{Commands: []string{
+		`printf '<%s>' "$LINEAR_API_KEY"`,
+	}}}
+
+	results, err := RunVerify(context.Background(), dir, cfg)
+	if err != nil {
+		t.Fatalf("RunVerify: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if strings.Contains(results[0].Output, "lin_secret_must_not_leak_zz") {
+		t.Fatalf("LINEAR_API_KEY leaked into verify env: %q", results[0].Output)
+	}
+	if results[0].Output != "<>" {
+		t.Fatalf("verify output = %q, want <>", results[0].Output)
+	}
+}
+
+func TestRunVerifyEnvPassthroughLetsNamedVarThrough(t *testing.T) {
+	t.Setenv("CARGO_HOME", "/tmp/cargo-home-227")
+	dir := t.TempDir()
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{
+		Commands:       []string{`printf '<%s>' "$CARGO_HOME"`},
+		EnvPassthrough: []string{"CARGO_HOME"},
+	}}
+
+	results, err := RunVerify(context.Background(), dir, cfg)
+	if err != nil {
+		t.Fatalf("RunVerify: %v", err)
+	}
+	if !strings.Contains(results[0].Output, "/tmp/cargo-home-227") {
+		t.Fatalf("CARGO_HOME did not pass through: %q", results[0].Output)
+	}
+}
+
+func TestSubprocessEnvSkipsUnsetPassthroughNames(t *testing.T) {
+	t.Setenv("DEFINITELY_SET_227", "v1")
+	os.Unsetenv("DEFINITELY_UNSET_227")
+
+	env := subprocessEnv([]string{"DEFINITELY_SET_227", "DEFINITELY_UNSET_227", "DEFINITELY_SET_227"})
+
+	var sawSet, sawUnsetMarker int
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "DEFINITELY_SET_227=") {
+			sawSet++
+		}
+		if strings.HasPrefix(kv, "DEFINITELY_UNSET_227") {
+			sawUnsetMarker++
+		}
+	}
+	if sawSet != 1 {
+		t.Fatalf("DEFINITELY_SET_227 appeared %d times, want 1 (dedup)", sawSet)
+	}
+	if sawUnsetMarker != 0 {
+		t.Fatalf("unset passthrough name leaked into env: %v", env)
 	}
 }

--- a/internal/workspace/subprocess_env.go
+++ b/internal/workspace/subprocess_env.go
@@ -1,0 +1,50 @@
+package workspace
+
+import "os"
+
+// baselineHookEnvAllowlist is the always-inherited env-var allowlist for hook
+// and verify subprocesses. Operators extend it per-workflow via
+// `hooks.env_passthrough` / `verify.env_passthrough`. Tracker tokens, SSH
+// credentials, and any other secret outside this list are excluded by default.
+// See docs/design/hook-verify-env-allowlist.md (#227).
+var baselineHookEnvAllowlist = []string{
+	"PATH",
+	"HOME",
+	"USER",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"TZ",
+	"TERM",
+}
+
+// subprocessEnv builds the `cmd.Env` slice for a hook or verify subprocess.
+// Names from baselineHookEnvAllowlist plus passthrough are inherited from the
+// worker's environment when set. Names that are not set in the worker's env
+// are silently dropped so passthrough lists can include "may or may not be
+// present" vars without spurious config-validation noise. Duplicate names
+// across the two sources are deduplicated so `cmd.Env` does not carry the
+// same `K=V` twice.
+func subprocessEnv(passthrough []string) []string {
+	seen := make(map[string]struct{}, len(baselineHookEnvAllowlist)+len(passthrough))
+	env := make([]string, 0, len(baselineHookEnvAllowlist)+len(passthrough))
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		if v, ok := os.LookupEnv(name); ok {
+			env = append(env, name+"="+v)
+		}
+	}
+	for _, name := range baselineHookEnvAllowlist {
+		add(name)
+	}
+	for _, name := range passthrough {
+		add(name)
+	}
+	return env
+}


### PR DESCRIPTION
## Summary

Closes #227. Hook scripts (\`after_create\`, \`before_run\`, \`after_run\`, \`before_remove\`) and verify commands inherited the worker process's full env via Go's default \`exec.Cmd.Env=nil\` behavior. That gave every workflow script direct access to \`LINEAR_API_KEY\`, \`GITHUB_TOKEN\`, \`GITEA_TOKEN\`, \`SSH_AUTH_SOCK\`, and any other secret in the operator's \`.env\` — a malicious or buggy WORKFLOW.md could \`env > /tmp/dump\` and exfiltrate. SPEC §15.5 recommends narrowing client-side credentials; a hook script doesn't need the tracker token to do its job.

## Changes

- **Helper**: \`workspace.subprocessEnv(passthrough []string)\` builds \`cmd.Env\` from a fixed POSIX baseline (PATH, HOME, USER, LANG, LC_ALL, LC_CTYPE, TZ, TERM) plus opt-in names from \`passthrough\`. Unset names are silently dropped; duplicates deduped.
- **Schema**: \`WorkspaceHooks.EnvPassthrough\` (\`hooks.env_passthrough:\`) and \`VerifyConfig.EnvPassthrough\` (\`verify.env_passthrough:\`). Separate per the design doc — hooks/verify typically need different env (hooks may want git-identity vars; verify may want \`CARGO_HOME\` / \`GOMODCACHE\`).
- **Plumbing**: \`RunWorkspaceHook\` grows an \`envPassthrough []string\` param; \`runWorkspaceHookCommand\` sets \`cmd.Env\` from the resolved env. \`RunVerify\` reads \`wf.Verify.EnvPassthrough\` directly. Worker callers thread \`hooks.EnvPassthrough\` through; \`ReconcileConfig\` gains \`HookEnvPassthrough\` (wired in \`cmd/worker/main.go\`).
- **Docs**: new \`docs/design/hook-verify-env-allowlist.md\` (design + migration note); \`docs/security-posture.md\` "What is defended today" lists the new allowlist.

## Tests

- \`TestRunWorkspaceHookEnvDropsNonAllowlistedSecretsByDefault\`: sets \`LINEAR_API_KEY\`+\`GITHUB_TOKEN\`, runs a hook that prints them, asserts secret bytes absent and slots empty; PATH still passes.
- \`TestRunWorkspaceHookEnvPassthroughLetsNamedVarThrough\`: explicit passthrough surfaces the named var; non-listed secret stays dropped.
- \`TestRunVerifyEnvDropsNonAllowlistedSecretsByDefault\` / \`TestRunVerifyEnvPassthroughLetsNamedVarThrough\`: same coverage for verify.
- \`TestSubprocessEnvSkipsUnsetPassthroughNames\`: dedup + unset-name drop on the helper itself.
- Existing hook/verify tests updated for new signature; full \`go test ./...\` green.

## Migration

Behavioral change: workflows that depended on a secret env var being inherited by a hook or verify command must opt it in via \`hooks.env_passthrough\` / \`verify.env_passthrough\`. The loader does not flag affected workflows — it's a runtime change visible in script output. \`docs/security-posture.md\` and \`docs/design/hook-verify-env-allowlist.md\` document the model.

## Test plan

- [x] \`go test ./internal/workspace\`
- [x] \`go test ./...\`
- [x] \`go vet ./...\`