### PR TITLE
fix(runner): emit startup_failed / unsupported_tool_call / turn_input_required per SPEC §10.4 (#214)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -240,9 +240,11 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 			"version": "0.1.0",
 		},
 	}); err != nil {
+		c.recordStartupFailed("initialize", err)
 		return fmt.Errorf("codex app-server initialize: %w", err)
 	}
 	if err := c.notify("initialized", map[string]any{}); err != nil {
+		c.recordStartupFailed("initialized", err)
 		return err
 	}
 
@@ -253,10 +255,12 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 		"dynamicTools":   appServerDynamicToolSpecs(in.Workflow.Config),
 	})
 	if err != nil {
+		c.recordStartupFailed("thread/start", err)
 		return fmt.Errorf("codex app-server thread/start: %w", err)
 	}
 	threadID, err := extractString(threadResult, "thread", "id")
 	if err != nil {
+		c.recordStartupFailed("thread/start", err)
 		return fmt.Errorf("codex app-server thread/start: %w", err)
 	}
 	c.threadID = threadID
@@ -286,10 +290,16 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 			"sandboxPolicy":  in.Workflow.Config.Codex.TurnSandboxPolicy,
 		})
 		if err != nil {
+			if turn == 1 {
+				c.recordStartupFailed("turn/start", err)
+			}
 			return fmt.Errorf("codex app-server turn/start: %w", err)
 		}
 		turnID, err := extractString(turnResult, "turn", "id")
 		if err != nil {
+			if turn == 1 {
+				c.recordStartupFailed("turn/start", err)
+			}
 			return fmt.Errorf("codex app-server turn/start: %w", err)
 		}
 		c.turnID = turnID
@@ -557,6 +567,17 @@ func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 						c.recordInputRequiredMessage(method, msg)
 						return &InputRequiredError{Method: method}
 					}
+					// SPEC §10.4 turn_input_required also fires for an
+					// approval request that is not auto-approved — the
+					// runner's wire response is a decline / empty
+					// permissions / deny per protocolServerRequestResult,
+					// which is itself a signal that the operator must
+					// act. Without the event the orchestrator cannot
+					// distinguish this from a transient turn failure.
+					if approvalDeclinedServerRequest(method, c.approvalPolicy) {
+						c.recordInputRequiredMessage(method, msg)
+						return &InputRequiredError{Method: method}
+					}
 					c.lastTerminal = time.Now()
 					continue
 				}
