### PR TITLE
fix(gitea+tracker): per-request timeouts for Gitea and GitHub HTTP clients (#295)

### DIFF
--- a/internal/gitea/client.go
+++ b/internal/gitea/client.go
@@ -7,12 +7,35 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 )
+
+// defaultGiteaRequestTimeout bounds a single Gitea HTTP request when the
+// caller does not set Client.RequestTimeout explicitly. SPEC §8.1's
+// poll-tick cadence is minute-scale, so a 30 s per-request ceiling
+// catches hung-but-not-yet-RST connections (the failure mode #295
+// described — TCP half-open, NLB blackhole, slow server) well before
+// the OS-level keepalive RTO trips.
+const defaultGiteaRequestTimeout = 30 * time.Second
 
 type Client struct {
 	BaseURL string
 	Token   string
 	HTTP    *http.Client
+	// RequestTimeout caps the wall-clock duration of a single Gitea
+	// request. Zero falls back to defaultGiteaRequestTimeout. Closes
+	// #295: without a per-request bound, a hung upstream would wedge
+	// the worker's poll loop until the OS keepalive timeout (typically
+	// tcp_keepalive_time=7200s on Linux) and leak goroutines + fds in
+	// the meantime.
+	RequestTimeout time.Duration
+}
+
+func (c Client) requestTimeout() time.Duration {
+	if c.RequestTimeout > 0 {
+		return c.RequestTimeout
+	}
+	return defaultGiteaRequestTimeout
 }
 
 type CreatePullRequestInput struct {
@@ -101,13 +124,16 @@ func (c Client) FindOpenPullRequest(ctx context.Context, in FindOpenPullRequestI
 	base := strings.TrimRight(c.BaseURL, "/") + fmt.Sprintf("/api/v1/repos/%s/%s/pulls", in.Owner, in.Repo)
 	for page := 1; page <= listPullsMaxPages; page++ {
 		u := fmt.Sprintf("%s?state=open&page=%d&limit=%d", base, page, listPullsPageSize)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, u, nil)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
 		req.Header.Set("Authorization", "token "+c.Token)
 		resp, err := client.Do(req)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
 		var batch []struct {
@@ -120,10 +146,12 @@ func (c Client) FindOpenPullRequest(ctx context.Context, in FindOpenPullRequestI
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			resp.Body.Close()
+			cancel()
 			return nil, fmt.Errorf("list pull requests failed: %s", resp.Status)
 		}
 		err = json.NewDecoder(resp.Body).Decode(&batch)
 		resp.Body.Close()
+		cancel()
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +183,9 @@ func (c Client) CreatePullRequest(ctx context.Context, in CreatePullRequestInput
 	}
 	b, _ := json.Marshal(payload)
 	url := strings.TrimRight(c.BaseURL, "/") + fmt.Sprintf("/api/v1/repos/%s/%s/pulls", in.Owner, in.Repo)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(b))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitea/client_timeout_test.go
+++ b/internal/gitea/client_timeout_test.go
@@ -1,0 +1,91 @@
+package gitea
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestClientRequestTimeoutFallsBackToDefault pins the closing-#295
+// behavior: a client constructed without an explicit RequestTimeout
+// uses defaultGiteaRequestTimeout (30 s). Without the gate, a hung
+// Gitea response would block the worker's poll loop indefinitely.
+func TestClientRequestTimeoutFallsBackToDefault(t *testing.T) {
+	c := Client{}
+	if got := c.requestTimeout(); got != defaultGiteaRequestTimeout {
+		t.Errorf("zero RequestTimeout: got %v, want %v", got, defaultGiteaRequestTimeout)
+	}
+}
+
+func TestClientRequestTimeoutHonorsExplicitOverride(t *testing.T) {
+	c := Client{RequestTimeout: 250 * time.Millisecond}
+	if got := c.requestTimeout(); got != 250*time.Millisecond {
+		t.Errorf("explicit override: got %v, want 250ms", got)
+	}
+}
+
+// TestFindOpenPullRequestAbortsHungServer is the #295 acceptance test:
+// a Gitea endpoint that never replies must abort within
+// RequestTimeout rather than wedging the caller until the OS keepalive
+// trips. The test sets RequestTimeout=200ms; without the per-request
+// context.WithTimeout wrap, this test would block until the outer
+// context deadline (or longer).
+func TestFindOpenPullRequestAbortsHungServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a hung upstream by waiting past the client's
+		// RequestTimeout. r.Context().Done() fires when the client
+		// transport cancels the request, so the handler exits promptly
+		// once the per-request deadline trips.
+		select {
+		case <-time.After(3 * time.Second):
+		case <-r.Context().Done():
+		}
+	}))
+	srv.Config.SetKeepAlivesEnabled(false)
+	defer func() {
+		// Force-close any active TCP connections so srv.Close() does
+		// not block on httptest's idle-connection bookkeeping.
+		srv.CloseClientConnections()
+		srv.Close()
+	}()
+
+	c := Client{
+		BaseURL:        srv.URL,
+		Token:          "stub-token",
+		HTTP:           srv.Client(),
+		RequestTimeout: 200 * time.Millisecond,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := c.FindOpenPullRequest(ctx, FindOpenPullRequestInput{
+		Owner: "owner",
+		Repo:  "repo",
+		Head:  "branch",
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("expected timeout error from hung server, got nil")
+	}
+	if !strings.Contains(err.Error(), "deadline exceeded") && !strings.Contains(err.Error(), "context") {
+		t.Errorf("expected context-deadline error, got %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("FindOpenPullRequest blocked %v — RequestTimeout did not fire", elapsed)
+	}
+}
+
+// CreatePullRequest uses the same Client.requestTimeout() wrap as
+// FindOpenPullRequest (covered by TestFindOpenPullRequestAbortsHungServer)
+// — both code paths go through `context.WithTimeout(ctx, c.requestTimeout())`
+// immediately before `http.NewRequestWithContext`. A dedicated POST-side
+// hung-server integration test is intentionally omitted: httptest.Server.Close()
+// blocks waiting on in-flight POSTs even after the client cancels (the
+// transport's CloseIdleConnections does not reach handlers parked on
+// `<-r.Context().Done()` for a connection mid-request-body), and the
+// resulting test hang is a worse failure than no test. The helper-level
+// coverage above plus the GET-side integration test is sufficient.

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -32,9 +32,31 @@ type GitHubClient struct {
 	Config  workflow.TrackerConfig
 	HTTP    *http.Client
 	Logf    func(format string, args ...any)
+	// RequestTimeout caps the wall-clock duration of a single GitHub
+	// REST request. Zero falls back to defaultGitHubRequestTimeout.
+	// Closes #295: without a per-request bound, a hung api.github.com
+	// response (TCP half-open, NLB blackhole, slow server) would wedge
+	// the worker's poll loop until the OS keepalive timeout
+	// (`tcp_keepalive_time=7200s` default on Linux) and leak goroutines
+	// + fds in the meantime.
+	RequestTimeout time.Duration
 
 	paginationCapHits atomic.Int64
 	issueNumbers      sync.Map // map[string]int — global issue ID → repo issue number, populated by listing
+}
+
+// defaultGitHubRequestTimeout bounds a single GitHub REST request when
+// the caller does not set GitHubClient.RequestTimeout explicitly.
+// 30 s is well above the GitHub API's documented response targets and
+// short enough that a wedged connection fails fast in a SPEC §8.1
+// minute-scale poll tick.
+const defaultGitHubRequestTimeout = 30 * time.Second
+
+func (c *GitHubClient) requestTimeout() time.Duration {
+	if c == nil || c.RequestTimeout <= 0 {
+		return defaultGitHubRequestTimeout
+	}
+	return c.RequestTimeout
 }
 
 type githubIssue struct {
@@ -178,7 +200,9 @@ func (c *GitHubClient) listIssuesPage(ctx context.Context, issueState, label str
 	}
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, false, err
 	}
@@ -245,7 +269,9 @@ func (c *GitHubClient) listOpenPullRequestsPage(ctx context.Context, page int) (
 	q.Set("page", strconv.Itoa(page))
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, false, err
 	}
@@ -459,7 +485,9 @@ func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []str
 
 func (c *GitHubClient) getIssueByNumber(ctx context.Context, issueNumber int) (githubIssue, bool, error) {
 	endpoint := fmt.Sprintf("%s/repos/%s/%s/issues/%d", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo), issueNumber)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return githubIssue{}, false, err
 	}

--- a/internal/tracker/github_timeout_test.go
+++ b/internal/tracker/github_timeout_test.go
@@ -1,0 +1,56 @@
+package tracker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestGitHubClientRequestTimeoutFallsBackToDefault(t *testing.T) {
+	c := &GitHubClient{}
+	if got := c.requestTimeout(); got != defaultGitHubRequestTimeout {
+		t.Errorf("zero RequestTimeout: got %v, want %v", got, defaultGitHubRequestTimeout)
+	}
+}
+
+func TestGitHubClientRequestTimeoutHonorsExplicitOverride(t *testing.T) {
+	c := &GitHubClient{RequestTimeout: 250 * time.Millisecond}
+	if got := c.requestTimeout(); got != 250*time.Millisecond {
+		t.Errorf("explicit override: got %v, want 250ms", got)
+	}
+}
+
+// TestGitHubClientListIssuesAbortsHungServer is the #295 acceptance
+// test for the GitHub adapter: a hung api.github.com response must
+// abort within RequestTimeout rather than wedging the worker's poll
+// loop until the OS-level keepalive RTO trips.
+func TestGitHubClientListIssuesAbortsHungServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := NewGitHubClient(workflow.TrackerConfig{
+		APIKey:       "stub-token",
+		ActiveStates: []string{"open"},
+	}, srv.URL, "owner", "repo")
+	c.HTTP = srv.Client()
+	c.RequestTimeout = 200 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := c.ListActiveIssues(ctx)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("expected timeout error from hung server, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("ListActiveIssues blocked %v — RequestTimeout did not fire", elapsed)
+	}
+}


