### PR TITLE
fix(worker+orchestrator): SPEC §13.1 structured key=value logs with issue_id/issue_identifier (#240)

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -823,8 +823,9 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 }
 
 type workspaceCleanup struct {
-	issueID IssueID
-	path    string
+	issueID    IssueID
+	identifier string
+	path       string
 }
 
 func appendBlockedWorkspaceCleanup(cleanups []workspaceCleanup, id IssueID, blocked *BlockedEntry) []workspaceCleanup {
@@ -835,7 +836,7 @@ func appendBlockedWorkspaceCleanup(cleanups []workspaceCleanup, id IssueID, bloc
 	if path == "" {
 		return cleanups
 	}
-	return append(cleanups, workspaceCleanup{issueID: id, path: path})
+	return append(cleanups, workspaceCleanup{issueID: id, identifier: blocked.Identifier, path: path})
 }
 
 func reconcileCancelFollowup(cancelEntries []*RunningEntry, cleanupEntries []workspaceCleanup, result chan<- []*RunningEntry) func() {
@@ -847,7 +848,11 @@ func reconcileCancelFollowup(cancelEntries []*RunningEntry, cleanupEntries []wor
 		}
 		for _, cleanup := range cleanupEntries {
 			if err := os.RemoveAll(cleanup.path); err != nil {
-				log.Printf("event=blocked_workspace_remove_failed issue_id=%s workspace=%q error=%q", cleanup.issueID, cleanup.path, err)
+				if cleanup.identifier != "" {
+					log.Printf("event=blocked_workspace_remove_failed issue_id=%s issue_identifier=%s workspace=%q error=%q", cleanup.issueID, cleanup.identifier, cleanup.path, err)
+				} else {
+					log.Printf("event=blocked_workspace_remove_failed issue_id=%s workspace=%q error=%q", cleanup.issueID, cleanup.path, err)
+				}
 			}
 		}
 		if result != nil {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -847,7 +847,7 @@ func reconcileCancelFollowup(cancelEntries []*RunningEntry, cleanupEntries []wor
 		}
 		for _, cleanup := range cleanupEntries {
 			if err := os.RemoveAll(cleanup.path); err != nil {
-				log.Printf("orchestrator: remove blocked workspace for issue %s at %s: %v", cleanup.issueID, cleanup.path, err)
+				log.Printf("event=blocked_workspace_remove_failed issue_id=%s workspace=%q error=%q", cleanup.issueID, cleanup.path, err)
 			}
 		}
 		if result != nil {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -465,7 +465,7 @@ func selectRoutedCandidates(issues []tracker.Issue, cfg workflow.Config) ([]trac
 				out = append(out, issue)
 				continue
 			}
-			log.Printf("tracker route skipped issue %s: no configured service matched", issue.ID)
+			log.Printf("event=tracker_route_skipped issue_id=%s issue_identifier=%s reason=%q", issue.ID, issue.Identifier, "no configured service matched")
 		case 1:
 			issue.ServiceName = matches[0].Name
 			out = append(out, issue)
@@ -759,7 +759,7 @@ func RunPollLoop(ctx context.Context, poller *Poller, interval time.Duration) er
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			log.Printf("tracker poll error: %v", err)
+			log.Printf("event=tracker_poll_error error=%q", err)
 		}
 		intervalTimer.Reset(interval)
 		select {

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -174,7 +174,7 @@ func (r *WorkflowRuntime) emit(ctx context.Context, kind, msg string, payload an
 		taskID = "workflow-runtime"
 	}
 	if err := r.emitter.AddEventWithPayload(ctx, taskID, kind, msg, payload); err != nil {
-		log.Printf("workflow runtime: emit %s event: %v", kind, err)
+		log.Printf("event=workflow_runtime_emit_failed task_id=%s issue_id=%s kind=%s error=%q", taskID, taskID, kind, err)
 	}
 }
 
@@ -277,7 +277,7 @@ func RunPollLoopWithRuntime(ctx context.Context, poller pollOnce, runtime *Workf
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			log.Printf("tracker poll error: %v", err)
+			log.Printf("event=tracker_poll_error error=%q", err)
 		}
 		polls++
 		if runtimePoller, ok := poller.(*RuntimePoller); ok {

--- a/internal/worker/log.go
+++ b/internal/worker/log.go
@@ -27,12 +27,14 @@ func LogIssueEventf(t task.Task, event, format string, args ...any) {
 }
 
 // LogTaskIDEventf is the narrow form used by call sites that only have the
-// task id in scope (e.g. helpers passed taskID by value rather than the
-// full Task struct). `issue_identifier` is omitted since the caller cannot
-// supply it; `issue_id` is set equal to `task_id` because TaskFromIssue
-// keys Task.ID by the tracker issue id.
-func LogTaskIDEventf(taskID, event, format string, args ...any) {
-	log.Printf("%s %s", taskIDLogPrefix(event, taskID), fmt.Sprintf(format, args...))
+// task id (and optionally the issue identifier) in scope rather than the
+// full Task struct. Pass identifier="" when the caller does not know it;
+// the issue_identifier= key is then omitted (rather than emitted empty) so
+// log filters do not misparse it as a real empty identifier. `issue_id` is
+// set equal to `task_id` because TaskFromIssue keys Task.ID by the tracker
+// issue id.
+func LogTaskIDEventf(taskID, identifier, event, format string, args ...any) {
+	log.Printf("%s %s", taskIDLogPrefix(event, taskID, identifier), fmt.Sprintf(format, args...))
 }
 
 // LogReconcileEventf is the helper for reconciliation / orchestrator-wide
@@ -59,6 +61,10 @@ func issueLogPrefix(event string, t task.Task) string {
 	return b.String()
 }
 
-func taskIDLogPrefix(event, taskID string) string {
-	return "event=" + event + " task_id=" + taskID + " issue_id=" + taskID
+func taskIDLogPrefix(event, taskID, identifier string) string {
+	prefix := "event=" + event + " task_id=" + taskID + " issue_id=" + taskID
+	if identifier != "" {
+		prefix += " issue_identifier=" + identifier
+	}
+	return prefix
 }

--- a/internal/worker/log.go
+++ b/internal/worker/log.go
@@ -1,0 +1,64 @@
+// SPEC §13.1 mandates `key=value` structured logging carrying `issue_id`,
+// `issue_identifier` (and `session_id` for coding-agent session logs) on
+// every issue-related log line. The helpers in this file produce that
+// shape without dragging in a structured-logger dependency; ad-hoc
+// `log.Printf` lines in the worker / orchestrator route through them so
+// operators tailing stderr can correlate with `/api/v1/state`
+// (`issue_id`/`issue_identifier`) and grep / Loki / journald see real
+// fields instead of prose.
+
+package worker
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+)
+
+// LogIssueEventf formats a SPEC §13.1 issue-lifecycle log line for a known
+// task: `event=<kind> task_id=<id> issue_id=<id> issue_identifier=<src> <msg>`.
+// Pair with Emit() for runtime-event surfaces; this helper covers the
+// log-only failure paths (workspace hooks, retry-queue plumbing, artifact
+// writes) where the orchestrator does not also fold a runtime event.
+func LogIssueEventf(t task.Task, event, format string, args ...any) {
+	log.Printf("%s %s", issueLogPrefix(event, t), fmt.Sprintf(format, args...))
+}
+
+// LogTaskIDEventf is the narrow form used by call sites that only have the
+// task id in scope (e.g. helpers passed taskID by value rather than the
+// full Task struct). `issue_identifier` is omitted since the caller cannot
+// supply it; `issue_id` is set equal to `task_id` because TaskFromIssue
+// keys Task.ID by the tracker issue id.
+func LogTaskIDEventf(taskID, event, format string, args ...any) {
+	log.Printf("%s %s", taskIDLogPrefix(event, taskID), fmt.Sprintf(format, args...))
+}
+
+// LogReconcileEventf is the helper for reconciliation / orchestrator-wide
+// log lines that have no per-issue context yet (startup reconcile fetches,
+// poll-loop errors). It still emits `event=<kind>` so log filters can group
+// by event class instead of regex-matching prose.
+func LogReconcileEventf(event, format string, args ...any) {
+	log.Printf("event=%s %s", event, fmt.Sprintf(format, args...))
+}
+
+func issueLogPrefix(event string, t task.Task) string {
+	var b strings.Builder
+	b.Grow(64)
+	b.WriteString("event=")
+	b.WriteString(event)
+	b.WriteString(" task_id=")
+	b.WriteString(t.ID)
+	b.WriteString(" issue_id=")
+	b.WriteString(t.ID)
+	if t.SourceEventID != "" {
+		b.WriteString(" issue_identifier=")
+		b.WriteString(t.SourceEventID)
+	}
+	return b.String()
+}
+
+func taskIDLogPrefix(event, taskID string) string {
+	return "event=" + event + " task_id=" + taskID + " issue_id=" + taskID
+}

--- a/internal/worker/log_audit_test.go
+++ b/internal/worker/log_audit_test.go
@@ -1,0 +1,111 @@
+package worker_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestNoStdLibLogPrintfMissingStructuredContext is the SPEC §13.1 lint-style
+// guard: every `log.Printf` in internal/worker, internal/runner, and
+// internal/orchestrator must either route through one of the structured
+// helpers (LogIssueEventf / LogTaskIDEventf / LogReconcileEventf) or
+// hard-code the canonical `event=` / `issue_id=` / `task_id=` keys inline.
+//
+// The check is intentionally text-based — it deliberately mis-trips a
+// regression like `log.Printf("task %s: ...", t.ID, ...)` because that's
+// exactly the prose pattern #240 retired. The audit walks .go files only;
+// it ignores _test.go because tests are allowed to dump arbitrary log
+// shapes for assertions.
+func TestNoStdLibLogPrintfMissingStructuredContext(t *testing.T) {
+	repoRoot := repoRootForAuditTest(t)
+	roots := []string{
+		filepath.Join(repoRoot, "internal", "worker"),
+		filepath.Join(repoRoot, "internal", "runner"),
+		filepath.Join(repoRoot, "internal", "orchestrator"),
+	}
+	printfRE := regexp.MustCompile(`\blog\.Printf\(`)
+	structuredRE := regexp.MustCompile(`"event=|"task_id=|"issue_id=`)
+
+	var offenders []string
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			// The helpers themselves wrap stdlib log.Printf — that's the
+			// only sanctioned use, so skip the file that defines them.
+			if filepath.Base(path) == "log.go" {
+				return nil
+			}
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			for lineIdx, line := range strings.Split(string(data), "\n") {
+				if !printfRE.MatchString(line) {
+					continue
+				}
+				if structuredRE.MatchString(line) {
+					continue
+				}
+				offenders = append(offenders, path+":"+itoa(lineIdx+1)+": "+strings.TrimSpace(line))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("SPEC §13.1: log.Printf without `event=` / `task_id=` / `issue_id=` (use LogIssueEventf / LogTaskIDEventf / LogReconcileEventf instead):\n  %s", strings.Join(offenders, "\n  "))
+	}
+}
+
+func itoa(n int) string {
+	// strconv.Itoa would do, but this keeps the import block lean.
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	if n < 0 {
+		b = append(b, '-')
+		n = -n
+	}
+	digits := make([]byte, 0, 10)
+	for n > 0 {
+		digits = append(digits, byte('0'+n%10))
+		n /= 10
+	}
+	for i := len(digits) - 1; i >= 0; i-- {
+		b = append(b, digits[i])
+	}
+	return string(b)
+}
+
+func repoRootForAuditTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.mod walking up from %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/internal/worker/log_test.go
+++ b/internal/worker/log_test.go
@@ -61,17 +61,31 @@ func TestLogIssueEventfOmitsIdentifierWhenAbsent(t *testing.T) {
 
 func TestLogTaskIDEventfMirrorsTaskAndIssueIDs(t *testing.T) {
 	got := captureLog(t, func() {
-		LogTaskIDEventf("tsk-9", "verification_write_failed", "error=%q", "disk full")
+		LogTaskIDEventf("tsk-9", "ENG-9", "verification_write_failed", "error=%q", "disk full")
 	})
 	for _, want := range []string{
 		"event=verification_write_failed",
 		"task_id=tsk-9",
 		"issue_id=tsk-9",
+		"issue_identifier=ENG-9",
 		`error="disk full"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("LogTaskIDEventf output missing %q in:\n%s", want, got)
 		}
+	}
+}
+
+// TestLogTaskIDEventfOmitsEmptyIdentifier covers the reconcile path where
+// the caller has only a synthetic task id and no tracker identifier: the
+// helper must omit the `issue_identifier=` key entirely rather than emit an
+// empty value (which would mis-parse in log aggregators).
+func TestLogTaskIDEventfOmitsEmptyIdentifier(t *testing.T) {
+	got := captureLog(t, func() {
+		LogTaskIDEventf("reconcile-startup", "", "kept_active_workspace", "key=%s", "lin-1")
+	})
+	if strings.Contains(got, "issue_identifier=") {
+		t.Errorf("empty identifier should omit the key, got:\n%s", got)
 	}
 }
 

--- a/internal/worker/log_test.go
+++ b/internal/worker/log_test.go
@@ -1,0 +1,88 @@
+package worker
+
+import (
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+)
+
+// captureLog redirects the stdlib log writer to a buffer for the duration of
+// fn and returns whatever was emitted. The default log flags are stripped so
+// assertions can match the raw structured payload.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	origOut := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+	})
+	fn()
+	return buf.String()
+}
+
+func TestLogIssueEventfEmitsSpec13_1Context(t *testing.T) {
+	got := captureLog(t, func() {
+		LogIssueEventf(task.Task{ID: "lin-42", SourceEventID: "LIN-42"}, "after_run_hook_failed", "error=%q", "exit 1")
+	})
+	for _, want := range []string{
+		"event=after_run_hook_failed",
+		"task_id=lin-42",
+		"issue_id=lin-42",
+		"issue_identifier=LIN-42",
+		`error="exit 1"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("LogIssueEventf output missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestLogIssueEventfOmitsIdentifierWhenAbsent covers the case where Task was
+// hand-constructed without SourceEventID (e.g. legacy tests). The identifier
+// key is omitted rather than emitted as an empty value, so log filters do
+// not misinterpret `issue_identifier=` as a real empty identifier.
+func TestLogIssueEventfOmitsIdentifierWhenAbsent(t *testing.T) {
+	got := captureLog(t, func() {
+		LogIssueEventf(task.Task{ID: "lin-7"}, "workspace_remove_failed", "reason=%s", "afterhook")
+	})
+	if strings.Contains(got, "issue_identifier=") {
+		t.Errorf("missing identifier should not emit empty issue_identifier= ; got:\n%s", got)
+	}
+	if !strings.Contains(got, "task_id=lin-7") || !strings.Contains(got, "issue_id=lin-7") {
+		t.Errorf("missing required task/issue ids in:\n%s", got)
+	}
+}
+
+func TestLogTaskIDEventfMirrorsTaskAndIssueIDs(t *testing.T) {
+	got := captureLog(t, func() {
+		LogTaskIDEventf("tsk-9", "verification_write_failed", "error=%q", "disk full")
+	})
+	for _, want := range []string{
+		"event=verification_write_failed",
+		"task_id=tsk-9",
+		"issue_id=tsk-9",
+		`error="disk full"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("LogTaskIDEventf output missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestLogReconcileEventfOmitsIssueContext(t *testing.T) {
+	got := captureLog(t, func() {
+		LogReconcileEventf("startup_reconciliation_failed", "error=%q", "boom")
+	})
+	if !strings.Contains(got, "event=startup_reconciliation_failed") {
+		t.Errorf("missing event= in:\n%s", got)
+	}
+	if strings.Contains(got, "task_id=") || strings.Contains(got, "issue_id=") {
+		t.Errorf("reconciliation log must not carry per-issue context, got:\n%s", got)
+	}
+}

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -63,7 +63,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	if taskID == "" {
 		taskID = defaultReconcileTaskID
 	}
-	Emit(ctx, cfg.Emitter, taskID, task.EventReconcileStart, "startup reconciliation started", map[string]any{
+	Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileStart, "startup reconciliation started", map[string]any{
 		"workspace_root":  cfg.WorkspaceRoot,
 		"active_states":   cfg.ActiveStates,
 		"terminal_states": cfg.TerminalStates,
@@ -82,7 +82,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	activeIssues, err := cfg.Tracker.ListIssuesByStates(ctx, activeStates)
 	if err != nil {
 		LogReconcileEventf("startup_reconcile_active_fetch_failed", "error=%q note=%q", err, "SPEC §8.6: log and continue; no cleanup performed")
-		Emit(ctx, cfg.Emitter, taskID, task.EventReconcileEnd, "startup reconciliation skipped", map[string]any{
+		Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileEnd, "startup reconciliation skipped", map[string]any{
 			"status": "skipped",
 			"reason": "active_fetch_failed",
 			"error":  err.Error(),
@@ -130,7 +130,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 		}
 		if _, ok := activeKeys[workspace.Key]; ok {
 			kept++
-			Emit(ctx, cfg.Emitter, taskID, task.EventReconcileWorkspace, "kept active workspace", map[string]any{
+			Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept active workspace", map[string]any{
 				"path":   workspace.Path,
 				"key":    workspace.Key,
 				"action": "keep",
@@ -140,7 +140,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 		}
 		if activeIssue, ok := activeReworkIssueForWorkspace(workspace.Key, activeIssues, activeKeysForIssue); ok {
 			kept++
-			Emit(ctx, cfg.Emitter, taskID, task.EventReconcileWorkspace, "kept active workspace", map[string]any{
+			Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept active workspace", map[string]any{
 				"path":       workspace.Path,
 				"key":        workspace.Key,
 				"issue_id":   activeIssue.ID,
@@ -162,7 +162,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 		}
 		if !canRemoveUnknown {
 			kept++
-			Emit(ctx, cfg.Emitter, taskID, task.EventReconcileWorkspace, "kept unknown workspace", map[string]any{
+			Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept unknown workspace", map[string]any{
 				"path":   workspace.Path,
 				"key":    workspace.Key,
 				"action": "keep",
@@ -194,7 +194,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	} else {
 		endPayload["status"] = "ok"
 	}
-	Emit(ctx, cfg.Emitter, taskID, task.EventReconcileEnd, "startup reconciliation finished", endPayload)
+	Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileEnd, "startup reconciliation finished", endPayload)
 	return nil
 }
 
@@ -263,13 +263,13 @@ func issueWorkspaceSourceDirs(trackerKind string) []string {
 }
 
 func removeWorkspace(ctx context.Context, cfg ReconcileConfig, taskID, path string, issue tracker.Issue, reason string) (bool, error) {
-	if err := runWorkspaceHook(ctx, cfg.Emitter, taskID, path, workspace.HookBeforeRemove, cfg.BeforeRemoveHook, cfg.HookTimeoutMillis, cfg.HookEnvPassthrough); err != nil {
+	if err := runWorkspaceHook(ctx, cfg.Emitter, taskID, issue.Identifier, path, workspace.HookBeforeRemove, cfg.BeforeRemoveHook, cfg.HookTimeoutMillis, cfg.HookEnvPassthrough); err != nil {
 		log.Printf("event=before_remove_hook_failed task_id=%s issue_id=%s issue_identifier=%s reason=%s workspace=%q error=%q", taskID, issue.ID, issue.Identifier, reason, path, err)
 	}
 	if err := workspace.SafeRemove(cfg.WorkspaceRoot, path); err != nil {
 		return false, fmt.Errorf("remove %s workspace %s: %w", reason, path, err)
 	}
-	Emit(ctx, cfg.Emitter, taskID, task.EventReconcileWorkspace, "removed workspace", map[string]any{
+	Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "removed workspace", map[string]any{
 		"path":       path,
 		"issue_id":   issue.ID,
 		"identifier": issue.Identifier,
@@ -448,7 +448,7 @@ func sanitizeLegacyWorkspaceKey(s string) string {
 type LogEventEmitter struct{}
 
 func (LogEventEmitter) AddEvent(_ context.Context, taskID, kind, msg string) error {
-	LogTaskIDEventf(taskID, kind, "msg=%q", msg)
+	LogTaskIDEventf(taskID, "", kind, "msg=%q", msg)
 	return nil
 }
 
@@ -456,7 +456,7 @@ func (LogEventEmitter) AddEventWithPayload(ctx context.Context, taskID, kind, ms
 	if payload == nil {
 		return LogEventEmitter{}.AddEvent(ctx, taskID, kind, msg)
 	}
-	LogTaskIDEventf(taskID, kind, "msg=%q payload=%v", msg, payload)
+	LogTaskIDEventf(taskID, "", kind, "msg=%q payload=%v", msg, payload)
 	return nil
 }
 

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -81,7 +81,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	// false when `terminalIssues` is empty.
 	activeIssues, err := cfg.Tracker.ListIssuesByStates(ctx, activeStates)
 	if err != nil {
-		log.Printf("startup reconcile: fetch active issues failed: %v (SPEC §8.6: log and continue; no cleanup performed)", err)
+		LogReconcileEventf("startup_reconcile_active_fetch_failed", "error=%q note=%q", err, "SPEC §8.6: log and continue; no cleanup performed")
 		Emit(ctx, cfg.Emitter, taskID, task.EventReconcileEnd, "startup reconciliation skipped", map[string]any{
 			"status": "skipped",
 			"reason": "active_fetch_failed",
@@ -93,7 +93,7 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	terminalFetchOK := true
 	var terminalFetchErr error
 	if err != nil {
-		log.Printf("startup reconcile: fetch terminal issues failed: %v (SPEC §8.6: log and continue; terminal cleanup skipped)", err)
+		LogReconcileEventf("startup_reconcile_terminal_fetch_failed", "error=%q note=%q", err, "SPEC §8.6: log and continue; terminal cleanup skipped")
 		terminalFetchOK = false
 		terminalFetchErr = err
 		terminalIssues = nil
@@ -264,7 +264,7 @@ func issueWorkspaceSourceDirs(trackerKind string) []string {
 
 func removeWorkspace(ctx context.Context, cfg ReconcileConfig, taskID, path string, issue tracker.Issue, reason string) (bool, error) {
 	if err := runWorkspaceHook(ctx, cfg.Emitter, taskID, path, workspace.HookBeforeRemove, cfg.BeforeRemoveHook, cfg.HookTimeoutMillis, cfg.HookEnvPassthrough); err != nil {
-		log.Printf("task %s: before_remove hook failed for %s workspace %s: %v", taskID, reason, path, err)
+		log.Printf("event=before_remove_hook_failed task_id=%s issue_id=%s issue_identifier=%s reason=%s workspace=%q error=%q", taskID, issue.ID, issue.Identifier, reason, path, err)
 	}
 	if err := workspace.SafeRemove(cfg.WorkspaceRoot, path); err != nil {
 		return false, fmt.Errorf("remove %s workspace %s: %w", reason, path, err)
@@ -448,7 +448,7 @@ func sanitizeLegacyWorkspaceKey(s string) string {
 type LogEventEmitter struct{}
 
 func (LogEventEmitter) AddEvent(_ context.Context, taskID, kind, msg string) error {
-	log.Printf("task %s: %s: %s", taskID, kind, msg)
+	LogTaskIDEventf(taskID, kind, "msg=%q", msg)
 	return nil
 }
 
@@ -456,13 +456,13 @@ func (LogEventEmitter) AddEventWithPayload(ctx context.Context, taskID, kind, ms
 	if payload == nil {
 		return LogEventEmitter{}.AddEvent(ctx, taskID, kind, msg)
 	}
-	log.Printf("task %s: %s: %s payload=%v", taskID, kind, msg, payload)
+	LogTaskIDEventf(taskID, kind, "msg=%q payload=%v", msg, payload)
 	return nil
 }
 
 // LogReconcileError records reconciliation failure before the worker exits.
 func LogReconcileError(err error) {
 	if err != nil {
-		log.Printf("startup reconciliation failed: %v", err)
+		LogReconcileEventf("startup_reconciliation_failed", "error=%q", err)
 	}
 }

--- a/internal/worker/run_test.go
+++ b/internal/worker/run_test.go
@@ -60,7 +60,7 @@ func (f *fakeEmitter) byKind(kind string) []recordedEvent {
 
 func TestEmitRecordsEventOnFakeEmitter(t *testing.T) {
 	ev := &fakeEmitter{}
-	worker.Emit(context.Background(), ev, "tsk_1", task.EventRunnerStart, "runner started", map[string]any{"model": "mock"})
+	worker.Emit(context.Background(), ev, "tsk_1", "", task.EventRunnerStart, "runner started", map[string]any{"model": "mock"})
 	if len(ev.events) != 1 {
 		t.Fatalf("events = %d, want 1", len(ev.events))
 	}
@@ -80,12 +80,12 @@ func TestEmitRecordsEventOnFakeEmitter(t *testing.T) {
 
 func TestEmitNilEmitterIsNoop(t *testing.T) {
 	// Should not panic when worker is started without an emitter (e.g. tests).
-	worker.Emit(context.Background(), nil, "tsk_1", task.EventRunnerStart, "ignored", nil)
+	worker.Emit(context.Background(), nil, "tsk_1", "", task.EventRunnerStart, "ignored", nil)
 }
 
 func TestEmitLogsEmitterError(t *testing.T) {
 	ev := &fakeEmitter{err: errors.New("db down")}
-	worker.Emit(context.Background(), ev, "tsk_1", task.EventPush, "push", nil)
+	worker.Emit(context.Background(), ev, "tsk_1", "", task.EventPush, "push", nil)
 	if len(ev.events) != 1 {
 		t.Fatalf("event should still be recorded by fake even when error returned")
 	}
@@ -856,7 +856,7 @@ func TestResolveWorkflow_EmitsResolvedEvent(t *testing.T) {
 		t.Fatalf("load workflow: %v", err)
 	}
 	ev := &fakeEmitter{}
-	wf, src, err := worker.ResolveWorkflow(context.Background(), ev, "tsk_1", loaded)
+	wf, src, err := worker.ResolveWorkflow(context.Background(), ev, "tsk_1", "", loaded)
 	if err != nil {
 		t.Fatalf("ResolveWorkflow: %v", err)
 	}
@@ -925,7 +925,7 @@ func TestResolveWorkflow_LogsResolutionLine(t *testing.T) {
 		log.SetFlags(origFlags)
 	})
 
-	if _, _, err := worker.ResolveWorkflow(context.Background(), &fakeEmitter{}, "tsk_log", wf); err != nil {
+	if _, _, err := worker.ResolveWorkflow(context.Background(), &fakeEmitter{}, "tsk_log", "", wf); err != nil {
 		t.Fatalf("ResolveWorkflow: %v", err)
 	}
 
@@ -972,7 +972,7 @@ func TestResolveWorkflow_LogsResolutionLineOmitsEmptyShadowed(t *testing.T) {
 		log.SetFlags(origFlags)
 	})
 
-	if _, _, err := worker.ResolveWorkflow(context.Background(), &fakeEmitter{}, "tsk_log2", wf); err != nil {
+	if _, _, err := worker.ResolveWorkflow(context.Background(), &fakeEmitter{}, "tsk_log2", "", wf); err != nil {
 		t.Fatalf("ResolveWorkflow: %v", err)
 	}
 
@@ -991,7 +991,7 @@ func TestResolveWorkflow_LogsResolutionLineOmitsEmptyShadowed(t *testing.T) {
 func TestResolveWorkflow_DefaultSourceOmitsPath(t *testing.T) {
 	ev := &fakeEmitter{}
 	wf := &workflow.Workflow{Config: workflow.DefaultConfig(), PromptTemplate: workflow.DefaultPrompt(), Source: workflow.SourceDefault}
-	_, src, err := worker.ResolveWorkflow(context.Background(), ev, "tsk_2", wf)
+	_, src, err := worker.ResolveWorkflow(context.Background(), ev, "tsk_2", "", wf)
 	if err != nil {
 		t.Fatalf("ResolveWorkflow: %v", err)
 	}
@@ -1047,7 +1047,7 @@ func TestVerifyAllowFailure_ReturnsDegradedWithoutError(t *testing.T) {
 		},
 	}
 
-	degraded, err := worker.RunVerifyPhase(context.Background(), ev, "tsk_af", dir, cfg)
+	degraded, err := worker.RunVerifyPhase(context.Background(), ev, "tsk_af", "", dir, cfg)
 	if err != nil {
 		t.Fatalf("RunVerifyPhase with allow_failure=true must not return error, got: %v", err)
 	}
@@ -1080,7 +1080,7 @@ func TestVerifyFails_BlocksPRWhenAllowFailureOff(t *testing.T) {
 		},
 	}
 
-	degraded, err := worker.RunVerifyPhase(context.Background(), ev, "tsk_naf", dir, cfg)
+	degraded, err := worker.RunVerifyPhase(context.Background(), ev, "tsk_naf", "", dir, cfg)
 	if err == nil {
 		t.Fatal("RunVerifyPhase must return error when verify fails and allow_failure=false")
 	}
@@ -1195,7 +1195,7 @@ func TestVerifyAllowFailure_DoesNotMaskParentCancel(t *testing.T) {
 	}()
 
 	start := time.Now()
-	degraded, err := worker.RunVerifyPhase(ctx, ev, "tsk_cancel", dir, cfg)
+	degraded, err := worker.RunVerifyPhase(ctx, ev, "tsk_cancel", "", dir, cfg)
 	elapsed := time.Since(start)
 
 	if elapsed > 2*time.Second {

--- a/internal/worker/run_test.go
+++ b/internal/worker/run_test.go
@@ -931,7 +931,9 @@ func TestResolveWorkflow_LogsResolutionLine(t *testing.T) {
 
 	got := buf.String()
 	wantSubstrings := []string{
-		"task tsk_log: workflow resolved",
+		"event=workflow_resolved",
+		"task_id=tsk_log",
+		"issue_id=tsk_log",
 		"source=file",
 		"path=" + workflowPath,
 	}

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -186,10 +186,10 @@ func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, identifier, 
 
 func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, identifier, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, reason string) {
 	if err := runWorkspaceHook(ctx, ev, taskID, identifier, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs, envPassthrough); err != nil {
-		LogTaskIDEventf(taskID, "before_remove_hook_failed", "reason=%s error=%q", reason, err)
+		LogTaskIDEventf(taskID, identifier, "before_remove_hook_failed", "reason=%s error=%q", reason, err)
 	}
 	if err := workspace.SafeRemove(workspaceRoot, workdir); err != nil {
-		LogTaskIDEventf(taskID, "workspace_remove_failed", "reason=%s workdir=%q error=%q", reason, workdir, err)
+		LogTaskIDEventf(taskID, identifier, "workspace_remove_failed", "reason=%s workdir=%q error=%q", reason, workdir, err)
 	}
 }
 

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -101,7 +100,7 @@ func logWorkflowResolved(taskID string, res *workflow.Resolution) {
 	if len(res.ShadowedBy) > 0 {
 		parts = append(parts, "shadowed=["+strings.Join(res.ShadowedBy, ",")+"]")
 	}
-	log.Printf("task %s: workflow resolved: %s", taskID, strings.Join(parts, " "))
+	LogTaskIDEventf(taskID, "workflow_resolved", "%s", strings.Join(parts, " "))
 }
 
 // failingStore is the subset of queue.Store handleTaskFailure needs.
@@ -126,7 +125,7 @@ type failingStore interface {
 func handleTaskFailure(ctx context.Context, store failingStore, t task.Task, cfg workflow.Config, err error, nonRetryable bool) bool {
 	if nonRetryable {
 		if ferr := store.FailTerminal(ctx, t.ID, err.Error()); ferr != nil {
-			log.Printf("task %s FailTerminal error: %v", t.ID, ferr)
+			LogIssueEventf(t, "fail_terminal_store_error", "error=%q", ferr)
 			return false
 		}
 		return true
@@ -135,14 +134,14 @@ func handleTaskFailure(ctx context.Context, store failingStore, t task.Task, cfg
 		budget := cfg.Agent.MaxTimeoutRetriesValue()
 		requeued, ferr := store.FailTimeout(ctx, t.ID, err.Error(), budget)
 		if ferr != nil {
-			log.Printf("task %s FailTimeout error: %v", t.ID, ferr)
+			LogIssueEventf(t, "fail_timeout_store_error", "error=%q", ferr)
 			return false
 		}
 		return !requeued
 	}
 	terminal, ferr := store.Fail(ctx, t.ID, err.Error())
 	if ferr != nil {
-		log.Printf("task %s Fail error: %v", t.ID, ferr)
+		LogIssueEventf(t, "fail_store_error", "error=%q", ferr)
 		return false
 	}
 	return terminal
@@ -187,10 +186,10 @@ func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, workdir stri
 
 func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, reason string) {
 	if err := runWorkspaceHook(ctx, ev, taskID, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs, envPassthrough); err != nil {
-		log.Printf("task %s: before_remove hook failed after %s hook failure: %v", taskID, reason, err)
+		LogTaskIDEventf(taskID, "before_remove_hook_failed", "reason=%s error=%q", reason, err)
 	}
 	if err := workspace.SafeRemove(workspaceRoot, workdir); err != nil {
-		log.Printf("task %s: remove workspace %s after %s hook failure: %v", taskID, workdir, reason, err)
+		LogTaskIDEventf(taskID, "workspace_remove_failed", "reason=%s workdir=%q error=%q", reason, workdir, err)
 	}
 }
 
@@ -324,14 +323,14 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		emitTaskPhase(from, to)
 	}}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
 		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
-			log.Printf("task %s: after_run hook failed after runner error: %v", t.ID, err)
+			LogIssueEventf(t, "after_run_hook_failed", "after_runner_error=true error=%q", err)
 		}
 		WriteFailureArtifacts(ctx, workdir, nil, "runner failed: "+ErrSummary(runErr))
 		return &RunTaskError{Cfg: wcfg, Err: runErr}
 	}
 
 	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
-		log.Printf("task %s: after_run hook failed: %v", t.ID, err)
+		LogIssueEventf(t, "after_run_hook_failed", "error=%q", err)
 	}
 
 	if err := workspace.EnforcePolicy(ctx, workdir, wcfg); err != nil {
@@ -413,11 +412,11 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	// CHANGED_FILES.txt is available as a workspace artifact for post-run
 	// inspection. This does not push anything; that is the agent's job.
 	if err := workspace.WriteChangedFiles(workdir, nil); err != nil {
-		log.Printf("task %s: seed changed files artifact: %v", t.ID, err)
+		LogIssueEventf(t, "changed_files_seed_failed", "error=%q", err)
 	}
 	changed, _ := workspace.AllChangedFiles(ctx, workdir)
 	if err := workspace.WriteChangedFiles(workdir, changed); err != nil {
-		log.Printf("task %s: write changed files artifact: %v", t.ID, err)
+		LogIssueEventf(t, "changed_files_write_failed", "error=%q", err)
 	}
 	clearPolicyViolationFeedback(workspaceRoot, t)
 
@@ -622,7 +621,7 @@ func RunVerifyPhase(ctx context.Context, ev EventEmitter, taskID, workdir string
 	start := time.Now()
 	results, verifyErr := workspace.RunVerify(ctx, workdir, cfg)
 	if writeErr := workspace.WriteVerification(workdir, results); writeErr != nil {
-		log.Printf("task %s: write verification artifact: %v", taskID, writeErr)
+		LogTaskIDEventf(taskID, "verification_write_failed", "error=%q", writeErr)
 	}
 	payload := map[string]any{
 		"duration_ms":   time.Since(start).Milliseconds(),
@@ -789,7 +788,7 @@ func Emit(ctx context.Context, ev EventEmitter, taskID, kind, msg string, payloa
 		return
 	}
 	if err := ev.AddEventWithPayload(ctx, taskID, kind, msg, payload); err != nil {
-		log.Printf("task %s: emit %s event: %v", taskID, kind, err)
+		LogTaskIDEventf(taskID, "event_emit_failed", "kind=%s error=%q", kind, err)
 	}
 }
 

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -65,7 +65,11 @@ func issueRenderVarsForTask(t task.Task) map[string]any {
 	}
 }
 
-func ResolveWorkflow(ctx context.Context, ev EventEmitter, taskID string, wf *workflow.Workflow) (*workflow.Workflow, string, error) {
+// ResolveWorkflow returns the resolved workflow for a task, emitting the
+// canonical workflow_resolved event + log line. identifier is the tracker
+// issue identifier (Task.SourceEventID); pass "" if unknown — the log line
+// then omits issue_identifier= rather than emitting an empty value.
+func ResolveWorkflow(ctx context.Context, ev EventEmitter, taskID, identifier string, wf *workflow.Workflow) (*workflow.Workflow, string, error) {
 	if wf == nil {
 		return nil, "", fmt.Errorf("service workflow is required")
 	}
@@ -79,20 +83,16 @@ func ResolveWorkflow(ctx context.Context, ev EventEmitter, taskID string, wf *wo
 	if res.Path != "" {
 		payload["path"] = res.Path
 	}
-	Emit(ctx, ev, taskID, task.EventWorkflowResolved, "workflow resolved", payload)
-	logWorkflowResolved(taskID, res)
+	Emit(ctx, ev, taskID, identifier, task.EventWorkflowResolved, "workflow resolved", payload)
+	logWorkflowResolved(taskID, identifier, res)
 	return wf, string(res.Source), nil
 }
 
-// logWorkflowResolved prints a single info-level line summarizing how the
-// workflow was discovered. Format:
-//
-//	task <id>: workflow resolved: source=<source> path=<path>
-//
-// The path segment is omitted when empty so the common case (source=default)
-// stays short. The retained shadowed segment is only emitted for future
-// non-legacy metadata; ignored .aiops/.github workflow files must not populate it.
-func logWorkflowResolved(taskID string, res *workflow.Resolution) {
+// logWorkflowResolved prints the structured `event=workflow_resolved` line
+// summarizing how the workflow was discovered. The path segment is omitted
+// when empty so the common case (source=default) stays short; identifier is
+// passed through to LogTaskIDEventf and omitted when "".
+func logWorkflowResolved(taskID, identifier string, res *workflow.Resolution) {
 	parts := []string{"source=" + string(res.Source)}
 	if res.Path != "" {
 		parts = append(parts, "path="+res.Path)
@@ -100,7 +100,7 @@ func logWorkflowResolved(taskID string, res *workflow.Resolution) {
 	if len(res.ShadowedBy) > 0 {
 		parts = append(parts, "shadowed=["+strings.Join(res.ShadowedBy, ",")+"]")
 	}
-	LogTaskIDEventf(taskID, "workflow_resolved", "%s", strings.Join(parts, " "))
+	LogTaskIDEventf(taskID, identifier, "workflow_resolved", "%s", strings.Join(parts, " "))
 }
 
 // failingStore is the subset of queue.Store handleTaskFailure needs.
@@ -156,9 +156,9 @@ func handleTaskFailure(ctx context.Context, store failingStore, t task.Task, cfg
 // workflow, run agent session, enforce policy/secret-scan/RUN_SUMMARY gates,
 // emit events, and clean up.
 
-func emitHookResults(ctx context.Context, ev EventEmitter, taskID string, results []workspace.HookResult) {
+func emitHookResults(ctx context.Context, ev EventEmitter, taskID, identifier string, results []workspace.HookResult) {
 	for _, res := range results {
-		Emit(ctx, ev, taskID, task.EventWorkspaceHookEnd, string(res.Name)+" hook completed", map[string]any{
+		Emit(ctx, ev, taskID, identifier, task.EventWorkspaceHookEnd, string(res.Name)+" hook completed", map[string]any{
 			"hook":        string(res.Name),
 			"command":     res.Command,
 			"exit_code":   res.ExitCode,
@@ -170,22 +170,22 @@ func emitHookResults(ctx context.Context, ev EventEmitter, taskID string, result
 	}
 }
 
-func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, workdir string, name workspace.HookName, hook workflow.WorkspaceHook, timeoutMs int, envPassthrough []string) error {
+func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, identifier, workdir string, name workspace.HookName, hook workflow.WorkspaceHook, timeoutMs int, envPassthrough []string) error {
 	if len(hook.Commands) == 0 {
 		return nil
 	}
-	Emit(ctx, ev, taskID, task.EventWorkspaceHookStart, string(name)+" hook started", map[string]any{
+	Emit(ctx, ev, taskID, identifier, task.EventWorkspaceHookStart, string(name)+" hook started", map[string]any{
 		"hook":       string(name),
 		"commands":   len(hook.Commands),
 		"timeout_ms": timeoutMs,
 	})
 	results, err := workspace.RunWorkspaceHook(ctx, workdir, name, hook, timeoutMs, envPassthrough)
-	emitHookResults(ctx, ev, taskID, results)
+	emitHookResults(ctx, ev, taskID, identifier, results)
 	return err
 }
 
-func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, reason string) {
-	if err := runWorkspaceHook(ctx, ev, taskID, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs, envPassthrough); err != nil {
+func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, identifier, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, reason string) {
+	if err := runWorkspaceHook(ctx, ev, taskID, identifier, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs, envPassthrough); err != nil {
 		LogTaskIDEventf(taskID, "before_remove_hook_failed", "reason=%s error=%q", reason, err)
 	}
 	if err := workspace.SafeRemove(workspaceRoot, workdir); err != nil {
@@ -199,7 +199,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	currentPhase := task.RunAttemptPhase("")
 	phaseTerminal := false
 	emitTaskPhase := func(from, to task.RunAttemptPhase) {
-		EmitPhaseTransition(ctx, ev, t.ID, from, to)
+		EmitPhaseTransition(ctx, ev, t.ID, t.SourceEventID, from, to)
 		currentPhase = to
 		phaseTerminal = isTerminalPhase(to)
 	}
@@ -210,7 +210,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	}()
 
 	emitTaskPhase("", task.PhasePreparingWorkspace)
-	wf, workflowSource, err := ResolveWorkflow(ctx, ev, t.ID, cfg.Workflow)
+	wf, workflowSource, err := ResolveWorkflow(ctx, ev, t.ID, t.SourceEventID, cfg.Workflow)
 	if err != nil {
 		return &RunTaskError{Err: err}
 	}
@@ -231,8 +231,8 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 			return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("resolve workspace base: %w", err)}
 		}
 	}
-	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterCreate, hooks.AfterCreate, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
-		removeWorkdirAfterHookFailure(ctx, ev, t.ID, workspaceRoot, workdir, hooks.BeforeRemove, hooks.TimeoutMs, hooks.EnvPassthrough, "after_create")
+	if err := runWorkspaceHook(ctx, ev, t.ID, t.SourceEventID, workdir, workspace.HookAfterCreate, hooks.AfterCreate, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
+		removeWorkdirAfterHookFailure(ctx, ev, t.ID, t.SourceEventID, workspaceRoot, workdir, hooks.BeforeRemove, hooks.TimeoutMs, hooks.EnvPassthrough, "after_create")
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
@@ -263,7 +263,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	}
 	policyFeedback, policyFeedbackPath, feedbackErr := readPolicyViolationFeedback(workspaceRoot, t)
 	if feedbackErr != nil {
-		Emit(ctx, ev, t.ID, task.EventPolicyFeedbackReadError, "failed to read prior policy violation feedback", map[string]any{
+		Emit(ctx, ev, t.ID, t.SourceEventID, task.EventPolicyFeedbackReadError, "failed to read prior policy violation feedback", map[string]any{
 			"path":  policyFeedbackPath,
 			"error": ErrSummary(feedbackErr),
 		})
@@ -271,7 +271,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("read policy violation feedback: %w", feedbackErr), NonRetryable: true}
 	} else if policyFeedback != nil {
 		policyBudget := wcfg.Agent.PolicyViolationBudgetValue()
-		Emit(ctx, ev, t.ID, task.EventPolicyFeedbackLoaded, "loaded prior policy violation feedback", map[string]any{
+		Emit(ctx, ev, t.ID, t.SourceEventID, task.EventPolicyFeedbackLoaded, "loaded prior policy violation feedback", map[string]any{
 			"path":            policyFeedbackPath,
 			"violation_count": policyFeedback.Count,
 			"summary":         policyFeedback.Summary,
@@ -314,7 +314,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		}
 	}
 
-	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookBeforeRun, hooks.BeforeRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
+	if err := runWorkspaceHook(ctx, ev, t.ID, t.SourceEventID, workdir, workspace.HookBeforeRun, hooks.BeforeRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
 		WriteFailureArtifacts(ctx, workdir, nil, "before_run hook failed: "+ErrSummary(err))
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
@@ -322,14 +322,14 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: workspaceRoot, Prompt: prompt, PhaseTransitionSink: func(from, to task.RunAttemptPhase) {
 		emitTaskPhase(from, to)
 	}}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
-		if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
+		if err := runWorkspaceHook(ctx, ev, t.ID, t.SourceEventID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
 			LogIssueEventf(t, "after_run_hook_failed", "after_runner_error=true error=%q", err)
 		}
 		WriteFailureArtifacts(ctx, workdir, nil, "runner failed: "+ErrSummary(runErr))
 		return &RunTaskError{Cfg: wcfg, Err: runErr}
 	}
 
-	if err := runWorkspaceHook(ctx, ev, t.ID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
+	if err := runWorkspaceHook(ctx, ev, t.ID, t.SourceEventID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
 		LogIssueEventf(t, "after_run_hook_failed", "error=%q", err)
 	}
 
@@ -343,7 +343,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		if feedback != nil && policyBudget > 0 && feedback.Count >= policyBudget {
 			willRetry = false
 		}
-		recordPolicyViolation(ctx, ev, t.ID, err, feedback, feedbackPath, willRetry, feedbackErr, policyBudget)
+		recordPolicyViolation(ctx, ev, t.ID, t.SourceEventID, err, feedback, feedbackPath, willRetry, feedbackErr, policyBudget)
 		WriteFailureArtifacts(ctx, workdir, nil, "policy check failed: "+ErrSummary(err))
 		if feedbackErr != nil {
 			return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("write policy violation feedback: %w; original policy error: %v", feedbackErr, err), NonRetryable: true}
@@ -354,11 +354,11 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
-	if _, err := RunVerifyPhase(ctx, ev, t.ID, workdir, wcfg); err != nil {
+	if _, err := RunVerifyPhase(ctx, ev, t.ID, t.SourceEventID, workdir, wcfg); err != nil {
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
-	if err := enforceAnalysisOnlyChanges(ctx, ev, t.ID, workdir, workspaceBase, wcfg); err != nil {
+	if err := enforceAnalysisOnlyChanges(ctx, ev, t.ID, t.SourceEventID, workdir, workspaceBase, wcfg); err != nil {
 		WriteFailureArtifacts(ctx, workdir, nil, ErrSummary(err))
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
@@ -375,11 +375,11 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	// the scanner on this path keeps the failure attribution unambiguous.
 	_, status, checkErr := workspace.CheckSummary(workdir)
 	if checkErr != nil {
-		Emit(ctx, ev, t.ID, "summary_missing", "read RUN_SUMMARY.md failed", map[string]any{
+		Emit(ctx, ev, t.ID, t.SourceEventID, "summary_missing", "read RUN_SUMMARY.md failed", map[string]any{
 			"path":  workspace.SummaryPath,
 			"error": ErrSummary(checkErr),
 		})
-		Emit(ctx, ev, t.ID, task.EventFailedAttempt, "missing run summary artifact", map[string]any{
+		Emit(ctx, ev, t.ID, t.SourceEventID, task.EventFailedAttempt, "missing run summary artifact", map[string]any{
 			"reason": "summary_unreadable",
 			"path":   workspace.SummaryPath,
 		})
@@ -387,11 +387,11 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("read %s: %w", workspace.SummaryPath, checkErr)}
 	}
 	if status != workspace.SummaryOK {
-		Emit(ctx, ev, t.ID, "summary_missing", "runner did not produce RUN_SUMMARY.md", map[string]any{
+		Emit(ctx, ev, t.ID, t.SourceEventID, "summary_missing", "runner did not produce RUN_SUMMARY.md", map[string]any{
 			"path":   workspace.SummaryPath,
 			"status": string(status),
 		})
-		Emit(ctx, ev, t.ID, task.EventFailedAttempt, "missing run summary artifact", map[string]any{
+		Emit(ctx, ev, t.ID, t.SourceEventID, task.EventFailedAttempt, "missing run summary artifact", map[string]any{
 			"reason": "summary_" + string(status),
 			"path":   workspace.SummaryPath,
 		})
@@ -403,7 +403,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 	// though push is now the agent's responsibility — it acts as a final
 	// gate that fails the task before the orchestrator records success, so
 	// a branch carrying credential leaks is never considered complete.
-	if err := runSecretScan(ctx, ev, t.ID, workdir, wf.Config); err != nil {
+	if err := runSecretScan(ctx, ev, t.ID, t.SourceEventID, workdir, wf.Config); err != nil {
 		WriteFailureArtifacts(ctx, workdir, nil, "secret scan blocked: "+ErrSummary(err))
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
@@ -446,7 +446,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 		timeout = 30 * time.Minute
 	}
 
-	Emit(ctx, ev, in.Task.ID, task.EventRunnerStart, "runner started", map[string]any{
+	Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerStart, "runner started", map[string]any{
 		"model":           in.Task.Model,
 		"timeout_ms":      timeout.Milliseconds(),
 		"workflow_source": workflowSource,
@@ -462,7 +462,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 			upstreamPhaseSink(from, to)
 			return
 		}
-		EmitPhaseTransition(ctx, ev, in.Task.ID, from, to)
+		EmitPhaseTransition(ctx, ev, in.Task.ID, in.Task.SourceEventID, from, to)
 	}
 	in.PhaseTransitionSink(task.PhaseBuildingPrompt, task.PhaseLaunchingAgentProcess)
 	emittedRuntimeEvents := map[string]bool{}
@@ -473,7 +473,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 			upstreamRuntimeSink(event)
 			return
 		}
-		EmitRuntimeEvents(ctx, ev, in.Task.ID, []task.RuntimeEvent{event})
+		EmitRuntimeEvents(ctx, ev, in.Task.ID, in.Task.SourceEventID, []task.RuntimeEvent{event})
 	}
 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -487,7 +487,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 		if emittedRuntimeEvents[runtimeEventKey(event)] {
 			continue
 		}
-		EmitRuntimeEvents(ctx, ev, in.Task.ID, []task.RuntimeEvent{event})
+		EmitRuntimeEvents(ctx, ev, in.Task.ID, in.Task.SourceEventID, []task.RuntimeEvent{event})
 	}
 
 	if runErr != nil {
@@ -500,8 +500,8 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 				"elapsed_ms": stall.Elapsed.Milliseconds(),
 			}
 			addOutputFields(stallPayload, res)
-			Emit(ctx, ev, in.Task.ID, task.EventStalled, stall.Error(), stallPayload)
-			Emit(ctx, ev, in.Task.ID, task.EventRunnerTimeout, stall.Error(), stallPayload)
+			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventStalled, stall.Error(), stallPayload)
+			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, stall.Error(), stallPayload)
 			return res, runErr
 		}
 		var turnTimeout *runner.TurnTimeoutError
@@ -513,7 +513,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 				"elapsed_ms": turnTimeout.Elapsed.Milliseconds(),
 			}
 			addOutputFields(timeoutPayload, res)
-			Emit(ctx, ev, in.Task.ID, task.EventRunnerTimeout, turnTimeout.Error(), timeoutPayload)
+			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, turnTimeout.Error(), timeoutPayload)
 			return res, runErr
 		}
 		var readTimeout *runner.ReadTimeoutError
@@ -525,7 +525,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 				"elapsed_ms": elapsed.Milliseconds(),
 			}
 			addOutputFields(timeoutPayload, res)
-			Emit(ctx, ev, in.Task.ID, task.EventRunnerTimeout, readTimeout.Error(), timeoutPayload)
+			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, readTimeout.Error(), timeoutPayload)
 			return res, runErr
 		}
 		var te *runner.TimeoutError
@@ -541,7 +541,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 				"elapsed_ms": te.Elapsed.Milliseconds(),
 			}
 			addOutputFields(timeoutPayload, res)
-			Emit(ctx, ev, in.Task.ID, task.EventRunnerTimeout, te.Error(), timeoutPayload)
+			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, te.Error(), timeoutPayload)
 			return res, runErr
 		}
 		in.PhaseTransitionSink(currentPhase, task.PhaseFailed)
@@ -552,7 +552,7 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 			"ok":          false,
 		}
 		addOutputFields(failurePayload, res)
-		Emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner failed", failurePayload)
+		Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerEnd, "runner failed", failurePayload)
 		return res, runErr
 	}
 
@@ -566,30 +566,30 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 		endPayload["summary"] = res.Summary
 	}
 	addOutputFields(endPayload, res)
-	Emit(ctx, ev, in.Task.ID, task.EventRunnerEnd, "runner completed", endPayload)
+	Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerEnd, "runner completed", endPayload)
 	return res, nil
 }
 
 // EmitPhaseTransition records SPEC §7.2 run-attempt phase transitions with the
 // canonical phase names in a structured payload.
-func EmitPhaseTransition(ctx context.Context, ev EventEmitter, taskID string, from, to task.RunAttemptPhase) {
+func EmitPhaseTransition(ctx context.Context, ev EventEmitter, taskID, identifier string, from, to task.RunAttemptPhase) {
 	if to == "" {
 		return
 	}
 	payload := task.PhaseTransitionEvent(from, to)
-	Emit(ctx, ev, taskID, task.EventRunPhaseTransition, string(to), payload)
+	Emit(ctx, ev, taskID, identifier, task.EventRunPhaseTransition, string(to), payload)
 }
 
 // EmitRuntimeEvents forwards SPEC §10.4 app-server runtime events captured by
 // the runner into the task event stream. The runtime event name is already the
 // task event kind; payload is preserved verbatim so downstream conformance
 // checks can inspect the app-server details without parsing runner output.
-func EmitRuntimeEvents(ctx context.Context, ev EventEmitter, taskID string, events []task.RuntimeEvent) {
+func EmitRuntimeEvents(ctx context.Context, ev EventEmitter, taskID, identifier string, events []task.RuntimeEvent) {
 	for _, event := range events {
 		if event.Event == "" {
 			continue
 		}
-		Emit(ctx, ev, taskID, event.Event, event.Event, event.Payload)
+		Emit(ctx, ev, taskID, identifier, event.Event, event.Event, event.Payload)
 	}
 }
 
@@ -612,8 +612,8 @@ func runtimeEventKey(event task.RuntimeEvent) string {
 // Returns (degraded, err). When err is non-nil, verify failed AND
 // allow_failure was off; the caller propagates the error. When
 // degraded=true, err is nil.
-func RunVerifyPhase(ctx context.Context, ev EventEmitter, taskID, workdir string, cfg workflow.Config) (bool, error) {
-	Emit(ctx, ev, taskID, task.EventVerifyStart, "verify started", map[string]any{
+func RunVerifyPhase(ctx context.Context, ev EventEmitter, taskID, identifier, workdir string, cfg workflow.Config) (bool, error) {
+	Emit(ctx, ev, taskID, identifier, task.EventVerifyStart, "verify started", map[string]any{
 		"commands":      cfg.Verify.Commands,
 		"timeout_ms":    cfg.Verify.Timeout.Milliseconds(),
 		"allow_failure": cfg.Verify.AllowFailure,
@@ -621,7 +621,7 @@ func RunVerifyPhase(ctx context.Context, ev EventEmitter, taskID, workdir string
 	start := time.Now()
 	results, verifyErr := workspace.RunVerify(ctx, workdir, cfg)
 	if writeErr := workspace.WriteVerification(workdir, results); writeErr != nil {
-		LogTaskIDEventf(taskID, "verification_write_failed", "error=%q", writeErr)
+		LogTaskIDEventf(taskID, identifier, "verification_write_failed", "error=%q", writeErr)
 	}
 	payload := map[string]any{
 		"duration_ms":   time.Since(start).Milliseconds(),
@@ -631,7 +631,7 @@ func RunVerifyPhase(ctx context.Context, ev EventEmitter, taskID, workdir string
 	}
 	if verifyErr == nil {
 		payload["status"] = "ok"
-		Emit(ctx, ev, taskID, task.EventVerifyEnd, "verify completed", payload)
+		Emit(ctx, ev, taskID, identifier, task.EventVerifyEnd, "verify completed", payload)
 		return false, nil
 	}
 	payload["error"] = ErrSummary(verifyErr)
@@ -642,16 +642,16 @@ func RunVerifyPhase(ctx context.Context, ev EventEmitter, taskID, workdir string
 	// returns ctx.Err() directly on parent-cancel, so errors.Is matches.
 	if errors.Is(verifyErr, context.Canceled) || errors.Is(verifyErr, context.DeadlineExceeded) {
 		payload["status"] = "canceled"
-		Emit(ctx, ev, taskID, task.EventVerifyEnd, "verify canceled", payload)
+		Emit(ctx, ev, taskID, identifier, task.EventVerifyEnd, "verify canceled", payload)
 		return false, verifyErr
 	}
 	if cfg.Verify.AllowFailure {
 		payload["status"] = "failed_allowed"
-		Emit(ctx, ev, taskID, task.EventVerifyEnd, "verify failed (investigation mode)", payload)
+		Emit(ctx, ev, taskID, identifier, task.EventVerifyEnd, "verify failed (investigation mode)", payload)
 		return true, nil
 	}
 	payload["status"] = "failed"
-	Emit(ctx, ev, taskID, task.EventVerifyEnd, "verify failed", payload)
+	Emit(ctx, ev, taskID, identifier, task.EventVerifyEnd, "verify failed", payload)
 	WriteFailureArtifacts(ctx, workdir, results, "verify failed: "+ErrSummary(verifyErr))
 	return false, verifyErr
 }
@@ -682,11 +682,11 @@ func countVerifyFailures(results []workspace.VerifyResult) int {
 // When the scan is disabled or unconfigured, no events are emitted; this
 // preserves the worker's previous behavior for repos that have not opted
 // in.
-func runSecretScan(ctx context.Context, ev EventEmitter, taskID string, workdir string, cfg workflow.Config) error {
-	return runSecretScanWith(ctx, ev, taskID, workdir, cfg, workspace.RunSecretScan)
+func runSecretScan(ctx context.Context, ev EventEmitter, taskID, identifier string, workdir string, cfg workflow.Config) error {
+	return runSecretScanWith(ctx, ev, taskID, identifier, workdir, cfg, workspace.RunSecretScan)
 }
 
-func runSecretScanWith(ctx context.Context, ev EventEmitter, taskID string, workdir string, cfg workflow.Config, scan secretScanFn) error {
+func runSecretScanWith(ctx context.Context, ev EventEmitter, taskID, identifier string, workdir string, cfg workflow.Config, scan secretScanFn) error {
 	scfg := cfg.Verify.SecretScan
 	if !scfg.Enabled || len(scfg.Command) == 0 {
 		return nil
@@ -736,7 +736,7 @@ func runSecretScanWith(ctx context.Context, ev EventEmitter, taskID string, work
 // `agent.policy_violation_budget` (resolved via PolicyViolationBudgetValue),
 // emitted alongside the running count so dashboards can render "violation N
 // of M (final attempt)".
-func recordPolicyViolation(ctx context.Context, ev EventEmitter, taskID string, err error, feedback *policyViolationFeedback, feedbackPath string, willRetry bool, feedbackErr error, budget int) {
+func recordPolicyViolation(ctx context.Context, ev EventEmitter, taskID, identifier string, err error, feedback *policyViolationFeedback, feedbackPath string, willRetry bool, feedbackErr error, budget int) {
 	if ev == nil {
 		return
 	}
@@ -783,12 +783,17 @@ func WriteFailureArtifacts(ctx context.Context, workdir string, verifyResults []
 }
 
 // Emit records a structured task event. It is a no-op when ev is nil.
-func Emit(ctx context.Context, ev EventEmitter, taskID, kind, msg string, payload any) {
+// identifier is the tracker issue identifier (Task.SourceEventID) carried
+// alongside taskID so the fallback `event_emit_failed` log on emitter error
+// satisfies SPEC §13.1's required context fields. Pass "" when the caller
+// does not have the identifier (e.g. reconciliation paths that synthesise a
+// non-task taskID); the log line then omits issue_identifier=.
+func Emit(ctx context.Context, ev EventEmitter, taskID, identifier, kind, msg string, payload any) {
 	if ev == nil {
 		return
 	}
 	if err := ev.AddEventWithPayload(ctx, taskID, kind, msg, payload); err != nil {
-		LogTaskIDEventf(taskID, "event_emit_failed", "kind=%s error=%q", kind, err)
+		LogTaskIDEventf(taskID, identifier, "event_emit_failed", "kind=%s error=%q", kind, err)
 	}
 }
 
@@ -837,14 +842,14 @@ const analysisOnlyDirective = "\n\n---\n\n" +
 	"as `.aiops/PLAN.md`; any optional tracker handoff must happen through " +
 	"agent-side tools advertised to you by the runtime."
 
-func enforceAnalysisOnlyChanges(ctx context.Context, ev EventEmitter, taskID, workdir, baseRef string, cfg workflow.Config) error {
+func enforceAnalysisOnlyChanges(ctx context.Context, ev EventEmitter, taskID, identifier, workdir, baseRef string, cfg workflow.Config) error {
 	if cfg.Policy.Mode != "analysis_only" {
 		return nil
 	}
 	planPath := filepath.Join(workdir, ".aiops", "PLAN.md")
 	plan, err := os.ReadFile(planPath)
 	if err != nil || strings.TrimSpace(string(plan)) == "" {
-		Emit(ctx, ev, taskID, task.EventAnalysisOnlyViolation, "analysis-only run did not produce .aiops/PLAN.md", map[string]any{
+		Emit(ctx, ev, taskID, identifier, task.EventAnalysisOnlyViolation, "analysis-only run did not produce .aiops/PLAN.md", map[string]any{
 			"path": ".aiops/PLAN.md",
 		})
 		if err != nil {
@@ -864,7 +869,7 @@ func enforceAnalysisOnlyChanges(ctx context.Context, ev EventEmitter, taskID, wo
 		violations = append(violations, path)
 	}
 	if len(violations) > 0 {
-		Emit(ctx, ev, taskID, task.EventAnalysisOnlyViolation, "analysis-only run changed source files", map[string]any{
+		Emit(ctx, ev, taskID, identifier, task.EventAnalysisOnlyViolation, "analysis-only run changed source files", map[string]any{
 			"files": violations,
 		})
 		return fmt.Errorf("analysis-only run changed source files: %s", strings.Join(violations, ", "))
@@ -874,7 +879,7 @@ func enforceAnalysisOnlyChanges(ctx context.Context, ev EventEmitter, taskID, wo
 		return fmt.Errorf("inspect analysis-only commits: %w", err)
 	}
 	if committed {
-		Emit(ctx, ev, taskID, task.EventAnalysisOnlyViolation, "analysis-only run created commits", nil)
+		Emit(ctx, ev, taskID, identifier, task.EventAnalysisOnlyViolation, "analysis-only run created commits", nil)
 		return fmt.Errorf("analysis-only run created commits")
 	}
 	return nil

--- a/internal/worker/secretscan_test.go
+++ b/internal/worker/secretscan_test.go
@@ -52,7 +52,7 @@ func TestRunSecretScanWith_DisabledIsNoop(t *testing.T) {
 		return workspace.SecretScanResult{}
 	}
 	cfg := workflow.Config{} // SecretScan zero value: disabled
-	if err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", cfg, stub); err != nil {
+	if err := runSecretScanWith(context.Background(), ev, "tsk", "", "/tmp", cfg, stub); err != nil {
 		t.Fatalf("disabled scan must not error, got %v", err)
 	}
 	if called {
@@ -68,7 +68,7 @@ func TestRunSecretScanWith_CleanEmitsStartAndClean(t *testing.T) {
 	stub := func(_ context.Context, _ string, _ workflow.SecretScanConfig) workspace.SecretScanResult {
 		return workspace.SecretScanResult{Status: workspace.SecretScanClean, ExitCode: 0, DurationMs: 12}
 	}
-	if err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", enabledSecretScanCfg(), stub); err != nil {
+	if err := runSecretScanWith(context.Background(), ev, "tsk", "", "/tmp", enabledSecretScanCfg(), stub); err != nil {
 		t.Fatalf("clean scan must not error, got %v", err)
 	}
 	got := secretScanKinds(ev)
@@ -88,7 +88,7 @@ func TestRunSecretScanWith_ViolationBlocksPushAndEmitsViolationEvent(t *testing.
 			Stdout:     "leak found in file foo.go\n",
 		}
 	}
-	err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", enabledSecretScanCfg(), stub)
+	err := runSecretScanWith(context.Background(), ev, "tsk", "", "/tmp", enabledSecretScanCfg(), stub)
 	if err == nil {
 		t.Fatal("violation with default fail_on_finding must abort push")
 	}
@@ -114,7 +114,7 @@ func TestRunSecretScanWith_ViolationWarnOnlyAllowsPush(t *testing.T) {
 	stub := func(_ context.Context, _ string, _ workflow.SecretScanConfig) workspace.SecretScanResult {
 		return workspace.SecretScanResult{Status: workspace.SecretScanViolation, ExitCode: 1}
 	}
-	if err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", cfg, stub); err != nil {
+	if err := runSecretScanWith(context.Background(), ev, "tsk", "", "/tmp", cfg, stub); err != nil {
 		t.Fatalf("warn-only must not block push, got %v", err)
 	}
 	kinds := secretScanKinds(ev)
@@ -131,7 +131,7 @@ func TestRunSecretScanWith_ExecErrorBlocksAndEmitsErrorEvent(t *testing.T) {
 			Err:    errors.New("exec: gitleaks: not found"),
 		}
 	}
-	err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", enabledSecretScanCfg(), stub)
+	err := runSecretScanWith(context.Background(), ev, "tsk", "", "/tmp", enabledSecretScanCfg(), stub)
 	if err == nil {
 		t.Fatal("exec error must block push")
 	}
@@ -150,7 +150,7 @@ func TestRunSecretScanWith_StartPayloadCarriesCommand(t *testing.T) {
 		return workspace.SecretScanResult{Status: workspace.SecretScanClean}
 	}
 	cfg := enabledSecretScanCfg()
-	if err := runSecretScanWith(context.Background(), ev, "tsk", "/tmp", cfg, stub); err != nil {
+	if err := runSecretScanWith(context.Background(), ev, "tsk", "", "/tmp", cfg, stub); err != nil {
 		t.Fatalf("clean scan must not error, got %v", err)
 	}
 	if len(ev.events) < 1 {


### PR DESCRIPTION
Closes #240.

## Summary

SPEC §13.1 mandates `key=value` structured log lines carrying `issue_id` and `issue_identifier` (and `session_id` for coding-agent session logs) on every issue-related log line. The `Emit()` / runtime-event surface was already correct, but the parallel `log.Printf` calls in worker / orchestrator emitted prose (`task %s: workflow resolved: ...`) with `task %s` as the only key — operators tailing stderr could not correlate to `/api/v1/state` (which uses `issue_id`/`issue_identifier`) and Loki/journald saw zero structured fields.

## Implementation

- New `internal/worker/log.go` with three helpers:
  - `LogIssueEventf(t task.Task, event, format, args...)` — full `event=<kind> task_id=<id> issue_id=<id> issue_identifier=<src>` prefix.
  - `LogTaskIDEventf(taskID, event, format, args...)` — narrow form for call sites that only have the task id.
  - `LogReconcileEventf(event, format, args...)` — orchestrator-wide log lines with no per-issue context.
- Convert every issue-related `log.Printf` in `internal/worker` and `internal/orchestrator` to the structured shape: `workflow_resolved`, `fail_*_store_error`, `before_remove_hook_failed`, `after_run_hook_failed`, `changed_files_seed_failed`/`changed_files_write_failed`, `verification_write_failed`, `event_emit_failed`, `tracker_route_skipped`, `tracker_poll_error`, `workflow_runtime_emit_failed`, `blocked_workspace_remove_failed`, `startup_reconcile_*_fetch_failed`, `startup_reconciliation_failed`.
- `LogEventEmitter.AddEvent` / `AddEventWithPayload` now route through `LogTaskIDEventf`.
- `internal/runner` has no `log.Printf` in scope.

Phase 2 (slog adoption) and Phase 3 (sink configuration) from #240 are out of scope for this change; they need broader operator-visible UX decisions and a separate PR.

## Test plan

- [x] `TestLogIssueEventfEmitsSpec13_1Context` — full prefix
- [x] `TestLogIssueEventfOmitsIdentifierWhenAbsent` — missing SourceEventID is omitted (no empty `issue_identifier=`)
- [x] `TestLogTaskIDEventfMirrorsTaskAndIssueIDs` — issue_id mirrors task_id
- [x] `TestLogReconcileEventfOmitsIssueContext` — reconciliation logs do not fabricate per-issue keys
- [x] `TestNoStdLibLogPrintfMissingStructuredContext` — lint-style audit walks `internal/worker`, `internal/runner`, `internal/orchestrator` and fails CI if a future `log.Printf` misses `event=` / `task_id=` / `issue_id=`
- [x] Updated `TestResolveWorkflow_LogsResolutionLine` to assert the new shape (old prose substring pinned the SPEC-non-compliant format)
- [x] `go test ./internal/worker/ ./internal/orchestrator/` green
- [x] `gofmt -l` clean

@codex review