@@ -643,6 +664,38 @@ func (c *appServerClient) recordRuntimeEvent(event string, payload map[string]an
 	if c.runtimeEventSink != nil {
 		c.runtimeEventSink(runtimeEvent)
 	}
+}
+
+// recordUnsupportedToolCall emits task.EventUnsupportedToolCall (SPEC §10.4)
+// with the tool name and the (already JSON-marshaled) arguments slice the
+// agent supplied. Arguments come from codex over JSON-RPC, so we surface them
+// verbatim — they were never going to be a secret-leak surface since the
+// agent chose them.
+func (c *appServerClient) recordUnsupportedToolCall(name string, arguments json.RawMessage) {
+	payload := map[string]any{"tool": name}
+	if len(arguments) > 0 {
+		var parsed any
+		if err := json.Unmarshal(arguments, &parsed); err == nil {
+			payload["arguments"] = parsed
+		} else {
+			payload["arguments_raw"] = string(arguments)
+		}
+	}
+	c.recordRuntimeEvent(task.EventUnsupportedToolCall, c.withRuntimeContext(payload))
+}
+
+// recordStartupFailed emits task.EventStartupFailed (SPEC §10.4) tagged with
+// the startup phase (initialize / initialized / thread/start / turn/start)
+// that just failed. The payload `error` carries the Go error's Error()
+// string; the upstream errors come from JSON-RPC framing or extractString,
+// neither of which echoes user-controlled params, so it is safe to surface
+// without the safeTurnReason redaction pass.
+func (c *appServerClient) recordStartupFailed(phase string, err error) {
+	payload := map[string]any{"phase": phase}
+	if err != nil {
+		payload["error"] = err.Error()
+	}
+	c.recordRuntimeEvent(task.EventStartupFailed, c.withRuntimeContext(payload))
 }
 
 func (c *appServerClient) recordPhaseTransition(from, to task.RunAttemptPhase) {
@@ -740,6 +793,23 @@ func inputRequiredServerRequest(method string) bool {
 	switch method {
 	case "item/tool/requestUserInput", "mcpServer/elicitation/request":
 		return true
+	default:
+		return false
+	}
+}
+
+// approvalDeclinedServerRequest reports whether a server request method goes
+// through the decline / deny / empty-permissions branch in
+// protocolServerRequestResult under the current approval policy. SPEC §10.4
+// treats a declined approval as operator-required input.
+func approvalDeclinedServerRequest(method string, approvalPolicy any) bool {
+	switch method {
+	case "item/commandExecution/requestApproval",
+		"item/fileChange/requestApproval",
+		"item/permissions/requestApproval",
+		"execCommandApproval",
+		"applyPatchApproval":
+		return !autoApproveRequest(method, approvalPolicy)
 	default:
 		return false
 	}
@@ -1034,6 +1104,14 @@ func (c *appServerClient) handleDynamicToolCall(ctx context.Context, msg map[str
 		if err != nil {
 			return err
 		}
+	} else {
+		// SPEC §10.4 unsupported_tool_call: the wire still carries the
+		// structured failure result, but the orchestrator/state surface
+		// needs a typed event to distinguish "agent invoked an
+		// unadvertised tool" from "advertised tool failed". The structured
+		// failure path above already emits its own error; this branch is
+		// reached only when the tool name is not in c.tools.
+		c.recordUnsupportedToolCall(name, arguments)
 	}
 	var payload any
 	if err := json.Unmarshal([]byte(result), &payload); err != nil {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -382,6 +382,145 @@ for line in sys.stdin:
 	assertInputRequiredEvent(t, res.RuntimeEvents, "mcpServer/elicitation/request")
 }
 
+// TestCodexAppServerRunnerEmitsStartupFailedOnInitializeError pins SPEC §10.4:
+// a JSON-RPC error response to `initialize` is a startup failure and must
+// surface as task.EventStartupFailed so /api/v1/state can distinguish "failed
+// to start" from "ran a turn and failed".
+func TestCodexAppServerRunnerEmitsStartupFailedOnInitializeError(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'error': {'code': -32603, 'message': 'codex bad startup'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "startup fails")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err == nil {
+		t.Fatalf("Run error = nil, want startup failure")
+	}
+	events := runtimeEventsNamed(res.RuntimeEvents, task.EventStartupFailed)
+	if len(events) != 1 {
+		t.Fatalf("startup_failed events = %d, want 1; events=%#v", len(events), res.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, events[0], "phase"); got != "initialize" {
+		t.Fatalf("startup_failed phase = %#v, want initialize", got)
+	}
+	if got := runtimeEventField(t, events[0], "error"); got == nil || got == "" {
+		t.Fatalf("startup_failed error = %#v, want a non-empty error string", got)
+	}
+}
+
+// TestCodexAppServerRunnerEmitsStartupFailedOnThreadStartError pins the
+// equivalent for the `thread/start` failure site.
+func TestCodexAppServerRunnerEmitsStartupFailedOnThreadStartError(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'error': {'code': -32603, 'message': 'thread denied'}}), flush=True)
+        break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "thread fails")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err == nil {
+		t.Fatalf("Run error = nil, want thread/start failure")
+	}
+	events := runtimeEventsNamed(res.RuntimeEvents, task.EventStartupFailed)
+	if len(events) != 1 {
+		t.Fatalf("startup_failed events = %d, want 1; events=%#v", len(events), res.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, events[0], "phase"); got != "thread/start" {
+		t.Fatalf("startup_failed phase = %#v, want thread/start", got)
+	}
+}
+
+// TestCodexAppServerRunnerEmitsUnsupportedToolCallForUnknownTool pins SPEC
+// §10.4: when the agent invokes a tool the runtime did not advertise, the
+// orchestrator must learn about it via task.EventUnsupportedToolCall (the
+// wire still carries the structured failure result, but observability needs
+// a typed event).
+func TestCodexAppServerRunnerEmitsUnsupportedToolCallForUnknownTool(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'jsonrpc': '2.0', 'id': 'call-1', 'method': 'item/tool/call', 'params': {'name': 'missing_tool', 'arguments': {}}}), flush=True)
+    elif msg.get('id') == 'call-1':
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'done after unsupported tool'}}), flush=True)
+        break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "unsupported tool")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	events := runtimeEventsNamed(res.RuntimeEvents, task.EventUnsupportedToolCall)
+	if len(events) != 1 {
+		t.Fatalf("unsupported_tool_call events = %d, want 1; events=%#v", len(events), res.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, events[0], "tool"); got != "missing_tool" {
+		t.Fatalf("unsupported_tool_call tool = %#v, want missing_tool", got)
+	}
+}
+
+// TestCodexAppServerRunnerEmitsTurnInputRequiredOnDeclinedApproval pins SPEC
+// §10.4 turn_input_required: an approval request that is not auto-approved
+// (here `item/commandExecution/requestApproval` with the default `never`
+// approval policy) is operator-required input — the runner must emit the
+// event and bail with InputRequiredError so the orchestrator can mark the
+// issue blocked, just as it does for `item/tool/requestUserInput`.
+func TestCodexAppServerRunnerEmitsTurnInputRequiredOnDeclinedApproval(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'jsonrpc': '2.0', 'id': 'approve-1', 'method': 'item/commandExecution/requestApproval', 'params': {'command': 'rm -rf /'}}), flush=True)
+    elif msg.get('id') == 'approve-1':
+        result = msg.get('result', {})
+        if result.get('decision') != 'decline':
+            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'expected decline', 'got': msg}}), flush=True)
+        break
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "declined approval")
+	in := appServerInput(wd)
+	// "untrusted" is the non-auto-approving policy: autoApproveRequest only
+	// short-circuits on "never" / "on-failure" string policies, so any other
+	// string drives the decline branch in protocolServerRequestResult.
+	in.Workflow.Config.Codex.ApprovalPolicy = "untrusted"
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err == nil || !strings.Contains(err.Error(), "input required") {
+		t.Fatalf("Run error = %v, want input required for declined approval", err)
+	}
+	assertInputRequiredEvent(t, res.RuntimeEvents, "item/commandExecution/requestApproval")
+}
+
 func TestCodexAppServerRunnerEmitsSpecPhaseTransitions(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json
@@ -1390,73 +1529,13 @@ for line in sys.stdin:
 	}
 }
 
