### PR TITLE
fix(orchestrator): SPEC §16.6 retry-fire candidate fetch (#191)

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -32,6 +32,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
@@ -123,6 +124,15 @@ type Deps struct {
 	Scheduler         Scheduler
 	MaxFailureRetries *int
 	MaxTurns          *int
+	// CandidateLister, when set, enables the SPEC §16.6 retry-fire
+	// candidate-fetch step. A fired failure-retry timer fetches the
+	// active candidate list, confirms the issue is still present,
+	// releases the claim when it is not, and surfaces a typed
+	// "retry poll failed" reschedule when the fetch itself fails.
+	// Production wires this from the same multi-tracker lister the
+	// poll loop uses; when nil, retry fires dispatch directly from
+	// the cached entry.Issue (legacy behavior, kept for unit tests).
+	CandidateLister ActiveIssueLister
 }
 
 // Orchestrator is the SPEC §3.1 / §7.4 "single authority" that owns
@@ -143,6 +153,13 @@ type Orchestrator struct {
 	// the same setting before they return.
 	maxTurns  int
 	retryWake chan struct{}
+
+	// candidateLister supplies the SPEC §16.6 candidate fetch that a
+	// fired failure-retry timer consults before re-dispatching. The
+	// field is read on every retry fire and written when the runtime
+	// poller rebuilds its tracker set, so a mutex guards the swap.
+	candidateListerMu sync.Mutex
+	candidateLister   ActiveIssueLister
 
 	// runCtx is captured by Run so followup goroutines can cancel
 	// their work when the actor stops. Set once at the top of Run
@@ -178,6 +195,7 @@ func New(state *OrchestratorState, deps Deps) *Orchestrator {
 		maxFailureRetries: maxFailureRetries,
 		maxTurns:          maxTurns,
 		retryWake:         make(chan struct{}, 1),
+		candidateLister:   deps.CandidateLister,
 		started:           make(chan struct{}),
 	}
 	if aware, ok := deps.Dispatcher.(interface{ AttachOrchestrator(*Orchestrator) }); ok {
@@ -250,6 +268,26 @@ func (o *Orchestrator) retryWakeCh() <-chan struct{} {
 
 func (o *Orchestrator) wakeRetryPollLoop() {
 	_ = o.queuePollWake()
+}
+
+// SetCandidateLister installs (or swaps) the lister the actor consults on a
+// fired failure-retry timer. Safe to call before or after Run.
+func (o *Orchestrator) SetCandidateLister(l ActiveIssueLister) {
+	if o == nil {
+		return
+	}
+	o.candidateListerMu.Lock()
+	o.candidateLister = l
+	o.candidateListerMu.Unlock()
+}
+
+func (o *Orchestrator) currentCandidateLister() ActiveIssueLister {
+	if o == nil {
+		return nil
+	}
+	o.candidateListerMu.Lock()
+	defer o.candidateListerMu.Unlock()
+	return o.candidateLister
 }
 
 func (o *Orchestrator) queuePollWake() bool {
@@ -1139,68 +1177,189 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		o := r.o
 		return func() { o.wakeRetryPollLoop() }
 	}
-	// Use entry.Issue rather than the timer-captured r.issue: reconciliation
-	// may have refreshed the tracker state while the retry was queued, and
-	// both the per-state capacity gate and the spawned worker must see the
-	// live state.
+	// SPEC §16.6 on_retry_timer: the fired failure-retry timer must (1)
+	// fetch active candidates, (2) re-schedule with "retry poll failed"
+	// on fetch error, (3) release the claim if the issue is absent, and
+	// only then (4/5) dispatch from the refreshed tracker state. When a
+	// CandidateLister is wired (production via RuntimePoller) we defer
+	// the I/O to a followup; without one we fall back to direct dispatch
+	// from the cached entry.Issue so existing unit tests keep working.
+	o := r.o
+	if lister := o.currentCandidateLister(); lister != nil {
+		entry.Timer = nil
+		id := r.id
+		attempt := r.attempt
+		return func() {
+			ctx := o.runCtx
+			issues, fetchErr := lister.ListActiveIssues(ctx)
+			found := findIssueByID(issues, id)
+			if fetchErr != nil && found == nil {
+				// Either the whole fetch failed, or a multi-tracker partial
+				// failure happened on the tracker that owns this issue. We
+				// can't tell "absent" from "tracker down" — treat as fetch
+				// failure per SPEC §16.6 and reschedule with the typed error.
+				_ = o.submit(ctx, &retryPollFailedOp{
+					o:        o,
+					id:       id,
+					attempt:  attempt,
+					fetchErr: fetchErr,
+				})
+				return
+			}
+			_ = o.submit(ctx, &retryFireAfterFetchOp{
+				o:       o,
+				id:      id,
+				attempt: attempt,
+				kind:    RetryKindFailure,
+				found:   found,
+			})
+		}
+	}
+	return retryFireDispatchTail(st, entry, r.id, r.attempt, r.kind, o)
+}
+
+// retryFireDispatchTail runs the post-fetch tail of a failure-retry fire:
+// honor global + per-state capacity gates, then either spawn or re-arm a
+// short capacity-recheck timer. Shared between the legacy direct-dispatch
+// path (no CandidateLister) and the SPEC §16.6 post-fetch path.
+func retryFireDispatchTail(st *OrchestratorState, entry *RetryEntry, id IssueID, attempt int, kind RetryKind, o *Orchestrator) func() {
+	// Use entry.Issue rather than any timer-captured snapshot: reconciliation
+	// (and the SPEC §16.6 candidate fetch) may have refreshed the tracker
+	// state, and both the per-state capacity gate and the spawned worker
+	// must see the live state.
 	issue := entry.Issue
 	if st.RunningCount() >= st.MaxConcurrentAgents {
 		// Retry timers must obey the same capacity gate as fresh dispatch.
 		// Leave the retry queued and arm a short follow-up timer so the issue
 		// is retried after capacity can free instead of spawning over the cap.
-		if entry.Timer != nil {
-			entry.Timer.Stop()
-		}
-		o := r.o
-		id := r.id
-		attempt := r.attempt
-		kind := r.kind
-		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
-		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
-			defer recoverPanic("orchestrator.retry_capacity_timer")
-			_ = o.submit(o.runCtx, &retryFireOp{
-				o:       o,
-				id:      id,
-				issue:   issue,
-				attempt: attempt,
-				kind:    kind,
-			})
-		})
-		return nil
+		return rearmRetryCapacityRecheck(entry, id, issue, attempt, kind, o, "orchestrator.retry_capacity_timer")
 	}
 	if st.StateCapacityFull(issue.State) {
 		// Retry timers must also obey per-state capacity gates. Leave the retry
 		// queued and arm a short follow-up timer so noisy states cannot exceed
 		// max_concurrent_agents_by_state while other states are running.
-		if entry.Timer != nil {
-			entry.Timer.Stop()
-		}
-		o := r.o
-		id := r.id
-		attempt := r.attempt
-		kind := r.kind
-		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
-		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
-			defer recoverPanic("orchestrator.retry_state_capacity_timer")
-			_ = o.submit(o.runCtx, &retryFireOp{
-				o:       o,
-				id:      id,
-				issue:   issue,
-				attempt: attempt,
-				kind:    kind,
-			})
-		})
-		return nil
+		return rearmRetryCapacityRecheck(entry, id, issue, attempt, kind, o, "orchestrator.retry_state_capacity_timer")
 	}
 	// Consume the retry entry but keep Claimed: the re-dispatch
 	// immediately re-adds Running, and dropping Claimed in between
 	// would let a concurrent tick race in.
-	delete(st.RetryAttempts, r.id)
-	o := r.o
-	attempt := r.attempt
+	delete(st.RetryAttempts, id)
 	return func() {
-		o.spawn(r.id, issue, &attempt, 0)
+		a := attempt
+		o.spawn(id, issue, &a, 0)
 	}
