### PR TITLE
fix(gitea): populate Labels + BlockedBy on normalized Issue (#210)

### DIFF
--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -199,6 +200,13 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 				State:       state,
 				CreatedAt:   createdAt,
 				UpdatedAt:   updatedAt,
+				Labels:      extractGiteaLabels(issue.Labels),
+				BlockedBy:   c.buildBlockedBy(ctx, issue.Body),
+				// Priority: Gitea has no native priority field — see
+				// dependsOnRegexp comment / SPEC §4.1.1 note. Left at the zero
+				// value; dispatch sort treats every Gitea issue as equal priority
+				// and falls back to created_at. Operators can opt in to
+				// label-driven priority in a follow-up.
 			})
 		}
 		if !hasNext && len(batch) < listIssuesPageSize {
@@ -322,6 +330,70 @@ func hasNextPage(linkHeaders []string) bool {
 		}
 	}
 	return false
+}
+
+// dependsOnRegexp matches the documented Gitea cross-reference syntax
+// `Depends on #N` (case-insensitive, anywhere in body) per SPEC §11.3.
+// Gitea has no native priority field, so `Priority` on the normalized Issue
+// stays zero for this tracker; the dispatch sort falls back to created_at
+// per §8.2. Operators who want label-driven priority can wire it as a
+// follow-up.
+var dependsOnRegexp = regexp.MustCompile(`(?i)depends on #(\d+)`)
+
+// extractGiteaLabels returns lowercased label names per SPEC §11.3
+// normalization. The Gitea label payload (`Label.Name`) is already deserialized
+// by IssueStateFromLabels; we just project it onto the cross-tracker Issue
+// shape.
+func extractGiteaLabels(labels []Label) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		name := strings.TrimSpace(l.Name)
+		if name == "" {
+			continue
+		}
+		out = append(out, strings.ToLower(name))
+	}
+	return out
+}
+
+// buildBlockedBy parses `Depends on #N` references from issue.Body and looks
+// up each blocker's current workflow state via a follow-up Gitea fetch so the
+// §8.2 Todo blocker rule can compare against the blocker's State. Lookup
+// failures are silently skipped (best-effort): a missing or deleted blocker
+// drops out of the list rather than aborting candidate enumeration. Lookups
+// are O(distinct refs) per source issue; this is acceptable for typical
+// workflows (0–3 blockers per issue).
+func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string) []tracker.BlockerRef {
+	matches := dependsOnRegexp.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := map[int]struct{}{}
+	var out []tracker.BlockerRef
+	for _, m := range matches {
+		n, err := strconv.Atoi(m[1])
+		if err != nil || n <= 0 {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		issue, found, err := c.getIssueByNumber(ctx, n)
+		if err != nil || !found {
+			continue
+		}
+		state, _ := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
+		out = append(out, tracker.BlockerRef{
+			ID:         giteaIssueID(issue),
+			Identifier: fmt.Sprintf("#%d", issue.Number),
+			State:      state,
+		})
+	}
+	return out
 }
 
 func giteaIssueID(issue Issue) string {

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -405,11 +405,11 @@ func TestTrackerClientListIssuesByStatesNormalizesLabelsAndBlockedBy(t *testing.
 		case "/api/v1/repos/owner/repo/issues":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode([]Issue{{
-				ID:      101,
-				Number:  1,
-				Title:   "first",
-				Body:    "Needs the blocker resolved.\n\nDepends on #42\nAlso Depends on #43 and depends on #42 again.",
-				HTMLURL: "https://gitea.local/o/r/issues/1",
+				ID:        101,
+				Number:    1,
+				Title:     "first",
+				Body:      "Needs the blocker resolved.\n\nDepends on #42\nAlso Depends on #43 and depends on #42 again.",
+				HTMLURL:   "https://gitea.local/o/r/issues/1",
 				CreatedAt: "2026-05-16T23:59:00Z",
 				UpdatedAt: "2026-05-17T00:00:00Z",
 				Labels: []Label{

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -394,6 +394,144 @@ func TestTrackerClientListIssuesByStatesContinuesWhenServerCapsPageBelowRequeste
 	}
 }
 
+// TestTrackerClientListIssuesByStatesNormalizesLabelsAndBlockedBy pins the
+// SPEC §4.1.1 / §11.3 Issue normalization for the Gitea tracker: labels are
+// lowercased and `Depends on #N` body references become BlockerRef entries
+// populated by a follow-up issue lookup (so the §8.2 Todo blocker rule has the
+// State it needs).
+func TestTrackerClientListIssuesByStatesNormalizesLabelsAndBlockedBy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]Issue{{
+				ID:      101,
+				Number:  1,
+				Title:   "first",
+				Body:    "Needs the blocker resolved.\n\nDepends on #42\nAlso Depends on #43 and depends on #42 again.",
+				HTMLURL: "https://gitea.local/o/r/issues/1",
+				CreatedAt: "2026-05-16T23:59:00Z",
+				UpdatedAt: "2026-05-17T00:00:00Z",
+				Labels: []Label{
+					{Name: "Aiops/Todo"},
+					{Name: "Priority/P1"},
+					{Name: "  "},
+					{Name: "Type/Bug"},
+				},
+			}})
+		case "/api/v1/repos/owner/repo/issues/42":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID:     142,
+				Number: 42,
+				Title:  "blocker still open",
+				Labels: []Label{{Name: "aiops/in-progress"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/43":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID:     143,
+				Number: 43,
+				Title:  "blocker done",
+				Labels: []Label{{Name: "aiops/done"}},
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{
+		APIKey:       "secret",
+		ActiveStates: []string{"AI Ready"},
+	}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want 1", len(issues))
+	}
+	got := issues[0]
+	wantLabels := []string{"aiops/todo", "priority/p1", "type/bug"}
+	if !slices.Equal(got.Labels, wantLabels) {
+		t.Fatalf("Labels = %#v, want %#v (lowercased, empty entries dropped)", got.Labels, wantLabels)
+	}
+	if len(got.BlockedBy) != 2 {
+		t.Fatalf("BlockedBy len = %d, want 2 (deduped #42 + #43); got=%#v", len(got.BlockedBy), got.BlockedBy)
+	}
+	wantBlockers := map[string]string{"#42": "In Progress", "#43": "Done"}
+	for _, b := range got.BlockedBy {
+		want, ok := wantBlockers[b.Identifier]
+		if !ok {
+			t.Fatalf("unexpected blocker %#v", b)
+		}
+		if b.State != want {
+			t.Fatalf("blocker %s state = %q, want %q", b.Identifier, b.State, want)
+		}
+		if b.ID == "" {
+			t.Fatalf("blocker %s ID empty; want canonical Gitea ID", b.Identifier)
+		}
+	}
+	if got.Priority != 0 {
+		t.Fatalf("Priority = %d, want 0 (Gitea has no native priority; left at zero per dependsOnRegexp comment)", got.Priority)
+	}
+}
+
+// TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure: a missing
+// blocker (404 or transient failure) silently drops out of BlockedBy rather
+// than aborting candidate enumeration. Best-effort semantics per #210.
+func TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]Issue{{
+				ID:        101,
+				Number:    1,
+				Title:     "first",
+				Body:      "Depends on #999 (deleted)\nDepends on #43",
+				HTMLURL:   "https://gitea.local/o/r/issues/1",
+				CreatedAt: "2026-05-16T23:59:00Z",
+				UpdatedAt: "2026-05-17T00:00:00Z",
+				Labels:    []Label{{Name: "aiops/todo"}},
+			}})
+		case "/api/v1/repos/owner/repo/issues/999":
+			http.NotFound(w, r)
+		case "/api/v1/repos/owner/repo/issues/43":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID:     143,
+				Number: 43,
+				Title:  "still exists",
+				Labels: []Label{{Name: "aiops/done"}},
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{
+		APIKey:       "secret",
+		ActiveStates: []string{"AI Ready"},
+	}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want 1", len(issues))
+	}
+	if len(issues[0].BlockedBy) != 1 || issues[0].BlockedBy[0].Identifier != "#43" {
+		t.Fatalf("BlockedBy = %#v, want only #43 (missing #999 silently dropped)", issues[0].BlockedBy)
+	}
+}
+
 func serverURL(r *http.Request) string {
 	return "http://" + r.Host
 }


