### PR TITLE
fix(orchestrator): don't let a wedged worker block global reconciliation (#285)

### DIFF
--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -173,15 +173,21 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 	if p.stateTracker == nil {
 		return nil, errors.New("orchestrator poller reconciliation requires state tracker")
 	}
+	var fetchErr error
 	// SPEC §16.3 reconcile_running_issues order: Part A (stall reconciliation)
 	// first so any wedged worker is cancelled before Part B's tracker-state
-	// refresh would otherwise leave it claimed indefinitely.
+	// refresh would otherwise leave it claimed indefinitely. A WorkerExitTimeout
+	// on a worker that ignores cancellation surfaces as context.DeadlineExceeded;
+	// surface that as a non-fatal poll error so one stuck run cannot block Part B
+	// from reconciling unrelated inactive/terminal issues in the same tick.
 	if err := p.orchestrator.ReconcileStalledRuns(ctx, p.reconcile.StallTimeoutMs, p.reconcile.WorkerExitTimeout); err != nil {
-		return nil, err
+		if ctx.Err() != nil {
+			return nil, err
+		}
+		fetchErr = errors.Join(fetchErr, err)
 	}
 	activeIssuesByID := issueMap(activeIssues)
 	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
-	var fetchErr error
 	refreshedIssuesByID, err := p.refreshRunningIssueStates(ctx, activeIssuesByID)
 	if err != nil {
 		fetchErr = errors.Join(fetchErr, err)

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -949,6 +949,64 @@ func TestPollOnceDispatchesActiveCandidatesWhenCanceledWorkerDoesNotExitBeforeTi
 	waitForStuckCancellationDispatcherCount(t, dispatcher, 2)
 }
 
+// TestPollOnceContinuesReconciliationWhenStalledRunCleanupTimesOut pins the
+// #285 regression: a Part A (SPEC §8.5) stall reconciliation that times out
+// waiting for a wedged worker to exit must not block Part B's tracker-state
+// reconciliation for unrelated running issues in the same poll tick. Without
+// the fix, one stuck worker would freeze global reconciliation until it
+// eventually exited.
+func TestPollOnceContinuesReconciliationWhenStalledRunCleanupTimesOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{
+		{ID: "wedged", Identifier: "LIN-1", State: "In Progress"},
+		{ID: "movable", Identifier: "LIN-2", State: "In Progress"},
+	}}
+	dispatcher := &stuckCancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 4), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		WorkerExitTimeout: time.Millisecond,
+		StallTimeoutMs:    50,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForStuckCancellationDispatcherCount(t, dispatcher, 2)
+
+	// Backdate the wedged run so Part A tries to cancel it; the stuck
+	// dispatcher never closes its done channel, so the cancel-wait times
+	// out with context.DeadlineExceeded.
+	orch.WithStateForTest(func(st *OrchestratorState) {
+		st.Running["wedged"].LastCodexAt = time.Now().Add(-10 * time.Second)
+	})
+
+	// Move the unrelated "movable" run to Cancelled. Part B must still
+	// reconcile it (cancel its worker context) even after Part A's wait
+	// timed out on the wedged run.
+	trackerClient.setIssues([]tracker.Issue{
+		{ID: "wedged", Identifier: "LIN-1", State: "In Progress"},
+		{ID: "movable", Identifier: "LIN-2", State: "Cancelled"},
+	})
+
+	if err := poller.PollOnce(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("stall poll once error = %v, want context deadline exceeded surfaced as non-fatal", err)
+	}
+
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForContextCanceled(t, dispatcher.contextAt(1))
+}
+
 func TestPollOnceFiltersTodoIssuesBlockedByNonTerminalBlockers(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary

Resolves #285 (follow-up review thread from merged PR #284).

In `reconcileTick`, any error from `ReconcileStalledRuns` (SPEC §8.5 Part A) caused an immediate `return nil, err` before Part B (tracker-state refresh + inactive reconciliation) executed. When a worker ignored its cancellation, the `WorkerExitTimeout` wait returned `context.DeadlineExceeded` and **every subsequent poll tick** skipped Part B for **all** runs — one stuck worker froze global reconciliation until it eventually exited, leaving unrelated inactive/terminal issues unreconciled and claimed.

## Fix

Treat Part A errors as a **non-fatal poll error** when the poll context is still alive: join into the returned error and continue to Part B. A canceled poll context still propagates (we bail).

```go
if err := p.orchestrator.ReconcileStalledRuns(ctx, ...); err != nil {
    if ctx.Err() != nil {
        return nil, err
    }
    fetchErr = errors.Join(fetchErr, err)
}
```

## Test plan

- [x] New regression test `TestPollOnceContinuesReconciliationWhenStalledRunCleanupTimesOut`:
  - Two running issues: `wedged` (stuck dispatcher that ignores cancellation, `LastCodexAt` backdated so Part A targets it) and `movable` (tracker moves to `Cancelled` so Part B should cancel it).
  - With the bug: `movable`'s context is never cancelled (Part B skipped). Verified the test fails on the unpatched code.
  - With the fix: both contexts get cancelled in the same poll tick. ✅
- [x] `go test ./internal/orchestrator/ -count=1` — all pass.
- [x] `go vet ./internal/orchestrator/...` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK9vBRoJpVrJ3uKdVqG9HA)_