### PR TITLE
feat(workflow): agent.policy_violation_budget knob (#230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ If the canonical file does not exist, the worker proceeds with built-in defaults
 | `agent.max_turns` | `20` clean turns per issue before continuation stops |
 | `agent.max_retry_attempts` | `1` failure retry after the first run (`0` disables) |
 | `agent.max_timeout_retries` | `1` timeout retry after the first timeout (`0` disables) |
+| `agent.policy_violation_budget` | `2` policy-violation feedback entries per issue before non-retryable fail (`0` disables suppression) |
 | `pr.draft` | `false` |
 | `pr.labels` | `[ai-generated, needs-review]` |
 | `server.port` | `4000` (`-1` disables the HTTP state server) |

--- a/internal/worker/policy_feedback.go
+++ b/internal/worker/policy_feedback.go
@@ -15,8 +15,6 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
 )
 
-const policyViolationStopAfter = 2
-
 type policyViolationFeedback struct {
 	IssueID    string             `json:"issue_id"`
 	Identifier string             `json:"identifier,omitempty"`

--- a/internal/worker/policy_feedback.go
+++ b/internal/worker/policy_feedback.go
@@ -140,6 +140,20 @@ func appendPolicyViolationFeedback(prompt string, feedback *policyViolationFeedb
 		b.WriteString("\n")
 	}
 	b.WriteString("- Before continuing, run a cheap diff-size check such as `git diff --shortstat` and `git diff --name-only` against the base branch.\n")
-	b.WriteString("- Next repeated policy violation will stop without another retry.\n")
+	// The terminality hint must match the actual runtime budget: with budget=0
+	// (suppression disabled) there is no "next attempt stops" backstop, and
+	// when the current count is still below budget-1 the next violation
+	// only consumes one more slot. Steering the agent with a false
+	// terminality assumption (the original hardcoded sentence) coaxed it
+	// into unnecessary behavior — see #230 review.
+	budget := cfg.Agent.PolicyViolationBudgetValue()
+	switch {
+	case budget == 0:
+		b.WriteString("- agent.policy_violation_budget = 0: the worker will keep retrying repeated policy violations; aim for the smallest correct diff but do not panic over a single retry.\n")
+	case feedback.Count+1 >= budget:
+		b.WriteString("- Next repeated policy violation will stop without another retry.\n")
+	default:
+		b.WriteString(fmt.Sprintf("- Policy violation budget %d/%d already consumed; the run stops non-retryably once the count reaches %d.\n", feedback.Count, budget, budget))
+	}
 	return b.String()
 }

--- a/internal/worker/policy_feedback_prompt_test.go
+++ b/internal/worker/policy_feedback_prompt_test.go
@@ -1,0 +1,61 @@
+package worker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// TestAppendPolicyViolationFeedbackTerminalityMatchesBudget pins #230 review:
+// the prompt augmentation must describe the actual runtime stop condition for
+// the configured `agent.policy_violation_budget`. The hardcoded "next
+// violation stops" sentence is correct only when the next attempt would hit
+// the cap; a budget of 0 has no stop condition; a higher budget leaves
+// headroom that should be communicated to the agent.
+func TestAppendPolicyViolationFeedbackTerminalityMatchesBudget(t *testing.T) {
+	feedback := &policyViolationFeedback{Count: 1}
+
+	cases := []struct {
+		name        string
+		budget      *int
+		wantContain string
+		wantAbsent  []string
+	}{
+		{
+			name:        "default budget 2, count 1: next attempt would hit cap",
+			budget:      nil,
+			wantContain: "Next repeated policy violation will stop",
+			wantAbsent:  []string{"budget = 0", "budget 1/"},
+		},
+		{
+			name:        "explicit budget 5, count 1: 3 more attempts remain",
+			budget:      ptrInt(5),
+			wantContain: "Policy violation budget 1/5 already consumed",
+			wantAbsent:  []string{"Next repeated policy violation will stop", "budget = 0"},
+		},
+		{
+			name:        "budget 0 disables suppression entirely",
+			budget:      ptrInt(0),
+			wantContain: "agent.policy_violation_budget = 0",
+			wantAbsent:  []string{"Next repeated policy violation will stop", "budget 1/"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := workflow.Config{Agent: workflow.AgentConfig{PolicyViolationBudget: tc.budget}}
+			out := appendPolicyViolationFeedback("base prompt", feedback, cfg)
+			if !strings.Contains(out, tc.wantContain) {
+				t.Fatalf("prompt missing %q\n---\n%s", tc.wantContain, out)
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Fatalf("prompt unexpectedly contains %q\n---\n%s", absent, out)
+				}
+			}
+		})
+	}
+}
+
+func ptrInt(v int) *int { return &v }

