### PR TITLE
fix(orchestrator): SPEC §8.1 step 2 per-tick dispatch preflight (#293)

### DIFF
--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -72,6 +72,12 @@ type Poller struct {
 	reconcile      ReconciliationConfig
 	reconcileKnown bool
 	routing        *workflow.Config
+	// preflight is the workflow.Config used for SPEC §8.1 step 2
+	// dispatch-preflight validation. nil disables the gate (legacy
+	// constructors / tests). RuntimePoller sets it on every workflow
+	// snapshot reload so `$VAR` resolution drift is detected on the
+	// next tick rather than at the next tracker call.
+	preflight *workflow.Config
 }
 
 // NewPoller returns a SPEC-aligned tracker poller backed by orchestrator-owned
@@ -108,6 +114,14 @@ func (p *Poller) PollOnce(ctx context.Context) error {
 	}
 	if p.orchestrator == nil {
 		return errors.New("orchestrator poller requires orchestrator")
+	}
+	if p.preflight != nil {
+		if err := validateDispatchPreflight(*p.preflight); err != nil {
+			if recErr := p.orchestrator.recordPreflightFailed(ctx, err); recErr != nil {
+				return errors.Join(fmt.Errorf("dispatch preflight failed: %w", err), recErr)
+			}
+			return fmt.Errorf("dispatch preflight failed: %w", err)
+		}
 	}
 	issues, activeErr := p.tracker.ListActiveIssues(ctx)
 	// Multi-tracker clients return (issues, errors.Join(...)) on partial success;

--- a/internal/orchestrator/preflight.go
+++ b/internal/orchestrator/preflight.go
@@ -1,0 +1,83 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// supportedTrackerKinds enumerates the tracker.kind values the orchestrator
+// can actually drive a poll tick against. Matches the loader's parse-time
+// validation (internal/workflow/loader.go) so the per-tick preflight does
+// not silently accept kinds the rest of the system rejects.
+var supportedTrackerKinds = map[string]struct{}{
+	"linear": {},
+	"gitea":  {},
+	"github": {},
+}
+
+// validateDispatchPreflight is the SPEC §8.1 step 2 / §6.3 per-tick
+// dispatch-preflight check. Startup loader validation only covers schema
+// shape; this function re-validates the *resolved* runtime view of the
+// workflow (post-`$VAR` expansion) on every poll tick so a token rotation,
+// subprocess unset, or hot-edit of operator env that leaves a key empty
+// at runtime surfaces as a typed `dispatch_preflight_failed` event rather
+// than a tracker-specific transport error.
+//
+// Returned error joins every individual failure so the operator-visible
+// event message carries the full reason set, not just the first one.
+func validateDispatchPreflight(cfg workflow.Config) error {
+	var errs []error
+	kind := strings.TrimSpace(cfg.Tracker.Kind)
+	if kind == "" {
+		errs = append(errs, errors.New("tracker.kind missing"))
+	} else if _, ok := supportedTrackerKinds[kind]; !ok {
+		errs = append(errs, fmt.Errorf("tracker.kind unsupported: %q", kind))
+	}
+	if strings.TrimSpace(cfg.Tracker.APIKey) == "" {
+		errs = append(errs, errors.New("tracker.api_key empty after $VAR resolution"))
+	}
+	if kind == "linear" && strings.TrimSpace(cfg.Tracker.ProjectSlug) == "" && !linearRouteCoversProjectSlug(cfg) {
+		errs = append(errs, errors.New("tracker.project_slug required for linear"))
+	}
+	if strings.TrimSpace(cfg.Codex.Command) == "" {
+		errs = append(errs, errors.New("codex.command empty"))
+	}
+	return errors.Join(errs...)
+}
+
+// linearRouteCoversProjectSlug reports whether one of the workflow's
+// service routes provides its own Linear `project_slug`. The check mirrors
+// the loader's "missing root project_slug is ok when services route it"
+// rule (services-routing extension D25); a per-tick preflight that fired
+// on every multi-service workflow would block dispatch even though the
+// loader accepted the config.
+func linearRouteCoversProjectSlug(cfg workflow.Config) bool {
+	for _, svc := range cfg.Services {
+		if strings.TrimSpace(svc.Tracker.ProjectSlug) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// recordPreflightFailed submits an actor-serialized op that appends a
+// `dispatch_preflight_failed` RuntimeEvent into the orchestrator state
+// log. The event surfaces in /api/v1/state's recent_events so an operator
+// can see the typed preflight reason rather than chasing a downstream
+// tracker error message.
+func (o *Orchestrator) recordPreflightFailed(ctx context.Context, reason error) error {
+	if o == nil || reason == nil {
+		return nil
+	}
+	return o.submit(ctx, opFunc(func(st *OrchestratorState) func() {
+		st.RecordEvent(RuntimeEvent{
+			Kind:    RuntimeEventDispatchPreflightFailed,
+			Message: reason.Error(),
+		})
+		return nil
+	}))
+}

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -1,0 +1,188 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestValidateDispatchPreflight_HappyPathReturnsNil(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "lin_xxxx", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	if err := validateDispatchPreflight(cfg); err != nil {
+		t.Fatalf("happy-path preflight: %v", err)
+	}
+}
+
+func TestValidateDispatchPreflight_EmptyAPIKeyAfterVarResolution(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	err := validateDispatchPreflight(cfg)
+	if err == nil {
+		t.Fatalf("expected error for empty api_key")
+	}
+	if !strings.Contains(err.Error(), "tracker.api_key empty") {
+		t.Errorf("unexpected reason: %v", err)
+	}
+}
+
+func TestValidateDispatchPreflight_MissingCodexCommand(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "lin_xxxx", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: ""},
+	}
+	err := validateDispatchPreflight(cfg)
+	if err == nil {
+		t.Fatalf("expected error for empty codex.command")
+	}
+	if !strings.Contains(err.Error(), "codex.command empty") {
+		t.Errorf("unexpected reason: %v", err)
+	}
+}
+
+func TestValidateDispatchPreflight_UnsupportedTrackerKind(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "jira", APIKey: "x", ProjectSlug: "p"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	err := validateDispatchPreflight(cfg)
+	if err == nil {
+		t.Fatalf("expected error for unsupported tracker.kind")
+	}
+	if !strings.Contains(err.Error(), "tracker.kind unsupported") {
+		t.Errorf("unexpected reason: %v", err)
+	}
+}
+
+func TestValidateDispatchPreflight_LinearProjectSlugMissingFailsButServiceRouteCovers(t *testing.T) {
+	missing := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "lin_xxxx"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	if err := validateDispatchPreflight(missing); err == nil {
+		t.Fatalf("expected error for missing linear project_slug")
+	}
+	covered := workflow.Config{
+		Tracker:  workflow.TrackerConfig{Kind: "linear", APIKey: "lin_xxxx"},
+		Codex:    workflow.CommandConfig{Command: "codex app-server"},
+		Services: []workflow.ServiceConfig{{Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "service-x"}}},
+	}
+	if err := validateDispatchPreflight(covered); err != nil {
+		t.Fatalf("service-routed project_slug should satisfy preflight: %v", err)
+	}
+}
+
+func TestValidateDispatchPreflight_JoinsMultipleReasons(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "", APIKey: ""},
+		Codex:   workflow.CommandConfig{Command: ""},
+	}
+	err := validateDispatchPreflight(cfg)
+	if err == nil {
+		t.Fatalf("expected joined error")
+	}
+	for _, want := range []string{"tracker.kind missing", "tracker.api_key empty", "codex.command empty"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("joined error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestPollOncePreflightFailureSkipsDispatchAndEmitsRuntimeEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	})
+	// Empty api_key + missing codex.command — preflight must catch both.
+	preflightCfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: ""},
+	}
+	poller.preflight = &preflightCfg
+
+	err := poller.PollOnce(ctx)
+	if err == nil {
+		t.Fatalf("expected preflight failure error")
+	}
+	if !strings.Contains(err.Error(), "dispatch preflight failed") {
+		t.Errorf("unexpected error shape: %v", err)
+	}
+	if dispatcher.count() != 0 {
+		t.Errorf("dispatch should be skipped on preflight failure, got count=%d", dispatcher.count())
+	}
+	view, snapErr := orch.Snapshot(ctx)
+	if snapErr != nil {
+		t.Fatalf("snapshot: %v", snapErr)
+	}
+	var saw bool
+	for _, ev := range view.RecentEvents {
+		if ev.Kind == RuntimeEventDispatchPreflightFailed {
+			saw = true
+			if !strings.Contains(ev.Message, "tracker.api_key empty") || !strings.Contains(ev.Message, "codex.command empty") {
+				t.Errorf("preflight event message does not carry both joined reasons: %q", ev.Message)
+			}
+		}
+	}
+	if !saw {
+		t.Errorf("RuntimeEventDispatchPreflightFailed not recorded in RecentEvents (have %d events)", len(view.RecentEvents))
+	}
+}
+
+func TestPollOncePreflightSuccessProceedsToFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	})
+	preflightCfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "lin_xxxx", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	poller.preflight = &preflightCfg
+
+	if err := poller.PollOnce(ctx); err != nil && !errors.Is(err, ErrNotDispatched) {
+		// Best-effort: dispatch may or may not occur depending on test
+		// fakes; the assertion that matters is no preflight error.
+		if strings.Contains(err.Error(), "dispatch preflight failed") {
+			t.Fatalf("preflight should have passed: %v", err)
+		}
+	}
+}

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -111,6 +111,8 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	if snap.Workflow.Config.Tracker.Kind == "linear" && len(snap.Workflow.Config.Services) > 0 {
 		poller.routing = &snap.Workflow.Config
 	}
