### PR TITLE
fix(tracker/github): implement FetchIssueStatesByIDs + lowercase labels per SPEC §11.1/§11.3 (#211)

### DIFF
--- a/docs/runbooks/github-local-automation.md
+++ b/docs/runbooks/github-local-automation.md
@@ -177,6 +177,18 @@ GitHub tracker pagination is fail-closed: if issue or open-PR pagination
 exceeds the configured scan cap, the poll returns an error instead of acting on
 a truncated issue set.
 
+Per-tick state refresh (SPEC §8.5 Part B) for already-running GitHub issues
+issues one `GET /repos/{owner}/{repo}/issues/{number}` per running issue,
+sequentially, in poll order. The repo issue number is taken from the cache
+populated by the active-issue list. Per-ID `404`/`410` responses are treated as
+"issue removed" and silently skipped so a single deleted issue does not abort
+reconciliation for the rest of the running set; other HTTP errors abort the
+refresh so a transient outage cannot silently degrade reconciliation. At the
+default GitHub primary REST rate limit (5,000 req/hour for a personal access
+token) this is comfortably within budget for tens of concurrent running issues
+on the default poll cadence; cut the worker count or extend the poll interval
+if the workload approaches that ceiling.
+
 ## Install unattended macOS LaunchAgents
 
 ```bash

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -33,6 +34,7 @@ type GitHubClient struct {
 	Logf    func(format string, args ...any)
 
 	paginationCapHits atomic.Int64
+	issueNumbers      sync.Map // map[string]int — global issue ID → repo issue number, populated by listing
 }
 
 type githubIssue struct {
@@ -147,6 +149,7 @@ func (c *GitHubClient) listIssuesForState(ctx context.Context, issueState, label
 			if mapped.ID == "" {
 				continue
 			}
+			c.cacheIssueNumber(mapped.ID, issue.Number)
 			if _, ok := seen[mapped.ID]; ok {
 				continue
 			}
@@ -283,7 +286,7 @@ func mapGitHubIssue(issue githubIssue, mappedState string) (Issue, error) {
 	}
 	labels := make([]string, 0, len(issue.Labels))
 	for _, label := range issue.Labels {
-		if name := strings.TrimSpace(label.Name); name != "" {
+		if name := strings.ToLower(strings.TrimSpace(label.Name)); name != "" {
 			labels = append(labels, name)
 		}
 	}
@@ -391,4 +394,147 @@ func (c *GitHubClient) recordPaginationCapHit(label string) {
 	if c.Logf != nil {
 		c.Logf("github pagination exceeded %d pages for label/state %q; aborting this tracker poll to avoid acting on a truncated result set", githubMaxIssuePages, label)
 	}
+}
+
+// FetchIssueStatesByIDs implements SPEC §11.1 for the GitHub adapter. GitHub's
+// REST API has no `[ID!]` bulk endpoint, so this iterates one
+// `GET /repos/{owner}/{repo}/issues/{number}` per ID using the repo issue
+// number cached during prior list calls. Per-ID 404/410 responses are treated
+// as "issue removed" and silently skipped so a single deleted issue does not
+// abort reconciliation for the rest of the running set. Other HTTP errors
+// abort the whole call so a transient outage cannot silently degrade per-tick
+// state refresh.
+//
+// IDs without a cached number (e.g. issues we have never listed in this
+// process) are skipped because there is no way to address them by global
+// numeric ID via the REST API. They will be cached on the next list cycle.
+//
+// State derivation: if any label on the issue matches a state configured in
+// active_states / terminal_states / inactive_states (case-insensitive), the
+// matched label is returned (lowercased, matching mapGitHubIssue's
+// normalization). Otherwise the issue's open/closed state is returned. This
+// matches the GitHub convention where workflow position is encoded as labels.
+func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+	if strings.TrimSpace(c.Token) == "" {
+		return nil, fmt.Errorf("GitHub tracker api_key is required")
+	}
+	if len(issueIDs) == 0 {
+		return map[string]string{}, nil
+	}
+	if strings.TrimSpace(c.Owner) == "" || strings.TrimSpace(c.Repo) == "" {
+		return nil, fmt.Errorf("repo.owner and repo.name are required for GitHub tracker polling")
+	}
+	configuredStates := githubConfiguredStates(c.Config)
+	states := make(map[string]string, len(issueIDs))
+	seen := map[string]struct{}{}
+	for _, issueID := range issueIDs {
+		issueID = strings.TrimSpace(issueID)
+		if issueID == "" {
+			continue
+		}
+		if _, ok := seen[issueID]; ok {
+			continue
+		}
+		seen[issueID] = struct{}{}
+		issueNumber, ok := c.cachedIssueNumber(issueID)
+		if !ok {
+			continue
+		}
+		issue, found, err := c.getIssueByNumber(ctx, issueNumber)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		c.cacheIssueNumber(strconv.FormatInt(issue.ID, 10), issue.Number)
+		state := githubResolveState(issue, configuredStates)
+		if state == "" {
+			continue
+		}
+		states[issueID] = state
+	}
+	return states, nil
+}
+
+func (c *GitHubClient) getIssueByNumber(ctx context.Context, issueNumber int) (githubIssue, bool, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/issues/%d", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo), issueNumber)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return githubIssue{}, false, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	client := c.HTTP
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return githubIssue{}, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+		return githubIssue{}, false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return githubIssue{}, false, fmt.Errorf("get GitHub issue #%d failed: %s", issueNumber, resp.Status)
+	}
+	var issue githubIssue
+	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
+		return githubIssue{}, false, err
+	}
+	return issue, true, nil
+}
+
+func (c *GitHubClient) cacheIssueNumber(issueID string, issueNumber int) {
+	if strings.TrimSpace(issueID) == "" || issueNumber <= 0 {
+		return
+	}
+	c.issueNumbers.Store(issueID, issueNumber)
+}
+
+func (c *GitHubClient) cachedIssueNumber(issueID string) (int, bool) {
+	got, ok := c.issueNumbers.Load(issueID)
+	if !ok {
+		return 0, false
+	}
+	issueNumber, ok := got.(int)
+	return issueNumber, ok && issueNumber > 0
+}
+
+func githubConfiguredStates(cfg workflow.TrackerConfig) []string {
+	out := make([]string, 0, len(cfg.ActiveStates)+len(cfg.TerminalStates)+len(cfg.InactiveStates))
+	seen := map[string]struct{}{}
+	for _, group := range [][]string{cfg.ActiveStates, cfg.TerminalStates, cfg.InactiveStates} {
+		for _, state := range group {
+			state = strings.ToLower(strings.TrimSpace(state))
+			if state == "" {
+				continue
+			}
+			if _, ok := seen[state]; ok {
+				continue
+			}
+			seen[state] = struct{}{}
+			out = append(out, state)
+		}
+	}
+	return out
+}
+
+func githubResolveState(issue githubIssue, configured []string) string {
+	labelSet := make(map[string]struct{}, len(issue.Labels))
+	for _, label := range issue.Labels {
+		name := strings.ToLower(strings.TrimSpace(label.Name))
+		if name != "" {
+			labelSet[name] = struct{}{}
+		}
+	}
+	for _, state := range configured {
+		if _, ok := labelSet[state]; ok {
+			return state
+		}
+	}
+	return strings.ToLower(strings.TrimSpace(issue.State))
 }

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -288,4 +288,127 @@ func TestGitHubClientRequiresTokenOwnerAndRepo(t *testing.T) {
 func TestGitHubClientSatisfiesTrackerInterfaces(t *testing.T) {
 	var _ Client = (*GitHubClient)(nil)
 	var _ StateIssueLister = (*GitHubClient)(nil)
+	var _ IssueStateRefresher = (*GitHubClient)(nil)
+}
+
+func TestMapGitHubIssueLowercasesLabels(t *testing.T) {
+	got, err := mapGitHubIssue(githubIssue{
+		ID:        1,
+		Number:    1,
+		Title:     "case test",
+		State:     "open",
+		CreatedAt: "2026-05-20T01:02:03Z",
+		UpdatedAt: "2026-05-20T01:02:03Z",
+		Labels:    []githubLabel{{Name: "Important"}, {Name: " Priority:P1 "}, {Name: ""}},
+	}, "open")
+	if err != nil {
+		t.Fatalf("mapGitHubIssue: %v", err)
+	}
+	want := []string{"important", "priority:p1"}
+	if len(got.Labels) != len(want) {
+		t.Fatalf("labels = %#v, want %#v", got.Labels, want)
+	}
+	for i := range want {
+		if got.Labels[i] != want[i] {
+			t.Fatalf("labels[%d] = %q, want %q", i, got.Labels[i], want[i])
+		}
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) {
+	var requestedPaths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case "/repos/acme/api/issues":
+			_ = json.NewEncoder(w).Encode([]githubIssue{
+				{ID: 101, Number: 1, Title: "running", HTMLURL: "https://github.com/acme/api/issues/1", State: "open", CreatedAt: "2026-05-20T01:02:03Z", UpdatedAt: "2026-05-20T01:02:03Z", Labels: []githubLabel{{Name: "priority:p2"}}},
+				{ID: 202, Number: 2, Title: "second", HTMLURL: "https://github.com/acme/api/issues/2", State: "open", CreatedAt: "2026-05-20T01:02:03Z", UpdatedAt: "2026-05-20T01:02:03Z", Labels: []githubLabel{{Name: "priority:p2"}}},
+				{ID: 303, Number: 3, Title: "third", HTMLURL: "https://github.com/acme/api/issues/3", State: "open", CreatedAt: "2026-05-20T01:02:03Z", UpdatedAt: "2026-05-20T01:02:03Z", Labels: []githubLabel{{Name: "priority:p2"}}},
+			})
+		case "/repos/acme/api/issues/1":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 101, Number: 1, State: "closed", CreatedAt: "2026-05-20T01:02:03Z", UpdatedAt: "2026-05-20T02:03:04Z", Labels: []githubLabel{{Name: "Done"}}})
+		case "/repos/acme/api/issues/2":
+			http.NotFound(w, r)
+		case "/repos/acme/api/issues/3":
+			w.WriteHeader(http.StatusGone)
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{
+		APIKey:         "test-token",
+		ActiveStates:   []string{"priority:p2"},
+		TerminalStates: []string{"done"},
+	}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	if _, err := client.ListActiveIssues(context.Background()); err != nil {
+		t.Fatalf("ListActiveIssues: %v", err)
+	}
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"101", "202", "303", "999"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+	if got, want := states, map[string]string{"101": "done"}; len(got) != len(want) || got["101"] != want["101"] {
+		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	wantPathPrefix := "/repos/acme/api/issues/1,/repos/acme/api/issues/2,/repos/acme/api/issues/3"
+	gotJoined := strings.Join(requestedPaths[2:], ",")
+	if gotJoined != wantPathPrefix {
+		t.Fatalf("requested paths after listing = %s, want %s", gotJoined, wantPathPrefix)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByIDsRequiresToken(t *testing.T) {
+	client := NewGitHubClient(workflow.TrackerConfig{}, "https://api.github.test", "acme", "api")
+	if _, err := client.FetchIssueStatesByIDs(context.Background(), []string{"1"}); err == nil || !strings.Contains(err.Error(), "GitHub tracker api_key") {
+		t.Fatalf("missing token error = %v", err)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByIDsEmptyInputReturnsEmptyMap(t *testing.T) {
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, "https://api.github.test", "acme", "api")
+	states, err := client.FetchIssueStatesByIDs(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs nil: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states = %#v, want empty map", states)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByIDsSurfacesNon404Errors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case "/repos/acme/api/issues":
+			_ = json.NewEncoder(w).Encode([]githubIssue{
+				{ID: 500, Number: 1, Title: "fails later", HTMLURL: "https://github.com/acme/api/issues/1", State: "open", CreatedAt: "2026-05-20T01:02:03Z", UpdatedAt: "2026-05-20T01:02:03Z", Labels: []githubLabel{{Name: "priority:p2"}}},
+			})
+		case "/repos/acme/api/issues/1":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token", ActiveStates: []string{"priority:p2"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	if _, err := client.ListActiveIssues(context.Background()); err != nil {
+		t.Fatalf("ListActiveIssues: %v", err)
+	}
+	_, err := client.FetchIssueStatesByIDs(context.Background(), []string{"500"})
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("FetchIssueStatesByIDs error = %v, want HTTP 500 surfaced", err)
+	}
 }


### PR DESCRIPTION
Closes #211.

## Summary

GitHub adapter had two SPEC gaps relative to Linear/Gitea:

1. **SPEC §11.1** lists `fetch_issue_states_by_ids` as REQUIRED. Without it, the orchestrator's per-tick reconcile (§8.5 Part B) silently skipped state refresh for GitHub-tracked running issues — the `IssueStateRefresher` type assertion in `poller.refreshRunningIssueStates` returned `ok=false`.
2. **SPEC §11.3** says labels must normalize to lowercase. Linear lowercased; GitHub did not, so a workflow branching on label value silently misbehaved when the tracker kind switched.

## Implementation

- Add `issueNumbers sync.Map` to `GitHubClient` and populate from each issue in `listIssuesForState`. GitHub REST has no `/issues/{global_id}` endpoint; we must dispatch by repo issue number. The cache maps global issue ID → repo issue number.
- Add `FetchIssueStatesByIDs`: per-ID `GET /repos/{owner}/{repo}/issues/{number}` using the cached number. IDs without a cached number are silently skipped (consistent with Gitea — they'll be cached on the next list cycle).
- Per-ID `404` / `410` are treated as "issue removed" and skipped; other HTTP errors abort the call (matching gitea fail-closed posture).
- State derivation: first label matching `active_states` / `terminal_states` / `inactive_states` configured on `TrackerConfig` wins (case-insensitive, returned lowercased); otherwise fall back to GitHub's `open`/`closed` state. This matches GitHub's convention of encoding workflow position as labels.
- `mapGitHubIssue` now applies `strings.ToLower(strings.TrimSpace(label.Name))` per §11.3.
- Runbook documents the per-tick refresh + rate-limit posture (sequential per-ID at the 5,000/hour PAT REST limit).

## Test plan

- [x] `TestMapGitHubIssueLowercasesLabels` — mixed-case input → lowercase output, empty filtered
- [x] `TestGitHubClientFetchIssueStatesByIDsUsesCachedIssueNumbers` — happy path + 404 + 410 + uncached-ID skipped
- [x] `TestGitHubClientFetchIssueStatesByIDsSurfacesNon404Errors` — HTTP 500 aborts the call
- [x] `TestGitHubClientFetchIssueStatesByIDsRequiresToken` / `EmptyInputReturnsEmptyMap`
- [x] `TestGitHubClientSatisfiesTrackerInterfaces` extended with `IssueStateRefresher`
- [x] `go test ./internal/tracker/ ./internal/orchestrator/ ./internal/gitea/` all pass
- [x] `gofmt -l` clean
- [x] `go vet ./...` clean

@codex review