### PR TITLE
feat(orchestrator): SPEC §8.5 Part A orchestrator-level stall reconciliation (#246)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1113,6 +1113,7 @@ func reconciliationConfigForWorkflow(cfg workflow.Config) orchestrator.Reconcili
 		TerminalStates:    cfg.Tracker.TerminalStates,
 		InactiveStates:    inferredInactiveStates(cfg.Tracker),
 		WorkerExitTimeout: 30 * time.Second,
+		StallTimeoutMs:    cfg.Codex.StallTimeoutMs,
 	}
 }
 

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -504,6 +504,44 @@ func (o *Orchestrator) ReconcileTrackerIssues(ctx context.Context, issuesByID ma
 	return o.ReconcileTrackerIssuesAndWait(ctx, issuesByID, activeStates, 0)
 }
 
+// ReconcileStalledRuns implements SPEC §8.5 Part A / §16.3
+// reconcile_stalled_runs: for each running issue compute elapsed time
+// since the last observed runtime event (RunningEntry.LastCodexAt,
+// falling back to StartedAt before any event has been seen) and, if it
+// exceeds stallTimeoutMs, cancel the worker so the finalize path
+// schedules a retry. stallTimeoutMs <= 0 skips detection entirely (SPEC
+// §6.4 default).
+//
+// The Codex app-server runner has its own self-stall detection; this
+// orchestrator-side path closes the gap when the runner goroutine itself
+// wedges or when a non-Codex runner (mock, codex exec) produces no
+// StallError. Without this an issue with `LastCodexAt` long in the past
+// would stay claimed forever.
+//
+// wait is the per-tick budget for waiting on cancelled worker
+// goroutines to exit (mirrors ReconcileTrackerIssuesAndWait). Use 0 for
+// fire-and-forget cancel.
+func (o *Orchestrator) ReconcileStalledRuns(ctx context.Context, stallTimeoutMs int, wait time.Duration) error {
+	if stallTimeoutMs <= 0 {
+		return nil
+	}
+	reply := make(chan []*RunningEntry, 1)
+	if err := o.submit(ctx, &reconcileStalledRunsOp{
+		timeout: time.Duration(stallTimeoutMs) * time.Millisecond,
+		now:     time.Now(),
+		result:  reply,
+	}); err != nil {
+		return err
+	}
+	var canceled []*RunningEntry
+	select {
+	case canceled = <-reply:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return waitForReconciledWorkers(ctx, canceled, wait)
+}
+
 // RefreshActiveTrackerIssues updates stored issue metadata for in-process runs
 // and queued retries whose issues are still observed in the active set, without
 // canceling any work. Use this when the active listing may be partial (so
@@ -735,6 +773,50 @@ func (r *runningRetryingAndBlockedIssueIDsOp) apply(st *OrchestratorState) func(
 	return func() {
 		if result != nil {
 			result <- issueIDs
+		}
+	}
+}
+
+// reconcileStalledRunsOp is the actor-side handler for SPEC §8.5 Part A.
+// It scans st.Running for entries whose LastCodexAt (or StartedAt when no
+// runtime event has been observed yet) is older than the configured
+// stall budget and cancels the worker. The entry stays Claimed: the
+// finalize op observes the canceled ctx as a worker failure and schedules
+// a normal failure retry (no ReconcileCancel — operator cancellation and
+// stall recovery have different semantics).
+type reconcileStalledRunsOp struct {
+	timeout time.Duration
+	now     time.Time
+	result  chan<- []*RunningEntry
+}
+
+func (r *reconcileStalledRunsOp) apply(st *OrchestratorState) func() {
+	var canceled []*RunningEntry
+	for id, run := range st.Running {
+		ref := run.LastCodexAt
+		if ref.IsZero() {
+			ref = run.StartedAt
+		}
+		if ref.IsZero() {
+			// Fresh dispatch without a StartedAt is exceedingly rare (a
+			// test fixture). Skip rather than treat the Unix epoch as a
+			// stall reference, which would cancel every such entry.
+			continue
+		}
+		if r.now.Sub(ref) <= r.timeout {
+			continue
+		}
+		canceled = append(canceled, run)
+		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: id, Identifier: run.Identifier, Message: "stalled"})
+	}
+	return func() {
+		for _, entry := range canceled {
+			if entry.CancelWorker != nil {
+				entry.CancelWorker()
+			}
+		}
+		if r.result != nil {
+			r.result <- canceled
 		}
 	}
 }

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -323,6 +323,97 @@ func TestScheduleRetry_TimerFireProducesExactlyOneReDispatch(t *testing.T) {
 	}
 }
 