### PR DESCRIPTION
## Summary

Closes #210. The Gitea adapter populated only 7 of the SPEC §4.1.1 normalized Issue fields; Labels / BlockedBy were silently empty. Consequences:

- **§8.2 Todo blocker rule** never fired on Gitea — \`BlockedBy\` was always nil, so dispatch happened even when \`Depends on #N\` pointed at an open issue.
- **Workflow templates** that iterate \`issue.labels\` saw an empty list for Gitea-routed issues; label-driven branch naming etc. degraded.
- **§8.2 priority sort** always tied at 0 for Gitea (acceptable — no native priority — but undocumented).

## Changes

- \`extractGiteaLabels\` lowercases \`Label.Name\` entries per SPEC §11.3, drops blank ones. Wired into the only Issue construction site.
- \`dependsOnRegexp = (?i)depends on #(\\d+)\` parses \`issue.Body\` for Gitea's documented cross-reference syntax. \`buildBlockedBy\` walks unique refs, calls \`getIssueByNumber\` for each, emits a \`BlockerRef\` with canonical ID + \`#N\` Identifier + resolved workflow State (via \`IssueStateFromLabels\`). Best-effort: 404 / transient errors silently drop the ref.
- Priority decision documented inline: Gitea has no native priority field, so the field stays zero. Operators who want label-driven priority can wire \`priority/*\` in a follow-up; this PR does not.

## Tests

- \`TestTrackerClientListIssuesByStatesNormalizesLabelsAndBlockedBy\` — mixed-case labels (including a whitespace-only entry); body repeats \`Depends on #42\` + \`Depends on #43\`. Asserts Labels lowercased + deduped, BlockedBy has 2 entries with correct Identifier + State + non-empty canonical ID, Priority stays 0.
- \`TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure\` — blocker #999 returns 404; #43 resolves. Asserts only #43 surfaces.

Full \`go test ./...\` green (one runner-package flake from parallel timeout — re-ran clean).

## Test plan

- [x] \`go test ./internal/gitea\`
- [x] \`go test ./...\`