### PR DESCRIPTION
Closes #295.

## Summary

`internal/gitea.Client` and `internal/tracker.GitHubClient` both defaulted to `http.DefaultClient` with no per-request deadline. The caller-supplied ctx in the poller paths is the orchestrator's long-lived `runCtx` with no per-tick budget, so a hung upstream (TCP half-open, NLB blackhole, slow server) would wedge the SPEC §8.1 poll loop and leak goroutines + fds until the OS keepalive RTO (`tcp_keepalive_time=7200s` default on Linux) tripped.

The Linear client (`internal/tracker/linear.go:557-562`) already wraps each request in `context.WithTimeout(ctx, defaultLinearRequestTimeout)` — this PR extends the same pattern to the other two adapters so the resilience posture is symmetric across all three trackers.

## Changes

- **`internal/gitea.Client`** gains `RequestTimeout time.Duration` (default `defaultGiteaRequestTimeout = 30s`). `FindOpenPullRequest` (paginated GET) and `CreatePullRequest` (POST) both wrap their outgoing context with `c.requestTimeout()`.
- **`internal/tracker.GitHubClient`** gains the same `RequestTimeout` field (default `defaultGitHubRequestTimeout = 30s`) and wraps all three HTTP call sites: list-issues page, list-open-pulls page, and per-issue refresh.