-func TestCodexAppServerRunnerDeclinesApprovalsWhenPolicyRequiresReview(t *testing.T) {
-	binDir := codexAppServerStubScript(t, `
-import json
-log=open(os.environ['CODEX_STDIN_LOG'], 'w')
-approval_methods = [
-    ('approval-command', 'item/commandExecution/requestApproval', {'command': 'go test ./...'}, {'decision': 'decline'}),
-    ('approval-file', 'item/fileChange/requestApproval', {'path': 'main.go'}, {'decision': 'decline'}),
-    (
-        'approval-permissions',
-        'item/permissions/requestApproval',
-        {'permissions': {'filesystem': {'write': True}, 'network': {'enabled': True}}},
-        {'permissions': {}},
-    ),
-]
-pending = list(approval_methods)
-for line in sys.stdin:
-    log.write(line); log.flush()
-    msg=json.loads(line)
-    if msg.get('method') == 'initialize':
-        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
-    elif msg.get('method') == 'thread/start':
-        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
-    elif msg.get('method') == 'turn/start':
-        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
-        req_id, method, params, _expected = pending.pop(0)
-        print(json.dumps({'jsonrpc': '2.0', 'id': req_id, 'method': method, 'params': params}), flush=True)
-    elif msg.get('id', '').startswith('approval-'):
-        req_id = msg['id']
-        expected = next(item[3] for item in approval_methods if item[0] == req_id)
-        if msg.get('result') != expected:
-            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'unexpected approval response', 'got': msg.get('result'), 'want': expected}}), flush=True)
-            break
-        if pending:
-            req_id, method, params, _expected = pending.pop(0)
-            print(json.dumps({'jsonrpc': '2.0', 'id': req_id, 'method': method, 'params': params}), flush=True)
-        else:
-            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'review policy enforced'}}), flush=True)
-            break
-    elif msg.get('method') == 'initialized':
-        pass
-`)
-	wd := codexWorkdir(t, "x")
-	in := appServerInput(wd)
-	in.Workflow.Config.Codex.ApprovalPolicy = map[string]any{
-		"reject": map[string]any{
-			"sandbox_approval": true,
-			"rules":            true,
-		},
-	}
-
-	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
-	if err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-	if res.Summary != "review policy enforced" {
-		t.Fatalf("Summary = %q, want review policy enforced", res.Summary)
-	}
-	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, want := range []string{`"decision":"decline"`, `"permissions":{}`} {
-		if !strings.Contains(string(stdin), want) {
-			t.Fatalf("stdin missing %s in policy-limited approval responses: %s", want, stdin)
-		}
-	}
-}
+// Replaced by TestCodexAppServerRunnerEmitsTurnInputRequiredOnDeclinedApproval:
+// the previous TestCodexAppServerRunnerDeclinesApprovalsWhenPolicyRequiresReview
+// pinned the SPEC §10.4-non-compliant silent-decline behavior (decline sent
+// over the wire, no turn_input_required event, agent continues). #214 makes
+// the runner emit turn_input_required and bail with InputRequiredError so the
+// orchestrator can mark the issue blocked when an approval cannot be
+// auto-approved.
 
 func TestProtocolServerRequestResultLegacyApprovalMethodsUseProtocolDecisions(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
Closes #214.

## Summary

SPEC §10.4 lists twelve runtime events the Codex app-server client SHOULD emit. Three were declared as `task.Event*` constants but the runner never actually fired them. Without them the orchestrator's snapshot / `/api/v1/state` cannot distinguish startup failures, unsupported tool calls, or operator-required approvals from generic turn failures.

## Implementation

- **`startup_failed`**: emit at the four startup failure sites in `run()` — `initialize`, `initialized`, `thread/start` (including `extractString` failure), and `turn/start` on the first turn only (later turns are operational, not startup). Payload carries `phase` + `error`. Errors come from JSON-RPC framing or `extractString`, not user-controlled params, so safe to surface verbatim without `safeTurnReason` redaction.
- **`unsupported_tool_call`**: emit in `handleDynamicToolCall` when `c.tools.Lookup` misses, alongside the existing structured failure on the wire. Payload carries tool name + parsed arguments.
- **`turn_input_required` for declined approvals**: an approval method that is NOT auto-approved gets a decline/deny/empty-permissions wire response — which is itself a signal that the operator must act. New `approvalDeclinedServerRequest()` guards a new branch in the run loop that emits the event and bails with `InputRequiredError`, matching the existing `inputRequiredServerRequest` path.

### Behavior change

Previously, declined approvals were silently sent and codex kept going. Now the issue blocks until the operator clears it. Set `codex.approval_policy` to a permissive rule set to keep auto-continue. Deleted `TestCodexAppServerRunnerDeclinesApprovalsWhenPolicyRequiresReview` — it pinned the SPEC-non-compliant silent-decline behavior; replaced by `TestCodexAppServerRunnerEmitsTurnInputRequiredOnDeclinedApproval`.

## Test plan

- [x] `TestCodexAppServerRunnerEmitsStartupFailedOnInitializeError`
- [x] `TestCodexAppServerRunnerEmitsStartupFailedOnThreadStartError`
- [x] `TestCodexAppServerRunnerEmitsUnsupportedToolCallForUnknownTool`
- [x] `TestCodexAppServerRunnerEmitsTurnInputRequiredOnDeclinedApproval`
- [x] All existing runner / orchestrator / worker / cmd tests pass
- [x] `gofmt -l` clean

@codex review