### PR TITLE
fix(worker): SPEC §13.1 session_id on post-session log helpers (#292)

### DIFF
--- a/internal/worker/log.go
+++ b/internal/worker/log.go
@@ -17,13 +17,44 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 )
 
+// sessionIDFromRuntimeEvents scans runner-produced runtime events for the
+// `session_started` event (SPEC §10.4) and returns the `session_id` payload
+// field it carries (e.g. `<thread_id>-<turn_id>`). Returns "" when no
+// session_started event is present, so callers can pass the result through
+// the session-aware log helpers without branching on whether the runner
+// reached its session-handshake phase.
+func sessionIDFromRuntimeEvents(events []task.RuntimeEvent) string {
+	for _, ev := range events {
+		if ev.Event != task.EventSessionStarted {
+			continue
+		}
+		payload, ok := ev.Payload.(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, ok := payload["session_id"].(string); ok && id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
 // LogIssueEventf formats a SPEC §13.1 issue-lifecycle log line for a known
 // task: `event=<kind> task_id=<id> issue_id=<id> issue_identifier=<src> <msg>`.
 // Pair with Emit() for runtime-event surfaces; this helper covers the
 // log-only failure paths (workspace hooks, retry-queue plumbing, artifact
 // writes) where the orchestrator does not also fold a runtime event.
 func LogIssueEventf(t task.Task, event, format string, args ...any) {
-	log.Printf("%s %s", issueLogPrefix(event, t), fmt.Sprintf(format, args...))
+	log.Printf("%s %s", issueLogPrefix(event, t, ""), fmt.Sprintf(format, args...))
+}
+
+// LogIssueSessionEventf is the session-aware variant for log lines that
+// fire after `session_started`: it threads SPEC §13.1's REQUIRED
+// `session_id` field through alongside the standard issue context. Pass
+// sessionID="" to fall back to the pre-session shape (the key is omitted
+// rather than emitted empty so aggregators do not mis-parse it).
+func LogIssueSessionEventf(t task.Task, sessionID, event, format string, args ...any) {
+	log.Printf("%s %s", issueLogPrefix(event, t, sessionID), fmt.Sprintf(format, args...))
 }
 
 // LogTaskIDEventf is the narrow form used by call sites that only have the
@@ -34,7 +65,14 @@ func LogIssueEventf(t task.Task, event, format string, args ...any) {
 // set equal to `task_id` because TaskFromIssue keys Task.ID by the tracker
 // issue id.
 func LogTaskIDEventf(taskID, identifier, event, format string, args ...any) {
-	log.Printf("%s %s", taskIDLogPrefix(event, taskID, identifier), fmt.Sprintf(format, args...))
+	log.Printf("%s %s", taskIDLogPrefix(event, taskID, identifier, ""), fmt.Sprintf(format, args...))
+}
+
+// LogTaskIDSessionEventf is the session-aware variant of LogTaskIDEventf
+// for callers that have only the task id in scope but already know the
+// session id (e.g. the post-runner event_emit failure path).
+func LogTaskIDSessionEventf(taskID, identifier, sessionID, event, format string, args ...any) {
+	log.Printf("%s %s", taskIDLogPrefix(event, taskID, identifier, sessionID), fmt.Sprintf(format, args...))
 }
 
 // LogReconcileEventf is the helper for reconciliation / orchestrator-wide
@@ -45,9 +83,9 @@ func LogReconcileEventf(event, format string, args ...any) {
 	log.Printf("event=%s %s", event, fmt.Sprintf(format, args...))
 }
 
-func issueLogPrefix(event string, t task.Task) string {
+func issueLogPrefix(event string, t task.Task, sessionID string) string {
 	var b strings.Builder
-	b.Grow(64)
+	b.Grow(96)
 	b.WriteString("event=")
 	b.WriteString(event)
 	b.WriteString(" task_id=")
@@ -58,13 +96,20 @@ func issueLogPrefix(event string, t task.Task) string {
 		b.WriteString(" issue_identifier=")
 		b.WriteString(t.SourceEventID)
 	}
+	if sessionID != "" {
+		b.WriteString(" session_id=")
+		b.WriteString(sessionID)
+	}
 	return b.String()
 }
 
-func taskIDLogPrefix(event, taskID, identifier string) string {
+func taskIDLogPrefix(event, taskID, identifier, sessionID string) string {
 	prefix := "event=" + event + " task_id=" + taskID + " issue_id=" + taskID
 	if identifier != "" {
 		prefix += " issue_identifier=" + identifier
+	}
+	if sessionID != "" {
+		prefix += " session_id=" + sessionID
 	}
 	return prefix
 }

--- a/internal/worker/log_test.go
+++ b/internal/worker/log_test.go
@@ -89,6 +89,84 @@ func TestLogTaskIDEventfOmitsEmptyIdentifier(t *testing.T) {
 	}
 }
 
+// TestLogIssueSessionEventfEmitsSessionID covers SPEC §13.1's REQUIRED
+// `session_id` context for coding-agent session logs: helpers fired after
+// `session_started` must carry the session id alongside the existing
+// task/issue identifiers.
+func TestLogIssueSessionEventfEmitsSessionID(t *testing.T) {
+	got := captureLog(t, func() {
+		LogIssueSessionEventf(task.Task{ID: "lin-42", SourceEventID: "LIN-42"}, "thread-1-turn-1", "after_run_hook_failed", "error=%q", "exit 1")
+	})
+	for _, want := range []string{
+		"event=after_run_hook_failed",
+		"task_id=lin-42",
+		"issue_id=lin-42",
+		"issue_identifier=LIN-42",
+		"session_id=thread-1-turn-1",
+		`error="exit 1"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("LogIssueSessionEventf output missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestLogIssueSessionEventfOmitsEmptySessionID covers the pre-session path
+// where session_started has not fired yet (e.g. the runner failed during
+// process spawn). The helper must omit `session_id=` rather than emit an
+// empty value so log aggregators do not mis-parse it as a real id.
+func TestLogIssueSessionEventfOmitsEmptySessionID(t *testing.T) {
+	got := captureLog(t, func() {
+		LogIssueSessionEventf(task.Task{ID: "lin-7", SourceEventID: "LIN-7"}, "", "after_run_hook_failed", "error=%q", "spawn")
+	})
+	if strings.Contains(got, "session_id=") {
+		t.Errorf("empty session id should omit the key, got:\n%s", got)
+	}
+	if !strings.Contains(got, "task_id=lin-7") || !strings.Contains(got, "issue_identifier=LIN-7") {
+		t.Errorf("missing required §13.1 context in:\n%s", got)
+	}
+}
+
+func TestLogTaskIDSessionEventfEmitsSessionID(t *testing.T) {
+	got := captureLog(t, func() {
+		LogTaskIDSessionEventf("tsk-9", "ENG-9", "thread-2-turn-3", "verification_write_failed", "error=%q", "disk full")
+	})
+	for _, want := range []string{
+		"event=verification_write_failed",
+		"task_id=tsk-9",
+		"issue_id=tsk-9",
+		"issue_identifier=ENG-9",
+		"session_id=thread-2-turn-3",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("LogTaskIDSessionEventf output missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestSessionIDFromRuntimeEventsExtractsSessionStartedPayload(t *testing.T) {
+	got := sessionIDFromRuntimeEvents([]task.RuntimeEvent{
+		{Event: task.EventTurnCompleted, Payload: map[string]any{"thread_id": "t-2"}},
+		{Event: task.EventSessionStarted, Payload: map[string]any{"session_id": "thread-1-turn-1", "thread_id": "thread-1"}},
+		{Event: task.EventTurnCompleted, Payload: map[string]any{"thread_id": "t-2"}},
+	})
+	if got != "thread-1-turn-1" {
+		t.Errorf("sessionIDFromRuntimeEvents = %q, want thread-1-turn-1", got)
+	}
+}
+
+func TestSessionIDFromRuntimeEventsReturnsEmptyWhenAbsent(t *testing.T) {
+	if got := sessionIDFromRuntimeEvents(nil); got != "" {
+		t.Errorf("nil events: got %q, want \"\"", got)
+	}
+	got := sessionIDFromRuntimeEvents([]task.RuntimeEvent{
+		{Event: task.EventTurnCompleted, Payload: map[string]any{"thread_id": "t-2"}},
+	})
+	if got != "" {
+		t.Errorf("no session_started: got %q, want \"\"", got)
+	}
+}
+
 func TestLogReconcileEventfOmitsIssueContext(t *testing.T) {
 	got := captureLog(t, func() {
 		LogReconcileEventf("startup_reconciliation_failed", "error=%q", "boom")

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -319,18 +319,20 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
-	if _, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: workspaceRoot, Prompt: prompt, PhaseTransitionSink: func(from, to task.RunAttemptPhase) {
+	res, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: workspaceRoot, Prompt: prompt, PhaseTransitionSink: func(from, to task.RunAttemptPhase) {
 		emitTaskPhase(from, to)
-	}}, wcfg.Agent.Timeout, workflowSource); runErr != nil {
+	}}, wcfg.Agent.Timeout, workflowSource)
+	sessionID := sessionIDFromRuntimeEvents(res.RuntimeEvents)
+	if runErr != nil {
 		if err := runWorkspaceHook(ctx, ev, t.ID, t.SourceEventID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
-			LogIssueEventf(t, "after_run_hook_failed", "after_runner_error=true error=%q", err)
+			LogIssueSessionEventf(t, sessionID, "after_run_hook_failed", "after_runner_error=true error=%q", err)
 		}
 		WriteFailureArtifacts(ctx, workdir, nil, "runner failed: "+ErrSummary(runErr))
 		return &RunTaskError{Cfg: wcfg, Err: runErr}
 	}
 
 	if err := runWorkspaceHook(ctx, ev, t.ID, t.SourceEventID, workdir, workspace.HookAfterRun, hooks.AfterRun, hooks.TimeoutMs, hooks.EnvPassthrough); err != nil {
-		LogIssueEventf(t, "after_run_hook_failed", "error=%q", err)
+		LogIssueSessionEventf(t, sessionID, "after_run_hook_failed", "error=%q", err)
 	}
 
 	if err := workspace.EnforcePolicy(ctx, workdir, wcfg); err != nil {


### PR DESCRIPTION
Closes #292.

## Summary

SPEC §13.1 makes `session_id` REQUIRED context on coding-agent session lifecycle logs. The package-level comment in `internal/worker/log.go` already names the field, but the helpers (`LogIssueEventf` / `LogTaskIDEventf` and the shared prefix builders) never expose a `sessionID` parameter — so a grep over operator logs for `session_id=` returns zero hits today and the §17.6 conformance check fails.

This PR adds the minimum machinery in `internal/worker` to close the gap:

- Two session-aware sibling helpers — **`LogIssueSessionEventf`** and **`LogTaskIDSessionEventf`** — that thread `session_id=<id>` after the existing `issue_identifier=` key. The session key is omitted when `sessionID == ""` (same pattern as `issue_identifier=`) so log aggregators do not mis-parse a present-but-empty value.
- Existing `LogIssueEventf` / `LogTaskIDEventf` keep their current signatures and shape; the shared prefix builders gain a `sessionID` argument with zero-value semantics.
- A small worker-package helper, **`sessionIDFromRuntimeEvents`**, scans `runner.Result.RuntimeEvents` for `session_started` (SPEC §10.4) and returns the `session_id` payload field. The codex app-server runner already records this field at `internal/runner/codex_app_server.go:649-655`; the worker just needed to read it.
- `runTask` now captures `RunRunnerWithTimeout`'s result (previously discarded), extracts the session id once, and uses the session-aware helper for the two `after_run_hook_failed` log lines that fire **after** the runner has emitted `session_started`.

Pre-session call sites (`workflow_resolved`, `before_remove_hook_failed`, `fail_*_store_error`, `workspace_remove_failed`) intentionally keep the legacy helpers — `sessionID` is `""` at those points and the new key would be omitted anyway.

## Scope

Single package: `internal/worker`. Three files changed, 134 LOC, well under the policy caps (≤12 files, ≤300 LOC).

The issue's "Call sites worth updating in the same PR" enumeration covered runner + orchestrator + worker; this PR ships the worker-side wiring and leaves the runner/orchestrator log lines as a separate follow-up so the change stays inside the self-fixable scope.

## Test plan

- New `internal/worker/log_test.go` cases:
  - `TestLogIssueSessionEventfEmitsSessionID` — helper produces `event=… task_id=… issue_id=… issue_identifier=… session_id=…`.
  - `TestLogIssueSessionEventfOmitsEmptySessionID` — `sessionID == ""` omits the key entirely.
  - `TestLogTaskIDSessionEventfEmitsSessionID` — same shape via the task-id path.
  - `TestSessionIDFromRuntimeEventsExtractsSessionStartedPayload` — payload field is read out of the `session_started` event.
  - `TestSessionIDFromRuntimeEventsReturnsEmptyWhenAbsent` — nil events / no `session_started` returns `""`.
- `go test -race -covermode=atomic ./...` passes on this branch.
- `gofmt -l $(git ls-files '*.go')` empty.
- `go mod tidy` leaves `go.mod` / `go.sum` clean.

## Refs

- SPEC §13.1 (Logging Conventions)
- `internal/worker/log.go:1-70` (package-level comment + helpers updated)
- `internal/orchestrator/runtime_events.go:97-114` (session_id producer; not touched in this PR)
- `internal/runner/codex_app_server.go:649-655` (session_id source; not touched in this PR)