+}
+
+func rearmRetryCapacityRecheck(entry *RetryEntry, id IssueID, issue tracker.Issue, attempt int, kind RetryKind, o *Orchestrator, site string) func() {
+	if entry.Timer != nil {
+		entry.Timer.Stop()
+	}
+	entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
+	entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
+		defer recoverPanic(site)
+		_ = o.submit(o.runCtx, &retryFireOp{
+			o:       o,
+			id:      id,
+			issue:   issue,
+			attempt: attempt,
+			kind:    kind,
+		})
+	})
+	return nil
+}
+
+func findIssueByID(issues []tracker.Issue, id IssueID) *tracker.Issue {
+	for i := range issues {
+		if IssueID(issues[i].ID) == id {
+			out := issues[i]
+			return &out
+		}
+	}
+	return nil
+}
+
+// retryPollFailedOp implements SPEC §16.6 step 1 alt: when a fired
+// failure-retry timer's candidate fetch fails, reschedule the same
+// retry (attempt+1) with a typed "retry poll failed" error so the
+// next backoff window can try the fetch again.
+type retryPollFailedOp struct {
+	o        *Orchestrator
+	id       IssueID
+	attempt  int
+	fetchErr error
+}
+
+func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
+	entry, ok := st.RetryAttempts[r.id]
+	if !ok {
+		// Reconciliation released the claim between fetch and apply.
+		return nil
+	}
+	if entry.Attempt != r.attempt || entry.Kind != RetryKindFailure {
+		// Replaced by a newer ScheduleRetry; the newer entry owns the
+		// re-dispatch.
+		return nil
+	}
+	issue := entry.Issue
+	identifier := entry.Identifier
+	nextAttempt := r.attempt + 1
+	runErr := "retry poll failed"
+	if r.fetchErr != nil {
+		runErr = "retry poll failed: " + r.fetchErr.Error()
+	}
+	o := r.o
+	st.RecordEvent(RuntimeEvent{
+		Kind:       RuntimeEventFailed,
+		IssueID:    r.id,
+		Identifier: identifier,
+		Message:    runErr,
+	})
+	return func() {
+		_ = o.ScheduleRetry(o.runCtx, issue, identifier, nextAttempt, runErr)
+	}
+}
+
+// retryFireAfterFetchOp implements SPEC §16.6 steps 3-5 after the
+// candidate fetch completes. found == nil means the issue is absent
+// from the active candidate set (step 3 / step 5: release the claim);
+// otherwise refresh entry.Issue with the live tracker state and proceed
+// to capacity check + dispatch.
+type retryFireAfterFetchOp struct {
+	o       *Orchestrator
+	id      IssueID
+	attempt int
+	kind    RetryKind
+	found   *tracker.Issue
+}
+
+func (r *retryFireAfterFetchOp) apply(st *OrchestratorState) func() {
+	entry, ok := st.RetryAttempts[r.id]
+	if !ok {
+		return nil
+	}
+	if entry.Attempt != r.attempt || entry.Kind != r.kind {
+		return nil
+	}
+	if r.found == nil {
+		// SPEC §16.6 steps 3 + 5: issue no longer in the active candidate
+		// set (either absent or moved to a non-active state). Drop the
+		// retry and release the claim.
+		identifier := entry.Identifier
+		st.ReleaseClaim(r.id)
+		st.RecordEvent(RuntimeEvent{
+			Kind:       RuntimeEventFailed,
+			IssueID:    r.id,
+			Identifier: identifier,
+			Message:    "retry released: issue absent from active candidates",
+		})
+		return nil
+	}
+	// SPEC §16.6 step 4: refresh entry.Issue from the live tracker state
+	// before proceeding to capacity check + dispatch. The per-state cap
+	// must see the latest state, not the dispatch-time snapshot.
+	entry.Issue = *r.found
+	st.ClaimedIssues[r.id] = *r.found
+	return retryFireDispatchTail(st, entry, r.id, r.attempt, r.kind, r.o)
 }
 
 // finalizeRunOp is the actor-side handler for a worker exit. Result.Err

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -1326,12 +1326,13 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 		return nil
 	}
 	o := r.o
-	if o.runCtx != nil && o.runCtx.Err() != nil {
+	if o.runCtx.Err() != nil {
 		// Orchestrator is shutting down between the fetch and this apply.
 		// The followup's ScheduleRetry would fail anyway; recording the
-		// event and clearing the timer would leave the entry orphaned
-		// with Timer == nil if the actor were ever restarted in-process.
-		// Drop silently and let shutdown reclaim state.
+		// event and then dropping the followup would only leak a
+		// "retry poll failed" line into shutdown logs while the entry
+		// goes nowhere. Drop silently and let process exit reclaim the
+		// entry along with everything else.
 		return nil
 	}
 	issue := entry.Issue

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -1325,6 +1325,15 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 		// re-dispatch.
 		return nil
 	}
+	o := r.o
+	if o.runCtx != nil && o.runCtx.Err() != nil {
+		// Orchestrator is shutting down between the fetch and this apply.
+		// The followup's ScheduleRetry would fail anyway; recording the
+		// event and clearing the timer would leave the entry orphaned
+		// with Timer == nil if the actor were ever restarted in-process.
+		// Drop silently and let shutdown reclaim state.
+		return nil
+	}
 	issue := entry.Issue
 	identifier := entry.Identifier
 	nextAttempt := r.attempt + 1
@@ -1332,7 +1341,6 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 	if r.fetchErr != nil {
 		runErr = "retry poll failed: " + r.fetchErr.Error()
 	}
