### PR TITLE
fix(worker): SPEC §6.4 workspace.root default no longer shadowed by env loader literal (#319)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,9 @@ DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
 GITEA_BASE_URL=http://gitea.local
 GITEA_TOKEN=replace-with-gitea-bot-token
 LINEAR_API_KEY=replace-with-linear-personal-key
-WORKSPACE_ROOT=/tmp/aiops-workspaces
+# WORKSPACE_ROOT is optional. When unset, the worker uses WORKFLOW.md
+# `workspace.root` (SPEC §6.4 default: `<system-temp>/symphony_workspaces`,
+# typically `/tmp/symphony_workspaces` on Linux). Set this only to override
+# the workflow value from outside WORKFLOW.md — e.g. a project-local path:
+# WORKSPACE_ROOT=/tmp/symphony_workspaces
 AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1083,11 +1083,13 @@ func TestStartupReconcileConfigFallsBackToEnvWorkspaceRoot(t *testing.T) {
 }
 
 func TestStartupReconcileConfigHonorsExplicitDefaultWorkflowWorkspaceRoot(t *testing.T) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("UserHomeDir: %v", err)
-	}
-	yamlRoot := filepath.Join(home, "aiops-workspaces")
+	// Pin SPEC §6.4 precedence: an explicit `workspace.root` in
+	// WORKFLOW.md wins over WORKSPACE_ROOT env even when its value
+	// equals the SPEC default itself. Pre-#319 this test used the
+	// personal-profile legacy `~/aiops-workspaces` literal — the same
+	// literal PR #316 retired at the workflow-loader floor — which kept
+	// the SPEC drift alive at the worker layer.
+	yamlRoot := filepath.Join(os.TempDir(), "symphony_workspaces")
 	workflowPath := writeWorkflowForStartupReconcileTest(t, fmt.Sprintf("workspace:\n  root: %s\n", yamlRoot))
 	wf, err := workflow.Load(workflowPath)
 	if err != nil {
@@ -1099,6 +1101,29 @@ func TestStartupReconcileConfigHonorsExplicitDefaultWorkflowWorkspaceRoot(t *tes
 	reconcile := startupReconcileConfigForWorkflow(wf.Config, nil)
 	if reconcile.WorkspaceRoot != yamlRoot {
 		t.Fatalf("WorkspaceRoot = %q, want explicit workflow default root %q", reconcile.WorkspaceRoot, yamlRoot)
+	}
+}
+
+// TestStartupReconcileConfigFallsBackToSPECWorkspaceRootDefault covers
+// the #319 fix: when WORKFLOW.md omits `workspace.root` and
+// WORKSPACE_ROOT is unset, the startup reconcile resolves to the SPEC
+// §6.4 default (`<system-temp>/symphony_workspaces`) that
+// workflow.DefaultConfig seeds. Pre-#319 the env loader's
+// `/tmp/aiops-workspaces` literal shadowed the SPEC default in this
+// case; `worker --print-config` reported one path while the runtime
+// used another.
+func TestStartupReconcileConfigFallsBackToSPECWorkspaceRootDefault(t *testing.T) {
+	workflowPath := writeWorkflowForStartupReconcileTest(t, "")
+	wf, err := workflow.Load(workflowPath)
+	if err != nil {
+		t.Fatalf("Load workflow: %v", err)
+	}
+	t.Setenv("WORKSPACE_ROOT", "")
+
+	reconcile := startupReconcileConfigForWorkflow(wf.Config, nil)
+	want := filepath.Join(os.TempDir(), "symphony_workspaces")
+	if reconcile.WorkspaceRoot != want {
+		t.Fatalf("WorkspaceRoot = %q, want SPEC §6.4 default %q", reconcile.WorkspaceRoot, want)
 	}
 }
 

--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -109,7 +109,7 @@ just `<workdir>/.git`) — the worker recovers on the next prepare.
 
 | Env var               | Default                                                                 | Purpose                                                  |
 | --------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------- |
