### PR TITLE
fix(orchestrator): fold active-session elapsed time into seconds_running per SPEC §13.5 (#253)

### DIFF
--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -172,6 +172,28 @@ the shape here without updating the handler — or vice versa — fails the buil
 IDs in those sets; for lifetime totals across FIFO eviction use the `_total`
 counters.
 
+### `codex_totals.seconds_running` semantics
+
+`seconds_running` is a **live aggregate** per SPEC §13.5 Runtime
+accounting (#253): the snapshot folds the elapsed time of every
+currently-running entry into the cumulative ended-session counter. The
+math uses `generated_at` so all running entries are measured against
+the same instant. Dashboards polling `/api/v1/state` every few seconds
+see a smoothly increasing counter while a long Codex turn works,
+rather than a flat number followed by a sudden jump on session end.
+
+Two consequences for dashboard authors:
+
+- Do **not** treat consecutive snapshots' `seconds_running` as a
+  delta-encoded stream: snapshot N+1 already includes the elapsed
+  time between the two snapshots for any still-running entries.
+  Subtracting snapshot N from snapshot N+1 would double-count.
+- A run that ends between two snapshots adds its elapsed time
+  exactly once. The finished entry is removed from the running set
+  before the ended-session counter increments, so the live aggregate
+  for that entry stops contributing at the same instant the
+  cumulative counter starts including it.
+
 ### Top-level metadata fields
 
 - `generated_at` — RFC3339 timestamp the handler stamped when materializing the snapshot.

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -688,8 +688,27 @@ type RetryView struct {
 // order is unspecified in Go, but downstream consumers (the §13.7 HTTP
 // handler, CLI status) sort by IssueID before display.
 func (s *OrchestratorState) Snapshot() StateView {
+	now := time.Now().UTC()
+	// SPEC §13.5 Runtime accounting: report runtime as a live aggregate at
+	// snapshot/render time. CodexTotals.SecondsRunning increments only on
+	// session end (AddSeconds in the worker-exit finalization path); without
+	// the per-snapshot fold a dashboard polling /api/v1/state would see a
+	// flat counter while a long run is in flight and a sudden jump on exit.
+	// Add elapsed time for each currently-running entry, measured against the
+	// snapshot's GeneratedAt so all rows share one instant. The ended-session
+	// counter and the live aggregate cannot double-count because a finished
+	// run is removed from s.Running before AddSeconds runs for it.
+	totals := s.CodexTotals
+	for _, r := range s.Running {
+		if r.StartedAt.IsZero() {
+			continue
+		}
+		if elapsed := now.Sub(r.StartedAt); elapsed > 0 {
+			totals.SecondsRunning += elapsed.Seconds()
+		}
+	}
 	view := StateView{
-		GeneratedAt:                time.Now().UTC(),
+		GeneratedAt:                now,
 		PollIntervalMs:             s.PollIntervalMs,
 		MaxConcurrentAgents:        s.MaxConcurrentAgents,
 		MaxConcurrentAgentsByState: copyStateConcurrencyLimits(s.MaxConcurrentAgentsByState),
@@ -701,7 +720,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 		FailedSuppressedCount:      len(s.Failed),
 		CumulativeCompletedTotal:   s.CumulativeCompletedTotal,
 		CumulativeFailedTotal:      s.CumulativeFailedTotal,
-		CodexTotals:                s.CodexTotals,
+		CodexTotals:                totals,
 		CodexRateLimits:            copyRateLimitSnapshot(s.CodexRateLimits),
 	}
 	for id, r := range s.Running {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -688,16 +688,25 @@ type RetryView struct {
 // order is unspecified in Go, but downstream consumers (the §13.7 HTTP
 // handler, CLI status) sort by IssueID before display.
 func (s *OrchestratorState) Snapshot() StateView {
-	now := time.Now().UTC()
+	// Keep the live-aggregate math on the monotonic clock: `time.Now()`
+	// carries a monotonic component that `time.Time.Sub` uses for elapsed
+	// calculations, but `time.Time.UTC()` strips it (Go stdlib documents
+	// the loss explicitly). RunningEntry.StartedAt is set from `time.Now()`
+	// in spawn (with monotonic reading intact), so subtracting two
+	// monotonic-bearing times keeps the elapsed reading invariant under
+	// wall-clock NTP steps. `GeneratedAt` is the operator-visible
+	// timestamp and needs UTC; do the strip only when populating it.
+	now := time.Now()
 	// SPEC §13.5 Runtime accounting: report runtime as a live aggregate at
 	// snapshot/render time. CodexTotals.SecondsRunning increments only on
 	// session end (AddSeconds in the worker-exit finalization path); without
 	// the per-snapshot fold a dashboard polling /api/v1/state would see a
 	// flat counter while a long run is in flight and a sudden jump on exit.
-	// Add elapsed time for each currently-running entry, measured against the
-	// snapshot's GeneratedAt so all rows share one instant. The ended-session
-	// counter and the live aggregate cannot double-count because a finished
-	// run is removed from s.Running before AddSeconds runs for it.
+	// Add elapsed time for each currently-running entry, measured against
+	// the same monotonic `now` so all rows share one instant. The
+	// ended-session counter and the live aggregate cannot double-count
+	// because a finished run is removed from s.Running before AddSeconds
+	// runs for it.
 	totals := s.CodexTotals
 	for _, r := range s.Running {
 		if r.StartedAt.IsZero() {
@@ -708,7 +717,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 		}
 	}
 	view := StateView{
-		GeneratedAt:                now,
+		GeneratedAt:                now.UTC(),
 		PollIntervalMs:             s.PollIntervalMs,
 		MaxConcurrentAgents:        s.MaxConcurrentAgents,
 		MaxConcurrentAgentsByState: copyStateConcurrencyLimits(s.MaxConcurrentAgentsByState),

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -476,8 +476,13 @@ func TestSnapshot_ShapeMatches13_3(t *testing.T) {
 	if len(view.Completed) != 1 || view.Completed[0] != id3 {
 		t.Errorf("Completed view wrong: %+v", view.Completed)
 	}
-	if view.CodexTotals.SecondsRunning != 0.5 {
-		t.Errorf("CodexTotals not surfaced: %+v", view.CodexTotals)
+	// SecondsRunning is now a live aggregate per SPEC §13.5 (#253):
+	// 0.5s from the ended iss3 run plus the live elapsed time for the
+	// still-running iss1 entry measured against GeneratedAt. The lower
+	// bound stays 0.5 (ended-session contribution); upper bound is
+	// generous to absorb scheduler jitter on slow CI hosts.
+	if view.CodexTotals.SecondsRunning < 0.5 || view.CodexTotals.SecondsRunning > 5 {
+		t.Errorf("CodexTotals.SecondsRunning = %v, want [0.5, 5] (ended-session 0.5 + live-aggregate for one running entry)", view.CodexTotals.SecondsRunning)
 	}
 
 	// Mutating the returned slice must not affect future snapshots.
@@ -761,5 +766,66 @@ func TestNewOrchestratorState_DefaultsApplyMaxRecentAtConstruction(t *testing.T)
 	}
 	if state.MaxRecentFailed != DefaultMaxRecentFailed {
 		t.Fatalf("MaxRecentFailed = %d, want %d", state.MaxRecentFailed, DefaultMaxRecentFailed)
+	}
+}
+
+// TestSnapshotFoldsLiveSessionRuntimeIntoCodexTotals pins SPEC §13.5 (#253):
+// a snapshot taken mid-run reports a live aggregate that includes the elapsed
+// time for the still-running entry, not just the ended-session counter.
+func TestSnapshotFoldsLiveSessionRuntimeIntoCodexTotals(t *testing.T) {
+	st := NewOrchestratorState(60_000, 4)
+	iss := issue("ENG-LIVE")
+	entry := runningEntry(t, iss)
+	// Force StartedAt 10s in the past so the live aggregate is unambiguous
+	// (no scheduler-jitter window to reason about).
+	entry.StartedAt = time.Now().UTC().Add(-10 * time.Second)
+	st.BeginDispatch(IssueID(iss.ID), entry)
+
+	view := st.Snapshot()
+	if got := view.CodexTotals.SecondsRunning; got < 9.5 || got > 12 {
+		t.Fatalf("CodexTotals.SecondsRunning = %v, want ~10 (live aggregate for active session)", got)
+	}
+}
+
+// TestSnapshotLiveAggregateDoesNotDoubleCountAfterFinish pins the
+// no-double-count invariant: a run that ends between two snapshots adds its
+// elapsed time exactly once. The ended-session counter (incremented in
+// AddSeconds) and the snapshot's live aggregate cannot stack because a
+// finished run is removed from s.Running before AddSeconds runs for it.
+func TestSnapshotLiveAggregateDoesNotDoubleCountAfterFinish(t *testing.T) {
+	st := NewOrchestratorState(60_000, 4)
+	iss := issue("ENG-FINISH")
+	id := IssueID(iss.ID)
+	entry := runningEntry(t, iss)
+	entry.StartedAt = time.Now().UTC().Add(-5 * time.Second)
+	st.BeginDispatch(id, entry)
+
+	st.FinishRunSucceeded(id, entry, 5*time.Second)
+
+	view := st.Snapshot()
+	// Only the ended-session contribution should remain — the live
+	// aggregate for an iss that no longer appears in s.Running must not
+	// double the 5s.
+	if got := view.CodexTotals.SecondsRunning; got < 4.5 || got > 5.5 {
+		t.Fatalf("CodexTotals.SecondsRunning = %v, want ~5 (ended-session only, no double-count)", got)
+	}
+	if len(view.Running) != 0 {
+		t.Fatalf("view.Running len = %d after FinishRunSucceeded, want 0", len(view.Running))
+	}
+}
+
+// TestSnapshotLiveAggregateIgnoresZeroStartedAt: an entry without a
+// StartedAt (e.g. a freshly-injected test fixture) contributes 0 to the live
+// aggregate, not the entire wall-clock time since the Unix epoch.
+func TestSnapshotLiveAggregateIgnoresZeroStartedAt(t *testing.T) {
+	st := NewOrchestratorState(60_000, 4)
+	iss := issue("ENG-ZERO")
+	entry := runningEntry(t, iss)
+	entry.StartedAt = time.Time{}
+	st.BeginDispatch(IssueID(iss.ID), entry)
+
+	view := st.Snapshot()
+	if got := view.CodexTotals.SecondsRunning; got != 0 {
+		t.Fatalf("CodexTotals.SecondsRunning = %v, want 0 (zero StartedAt is skipped)", got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #253. SPEC §13.5 Runtime accounting says runtime SHOULD be reported as a live aggregate at snapshot/render time, with implementations adding active-session elapsed time (derived from \`running.started_at\`) to the cumulative ended-session counter. The Go implementation maintained the ended-session counter (\`AddSeconds\` on worker exit) but copied \`s.CodexTotals\` verbatim, so a dashboard polling \`/api/v1/state\` every few seconds saw a flat \`seconds_running\` while a long Codex turn ran and a sudden jump on session end.

## Changes

\`Snapshot()\` now precomputes a local \`totals\` copy of \`s.CodexTotals\`, walks \`s.Running\`, and adds \`now.Sub(r.StartedAt).Seconds()\` for each entry with a non-zero \`StartedAt\`. The math uses the snapshot's \`GeneratedAt\` (captured once at the top) so all running entries are measured against one instant. No double-count: a finished run is removed from \`s.Running\` before \`AddSeconds\` runs for it.

## Tests

- \`TestSnapshotFoldsLiveSessionRuntimeIntoCodexTotals\`: entry with \`StartedAt = now-10s\` → \`seconds_running ∈ [9.5, 12]\`.
- \`TestSnapshotLiveAggregateDoesNotDoubleCountAfterFinish\`: 5s run finishing between snapshots contributes exactly once.
- \`TestSnapshotLiveAggregateIgnoresZeroStartedAt\`: zero \`StartedAt\` skipped (no Unix-epoch contribution).
- Existing \`TestSnapshot_ShapeMatches13_3\` widened to \`[0.5, 5]\` to accept the new live aggregate.
- Full \`go test ./...\` green.

## Docs

\`docs/runbooks/runtime-status.md\` adds a \`codex_totals.seconds_running\` semantics section warning dashboard authors that consecutive snapshots' values must not be delta-encoded and explaining the no-double-count invariant.

## Test plan

- [x] \`go test ./internal/orchestrator -run TestSnapshot\`
- [x] \`go test ./cmd/worker -run TestRuntimeStatusRunbookExampleMatchesHandler\`
- [x] \`go test ./...\`