### PR TITLE
fix(worker+orchestrator): prompt template `issue` carries all SPEC §4.1.1 fields (#217)

### DIFF
--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -690,7 +690,46 @@ func TaskFromIssue(issue tracker.Issue, cfg workflow.Config) (task.Task, error) 
 		Actor:         cfg.Tracker.Kind,
 		Model:         cfg.Agent.Default,
 		Priority:      50,
+		IssueRender:   IssueRenderVars(issue),
 	}, nil
+}
+
+// IssueRenderVars returns the SPEC §4.1.1 normalized issue snapshot the
+// prompt template's `issue` variable expects. Field set matches SPEC §12.1
+// "includes all normalized issue fields, including labels and blockers"; per
+// SPEC §5.4 strict template rendering, every field documented in §4.1.1
+// must be present (or empty) so a workflow that references it does not crash
+// with template_render_error. Labels and blocked_by are always slices (never
+// nil) so `{% for ... %}` over an empty issue does not surface a strict-mode
+// error. The actor field is an aiops-platform extension carried alongside
+// the SPEC fields and read from the tracker kind by the caller.
+func IssueRenderVars(issue tracker.Issue) map[string]any {
+	labels := append([]string(nil), issue.Labels...)
+	if labels == nil {
+		labels = []string{}
+	}
+	blockedBy := make([]map[string]any, 0, len(issue.BlockedBy))
+	for _, b := range issue.BlockedBy {
+		blockedBy = append(blockedBy, map[string]any{
+			"id":         b.ID,
+			"identifier": b.Identifier,
+			"state":      b.State,
+		})
+	}
+	return map[string]any{
+		"id":          issue.ID,
+		"identifier":  issue.Identifier,
+		"title":       issue.Title,
+		"description": issue.Description,
+		"priority":    issue.Priority,
+		"state":       issue.State,
+		"branch_name": issue.BranchName,
+		"url":         issue.URL,
+		"labels":      labels,
+		"blocked_by":  blockedBy,
+		"created_at":  issue.CreatedAt,
+		"updated_at":  issue.UpdatedAt,
+	}
 }
 
 func serviceConfigByName(cfg workflow.Config, name string) (workflow.ServiceConfig, bool) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -1514,6 +1514,85 @@ func TestTaskFromIssueRejectsUnknownService(t *testing.T) {
 	}
 }
 