-| `WORKSPACE_ROOT`      | `/tmp/aiops-workspaces`                                                 | Where per-task worktrees live.                           |
+| `WORKSPACE_ROOT`      | _unset_ — falls back to WORKFLOW.md `workspace.root` (SPEC §6.4 default `<system-temp>/symphony_workspaces`) | Where per-task worktrees live.                           |
 | `AIOPS_MIRROR_ROOT`   | `os.UserCacheDir()/aiops-platform/mirrors` (fallback `$TMPDIR/...`)     | Where bare mirror clones are cached.                     |
 
 On Linux containers `os.UserCacheDir()` resolves to `$XDG_CACHE_HOME` or

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -644,12 +644,17 @@ func (d WorkerTaskDispatcher) Spawn(ctx context.Context, issue tracker.Issue, at
 	return out
 }
 
+// workspacePathForTask resolves where the worker will materialize tk's
+// worktree. The dispatcher constructors (RuntimeDispatcher.Spawn,
+// cmd/worker, e2e harness, every poller_test fixture) all set
+// cfg.Workflow non-nil before reaching this path; the previous defensive
+// nil branch was load-bearing only when LoadConfigFromEnv stamped a
+// literal `/tmp/aiops-workspaces` onto cfg.WorkspaceRoot. Post-#319 that
+// literal is gone, so a nil Workflow would yield an empty root and a
+// useless workspace path — surfacing that as a nil-deref panic at the
+// call site beats silently writing to "" further downstream.
 func workspacePathForTask(cfg worker.Config, tk task.Task) string {
-	root := cfg.WorkspaceRoot
-	if cfg.Workflow != nil {
-		root = worker.EffectiveWorkspaceRoot(cfg, cfg.Workflow.Config)
-	}
-	return workspace.New(root).PathFor(tk)
+	return workspace.New(worker.EffectiveWorkspaceRoot(cfg, cfg.Workflow.Config)).PathFor(tk)
 }
 
 func (d WorkerTaskDispatcher) buildTask(issue tracker.Issue) (task.Task, string, error) {

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -34,11 +34,17 @@ type Config struct {
 // task should keep the legacy continue-driven loop.
 type IssueStateRefresherFactory func(t task.Task, cfg workflow.Config) runner.IssueStateRefresher
 
-// LoadConfigFromEnv reads the worker configuration from the environment using
-// the same defaults the original cmd/worker/main.go used.
+// LoadConfigFromEnv reads the worker configuration from the environment.
+//
+// WorkspaceRoot intentionally has no literal default here — when
+// WORKSPACE_ROOT is unset, Config.WorkspaceRoot stays empty and
+// EffectiveWorkspaceRoot falls back to the workflow's `Workspace.Root`
+// (the SPEC §6.4 default seeded by workflow.DefaultConfig). The previous
+// `/tmp/aiops-workspaces` fallback silently shadowed that SPEC default
+// regardless of WORKFLOW.md content; see #319.
 func LoadConfigFromEnv() Config {
 	return Config{
-		WorkspaceRoot: env("WORKSPACE_ROOT", "/tmp/aiops-workspaces"),
+		WorkspaceRoot: os.Getenv("WORKSPACE_ROOT"),
 		MirrorRoot:    os.Getenv("AIOPS_MIRROR_ROOT"),
 	}
 }
@@ -46,11 +52,4 @@ func LoadConfigFromEnv() Config {
 // PrintConfig dispatches the `worker --print-config <workdir>` subcommand.
 func PrintConfig(workdir string, stdout, stderr io.Writer) int {
 	return printConfig(workdir, stdout, stderr)
-}
-
-func env(k, d string) string {
-	if v := os.Getenv(k); v != "" {
-		return v
-	}
-	return d
 }

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -173,16 +173,18 @@ func TestRunTaskHonorsWorkspaceRootPrecedence(t *testing.T) {
 		yamlRoot := defaultWorkflowWorkspaceRootForTest(t)
 		cfg := workerCfgForIntegrationWithWorkspaceRoot(t, yamlRoot)
 		cfg.WorkspaceRoot = envRoot
+		tkLocal := tk
+		tkLocal.RepoOwner = uniqueRepoOwnerForTest(t)
 		t.Cleanup(func() {
-			os.RemoveAll(filepath.Join(yamlRoot, tk.RepoOwner))
+			os.RemoveAll(filepath.Join(yamlRoot, tkLocal.RepoOwner))
 		})
 
-		if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		if rterr := worker.RunTaskForTest(context.Background(), ev, tkLocal, cfg); rterr != nil {
 			t.Fatalf("runTask: %v", rterr.Err)
 		}
 
-		assertTaskWorkdir(t, yamlRoot, tk)
-		if _, err := os.Stat(filepath.Join(envRoot, "acme", "demo", "linear_issue", "issue-uuid")); !os.IsNotExist(err) {
+		assertTaskWorkdir(t, yamlRoot, tkLocal)
+		if _, err := os.Stat(filepath.Join(envRoot, tkLocal.RepoOwner, tkLocal.RepoName, "linear_issue", tkLocal.SourceEventID)); !os.IsNotExist(err) {
 			t.Fatalf("env workspace root should not be used when explicit workflow workspace.root equals default; stat err=%v", err)
 		}
 	})
@@ -197,20 +199,37 @@ func TestRunTaskHonorsWorkspaceRootPrecedence(t *testing.T) {
 		cfg := workerCfgForIntegration(t)
 		cfg.WorkspaceRoot = ""
 		specDefault := defaultWorkflowWorkspaceRootForTest(t)
+		tkLocal := tk
+		tkLocal.RepoOwner = uniqueRepoOwnerForTest(t)
 		t.Cleanup(func() {
-			os.RemoveAll(filepath.Join(specDefault, tk.RepoOwner))
+			os.RemoveAll(filepath.Join(specDefault, tkLocal.RepoOwner))
 		})
 
-		if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		if rterr := worker.RunTaskForTest(context.Background(), ev, tkLocal, cfg); rterr != nil {
 			t.Fatalf("runTask: %v", rterr.Err)
 		}
 
-		assertTaskWorkdir(t, specDefault, tk)
+		assertTaskWorkdir(t, specDefault, tkLocal)
 		legacyRoot := "/tmp/aiops-workspaces"
-		if _, err := os.Stat(filepath.Join(legacyRoot, tk.RepoOwner, tk.RepoName, "linear_issue", tk.SourceEventID)); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(legacyRoot, tkLocal.RepoOwner, tkLocal.RepoName, "linear_issue", tkLocal.SourceEventID)); !os.IsNotExist(err) {
 			t.Fatalf("pre-#319 legacy /tmp/aiops-workspaces path should not be used; stat err=%v", err)
 		}
 	})
+}
+
+// uniqueRepoOwnerForTest returns a RepoOwner unique to this
+// (process, subtest) pair. The two precedence subtests that exercise
+// the SPEC default (`<system-temp>/symphony_workspaces`) write into a
+// path shared across the host, so the fixed `acme/demo` owner/name pair
+// from initBareUpstreamWithWorkflow would let two concurrent `go test`
+// invocations — or a real worker running on the same host — collide on
+// the same `<owner>/<name>/linear_issue/<event>` subtree. PID rules
+// out cross-process collision; the sanitized subtest name rules out
+// in-process collision between sibling subtests.
+func uniqueRepoOwnerForTest(t *testing.T) string {
+	t.Helper()
+	safe := strings.ReplaceAll(filepath.Base(t.Name()), "/", "_")
+	return fmt.Sprintf("acme-pid%d-%s", os.Getpid(), safe)
 }
 
 func assertTaskWorkdir(t *testing.T, root string, tk task.Task) {

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -173,6 +173,9 @@ func TestRunTaskHonorsWorkspaceRootPrecedence(t *testing.T) {
 		yamlRoot := defaultWorkflowWorkspaceRootForTest(t)
 		cfg := workerCfgForIntegrationWithWorkspaceRoot(t, yamlRoot)
 		cfg.WorkspaceRoot = envRoot
+		t.Cleanup(func() {
+			os.RemoveAll(filepath.Join(yamlRoot, tk.RepoOwner))
+		})
 
 		if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
 			t.Fatalf("runTask: %v", rterr.Err)
@@ -181,6 +184,31 @@ func TestRunTaskHonorsWorkspaceRootPrecedence(t *testing.T) {
 		assertTaskWorkdir(t, yamlRoot, tk)
 		if _, err := os.Stat(filepath.Join(envRoot, "acme", "demo", "linear_issue", "issue-uuid")); !os.IsNotExist(err) {
 			t.Fatalf("env workspace root should not be used when explicit workflow workspace.root equals default; stat err=%v", err)
+		}
+	})
+
+	// SPEC §6.4 default fallback (#319): with no `workspace.root` in
+	// WORKFLOW.md and no WORKSPACE_ROOT env, the worker must land on
+	// `<system-temp>/symphony_workspaces` — the same path
+	// `worker --print-config` reports. Pre-#319 it silently landed on
+	// the env loader's `/tmp/aiops-workspaces` literal.
+	t.Run("spec default wins when neither env nor yaml set", func(t *testing.T) {
+		ev := &fakeEmitter{}
+		cfg := workerCfgForIntegration(t)
+		cfg.WorkspaceRoot = ""
+		specDefault := defaultWorkflowWorkspaceRootForTest(t)
+		t.Cleanup(func() {
+			os.RemoveAll(filepath.Join(specDefault, tk.RepoOwner))
+		})
+
+		if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+			t.Fatalf("runTask: %v", rterr.Err)
+		}
+
+		assertTaskWorkdir(t, specDefault, tk)
+		legacyRoot := "/tmp/aiops-workspaces"
+		if _, err := os.Stat(filepath.Join(legacyRoot, tk.RepoOwner, tk.RepoName, "linear_issue", tk.SourceEventID)); !os.IsNotExist(err) {
+			t.Fatalf("pre-#319 legacy /tmp/aiops-workspaces path should not be used; stat err=%v", err)
 		}
 	})
 }