## Test plan

- `internal/gitea/client_timeout_test.go`
  - Helper unit tests: zero falls back to default, explicit override honored.
  - `TestFindOpenPullRequestAbortsHungServer`: httptest handler hangs; client cancels within 200ms `RequestTimeout` instead of waiting for the outer 5s budget.
  - A POST-side hung-server integration test is intentionally omitted (rationale in-test): httptest.Server.Close() blocks on in-flight POST handlers parked on `<-r.Context().Done()` even after `CloseClientConnections`, so the test hang would be a worse failure than no test. Helper-level coverage plus the GET-side integration covers both code paths through the same `requestTimeout()` wrap.
- `internal/tracker/github_timeout_test.go`
  - Helper unit tests + `TestGitHubClientListIssuesAbortsHungServer` integration.
- `go test -race -covermode=atomic ./...` clean.
- `gofmt -l \$(git ls-files '*.go')` empty; `go mod tidy` clean.

## Scope

4 files / 210 LOC across `internal/gitea` + `internal/tracker`. Same mechanical pattern applied to both adapters.

## Refs

- SPEC §8.1 (poll cadence), §15.3 (harness hardening)
- `internal/tracker/linear.go:557-562` (existing pattern, now mirrored)
- `internal/orchestrator/poller.go:105` (long-lived runCtx that motivated the per-request bound)