### PR TITLE
fix(worker): tolerate tracker fetch failures in ReconcileStartup per SPEC §8.6 (#222)

### DIFF
--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -71,13 +71,32 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 
 	activeStates := nonEmptyStates(cfg.ActiveStates)
 	terminalStates := nonEmptyStates(cfg.TerminalStates)
+	// SPEC §8.6 / §11.4: transient tracker outages during boot must log a
+	// warning and continue startup, not abort the worker. An active-fetch
+	// failure is the worst case — without the active list we cannot confirm
+	// any workspace is safe to delete — so we emit reconcile_end with
+	// `status: skipped` and return nil, leaving every workspace intact. A
+	// terminal-fetch failure is non-fatal: active workspaces are still kept,
+	// terminal/unknown removal is skipped because `canRemoveUnknown` stays
+	// false when `terminalIssues` is empty.
 	activeIssues, err := cfg.Tracker.ListIssuesByStates(ctx, activeStates)
 	if err != nil {
-		return fmt.Errorf("fetch active issues: %w", err)
+		log.Printf("startup reconcile: fetch active issues failed: %v (SPEC §8.6: log and continue; no cleanup performed)", err)
+		Emit(ctx, cfg.Emitter, taskID, task.EventReconcileEnd, "startup reconciliation skipped", map[string]any{
+			"status": "skipped",
+			"reason": "active_fetch_failed",
+			"error":  err.Error(),
+		})
+		return nil
 	}
 	terminalIssues, err := cfg.Tracker.ListIssuesByStates(ctx, terminalStates)
+	terminalFetchOK := true
+	var terminalFetchErr error
 	if err != nil {
-		return fmt.Errorf("fetch terminal issues: %w", err)
+		log.Printf("startup reconcile: fetch terminal issues failed: %v (SPEC §8.6: log and continue; terminal cleanup skipped)", err)
+		terminalFetchOK = false
+		terminalFetchErr = err
+		terminalIssues = nil
 	}
 	activeKeysForIssue := cfg.ActiveWorkspaceKeys
 	if activeKeysForIssue == nil {
@@ -101,7 +120,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	if err != nil {
 		return err
 	}
-	if len(workspaces) > 0 && len(activeIssues)+len(terminalIssues) == 0 {
+	if terminalFetchOK && len(workspaces) > 0 && len(activeIssues)+len(terminalIssues) == 0 {
 		return fmt.Errorf("tracker returned no active or terminal issues; refusing to remove %d existing workspaces", len(workspaces))
 	}
 	var removed, kept int
@@ -160,12 +179,22 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 		}
 	}
 
-	Emit(ctx, cfg.Emitter, taskID, task.EventReconcileEnd, "startup reconciliation finished", map[string]any{
+	endPayload := map[string]any{
 		"active_issues":   len(activeIssues),
 		"terminal_issues": len(terminalIssues),
 		"kept":            kept,
 		"removed":         removed,
-	})
+	}
+	if !terminalFetchOK {
+		endPayload["status"] = "partial"
+		endPayload["reason"] = "terminal_fetch_failed"
+		if terminalFetchErr != nil {
+			endPayload["error"] = terminalFetchErr.Error()
+		}
+	} else {
+		endPayload["status"] = "ok"
+	}
+	Emit(ctx, cfg.Emitter, taskID, task.EventReconcileEnd, "startup reconciliation finished", endPayload)
 	return nil
 }
 

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -168,6 +168,127 @@ func TestReconcileStartupRefusesToRemoveWhenTrackerReturnsNoIssues(t *testing.T)
 	}
 }
 