+	preflightCfg := snap.Workflow.Config
+	poller.preflight = &preflightCfg
 	return poller, nil
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -653,6 +653,10 @@ type StateView struct {
 	CumulativeFailedTotal    int64
 	CodexTotals              CodexTotals
 	CodexRateLimits          *RateLimitSnapshot
+	// RecentEvents is the bounded orchestrator-wide event log (capped at
+	// MaxRuntimeEvents). It carries SPEC §13.7 operator-visible signals
+	// like dispatch_preflight_failed that are not scoped to one issue.
+	RecentEvents []RuntimeEvent
 }
 
 // RunningView is the per-running-entry projection in StateView. It
@@ -759,6 +763,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 		CumulativeFailedTotal:      s.CumulativeFailedTotal,
 		CodexTotals:                totals,
 		CodexRateLimits:            copyRateLimitSnapshot(s.CodexRateLimits),
+		RecentEvents:               append([]RuntimeEvent(nil), s.RecentEvents...),
 	}
 	for id, r := range s.Running {
 		// Deep-copy RetryAttempt so a snapshot consumer mutating the

--- a/internal/orchestrator/status.go
+++ b/internal/orchestrator/status.go
@@ -14,6 +14,13 @@ const (
 	RuntimeEventFailed           RuntimeEventKind = "failed"
 	RuntimeEventCandidateBlocked RuntimeEventKind = "blocked"
 	RuntimeEventInputBlocked     RuntimeEventKind = "input_blocked"
+	// RuntimeEventDispatchPreflightFailed flags SPEC §8.1 step 2 failures:
+	// the per-tick dispatch preflight could not validate the workflow's
+	// tracker / agent / API-key config, so the orchestrator skipped
+	// candidate fetch/sort/dispatch for the tick. The Message field carries
+	// the joined preflight reason(s); IssueID is empty because the gate is
+	// not scoped to a single issue.
+	RuntimeEventDispatchPreflightFailed RuntimeEventKind = "dispatch_preflight_failed"
 )
 
 // RuntimeEvent is an operator-facing event observed by the orchestrator runtime.

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -884,6 +884,7 @@ func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIn
 		"  clone_url: https://github.com/xrf9268-hue/aiops-platform.git\n" +
 		"tracker:\n" +
 		"  kind: " + trackerKind + "\n" +
+		"  api_key: lin_dummy_for_test\n" +
 		reloadTestLinearProjectSlugYAML(trackerKind) +
 		"  active_states: [\"" + activeState + "\"]\n" +
 		"  terminal_states: [\"Done\"]\n" +


### PR DESCRIPTION
Closes #293.

## Summary

SPEC §8.1's per-tick sequence has six steps; step 2 — *"Run dispatch preflight validation"* — was never implemented. Startup loader validation only checks schema shape; per-tick re-validation of the *resolved* runtime view (post-`\$VAR` expansion) does not exist, so a Linear token rotation, subprocess unset, or hot-edit of operator env that leaves `tracker.api_key` empty at runtime currently surfaces as an opaque 401 from the tracker call rather than the typed `dispatch_preflight_failed` event SPEC §13.4 expects.

This PR adds the SPEC §6.3 checks as a per-tick gate inserted at the top of `Poller.PollOnce`:

- **`validateDispatchPreflight(cfg workflow.Config) error`** runs the resolved-config checks: `tracker.kind` present and supported, `tracker.api_key` non-empty after `\$VAR` resolution, `tracker.project_slug` required for `linear` (unless a service route provides one), `codex.command` non-empty. Reasons are joined into one error so the operator-visible event carries the full set, not just the first one.
- **`Poller.preflight *workflow.Config`** is a new field set on every workflow-snapshot reload by `RuntimePoller.pollerForSnapshot`. Legacy constructors / unit tests keep working — `nil` disables the gate.
- On preflight failure, `Poller.PollOnce` records a typed `RuntimeEventDispatchPreflightFailed` into the orchestrator's `RecentEvents` log (actor-serialized via `recordPreflightFailed`) and returns the joined reason. Fetch / sort / dispatch are all skipped for the failing tick; the next tick re-tries once the operator fixes the gap.

To make the new event observable, `StateView` gains a `RecentEvents []RuntimeEvent` field populated by `Snapshot()` so tests and future `/api/v1/state` consumers can read the typed reason. The JSON wire-up in `cmd/worker` is left as a follow-up to keep this PR within the self-fixable scope.

## Scope

Single package: `internal/orchestrator`. 7 files / 300 LOC — at the policy LOC cap. One test-fixture line in `workflow_reloader_test.go` adds a dummy `api_key` to the shared YAML writer so the existing reload tests pass the new gate (the fakes still drive the tracker).

**SPEC ordering note.** SPEC §8.1 lists reconcile (step 1) before preflight (step 2). Current `PollOnce` ordering is fetch-before-reconcile, which already diverges from SPEC for unrelated reasons; the preflight is inserted at the very top of `PollOnce` so it fires before any tracker I/O. Re-ordering reconcile / fetch / preflight to match SPEC literally is out of scope.

## Test plan

- New `internal/orchestrator/preflight_test.go` covers:
  - Happy path returns nil.
  - Empty `api_key` after `\$VAR` resolution.
  - Empty `codex.command`.
  - Unsupported `tracker.kind`.
  - Missing `linear` `project_slug`, with the service-routed override that satisfies it.
  - Joined-reason composition (three reasons in one error message).
  - `PollOnce` failure path emits `RuntimeEventDispatchPreflightFailed` and skips dispatch.
  - `PollOnce` success path proceeds to fetch.
- `go test -race -covermode=atomic ./...` clean.
- `gofmt -l \$(git ls-files '*.go')` empty; `go mod tidy` clean.

## Refs

- SPEC §6.3 (dispatch config checks), §8.1 step 2 (per-tick preflight), §13.4 (typed errors), §13.7 (status surface)
- 2026-05-15 audit (`docs/audits/2026-05-15-spec-vs-go-gap-audit.md` §Silent areas)
- Code: `internal/orchestrator/poller.go:105-130`, `internal/orchestrator/preflight.go` (new), `internal/orchestrator/runtime_poller.go:112-115`