--- a/internal/worker/print_config.go
+++ b/internal/worker/print_config.go
@@ -54,13 +54,14 @@ type configView struct {
 // The remaining fields keep their original JSON tags so external
 // consumers see the same shape.
 type agentConfigView struct {
-	Default             string `json:"default"`
-	MaxConcurrentAgents int    `json:"max_concurrent_agents"`
-	MaxTurns            int    `json:"max_turns"`
-	MaxRetryBackoffMs   int    `json:"max_retry_backoff_ms"`
-	MaxRetryAttempts    *int   `json:"max_retry_attempts"`
-	Timeout             string `json:"timeout"`
-	MaxTimeoutRetries   *int   `json:"max_timeout_retries"`
+	Default               string `json:"default"`
+	MaxConcurrentAgents   int    `json:"max_concurrent_agents"`
+	MaxTurns              int    `json:"max_turns"`
+	MaxRetryBackoffMs     int    `json:"max_retry_backoff_ms"`
+	MaxRetryAttempts      *int   `json:"max_retry_attempts"`
+	Timeout               string `json:"timeout"`
+	MaxTimeoutRetries     *int   `json:"max_timeout_retries"`
+	PolicyViolationBudget int    `json:"policy_violation_budget"`
 }
 
 func newConfigView(cfg workflow.Config) configView {
@@ -69,13 +70,14 @@ func newConfigView(cfg workflow.Config) configView {
 		Tracker:   cfg.Tracker,
 		Workspace: cfg.Workspace,
 		Agent: agentConfigView{
-			Default:             cfg.Agent.Default,
-			MaxConcurrentAgents: cfg.Agent.MaxConcurrentAgents,
-			MaxTurns:            cfg.Agent.MaxTurns,
-			MaxRetryBackoffMs:   cfg.Agent.MaxRetryBackoffMs,
-			MaxRetryAttempts:    cfg.Agent.MaxRetryAttempts,
-			Timeout:             cfg.Agent.Timeout.String(),
-			MaxTimeoutRetries:   cfg.Agent.MaxTimeoutRetries,
+			Default:               cfg.Agent.Default,
+			MaxConcurrentAgents:   cfg.Agent.MaxConcurrentAgents,
+			MaxTurns:              cfg.Agent.MaxTurns,
+			MaxRetryBackoffMs:     cfg.Agent.MaxRetryBackoffMs,
+			MaxRetryAttempts:      cfg.Agent.MaxRetryAttempts,
+			Timeout:               cfg.Agent.Timeout.String(),
+			MaxTimeoutRetries:     cfg.Agent.MaxTimeoutRetries,
+			PolicyViolationBudget: cfg.Agent.PolicyViolationBudgetValue(),
 		},
 		Codex:   cfg.Codex,
 		Claude:  cfg.Claude,

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -253,12 +253,14 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		WriteFailureArtifacts(ctx, workdir, nil, "policy feedback read failed: "+ErrSummary(feedbackErr))
 		return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("read policy violation feedback: %w", feedbackErr), NonRetryable: true}
 	} else if policyFeedback != nil {
+		policyBudget := wcfg.Agent.PolicyViolationBudgetValue()
 		Emit(ctx, ev, t.ID, task.EventPolicyFeedbackLoaded, "loaded prior policy violation feedback", map[string]any{
 			"path":            policyFeedbackPath,
 			"violation_count": policyFeedback.Count,
 			"summary":         policyFeedback.Summary,
+			"budget":          policyBudget,
 		})
-		if policyFeedback.Count >= policyViolationStopAfter {
+		if policyBudget > 0 && policyFeedback.Count >= policyBudget {
 			WriteFailureArtifacts(ctx, workdir, nil, "policy violation retry budget already exhausted: "+policyFeedback.Summary)
 			return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("policy violation retry budget already exhausted after %d attempts: %s", policyFeedback.Count, policyFeedback.Summary), NonRetryable: true}
 		}
@@ -320,10 +322,11 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		if feedbackErr != nil {
 			willRetry = false
 		}
-		if feedback != nil && feedback.Count >= policyViolationStopAfter {
+		policyBudget := wcfg.Agent.PolicyViolationBudgetValue()
+		if feedback != nil && policyBudget > 0 && feedback.Count >= policyBudget {
 			willRetry = false
 		}
-		recordPolicyViolation(ctx, ev, t.ID, err, feedback, feedbackPath, willRetry, feedbackErr)
+		recordPolicyViolation(ctx, ev, t.ID, err, feedback, feedbackPath, willRetry, feedbackErr, policyBudget)
 		WriteFailureArtifacts(ctx, workdir, nil, "policy check failed: "+ErrSummary(err))
 		if feedbackErr != nil {
 			return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("write policy violation feedback: %w; original policy error: %v", feedbackErr, err), NonRetryable: true}
@@ -712,8 +715,11 @@ func runSecretScanWith(ctx context.Context, ev EventEmitter, taskID string, work
 }
 
 // recordPolicyViolation writes a structured `policy_violation` task event
-// before the worker fails the task.
-func recordPolicyViolation(ctx context.Context, ev EventEmitter, taskID string, err error, feedback *policyViolationFeedback, feedbackPath string, willRetry bool, feedbackErr error) {
+// before the worker fails the task. budget is the configured
+// `agent.policy_violation_budget` (resolved via PolicyViolationBudgetValue),
+// emitted alongside the running count so dashboards can render "violation N
+// of M (final attempt)".
+func recordPolicyViolation(ctx context.Context, ev EventEmitter, taskID string, err error, feedback *policyViolationFeedback, feedbackPath string, willRetry bool, feedbackErr error, budget int) {
 	if ev == nil {
 		return
 	}
@@ -722,6 +728,7 @@ func recordPolicyViolation(ctx context.Context, ev EventEmitter, taskID string, 
 		payload := map[string]any{
 			"violations": perr.Violations,
 			"will_retry": willRetry,
+			"budget":     budget,
 		}
 		if feedback != nil {
 			payload["violation_count"] = feedback.Count

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -436,6 +436,100 @@ func TestRunTaskPolicyViolationFeedbackStopsSecondViolation(t *testing.T) {
 	}
 }
 
+// TestRunTaskPolicyViolationBudgetRaiseDefersEarlyBailOut pins the new
+// `agent.policy_violation_budget` knob from #230: raising the budget from
+// the default of 2 to 3 must let the third policy-violating attempt run
+// (rather than short-circuit before runner) and only short-circuit on the
+// fourth. The runner-start emit on attempt 3 is the operator-visible
+// difference vs. the default.
+func TestRunTaskPolicyViolationBudgetRaiseDefersEarlyBailOut(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+	cfg := workerCfgForIntegration(t)
+	budget := 3
+	cfg.Workflow.Config.Agent.PolicyViolationBudget = &budget
+	cfg.Workflow.Config.Agent.Default = "mock-source-change"
+	cfg.Workflow.Config.Policy.DenyPaths = []string{"mock-source-change.txt"}
+	tk.Model = "mock-source-change"
+
+	// Drive two retryable violations to seed the feedback file.
+	for attempt := 1; attempt <= 2; attempt++ {
+		tk.Attempts = attempt
+		ev := &fakeEmitter{}
+		out := worker.RunTaskForTest(context.Background(), ev, tk, cfg)
+		if out == nil {
+			t.Fatalf("attempt %d succeeded, want policy-violation failure", attempt)
+		}
+		if out.NonRetryable {
+			t.Fatalf("attempt %d non-retryable with budget=3, want still retryable", attempt)
+		}
+	}
+
+	// Attempt 3 with default budget=2 would early-bail before runner_start.
+	// With budget=3 the runner must execute, the third violation lands, and
+	// the budget is then exhausted (non-retryable, count==budget).
+	tk.Attempts = 3
+	ev := &fakeEmitter{}
+	third := worker.RunTaskForTest(context.Background(), ev, tk, cfg)
+	if third == nil {
+		t.Fatal("third attempt succeeded, want policy-violation failure")
+	}
+	if !third.NonRetryable {
+		t.Fatalf("third attempt with budget=3 should exhaust budget non-retryably; got %+v", third)
+	}
+	if got := ev.byKind(task.EventRunnerStart); len(got) == 0 {
+		t.Fatal("third attempt did not emit runner_start; raised budget did not defer the early bail-out")
+	}
+	violations := ev.byKind(task.EventPolicyViolation)
+	if len(violations) != 1 {
+		t.Fatalf("policy_violation events = %d, want 1", len(violations))
+	}
+	if got := payloadField(t, violations[0].Payload, "budget"); got != float64(3) {
+		t.Fatalf("policy_violation budget = %v, want 3", got)
+	}
+	if got := payloadField(t, violations[0].Payload, "violation_count"); got != float64(3) {
+		t.Fatalf("policy_violation violation_count = %v, want 3", got)
+	}
+}
+
+// TestRunTaskPolicyViolationBudgetZeroDisablesSuppression: explicit budget=0
+// disables policy-violation-based suppression entirely; even the 10th attempt
+// is retryable.
+func TestRunTaskPolicyViolationBudgetZeroDisablesSuppression(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+	cfg := workerCfgForIntegration(t)
+	budget := 0
+	cfg.Workflow.Config.Agent.PolicyViolationBudget = &budget
+	cfg.Workflow.Config.Agent.Default = "mock-source-change"
+	cfg.Workflow.Config.Policy.DenyPaths = []string{"mock-source-change.txt"}
+	tk.Model = "mock-source-change"
+
+	tk.Attempts = 1
+	ev := &fakeEmitter{}
+	first := worker.RunTaskForTest(context.Background(), ev, tk, cfg)
+	if first == nil || first.NonRetryable {
+		t.Fatalf("first attempt: out=%v NonRetryable=%v, want retryable failure", first, first != nil && first.NonRetryable)
+	}
+
+	tk.Attempts = 2
+	ev = &fakeEmitter{}
+	second := worker.RunTaskForTest(context.Background(), ev, tk, cfg)
+	if second == nil || second.NonRetryable {
+		t.Fatalf("second attempt with budget=0 should still be retryable; got %+v", second)
+	}
+	violations := ev.byKind(task.EventPolicyViolation)
+	if len(violations) != 1 {
+		t.Fatalf("policy_violation events = %d, want 1", len(violations))
+	}
+	if got := payloadField(t, violations[0].Payload, "budget"); got != float64(0) {
+		t.Fatalf("policy_violation budget = %v, want 0", got)
+	}
+	if got := payloadField(t, violations[0].Payload, "will_retry"); got != true {
+		t.Fatalf("policy_violation will_retry = %v, want true (budget=0 disables suppression)", got)
+	}
+}
+
 func TestRunTaskPolicyViolationFeedbackReadErrorIsNonRetryable(t *testing.T) {
 	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
 	t.Setenv("REPO_URL", cloneURL)

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -222,6 +222,16 @@ type AgentConfig struct {
 	// of 1) from "explicitly set to 0" (no retry). Read via
 	// MaxTimeoutRetriesValue() rather than dereferencing directly.
 	MaxTimeoutRetries *int `yaml:"max_timeout_retries" json:"max_timeout_retries"`
+	// PolicyViolationBudget bounds how many policy-violation feedback
+	// entries an issue can accumulate before the worker fails the run
+	// non-retryably. The default of 2 preserves the historical hardcoded
+	// behavior; explicit 0 disables policy-violation-based suppression so
+	// aggressive workflows can iterate until verify converges or another
+	// non-retryable error fires. Read via PolicyViolationBudgetValue()
+	// rather than dereferencing directly. Negative values are clamped to 0
+	// (no policy-violation suppression). See #230 for the operator-visible
+	// budget motivation.
+	PolicyViolationBudget *int `yaml:"policy_violation_budget" json:"policy_violation_budget"`
 }
 
 // MaxTimeoutRetriesValue returns the effective runner-timeout retry
@@ -251,6 +261,24 @@ func (a AgentConfig) MaxRetryAttemptsValue() int {
 		return 0
 	}
 	return *a.MaxRetryAttempts
+}
+
+// DefaultPolicyViolationBudget is the historical hardcoded value preserved
+// when `agent.policy_violation_budget` is absent from WORKFLOW.md.
+const DefaultPolicyViolationBudget = 2
+
+// PolicyViolationBudgetValue returns the effective per-issue policy-violation
+// budget. A nil pointer (field omitted from YAML) yields
+// DefaultPolicyViolationBudget; an explicit value — including 0 — is honored
+// as configured. Negative values clamp to 0 (no suppression).
+func (a AgentConfig) PolicyViolationBudgetValue() int {
+	if a.PolicyViolationBudget == nil {
+		return DefaultPolicyViolationBudget
+	}
+	if *a.PolicyViolationBudget < 0 {
+		return 0
+	}
+	return *a.PolicyViolationBudget
 }
 
 type CommandConfig struct {


### PR DESCRIPTION
## Summary

Closes #230. Replace the hardcoded \`policyViolationStopAfter = 2\` constant in \`internal/worker/policy_feedback.go\` with the schema-configurable \`agent.policy_violation_budget\`. The default of 2 preserves historical behavior; explicit 0 disables policy-violation-based suppression entirely so aggressive workflows can iterate until verify converges or another non-retryable error fires.

The previous constant was invisible to operators (\`worker --print-config\` didn't surface it, no doc mentioned it, the event payload carried \`violation_count\` but not the cap). \"Why did my task stop after 2 retries?\" had no answer in docs.

## Changes

- **Schema**: \`AgentConfig.PolicyViolationBudget *int\` + \`PolicyViolationBudgetValue()\` follow the same nil-means-default convention as \`MaxRetryAttempts\` / \`MaxTimeoutRetries\`.
- **Runtime**: \`runtask.go\` reads the budget at both bailout sites and threads it into \`recordPolicyViolation\`. Short-circuit only fires when \`budget > 0 && count >= budget\`, so \`budget=0\` drops through to a retryable failure.
- **Event payload**: \`policy_feedback_loaded\` and \`policy_violation\` events now carry \`budget\`, giving dashboards a one-shot pull of the current cap (e.g. render \"violation 2 of 2 (final attempt)\").
- **--print-config**: \`agentConfigView\` publishes the resolved value.
- **README**: \"Workflow defaults\" table mentions the new knob.

## Tests

- \`TestRunTaskPolicyViolationBudgetRaiseDefersEarlyBailOut\`: budget=3 defers the early bail-out to attempt 4. Attempt 3 reaches the runner (\`runner_start\` emit), violates again, and exhausts the budget non-retryably. Payload carries \`budget=3 violation_count=3\`.
- \`TestRunTaskPolicyViolationBudgetZeroDisablesSuppression\`: both attempts stay retryable; payload carries \`budget=0 will_retry=true\`.
- Existing default-budget tests continue to pass.
- Full \`go test ./...\` green.

## Test plan

- [x] \`go test ./internal/worker -run TestRunTaskPolicyViolationBudget\`
- [x] \`go test ./...\`