+// TestReconcileStartupTolerantOfActiveFetchFailure pins SPEC §8.6 / §11.4:
+// a transient tracker outage during boot must NOT abort worker startup. The
+// active-fetch failure is the worst case — without it we cannot confirm any
+// workspace is safe to delete — so the helper logs, emits reconcile_end with
+// skipped status, and returns nil, leaving every workspace intact.
+func TestReconcileStartupTolerantOfActiveFetchFailure(t *testing.T) {
+	root := t.TempDir()
+	activePath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1")
+	terminalPath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-2")
+	for _, path := range []string{activePath, terminalPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	emitter := &fakeEmitter{}
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:   root,
+		ActiveStates:    []string{"AI Ready"},
+		TerminalStates:  []string{"Done"},
+		Tracker:         &fakeReconcileTrackerByCall{errByCall: []error{errors.New("tracker outage"), nil}},
+		Emitter:         emitter,
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup must not fail on tracker outage: %v", err)
+	}
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("active workspace must remain when active fetch fails: %v", err)
+	}
+	if _, err := os.Stat(terminalPath); err != nil {
+		t.Fatalf("any workspace must remain when active fetch fails (safety): %v", err)
+	}
+	endEvents := emitter.byKind(task.EventReconcileEnd)
+	if len(endEvents) != 1 {
+		t.Fatalf("reconcile_end events = %d, want 1", len(endEvents))
+	}
+	payload, ok := endEvents[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("reconcile_end payload = %T, want map", endEvents[0].Payload)
+	}
+	if status, _ := payload["status"].(string); status != "skipped" {
+		t.Fatalf("reconcile_end status = %q, want \"skipped\"", status)
+	}
+	if reason, _ := payload["reason"].(string); reason != "active_fetch_failed" {
+		t.Fatalf("reconcile_end reason = %q, want \"active_fetch_failed\"", reason)
+	}
+}
+
+// TestReconcileStartupTolerantOfTerminalFetchFailure: terminal-fetch failure
+// is non-fatal. Active workspaces are still kept; terminal/unknown removal is
+// skipped because terminalKeys is empty and canRemoveUnknown stays false.
+func TestReconcileStartupTolerantOfTerminalFetchFailure(t *testing.T) {
+	root := t.TempDir()
+	activePath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1")
+	maybeTerminalPath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-2")
+	for _, path := range []string{activePath, maybeTerminalPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	emitter := &fakeEmitter{}
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:  root,
+		ActiveStates:   []string{"In Progress"},
+		TerminalStates: []string{"Done"},
+		Tracker: &fakeReconcileTrackerByCall{
+			issuesByCall: [][]tracker.Issue{{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}, nil},
+			errByCall:    []error{nil, errors.New("tracker outage")},
+		},
+		Emitter:         emitter,
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup must not fail on terminal-fetch outage: %v", err)
+	}
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("active workspace must remain: %v", err)
+	}
+	if _, err := os.Stat(maybeTerminalPath); err != nil {
+		t.Fatalf("workspace must remain when terminal fetch failed (no confirmation it is safe to delete): %v", err)
+	}
+	endEvents := emitter.byKind(task.EventReconcileEnd)
+	if len(endEvents) != 1 {
+		t.Fatalf("reconcile_end events = %d, want 1", len(endEvents))
+	}
+	payload, _ := endEvents[0].Payload.(map[string]any)
+	if status, _ := payload["status"].(string); status != "partial" {
+		t.Fatalf("reconcile_end status = %q, want \"partial\"", status)
+	}
+	if reason, _ := payload["reason"].(string); reason != "terminal_fetch_failed" {
+		t.Fatalf("reconcile_end reason = %q, want \"terminal_fetch_failed\"", reason)
+	}
+}
+
+// TestReconcileStartupTolerantOfBothFetchFailures: both fail. Treated as the
+// active-fetch failure path (most conservative), nothing deleted.
+func TestReconcileStartupTolerantOfBothFetchFailures(t *testing.T) {
+	root := t.TempDir()
+	wsPath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-X")
+	if err := os.MkdirAll(wsPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:   root,
+		ActiveStates:    []string{"In Progress"},
+		TerminalStates:  []string{"Done"},
+		Tracker:         &fakeReconcileTrackerByCall{errByCall: []error{errors.New("active outage"), errors.New("terminal outage")}},
+		Emitter:         &fakeEmitter{},
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup must not fail on dual-fetch outage: %v", err)
+	}
+	if _, err := os.Stat(wsPath); err != nil {
+		t.Fatalf("workspace must remain when both fetches fail: %v", err)
+	}
+}
+
 func TestReconcileStartupMatchesCurrentSanitizedWorkspaceLayout(t *testing.T) {
 	root := t.TempDir()
 	activePath := filepath.Join(root, "acme", "repo", "linear-issue", "lin-1-needs-fix")
@@ -367,20 +488,6 @@ func TestReworkWorkspaceKeyPrefixesMatchCanonicalAndLegacyOffsetSuffixes(t *test
 	}
 }
 
-func TestReconcileStartupReturnsTrackerError(t *testing.T) {
-	root := t.TempDir()
-	if err := ReconcileStartup(context.Background(), ReconcileConfig{
-		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready"},
-		TerminalStates:  []string{"Done"},
-		Tracker:         fakeReconcileTracker{err: errors.New("tracker down")},
-		Emitter:         &fakeEmitter{},
-		ReconcileTaskID: "reconcile-startup",
-	}); err == nil {
-		t.Fatal("ReconcileStartup error = nil, want tracker error")
-	}
-}
-
 func TestReconcileStartupRunsBeforeRemoveHookAndStillRemovesOnFailure(t *testing.T) {
 	root := t.TempDir()
 	terminalPath := filepath.Join(root, "acme", "repo", "linear-issue", "LIN-1")
@@ -551,22 +658,6 @@ func TestReconcileStartupKeepsUnknownWorkspaceWhenTrackerHasActiveIssuesOnly(t *
 	}
 	if _, err := os.Stat(unknownPath); err != nil {
 		t.Fatalf("unknown workspace should remain when terminal query is empty: %v", err)
-	}
-}
-
-func TestReconcileStartupReturnsTerminalFetchError(t *testing.T) {
-	root := t.TempDir()
-	fake := &fakeReconcileTrackerByCall{errByCall: []error{nil, errors.New("terminal fetch failed")}}
-	err := ReconcileStartup(context.Background(), ReconcileConfig{
-		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready"},
-		TerminalStates:  []string{"Done"},
-		Tracker:         fake,
-		Emitter:         &fakeEmitter{},
-		ReconcileTaskID: "reconcile-startup",
-	})
-	if err == nil || !strings.Contains(err.Error(), "fetch terminal issues") {
-		t.Fatalf("ReconcileStartup error = %v, want terminal fetch context", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #222. SPEC §8.6 and §11.4 require startup reconcile to log + continue on tracker fetch failure, not abort the worker. The Go implementation propagated both \`ListIssuesByStates\` errors out of \`ReconcileStartup\`; \`cmd/worker/main.go\` treated that as a fatal startup error, so a transient tracker outage during boot prevented the worker from coming up at all — even though SPEC says the worker should boot, log the warning, and start polling normally.

## Changes

Tolerate the two tracker fetches inside \`ReconcileStartup\`:

- **Active fetch failure** is the worst case — without the active list we cannot confirm any workspace is safe to delete. Log warning, emit \`reconcile_end\` with \`{status: \"skipped\", reason: \"active_fetch_failed\", error: ...}\`, return nil. Every workspace stays intact; the next poll tick retries.
- **Terminal fetch failure** is non-fatal. Active workspaces still kept; terminal/unknown removal skipped (\`terminalKeys\` empty, \`canRemoveUnknown\` stays false). \`reconcile_end\` carries \`{status: \"partial\", reason: \"terminal_fetch_failed\", error: ...}\`.
- The existing safety-net error (\"tracker returned no active or terminal issues; refusing to remove N existing workspaces\") only fires when terminal fetch **succeeded** — otherwise an empty \`terminalIssues\` is an artifact of failure, not a tracker response.

\`cmd/worker/main.go\` is unchanged: other ReconcileStartup error paths (empty workspace root, missing tracker, missing states, \`os.ReadDir\` failure, safety-net trip with \`terminalFetchOK==true\`) still represent legitimate misconfiguration and should still abort startup. Only the tracker-fetch tolerance lives inside \`ReconcileStartup\`, which is what SPEC §8.6 actually mandates.

## Tests

New (replace the two now-obsolete tests that pinned the old return-error behavior):

- \`TestReconcileStartupTolerantOfActiveFetchFailure\` — active fetch fails → returns nil; both active and terminal workspaces remain; \`reconcile_end\` payload has \`status=skipped reason=active_fetch_failed\`.
- \`TestReconcileStartupTolerantOfTerminalFetchFailure\` — terminal fetch fails → returns nil; active and unknown workspaces remain (no terminal-key confirmation, so nothing deleted); \`reconcile_end\` payload has \`status=partial reason=terminal_fetch_failed\`.
- \`TestReconcileStartupTolerantOfBothFetchFailures\` — both fail → treated as active-failure path; nothing deleted.

Removed:
- \`TestReconcileStartupReturnsTrackerError\` and \`TestReconcileStartupReturnsTerminalFetchError\` — they asserted exactly the bug this issue describes.

Full \`go test ./...\` green.

## Test plan

- [x] \`go test ./internal/worker\`
- [x] \`go test ./...\`