### PR TITLE
docs(skills): /handle-pr skill for PR-handling workflow

### DIFF
--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -1,0 +1,49 @@
+---
+description: Audit and ship a GitHub PR through SPEC-aligned review rounds against upstream openai/symphony. Manual invoke only.
+argument-hint: "[pr-number]"
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(gofmt *)
+---
+
+# Handle PR #$ARGUMENTS
+
+本仓库是 OpenAI Symphony SPEC 的 Go 端口，SPEC 对齐是硬要求。处理 PR #$ARGUMENTS（xrf9268-hue/aiops-platform）按以下流程。
+
+## Upstream 已就位
+
+!`[ -d /tmp/symphony-upstream ] || git clone --depth 1 https://github.com/openai/symphony.git /tmp/symphony-upstream 2>&1 | tail -3`
+
+参考路径：`/tmp/symphony-upstream/SPEC.md` + `/tmp/symphony-upstream/elixir/lib/symphony_elixir/*.ex`。SPEC 文本歧义时直接 grep Elixir 源码找原算法行号，不要用 WebFetch 总结。
+
+## 当前 main HEAD
+
+!`git fetch origin main 2>&1 | tail -1 && git log --oneline origin/main -1`
+
+## 必做的几件不常规的事
+
+1. **读 AGENTS.md** 的 "SPEC alignment" 和 "Cross-cutting checklist when porting from the Elixir reference" 两节作为审查清单。每个 finding 至少归到一类：
+   - 算法级 SPEC 偏差（vs upstream `handle_*` 逐分支比对）
+   - 跨模块一致性漏镜像（grep 同概念其他 consumer，列出 aiops-platform 扩展 routing / fan-out / capacity caps / eligibility filter 是否都镜像了）
+   - Go 运行时硬化（followup goroutine 是否 `context.WithTimeout` / `defer recoverPanic` / `Timer.Stop()`——Elixir BEAM 隐式给的保证 Go 必须显式补）
+   - 测试是否安慰剂（assertion 真的读到新代码改的字段吗？）
+
+2. **修一轮派 subagent 独立审计一轮**：
+   - general-purpose agent，背景跑
+   - prompt brief 完整（PR head SHA、文件路径、upstream 参考路径、AGENTS.md 政策）
+   - **不透露你的结论**
+   - 要求 ≤700 字 + severity 标注 + 末尾 `MERGE-READY / NEEDS-CHANGES / BLOCKED` 判决
+   - 一般 2-3 轮收敛
+
+3. **Mutation test 验证新测试有效**：删掉新代码的关键行，跑新测试，确认 fail；恢复，确认 pass。安慰剂测试是最隐蔽的陷阱。
+
+4. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria。AGENTS.md rule 2 要求。
+
+5. **Scope 分离**：治理 / 文档改动从 main 开新分支单独 PR，不要塞进 fix PR。
+
+## 默认行为
+
+- 工作分支：系统会告诉你具体名字
+- 合并方式：squash（本仓库惯例），commit_message 写最终状态不要按轮次罗列
+- 强推统一 `--force-with-lease=<branch>:<known-sha>`
+- merge 前必须等用户明确许可
+- 中文回复，简洁；每次只汇报变化不复述

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,11 @@ coverage.out
 # macOS
 .DS_Store
 
-# Local Claude Code state (worktrees, plugin cache, transcripts)
-.claude/
+# Local Claude Code state (worktrees, plugin cache, transcripts).
+# Project skills under .claude/skills/ are version-controlled per
+# https://code.claude.com/docs/en/skills "Share skills → Project skills".
+.claude/*
+!.claude/skills/
 
 # Deploy SSH scaffolding (#221) — keep the dir + README tracked, ignore real keys
 deploy/ssh/*


### PR DESCRIPTION
## Why

We just walked PR #287 through four review rounds (original + three independent adversarial audits) and shipped the lessons as #305 (`AGENTS.md` cross-cutting checklist). The remaining piece is **operational**: making the workflow itself one keystroke instead of a copy-pasted prompt.

After this lands, processing a PR is `/handle-pr 287` in a fresh session — the upstream reference clones itself, current main HEAD prints itself, and the audit-loop discipline is in front of Claude from turn 1.

## What

**`.claude/skills/handle-pr/SKILL.md`** — 49-line project skill encoding:

- **Pre-rendered bash injections** (`` !`...` `` syntax) — clone `openai/symphony` to `/tmp/symphony-upstream` (idempotent) and print current `main` HEAD, so the session starts grounded.
- **Four classification categories** for findings: algorithm-level SPEC divergence / cross-module consistency / Go runtime hardening / placebo tests. Mirrors the `AGENTS.md` cross-cutting checklist landed in #305.
- **Audit loop instructions**: fix → push → blind adversarial subagent → repeat until `MERGE-READY` (2-3 rounds typical), with explicit instruction not to leak prior conclusions in the subagent brief.
- **Mutation-testing discipline**: delete the new line, re-run, confirm fail; restore. Earned by #287 round 3 catching a placebo test that passed via a pre-existing line.
- **Deferred-deviation hygiene**: open an issue with `area:spec-alignment` per `AGENTS.md` rule 2 (earned by #306).
- **Scope separation**: governance / docs in a separate branch (earned by #305 being extracted from #287).

**`.gitignore` patch** — keep `.claude/` ignored for local Claude Code state (worktrees, transcripts, plugin cache) but except `.claude/skills/` so project skills can be version-controlled per the official ["Share skills → Project skills"](https://code.claude.com/docs/en/skills) guidance.

## Frontmatter choices

Verified verbatim against https://code.claude.com/docs/en/skills:

- `disable-model-invocation: true` — manual invoke only. Side effects (push, force-push, merge) shouldn't trigger because Claude pattern-matched a phrase.
- `argument-hint: "[pr-number]"` — autocomplete UX. Quoted so YAML doesn't parse the brackets as a flow sequence.
- `allowed-tools: Bash(git *) Bash(go *) Bash(gofmt *) Bash(ls *) Bash(grep *) Bash(find *)` — pre-approve common engineering commands the workflow always needs.
- **No** `context: fork` — the workflow is stateful across rounds (commit → push → comment → re-audit); forking would lose that continuity.

## Test plan

- [x] Skill file format validated against the docs' frontmatter reference (`name` inferred from dir, `description`, `argument-hint`, `disable-model-invocation`, `allowed-tools`, `$ARGUMENTS` substitution, `!` bash injection at line start — all documented).
- [x] `git check-ignore .claude/skills/handle-pr/SKILL.md` exits 1 (not ignored) after the `.gitignore` patch.
- [ ] Real-world run on the next incoming PR — that's the actual test, and the skill will likely earn a tweak or two from observed friction.

## Related

- #287 (the worked example this skill distills)
- #305 (the `AGENTS.md` cross-cutting checklist this skill operationalizes)
- #306 (the deferred-deviation tracking pattern this skill enforces)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaDmLZVUrtfpdr3BnmU671)_