### PR TITLE
fix(orchestrator): recover() guards on actor + retry timer goroutines (#296)

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -202,11 +202,31 @@ func (o *Orchestrator) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case op := <-o.ops:
-			if followup := op.apply(o.state); followup != nil {
-				go followup()
+			followup := o.applyWithRecover(op)
+			if followup != nil {
+				safeGo("orchestrator.followup", followup)
 			}
 		}
 	}
+}
+
+// applyWithRecover invokes op.apply with a panic guard so a malformed
+// notification or unexpected nil deep in a state transition cannot
+// crash the actor goroutine — the only goroutine driving every
+// in-flight run. SPEC §7.4 requires serialized mutation, so on panic
+// the actor logs the event and drops the followup; the state may be
+// partially mutated but the actor keeps draining subsequent ops
+// instead of taking the whole worker down. Operators see the typed
+// `event=panic site=orchestrator.op_apply` line plus the runtime stack
+// so the failure is diagnosable.
+func (o *Orchestrator) applyWithRecover(op stateOp) (followup func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			recoverPanicValue("orchestrator.op_apply", r)
+			followup = nil
+		}
+	}()
+	return op.apply(o.state)
 }
 
 // WaitStarted blocks until Run has begun executing or ctx is cancelled.
@@ -1067,6 +1087,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 		Kind:       s.kind,
 	}
 	entry.Timer = time.AfterFunc(delay, func() {
+		defer recoverPanic("orchestrator.retry_timer")
 		_ = o.submit(o.runCtx, &retryFireOp{
 			o:       o,
 			id:      id,
@@ -1136,6 +1157,7 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		kind := r.kind
 		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
 		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
+			defer recoverPanic("orchestrator.retry_capacity_timer")
 			_ = o.submit(o.runCtx, &retryFireOp{
 				o:       o,
 				id:      id,
@@ -1159,6 +1181,7 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 		kind := r.kind
 		entry.DueAt = time.Now().Add(retryCapacityRecheckDelay)
 		entry.Timer = time.AfterFunc(retryCapacityRecheckDelay, func() {
+			defer recoverPanic("orchestrator.retry_state_capacity_timer")
 			_ = o.submit(o.runCtx, &retryFireOp{
 				o:       o,
 				id:      id,
@@ -1352,6 +1375,7 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 	}
 	resultCh := o.dispatcher.Spawn(runCtx, issue, attempt)
 	go func() {
+		defer recoverPanic("orchestrator.spawn_result_fanout")
 		var res WorkerResult
 		select {
 		case r, ok := <-resultCh:

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -621,6 +621,7 @@ func (d WorkerTaskDispatcher) Spawn(ctx context.Context, issue tracker.Issue, at
 	out := make(chan WorkerResult, 1)
 	go func() {
 		defer close(out)
+		defer recoverPanic("orchestrator.worker_task_dispatcher")
 		start := time.Now()
 		tk, recordedTaskID, err := d.buildTaskWithAttempt(issue, copiedAttempt)
 		if err != nil {

--- a/internal/orchestrator/recover.go
+++ b/internal/orchestrator/recover.go
@@ -1,0 +1,58 @@
+package orchestrator
+
+import (
+	"log"
+	"runtime/debug"
+)
+
+// recoverPanic is the orchestrator's process-survival guard for code
+// running on goroutines that the actor's serialization invariants do not
+// otherwise protect: per-op `followup` closures, `time.AfterFunc` retry
+// timers, and the spawn-result fan-out. SPEC §7.4 mandates one
+// serialization authority for state mutation, so any panic that escaped
+// these goroutines previously crashed the whole worker process — taking
+// every unrelated in-flight run with it — rather than failing just the
+// path that misbehaved.
+//
+// Usage:
+//
+//	defer recoverPanic("orchestrator.retry_timer")
+//
+// or wrap a goroutine launch via [safeGo].
+//
+// The handler logs a SPEC §13.1-shaped structured line (`event=panic
+// site=<name>`) so operators tailing stderr / journald see a typed entry
+// rather than the default `runtime/panic` trailer. The stack is captured
+// inline so the log carries enough detail to diagnose the failure
+// without a coredump.
+func recoverPanic(site string) {
+	if r := recover(); r != nil {
+		recoverPanicValue(site, r)
+	}
+}
+
+// recoverPanicValue is the same handler shape as recoverPanic but used
+// from inside a `defer func() { if r := recover(); r != nil { … } }()`
+// when the caller wants to consult the recovered value (for example,
+// to clear a return variable). Centralizing the log shape here keeps
+// every panic site emitting the same structured line.
+func recoverPanicValue(site string, r any) {
+	log.Printf("event=panic site=%s panic=%v stack=%q", site, r, string(debug.Stack()))
+}
+
+// safeGo launches fn on a fresh goroutine with a recover guard installed.
+// The helper centralizes the recover/log pattern used by the actor's
+// followup-op dispatch and the per-tick spawn / retry-timer paths, so
+// site updates do not have to repeat the `defer recoverPanic(...)`
+// boilerplate at every `go func()` call site.
+//
+// This is the narrow-scope close of #296 for the orchestrator package
+// only; the runner / worker / cmd-side `go func(` sites enumerated in
+// the issue are intentionally left for a follow-up. Inside the
+// orchestrator, every spawn now routes through here.
+func safeGo(site string, fn func()) {
+	go func() {
+		defer recoverPanic(site)
+		fn()
+	}()
+}

--- a/internal/orchestrator/recover_test.go
+++ b/internal/orchestrator/recover_test.go
@@ -1,0 +1,147 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// captureOrchestratorLog redirects the stdlib log writer to a buffer for
+// the duration of fn so the recover-panic site assertions can grep the
+// emitted line without picking up unrelated output from concurrent
+// goroutines.
+func captureOrchestratorLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	origOut := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(safeBufferWriter{buf: &buf, mu: &mu})
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+	})
+	fn()
+	mu.Lock()
+	defer mu.Unlock()
+	return buf.String()
+}
+
+type safeBufferWriter struct {
+	buf *bytes.Buffer
+	mu  *sync.Mutex
+}
+
+func (w safeBufferWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func TestSafeGoConfinesPanic(t *testing.T) {
+	done := make(chan struct{})
+	got := captureOrchestratorLog(t, func() {
+		safeGo("test.site", func() {
+			defer close(done)
+			panic("boom")
+		})
+		<-done
+		// Give the deferred recoverPanic time to flush its log line.
+		time.Sleep(10 * time.Millisecond)
+	})
+	for _, want := range []string{
+		"event=panic",
+		"site=test.site",
+		"panic=boom",
+		"stack=",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("safeGo panic log missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRecoverPanicEmitsStructuredLine(t *testing.T) {
+	got := captureOrchestratorLog(t, func() {
+		func() {
+			defer recoverPanic("test.deferred_site")
+			panic("nil-deref")
+		}()
+	})
+	if !strings.Contains(got, "event=panic site=test.deferred_site") {
+		t.Errorf("recoverPanic log missing event/site in:\n%s", got)
+	}
+	if !strings.Contains(got, "panic=nil-deref") {
+		t.Errorf("recoverPanic log missing panic= in:\n%s", got)
+	}
+}
+
+// panickyOp is a stateOp that panics from apply. The actor's
+// applyWithRecover guard must catch the panic, log it, and keep
+// draining ops instead of crashing the process.
+type panickyOp struct {
+	panicVal any
+}
+
+func (p panickyOp) apply(_ *OrchestratorState) func() { panic(p.panicVal) }
+
+// counterOp increments a counter from apply so the test can verify the
+// actor goroutine kept processing after the panicky op.
+type counterOp struct {
+	counter *atomic.Int64
+}
+
+func (c counterOp) apply(_ *OrchestratorState) func() {
+	c.counter.Add(1)
+	return nil
+}
+
+// TestActorRunSurvivesOpApplyPanic is the SPEC §7.4 / closing-#296
+// acceptance test: a panic inside `op.apply` must not crash the actor
+// goroutine. The test submits a panicky op followed by a counter op
+// and asserts (a) the panic is logged with the typed site tag and (b)
+// the actor accepted the subsequent op.
+func TestActorRunSurvivesOpApplyPanic(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: &cancellationDispatcher{},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+
+	var counter atomic.Int64
+	got := captureOrchestratorLog(t, func() {
+		go orch.Run(ctx)
+		if err := orch.WaitStarted(ctx); err != nil {
+			t.Fatalf("wait for orchestrator: %v", err)
+		}
+		if err := orch.submit(ctx, panickyOp{panicVal: "synthetic-test-panic"}); err != nil {
+			t.Fatalf("submit panicky op: %v", err)
+		}
+		if err := orch.submit(ctx, counterOp{counter: &counter}); err != nil {
+			t.Fatalf("submit counter op: %v", err)
+		}
+		// Wait briefly for the actor to process both ops.
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) && counter.Load() == 0 {
+			time.Sleep(5 * time.Millisecond)
+		}
+	})
+
+	if counter.Load() != 1 {
+		t.Fatalf("actor stopped draining ops after panic; counter=%d, log=%s", counter.Load(), got)
+	}
+	if !strings.Contains(got, "event=panic site=orchestrator.op_apply") {
+		t.Errorf("expected structured panic log line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "panic=synthetic-test-panic") {
+		t.Errorf("panic value not in log, got:\n%s", got)
+	}
+}

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -297,6 +297,7 @@ func sleepOrRetryWake(ctx context.Context, sleep func(context.Context, time.Dura
 	defer cancel()
 	sleepErr := make(chan error, 1)
 	go func() {
+		defer recoverPanic("orchestrator.workflow_reload_sleep")
 		sleepErr <- sleep(sleepCtx, interval)
 	}()
 	select {


### PR DESCRIPTION
Closes #296 for the `internal/orchestrator` package. The broader sweep across `internal/runner`, `internal/worker`, `cmd/worker`, and `cmd/gitea-poller` enumerated in the issue is deferred to a follow-up so the helper pattern can earn its keep here first.

## Summary

The orchestrator's actor goroutine is the single mutation authority per SPEC §7.4. Without a recover guard, a nil-deref or malformed notification deep in a state transition crashes the entire worker process — taking every unrelated in-flight run down with it — instead of failing just the path that misbehaved. The orchestrator's `time.AfterFunc` retry timers, per-op followup goroutines, and spawn result fan-out share the same fragility.

## Changes (all in `internal/orchestrator`)

- New `recover.go` with `recoverPanic(site)` deferred-style handler plus `safeGo(site, fn)` wrapper. Both emit a SPEC §13.1-shaped structured log line (`event=panic site=<name> panic=<val> stack=<…>`) so operators see a typed entry instead of the default `runtime/panic` trailer.
- `Orchestrator.Run` wraps `op.apply(state)` in `applyWithRecover` so a panicking op logs + drops its followup instead of crashing the actor goroutine. State may be partially mutated, but subsequent ops keep draining.
- `safeGo("orchestrator.followup", followup)` replaces the raw `go followup()` at `actor.go:206`.
- All three `time.AfterFunc` retry timers (initial fire, capacity recheck, per-state capacity recheck) gain `defer recoverPanic(...)`.
- `WorkerTaskDispatcher.Spawn`'s goroutine gains `defer recoverPanic`.
- The spawn result fan-out goroutine in `spawnOp.apply` gains `defer recoverPanic`.
- The workflow-reload sleep helper goroutine gains `defer recoverPanic`.

## Out of scope (intentional follow-up)

- `internal/runner/codex_app_server.go:83, 424` (scanner / reader)
- `internal/runner/shell_unix.go:41` (zombie reaper)
- `cmd/worker/main.go:320, 325, 488, 500` (HTTP / state-snapshot timers)
- `cmd/gitea-poller/main.go:145` (signal handler)

The follow-up will use the same `safeGo` / `recoverPanic` shape once the helper has earned its keep here.

## Test plan

- New `internal/orchestrator/recover_test.go`:
  - `TestSafeGoConfinesPanic` — induces a panic inside `safeGo`, asserts the structured log line carries event/site/panic/stack.
  - `TestRecoverPanicEmitsStructuredLine` — deferred-style helper.
  - **`TestActorRunSurvivesOpApplyPanic`** — the SPEC §7.4 / closing-#296 acceptance test: submits a panicking op followed by a counter op, asserts (a) panic is logged with `site=orchestrator.op_apply`, (b) the actor accepted the subsequent op (counter went to 1).
- `go test -race -covermode=atomic ./...` clean.
- `gofmt -l \$(git ls-files '*.go')` empty; `go mod tidy` clean.

## Scope

5 files / 233 LOC in `internal/orchestrator`. Well under the policy caps; sets up the helper pattern for the deferred follow-up sweep.

## Refs

- SPEC §7.4 (state serialization), §13.1 (logging conventions)
- `internal/orchestrator/actor.go:197-225` (actor main loop)
- `internal/orchestrator/actor.go:1069, 1138, 1161` (retry timers)
- `internal/orchestrator/poller.go:622` (WorkerTaskDispatcher.Spawn)