### PR TITLE
fix(workflow+tracker): rename tracker.base_url → endpoint per SPEC §5.3.1; Linear honors override (#242)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1163,7 +1163,7 @@ func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error)
 		}
 		return gitea.NewTrackerClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name), nil
 	case "github":
-		baseURL := cfg.Tracker.BaseURL
+		baseURL := cfg.Tracker.Endpoint
 		if baseURL == "" {
 			baseURL = env("GITHUB_API_BASE_URL", "https://api.github.com")
 		}

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1303,7 +1303,7 @@ func TestTrackerClientForWorkflowBuildsGitHubClient(t *testing.T) {
 	cfg.Repo.Name = "aiops-platform"
 	cfg.Tracker.Kind = "github"
 	cfg.Tracker.APIKey = "github-token"
-	cfg.Tracker.BaseURL = "https://api.github.test"
+	cfg.Tracker.Endpoint = "https://api.github.test"
 
 	client, err := trackerClientForWorkflow(cfg)
 	if err != nil {

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -318,7 +318,7 @@ config field is empty).
 | --- | --- | --- |
 | `linear` | `tracker.api_key: $LINEAR_API_KEY` (or any `$VAR`) | n/a |
 | `gitea`  | `tracker.api_key: $GITEA_TOKEN`  (or any `$VAR`) | `GITEA_BASE_URL` when `tracker.project_slug` is empty |
-| `github` | `tracker.api_key: $GITHUB_TOKEN` (or any `$VAR`) | `GITHUB_API_BASE_URL` when `tracker.base_url` is empty |
+| `github` | `tracker.api_key: $GITHUB_TOKEN` (or any `$VAR`) | `GITHUB_API_BASE_URL` when `tracker.endpoint` is empty |
 
 When the failure surfaces depends on how `tracker.api_key` is encoded
 in `WORKFLOW.md`:

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -64,7 +64,7 @@ type githubPullRequestSummary struct {
 
 func NewGitHubClient(cfg workflow.TrackerConfig, baseURL, owner, repo string) *GitHubClient {
 	if strings.TrimSpace(baseURL) == "" {
-		baseURL = cfg.BaseURL
+		baseURL = cfg.Endpoint
 	}
 	if strings.TrimSpace(baseURL) == "" {
 		baseURL = "https://api.github.com"

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -101,11 +101,17 @@ type LinearClient struct {
 
 const defaultLinearRequestTimeout = 30 * time.Second
 
+// DefaultLinearEndpoint is the Linear GraphQL endpoint per SPEC §5.3.1.
+const DefaultLinearEndpoint = "https://api.linear.app/graphql"
+
 func NewLinearClient(cfg workflow.TrackerConfig) *LinearClient {
-	base := "https://api.linear.app/graphql"
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	if endpoint == "" {
+		endpoint = DefaultLinearEndpoint
+	}
 	return &LinearClient{
 		APIKey:         cfg.APIKey,
-		BaseURL:        base,
+		BaseURL:        endpoint,
 		Config:         cfg,
 		HTTP:           http.DefaultClient,
 		RequestTimeout: defaultLinearRequestTimeout,

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -776,6 +776,48 @@ func TestNewLinearClient_DefaultsRequestTimeoutTo30s(t *testing.T) {
 	}
 }
 
+// TestNewLinearClientHonorsEndpointOverride pins SPEC §5.3.1 (#242): an
+// explicit `tracker.endpoint` configures the Linear client's BaseURL.
+// Workflows pointing at a httptest mock, a regional Linear endpoint, or a
+// proxy can express the override in WORKFLOW.md without code changes.
+func TestNewLinearClientHonorsEndpointOverride(t *testing.T) {
+	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k", Endpoint: "https://linear.example/graphql"})
+	if client.BaseURL != "https://linear.example/graphql" {
+		t.Fatalf("BaseURL = %q, want override from tracker.endpoint", client.BaseURL)
+	}
+}
+
+func TestNewLinearClientDefaultsToSpecEndpoint(t *testing.T) {
+	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k"})
+	if client.BaseURL != DefaultLinearEndpoint {
+		t.Fatalf("BaseURL = %q, want DefaultLinearEndpoint when override absent", client.BaseURL)
+	}
+}
+
+// TestNewLinearClientEndpointActuallyUsedForRequests verifies the override
+// reaches the wire — `cmd.Process.Pid`-style "the field exists" tests caught
+// the pre-#242 bug where BaseURL was set but immediately overwritten, so this
+// test issues a real HTTP request through the override.
+func TestNewLinearClientEndpointActuallyUsedForRequests(t *testing.T) {
+	var observed string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/custom-graphql"
+	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k", ProjectSlug: "aiops", Endpoint: endpoint, ActiveStates: []string{"AI Ready"}})
+	client.HTTP = srv.Client()
+	if _, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"}); err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if observed != "/custom-graphql" {
+		t.Fatalf("request path = %q, want /custom-graphql (Endpoint override reached the wire)", observed)
+	}
+}
+
 func TestListIssuesByStatesEmptyShortCircuitsWithoutAPICall(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -72,8 +72,8 @@ type TrackerConfig struct {
 	// deprecated alias. Reads/writes outside the loader should use
 	// Endpoint; this field exists so legacy WORKFLOW.md files keep
 	// parsing while the loader emits a deprecation log.
-	BaseURL string `yaml:"base_url" json:"base_url,omitempty"`
-	TeamKey string `yaml:"team_key" json:"team_key"`
+	BaseURL        string   `yaml:"base_url" json:"base_url,omitempty"`
+	TeamKey        string   `yaml:"team_key" json:"team_key"`
 	ProjectSlug    string   `yaml:"project_slug" json:"project_slug"`
 	ActiveStates   []string `yaml:"active_states" json:"active_states"`
 	TerminalStates []string `yaml:"terminal_states" json:"terminal_states"`

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -60,10 +60,20 @@ type ServiceTrackerRouteConfig struct {
 }
 
 type TrackerConfig struct {
-	Kind           string   `yaml:"kind" json:"kind"`
-	APIKey         string   `yaml:"api_key" json:"api_key"`
-	BaseURL        string   `yaml:"base_url" json:"base_url"`
-	TeamKey        string   `yaml:"team_key" json:"team_key"`
+	Kind   string `yaml:"kind" json:"kind"`
+	APIKey string `yaml:"api_key" json:"api_key"`
+	// Endpoint is the tracker base/GraphQL URL (SPEC §5.3.1). For
+	// `kind: linear` the default is `https://api.linear.app/graphql`;
+	// GitHub Enterprise / Gitea installs name their REST root here.
+	// `tracker.base_url` is accepted as a deprecated alias and migrated
+	// by the loader (see migrateTrackerEndpoint in loader.go).
+	Endpoint string `yaml:"endpoint" json:"endpoint"`
+	// BaseURL is the pre-#242 field name kept for one release as a
+	// deprecated alias. Reads/writes outside the loader should use
+	// Endpoint; this field exists so legacy WORKFLOW.md files keep
+	// parsing while the loader emits a deprecation log.
+	BaseURL string `yaml:"base_url" json:"base_url,omitempty"`
+	TeamKey string `yaml:"team_key" json:"team_key"`
 	ProjectSlug    string   `yaml:"project_slug" json:"project_slug"`
 	ActiveStates   []string `yaml:"active_states" json:"active_states"`
 	TerminalStates []string `yaml:"terminal_states" json:"terminal_states"`

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -1698,7 +1698,7 @@ repo:
 tracker:
   kind: github
   api_key: $AIOPS_TEST_GITHUB_TOKEN
-  base_url: https://api.github.test
+  endpoint: https://api.github.test
   active_states:
     - priority:p2
   terminal_states:
@@ -1719,8 +1719,8 @@ prompt
 	if wf.Config.Tracker.APIKey != "github-token" {
 		t.Fatalf("tracker.api_key did not expand from env: %q", wf.Config.Tracker.APIKey)
 	}
-	if wf.Config.Tracker.BaseURL != "https://api.github.test" {
-		t.Fatalf("tracker.base_url = %q", wf.Config.Tracker.BaseURL)
+	if wf.Config.Tracker.Endpoint != "https://api.github.test" {
+		t.Fatalf("tracker.endpoint = %q", wf.Config.Tracker.Endpoint)
 	}
 }
 

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -165,6 +165,7 @@ func Load(path string) (*Workflow, error) {
 			cfg.hooksTimeoutDefaulted = false
 		}
 		migratePollingInterval(frontBytes, &cfg)
+		migrateTrackerEndpoint(frontBytes, &cfg)
 	}
 	var rawStateCaps map[string]int
 	if hasFrontMatter && len(cfg.Agent.MaxConcurrentAgentsByState) > 0 {
@@ -207,6 +208,25 @@ func validateFrontMatterRoot(path string, frontBytes []byte) error {
 		return &Error{Category: CategoryWorkflowFrontMatterNotMap, Path: path, Message: "workflow front matter must decode to a map"}
 	}
 	return nil
+}
+
+// migrateTrackerEndpoint reconciles the SPEC §5.3.1 `tracker.endpoint`
+// field with the pre-#242 `tracker.base_url` alias: prefer endpoint when
+// set, fall back to base_url with a deprecation log, and finally clear
+// BaseURL on the resolved config so downstream code reads only Endpoint.
+func migrateTrackerEndpoint(frontBytes []byte, cfg *Config) {
+	endpointPresent := hasNestedKey(frontBytes, "tracker", "endpoint")
+	legacyPresent := hasNestedKey(frontBytes, "tracker", "base_url")
+	switch {
+	case endpointPresent:
+		if legacyPresent {
+			log.Printf("workflow: tracker.base_url is deprecated and ignored because tracker.endpoint is set")
+		}
+	case legacyPresent:
+		log.Printf("workflow: tracker.base_url is deprecated; use tracker.endpoint (SPEC §5.3.1)")
+		cfg.Tracker.Endpoint = cfg.Tracker.BaseURL
+	}
+	cfg.Tracker.BaseURL = ""
 }
 
 func migratePollingInterval(frontBytes []byte, cfg *Config) {
@@ -567,7 +587,7 @@ func expandConfigForWorkflowPath(workflowPath string, cfg *Config) error {
 	if cfg.Tracker.APIKey, err = resolveExplicitEnv("tracker.api_key", cfg.Tracker.APIKey); err != nil {
 		return err
 	}
-	if cfg.Tracker.BaseURL, err = resolveExplicitEnv("tracker.base_url", cfg.Tracker.BaseURL); err != nil {
+	if cfg.Tracker.Endpoint, err = resolveExplicitEnv("tracker.endpoint", cfg.Tracker.Endpoint); err != nil {
 		return err
 	}
 	if err := expandRepoConfig("repo.clone_url", &cfg.Repo); err != nil {

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -138,6 +138,56 @@ Prompt body
 	}
 }
 
+// TestLoadMigratesLegacyTrackerBaseURL pins the #242 deprecation alias:
+// `tracker.base_url` in a legacy WORKFLOW.md still parses, surfaces on the
+// renamed `Tracker.Endpoint` field, and clears the legacy `BaseURL` field
+// so downstream code reads only one place.
+func TestLoadMigratesLegacyTrackerBaseURL(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  base_url: https://tracker.example/legacy-base-url
+---
+prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Tracker.Endpoint; got != "https://tracker.example/legacy-base-url" {
+		t.Fatalf("Tracker.Endpoint = %q, want legacy base_url migrated to endpoint", got)
+	}
+	if wf.Config.Tracker.BaseURL != "" {
+		t.Fatalf("Tracker.BaseURL = %q, want cleared after migration", wf.Config.Tracker.BaseURL)
+	}
+}
+
+// TestLoadPrefersEndpointWhenBothFieldsSet: explicit `tracker.endpoint` wins
+// over the deprecated `tracker.base_url`.
+func TestLoadPrefersEndpointWhenBothFieldsSet(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  endpoint: https://tracker.example/canonical
+  base_url: https://tracker.example/legacy
+---
+prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Tracker.Endpoint; got != "https://tracker.example/canonical" {
+		t.Fatalf("Tracker.Endpoint = %q, want canonical endpoint to win over base_url", got)
+	}
+}
+
 func TestLoadResolvesExactEnvironmentReferences(t *testing.T) {
 	workspaceRoot := filepath.Join(t.TempDir(), "workspaces")
 	credentialPath := filepath.Join(t.TempDir(), "token")
@@ -156,7 +206,7 @@ repo:
   clone_url: $AIOPS_TEST_REPO_URL
 tracker:
   api_key: ${AIOPS_TEST_TRACKER_KEY}
-  base_url: $AIOPS_TEST_TRACKER_BASE_URL
+  endpoint: $AIOPS_TEST_TRACKER_BASE_URL
 workspace:
   root: $AIOPS_TEST_WORKSPACE_ROOT
 codex:
@@ -180,8 +230,8 @@ Prompt body
 	if got := wf.Config.Tracker.APIKey; got != "tracker-secret" {
 		t.Fatalf("tracker.api_key = %q", got)
 	}
-	if got := wf.Config.Tracker.BaseURL; got != "https://tracker.example/api" {
-		t.Fatalf("tracker.base_url = %q", got)
+	if got := wf.Config.Tracker.Endpoint; got != "https://tracker.example/api" {
+		t.Fatalf("tracker.endpoint = %q", got)
 	}
 	if got := wf.Config.Workspace.Root; got != workspaceRoot {
 		t.Fatalf("workspace.root = %q, want %q", got, workspaceRoot)
@@ -207,7 +257,7 @@ repo:
   name: r
   clone_url: https://gitea.example/$USER/aiops
 tracker:
-  base_url: https://tracker.example/$USER/api
+  endpoint: https://tracker.example/$USER/api
 workspace:
   root: .aiops-$USER
 codex:
@@ -231,8 +281,8 @@ Prompt body
 	if got := wf.Config.Repo.CloneURL; got != "https://gitea.example/$USER/aiops" {
 		t.Fatalf("repo.clone_url = %q", got)
 	}
-	if got := wf.Config.Tracker.BaseURL; got != "https://tracker.example/$USER/api" {
-		t.Fatalf("tracker.base_url = %q", got)
+	if got := wf.Config.Tracker.Endpoint; got != "https://tracker.example/$USER/api" {
+		t.Fatalf("tracker.endpoint = %q", got)
 	}
 	wantRoot := filepath.Join(dir, ".aiops-$USER")
 	if got := wf.Config.Workspace.Root; got != wantRoot {
@@ -314,7 +364,7 @@ repo:
   clone_url: $aiops_test_repo_url
 tracker:
   api_key: ${linear_token}
-  base_url: $Mixed_Case_Url
+  endpoint: $Mixed_Case_Url
 ---
 Prompt body
 `)
@@ -329,8 +379,8 @@ Prompt body
 	if got := wf.Config.Tracker.APIKey; got != "linear-secret" {
 		t.Fatalf("tracker.api_key = %q, lowercase ${} env not resolved", got)
 	}
-	if got := wf.Config.Tracker.BaseURL; got != "https://tracker.example/mixed" {
-		t.Fatalf("tracker.base_url = %q, mixed-case env not resolved", got)
+	if got := wf.Config.Tracker.Endpoint; got != "https://tracker.example/mixed" {
+		t.Fatalf("tracker.endpoint = %q, mixed-case env not resolved", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #242. Two related gaps:

1. **Name mismatch.** SPEC §5.3.1 names the field \`tracker.endpoint\`; the Go schema used \`tracker.base_url\`. A SPEC-literal WORKFLOW.md gets silently ignored.
2. **Override never plumbed.** \`NewLinearClient\` hardcoded \`BaseURL = "https://api.linear.app/graphql"\` regardless of \`cfg.BaseURL\`. Workflows targeting a httptest mock, a regional endpoint, or a proxy had no way to redirect without code edits.

## Changes

- **Schema**: \`TrackerConfig.Endpoint\` (\`yaml:\"endpoint\"\`) is the canonical SPEC-named field. \`BaseURL\` stays for one release as a deprecated parse alias.
- **Loader**: \`migrateTrackerEndpoint\` prefers \`endpoint:\`, falls back to \`base_url:\` with a deprecation log, then clears \`BaseURL\` so downstream reads exactly one field. Mirrors the existing \`migratePollingInterval\` pattern.
- **Linear client**: \`NewLinearClient\` reads \`cfg.Endpoint\`, falling back to new \`DefaultLinearEndpoint\` constant. Override actually reaches the wire.
- **GitHub client + cmd/worker**: switch consumer reads from \`cfg.BaseURL\` to \`cfg.Endpoint\`.
- **Env resolution**: loader's \`resolveExplicitEnv\` key renames from \`tracker.base_url\` to \`tracker.endpoint\`.
- **Docs**: \`docs/runbooks/local-dev.md\` env-fallback table updated.

## Tests

- \`TestLoadMigratesLegacyTrackerBaseURL\`: legacy \`base_url:\` surfaces on \`Tracker.Endpoint\`; \`BaseURL\` cleared.
- \`TestLoadPrefersEndpointWhenBothFieldsSet\`: explicit \`endpoint:\` wins.
- \`TestNewLinearClientHonorsEndpointOverride\`: client BaseURL reflects override.
- \`TestNewLinearClientDefaultsToSpecEndpoint\`: absent override → SPEC default.
- \`TestNewLinearClientEndpointActuallyUsedForRequests\`: drives a real HTTP request through a httptest server and asserts the URL path includes \`/custom-graphql\` — proves the override reaches the wire, catching the original dead-config bug.
- Existing tests/fixtures (loader, config, main_test) ported to \`Endpoint\`; YAML fixtures use \`endpoint:\` directly.
- Full \`go test ./...\` green.

## Test plan

- [x] \`go test ./internal/tracker -run TestNewLinearClient\`
- [x] \`go test ./internal/workflow -run TestLoadMigratesLegacyTrackerBaseURL\`
- [x] \`go test ./...\`