-	o := r.o
 	st.RecordEvent(RuntimeEvent{
 		Kind:       RuntimeEventFailed,
 		IssueID:    r.id,
@@ -1381,9 +1389,16 @@ func (r *retryFireAfterFetchOp) apply(st *OrchestratorState) func() {
 	}
 	// SPEC §16.6 step 4: refresh entry.Issue from the live tracker state
 	// before proceeding to capacity check + dispatch. The per-state cap
-	// must see the latest state, not the dispatch-time snapshot.
+	// must see the latest state, not the dispatch-time snapshot. Upstream
+	// handle_active_retry (orchestrator.ex:1142-1161) uses issue.identifier
+	// from the refreshed issue on every subsequent reschedule, so a
+	// Linear identifier rename between schedule and fire would otherwise
+	// leave runtime events stamped with the stale identifier.
 	entry.Issue = *r.found
 	st.ClaimedIssues[r.id] = *r.found
+	if id := strings.TrimSpace(r.found.Identifier); id != "" {
+		entry.Identifier = id
+	}
 	return retryFireDispatchTail(st, entry, r.id, r.attempt, r.kind, r.o)
 }
 

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -92,6 +92,20 @@ type RetryScheduler struct {
 const retryCapacityRecheckDelay = 100 * time.Millisecond
 const continuationRetryDelay = time.Second
 
+// retryFetchTimeout caps the SPEC §16.6 candidate-fetch call a fired
+// failure-retry timer makes. Tracker clients enforce per-request
+// network timeouts on their own (Linear / Gitea / GitHub all 30s per
+// PR #303), but a defensive ceiling here means the orchestrator does
+// not depend on every adapter to do so: if a future tracker client
+// (or a transport bug) silently drops cancellation, the fetch still
+// returns within this bound and the SPEC's "retry poll failed"
+// reschedule path takes over instead of leaving the issue stuck in
+// Claimed/RetryAttempts forever. The value is comfortably larger
+// than any adapter's own deadline so an honest slow tracker is not
+// punished. A package-level var (not const) so tests can shrink the
+// bound; runtime callers must not mutate it.
+var retryFetchTimeout = 45 * time.Second
+
 // NextDelay implements Scheduler.
 func (s RetryScheduler) NextDelay(req RetryRequest) time.Duration {
 	if req.Kind == RetryKindContinuation {
@@ -1189,16 +1203,27 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		entry.Timer = nil
 		id := r.id
 		attempt := r.attempt
+		kind := r.kind
 		return func() {
-			ctx := o.runCtx
-			issues, fetchErr := lister.ListActiveIssues(ctx)
+			// Per-fetch timeout. The followup runs on a fresh goroutine
+			// outside the actor, and o.runCtx has no deadline of its own.
+			// A tracker client that ignores ctx cancellation would otherwise
+			// pin this goroutine indefinitely — entry.Timer is already
+			// cleared and no retryFireOp would be resubmitted, leaving the
+			// issue stuck in Claimed/RetryAttempts forever. Surfacing the
+			// timeout as a "retry poll failed" reschedule keeps the SPEC
+			// §16.6 backoff window the only source of forward progress.
+			fetchCtx, cancel := context.WithTimeout(o.runCtx, retryFetchTimeout)
+			defer cancel()
+			issues, fetchErr := lister.ListActiveIssues(fetchCtx)
 			found := findIssueByID(issues, id)
 			if fetchErr != nil && found == nil {
-				// Either the whole fetch failed, or a multi-tracker partial
-				// failure happened on the tracker that owns this issue. We
-				// can't tell "absent" from "tracker down" — treat as fetch
-				// failure per SPEC §16.6 and reschedule with the typed error.
-				_ = o.submit(ctx, &retryPollFailedOp{
+				// Either the whole fetch failed (including timeout), or a
+				// multi-tracker partial failure happened on the tracker that
+				// owns this issue. We can't tell "absent" from "tracker down"
+				// — treat as fetch failure per SPEC §16.6 and reschedule
+				// with the typed error.
+				_ = o.submit(o.runCtx, &retryPollFailedOp{
 					o:        o,
 					id:       id,
 					attempt:  attempt,
@@ -1206,11 +1231,11 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 				})
 				return
 			}
-			_ = o.submit(ctx, &retryFireAfterFetchOp{
+			_ = o.submit(o.runCtx, &retryFireAfterFetchOp{
 				o:       o,
 				id:      id,
 				attempt: attempt,
-				kind:    RetryKindFailure,
+				kind:    kind,
 				found:   found,
 			})
 		}

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2098,4 +2099,178 @@ func idForIndex(i int) string {
 		i /= 10
 	}
 	return string(append(out, buf...))
+}
+
+// fakeCandidateLister is a stub ActiveIssueLister for SPEC §16.6 retry-fire
+// tests. Tests configure issues and err, then assert the retryFireOp branch.
+type fakeCandidateLister struct {
+	mu     sync.Mutex
+	issues []tracker.Issue
+	err    error
+	calls  int
+}
+
+func (f *fakeCandidateLister) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	out := make([]tracker.Issue, len(f.issues))
+	copy(out, f.issues)
+	return out, f.err
+}
+
+func (f *fakeCandidateLister) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// TestRetryFire_ReleasesClaimWhenIssueAbsentFromCandidates is the SPEC §16.6
+// step 3 / step 5 conformance check: when the candidate fetch returns
+// successfully but the issue isn't present (either deleted or no longer in an
+// active state), the retry releases the claim instead of re-dispatching.
+func TestRetryFire_ReleasesClaimWhenIssueAbsentFromCandidates(t *testing.T) {
+	disp := &fakeDispatcher{}
+	lister := &fakeCandidateLister{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:      disp,
+		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour}},
+		CandidateLister: lister,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-GONE", Identifier: "ENG-GONE", Title: "absent", State: "AI Ready"}
+	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 2, "transient"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 1 {
+		t.Fatalf("retrying entries = %d, want 1 queued retry", len(view.Retrying))
+	}
+
+	// Lister returns no issues: SPEC §16.6 step 3 — release the claim.
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(iss.ID),
+		issue:   iss,
+		attempt: 2,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 0
+	}, 2*time.Second)
+
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot after fire: %v", err)
+	}
+	if got := disp.count(); got != 0 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 0; absent issue must not be re-dispatched", got)
+	}
+	if len(v.Retrying) != 0 {
+		t.Fatalf("retrying view after absent fetch = %+v, want claim released", v.Retrying)
+	}
+	if lister.callCount() == 0 {
+		t.Fatal("candidate lister was not consulted on retry fire")
+	}
+}
+
+// TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError is the SPEC §16.6
+// step 1 alt conformance check: when the candidate fetch fails, the retry is
+// rescheduled with a typed "retry poll failed" error so the next backoff
+// window can try the fetch again — the claim must not be released.
+func TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError(t *testing.T) {
+	disp := &fakeDispatcher{}
+	lister := &fakeCandidateLister{err: errors.New("tracker unreachable")}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:      disp,
+		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour, time.Hour}},
+		CandidateLister: lister,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-FETCH-FAIL", Identifier: "ENG-FETCH-FAIL", Title: "fetch err", State: "AI Ready"}
+	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(iss.ID),
+		issue:   iss,
+		attempt: 1,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 1 && v.Retrying[0].Attempt == 2
+	}, 2*time.Second)
+
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := disp.count(); got != 0 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 0; fetch failure must not dispatch", got)
+	}
+	if len(v.Retrying) != 1 {
+		t.Fatalf("retrying entries = %d, want 1 rescheduled retry", len(v.Retrying))
+	}
+	got := v.Retrying[0]
+	if got.Attempt != 2 {
+		t.Fatalf("rescheduled attempt = %d, want attempt+1 = 2", got.Attempt)
+	}
+	if !strings.Contains(got.Error, "retry poll failed") {
+		t.Fatalf("rescheduled error = %q, want it to contain \"retry poll failed\"", got.Error)
+	}
+	if !strings.Contains(got.Error, "tracker unreachable") {
+		t.Fatalf("rescheduled error = %q, want the underlying fetch error wrapped in", got.Error)
+	}
+}
+
+// TestRetryFire_DispatchesWhenCandidateFetchReturnsIssue is the SPEC §16.6
+// step 4 conformance check: when the candidate fetch finds the issue, the
+// retry consumes its entry and dispatches a worker — and the dispatched
+// issue carries the fresh tracker state, not the dispatch-time snapshot.
+func TestRetryFire_DispatchesWhenCandidateFetchReturnsIssue(t *testing.T) {
+	disp := &fakeDispatcher{}
+	freshState := tracker.Issue{ID: "ENG-FOUND", Identifier: "ENG-FOUND", Title: "refreshed", State: "Rework"}
+	lister := &fakeCandidateLister{issues: []tracker.Issue{freshState}}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:      disp,
+		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour}},
+		CandidateLister: lister,
+	})
+	defer cancel()
+
+	stale := freshState
+	stale.State = "AI Ready"
+	if err := o.ScheduleRetry(context.Background(), stale, stale.Identifier, 1, "transient"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(stale.ID),
+		issue:   stale,
+		attempt: 1,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	waitFor(t, func() bool { return disp.count() == 1 }, 2*time.Second)
+	if got := disp.issueAt(0).State; got != "Rework" {
+		t.Fatalf("dispatched issue state = %q, want Rework from refreshed candidate fetch", got)
+	}
 }

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -2274,3 +2274,159 @@ func TestRetryFire_DispatchesWhenCandidateFetchReturnsIssue(t *testing.T) {
 		t.Fatalf("dispatched issue state = %q, want Rework from refreshed candidate fetch", got)
 	}
 }
