### PR TITLE
fix(workspace): drop -l from hook/verify shell to stop login-profile stdout leaking into HookResult.Output (#314)

### DIFF
--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -167,7 +167,7 @@ For legacy queue runs, `/events` is the most useful endpoint. Look for `enqueued
 - `repo.clone_url missing in WORKFLOW.md`: poller log line. Fix `WORKFLOW.md`, restart the poller.
 - Verification command failed (`go test ./...` non-zero): read `.aiops/RUN_SUMMARY.md` in the work branch if the runner produced one. Reproduce locally on the same branch.
 - Policy violation (deny path or size cap): re-scope the task into a smaller issue, or do it manually.
-- Runner command not found: confirm `codex.command` or `claude.command` resolves on the worker host. The shell runner uses `sh -lc`, so PATH must be set in the worker's login shell.
+- Runner command not found: confirm `codex.command` or `claude.command` resolves on the worker host. The codex/claude shell runner uses `sh -lc`, so PATH must be set in the worker's login shell. Workspace hooks (`hooks.after_create`, `hooks.before_run`, etc.) and `verify.commands` run under plain `sh -c` with the PATH captured once from the worker's login shell at startup — the same login-shell PATH that resolves `codex` also resolves hook/verify commands, but `/etc/profile.d/*` and `~/.profile` are not re-sourced per command, so their stdout cannot leak into hook/verify output buffers (#314).
 - Empty diff: agent decided nothing to do. Tighten the issue body, then move it to `Rework` (or the equivalent active Gitea `aiops/*` state label).
 
 ### Re-running a failed task

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -399,7 +399,14 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 	defer cancel()
 	waitDelay := workspaceHookWaitDelay(timeoutMs)
 
-	cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
+	// Hook commands run under `sh -c` (not `-lc`) so the user's login
+	// profile is not re-sourced per command. The PATH that a login shell
+	// would build is captured once at startup and propagated via cmd.Env
+	// (see loginPATH in path_snapshot.go and #314). Without this split,
+	// every hook command captured the stdout of /etc/profile.d/* into
+	// HookResult.Output — surfaced to operators in runtime events and
+	// consumed by policy-feedback parsers.
+	cmd := exec.CommandContext(runCtx, "sh", "-c", command)
 	cmd.Dir = workdir
 	cmd.Env = env
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -489,7 +496,10 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		}
 		start := time.Now()
 		buf := &cappedBuffer{Cap: VerifyOutputCap}
-		cmd := exec.CommandContext(runCtx, "sh", "-lc", command)
+		// `sh -c` (no `-l`): see runWorkspaceHookCommand and #314 for why
+		// the login flag was dropped. PATH inheritance is preserved via the
+		// loginPATH snapshot threaded through cmd.Env.
+		cmd := exec.CommandContext(runCtx, "sh", "-c", command)
 		cmd.Dir = workdir
 		cmd.Env = env
 		cmd.Stdout = buf

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -843,6 +843,61 @@ func TestRunVerifyEnvPassthroughLetsNamedVarThrough(t *testing.T) {
 	}
 }
 
+// TestRunWorkspaceHookDoesNotSourceUserLoginProfile is a regression for
+// #314: the hook runner used `sh -lc`, which under dash re-sources
+// /etc/profile.d/* per command and leaks any stdout those scripts emit into
+// HookResult.Output. The fix runs hooks under `sh -c`, so a $HOME/.profile
+// that prints to stdout (a portable stand-in for /etc/profile.d/nvm.sh)
+// must no longer contaminate the captured hook output.
+func TestRunWorkspaceHookDoesNotSourceUserLoginProfile(t *testing.T) {
+	home := t.TempDir()
+	profilePath := filepath.Join(home, ".profile")
+	if err := os.WriteFile(profilePath, []byte("printf 'LEAKED_FROM_PROFILE\\n'\n"), 0o644); err != nil {
+		t.Fatalf("seed .profile: %v", err)
+	}
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{`printf clean`}}
+
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil)
+	if err != nil {
+		t.Fatalf("RunWorkspaceHook: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Output != "clean" {
+		t.Fatalf("hook output = %q, want %q (login-profile stdout leaked into hook output buffer)", results[0].Output, "clean")
+	}
+}
+
+// TestRunVerifyDoesNotSourceUserLoginProfile mirrors the hook regression for
+// the verify command path (manager.go RunVerify): per #314, dropping the
+// `-l` flag must prevent $HOME/.profile from being sourced per command.
+func TestRunVerifyDoesNotSourceUserLoginProfile(t *testing.T) {
+	home := t.TempDir()
+	profilePath := filepath.Join(home, ".profile")
+	if err := os.WriteFile(profilePath, []byte("printf 'LEAKED_FROM_PROFILE\\n'\n"), 0o644); err != nil {
+		t.Fatalf("seed .profile: %v", err)
+	}
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	cfg := workflow.Config{Verify: workflow.VerifyConfig{Commands: []string{`printf clean`}}}
+
+	results, err := RunVerify(context.Background(), dir, cfg)
+	if err != nil {
+		t.Fatalf("RunVerify: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Output != "clean" {
+		t.Fatalf("verify output = %q, want %q (login-profile stdout leaked into verify output buffer)", results[0].Output, "clean")
+	}
+}
+
 func TestSubprocessEnvSkipsUnsetPassthroughNames(t *testing.T) {
 	t.Setenv("DEFINITELY_SET_227", "v1")
 	os.Unsetenv("DEFINITELY_UNSET_227")

--- a/internal/workspace/path_snapshot.go
+++ b/internal/workspace/path_snapshot.go
@@ -1,0 +1,71 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// loginPATH returns the PATH value a login shell would expose to a subprocess,
+// captured once per process. Hooks and verify commands use it so they inherit
+// version-manager additions (nvm, rustup, pyenv, etc.) without paying the cost
+// — or the stdout-capture cost — of sourcing the login profile on every command.
+//
+// Earned by #314: `sh -lc` re-sources `/etc/profile` (and friends) per command.
+// Under dash on the default Claude Code on the web image, `/etc/profile.d/nvm.sh`
+// prints "nvm\n" to stdout, which then leads every HookResult.Output and
+// VerifyResult.Output. Snapshotting PATH once and running per-command shells
+// without `-l` keeps the PATH-inheritance contract while removing the per-command
+// profile-source side-effect.
+func loginPATH() string {
+	loginPATHOnce.Do(func() {
+		loginPATHCached = captureLoginPATH()
+	})
+	return loginPATHCached
+}
+
+var (
+	loginPATHOnce   sync.Once
+	loginPATHCached string
+)
+
+const (
+	loginPATHBegin = "__AIOPS_LOGIN_PATH_BEGIN__"
+	loginPATHEnd   = "__AIOPS_LOGIN_PATH_END__"
+)
+
+// captureLoginPATH runs `sh -lc` once to read the PATH that a login shell
+// would build (worker's PATH + any additions from /etc/profile.d, ~/.profile,
+// etc.). The PATH is wrapped in sentinel markers in the captured stdout so
+// init-script output (e.g. dash + nvm.sh printing "nvm") cannot corrupt the
+// extracted value. Any failure path returns the worker's own PATH as a safe
+// fallback so hooks still find common tooling.
+func captureLoginPATH() string {
+	fallback := os.Getenv("PATH")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	script := "printf '" + loginPATHBegin + "%s" + loginPATHEnd + "' \"$PATH\""
+	cmd := exec.CommandContext(ctx, "sh", "-lc", script)
+	out, err := cmd.Output()
+	if err != nil {
+		return fallback
+	}
+	s := string(out)
+	begin := strings.Index(s, loginPATHBegin)
+	if begin < 0 {
+		return fallback
+	}
+	rest := s[begin+len(loginPATHBegin):]
+	end := strings.Index(rest, loginPATHEnd)
+	if end < 0 {
+		return fallback
+	}
+	path := rest[:end]
+	if path == "" {
+		return fallback
+	}
+	return path
+}

--- a/internal/workspace/subprocess_env.go
+++ b/internal/workspace/subprocess_env.go
@@ -36,6 +36,16 @@ func subprocessEnv(passthrough []string) []string {
 			return
 		}
 		seen[name] = struct{}{}
+		if name == "PATH" {
+			// Use the once-captured login-shell PATH so the subprocess
+			// inherits version-manager additions (nvm, rustup, etc.) without
+			// sourcing the login profile per command — which would otherwise
+			// echo profile stdout into the hook/verify output buffer (#314).
+			if v := loginPATH(); v != "" {
+				env = append(env, "PATH="+v)
+				return
+			}
+		}
 		if v, ok := os.LookupEnv(name); ok {
 			env = append(env, name+"="+v)
 		}


### PR DESCRIPTION
`runWorkspaceHookCommand` and `RunVerify` used `sh -lc`, which re-sources
the login profile per command. Under dash on the default Claude Code on
the web image, `/etc/profile.d/nvm.sh` prints "nvm\n" to stdout, so the
string led every captured HookResult.Output / VerifyResult.Output and
broke `TestRunWorkspaceHookStopsOnNonZeroAndCapturesOutput` and
`TestRunVerifyEnvDropsNonAllowlistedSecretsByDefault`.

The login-shell PATH is now captured once at startup (sentinel-wrapped so
init-script noise cannot corrupt extraction) and propagated explicitly via
`cmd.Env`; per-command shells run under `sh -c` so no profile is sourced
per command. Operators relying on nvm/cargo/rustup PATH additions are
unaffected — the same login-shell PATH that resolves `codex` continues to
resolve hook/verify commands.

Adds two regression tests that seed `$HOME/.profile` and assert the noise
does not appear in hook or verify output. The codex/claude shell runner
paths still use `sh -lc` (the cross-check called out in the issue is
out of scope here).