### PR TITLE
fix(runner): SPEC §16.5 per-turn tracker refresh closes operator-cancel latency

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -322,7 +322,12 @@ func run(ctx context.Context, args []string) error {
 	// NewRuntimePollerWithTrackerFactory creates internally. Without this
 	// the tracker fan-in built each tick would only update the poller's
 	// own (unused) dispatcher and operator-cancel would still wait for
-	// the next poll tick.
+	// the next poll tick. Must precede RunPollLoopWithRuntime below so
+	// the first PollOnce sees the external dispatcher; this is safe today
+	// because OrchestratorState is freshly constructed with no claimed
+	// issues, so the actor cannot Spawn before the poll loop drives it.
+	// Any future persisted-state recovery added before this point must
+	// move AttachDispatcher above it.
 	poller.AttachDispatcher(dispatcher)
 	go func() {
 		if err := orchestrator.RunWorkflowReloadLoop(ctx, runtime, orchestrator.WorkflowReloadLoopOptions{}); err != nil && ctx.Err() == nil {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -317,6 +317,13 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	// SPEC §16.5 per-turn refresh wires through the dispatcher the actor
+	// actually spawns workers with (the line-298 instance), not the one
+	// NewRuntimePollerWithTrackerFactory creates internally. Without this
+	// the tracker fan-in built each tick would only update the poller's
+	// own (unused) dispatcher and operator-cancel would still wait for
+	// the next poll tick.
+	poller.AttachDispatcher(dispatcher)
 	go func() {
 		if err := orchestrator.RunWorkflowReloadLoop(ctx, runtime, orchestrator.WorkflowReloadLoopOptions{}); err != nil && ctx.Err() == nil {
 			log.Printf("workflow reload loop exited: %v", err)

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/worker"
@@ -21,10 +22,11 @@ type RuntimePoller struct {
 	config         worker.Config
 	emitter        worker.EventEmitter
 
-	mu              sync.Mutex
-	poller          *Poller
-	dispatcher      *RuntimeDispatcher
-	lastSnapshotKey string
+	mu               sync.Mutex
+	poller           *Poller
+	dispatcher       *RuntimeDispatcher
+	lastSnapshotKey  string
+	currentRefresher IssueStateRefresher
 }
 
 func NewRuntimePoller(tracker IssueStateLister, orchestrator *Orchestrator, runtime *WorkflowRuntime, cfg worker.Config, emitter worker.EventEmitter) (*RuntimePoller, error) {
@@ -55,6 +57,30 @@ func NewRuntimePollerWithTrackerFactory(trackerFactory func(workflow.Config) (Is
 	}
 	rp.poller = initialPoller
 	return rp, nil
+}
+
+// AttachDispatcher rewires the dispatcher the RuntimePoller updates when
+// it builds a new tracker fan-in. Callers that construct their own
+// *RuntimeDispatcher externally (and pass it to orchestrator.Deps.Dispatcher
+// so the actor's Spawn uses it) must call this — otherwise the SPEC §16.5
+// refresher would land on the poller's internal dispatcher, which the
+// actor never sees. Passing nil is a no-op so tests that do not exercise
+// the refresher path can keep their existing construction.
+//
+// The poller copies its most recent tracker refresher onto the freshly
+// attached dispatcher so callers don't have to wait for the next workflow
+// snapshot change before the refresher hook activates.
+func (p *RuntimePoller) AttachDispatcher(d *RuntimeDispatcher) {
+	if p == nil || d == nil {
+		return
+	}
+	p.mu.Lock()
+	p.dispatcher = d
+	carry := p.currentRefresher
+	p.mu.Unlock()
+	if carry != nil {
+		d.SetIssueStateRefresher(carry)
+	}
 }
 
 func (p *RuntimePoller) PollOnce(ctx context.Context) error {
@@ -108,6 +134,10 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	p.trackers = trackerClients
 	p.lastSnapshotKey = key
 	multiLister := multiIssueStateLister{trackers: trackerClients}
+	p.currentRefresher = multiLister
+	if p.dispatcher != nil {
+		p.dispatcher.SetIssueStateRefresher(multiLister)
+	}
 	poller := NewPollerWithReconciliation(multiLister, p.orchestrator, snap.Reconciliation)
 	if snap.Workflow.Config.Tracker.Kind == "linear" && len(snap.Workflow.Config.Services) > 0 {
 		poller.routing = &snap.Workflow.Config
@@ -288,6 +318,28 @@ type RuntimeDispatcher struct {
 	baseConfig   worker.Config
 	emitter      worker.EventEmitter
 	orchestrator *Orchestrator
+
+	mu        sync.Mutex
+	refresher IssueStateRefresher
+}
+
+// SetIssueStateRefresher updates the tracker reader the dispatcher uses to
+// build SPEC §16.5 per-turn refresh closures handed to worker.RunTask. The
+// RuntimePoller calls it after each workflow-snapshot reload so the closure
+// always points at the current tracker fan-in (multiIssueStateLister).
+func (d *RuntimeDispatcher) SetIssueStateRefresher(refresher IssueStateRefresher) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.refresher = refresher
+}
+
+func (d *RuntimeDispatcher) currentRefresher() IssueStateRefresher {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.refresher
 }
 
 func NewRuntimeDispatcher(runtime *WorkflowRuntime, cfg worker.Config, emitter worker.EventEmitter) (*RuntimeDispatcher, error) {
@@ -327,5 +379,46 @@ func (d *RuntimeDispatcher) Spawn(ctx context.Context, issue tracker.Issue, atte
 func (d *RuntimeDispatcher) configForSnapshot(snap WorkflowSnapshot) worker.Config {
 	cfg := d.baseConfig
 	cfg.Workflow = snap.Workflow
+	refresher := d.currentRefresher()
+	if refresher != nil {
+		cfg.IssueStateRefresher = func(t task.Task, wcfg workflow.Config) runner.IssueStateRefresher {
+			issueID := strings.TrimSpace(t.ID)
+			if issueID == "" {
+				return nil
+			}
+			activeStates := normalizedStateSet(wcfg.Tracker.ActiveStates)
+			if len(activeStates) == 0 {
+				return nil
+			}
+			return func(ctx context.Context) (bool, error) {
+				statesByID, err := refresher.FetchIssueStatesByIDs(ctx, []string{issueID})
+				if err != nil {
+					return false, err
+				}
+				state, ok := statesByID[issueID]
+				if !ok || strings.TrimSpace(state) == "" {
+					// SPEC §16.5 "issue = refreshed_issue[0] or
+					// issue": no row means we treat the issue as
+					// still in its prior (active) state rather
+					// than aborting on a benign absence.
+					return true, nil
+				}
+				_, active := activeStates[strings.ToLower(strings.TrimSpace(state))]
+				return active, nil
+			}
+		}
+	}
 	return cfg
+}
+
+func normalizedStateSet(states []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		trimmed := strings.ToLower(strings.TrimSpace(state))
+		if trimmed == "" {
+			continue
+		}
+		out[trimmed] = struct{}{}
+	}
+	return out
 }

--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -1,0 +1,191 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+type stubRefresher struct {
+	calls   [][]string
+	states  map[string]string
+	fetchEr error
+}
+
+func (s *stubRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]string, error) {
+	s.calls = append(s.calls, append([]string(nil), ids...))
+	if s.fetchEr != nil {
+		return nil, s.fetchEr
+	}
+	out := map[string]string{}
+	for _, id := range ids {
+		if state, ok := s.states[id]; ok {
+			out[id] = state
+		}
+	}
+	return out, nil
+}
+
+// TestRuntimeDispatcherConfigForSnapshotBuildsRefresherClosure pins the
+// SPEC §16.5 wiring: when SetIssueStateRefresher is set, the worker.Config
+// returned for a snapshot carries a factory that the worker uses to build
+// the runner's per-turn refresher. The factory must consult the tracker
+// with the task's stable ID and report (in)active states from the
+// workflow's active_states vocabulary.
+func TestRuntimeDispatcherConfigForSnapshotBuildsRefresherClosure(t *testing.T) {
+	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
+	stub := &stubRefresher{states: map[string]string{
+		"issue-active":   "In Progress",
+		"issue-canceled": "Canceled",
+	}}
+	d.SetIssueStateRefresher(stub)
+
+	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
+		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress", "AI Ready"}},
+	}}}
+	cfg := d.configForSnapshot(snap)
+	if cfg.IssueStateRefresher == nil {
+		t.Fatal("configForSnapshot did not wire IssueStateRefresher factory")
+	}
+
+	wcfg := snap.Workflow.Config
+
+	t.Run("active state keeps run alive", func(t *testing.T) {
+		fn := cfg.IssueStateRefresher(task.Task{ID: "issue-active"}, wcfg)
+		if fn == nil {
+			t.Fatal("factory returned nil for valid task")
+		}
+		active, err := fn(context.Background())
+		if err != nil {
+			t.Fatalf("refresher err: %v", err)
+		}
+		if !active {
+			t.Fatalf("active = false, want true (state In Progress is in active set)")
+		}
+		if got := stub.calls; len(got) != 1 || len(got[0]) != 1 || got[0][0] != "issue-active" {
+			t.Fatalf("tracker calls = %#v, want exactly [[issue-active]]", got)
+		}
+	})
+
+	t.Run("inactive state stops the run", func(t *testing.T) {
+		fn := cfg.IssueStateRefresher(task.Task{ID: "issue-canceled"}, wcfg)
+		active, err := fn(context.Background())
+		if err != nil {
+			t.Fatalf("refresher err: %v", err)
+		}
+		if active {
+			t.Fatal("active = true, want false (state Canceled is not in active set)")
+		}
+	})
+
+	t.Run("missing row keeps run alive per SPEC fallback", func(t *testing.T) {
+		fn := cfg.IssueStateRefresher(task.Task{ID: "issue-unknown"}, wcfg)
+		active, err := fn(context.Background())
+		if err != nil {
+			t.Fatalf("refresher err: %v", err)
+		}
+		if !active {
+			t.Fatal("active = false, want true; SPEC §16.5 keeps prior state when refresh returns no row")
+		}
+	})
+
+	t.Run("fetch error surfaces", func(t *testing.T) {
+		boom := errors.New("tracker boom")
+		errStub := &stubRefresher{fetchEr: boom}
+		d.SetIssueStateRefresher(errStub)
+		errCfg := d.configForSnapshot(snap)
+		fn := errCfg.IssueStateRefresher(task.Task{ID: "issue-active"}, wcfg)
+		active, err := fn(context.Background())
+		if active {
+			t.Fatal("active = true on fetch error, want false")
+		}
+		if !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want wrapped tracker boom", err)
+		}
+	})
+}
+
+// TestRuntimeDispatcherConfigForSnapshotReturnsNilWithoutRefresher pins the
+// fallback: without SetIssueStateRefresher the dispatcher leaves
+// IssueStateRefresher unset so RunTask keeps the legacy continueRun-only
+// path (e.g. tests, mock runners).
+func TestRuntimeDispatcherConfigForSnapshotReturnsNilWithoutRefresher(t *testing.T) {
+	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
+	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
+		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress"}},
+	}}}
+	cfg := d.configForSnapshot(snap)
+	if cfg.IssueStateRefresher != nil {
+		t.Fatal("IssueStateRefresher should be nil when dispatcher has no tracker refresher set")
+	}
+}
+
+// TestRuntimePollerAttachDispatcherCarriesCurrentRefresher pins the
+// cmd/worker/main.go startup sequence: NewRuntimePollerWithTrackerFactory
+// builds the initial tracker fan-in (and SetIssueStateRefresher's it
+// onto its internal dispatcher) before the caller has a chance to
+// AttachDispatcher with the external dispatcher used by the actor. The
+// attach call must replay the current refresher so the first PollOnce
+// — which sees an unchanged snapshot key and short-circuits the
+// SetIssueStateRefresher path — does not leave the actor's dispatcher
+// without a refresher.
+func TestRuntimePollerAttachDispatcherCarriesCurrentRefresher(t *testing.T) {
+	stub := &stubRefresher{states: map[string]string{"issue-1": "In Progress"}}
+	internal := &RuntimeDispatcher{}
+	rp := &RuntimePoller{dispatcher: internal}
+	// Simulate pollerForSnapshot having stored the multiLister.
+	rp.mu.Lock()
+	rp.currentRefresher = stub
+	rp.mu.Unlock()
+	internal.SetIssueStateRefresher(stub)
+
+	external := &RuntimeDispatcher{}
+	rp.AttachDispatcher(external)
+	if external.currentRefresher() == nil {
+		t.Fatal("AttachDispatcher did not carry the current refresher onto the external dispatcher")
+	}
+
+	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
+		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress"}},
+	}}}
+	cfg := external.configForSnapshot(snap)
+	if cfg.IssueStateRefresher == nil {
+		t.Fatal("external dispatcher has no IssueStateRefresher factory after AttachDispatcher")
+	}
+	fn := cfg.IssueStateRefresher(task.Task{ID: "issue-1"}, snap.Workflow.Config)
+	if fn == nil {
+		t.Fatal("factory returned nil for valid task on external dispatcher")
+	}
+	active, err := fn(context.Background())
+	if err != nil {
+		t.Fatalf("refresher err: %v", err)
+	}
+	if !active {
+		t.Fatal("active = false, want true; external dispatcher should call through to the stub refresher")
+	}
+	if len(stub.calls) == 0 {
+		t.Fatal("stub refresher never invoked; external dispatcher is wired to a different tracker")
+	}
+}
+
+// TestRuntimeDispatcherConfigForSnapshotEmptyActiveStatesDisablesFactory
+// guards a foot-gun: if active_states is empty the refresher would mark
+// every state as inactive and kill workers after the first turn. The
+// factory must return nil so the runner falls back to continueRun.
+func TestRuntimeDispatcherConfigForSnapshotEmptyActiveStatesDisablesFactory(t *testing.T) {
+	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
+	d.SetIssueStateRefresher(&stubRefresher{states: map[string]string{"issue-1": "In Progress"}})
+	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{}}}
+	cfg := d.configForSnapshot(snap)
+	if cfg.IssueStateRefresher == nil {
+		t.Fatal("factory should be set on dispatcher; we test its per-task output instead")
+	}
+	fn := cfg.IssueStateRefresher(task.Task{ID: "issue-1"}, snap.Workflow.Config)
+	if fn != nil {
+		t.Fatal("per-task refresher should be nil when active_states is empty (avoids the 'kills everyone' foot-gun)")
+	}
+}

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -213,13 +213,22 @@ type appServerClient struct {
 	runtimeEvents       []task.RuntimeEvent
 	runtimeEventSink    func(task.RuntimeEvent)
 	phaseTransitionSink func(from, to task.RunAttemptPhase)
-	continueRun         bool
-	tools               DynamicToolSet
-	turnTimeoutMs       int
-	readTimeoutMs       int
-	stallTimeoutMs      int
-	approvalPolicy      any
-	lastTerminal        time.Time
+	// continueRun is the agent-emitted "should we keep going?" signal
+	// from turn/completed notifications (`params.continue`). It only
+	// gates the legacy path: when refreshIssueState is wired, SPEC §16.5
+	// per-turn tracker refresh is the authoritative continuation gate
+	// and continueRun is consulted only as the agent's secondary opinion.
+	// Keeping both lets cooperative agents end early (continueRun=false)
+	// while still letting the operator cancel an otherwise-productive
+	// worker by moving the issue out of the active states.
+	continueRun        bool
+	refreshIssueState  IssueStateRefresher
+	tools              DynamicToolSet
+	turnTimeoutMs      int
+	readTimeoutMs      int
+	stallTimeoutMs     int
+	approvalPolicy     any
+	lastTerminal       time.Time
 }
 
 func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) error {
@@ -227,6 +236,7 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	c.phaseTransitionSink = in.PhaseTransitionSink
 	c.nextID = 1
 	c.continueRun = false
+	c.refreshIssueState = in.RefreshIssueState
 	c.tools = DynamicToolsForWorkflow(workflow.Workflow{Config: in.Workflow.Config})
 	c.turnTimeoutMs = in.Workflow.Config.Codex.TurnTimeoutMs
 	c.readTimeoutMs = in.Workflow.Config.Codex.ReadTimeoutMs
@@ -335,6 +345,22 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 				return &TurnTimeoutError{Timeout: time.Duration(c.turnTimeoutMs) * time.Millisecond, Elapsed: time.Since(turnStarted), Cause: err}
 			}
 			return err
