### PR TITLE
fix(workspace): PR #291 follow-ups — reuse-path gate cleanups + test rigor (#310)

### DIFF
--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -95,8 +95,7 @@ nuke-and-recreate path, reports `createdNow=true`, and fires
    symlink. The recreate path's `os.RemoveAll` removes the symlink
    itself, not its target.
 2. **Valid git worktree.** `git rev-parse --git-dir` must succeed.
-   Catches the "crashed `worktree add` / `rm -rf .git` race / chmod
-   broke linkage" cases.
+   Catches the "crashed `worktree add` / `rm -rf .git` race" cases.
 3. **Linked to OUR mirror.** `git rev-parse --git-common-dir` must
    resolve (via `filepath.EvalSymlinks`) to the same path as the
    cached bare mirror for `t.CloneURL`. Catches an independent

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -243,14 +243,39 @@ func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string,
 	// (`os.RemoveAll` removes the symlink itself, not its target) and
 	// report `createdNow=true` so the worker fires `after_create` on
 	// the recovery run.
+	// foreignCommonDir is non-empty only when the gate ran the
+	// `--git-common-dir` probe successfully and the result pointed at a
+	// different mirror (e.g. `t.CloneURL`'s host changed between prepares
+	// and `mirrorPathFor` routed it to a new mirror). We use it later to
+	// prune the orphaned worktree admin entry from the foreign mirror
+	// before recreating against the new one — otherwise the entry would
+	// linger until `gc.worktreePruneExpire` (3 months default) expires it.
+	var foreignCommonDir string
 	reusable := false
 	if workdirExists {
 		lstatInfo, lstatErr := os.Lstat(workdir)
 		if lstatErr == nil && lstatInfo.Mode()&os.ModeSymlink == 0 {
 			if err := runQuiet(ctx, workdir, "git", "rev-parse", "--git-dir"); err == nil {
-				cdOut, cdErr := exec.CommandContext(ctx, "git", "-C", workdir, "rev-parse", "--git-common-dir").Output()
-				if cdErr == nil && sameRealPath(strings.TrimSpace(string(cdOut)), workdir, mirror) {
-					reusable = true
+				// Silence the probe's stderr: on a broken-but-existing
+				// `.git` (mid-corruption, partial `worktree add` crash,
+				// race with `os.RemoveAll`) git prints `fatal: not a git
+				// repository` while we're about to fall through to the
+				// recreate path anyway. Without io.Discard that fatal line
+				// pollutes the worker's inherited fd 2 and obscures the
+				// recovery the gate is about to perform.
+				probe := exec.CommandContext(ctx, "git", "-C", workdir, "rev-parse", "--git-common-dir")
+				probe.Stderr = io.Discard
+				cdOut, cdErr := probe.Output()
+				if cdErr == nil {
+					common := strings.TrimSpace(string(cdOut))
+					if sameRealPath(common, workdir, mirror) {
+						reusable = true
+					} else if common != "" {
+						foreignCommonDir = common
+						if !filepath.IsAbs(foreignCommonDir) {
+							foreignCommonDir = filepath.Join(workdir, foreignCommonDir)
+						}
+					}
 				}
 			}
 		}
@@ -282,30 +307,40 @@ func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string,
 		if err := run(ctx, workdir, "git", "checkout", "--force", "--no-track", "-B", t.WorkBranch, startRef); err != nil {
 			return "", false, fmt.Errorf("worktree checkout: %w", err)
 		}
-		_ = run(ctx, workdir, "git", "remote", "set-url", "origin", t.CloneURL)
 		return workdir, false, nil
 	}
 
-	// First touch (or recovery from a corrupted leftover). Drop any stale
-	// worktree entry the mirror still tracks for this path before asking
-	// it to add a new one. Failures are ignored and stderr silenced
-	// because the common case ("no such worktree") prints a scary fatal
-	// line that obscures real worker logs.
+	// First touch (or recovery from a corrupted leftover). If the gate
+	// just rejected a workspace that linked to a *different* mirror,
+	// prune the orphaned admin entry off that mirror first so its
+	// `worktrees/` directory stays in sync with what's actually on disk.
+	// Without this, the foreign mirror keeps a dead worktree record until
+	// `gc.worktreePruneExpire` (3 months default) expires it; harmless in
+	// the common case, confusing for an operator inspecting
+	// `git worktree list` and a latent collision risk if the same
+	// workspace path is ever re-targeted to the old mirror.
+	if foreignCommonDir != "" {
+		_ = runQuiet(ctx, foreignCommonDir, "git", "worktree", "prune")
+	}
+	// Drop any stale worktree entry the mirror still tracks for this path
+	// before asking it to add a new one. Failures are ignored and stderr
+	// silenced because the common case ("no such worktree") prints a scary
+	// fatal line that obscures real worker logs.
 	_ = runQuiet(ctx, mirror, "git", "worktree", "remove", "--force", workdir)
 	_ = os.RemoveAll(workdir)
 	if err := runQuiet(ctx, mirror, "git", "worktree", "prune"); err != nil {
 		return "", false, fmt.Errorf("worktree prune: %w", err)
 	}
 	// Using -B makes the operation idempotent if a previous attempt left
-	// an in-mirror branch behind.
+	// an in-mirror branch behind. The new worktree inherits remote config
+	// from the linked bare mirror, where `EnsureMirror`'s `git clone --bare`
+	// already recorded origin = t.CloneURL (see internal/workspace/mirror.go);
+	// we deliberately do not re-`git remote set-url` from inside the
+	// worktree because there is no per-worktree config and the write would
+	// land back in the shared mirror config redundantly.
 	if err := run(ctx, mirror, "git", "worktree", "add", "--no-track", "-B", t.WorkBranch, workdir, startRef); err != nil {
 		return "", false, fmt.Errorf("worktree add: %w", err)
 	}
-	// The mirror's "origin" remote points at the upstream URL, but inside
-	// the worktree git resolves remotes via the linked repo, so push works
-	// out of the box. We still set the URL explicitly for clarity in case
-	// downstream tooling inspects `git remote -v` from within the worktree.
-	_ = run(ctx, workdir, "git", "remote", "set-url", "origin", t.CloneURL)
 	return workdir, true, nil
 }
 

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -618,6 +618,261 @@ func TestPrepareGitWorkspace_RecreatesCorruptedWorkdir(t *testing.T) {
 	}
 }
 