+
+// blockingCandidateLister blocks ListActiveIssues until either the caller's
+// context is cancelled or the explicit unblock channel is closed. It is the
+// stand-in for a tracker client that ignores ctx cancellation: the retry
+// fire's per-fetch timeout must still fire and reschedule the retry rather
+// than leaving the issue stuck in Claimed forever.
+type blockingCandidateLister struct {
+	unblock <-chan struct{}
+}
+
+func (l *blockingCandidateLister) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-l.unblock:
+		return nil, nil
+	}
+}
+
+// TestRetryFire_FetchTimeoutReschedulesAsRetryPollFailed asserts the SPEC
+// §16.6 hardening contract: when the candidate fetch outruns
+// retryFetchTimeout (modeled here by a lister that only returns on context
+// cancellation), the retry must reschedule via the "retry poll failed"
+// branch instead of orphaning the claim. Without the per-fetch timeout
+// the followup goroutine would pin indefinitely with entry.Timer already
+// cleared, so this regression covers the hardening fix.
+func TestRetryFire_FetchTimeoutReschedulesAsRetryPollFailed(t *testing.T) {
+	prevTimeout := retryFetchTimeout
+	retryFetchTimeout = 50 * time.Millisecond
+	defer func() { retryFetchTimeout = prevTimeout }()
+
+	disp := &fakeDispatcher{}
+	lister := &blockingCandidateLister{unblock: make(chan struct{})}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:      disp,
+		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour, time.Hour}},
+		CandidateLister: lister,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-TIMEOUT", Identifier: "ENG-TIMEOUT", Title: "hang", State: "AI Ready"}
+	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(iss.ID),
+		issue:   iss,
+		attempt: 1,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 1 && v.Retrying[0].Attempt == 2
+	}, 2*time.Second)
+
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := disp.count(); got != 0 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 0; fetch timeout must not dispatch", got)
+	}
+	if len(v.Retrying) != 1 {
+		t.Fatalf("retrying entries = %d, want 1 rescheduled retry; the claim must not orphan", len(v.Retrying))
+	}
+	got := v.Retrying[0]
+	if got.Attempt != 2 {
+		t.Fatalf("rescheduled attempt = %d, want attempt+1 = 2 per SPEC §16.6", got.Attempt)
+	}
+	if !strings.Contains(got.Error, "retry poll failed") {
+		t.Fatalf("rescheduled error = %q, want the typed \"retry poll failed\" prefix", got.Error)
+	}
+	if !strings.Contains(got.Error, context.DeadlineExceeded.Error()) {
+		t.Fatalf("rescheduled error = %q, want the deadline-exceeded reason wrapped in", got.Error)
+	}
+}
+
+// routingFilteringCandidateLister rejects issues whose ID does not match
+// the allowed set, modelling the SPEC §16.6 retry-fire candidate fetch
+// after selectRoutedCandidates has stripped issues that have since routed
+// to another service. The routed wrapper installed by RuntimePoller does
+// the real filtering; this lister just lets the actor-level test assert
+// that a "routed away" issue surfaces as absent rather than dispatched.
+type routingFilteringCandidateLister struct {
+	mu      sync.Mutex
+	allowed map[string]tracker.Issue
+}
+
+func (l *routingFilteringCandidateLister) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]tracker.Issue, 0, len(l.allowed))
+	for _, iss := range l.allowed {
+		out = append(out, iss)
+	}
+	return out, nil
+}
+
+// TestRetryFire_RoutedAwayIssueReleasesClaim asserts the SPEC §16.6
+// candidate-fetch contract holds when the lister applies service routing
+// on top of the active-state filter: an issue that is still in an active
+// state but has routed to another service must look absent to the retry
+// timer (no dispatch, claim released) instead of being dispatched against
+// a workflow that no longer owns it. The companion runtime-poller wiring
+// (routedActiveIssueLister) is what makes this fall out in production;
+// this test pins the actor-side contract so a future refactor cannot
+// silently regress it.
+func TestRetryFire_RoutedAwayIssueReleasesClaim(t *testing.T) {
+	disp := &fakeDispatcher{}
+	// The retry was scheduled when the issue still matched this workflow's
+	// service route; by the time the timer fires the route has changed,
+	// so the lister no longer surfaces it.
+	lister := &routingFilteringCandidateLister{allowed: map[string]tracker.Issue{}}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:      disp,
+		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour}},
+		CandidateLister: lister,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-ROUTED", Identifier: "ENG-ROUTED", Title: "moved", State: "AI Ready", ServiceName: "old-service"}
+	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(iss.ID),
+		issue:   iss,
+		attempt: 1,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 0
+	}, 2*time.Second)
+
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot after fire: %v", err)
+	}
+	if got := disp.count(); got != 0 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 0; routed-away issue must not be dispatched", got)
+	}
+	if len(v.Retrying) != 0 {
+		t.Fatalf("retrying view after routed-away fetch = %+v, want claim released", v.Retrying)
+	}
+}

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -2517,23 +2517,53 @@ func TestRetryFire_TodoIssueBlockedByOpenDependencyReleasesClaim(t *testing.T) {
 	}
 }
 