+// TestReconcileStalledRunsCancelsWorkerPastTimeout pins SPEC §8.5 Part A:
+// a running entry whose LastCodexAt is older than the configured stall
+// budget gets its worker context cancelled, and the finalize path treats
+// the resulting context.Canceled as a normal worker failure (claim
+// retained, retry scheduled), NOT as a reconciled cancel.
+func TestReconcileStalledRunsCancelsWorkerPastTimeout(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "STALL-1", Identifier: "STALL-1", Title: "stuck", State: "AI Ready"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	// Force the running entry's LastCodexAt into the past so the stall
+	// budget (100ms) is comfortably exceeded.
+	o.WithStateForTest(func(st *OrchestratorState) {
+		st.Running["STALL-1"].LastCodexAt = time.Now().Add(-10 * time.Second)
+	})
+
+	if err := o.ReconcileStalledRuns(context.Background(), 100, 0); err != nil {
+		t.Fatalf("ReconcileStalledRuns: %v", err)
+	}
+
+	select {
+	case <-disp.contextAt(0).Done():
+	case <-time.After(time.Second):
+		t.Fatal("stalled worker context was not cancelled by ReconcileStalledRuns")
+	}
+}
+
+// TestReconcileStalledRunsLeavesActiveRunsAlone pins the no-false-positive
+// invariant: an entry with a recent LastCodexAt must not be cancelled
+// even when the stall budget is small.
+func TestReconcileStalledRunsLeavesActiveRunsAlone(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ACTIVE-1", Identifier: "ACTIVE-1", State: "AI Ready"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	o.WithStateForTest(func(st *OrchestratorState) {
+		st.Running["ACTIVE-1"].LastCodexAt = time.Now()
+	})
+
+	if err := o.ReconcileStalledRuns(context.Background(), 5_000, 0); err != nil {
+		t.Fatalf("ReconcileStalledRuns: %v", err)
+	}
+
+	select {
+	case <-disp.contextAt(0).Done():
+		t.Fatal("active worker context was cancelled even though LastCodexAt is recent")
+	case <-time.After(100 * time.Millisecond):
+		// Expected — context still live.
+	}
+}
+
+// TestReconcileStalledRunsSkipsWhenTimeoutDisabled covers SPEC §8.5 Part A's
+// "if stall_timeout_ms <= 0, skip stall detection entirely" clause.
+func TestReconcileStalledRunsSkipsWhenTimeoutDisabled(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "OFF-1", Identifier: "OFF-1", State: "AI Ready"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	// Even with an ancient LastCodexAt, stall detection is a no-op when
+	// the budget is 0.
+	o.WithStateForTest(func(st *OrchestratorState) {
+		st.Running["OFF-1"].LastCodexAt = time.Now().Add(-10 * time.Second)
+	})
+	if err := o.ReconcileStalledRuns(context.Background(), 0, 0); err != nil {
+		t.Fatalf("ReconcileStalledRuns: %v", err)
+	}
+	select {
+	case <-disp.contextAt(0).Done():
+		t.Fatal("stall_timeout_ms=0 should disable detection but the worker was cancelled")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestReconcileTrackerIssuesCancelsRunWhenServiceRouteChanges(t *testing.T) {
 	disp := &fakeDispatcher{}
 	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})

--- a/internal/orchestrator/export_test.go
+++ b/internal/orchestrator/export_test.go
@@ -1,0 +1,16 @@
+package orchestrator
+
+import "context"
+
+// WithStateForTest runs fn against OrchestratorState on the actor goroutine.
+// Test-only helper for surgical mutations (e.g. backdating LastCodexAt to
+// trigger a stall reconciliation without sleeping for the full budget).
+// Production code must go through the typed op surface.
+func (o *Orchestrator) WithStateForTest(fn func(*OrchestratorState)) {
+	done := make(chan struct{})
+	_ = o.submit(context.Background(), opFunc(func(st *OrchestratorState) func() {
+		fn(st)
+		return func() { close(done) }
+	}))
+	<-done
+}

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -50,6 +50,15 @@ type ReconciliationConfig struct {
 	// reconciliation cancel. Zero means the poll tick only requests cancellation;
 	// the worker watcher will clean up asynchronously.
 	WorkerExitTimeout time.Duration
+
+	// StallTimeoutMs is SPEC §8.5 Part A's `codex.stall_timeout_ms`: the
+	// per-issue budget for "no runtime event observed" before the orchestrator
+	// cancels the worker so it can be retried (SPEC §16.3
+	// reconcile_stalled_runs). The runner has its own self-stall detection;
+	// this guards against the case where the runner goroutine itself wedges
+	// and never produces a StallError. Zero (or negative) disables detection
+	// at the orchestrator layer.
+	StallTimeoutMs int
 }
 
 // Poller connects tracker polling to the orchestrator runtime state. It has no
@@ -163,6 +172,12 @@ func (l activeIssueListerFromStates) ListActiveIssues(ctx context.Context) ([]tr
 func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue) (map[string]tracker.Issue, error) {
 	if p.stateTracker == nil {
 		return nil, errors.New("orchestrator poller reconciliation requires state tracker")
+	}
+	// SPEC §16.3 reconcile_running_issues order: Part A (stall reconciliation)
+	// first so any wedged worker is cancelled before Part B's tracker-state
+	// refresh would otherwise leave it claimed indefinitely.
+	if err := p.orchestrator.ReconcileStalledRuns(ctx, p.reconcile.StallTimeoutMs, p.reconcile.WorkerExitTimeout); err != nil {
+		return nil, err
 	}
 	activeIssuesByID := issueMap(activeIssues)
 	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -193,6 +193,7 @@ func (r *WorkflowRuntime) snapshotFromWorkflow(wf *workflow.Workflow, fingerprin
 		TerminalStates:    wf.Config.Tracker.TerminalStates,
 		InactiveStates:    wf.Config.Tracker.InactiveStates,
 		WorkerExitTimeout: 30 * time.Second,
+		StallTimeoutMs:    wf.Config.Codex.StallTimeoutMs,
 	}
 	if r != nil && r.reconciliationConfig != nil {
 		reconcile = r.reconciliationConfig(wf.Config)


### PR DESCRIPTION
Closes #246.

## Summary

SPEC §16.3 `reconcile_running_issues` lists Part A (`reconcile_stalled_runs`) as the FIRST step of each poll tick — before Part B's tracker-state refresh. The Go implementation had Part B but no Part A: the runner's self-stall detection (`codex_app_server.go`) only fires while the runner goroutine is alive, so a wedged runner with a live subprocess would keep the issue claimed forever. The mock and `codex exec` runners have no stall detection at all.

`LastCodexAt` was already on `RunningEntry` (D14); only the reconcile step was missing.

## Implementation

- `Orchestrator.ReconcileStalledRuns(ctx, stallTimeoutMs, wait)`: scans `st.Running` for entries whose `LastCodexAt` (falling back to `StartedAt` before any runtime event is observed) is older than `stallTimeoutMs`, cancels the worker context. Zero/negative `stallTimeoutMs` disables detection (SPEC §6.4 default).
- The cancelled entry stays Claimed and does **not** set `ReconcileCancel`: `finalizeRunOp` observes the `context.Canceled` as a normal worker failure and schedules a retry. Operator-initiated cancellation and stall-driven cancellation have different semantics; reusing the failure-retry path keeps backoff/budget accounting aligned.
- Wired into `Poller.reconcileTick` as the first step (per §16.3 order) via a new `StallTimeoutMs` field on `ReconciliationConfig`. The field is populated from `workflow.Config.Codex.StallTimeoutMs` by both the runtime workflow wiring (`workflow_runtime.go`) and the worker entry (`cmd/worker/main.go`).
- `export_test.go` adds `WithStateForTest` so tests can backdate `LastCodexAt` without sleeping for the full stall budget.

## Test plan

- [x] `TestReconcileStalledRunsCancelsWorkerPastTimeout` — backdated `LastCodexAt` + 100ms budget → worker context cancelled
- [x] `TestReconcileStalledRunsLeavesActiveRunsAlone` — recent `LastCodexAt` + 5s budget → no false positive
- [x] `TestReconcileStalledRunsSkipsWhenTimeoutDisabled` — `stall_timeout_ms=0` is a no-op
- [x] `go test ./internal/orchestrator/ ./cmd/worker/ ./internal/worker/` green
- [x] `gofmt -l` clean; `go vet ./...` clean

@codex review