+// TestPrepareGitWorkspace_RecreatesWhenPathIsSymlinkToPeerWorktree covers
+// the load-bearing scenario for the symlink gate: a symlink planted at the
+// workspace path that points at a peer worktree of the SAME mirror.
+// `git rev-parse --git-common-dir` would happily report the matching
+// mirror (so the foreign-repo gate would not trip), and without the
+// `os.Lstat` symlink check the reuse-path `git reset` / `git checkout -B`
+// would silently mutate the peer worktree's tracked state and work-branch
+// ref. The gate must refuse the reuse, recreate a fresh worktree, and
+// leave the peer worktree's branch tip and tracked files untouched.
+func TestPrepareGitWorkspace_RecreatesWhenPathIsSymlinkToPeerWorktree(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+	victim := makeTask("task-sibling-victim", upstream)
+	pivot := makeTask("task-sibling-pivot", upstream)
+
+	victimDir, _, err := mgr.PrepareGitWorkspace(ctx, victim)
+	if err != nil {
+		t.Fatalf("prepare victim: %v", err)
+	}
+	if err := configureGitIdentity(victimDir); err != nil {
+		t.Fatalf("configure victim identity: %v", err)
+	}
+	// Commit a distinctive tracked change on the victim's work branch so a
+	// stray `git checkout -B <pivot-work-branch>` inside the victim would
+	// either move the branch ref off the commit or rewrite the tracked
+	// file. Either mutation is observable from the bare mirror's refs and
+	// from the victim worktree's content.
+	if err := os.WriteFile(filepath.Join(victimDir, "victim.txt"), []byte("victim-content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", victimDir, "add", "victim.txt"},
+		{"git", "-C", victimDir, "commit", "-q", "-m", "victim commit"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	victimHeadBefore, err := exec.Command("git", "-C", victimDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("victim rev-parse HEAD: %v", err)
+	}
+
+	pivotDir, _, err := mgr.PrepareGitWorkspace(ctx, pivot)
+	if err != nil {
+		t.Fatalf("prepare pivot: %v", err)
+	}
+	if pivotDir == victimDir {
+		t.Fatalf("pivot and victim collapsed to same workdir %q", pivotDir)
+	}
+	// Replace the pivot workspace path with a symlink pointing at the
+	// victim's peer worktree (same mirror).
+	if err := os.RemoveAll(pivotDir); err != nil {
+		t.Fatalf("remove pivot dir for symlink swap: %v", err)
+	}
+	if err := os.Symlink(victimDir, pivotDir); err != nil {
+		t.Fatalf("plant sibling symlink: %v", err)
+	}
+
+	pivotDir2, createdNow, err := mgr.PrepareGitWorkspace(ctx, pivot)
+	if err != nil {
+		t.Fatalf("re-prepare pivot after symlink swap: %v", err)
+	}
+	if pivotDir2 != pivotDir {
+		t.Fatalf("pivot dir changed: %s vs %s", pivotDir2, pivotDir)
+	}
+	if !createdNow {
+		t.Fatal("re-prepare pivot reported createdNow=false; sibling symlink must fall through to recreate")
+	}
+
+	// Victim worktree's branch tip and tracked content must be unchanged
+	// — neither the pivot's `git reset` nor the pivot's `git checkout -B`
+	// can have been redirected into it.
+	victimHeadAfter, err := exec.Command("git", "-C", victimDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("victim rev-parse HEAD after: %v", err)
+	}
+	if string(victimHeadAfter) != string(victimHeadBefore) {
+		t.Fatalf("victim work branch moved by pivot reuse: before=%q after=%q", victimHeadBefore, victimHeadAfter)
+	}
+	if body, err := os.ReadFile(filepath.Join(victimDir, "victim.txt")); err != nil {
+		t.Fatalf("victim tracked file removed: %v", err)
+	} else if string(body) != "victim-content\n" {
+		t.Fatalf("victim tracked file mutated: %q", body)
+	}
+
+	// The recreated pivot worktree must be a real worktree (not a
+	// symlink) and on the pivot's work branch.
+	lstatInfo, err := os.Lstat(pivotDir2)
+	if err != nil {
+		t.Fatalf("lstat recreated pivot: %v", err)
+	}
+	if lstatInfo.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("recreated pivot is still a symlink: %v", lstatInfo.Mode())
+	}
+	branchOut, err := exec.Command("git", "-C", pivotDir2, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("pivot rev-parse --abbrev-ref HEAD: %v", err)
+	}
+	if got := strings.TrimSpace(string(branchOut)); got != pivot.WorkBranch {
+		t.Fatalf("recreated pivot on branch %q, want %q", got, pivot.WorkBranch)
+	}
+}
+
+// TestPrepareGitWorkspace_ReuseSurvivesIntentToAddFromPriorDiffstat locks
+// the reuse-path `git reset --quiet HEAD -- .` invariant at the workspace
+// boundary. A prior run's `EnforcePolicy` / `Diffstat` calls
+// `git add --intent-to-add --all`, leaving untracked files staged as
+// empty-blob entries in the index. Without the reset, the next prepare's
+// `git checkout --force -B` would treat those entries as
+// "files-in-index-not-in-target-ref" and delete them from the working
+// tree — silently nuking cached deps and hook artifacts that SPEC §9.1
+// reuse semantics promise to preserve.
+//
+// `TestPrepareGitWorkspace_RerunReusesWorkspaceAcrossRuns` covers the
+// happy reuse path but never calls Diffstat, so the reset is a no-op
+// there. Only the worker-integration test
+// `TestRunTaskReusesWorkspaceAcrossRunsAndGatesAfterCreate` exercises
+// this scenario today, which means removing the reset only fails the
+// worker test, not anything in the workspace package. This test pins the
+// invariant where the code lives.
+func TestPrepareGitWorkspace_ReuseSurvivesIntentToAddFromPriorDiffstat(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+	tk := makeTask("task-intent-to-add", upstream)
+
+	dir, createdNow, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("first prepare: %v", err)
+	}
+	if !createdNow {
+		t.Fatal("first prepare reported createdNow=false")
+	}
+	// Cached untracked artifacts a prior agent run would leave behind
+	// (build outputs, .aiops policy feedback, etc.).
+	if err := os.WriteFile(filepath.Join(dir, "cached-dep.txt"), []byte("cache\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".aiops"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".aiops", "POLICY_VIOLATION_FEEDBACK.md"), []byte("feedback\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Diffstat runs `git add --intent-to-add --all`, leaving cached-dep.txt
+	// and the .aiops file in the index as empty-blob entries. The next
+	// prepare's reset must drop those entries before the checkout, or
+	// `git checkout --force -B` would treat them as removable.
+	if _, err := Diffstat(ctx, dir); err != nil {
+		t.Fatalf("Diffstat: %v", err)
+	}
+
+	dir2, createdNow, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("second prepare: %v", err)
+	}
+	if createdNow {
+		t.Fatal("second prepare reported createdNow=true; SPEC §9.1 reuse expected")
+	}
+	if dir != dir2 {
+		t.Fatalf("workspace dir changed across runs: %s vs %s", dir, dir2)
+	}
+	for _, rel := range []string{"cached-dep.txt", filepath.Join(".aiops", "POLICY_VIOLATION_FEEDBACK.md")} {
+		if body, err := os.ReadFile(filepath.Join(dir2, rel)); err != nil {
+			t.Fatalf("untracked artifact %q removed across reuse despite intent-to-add gate: %v", rel, err)
+		} else if len(body) == 0 {
+			t.Fatalf("untracked artifact %q truncated on reuse: empty body", rel)
+		}
+	}
+}
+
+// TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName covers the
+// `startRef = t.BaseBranch` fallback in PrepareGitWorkspace. The production
+// path (HTTPS clone via EnsureMirror) always populates
+// `refs/remotes/origin/<base>` through the post-clone fetch refspec
+// rewrite, so `git rev-parse --verify origin/<base>` succeeds and the
+// fallback never fires in production. This test drives the fallback
+// explicitly by deleting `refs/remotes/origin/main` from a freshly
+// prepared mirror and emptying the fetch refspec so the next
+// `ensureMirrorLocked`'s fetch does not repopulate it — guarding the
+// fallback against a future refactor of EnsureMirror's refspec layout
+// (and ensuring `file://` test fixtures continue to work even when the
+// mirror only carries `refs/heads/<base>`).
+func TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	// Prime the mirror via a first task so the bare clone + refspec config
+	// exist on disk.
+	primer := makeTask("task-primer", upstream)
+	if _, _, err := mgr.PrepareGitWorkspace(ctx, primer); err != nil {
+		t.Fatalf("prime mirror: %v", err)
+	}
+
+	mirror := mirrorPathFor(MirrorRoot(mgr.MirrorRoot), upstream)
+	// Capture the expected start-ref commit (refs/heads/main on the bare
+	// mirror) so we can assert the recreated worktree's HEAD matches it
+	// once the fallback resolves to bare `main` instead of `origin/main`.
+	mainCommit, err := exec.Command("git", "--git-dir", mirror, "rev-parse", "refs/heads/main").Output()
+	if err != nil {
+		t.Fatalf("mirror rev-parse refs/heads/main: %v", err)
+	}
+	// Strip `refs/remotes/origin/*` and empty the fetch refspec so the
+	// next prepare's `git fetch --prune --tags origin` does not bring
+	// `origin/main` back. With no refspec, the fetch is effectively a
+	// no-op for ref tracking; the mirror keeps its `refs/heads/main` from
+	// the original `git clone --bare`.
+	if out, err := exec.Command("git", "--git-dir", mirror, "update-ref", "-d", "refs/remotes/origin/main").CombinedOutput(); err != nil {
+		t.Fatalf("delete refs/remotes/origin/main: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "--git-dir", mirror, "config", "--unset-all", "remote.origin.fetch").CombinedOutput(); err != nil {
+		t.Fatalf("unset remote.origin.fetch: %v\n%s", err, out)
+	}
+	// Sanity: confirm the precondition the fallback branch needs — the
+	// remote-tracking ref is gone but the bare head ref survives.
+	if err := exec.Command("git", "--git-dir", mirror, "rev-parse", "--verify", "refs/remotes/origin/main").Run(); err == nil {
+		t.Fatal("precondition broken: refs/remotes/origin/main still resolves on the mirror")
+	}
+	if err := exec.Command("git", "--git-dir", mirror, "rev-parse", "--verify", "refs/heads/main").Run(); err != nil {
+		t.Fatalf("precondition broken: refs/heads/main missing on mirror: %v", err)
+	}
+
+	// New task → first-touch path runs through the startRef resolution.
+	// With `origin/main` deleted, the `git rev-parse --verify origin/main`
+	// gate fails and startRef falls back to bare `main`; the subsequent
+	// `git worktree add ... main` must succeed against the mirror's
+	// `refs/heads/main`.
+	tk := makeTask("task-fallback", upstream)
+	dir, createdNow, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare with startRef fallback: %v", err)
+	}
+	if !createdNow {
+		t.Fatal("first prepare for new task reported createdNow=false")
+	}
+	headOut, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("worktree rev-parse HEAD: %v", err)
+	}
+	if strings.TrimSpace(string(headOut)) != strings.TrimSpace(string(mainCommit)) {
+		t.Fatalf("worktree HEAD = %q, want bare-main commit %q after startRef fallback",
+			strings.TrimSpace(string(headOut)), strings.TrimSpace(string(mainCommit)))
+	}
+	branchOut, err := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("worktree rev-parse --abbrev-ref HEAD: %v", err)
+	}
+	if got := strings.TrimSpace(string(branchOut)); got != tk.WorkBranch {
+		t.Fatalf("worktree on branch %q, want %q", got, tk.WorkBranch)
+	}
+}
+
 func TestPathForUsesStableSanitizedIssueIdentifier(t *testing.T) {
 	mgr := &Manager{Root: "/workspaces"}
 


### PR DESCRIPTION
## Summary

Closes #310. Addresses the seven follow-ups deferred from PR #291's post-merge review of the SPEC §9.1 reuse-path + §9.4 `after_create` gate. None were correctness-blocking, but several locked invariants only at the worker-integration boundary; this PR pulls them down to the workspace package and trims two cleanups.

## Changes

### `internal/workspace/manager.go`

- **Item 3** — silence stderr on the `--git-common-dir` probe via `cmd.Stderr = io.Discard`. The probe runs against a workspace that might be mid-corruption; without the redirect git's `fatal: not a git repository` pollutes the worker's inherited fd 2 right before the gate falls through to the recovery path. Adjacent probes already use `runQuiet` for the same reason.
- **Item 4** — drop both `git remote set-url origin t.CloneURL` calls (reuse path + first-touch). Worktrees do not have per-worktree config, so writing from inside a worktree lands in the shared mirror config — which `EnsureMirror`'s `git clone --bare` already populated with the right URL. Replaced with a comment near the worktree-add naming the bare-clone step as the single source of truth.
- **Item 5** — when the `--git-common-dir` gate rejects a workspace that links to a *different* mirror (sibling-issue pivot, host changed between prepares, etc.), capture the foreign mirror's common-dir and run `git worktree prune` against it before recreating against the new mirror. Without this, the foreign mirror's `worktrees/` admin entry lingers until `gc.worktreePruneExpire` (3 months default) — harmless in the common case, confusing for an operator inspecting `git worktree list`, and a latent collision risk if the same workspace path is ever re-targeted to the old mirror.

### `docs/runbooks/workspace-cache.md`

- **Item 7** — drop "chmod broke linkage" from the §gate-2 prose. `TestPrepareGitWorkspace_RecreatesCorruptedWorkdir` only exercises the `rm -rf .git` flavor; the prose now matches what the regression net actually covers.

### `internal/workspace/mirror_test.go`

- **Item 1** — `TestPrepareGitWorkspace_RecreatesWhenPathIsSymlinkToPeerWorktree` exercises the load-bearing scenario for the `os.Lstat` symlink gate: a symlink planted at the workspace path that points at a peer worktree of the **same** mirror. Without the lstat check the foreign-repo gate would let it through (common-dir matches) and the reuse-path `git reset` / `git checkout -B` would mutate the peer worktree's branch tip and tracked content. The test asserts the peer's HEAD and tracked file are untouched and the recreated workspace is a real worktree, not a symlink.
- **Item 2** — `TestPrepareGitWorkspace_ReuseSurvivesIntentToAddFromPriorDiffstat` locks the `git reset --quiet HEAD -- .` invariant at the workspace boundary. The existing happy-reuse test never calls `Diffstat` so the reset is a no-op there; only the worker-integration test exercised this path. The new test calls `Diffstat` between two prepares — which runs `git add --intent-to-add --all` — then asserts cached untracked artifacts survive the second prepare.
- **Item 6** — `TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName` drives the `startRef = t.BaseBranch` fallback by deleting `refs/remotes/origin/main` from a primed mirror and emptying `remote.origin.fetch` so the next `ensureMirrorLocked`'s fetch does not repopulate it. The fallback is correct in production (HTTPS clones always populate `refs/remotes/origin/*` through the standard refspec) but was untested; the new test guards it against a future refactor of `EnsureMirror`'s refspec layout.

## Acceptance criteria (from #310)

- [x] Item 1: sibling-worktree symlink regression test added.
- [x] Item 2: workspace-package unit test calls `Diffstat` between prepares.
- [x] Item 3: `--git-common-dir` probe silences stderr.
- [x] Item 4: redundant `set-url` calls removed; worktree-add carries a comment pointing at the bare-clone step.
- [x] Item 5: foreign-mirror rejection prunes the orphaned old-mirror worktree entry.
- [x] Item 6: `startRef` fallback test added.
- [x] Item 7: runbook prose trimmed to match test coverage.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./internal/workspace/...` clean.
- [x] Three new tests pass: `TestPrepareGitWorkspace_RecreatesWhenPathIsSymlinkToPeerWorktree`, `TestPrepareGitWorkspace_ReuseSurvivesIntentToAddFromPriorDiffstat`, `TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName`.
- [x] Existing `internal/workspace/` tests pass — modulo two pre-existing env-capture failures unrelated to this change and reproduced on clean `main`: `TestRunWorkspaceHookStopsOnNonZeroAndCapturesOutput`, `TestRunVerifyEnvDropsNonAllowlistedSecretsByDefault`.
- [x] `TestRunTaskReusesWorkspaceAcrossRunsAndGatesAfterCreate` (worker-integration SPEC §9.1+§9.4) still passes — confirms the `set-url` drop and the foreign-mirror prune do not regress the reuse path.

## Refs

- PR #291 (the SPEC §9.1+§9.4 realignment; merged with these items deferred)
- Issue #245 (parent — closed by #291)
- Code: `internal/workspace/manager.go:192-322`, `internal/workspace/mirror.go:81-96`
- Tests: `internal/workspace/mirror_test.go`, `internal/worker/runtask_integration_test.go:699-751`

https://claude.ai/code/session_01DMpRZhPa5GW6gd9btQu7Yy

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMpRZhPa5GW6gd9btQu7Yy)_