-// TestRetryFireAfterFetch_RefreshesEntryIdentifier asserts the LOW-severity
-// finding from the post-merge audit: when the candidate fetch surfaces a
-// refreshed issue whose Identifier has been renamed upstream (Linear
-// supports identifier renames on team key changes), retryFireAfterFetchOp
-// must propagate the new Identifier into entry.Identifier so subsequent
-// runtime events and retry reschedules stamp the live value, not the
-// stale schedule-time snapshot.
-func TestRetryFireAfterFetch_RefreshesEntryIdentifier(t *testing.T) {
+// TestRetryFireAfterFetch_RefreshedIdentifierSurfacesInSnapshot pins the
+// LOW-severity audit finding: when the candidate fetch surfaces a refreshed
+// issue with a renamed Identifier (Linear supports identifier renames on
+// team key changes), retryFireAfterFetchOp.apply must mutate
+// entry.Identifier — not just entry.Issue — so subsequent runtime events
+// and retry reschedules stamp the live value, not the stale schedule-time
+// snapshot.
+//
+// The previous version of this test asserted only against the dispatched
+// issue (`disp.issueAt(0).Identifier`), which is fed by
+// `entry.Issue = *r.found` — the pre-existing line. A mutation test
+// (deleting the new `entry.Identifier = id` line) showed it still
+// passed: the assertion never exercised the entry.Identifier field.
+//
+// The fix: block dispatch at the capacity gate so the entry stays in
+// RetryAttempts after the fetch+refresh. The Retrying snapshot view
+// reads RetryEntry.Identifier directly (state.go:818), so asserting
+// against `v.Retrying[0].Identifier` does pin the new mutation. With
+// the new line deleted, the entry retains the stale "OLD-1" and the
+// test fails.
+func TestRetryFireAfterFetch_RefreshedIdentifierSurfacesInSnapshot(t *testing.T) {
 	disp := &fakeDispatcher{}
-	freshState := tracker.Issue{ID: "ID-STABLE", Identifier: "NEW-1", Title: "renamed", State: "Rework"}
-	lister := &fakeCandidateLister{issues: []tracker.Issue{freshState}}
-	o, cancel := startActor(t, Deps{
+	fresh := tracker.Issue{ID: "ID-STABLE", Identifier: "NEW-1", Title: "renamed", State: "Rework"}
+	lister := &fakeCandidateLister{issues: []tracker.Issue{fresh}}
+
+	// Cap capacity at 1 and fill it with a different issue so the retry's
+	// dispatch tail trips the global cap and re-arms via
+	// rearmRetryCapacityRecheck — leaving the refreshed entry in
+	// RetryAttempts for the snapshot to observe.
+	st := NewOrchestratorState(15000, 1)
+	o := New(st, Deps{
 		Dispatcher:      disp,
 		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour}},
 		CandidateLister: lister,
 	})
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	blocker := tracker.Issue{ID: "ID-BLOCKER", Identifier: "BLOCKER-1", Title: "blocker", State: "Rework"}
+	if err := o.RequestDispatch(context.Background(), blocker, nil); err != nil {
+		t.Fatalf("dispatch blocker: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
 
 	stale := tracker.Issue{ID: "ID-STABLE", Identifier: "OLD-1", Title: "renamed", State: "AI Ready"}
 	if err := o.ScheduleRetry(context.Background(), stale, stale.Identifier, 1, "transient"); err != nil {
@@ -2550,9 +2580,24 @@ func TestRetryFireAfterFetch_RefreshesEntryIdentifier(t *testing.T) {
 		t.Fatalf("submit retry fire: %v", err)
 	}
 
-	waitFor(t, func() bool { return disp.count() == 1 }, 2*time.Second)
-	got := disp.issueAt(0)
-	if got.Identifier != "NEW-1" {
-		t.Fatalf("dispatched issue identifier = %q, want NEW-1 from refreshed candidate fetch", got.Identifier)
+	// The retry-fire chain: candidate fetch → retryFireAfterFetchOp.apply
+	// (refreshes entry.Issue + entry.Identifier from r.found) →
+	// retryFireDispatchTail observes RunningCount=1 >= cap=1 →
+	// rearmRetryCapacityRecheck leaves the entry in RetryAttempts. The
+	// Retrying snapshot view must surface the refreshed identifier.
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 1 && v.Retrying[0].Identifier == "NEW-1"
+	}, 2*time.Second)
+
+	v, _ := o.Snapshot(context.Background())
+	if got := disp.count(); got != 1 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 1 (blocker only); retry must not spawn under capacity", got)
+	}
+	if len(v.Retrying) != 1 {
+		t.Fatalf("retrying entries = %d, want 1 (capacity-deferred refreshed entry)", len(v.Retrying))
+	}
+	if v.Retrying[0].Identifier != "NEW-1" {
+		t.Fatalf("Retrying[0].Identifier = %q, want NEW-1 from refreshed candidate fetch — entry.Identifier mutation is missing", v.Retrying[0].Identifier)
 	}
 }

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 // fakeDispatcher records every Spawn call and lets the test control
@@ -2356,25 +2357,29 @@ func TestRetryFire_FetchTimeoutReschedulesAsRetryPollFailed(t *testing.T) {
 	}
 }
 
-// routingFilteringCandidateLister rejects issues whose ID does not match
-// the allowed set, modelling the SPEC §16.6 retry-fire candidate fetch
-// after selectRoutedCandidates has stripped issues that have since routed
-// to another service. The routed wrapper installed by RuntimePoller does
-// the real filtering; this lister just lets the actor-level test assert
-// that a "routed away" issue surfaces as absent rather than dispatched.
-type routingFilteringCandidateLister struct {
-	mu      sync.Mutex
-	allowed map[string]tracker.Issue
+// stubActiveIssueLister returns canned issues without applying any
+// downstream filters. Tests stack the real production wrappers
+// (routedActiveIssueLister, eligibleActiveIssueLister) on top of it
+// so the assertions exercise the actual filter code rather than a
+// mock that pre-filters.
+type stubActiveIssueLister struct {
+	mu     sync.Mutex
+	issues []tracker.Issue
+	err    error
 }
 
-func (l *routingFilteringCandidateLister) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	out := make([]tracker.Issue, 0, len(l.allowed))
-	for _, iss := range l.allowed {
-		out = append(out, iss)
-	}
-	return out, nil
+func (s *stubActiveIssueLister) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]tracker.Issue, len(s.issues))
+	copy(out, s.issues)
+	return out, s.err
+}
+
+func (s *stubActiveIssueLister) replace(issues []tracker.Issue) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.issues = issues
 }
 
 // TestRetryFire_RoutedAwayIssueReleasesClaim asserts the SPEC §16.6
@@ -2382,16 +2387,25 @@ func (l *routingFilteringCandidateLister) ListActiveIssues(_ context.Context) ([
 // on top of the active-state filter: an issue that is still in an active
 // state but has routed to another service must look absent to the retry
 // timer (no dispatch, claim released) instead of being dispatched against
-// a workflow that no longer owns it. The companion runtime-poller wiring
-// (routedActiveIssueLister) is what makes this fall out in production;
-// this test pins the actor-side contract so a future refactor cannot
-// silently regress it.
+// a workflow that no longer owns it. The test installs the real
+// routedActiveIssueLister wrap (the production code path) over a stub
+// inner lister, so a future refactor that bypasses the wrap will fail
+// here — not just a mock that pre-filters.
 func TestRetryFire_RoutedAwayIssueReleasesClaim(t *testing.T) {
 	disp := &fakeDispatcher{}
-	// The retry was scheduled when the issue still matched this workflow's
-	// service route; by the time the timer fires the route has changed,
-	// so the lister no longer surfaces it.
-	lister := &routingFilteringCandidateLister{allowed: map[string]tracker.Issue{}}
+	inner := &stubActiveIssueLister{}
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear"},
+		Services: []workflow.ServiceConfig{
+			{
+				Name:    "api",
+				Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"},
+				Repo:    workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"},
+			},
+		},
+	}
+	lister := routedActiveIssueLister{inner: inner, cfg: cfg}
+
 	o, cancel := startActor(t, Deps{
 		Dispatcher:      disp,
 		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour}},
@@ -2399,10 +2413,17 @@ func TestRetryFire_RoutedAwayIssueReleasesClaim(t *testing.T) {
 	})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "ENG-ROUTED", Identifier: "ENG-ROUTED", Title: "moved", State: "AI Ready", ServiceName: "old-service"}
+	// At schedule time the issue still matched the "api" service route.
+	iss := tracker.Issue{ID: "ENG-ROUTED", Identifier: "ENG-ROUTED", Title: "moved", State: "AI Ready", ProjectSlug: "api-platform"}
 	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
 		t.Fatalf("ScheduleRetry: %v", err)
 	}