+		}
+		// SPEC §16.5: refresh tracker state between turns so an
+		// operator who cancelled the issue mid-run sees the worker
+		// exit after the current turn rather than at the next
+		// orchestrator poll tick. Errors here are surfaced verbatim per
+		// SPEC ("if refreshed_issue failed: fail"); a nil refresher
+		// keeps the legacy continueRun-only path for callers (mock
+		// runner, tests) with no tracker hook.
+		if c.refreshIssueState != nil {
+			active, err := c.refreshIssueState(ctx)
+			if err != nil {
+				return fmt.Errorf("codex app-server refresh issue state: %w", err)
+			}
+			if !active {
+				return nil
+			}
 		}
 		if !c.continueRun {
 			return nil

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -221,14 +221,14 @@ type appServerClient struct {
 	// Keeping both lets cooperative agents end early (continueRun=false)
 	// while still letting the operator cancel an otherwise-productive
 	// worker by moving the issue out of the active states.
-	continueRun        bool
-	refreshIssueState  IssueStateRefresher
-	tools              DynamicToolSet
-	turnTimeoutMs      int
-	readTimeoutMs      int
-	stallTimeoutMs     int
-	approvalPolicy     any
-	lastTerminal       time.Time
+	continueRun       bool
+	refreshIssueState IssueStateRefresher
+	tools             DynamicToolSet
+	turnTimeoutMs     int
+	readTimeoutMs     int
+	stallTimeoutMs    int
+	approvalPolicy    any
+	lastTerminal      time.Time
 }
 
 func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) error {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -894,7 +894,9 @@ func TestCodexAppServerRunnerExitsWhenIssueLeavesActiveStateBetweenTurns(t *test
 	codexAppServerStubScript(t, `
 import json
 turns=0
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
 for line in sys.stdin:
+    log.write(line); log.flush()
     msg=json.loads(line)
     if msg.get('method') == 'initialize':
         print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
@@ -935,6 +937,17 @@ for line in sys.stdin:
 	}
 	if res.Summary != "turn 2 done" {
 		t.Fatalf("Summary = %q, want last completed turn's message", res.Summary)
+	}
+	// The stdin log captures every JSON-RPC message the runner sent to
+	// codex. Counting turn/start requests proves the runner *didn't even
+	// send* a third turn — without this, "only 2 completions" could just
+	// mean the third response never returned in time.
+	stdinLog, err := os.ReadFile(os.Getenv("CODEX_STDIN_LOG"))
+	if err != nil {
+		t.Fatalf("read CODEX_STDIN_LOG: %v", err)
+	}
+	if got := strings.Count(string(stdinLog), `"method":"turn/start"`); got != 2 {
+		t.Fatalf("turn/start requests sent = %d, want 2 (runner should not send a third turn after refresher returns inactive); stdin=\n%s", got, stdinLog)
 	}
 }
 

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -884,6 +884,94 @@ for line in sys.stdin:
 	}
 }
 
+// TestCodexAppServerRunnerExitsWhenIssueLeavesActiveStateBetweenTurns pins
+// SPEC §16.5: after each turn the runner consults the tracker and exits
+// cleanly when the linked issue is no longer active, even when the agent
+// is requesting another turn via params.continue=true. Without this gate
+// the worker would burn the full agent.max_turns budget before the
+// orchestrator's next per-tick reconcile noticed the operator cancel.
+func TestCodexAppServerRunnerExitsWhenIssueLeavesActiveStateBetweenTurns(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+turns=0
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        turns += 1
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'turn %d done' % turns, 'continue': True}}), flush=True)
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Agent.MaxTurns = 8
+
+	var refreshCalls int
+	in.RefreshIssueState = func(ctx context.Context) (bool, error) {
+		refreshCalls++
+		// First turn: issue is still active, runner should request
+		// another turn. Second turn: operator cancelled (issue moved to
+		// "Done"); refresher reports inactive and the runner must exit
+		// before sending the third turn/start even though the agent's
+		// continue=true would otherwise keep the loop running.
+		return refreshCalls < 2, nil
+	}
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if refreshCalls != 2 {
+		t.Fatalf("RefreshIssueState calls = %d, want 2 (one after each completed turn before the third start)", refreshCalls)
+	}
+	completed := runtimeEventsNamed(res.RuntimeEvents, task.EventTurnCompleted)
+	if len(completed) != 2 {
+		t.Fatalf("turn_completed events = %d, want exactly 2 (refresher cut off the agent's third turn); events=%#v", len(completed), res.RuntimeEvents)
+	}
+	if res.Summary != "turn 2 done" {
+		t.Fatalf("Summary = %q, want last completed turn's message", res.Summary)
+	}
+}
+
+// TestCodexAppServerRunnerSurfacesRefreshIssueStateError pins the SPEC
+// §16.5 "if refreshed_issue failed: fail" branch: a tracker outage during
+// the per-turn refresh aborts the loop with the refresher's error
+// wrapped, instead of letting the worker continue running with stale
+// continuation state.
+func TestCodexAppServerRunnerSurfacesRefreshIssueStateError(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'mid-run', 'continue': True}}), flush=True)
+    elif msg.get('method') == 'initialized':
+        pass
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Agent.MaxTurns = 4
+	refresherErr := errors.New("tracker unreachable")
+	in.RefreshIssueState = func(ctx context.Context) (bool, error) {
+		return false, refresherErr
+	}
+
+	_, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err == nil || !errors.Is(err, refresherErr) {
+		t.Fatalf("Run error = %v, want wrapped refresher error %q", err, refresherErr)
+	}
+}
+
 func TestCodexAppServerRunnerTreatsFailedTurnCompletedAsError(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -23,7 +23,25 @@ type RunInput struct {
 
 	RuntimeEventSink    func(task.RuntimeEvent)
 	PhaseTransitionSink func(from, to task.RunAttemptPhase)
+
+	// RefreshIssueState, when non-nil, implements SPEC §16.5's per-turn
+	// tracker refresh: the runner calls it after each agent turn finishes
+	// and exits cleanly when the issue is no longer in the workflow's
+	// active states. Without it the runner falls back to the agent-driven
+	// `continue` notification flag and operator-cancel only becomes
+	// visible at the next orchestrator poll tick. Nil keeps the legacy
+	// behavior for callers (tests, mock runners) that have no tracker.
+	RefreshIssueState IssueStateRefresher
 }
+
+// IssueStateRefresher is the SPEC §16.5 per-turn tracker hook. The runner
+// invokes it after `awaitTurnCompletion` succeeds; the returned bool reports
+// whether the linked issue is still in an active workflow state. A non-nil
+// error short-circuits the turn loop with the wrapped error (SPEC: "if
+// refreshed_issue failed: fail"). Defined as a function value rather than an
+// interface so callers can adapt any tracker client (or test fake) without
+// pulling internal/tracker into the runner package.
+type IssueStateRefresher func(ctx context.Context) (active bool, err error)
 
 type Result struct {
 	Summary       string

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
@@ -17,7 +19,20 @@ type Config struct {
 	WorkspaceRoot string
 	MirrorRoot    string
 	Workflow      *workflow.Workflow
+	// IssueStateRefresher, when non-nil, is consulted by RunTask to build
+	// the runner-level SPEC §16.5 per-turn refresh hook
+	// (runner.RunInput.RefreshIssueState). Returning nil for a task opts
+	// that run out of the refresh (e.g. mock tasks with no tracker row);
+	// the runner then falls back to the agent-driven continue flag.
+	IssueStateRefresher IssueStateRefresherFactory
 }
+
+// IssueStateRefresherFactory builds a per-task refresher closure that the
+// runner invokes between turns. The factory receives the task and the
+// workflow config that resolved for it (so the closure can read the
+// active_states vocabulary) and returns either a callable or nil when the
+// task should keep the legacy continue-driven loop.
+type IssueStateRefresherFactory func(t task.Task, cfg workflow.Config) runner.IssueStateRefresher
 
 // LoadConfigFromEnv reads the worker configuration from the environment using
 // the same defaults the original cmd/worker/main.go used.

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -329,7 +329,11 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		return &RunTaskError{Cfg: wcfg, Err: err}
 	}
 
-	res, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: workspaceRoot, Prompt: prompt, PhaseTransitionSink: func(from, to task.RunAttemptPhase) {
+	var refreshIssueState runner.IssueStateRefresher
+	if cfg.IssueStateRefresher != nil {
+		refreshIssueState = cfg.IssueStateRefresher(t, wcfg)
+	}
+	res, runErr := RunRunnerWithTimeout(ctx, ev, r, runner.RunInput{Task: t, Workflow: *wf, Workdir: workdir, WorkspaceRoot: workspaceRoot, Prompt: prompt, RefreshIssueState: refreshIssueState, PhaseTransitionSink: func(from, to task.RunAttemptPhase) {
 		emitTaskPhase(from, to)
 	}}, wcfg.Agent.Timeout, workflowSource)
 	sessionID := sessionIDFromRuntimeEvents(res.RuntimeEvents)


### PR DESCRIPTION
The codex app-server runner's turn loop was gating continuation on the
agent-emitted params.continue flag, leaving the operator-cancel signal
(issue moved out of active_states) invisible to a productive worker
until the next orchestrator poll tick. SPEC §16.5 wants the refresh to
land between turns so cancel becomes visible after the current turn.

Adds runner.IssueStateRefresher as an optional per-turn hook on
RunInput, wired through worker.Config + RuntimeDispatcher so the
multiIssueStateLister fan-in becomes the authoritative continuation
gate. The agent's continueRun flag is kept as a secondary
opinion — cooperative agents can still end early, but the operator
cancel reaches the worker within one turn duration regardless.

Regression coverage in internal/runner pins the mid-session inactive
exit and the SPEC "if refreshed_issue failed: fail" branch;
internal/orchestrator pins the factory closure (active/inactive/missing
row/error) and the AttachDispatcher carry-over that handles the
cmd/worker/main.go two-dispatcher startup sequence.

Refs: #218