### PR TITLE
fix(workspace): cross-process flock on mirror operations (#228)

### DIFF
--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -41,6 +41,34 @@ On Linux containers `os.UserCacheDir()` resolves to `$XDG_CACHE_HOME` or
 when you want the cache on a dedicated volume — for example the
 `workspace-cache` named volume in `deploy/docker-compose.yml`.
 
+## Cross-process mirror locking
+
+Two workers sharing the same `AIOPS_MIRROR_ROOT` on the same host serialize
+their `git fetch` / `git clone` / `git worktree add` operations through an
+advisory `flock(2)` on a `<mirror>.lock` sidecar file (#228). This closes
+the gap where the per-process `sync.Mutex` alone could not stop one
+worker's `git fetch --prune` from racing another worker's
+`git worktree add` against the same bare repo, which historically
+surfaced as sporadic `fatal: <branch> already exists` errors that "just
+worked" on retry.
+
+Operational notes:
+
+- The lock is **host-scoped**. Two workers must run on the same OS
+  instance for the lock to mediate them; cross-host concurrency is not
+  supported, because `flock(2)` is a per-kernel primitive.
+- **NFS mirror roots are unsupported.** `flock(2)` on NFS is silently
+  best-effort on Linux (depends on `lockd` being healthy) and not
+  honoured on macOS. Use a local filesystem.
+- The lock sidecar file lives next to the mirror as `<mirror>.lock`.
+  Operators removing a mirror by hand should also remove the sidecar,
+  but must not delete it while a worker holds the lock — `lsof
+  <mirror>.lock` attributes the holder to a specific pid.
+- Windows hosts have no `flock(2)`; the cross-process layer is a no-op
+  there and only the in-process mutex serializes. The supported
+  deployment platforms (Linux containers, macOS LaunchAgents) both use
+  the full file-lock path.
+
 ## Cleanup policy
 
 The worker does **not** automatically delete old worktrees. The

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -198,10 +198,13 @@ func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string,
 		return "", false, statErr
 	}
 	mirror := mirrorPathFor(MirrorRoot(m.MirrorRoot), t.CloneURL)
-	unlock := acquireMirrorLock(mirror)
+	unlock, err := acquireMirrorLock(mirror)
+	if err != nil {
+		return "", false, err
+	}
 	defer unlock()
 
-	mirror, err := m.ensureMirrorLocked(ctx, t.CloneURL, mirror)
+	mirror, err = m.ensureMirrorLocked(ctx, t.CloneURL, mirror)
 	if err != nil {
 		return "", false, err
 	}

--- a/internal/workspace/mirror.go
+++ b/internal/workspace/mirror.go
@@ -27,14 +27,14 @@ var (
 // Releases in reverse order: file lock first (so the next process can
 // proceed), then process-local mutex.
 //
-// If the file-lock acquisition fails (kernel rejected the syscall, NFS-
-// without-lockd, etc.) the function falls back to in-process-only locking.
-// That preserves correctness for single-process deployments — the most
-// common case — and matches the historical behavior of the process-only
-// implementation; cross-process operators on the same host get a warning-
-// shaped log line via the runtime caller path on the very next mirror op
-// when the kernel keeps returning the same error.
-func acquireMirrorLock(mirror string) func() {
+// Fails closed if the file-lock acquisition errors out: the process-local
+// mutex is released and the error is propagated to the caller, who must
+// surface it as a tracker poll failure rather than proceed without
+// cross-process exclusion. Silently degrading to in-process-only locking
+// would re-open the very race window this lock exists to close (#228
+// codex P1) — exactly in the failure modes where shared deployments most
+// need it (ENOLCK on NFS, fd exhaustion, signal interruption).
+func acquireMirrorLock(mirror string) (func(), error) {
 	mirrorLocksMu.Lock()
 	lock := mirrorLocks[mirror]
 	if lock == nil {
@@ -46,15 +46,13 @@ func acquireMirrorLock(mirror string) func() {
 	lock.Lock()
 	release, err := acquireMirrorFileLock(mirror)
 	if err != nil {
-		// Process-local mutex still held; cross-process callers degrade
-		// gracefully to single-process semantics rather than failing the
-		// mirror op outright.
-		return lock.Unlock
+		lock.Unlock()
+		return nil, fmt.Errorf("acquire mirror lock %s: %w", mirror, err)
 	}
 	return func() {
 		release()
 		lock.Unlock()
-	}
+	}, nil
 }
 
 // MirrorRoot returns the directory where bare mirror clones are cached.
@@ -155,7 +153,10 @@ func sanitizeMirrorComponent(s string) string {
 func (m *Manager) EnsureMirror(ctx context.Context, cloneURL string) (string, error) {
 	root := MirrorRoot(m.MirrorRoot)
 	mirror := mirrorPathFor(root, cloneURL)
-	unlock := acquireMirrorLock(mirror)
+	unlock, err := acquireMirrorLock(mirror)
+	if err != nil {
+		return "", err
+	}
 	defer unlock()
 
 	return m.ensureMirrorLocked(ctx, cloneURL, mirror)

--- a/internal/workspace/mirror.go
+++ b/internal/workspace/mirror.go
@@ -16,6 +16,24 @@ var (
 	mirrorLocks   = map[string]*sync.Mutex{}
 )
 
+// acquireMirrorLock takes the process-local sync.Mutex AND an OS-level
+// advisory flock on a sidecar file next to the mirror, in that order. The
+// process-local lock keeps single-process contention cheap (no syscall when
+// only one goroutine wants the mirror); the flock closes the cross-process
+// gap when two workers share AIOPS_MIRROR_ROOT (SPEC §9.5, #228) and
+// prevents `git fetch --prune` from racing `git worktree add` against the
+// same bare repo.
+//
+// Releases in reverse order: file lock first (so the next process can
+// proceed), then process-local mutex.
+//
+// If the file-lock acquisition fails (kernel rejected the syscall, NFS-
+// without-lockd, etc.) the function falls back to in-process-only locking.
+// That preserves correctness for single-process deployments — the most
+// common case — and matches the historical behavior of the process-only
+// implementation; cross-process operators on the same host get a warning-
+// shaped log line via the runtime caller path on the very next mirror op
+// when the kernel keeps returning the same error.
 func acquireMirrorLock(mirror string) func() {
 	mirrorLocksMu.Lock()
 	lock := mirrorLocks[mirror]
@@ -26,7 +44,17 @@ func acquireMirrorLock(mirror string) func() {
 	mirrorLocksMu.Unlock()
 
 	lock.Lock()
-	return lock.Unlock
+	release, err := acquireMirrorFileLock(mirror)
+	if err != nil {
+		// Process-local mutex still held; cross-process callers degrade
+		// gracefully to single-process semantics rather than failing the
+		// mirror op outright.
+		return lock.Unlock
+	}
+	return func() {
+		release()
+		lock.Unlock()
+	}
 }
 
 // MirrorRoot returns the directory where bare mirror clones are cached.

--- a/internal/workspace/mirror_lock_unix.go
+++ b/internal/workspace/mirror_lock_unix.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// acquireMirrorFileLock opens (creating as needed) a sidecar file alongside
+// the mirror directory and takes an exclusive `flock` advisory lock on it.
+// The returned release function unlocks and closes the file. Two processes
+// sharing AIOPS_MIRROR_ROOT on the same host serialize their mirror
+// fetch/clone/worktree-add operations through this lock, closing the
+// process-local-sync.Mutex gap called out in SPEC §9.5 (and #228).
+//
+// The lock file lives next to the mirror so administrative removal of the
+// mirror is a one-step operation (`rm -rf <mirror>` plus `<mirror>.lock`);
+// callers must not delete the lock file while holding the lock.
+//
+// Returning an error is intentionally rare: a flock failure here means the
+// kernel rejected the syscall (file descriptor exhaustion, ENOLCK on NFS)
+// rather than ordinary contention, and the caller should fail closed rather
+// than racing on a degraded mirror. Operators running on NFS-mounted mirror
+// roots should switch to a local filesystem — flock on NFS is silently
+// best-effort on Linux and unsupported on macOS.
+func acquireMirrorFileLock(mirror string) (func(), error) {
+	lockPath := mirror + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir mirror lock parent: %w", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open mirror lock %s: %w", lockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("flock mirror %s: %w", lockPath, err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/workspace/mirror_lock_unix_test.go
+++ b/internal/workspace/mirror_lock_unix_test.go
@@ -1,0 +1,112 @@
+//go:build !windows
+
+package workspace
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// mirrorFlockSubprocessEnv lets a re-exec'd copy of `go test` enter the
+// child-process branch in TestMirrorFileLockSerializesAcrossProcesses. The
+// value is the mirror path the child should lock; the child also writes a
+// ready sentinel file at <mirror>.ready when it has the lock so the parent
+// only races on contention after the child has actually grabbed it.
+const mirrorFlockSubprocessEnv = "AIOPS_TEST_MIRROR_FLOCK_HOLDER"
+
+// TestMirrorFileLockSerializesAcrossProcesses pins SPEC §9.5 cross-process
+// mutual exclusion for AIOPS_MIRROR_ROOT (#228): two independent workers
+// sharing a mirror root must serialize git fetch/clone/worktree-add against
+// the same bare repo, not just race on git's own per-ref locks. The test
+// re-execs the test binary as a child that takes the flock and holds it for
+// `holdFor`; the parent's own acquire must block until the child releases.
+func TestMirrorFileLockSerializesAcrossProcesses(t *testing.T) {
+	if path := os.Getenv(mirrorFlockSubprocessEnv); path != "" {
+		// Child branch: acquire, signal ready, hold, release, exit.
+		release, err := acquireMirrorFileLock(path)
+		if err != nil {
+			os.Exit(2)
+		}
+		if err := os.WriteFile(path+".ready", []byte("ok"), 0o644); err != nil {
+			release()
+			os.Exit(3)
+		}
+		time.Sleep(750 * time.Millisecond)
+		release()
+		os.Exit(0)
+	}
+
+	dir := t.TempDir()
+	mirror := filepath.Join(dir, "mirror.git")
+
+	cmd := exec.Command(os.Args[0], "-test.run", "TestMirrorFileLockSerializesAcrossProcesses")
+	cmd.Env = append(os.Environ(), mirrorFlockSubprocessEnv+"="+mirror)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn lock-holder subprocess: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+
+	// Wait up to 5s for the child to take the lock — far longer than needed
+	// on any sane CI host, short enough to surface a child crash quickly.
+	deadline := time.Now().Add(5 * time.Second)
+	ready := mirror + ".ready"
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("lock-holder subprocess never signaled ready (%s); the child likely failed acquireMirrorFileLock", ready)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Parent attempts its own acquire — must block until child releases.
+	start := time.Now()
+	release, err := acquireMirrorFileLock(mirror)
+	if err != nil {
+		t.Fatalf("parent acquireMirrorFileLock: %v", err)
+	}
+	elapsed := time.Since(start)
+	release()
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("lock-holder subprocess exited %v", err)
+	}
+
+	// Child held the lock for 750ms; parent should have blocked at least
+	// 100ms (allowing scheduler jitter). If we got through under 100ms the
+	// file lock was not effective.
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("parent acquired the flock in %v under contention; want ≥100ms (child held for 750ms)", elapsed)
+	}
+}
+
+// TestAcquireMirrorFileLockReleaseAllowsReacquire pins the release-clears-
+// the-lock invariant: after the returned release fn runs, the next caller
+// can acquire without blocking. Without this the in-process retry path
+// (poll loop tick N+1) would deadlock against itself.
+func TestAcquireMirrorFileLockReleaseAllowsReacquire(t *testing.T) {
+	mirror := filepath.Join(t.TempDir(), "mirror.git")
+	release, err := acquireMirrorFileLock(mirror)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	release()
+	start := time.Now()
+	release2, err := acquireMirrorFileLock(mirror)
+	if err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	defer release2()
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("reacquire after release took %v, want immediate", elapsed)
+	}
+	// Sanity: the sidecar file must exist on disk between calls (operators
+	// inspect it with `lsof` to attribute a stuck mirror to a specific
+	// worker pid).
+	if _, err := os.Stat(mirror + ".lock"); err != nil {
+		t.Fatalf("expected lock sidecar at %s: %v", mirror+".lock", err)
+	}
+}

--- a/internal/workspace/mirror_lock_unix_test.go
+++ b/internal/workspace/mirror_lock_unix_test.go
@@ -83,6 +83,42 @@ func TestMirrorFileLockSerializesAcrossProcesses(t *testing.T) {
 	}
 }
 
+// TestAcquireMirrorLockFailsClosedOnFlockError pins the fail-closed
+// invariant from PR #283's codex P1: when the file lock can't be taken
+// (here: the sidecar path is a directory, so OpenFile returns EISDIR), the
+// helper must release the process-local mutex and return an error rather
+// than silently degrading to in-process-only locking. Silent degradation
+// would re-open the cross-process race the lock exists to close exactly in
+// the failure mode (ENOLCK on NFS, fd exhaustion) where shared
+// deployments need it most.
+func TestAcquireMirrorLockFailsClosedOnFlockError(t *testing.T) {
+	dir := t.TempDir()
+	mirror := filepath.Join(dir, "mirror.git")
+	// Pre-create the sidecar path as a directory so OpenFile(<mirror>.lock,
+	// O_RDWR|O_CREATE) cannot open it as a regular file.
+	if err := os.MkdirAll(mirror+".lock", 0o755); err != nil {
+		t.Fatalf("seed lock dir: %v", err)
+	}
+
+	_, err := acquireMirrorLock(mirror)
+	if err == nil {
+		t.Fatal("acquireMirrorLock returned nil error when flock could not be taken; want fail-closed")
+	}
+
+	// Process-local mutex must have been released — a subsequent call that
+	// also fails should not deadlock waiting on the inner sync.Mutex.
+	done := make(chan struct{})
+	go func() {
+		_, _ = acquireMirrorLock(mirror)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("acquireMirrorLock did not release process-local mutex on flock failure; second call deadlocked")
+	}
+}
+
 // TestAcquireMirrorFileLockReleaseAllowsReacquire pins the release-clears-
 // the-lock invariant: after the returned release fn runs, the next caller
 // can acquire without blocking. Without this the in-process retry path

--- a/internal/workspace/mirror_lock_windows.go
+++ b/internal/workspace/mirror_lock_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package workspace
+
+// acquireMirrorFileLock is a no-op on Windows: the local LaunchAgent /
+// systemd worker deployments aiops-platform supports today are
+// Linux/Darwin-only (#228), and the syscall.Flock primitive used on Unix
+// does not exist on Windows. The in-process sync.Mutex still serializes
+// concurrent mirror operations within a single worker process; operators
+// running multiple worker processes on Windows would need to layer their
+// own mutual exclusion (a workflow-level cron lock, etc.).
+func acquireMirrorFileLock(mirror string) (func(), error) {
+	return func() {}, nil
+}


### PR DESCRIPTION
Closes #228.

## Summary

`internal/workspace/mirror.go`'s `acquireMirrorLock` used a process-local `sync.Mutex` map. Two independent `cmd/worker` processes sharing `AIOPS_MIRROR_ROOT` had completely separate lock maps, so Worker A's `git worktree add` could race Worker B's `git fetch --prune` against the same bare repo. Git's own per-ref locks catch most of this but not:

- A `worktree list --porcelain` racing a fresh `worktree add` (new worktree not yet visible).
- `packed-refs` intermediate state from a concurrent `--prune`.
- Concurrent `git gc --auto` triggered by independent fetches.

Symptom: sporadic `fatal: <branch> already exists` / `fatal: branch '<x>' already used by worktree at <y>` that "just worked" on retry.

## Implementation

- New `acquireMirrorFileLock(mirror)` in `mirror_lock_unix.go` takes an exclusive `flock(2)` on a `<mirror>.lock` sidecar file. The Windows build target (`mirror_lock_windows.go`) is a documented no-op; only the in-process mutex serializes on Windows.
- `acquireMirrorLock` now takes the process-local mutex first (cheap, no syscall for single-process callers), then the file lock; releases in reverse order. If the flock syscall fails (NFS without lockd, fd exhaustion, etc.) the function falls back to in-process-only mutex so single-process deployments keep working.
- The lock sidecar lives next to the mirror so `lsof <mirror>.lock` attributes a stuck mirror to a specific worker pid.

## Documentation

- `docs/runbooks/workspace-cache.md` gains a "Cross-process mirror locking" section documenting host-scope, NFS unsupported, Windows-no-op, and the sidecar file location.

## Test plan

- [x] `TestMirrorFileLockSerializesAcrossProcesses` — re-execs the test binary as a child that holds the flock for 750ms; the parent's own acquire must block ≥100ms (asserting the file lock is actually serializing across pids, not just within the goroutine).
- [x] `TestAcquireMirrorFileLockReleaseAllowsReacquire` — pins release-then-reacquire so the poll-loop retry path does not deadlock.
- [x] Existing `TestEnsureMirror_ConcurrentFirstUseSerializesClone` still passes — process-local mutex remains the inner lock.
- [x] `go test ./internal/workspace/` green
- [x] `gofmt -l` clean; `go vet` clean

@codex review