+
+	// Between schedule and fire the issue routes away — its ProjectSlug
+	// now points at ops-platform, which has no matching service entry.
+	// selectRoutedCandidates inside routedActiveIssueLister must drop
+	// it, so the retry-fire path sees an empty candidate set.
+	inner.replace([]tracker.Issue{{ID: "ENG-ROUTED", Identifier: "ENG-ROUTED", Title: "moved", State: "AI Ready", ProjectSlug: "ops-platform"}})
 
 	if err := o.submit(context.Background(), &retryFireOp{
 		o:       o,
@@ -2428,5 +2449,110 @@ func TestRetryFire_RoutedAwayIssueReleasesClaim(t *testing.T) {
 	}
 	if len(v.Retrying) != 0 {
 		t.Fatalf("retrying view after routed-away fetch = %+v, want claim released", v.Retrying)
+	}
+}
+
+// TestRetryFire_TodoIssueBlockedByOpenDependencyReleasesClaim is the
+// HIGH-severity regression test for the cross-cutting filter gap a
+// post-merge adversarial audit found: the poll loop applies
+// filterEligibleCandidates between active-state fetch and dispatch
+// (poller.go), and the retry-fire lister chain must mirror it. Without
+// the eligibleActiveIssueLister wrap, a Todo issue whose retry was
+// scheduled when its blocker was terminal would still be dispatched
+// after the blocker re-opens, because the active-state filter alone
+// would not reject it. The wrap is in runtime_poller.go; this test
+// pins the actor-side contract using the real production wrap stack.
+func TestRetryFire_TodoIssueBlockedByOpenDependencyReleasesClaim(t *testing.T) {
+	disp := &fakeDispatcher{}
+	inner := &stubActiveIssueLister{}
+	// Mirror the poll loop's filter chain — active → eligible. No routing
+	// configured so this isolates the eligibility filter alone.
+	lister := eligibleActiveIssueLister{inner: inner, terminalStates: []string{"Done", "Cancelled"}}
+
+	o, cancel := startActor(t, Deps{
+		Dispatcher:      disp,
+		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour}},
+		CandidateLister: lister,
+	})
+	defer cancel()
+
+	// Retry was scheduled when the Todo issue's only blocker was terminal.
+	iss := tracker.Issue{ID: "ENG-TODO", Identifier: "ENG-TODO", Title: "todo", State: "Todo"}
+	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+
+	// Between schedule and fire the blocker re-opens — its state is now
+	// "In Progress", which is non-terminal. The poll loop would refuse
+	// this issue via filterEligibleCandidates; retry-fire must too.
+	inner.replace([]tracker.Issue{{
+		ID: "ENG-TODO", Identifier: "ENG-TODO", Title: "todo", State: "Todo",
+		BlockedBy: []tracker.BlockerRef{{ID: "ENG-BLOCK", Identifier: "ENG-BLOCK", State: "In Progress"}},
+	}})
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(iss.ID),
+		issue:   iss,
+		attempt: 1,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 0
+	}, 2*time.Second)
+
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot after fire: %v", err)
+	}
+	if got := disp.count(); got != 0 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 0; Todo with non-terminal blocker must not be dispatched", got)
+	}
+	if len(v.Retrying) != 0 {
+		t.Fatalf("retrying view after blocked-Todo fetch = %+v, want claim released to match poll-loop filter", v.Retrying)
+	}
+}
+
+// TestRetryFireAfterFetch_RefreshesEntryIdentifier asserts the LOW-severity
+// finding from the post-merge audit: when the candidate fetch surfaces a
+// refreshed issue whose Identifier has been renamed upstream (Linear
+// supports identifier renames on team key changes), retryFireAfterFetchOp
+// must propagate the new Identifier into entry.Identifier so subsequent
+// runtime events and retry reschedules stamp the live value, not the
+// stale schedule-time snapshot.
+func TestRetryFireAfterFetch_RefreshesEntryIdentifier(t *testing.T) {
+	disp := &fakeDispatcher{}
+	freshState := tracker.Issue{ID: "ID-STABLE", Identifier: "NEW-1", Title: "renamed", State: "Rework"}
+	lister := &fakeCandidateLister{issues: []tracker.Issue{freshState}}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:      disp,
+		Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour}},
+		CandidateLister: lister,
+	})
+	defer cancel()
+
+	stale := tracker.Issue{ID: "ID-STABLE", Identifier: "OLD-1", Title: "renamed", State: "AI Ready"}
+	if err := o.ScheduleRetry(context.Background(), stale, stale.Identifier, 1, "transient"); err != nil {
+		t.Fatalf("ScheduleRetry: %v", err)
+	}
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(stale.ID),
+		issue:   stale,
+		attempt: 1,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	waitFor(t, func() bool { return disp.count() == 1 }, 2*time.Second)
+	got := disp.issueAt(0)
+	if got.Identifier != "NEW-1" {
+		t.Fatalf("dispatched issue identifier = %q, want NEW-1 from refreshed candidate fetch", got.Identifier)
 	}
 }

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -107,12 +107,20 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	p.tracker = trackerClients[0]
 	p.trackers = trackerClients
 	p.lastSnapshotKey = key
-	poller := NewPollerWithReconciliation(multiIssueStateLister{trackers: trackerClients}, p.orchestrator, snap.Reconciliation)
+	multiLister := multiIssueStateLister{trackers: trackerClients}
+	poller := NewPollerWithReconciliation(multiLister, p.orchestrator, snap.Reconciliation)
 	if snap.Workflow.Config.Tracker.Kind == "linear" && len(snap.Workflow.Config.Services) > 0 {
 		poller.routing = &snap.Workflow.Config
 	}
 	preflightCfg := snap.Workflow.Config
 	poller.preflight = &preflightCfg
+	// Feed the orchestrator the same lister the poll loop uses so a
+	// fired failure-retry timer can run the SPEC §16.6 candidate fetch
+	// against the same active-state vocabulary.
+	p.orchestrator.SetCandidateLister(activeIssueListerFromStates{
+		tracker: multiLister,
+		states:  snap.Reconciliation.ActiveStates,
+	})
 	return poller, nil
 }
 

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -116,10 +116,13 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	poller.preflight = &preflightCfg
 	// Feed the orchestrator the same lister the poll loop uses so a
 	// fired failure-retry timer can run the SPEC §16.6 candidate fetch
-	// against the same active-state vocabulary. When the workflow
-	// configures service routing, the lister must also mirror the
-	// poll loop's selectRoutedCandidates filter so a retry cannot
-	// dispatch an issue that has since routed to another service.
+	// against the same active-state vocabulary. The lister must mirror
+	// every filter the poll loop applies between ListActiveIssues and
+	// dispatch (poller.go:152): service routing (selectRoutedCandidates)
+	// when configured, plus filterEligibleCandidates' required-field
+	// and Todo-blocked-by-non-terminal checks. Mirror order matches the
+	// poll loop: active → routed → eligible. Skipping any of these
+	// means a retry can dispatch an issue the poll loop would refuse.
 	var retryLister ActiveIssueLister = activeIssueListerFromStates{
 		tracker: multiLister,
 		states:  snap.Reconciliation.ActiveStates,
@@ -127,6 +130,7 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	if poller.routing != nil {
 		retryLister = routedActiveIssueLister{inner: retryLister, cfg: *poller.routing}
 	}
+	retryLister = eligibleActiveIssueLister{inner: retryLister, terminalStates: snap.Reconciliation.TerminalStates}
 	p.orchestrator.SetCandidateLister(retryLister)
 	return poller, nil
 }
@@ -246,6 +250,27 @@ func (l routedActiveIssueLister) ListActiveIssues(ctx context.Context) ([]tracke
 		return routed, errors.Join(fetchErr, routeErr)
 	}
 	return routed, nil
+}
+
+// eligibleActiveIssueLister wraps an ActiveIssueLister with the same
+// eligibility filter the poll loop applies between routing and dispatch
+// (filterEligibleCandidates in poller.go). The filter drops issues
+// missing required SPEC §4.1.1 fields (ID / Identifier / Title / State)
+// and Todo-state issues whose BlockedBy carries a non-terminal blocker.
+// Without this wrap a queued failure-retry whose Todo issue gained a
+// fresh non-terminal blocker between schedule and fire would still be
+// dispatched, while the poll loop would refuse the same issue on the
+// next tick. The fetch error is propagated unchanged because an empty
+// post-filter result is meaningful (genuine absence) but only if the
+// fetch itself succeeded.
+type eligibleActiveIssueLister struct {
+	inner          ActiveIssueLister
+	terminalStates []string
+}
+
+func (l eligibleActiveIssueLister) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	issues, fetchErr := l.inner.ListActiveIssues(ctx)
+	return filterEligibleCandidates(issues, l.terminalStates), fetchErr
 }
 
 func snapshotWorkflowKey(snap WorkflowSnapshot) string {

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -116,11 +116,18 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	poller.preflight = &preflightCfg
 	// Feed the orchestrator the same lister the poll loop uses so a
 	// fired failure-retry timer can run the SPEC §16.6 candidate fetch
-	// against the same active-state vocabulary.
-	p.orchestrator.SetCandidateLister(activeIssueListerFromStates{
+	// against the same active-state vocabulary. When the workflow
+	// configures service routing, the lister must also mirror the
+	// poll loop's selectRoutedCandidates filter so a retry cannot
+	// dispatch an issue that has since routed to another service.
+	var retryLister ActiveIssueLister = activeIssueListerFromStates{
 		tracker: multiLister,
 		states:  snap.Reconciliation.ActiveStates,
-	})
+	}
+	if poller.routing != nil {
+		retryLister = routedActiveIssueLister{inner: retryLister, cfg: *poller.routing}
+	}
+	p.orchestrator.SetCandidateLister(retryLister)
 	return poller, nil
 }
 
@@ -215,6 +222,30 @@ func (l multiIssueStateLister) FetchIssueStatesByIDs(ctx context.Context, issueI
 		return refresher.FetchIssueStatesByIDs(ctx, issueIDs)
 	}
 	return map[string]string{}, nil
