### PR TITLE
fix(workflow): consolidate normalizeStateConcurrencyLimits (#294)

### DIFF
--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -12,10 +12,10 @@ package orchestrator
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 // IssueID is the tracker-assigned stable identifier (tracker.Issue.ID).
@@ -449,8 +449,11 @@ func (s *OrchestratorState) runningIssueIDs() map[IssueID]struct{} {
 	return counted
 }
 
+// normalizeStateConcurrencyKey delegates to the canonical
+// [workflow.NormalizeStateConcurrencyKey] so the dispatch-time lookup
+// shape and the load-time key shape can never drift apart (#294).
 func normalizeStateConcurrencyKey(state string) string {
-	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(state)), " ", "_")
+	return workflow.NormalizeStateConcurrencyKey(state)
 }
 
 // BeginDispatch records the SPEC §16.4 dispatch step: an eligible

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -222,19 +222,14 @@ func copyStateConcurrencyLimits(in map[string]int) map[string]int {
 	return out
 }
 
+// normalizeStateConcurrencyLimits is an internal-package alias for the
+// canonical [workflow.NormalizeStateConcurrencyLimits] helper. Keeping a
+// thin local wrapper avoids touching every call site that depended on
+// the old local function while the consolidation closes #294: the
+// initial-load (loader.go) and the snapshot-build (this file) paths now
+// go through one set of semantics.
 func normalizeStateConcurrencyLimits(in map[string]int) map[string]int {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make(map[string]int, len(in))
-	for state, limit := range in {
-		key := normalizeStateConcurrencyKey(state)
-		if key == "" || limit <= 0 {
-			continue
-		}
-		out[key] = limit
-	}
-	return out
+	return workflow.NormalizeStateConcurrencyLimits(in)
 }
 
 func workflowFileFingerprint(path string) (string, error) {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -191,7 +191,7 @@ func Load(path string) (*Workflow, error) {
 			return nil, err
 		}
 	}
