### PR TITLE
test(workspace+worker): disable commit/tag gpgsign in fixture repos (#288)

### DIFF
--- a/internal/runner/mock.go
+++ b/internal/runner/mock.go
@@ -80,7 +80,7 @@ pushing, opening PRs, or writing tracker comments on the runner's behalf.
 		}
 		gitCommands := [][]string{
 			{"git", "add", commitPath},
-			{"git", "-c", "user.email=mock@example.com", "-c", "user.name=mock", "commit", "-q", "-m", "mock source commit"},
+			{"git", "-c", "user.email=mock@example.com", "-c", "user.name=mock", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "commit", "-q", "-m", "mock source commit"},
 		}
 		for _, args := range gitCommands {
 			cmd := exec.CommandContext(ctx, args[0], args[1:]...)

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -39,6 +39,8 @@ func initBareUpstreamWithWorkflow(t *testing.T, workflowBody string) (cloneURL s
 		{"git", "init", "-q", "-b", "main", work},
 		{"git", "-C", work, "config", "user.email", "u@example.com"},
 		{"git", "-C", work, "config", "user.name", "u"},
+		{"git", "-C", work, "config", "commit.gpgsign", "false"},
+		{"git", "-C", work, "config", "tag.gpgsign", "false"},
 	} {
 		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
 			t.Fatalf("%v: %v\n%s", args, err, out)
@@ -857,6 +859,8 @@ func TestAnalysisOnlyRunRequiresFreshPlanArtifact(t *testing.T) {
 		{"git", "clone", "-q", seed, work},
 		{"git", "-C", work, "config", "user.email", "u@example.com"},
 		{"git", "-C", work, "config", "user.name", "u"},
+		{"git", "-C", work, "config", "commit.gpgsign", "false"},
+		{"git", "-C", work, "config", "tag.gpgsign", "false"},
 	} {
 		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
 			t.Fatalf("%v: %v\n%s", args, err, out)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -28,6 +28,8 @@ func initRepo(t *testing.T) string {
 		{"git", "init", "-q", "-b", "main"},
 		{"git", "config", "user.email", "test@example.com"},
 		{"git", "config", "user.name", "test"},
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "config", "tag.gpgsign", "false"},
 	} {
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Dir = dir
@@ -647,6 +649,8 @@ func TestAllChangedFilesIncludesArtifactsWhenSnapshotAfterWrite(t *testing.T) {
 	mustGit(t, dir, "init", "-q")
 	mustGit(t, dir, "config", "user.email", "test@example.com")
 	mustGit(t, dir, "config", "user.name", "test")
+	mustGit(t, dir, "config", "commit.gpgsign", "false")
+	mustGit(t, dir, "config", "tag.gpgsign", "false")
 	mustGit(t, dir, "commit", "--allow-empty", "-q", "-m", "init")
 
 	if err := os.WriteFile(filepath.Join(dir, "src.go"), []byte("package main\n"), 0o644); err != nil {

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -33,6 +33,8 @@ func initBareUpstream(t *testing.T) string {
 		{"git", "init", "-q", "-b", "main", work},
 		{"git", "-C", work, "config", "user.email", "u@example.com"},
 		{"git", "-C", work, "config", "user.name", "u"},
+		{"git", "-C", work, "config", "commit.gpgsign", "false"},
+		{"git", "-C", work, "config", "tag.gpgsign", "false"},
 	} {
 		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
 			t.Fatalf("%v: %v\n%s", args, err, out)
@@ -570,11 +572,15 @@ func unsetEnvForTest(t *testing.T, keys ...string) {
 // worktree. PrepareGitWorkspace inherits config from the bare mirror, but the
 // mirror is created without an identity (we never commit inside it), so a
 // commit issued from the worktree would otherwise fail in CI environments
-// without a global git identity.
+// without a global git identity. The gpgsign disables protect the fixture
+// from inheriting a host-level commit.gpgsign=true when the signing program
+// is missing or broken (see #288).
 func configureGitIdentity(dir string) error {
 	for _, args := range [][]string{
 		{"git", "-C", dir, "config", "user.email", "u@example.com"},
 		{"git", "-C", dir, "config", "user.name", "u"},
+		{"git", "-C", dir, "config", "commit.gpgsign", "false"},
+		{"git", "-C", dir, "config", "tag.gpgsign", "false"},
 	} {
 		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
 			return errFromOut(args, err, out)


### PR DESCRIPTION
Closes #288.

## Summary

Fixture git repos and the mock runner now set `commit.gpgsign=false` and `tag.gpgsign=false` alongside the existing `user.email`/`user.name` config, so that seed/test commits don't inherit a host-level `commit.gpgsign=true` that would force them through a missing or broken signing program.

Sites updated:

- `internal/workspace/mirror_test.go` — `initBareUpstream` + the `configureGitIdentity` helper.
- `internal/workspace/manager_test.go` — `initRepo` + the `TestAllChangedFilesIncludesArtifactsWhenSnapshotAfterWrite` fixture.
- `internal/worker/runtask_integration_test.go` — `initBareUpstreamWithWorkflow` + the per-test clone in `TestAnalysisOnlyRunRequiresFreshPlanArtifact`.
- `internal/runner/mock.go` — the `mock` runner's per-task `git commit`. Tests that exercise the mock runner via `runTask` also hit this commit, and its inherited gpgsign caused the same failure shape as the fixture commits.

## Reproduction

```
git config --global commit.gpgsign true
git config --global tag.gpgsign true
git config --global gpg.program /bin/false   # any broken/missing signer
go test ./internal/workspace/... ./internal/worker/...
```

Before this change: ~30 failures across the two packages, all with the same shape:

```
[git -C /tmp/.../seed commit -q -m seed]: exit status 128
error: ... signing failed: ...
fatal: failed to write commit object
```

After this change: only 3 pre-existing host-environment failures remain, none signing-related. They are out of scope for #288 and reproduce identically with `commit.gpgsign` unset:

- `TestRunWorkspaceHookStopsOnNonZeroAndCapturesOutput` and `TestRunVerifyEnvDropsNonAllowlistedSecretsByDefault` — the `sh -lc` invocation (documented design; see `docs/runbooks/personal-daily-workflow.md`) sources `/etc/profile.d/nvm.sh` on this host, which prints `nvm` to stdout and pollutes the captured hook output. The fix is host-specific (a clean shell sandbox) or a separate design conversation about `sh -lc` vs `sh -c`.
- `TestRunTaskPolicyViolationFeedbackWriteErrorIsNonRetryable` — the test `chmod`s a feedback dir to `0o555` and expects the write to fail; running as root (uid 0) the chmod is not honored. Pre-existing.

## Acceptance criteria (#288)

- [x] Every test that creates a git fixture repo also disables `commit.gpgsign` and `tag.gpgsign` on it.
- [x] `go test ./internal/workspace/... ./internal/worker/...` no longer fails on a host with `commit.gpgsign=true` in `~/.gitconfig` and no working signing program (remaining failures are unrelated host-env issues, documented above).
- [ ] (Optional) shared `seedTestRepoConfig` helper — skipped: inlined two extra config lines per site keeps the diff small and matches the existing per-site config style. Happy to refactor into a shared helper if reviewers prefer.

@codex review

---
_Generated by [Claude Code](https://claude.ai/code/session_01F18U55ovjuUx43QKKdJQRx)_