+}
+
+// routedActiveIssueLister wraps an ActiveIssueLister with the same
+// service-routing filter the poll loop applies in (*Poller).runOnce
+// (see poller.go selectRoutedCandidates). SPEC §16.6's on_retry_timer
+// only knows about candidate fetch; service routing is an
+// aiops-platform extension layered on top, and the retry-fire path
+// must mirror the poll loop's filter so a queued retry whose issue
+// has since routed to another service cannot bypass the gate. Routing
+// errors are propagated so a fetch that resolves to an ambiguous
+// route is treated as a fetch failure (reschedule via "retry poll
+// failed"), not as a silent absence (release claim).
+type routedActiveIssueLister struct {
+	inner ActiveIssueLister
+	cfg   workflow.Config
+}
+
+func (l routedActiveIssueLister) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	issues, fetchErr := l.inner.ListActiveIssues(ctx)
+	routed, routeErr := selectRoutedCandidates(issues, l.cfg)
+	if fetchErr != nil || routeErr != nil {
+		return routed, errors.Join(fetchErr, routeErr)
+	}
+	return routed, nil
 }
 
 func snapshotWorkflowKey(snap WorkflowSnapshot) string {

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -645,6 +645,70 @@ func TestRuntimePollerOnlyAppliesRoutingToLinearServiceWorkflows(t *testing.T) {
 	}
 }
 
+// TestRuntimePollerRetryListerWrapsEligibilityFilterWithoutServiceRouting
+// pins the no-routing branch of the retry-fire lister chain: when the
+// workflow has no Services (gitea, service-less Linear), the orchestrator
+// must still receive an eligibleActiveIssueLister wrap so Todo issues with
+// non-terminal blockers are filtered the same way the poll loop filters
+// them. Without this test a future refactor that conditionally dropped
+// the eligibility wrap in the no-routing branch would silently regress —
+// the routing-branch test below would still pass.
+func TestRuntimePollerRetryListerWrapsEligibilityFilterWithoutServiceRouting(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "gitea", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	initial.Config.Repo = workflow.RepoConfig{Owner: "acme", Name: "fallback", CloneURL: "git@example.com:acme/fallback.git", DefaultBranch: "main"}
+	// No Services configured — no routing wrap, eligibility wrap only.
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeIssueStateTracker{}
+	dispatcher := &recordingDispatcher{}
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+
+	lister := orch.currentCandidateLister()
+	if lister == nil {
+		t.Fatal("orchestrator candidate lister not installed by RuntimePoller for no-routing path")
+	}
+
+	// Behavioral assertion: feed in a Todo issue blocked by a non-terminal
+	// blocker and confirm the eligibility wrap drops it. Without the wrap
+	// the issue would surface and the retry would dispatch.
+	trackerClient.issues = []tracker.Issue{{
+		ID: "gitea-blocked", Identifier: "BLOCKED-1", Title: "blocked todo", State: "Todo",
+		BlockedBy: []tracker.BlockerRef{{ID: "gitea-blocker", Identifier: "BLOCKER-1", State: "In Progress"}},
+	}}
+	got, err := lister.ListActiveIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveIssues: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("no-routing lister surfaced Todo+non-terminal-blocker = %+v, want filterEligibleCandidates to drop it (eligibility wrap missing?)", got)
+	}
+
+	// Positive control: a clean issue passes the wrap.
+	trackerClient.issues = []tracker.Issue{{ID: "gitea-ready", Identifier: "READY-1", Title: "ready", State: "AI Ready"}}
+	got, err = lister.ListActiveIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveIssues (positive control): %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "gitea-ready" {
+		t.Fatalf("no-routing lister surfaced issues = %+v, want exactly gitea-ready", got)
+	}
+}
+
 // TestRuntimePollerRetryListerMirrorsPollLoopFilters asserts the SPEC §16.6
 // retry-fire lister installed on the orchestrator mirrors every filter the
 // poll loop applies between ListActiveIssues and dispatch (poller.go:152):

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -645,6 +645,85 @@ func TestRuntimePollerOnlyAppliesRoutingToLinearServiceWorkflows(t *testing.T) {
 	}
 }
 