@@ -202,13 +230,15 @@ func workerCfgForIntegrationWithWorkspaceRoot(t *testing.T, root string) worker.
 	return workerCfgForIntegrationWithWorkflow(t, body)
 }
 
+// defaultWorkflowWorkspaceRootForTest returns the SPEC §6.4 default
+// `workspace.root` (`<system-temp>/symphony_workspaces`) — the same path
+// DefaultConfig seeds and `worker --print-config` reports. The pre-#319
+// helper returned `~/aiops-workspaces`, the personal-profile legacy that
+// PR #316 retired at the loader floor; tests that pinned that literal
+// kept the SPEC drift alive at the worker layer.
 func defaultWorkflowWorkspaceRootForTest(t *testing.T) string {
 	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("user home dir: %v", err)
-	}
-	return filepath.Join(home, "aiops-workspaces")
+	return filepath.Join(os.TempDir(), "symphony_workspaces")
 }
 
 func writeServiceWorkflowForIntegration(t *testing.T, body string) string {

--- a/internal/worker/workspace_root.go
+++ b/internal/worker/workspace_root.go
@@ -6,10 +6,29 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+// EffectiveWorkspaceRoot resolves the worker's runtime workspace root with
+// SPEC §6.4 precedence:
+//
+//  1. WORKFLOW.md `workspace.root` (explicit; RootSet=true) wins outright.
+//  2. WORKSPACE_ROOT env (non-empty cfg.WorkspaceRoot) wins over the
+//     SPEC default — operators can still steer a host without touching
+//     WORKFLOW.md.
+//  3. Otherwise fall back to the workflow's `Workspace.Root`, which
+//     DefaultConfig seeds with the SPEC §6.4 default
+//     (`<system-temp>/symphony_workspaces`).
+//
+// Pre-#319 the env loader's literal `/tmp/aiops-workspaces` fallback
+// silently shadowed the SPEC default whenever a WORKFLOW.md omitted
+// `workspace.root`. The env layer no longer carries a default literal
+// (see LoadConfigFromEnv), so an unset env var leaves cfg.WorkspaceRoot
+// empty and the SPEC default wins by precedence.
 func EffectiveWorkspaceRoot(cfg Config, wcfg workflow.Config) string {
-	root := strings.TrimSpace(wcfg.Workspace.Root)
-	if wcfg.Workspace.RootSet() && root != "" {
-		return root
+	workflowRoot := strings.TrimSpace(wcfg.Workspace.Root)
+	if wcfg.Workspace.RootSet() && workflowRoot != "" {
+		return workflowRoot
 	}
-	return cfg.WorkspaceRoot
+	if envRoot := strings.TrimSpace(cfg.WorkspaceRoot); envRoot != "" {
+		return envRoot
+	}
+	return workflowRoot
 }

--- a/internal/worker/workspace_root_test.go
+++ b/internal/worker/workspace_root_test.go
@@ -1,0 +1,122 @@
+package worker_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	worker "github.com/xrf9268-hue/aiops-platform/internal/worker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// TestEffectiveWorkspaceRoot_PrecedencePerSPEC pins SPEC §6.4 precedence
+// at the helper level and locks the #319 fix in place:
+//
+//  1. RootSet (explicit yaml) > env > workflow-default.
+//  2. An unset WORKSPACE_ROOT (empty cfg.WorkspaceRoot) falls through to
+//     the workflow's default `Workspace.Root` rather than a private
+//     env-loader literal.
+//
+// The "spec default fallback" and "env overrides spec default" cases
+// are the ones that regressed before #319: the env loader's
+// `/tmp/aiops-workspaces` literal shadowed `DefaultConfig.Workspace.Root`
+// (`<system-temp>/symphony_workspaces`) for any WORKFLOW.md that omitted
+// `workspace.root`.
+func TestEffectiveWorkspaceRoot_PrecedencePerSPEC(t *testing.T) {
+	specDefault := filepath.Join(os.TempDir(), "symphony_workspaces")
+
+	t.Run("rootSet yaml wins over env", func(t *testing.T) {
+		wcfg := loadWorkflowConfigForTest(t, "workspace:\n  root: /yaml/root\n")
+		got := worker.EffectiveWorkspaceRoot(worker.Config{WorkspaceRoot: "/env/root"}, wcfg)
+		if got != "/yaml/root" {
+			t.Fatalf("EffectiveWorkspaceRoot = %q, want %q", got, "/yaml/root")
+		}
+	})
+
+	t.Run("rootSet but empty falls back to env", func(t *testing.T) {
+		// Operator wrote `workspace.root: ""` (RootSet=true, value empty).
+		// The empty value can't be honored, so env takes precedence next.
+		wcfg := loadWorkflowConfigForTest(t, "workspace:\n  root: \"\"\n")
+		got := worker.EffectiveWorkspaceRoot(worker.Config{WorkspaceRoot: "/env/root"}, wcfg)
+		if got != "/env/root" {
+			t.Fatalf("EffectiveWorkspaceRoot = %q, want %q", got, "/env/root")
+		}
+	})
+
+	t.Run("env overrides spec default when rootSet false", func(t *testing.T) {
+		wcfg := loadWorkflowConfigForTest(t, "")
+		got := worker.EffectiveWorkspaceRoot(worker.Config{WorkspaceRoot: "/env/root"}, wcfg)
+		if got != "/env/root" {
+			t.Fatalf("EffectiveWorkspaceRoot = %q, want %q", got, "/env/root")
+		}
+	})
+
+	t.Run("spec default wins when nothing else set", func(t *testing.T) {
+		wcfg := loadWorkflowConfigForTest(t, "")
+		got := worker.EffectiveWorkspaceRoot(worker.Config{WorkspaceRoot: ""}, wcfg)
+		if got != specDefault {
+			t.Fatalf("EffectiveWorkspaceRoot = %q, want SPEC §6.4 default %q", got, specDefault)
+		}
+	})
+
+	t.Run("whitespace-only env falls through to spec default", func(t *testing.T) {
+		wcfg := loadWorkflowConfigForTest(t, "")
+		got := worker.EffectiveWorkspaceRoot(worker.Config{WorkspaceRoot: "   "}, wcfg)
+		if got != specDefault {
+			t.Fatalf("EffectiveWorkspaceRoot = %q, want SPEC §6.4 default %q", got, specDefault)
+		}
+	})
+}
+
+// loadWorkflowConfigForTest writes a minimal WORKFLOW.md with the given
+// extra front-matter (e.g. a `workspace:` block) and returns the parsed
+// Config. Going through the real loader is what makes `RootSet=true`
+// observable — the field is unexported and only the loader flips it
+// when `workspace.root` is present in the YAML.
+func loadWorkflowConfigForTest(t *testing.T, extraFrontMatter string) workflow.Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	body := "---\n" + extraFrontMatter + `repo:
+  owner: acme
+  name: demo
+  clone_url: https://example.invalid/acme/demo.git
+  default_branch: main
+tracker:
+  kind: gitea
+` + "---\nPrompt body\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	wf, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("Load workflow: %v", err)
+	}
+	return wf.Config
+}
+
+// TestLoadConfigFromEnv_NoLiteralWorkspaceRootDefault pins the
+// loader-floor invariant from #319: when WORKSPACE_ROOT is unset
+// Config.WorkspaceRoot must stay empty so EffectiveWorkspaceRoot can
+// fall through to the workflow's SPEC default. Pre-#319 the loader
+// returned the literal `/tmp/aiops-workspaces`.
+func TestLoadConfigFromEnv_NoLiteralWorkspaceRootDefault(t *testing.T) {
+	t.Setenv("WORKSPACE_ROOT", "")
+
+	cfg := worker.LoadConfigFromEnv()
+	if cfg.WorkspaceRoot != "" {
+		t.Fatalf("LoadConfigFromEnv().WorkspaceRoot = %q, want \"\" (no literal default; see #319)", cfg.WorkspaceRoot)
+	}
+}
+
+// TestLoadConfigFromEnv_HonorsWorkspaceRootEnv covers the still-supported
+// override path: an explicit WORKSPACE_ROOT flows through to
+// Config.WorkspaceRoot verbatim.
+func TestLoadConfigFromEnv_HonorsWorkspaceRootEnv(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "operator-root")
+	t.Setenv("WORKSPACE_ROOT", want)
+
+	cfg := worker.LoadConfigFromEnv()
+	if cfg.WorkspaceRoot != want {
+		t.Fatalf("LoadConfigFromEnv().WorkspaceRoot = %q, want %q", cfg.WorkspaceRoot, want)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #319.

`EffectiveWorkspaceRoot` previously consulted the workflow value only when `RootSet()=true`, then unconditionally returned `cfg.WorkspaceRoot` — which `LoadConfigFromEnv` pre-populated with the literal `/tmp/aiops-workspaces` even when `WORKSPACE_ROOT` was unset. Net effect: a `WORKFLOW.md` that omitted `workspace.root` always landed on the legacy aiops path despite `worker --print-config` reporting the SPEC §6.4 default (`<system-temp>/symphony_workspaces`).

The fix splits the precedence into three explicit tiers — explicit yaml > non-empty env > workflow default — and drops the env loader's literal fallback so an unset `WORKSPACE_ROOT` truly falls through to `workflow.DefaultConfig`'s SPEC value.

## Acceptance criteria

- [x] (1) `EffectiveWorkspaceRoot` falls back to the workflow's `Workspace.Root` (SPEC default) when `RootSet()` is false **and** `WORKSPACE_ROOT` is unset — only env-set values override the SPEC default.
- [x] (2) Env loader's `/tmp/aiops-workspaces` literal removed; SPEC default wins by precedence (`internal/worker/config.go`).
- [x] (3) `worker --print-config` output for a WORKFLOW.md without `workspace.root` matches SPEC §6.4 default on a clean host. Pinned by new `TestStartupReconcileConfigFallsBackToSPECWorkspaceRootDefault`.
- [x] (4) `internal/worker/runtask_integration_test.go` `defaultWorkflowWorkspaceRootForTest` and `cmd/worker/main_test.go` `TestStartupReconcileConfigHonorsExplicitDefaultWorkflowWorkspaceRoot` updated to use the SPEC default rather than the personal-profile `~/aiops-workspaces` literal.

## Changes

**Core fix**

- `internal/worker/workspace_root.go` — three-tier precedence with a self-describing godoc explaining the pre-#319 regression.
- `internal/worker/config.go` — `LoadConfigFromEnv` reads `WORKSPACE_ROOT` directly via `os.Getenv`; unused `env()` helper removed.

**Follow-up cleanup (from independent review)**

- `internal/orchestrator/poller.go` — drop the dead `cfg.Workflow == nil` branch in `workspacePathForTask`. It was load-bearing only when the env loader stamped a literal onto `cfg.WorkspaceRoot`; post-fix it would yield an empty workspace path. All dispatcher constructors set `Workflow` non-nil, so a nil now surfaces as a loud panic at the call site rather than silently writing to `""`.

**Tests**

- NEW `internal/worker/workspace_root_test.go` — pins all four precedence permutations at the helper level (including the regression case) plus the `LoadConfigFromEnv` loader-floor invariant.
- `internal/worker/runtask_integration_test.go` — new subtest `spec default wins when neither env nor yaml set` covers the regression end-to-end and asserts the legacy `/tmp/aiops-workspaces` path is not used. `uniqueRepoOwnerForTest` isolates the two SPEC-default subtests' shared host path by per-(process, subtest) `RepoOwner`.
- NEW `cmd/worker/main_test.go` `TestStartupReconcileConfigFallsBackToSPECWorkspaceRootDefault` covers the same regression at the startup-reconcile layer.

**Docs**

- `docs/runbooks/workspace-cache.md` — env-var table now reflects the SPEC fallback.
- `.env.example` — `WORKSPACE_ROOT` commented out with an explanation that it's optional and defaults to the workflow's SPEC value.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` (all 14 packages pass)
- [x] `go test ./internal/worker/ -run 'TestEffectiveWorkspaceRoot|TestLoadConfigFromEnv|TestRunTaskHonorsWorkspaceRootPrecedence' -v -count=1` — all subtests pass; new "spec default wins when neither env nor yaml set" subtest specifically would have failed pre-fix.
- [x] `go test ./cmd/worker/ -run TestStartupReconcile -v -count=1` — `TestStartupReconcileConfigFallsBackToSPECWorkspaceRootDefault` passes; would have failed pre-fix.
- [x] Independent agent review (general-purpose subagent) reports "ship it" with two non-blocking nits, both addressed in commit `23d22dd`.

Related: #244 (DEVIATIONS D28), #316 (the loader-floor SPEC alignment that surfaced this gap).

---
_Generated by [Claude Code](https://claude.ai/code/session_015nrPkZxMGHuktzP3X45vvU)_