-	cfg.Agent.MaxConcurrentAgentsByState = normalizeStateConcurrencyLimits(cfg.Agent.MaxConcurrentAgentsByState)
+	cfg.Agent.MaxConcurrentAgentsByState = NormalizeStateConcurrencyLimits(cfg.Agent.MaxConcurrentAgentsByState)
 	source := SourceFile
 	if !hasFrontMatter {
 		source = SourcePromptOnly
@@ -411,7 +411,7 @@ func validateConfig(path string, cfg Config) error {
 		if limit <= 0 {
 			return fmt.Errorf("%s: agent.max_concurrent_agents_by_state[%q] must be positive", path, state)
 		}
-		key := normalizeTrackerStateKey(state)
+		key := NormalizeStateConcurrencyKey(state)
 		if first, ok := seenStateCaps[key]; ok {
 			return fmt.Errorf("%s: agent.max_concurrent_agents_by_state[%q] duplicates %q after normalization to %q", path, state, first, key)
 		}
@@ -761,22 +761,51 @@ func isExplicitEnvName(name string) bool {
 	return true
 }
 
-func normalizeStateConcurrencyLimits(limits map[string]int) map[string]int {
+// NormalizeStateConcurrencyLimits canonicalizes the per-state concurrency
+// cap map (`agent.max_concurrent_agents_by_state`). It is the single
+// source of truth shared between the loader's initial-load path
+// (internal/workflow/loader.go) and the orchestrator's snapshot-build
+// path (internal/orchestrator/workflow_runtime.go); both call this
+// helper so a `WORKFLOW.md` reload cannot produce a differently-shaped
+// in-memory map than the initial load did.
+//
+// Semantics (closes #294):
+//   - Whitespace/case-folded keys: state names are normalized via
+//     [NormalizeStateConcurrencyKey] so `"In Progress"`, `"in progress"`,
+//     and `"  in progress "` all map to the same bucket.
+//   - Empty / whitespace-only keys are DROPPED. The orchestrator looks
+//     up caps by `NormalizeStateConcurrencyKey(stateName)`, which can
+//     never produce the empty string from a real tracker state, so any
+//     preserved empty-key entry would be permanently dead.
+//   - Non-positive limits (`<= 0`) are DROPPED. SPEC §5.3.5 caps are a
+//     positive integer; `0` would silently mean "never dispatch this
+//     state" but operators expressing that intent would set the issue
+//     to a different active-states list, not a `0` cap.
+//
+// Both rules drop entries the orchestrator could not use anyway,
+// trading a little operator-feedback granularity for shape parity
+// across the load/reload boundary.
+func NormalizeStateConcurrencyLimits(limits map[string]int) map[string]int {
 	if len(limits) == 0 {
 		return nil
 	}
-	normalized := make(map[string]int, len(limits))
+	out := make(map[string]int, len(limits))
 	for state, limit := range limits {
-		key := normalizeTrackerStateKey(state)
-		if key == "" {
-			normalized[state] = limit
+		key := NormalizeStateConcurrencyKey(state)
+		if key == "" || limit <= 0 {
 			continue
 		}
-		normalized[key] = limit
+		out[key] = limit
 	}
-	return normalized
+	return out
 }
 
-func normalizeTrackerStateKey(state string) string {
+// NormalizeStateConcurrencyKey canonicalizes a single tracker state name
+// for use as a key in the per-state concurrency cap map. The shape
+// (`strings.ToLower` + trim + space→underscore) matches how the
+// orchestrator looks up caps when a worker session is dispatching, so
+// the keys produced by [NormalizeStateConcurrencyLimits] line up with
+// the runtime lookup path.
+func NormalizeStateConcurrencyKey(state string) string {
 	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(state)), " ", "_")
 }

--- a/internal/workflow/normalize_test.go
+++ b/internal/workflow/normalize_test.go
@@ -1,0 +1,90 @@
+package workflow
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestNormalizeStateConcurrencyLimits_DropsEmptyKeyAndNonPositive pins
+// the closing-#294 decision recorded in the helper's docstring: empty /
+// whitespace-only keys and non-positive limits are dropped, not
+// preserved. The earlier loader.go variant preserved them and the
+// orchestrator's variant dropped them — that divergence is what #294
+// asked us to resolve, and resolving it in favor of "drop" is what the
+// orchestrator's runtime lookup path needs (it never produces an empty
+// key from a real tracker state, so a preserved entry would be dead).
+func TestNormalizeStateConcurrencyLimits_DropsEmptyKeyAndNonPositive(t *testing.T) {
+	in := map[string]int{
+		"":            5,  // empty key → drop
+		"   ":         3,  // whitespace key → drop
+		"In Progress": 0,  // zero limit → drop
+		"Review":      -2, // negative limit → drop
+		"Triage":      2,  // keep, normalized
+		"in progress": 4,  // case-folded into in_progress
+	}
+	got := NormalizeStateConcurrencyLimits(in)
+	want := map[string]int{
+		"triage":      2,
+		"in_progress": 4,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NormalizeStateConcurrencyLimits diverges from #294 decision:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+func TestNormalizeStateConcurrencyLimits_NilIn_NilOut(t *testing.T) {
+	if got := NormalizeStateConcurrencyLimits(nil); got != nil {
+		t.Errorf("nil input: got %#v, want nil", got)
+	}
+	if got := NormalizeStateConcurrencyLimits(map[string]int{}); got != nil {
+		t.Errorf("empty input: got %#v, want nil", got)
+	}
+}
+
+// TestNormalizeStateConcurrencyLimits_LoadReloadParity is the SPEC §6.2
+// reload-vs-load shape parity the issue described: the loader's
+// initial-load path and the orchestrator's snapshot-build path must
+// produce a bit-identical map for any input. Before #294 the two
+// diverged on empty / non-positive entries; after consolidation they
+// both call this helper, so a fixture containing every edge input
+// round-trips identically.
+func TestNormalizeStateConcurrencyLimits_LoadReloadParity(t *testing.T) {
+	fixture := map[string]int{
+		"":            7,
+		"In Progress": 0,
+		"  rework  ":  3,
+		"Review":      5,
+		"REVIEW":      9, // duplicates Review after case-fold — last write wins
+	}
+	first := NormalizeStateConcurrencyLimits(fixture)
+	second := NormalizeStateConcurrencyLimits(first)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("load/reload parity violated:\n load   %#v\n reload %#v", first, second)
+	}
+	// Round-trip stability: applying the normalization to its own
+	// output is a no-op (idempotence), guarding against future edits
+	// that re-introduce a transform that depends on canonicalization.
+	third := NormalizeStateConcurrencyLimits(second)
+	if !reflect.DeepEqual(second, third) {
+		t.Fatalf("normalize is not idempotent:\n once  %#v\n twice %#v", second, third)
+	}
+}
+
+func TestNormalizeStateConcurrencyKey_Shape(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"In Progress", "in_progress"},
+		{"  in progress ", "in_progress"},
+		{"REWORK", "rework"},
+		{"", ""},
+		{"   ", ""},
+		{"AI Ready", "ai_ready"},
+	}
+	for _, tc := range cases {
+		if got := NormalizeStateConcurrencyKey(tc.in); got != tc.want {
+			t.Errorf("NormalizeStateConcurrencyKey(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #294.

## Summary

`normalizeStateConcurrencyLimits` lived twice in the codebase with divergent edge-case handling. The loader (`internal/workflow/loader.go`) preserved empty keys and non-positive limits; the orchestrator (`internal/orchestrator/workflow_runtime.go`) dropped both. Initial-load and reload-snapshot fed off the same `cfg.Agent.MaxConcurrentAgentsByState` map and silently produced differently-shaped in-memory state — exactly the divergence #294 flagged.

The shared key-normalizer was also duplicated under two names: `normalizeStateConcurrencyKey` (orchestrator) and `normalizeTrackerStateKey` (loader), with identical bodies.

## Consolidation

- **`workflow.NormalizeStateConcurrencyLimits`** is the single source of truth. Its docstring records the #294 semantics decision: empty / whitespace-only keys and non-positive limits are **DROPPED**. The orchestrator's runtime lookup path normalizes by the same case-folding, so a preserved empty-key entry would be permanently dead — dropping is the strictly-better choice.
- **`workflow.NormalizeStateConcurrencyKey`** replaces both `normalizeStateConcurrencyKey` and `normalizeTrackerStateKey`.
- `internal/orchestrator/workflow_runtime.go` and `internal/orchestrator/state.go` keep thin local wrappers that delegate to the workflow helpers, so existing call sites compile unchanged.

## Behavior change

Inputs that the *initial-load* path previously preserved are now dropped at load:

| Input | Before | After |
|---|---|---|
| `{ "": 5 }` | `{"": 5}` (dead entry) | `{}` |
| `{ "In Progress": 0 }` | `{"in_progress": 0}` (dead entry) | `{}` |
| `{ "In Progress": 3 }` | `{"in_progress": 3}` | `{"in_progress": 3}` |
| `{ "  rework  ": 2, "REWORK": 4 }` | `{"rework": 4}` (case-fold collision; last wins) | same |

The reload-snapshot path's behavior is unchanged — it already dropped these entries.

## Test plan

- New `internal/workflow/normalize_test.go` covers:
  - `TestNormalizeStateConcurrencyLimits_DropsEmptyKeyAndNonPositive` pins the #294 decision.
  - `TestNormalizeStateConcurrencyLimits_NilIn_NilOut` covers nil/empty input fast-paths.
  - `TestNormalizeStateConcurrencyLimits_LoadReloadParity` — the property #294's acceptance criteria explicitly named: runs the helper twice on a fixture containing empty / zero / mixed-case / whitespace inputs and asserts the output is bit-identical, plus an idempotence assertion (third pass == second).
  - `TestNormalizeStateConcurrencyKey_Shape` table tests the case-fold / trim / space→underscore behavior.
- `go test -race -covermode=atomic ./...` clean.
- `gofmt -l \$(git ls-files '*.go')` empty; `go mod tidy` clean.

## Scope

Substantive logic in `internal/workflow`. Mechanical wrappers in `internal/orchestrator`. 4 files / 141 LOC, well under the policy caps.

## Refs

- `internal/workflow/loader.go:194, 414, 764-808` (canonical helper + call sites)
- `internal/orchestrator/state.go:452-456`, `internal/orchestrator/workflow_runtime.go:225-232` (delegation wrappers)
- Related: D15 / #89 / #159 (per-state concurrency consumers)