+// TestRuntimePollerInstallsRoutedCandidateListerForServiceRouting asserts
+// the SPEC §16.6 retry-fire lister installed on the orchestrator mirrors
+// the poll loop's selectRoutedCandidates filter when the workflow
+// configures service routing. Without this wiring a queued retry whose
+// issue has since routed to another service can still be dispatched
+// against this workflow, which would run an agent against work the
+// workflow no longer owns until the next reconciliation tick caught up.
+func TestRuntimePollerInstallsRoutedCandidateListerForServiceRouting(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	initial.Config.Services = []workflow.ServiceConfig{
+		{
+			Name:    "api",
+			Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"},
+			Repo:    workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"},
+		},
+	}
+	initial.Config.Tracker.ProjectSlug = ""
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeProjectScopedIssueTracker{
+		issuesByProject: map[string][]tracker.Issue{
+			"api-platform": {{ID: "api-1", Identifier: "API-1", Title: "matches route", State: "AI Ready", ProjectSlug: "api-platform"}},
+		},
+	}
+	dispatcher := &recordingDispatcher{}
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	poller, err := NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (IssueStateLister, error) {
+		return trackerClient.forProject(cfg.Tracker.ProjectSlug), nil
+	}, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+
+	lister := orch.currentCandidateLister()
+	if lister == nil {
+		t.Fatal("orchestrator candidate lister not installed by RuntimePoller")
+	}
+	routed, ok := lister.(routedActiveIssueLister)
+	if !ok {
+		t.Fatalf("orchestrator candidate lister type = %T, want routedActiveIssueLister when Services are configured", lister)
+	}
+
+	// In-route issue passes through.
+	got, err := routed.ListActiveIssues(ctx)
+	if err != nil {
+		t.Fatalf("routed ListActiveIssues: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "api-1" {
+		t.Fatalf("routed lister surfaced issues = %+v, want exactly api-1", got)
+	}
+	if got[0].ServiceName != "api" {
+		t.Fatalf("routed issue service = %q, want \"api\" stamped by selectRoutedCandidates", got[0].ServiceName)
+	}
+
+	// Issue that routes outside this workflow's services is filtered out:
+	// flip the tracker to surface only an off-route ticket and re-fetch.
+	trackerClient.replace(map[string][]tracker.Issue{
+		"api-platform": {{ID: "ops-9", Identifier: "OPS-9", Title: "now routed to ops", State: "AI Ready", ProjectSlug: "ops-platform"}},
+	})
+	got, err = routed.ListActiveIssues(ctx)
+	if err != nil {
+		t.Fatalf("routed ListActiveIssues after route flip: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("routed lister surfaced off-route issues = %+v, want SPEC §16.6 retry fetch to drop them so the claim is released", got)
+	}
+}
+
 func TestWorkflowRuntimeReloadFailureKeepsPreviousConfigAndEmitsFailureEvent(t *testing.T) {
 	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
 	initial, err := workflow.Load(path)
@@ -846,6 +925,16 @@ func (f *fakeProjectScopedIssueTracker) ListIssuesByStates(_ context.Context, st
 		}
 	}
 	return out, nil
+}
+
+func (f *fakeProjectScopedIssueTracker) replace(issues map[string][]tracker.Issue) {
+	root := f.root
+	if root == nil {
+		root = f
+	}
+	root.mu.Lock()
+	defer root.mu.Unlock()
+	root.issuesByProject = issues
 }
 
 func (f *fakeProjectScopedIssueTracker) projects() []string {

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -645,14 +645,16 @@ func TestRuntimePollerOnlyAppliesRoutingToLinearServiceWorkflows(t *testing.T) {
 	}
 }
 
-// TestRuntimePollerInstallsRoutedCandidateListerForServiceRouting asserts
-// the SPEC §16.6 retry-fire lister installed on the orchestrator mirrors
-// the poll loop's selectRoutedCandidates filter when the workflow
-// configures service routing. Without this wiring a queued retry whose
-// issue has since routed to another service can still be dispatched
-// against this workflow, which would run an agent against work the
-// workflow no longer owns until the next reconciliation tick caught up.
-func TestRuntimePollerInstallsRoutedCandidateListerForServiceRouting(t *testing.T) {
+// TestRuntimePollerRetryListerMirrorsPollLoopFilters asserts the SPEC §16.6
+// retry-fire lister installed on the orchestrator mirrors every filter the
+// poll loop applies between ListActiveIssues and dispatch (poller.go:152):
+// active-state → selectRoutedCandidates → filterEligibleCandidates. The
+// chain shape is exercised both by type assertion (so a future refactor
+// that drops a wrap fails here) and behaviorally (so a future filter
+// added to the poll loop but not mirrored to the retry path also fails).
+// Cross-cutting consistency is the new AGENTS.md "Audit adjacent paths"
+// rule earned by #287; this test pins it.
+func TestRuntimePollerRetryListerMirrorsPollLoopFilters(t *testing.T) {
 	ctx := context.Background()
 	path := writeWorkflowForReloadTest(t, "linear", 30000, "AI Ready")
 	initial, err := workflow.Load(path)
@@ -693,34 +695,56 @@ func TestRuntimePollerInstallsRoutedCandidateListerForServiceRouting(t *testing.
 	if lister == nil {
 		t.Fatal("orchestrator candidate lister not installed by RuntimePoller")
 	}
-	routed, ok := lister.(routedActiveIssueLister)
+	// Outer wrap must be eligibility filter (matches poll loop's
+	// filterEligibleCandidates step). Without this wrap a Todo issue
+	// with a non-terminal blocker would be dispatched on retry.
+	eligible, ok := lister.(eligibleActiveIssueLister)
 	if !ok {
-		t.Fatalf("orchestrator candidate lister type = %T, want routedActiveIssueLister when Services are configured", lister)
+		t.Fatalf("orchestrator candidate lister type = %T, want eligibleActiveIssueLister as outer wrap", lister)
+	}
+	// Inner wrap (with Services configured) must be routing filter.
+	if _, ok := eligible.inner.(routedActiveIssueLister); !ok {
+		t.Fatalf("eligibleActiveIssueLister.inner type = %T, want routedActiveIssueLister when Services are configured", eligible.inner)
 	}
 
-	// In-route issue passes through.
-	got, err := routed.ListActiveIssues(ctx)
+	// In-route + eligible issue passes the full chain.
+	got, err := lister.ListActiveIssues(ctx)
 	if err != nil {
-		t.Fatalf("routed ListActiveIssues: %v", err)
+		t.Fatalf("ListActiveIssues: %v", err)
 	}
 	if len(got) != 1 || got[0].ID != "api-1" {
-		t.Fatalf("routed lister surfaced issues = %+v, want exactly api-1", got)
+		t.Fatalf("lister surfaced issues = %+v, want exactly api-1 (in-route + eligible)", got)
 	}
 	if got[0].ServiceName != "api" {
 		t.Fatalf("routed issue service = %q, want \"api\" stamped by selectRoutedCandidates", got[0].ServiceName)
 	}
 
-	// Issue that routes outside this workflow's services is filtered out:
-	// flip the tracker to surface only an off-route ticket and re-fetch.
+	// Off-route issue gets dropped by the routing layer.
 	trackerClient.replace(map[string][]tracker.Issue{
 		"api-platform": {{ID: "ops-9", Identifier: "OPS-9", Title: "now routed to ops", State: "AI Ready", ProjectSlug: "ops-platform"}},
 	})
-	got, err = routed.ListActiveIssues(ctx)
+	got, err = lister.ListActiveIssues(ctx)
 	if err != nil {
-		t.Fatalf("routed ListActiveIssues after route flip: %v", err)
+		t.Fatalf("ListActiveIssues after route flip: %v", err)
 	}
 	if len(got) != 0 {
-		t.Fatalf("routed lister surfaced off-route issues = %+v, want SPEC §16.6 retry fetch to drop them so the claim is released", got)
+		t.Fatalf("lister surfaced off-route issues = %+v, want SPEC §16.6 retry fetch to drop them so the claim is released", got)
+	}
+
+	// Todo issue with a non-terminal blocker gets dropped by the
+	// eligibility layer — the gap the post-merge audit found.
+	trackerClient.replace(map[string][]tracker.Issue{
+		"api-platform": {{
+			ID: "api-2", Identifier: "API-2", Title: "blocked todo", State: "Todo", ProjectSlug: "api-platform",
+			BlockedBy: []tracker.BlockerRef{{ID: "api-blocker", Identifier: "API-BLOCKER", State: "In Progress"}},
+		}},
+	})
+	got, err = lister.ListActiveIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveIssues after blocker flip: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("lister surfaced Todo issue with non-terminal blocker = %+v, want filterEligibleCandidates to drop it", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #191. The fired failure-retry timer now follows SPEC §16.6's 5-step contract explicitly:

1. Fetch active candidate issues.
2. Find the specific issue by `issue_id`.
3. If not found → **release the claim**.
4. If found and slots available → dispatch from the refreshed tracker state.
5. If found but no longer active → release the claim (folded into step 3, since `ListActiveIssues` returns only active issues).

Before this change, `retryFireOp.apply` dispatched directly from the cached `entry.Issue` snapshot. A transient candidate-fetch failure was silently absorbed by the implicit "next reconcile will catch it" path, and the "issue genuinely absent" branch was conflated with the stale-entry guard. Both gaps are now closed:

- **Fetch error path** submits a new `retryPollFailedOp` that reschedules with a typed `"retry poll failed: <err>"` reason and `attempt+1` so the next backoff window can try again.
- **Issue absent path** submits a new `retryFireAfterFetchOp` that calls `state.ReleaseClaim(id)` and records a `RuntimeEventFailed("retry released: issue absent from active candidates")` for observability.
- **Dispatch path** refreshes `entry.Issue` from the freshly-fetched tracker state before running the existing capacity gates (factored into `retryFireDispatchTail` so both the new and legacy entry points share it).

A new optional `CandidateLister ActiveIssueLister` on `orchestrator.Deps` wires the same multi-tracker lister the poll loop uses; `RuntimePoller.pollerForSnapshot` installs it on every workflow snapshot reload so the active-state vocabulary stays in sync. When the lister is `nil` (most unit tests), retry fires fall back to the legacy direct-dispatch path so existing behavior is preserved verbatim.

## Test plan

Added three SPEC §16.6 conformance tests in `internal/orchestrator/actor_test.go`:

- [x] `TestRetryFire_ReleasesClaimWhenIssueAbsentFromCandidates` — successful fetch returns no issues → claim released, no dispatch.
- [x] `TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError` — fetch fails → retry rescheduled with `attempt+1` and `Error` contains `"retry poll failed"` plus the wrapped underlying message.
- [x] `TestRetryFire_DispatchesWhenCandidateFetchReturnsIssue` — fetch returns the issue with a refreshed state → dispatched worker carries the fresh state, not the dispatch-time snapshot.
- [x] Full `go test ./internal/orchestrator/...` (+ `-race`) passes; existing `TestRetryFireUsesRefreshedIssueWhenReconciledMidQueue` / `TestRetryFire_RespectsPerStateCapacityBeforeSpawning` / `TestTrackerRecheckedDispatchDoesNotConsumeFailureRetry` continue to pass via the legacy fallback.

@codex review

https://claude.ai/code/session_019Ro8rz8GEmW6m4QQPHeaXM

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ro8rz8GEmW6m4QQPHeaXM)_