+// TestIssueRenderVarsCoversSpec4_1_1FieldSet pins SPEC §4.1.1 + §12.1: the
+// prebuilt issue snapshot the worker hands to the prompt template must
+// expose every normalized field. Empty labels/blocked_by must materialize as
+// empty slices (not nil) so strict-mode templates iterating over them do
+// not surface a render error.
+func TestIssueRenderVarsCoversSpec4_1_1FieldSet(t *testing.T) {
+	created := mustTime("2026-05-20T10:00:00Z")
+	updated := mustTime("2026-05-21T12:00:00Z")
+	got := IssueRenderVars(tracker.Issue{
+		ID:          "lin-456",
+		Identifier:  "LIN-456",
+		Title:       "integration",
+		Description: "desc",
+		Priority:    2,
+		State:       "In Progress",
+		BranchName:  "feat/auth-cleanup",
+		URL:         "https://linear.app/x/issue/LIN-456",
+		Labels:      []string{"priority:p2", "area:auth"},
+		BlockedBy: []tracker.BlockerRef{
+			{ID: "lin-200", Identifier: "LIN-200", State: "Todo"},
+		},
+		CreatedAt: created,
+		UpdatedAt: updated,
+	})
+	for _, k := range []string{
+		"id", "identifier", "title", "description", "priority", "state",
+		"branch_name", "url", "labels", "blocked_by", "created_at", "updated_at",
+	} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("IssueRenderVars missing key %q in %#v", k, got)
+		}
+	}
+	labels, _ := got["labels"].([]string)
+	if len(labels) != 2 || labels[0] != "priority:p2" {
+		t.Errorf("labels = %#v, want copy preserving order", got["labels"])
+	}
+	blockedBy, _ := got["blocked_by"].([]map[string]any)
+	if len(blockedBy) != 1 || blockedBy[0]["identifier"] != "LIN-200" || blockedBy[0]["state"] != "Todo" {
+		t.Errorf("blocked_by = %#v, want one normalized blocker", got["blocked_by"])
+	}
+}
+
+// TestIssueRenderVarsEmptySlicesMaterializeNonNil pins the empty-collection
+// invariant: a tracker.Issue with no labels / no blockers must render as
+// empty slices, never nil, so strict-mode templates iterating with
+// `{% for ... %}` do not crash. nil interface{} would also be rendered as
+// `<nil>` by fmt.Sprint, which surprises operators.
+func TestIssueRenderVarsEmptySlicesMaterializeNonNil(t *testing.T) {
+	got := IssueRenderVars(tracker.Issue{ID: "x", Identifier: "X-1"})
+	labels, ok := got["labels"].([]string)
+	if !ok || labels == nil || len(labels) != 0 {
+		t.Errorf("labels = %#v, want non-nil empty []string", got["labels"])
+	}
+	blockedBy, ok := got["blocked_by"].([]map[string]any)
+	if !ok || blockedBy == nil || len(blockedBy) != 0 {
+		t.Errorf("blocked_by = %#v, want non-nil empty []map[string]any", got["blocked_by"])
+	}
+}
+
+// TestTaskFromIssuePopulatesIssueRender pins the wiring: TaskFromIssue must
+// stamp the SPEC §4.1.1 snapshot onto Task.IssueRender so the worker's
+// runtask can populate the prompt template's `issue` variable.
+func TestTaskFromIssuePopulatesIssueRender(t *testing.T) {
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "acme", Name: "demo", CloneURL: "git@example.com:acme/demo.git", DefaultBranch: "main"},
+	}
+	issue := tracker.Issue{ID: "lin-1", Identifier: "LIN-1", Title: "x", State: "In Progress", Labels: []string{"a"}}
+	got, err := TaskFromIssue(issue, cfg)
+	if err != nil {
+		t.Fatalf("TaskFromIssue: %v", err)
+	}
+	if got.IssueRender == nil {
+		t.Fatal("TaskFromIssue IssueRender = nil, want SPEC §4.1.1 snapshot")
+	}
+	if got.IssueRender["state"] != "In Progress" {
+		t.Errorf("IssueRender[state] = %#v, want In Progress", got.IssueRender["state"])
+	}
+}
+
 func TestPollOnceSortsCandidatesByTrackerPriorityCreatedAtIdentifier(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -158,6 +158,15 @@ type Task struct {
 	AvailableAt   time.Time `json:"available_at"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
+	// IssueRender is the SPEC §4.1.1 normalized issue snapshot, pre-built at
+	// dispatch time so the worker's runtask can populate the prompt
+	// template's `issue` variable without re-importing tracker.Issue. SPEC
+	// §12.1 requires the full normalized field set to be visible to the
+	// template; §5.4 fails rendering on unknown variables, so a workflow
+	// referencing `issue.priority` or `{% for label in issue.labels %}`
+	// would crash without this. Excluded from JSON/Postgres persistence
+	// because it is reconstructed per dispatch.
+	IssueRender map[string]any `json:"-"`
 }
 
 type Event struct {

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -43,6 +43,29 @@ type RunTaskError struct {
 // WORKFLOW.md that was loaded at process startup. Returning the workflow_source
 // string lets callers stamp it onto the runner_start payload as a quick-look
 // field; the full provenance lives on the workflow_resolved event itself.
+// issueRenderVarsForTask returns the SPEC §4.1.1 normalized issue snapshot
+// for the prompt template's `issue` variable. The orchestrator's
+// TaskFromIssue precomputes IssueRender at dispatch; this helper falls back
+// to the minimal Task-derived map for callers that build tasks by hand
+// (e.g. legacy queue.Postgres consumers and worker tests) so they still
+// render, just without the §4.1.1 fields the helper cannot reconstruct.
+func issueRenderVarsForTask(t task.Task) map[string]any {
+	if t.IssueRender != nil {
+		out := make(map[string]any, len(t.IssueRender)+1)
+		for k, v := range t.IssueRender {
+			out[k] = v
+		}
+		out["actor"] = t.Actor
+		return out
+	}
+	return map[string]any{
+		"identifier":  t.SourceEventID,
+		"title":       t.Title,
+		"description": t.Description,
+		"actor":       t.Actor,
+	}
+}
+
 func ResolveWorkflow(ctx context.Context, ev EventEmitter, taskID string, wf *workflow.Workflow) (*workflow.Workflow, string, error) {
 	if wf == nil {
 		return nil, "", fmt.Errorf("service workflow is required")
@@ -228,12 +251,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 			"description": t.Description,
 			"actor":       t.Actor,
 		},
-		"issue": map[string]any{
-			"identifier":  t.SourceEventID,
-			"title":       t.Title,
-			"description": t.Description,
-			"actor":       t.Actor,
-		},
+		"issue": issueRenderVarsForTask(t),
 		"repo": map[string]any{
 			"owner":  t.RepoOwner,
 			"name":   t.RepoName,

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -9,8 +9,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	worker "github.com/xrf9268-hue/aiops-platform/internal/worker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
@@ -338,6 +341,71 @@ func TestRunTaskLeavesFirstAttemptAbsentForDefaultFilter(t *testing.T) {
 	}
 	if !strings.Contains(string(prompt), "attempt first run for integration") {
 		t.Fatalf("rendered prompt = %q, want first attempt absent so default filter applies", prompt)
+	}
+}
+
+// TestRunTaskPromptTemplateSeesAllSpec4_1_1IssueFields pins SPEC §12.1: the
+// `issue` template variable must carry every normalized SPEC §4.1.1 field,
+// not just identifier/title/description. A workflow that references any
+// of {id, priority, state, branch_name, url, labels, blocked_by,
+// created_at, updated_at} must render without a strict-mode
+// template_render_error (SPEC §5.4).
+func TestRunTaskPromptTemplateSeesAllSpec4_1_1IssueFields(t *testing.T) {
+	// The repo's local template engine supports {{ var }} expansion with
+	// snake_case path traversal (no {% for %} loops); SPEC §12.1's acceptance
+	// is that every §4.1.1 field is referenceable without
+	// template_render_error. Slices render via fmt.Sprint default.
+	template := `id={{ issue.id }} pri={{ issue.priority }} state={{ issue.state }} branch={{ issue.branch_name }} ` +
+		`url={{ issue.url }} labels={{ issue.labels }} blocked={{ issue.blocked_by }} ` +
+		`created={{ issue.created_at }} updated={{ issue.updated_at }}`
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, strings.Replace(linearWorkflowBody, "do the work for {{task.title}}", template, 1))
+	t.Setenv("REPO_URL", cloneURL)
+	tk.SourceEventID = "LIN-456"
+	tk.IssueRender = orchestrator.IssueRenderVars(tracker.Issue{
+		ID:          "lin-456",
+		Identifier:  "LIN-456",
+		Title:       "integration",
+		Description: "desc",
+		Priority:    2,
+		State:       "In Progress",
+		BranchName:  "feat/auth-cleanup",
+		URL:         "https://linear.app/x/issue/LIN-456",
+		Labels:      []string{"priority:p2", "area:auth"},
+		BlockedBy: []tracker.BlockerRef{
+			{ID: "lin-200", Identifier: "LIN-200", State: "Todo"},
+		},
+		CreatedAt: time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC),
+	})
+
+	ev := &fakeEmitter{}
+	cfg := workerCfgForIntegration(t)
+	cfg.Workflow.PromptTemplate = template
+
+	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		t.Fatalf("runTask: %v", rterr.Err)
+	}
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "lin-456")
+	prompt, err := os.ReadFile(filepath.Join(workdir, ".aiops", "PROMPT.md"))
+	if err != nil {
+		t.Fatalf("read rendered prompt: %v", err)
+	}
+	got := string(prompt)
+	for _, want := range []string{
+		"id=lin-456",
+		"pri=2",
+		"state=In Progress",
+		"branch=feat/auth-cleanup",
+		"url=https://linear.app/x/issue/LIN-456",
+		"priority:p2",
+		"area:auth",
+		"LIN-200",
+		"2026-05-20",
+		"2026-05-21",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered prompt missing %q:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #217.

## Summary

SPEC §12.1 says the prompt template's `issue` variable "includes all normalized issue fields, including labels and blockers." SPEC §5.4 fails template rendering on unknown variables, so a workflow that references `{{ issue.priority }}`, `{{ issue.state }}`, `{{ issue.url }}`, or any §4.1.1 field beyond identifier/title/description currently crashes with `template_render_error` and the issue becomes a perpetual failure.

The Go worker built the `issue` map from a four-field Task subset (identifier/title/description/actor) instead of from the full `tracker.Issue` that produced the task.

## Implementation

- New `IssueRenderVars(issue tracker.Issue) map[string]any` helper in `internal/orchestrator` builds the SPEC §4.1.1 snapshot: `id`, `identifier`, `title`, `description`, `priority`, `state`, `branch_name`, `url`, `labels`, `blocked_by`, `created_at`, `updated_at`. `labels` and `blocked_by` always materialize as non-nil slices so strict-mode templates do not surface render errors on empty collections.
- `TaskFromIssue` stamps the snapshot onto a new `Task.IssueRender` field (`map[string]any`, `json:"-"` so the postgres queue and any future serialization paths reconstruct it from the issue on next dispatch instead of persisting a duplicate of the tracker state).
- `runtask.go`'s `renderVars` now uses `issueRenderVarsForTask(t)`, which prefers the precomputed `IssueRender` and falls back to the minimal Task-derived map for callers that build tasks by hand (legacy `queue.Postgres` consumers, worker tests pre-dating `TaskFromIssue`).

## Test plan

- [x] `TestIssueRenderVarsCoversSpec4_1_1FieldSet` — every SPEC §4.1.1 key present
- [x] `TestIssueRenderVarsEmptySlicesMaterializeNonNil` — strict-mode safety
- [x] `TestTaskFromIssuePopulatesIssueRender` — wiring smoke test
- [x] `TestRunTaskPromptTemplateSeesAllSpec4_1_1IssueFields` — end-to-end render with every §4.1.1 field referenced (no template_render_error)
- [x] `go test ./internal/worker/ ./internal/orchestrator/ ./internal/task/` green
- [x] `gofmt -l` clean

@codex review