### PR TITLE
fix(tracker/linear): drop non-existent customFieldValues field from poll query (#326)

### DIFF
--- a/docs/workflows/services-routing.md
+++ b/docs/workflows/services-routing.md
@@ -33,8 +33,6 @@ services:
       project_slug: api-platform
       team_key: ENG
       labels: [backend]
-      custom_fields:
-        Runtime: go
 ```
 
 Each service object has these fields:
@@ -49,7 +47,10 @@ Each service object has these fields:
 | `tracker.project_slug` | string | conditional | top-level `tracker.project_slug` if omitted | Linear project slug predicate and polling scope for this service. |
 | `tracker.team_key` | string | no | none | Linear team key predicate. |
 | `tracker.labels` | string array | no | empty | Linear labels that must be present on the issue. |
-| `tracker.custom_fields` | string map | no | empty | Linear custom field name/value predicates that must match the issue. |
+
+`tracker.custom_fields` is currently rejected at workflow load: Linear's GraphQL
+schema does not expose Issue custom fields, so the predicate can never match a
+polled issue. See [#326](https://github.com/xrf9268-hue/aiops-platform/issues/326).
 
 The top-level `tracker.project_slug` may provide the polling scope for services
 that omit `services[].tracker.project_slug`. A service-only Linear workflow may
@@ -68,7 +69,7 @@ Validation happens when `WORKFLOW.md` is loaded:
 - Every service requires `name` and `repo.clone_url`.
 - Service names must be unique case-insensitively.
 - Every Linear service route must define at least one route predicate among
-  `project_slug`, `team_key`, `labels`, or `custom_fields`.
+  `project_slug`, `team_key`, or `labels`.
 - Every Linear service route must have a project slug either in
   `services[].tracker.project_slug` or top-level `tracker.project_slug`, so the
   poller has an explicit project scope.

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -64,8 +64,8 @@ polling:
 #       project_slug: api-platform
 #       team_key: ENG
 #       labels: [backend]
-#       custom_fields:
-#         Runtime: go
+# `tracker.custom_fields:` is currently rejected at workflow load —
+# Linear's GraphQL schema does not expose Issue custom fields. See #326.
 
 workspace:
   root: ~/aiops-workspaces/personal

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -1234,6 +1234,12 @@ func TestFilterEligibleCandidatesUsesOnlyConfiguredTerminalSet(t *testing.T) {
 	}
 }
 
+// TestSelectRoutedCandidatesMatchesLinearProjectTeamLabelAndCustomField pins
+// the routing-predicate matching primitive at the orchestrator layer. The
+// custom_fields predicate is rejected at workflow load (#326) because
+// Linear's GraphQL schema does not expose Issue custom fields, but the
+// matching loop itself is still defensive — keeping the primitive intact
+// preserves a deprecation runway if Linear ever surfaces the field.
 func TestSelectRoutedCandidatesMatchesLinearProjectTeamLabelAndCustomField(t *testing.T) {
 	cfg := workflow.Config{Services: []workflow.ServiceConfig{
 		{

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -140,6 +140,14 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 	if len(nonEmpty) == 0 {
 		return nil, nil
 	}
+	// customFieldValues is intentionally NOT requested. Linear's GraphQL
+	// schema does not expose a customFieldValues field on Issue (only
+	// customerTicketCount matches `custom*`); requesting it produced
+	// HTTP 400 GRAPHQL_VALIDATION_FAILED on every poll (#326). The
+	// upstream Elixir reference (elixir/lib/symphony_elixir/linear/client.ex)
+	// also omits any custom-field fragment for the same reason.
+	// `services[].tracker.custom_fields` route predicates are rejected at
+	// workflow load time until Linear surfaces a working query field.
 	query := `query ListIssues($projectSlug: String!, $states: [String!], $first: Int!, $after: String) {
   issues(filter: { project: { slugId: { eq: $projectSlug } }, state: { name: { in: $states } } }, first: $first, after: $after) {
     nodes {
@@ -155,7 +163,6 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
       project { slugId }
       team { key }
       labels(first: 50) { nodes { name } }
-      customFieldValues(first: 50) { nodes { customField { name } value } }
       state { name }
     }
     pageInfo { hasNextPage endCursor }
@@ -188,14 +195,6 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 								Name string `json:"name"`
 							} `json:"nodes"`
 						} `json:"labels"`
-						CustomFieldValues struct {
-							Nodes []struct {
-								CustomField struct {
-									Name string `json:"name"`
-								} `json:"customField"`
-								Value json.RawMessage `json:"value"`
-							} `json:"nodes"`
-						} `json:"customFieldValues"`
 						State struct {
 							Name string `json:"name"`
 						} `json:"state"`
@@ -237,14 +236,10 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 					labels = append(labels, strings.ToLower(strings.TrimSpace(label.Name)))
 				}
 			}
-			customFields := make(map[string]string, len(n.CustomFieldValues.Nodes))
-			for _, field := range n.CustomFieldValues.Nodes {
-				if strings.TrimSpace(field.CustomField.Name) == "" {
-					continue
-				}
-				customFields[strings.TrimSpace(field.CustomField.Name)] = stringifyLinearCustomFieldValue(field.Value)
-			}
-			issues = append(issues, Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, BranchName: n.BranchName, CreatedAt: createdAt, UpdatedAt: updatedAt, ProjectSlug: n.Project.SlugID, TeamKey: n.Team.Key, Labels: labels, CustomFields: customFields, State: n.State.Name, BlockedBy: blockers})
+			// Issue.CustomFields stays nil — Linear's GraphQL schema does not
+			// expose any custom-field data on Issue (introspection confirms
+			// only `customerTicketCount` matches `custom*`). See #326.
+			issues = append(issues, Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, BranchName: n.BranchName, CreatedAt: createdAt, UpdatedAt: updatedAt, ProjectSlug: n.Project.SlugID, TeamKey: n.Team.Key, Labels: labels, State: n.State.Name, BlockedBy: blockers})
 		}
 		if !out.Data.Issues.PageInfo.HasNextPage {
 			return issues, nil
@@ -267,17 +262,6 @@ func parseLinearIssueTime(field, value string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("parse Linear issue %s %q: %w", field, value, err)
 	}
 	return parsed, nil
-}
-
-func stringifyLinearCustomFieldValue(raw json.RawMessage) string {
-	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
-		return ""
-	}
-	var s string
-	if err := json.Unmarshal(raw, &s); err == nil {
-		return strings.TrimSpace(s)
-	}
-	return strings.TrimSpace(string(raw))
 }
 
 func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -323,13 +323,20 @@ func TestListIssuesByStatesMapsSpecDomainFields(t *testing.T) {
 			Query string `json:"query"`
 		}
 		_ = json.Unmarshal(body, &payload)
-		for _, fragment := range []string{"priority", "branchName", "createdAt", "updatedAt", "project { slugId }", "team { key }", "labels(first: 50)", "customFieldValues(first: 50)", "customField { name }"} {
+		for _, fragment := range []string{"priority", "branchName", "createdAt", "updatedAt", "project { slugId }", "team { key }", "labels(first: 50)"} {
 			if !strings.Contains(payload.Query, fragment) {
 				t.Fatalf("ListIssues query = %s, want fragment %q", payload.Query, fragment)
 			}
 		}
+		// Per #326, customFieldValues is NOT in Linear's GraphQL schema; the
+		// query must omit it so the request stops 400'ing.
+		for _, banned := range []string{"customFieldValues", "customField {"} {
+			if strings.Contains(payload.Query, banned) {
+				t.Fatalf("ListIssues query must not request %q (Linear schema rejects it): %s", banned, payload.Query)
+			}
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"branchName":"agent/lin-1","createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[{"name":"Backend"},{"name":"Customer"}]},"customFieldValues":{"nodes":[{"customField":{"name":"Runtime"},"value":"go"}]},"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"branchName":"agent/lin-1","createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[{"name":"Backend"},{"name":"Customer"}]},"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
 	}))
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "api-platform"})
@@ -356,8 +363,8 @@ func TestListIssuesByStatesMapsSpecDomainFields(t *testing.T) {
 	if got := strings.Join(issue.Labels, ","); got != "backend,customer" {
 		t.Fatalf("labels = %q, want lower-cased backend,customer", got)
 	}
-	if issue.CustomFields["Runtime"] != "go" {
-		t.Fatalf("custom field Runtime = %q, want go", issue.CustomFields["Runtime"])
+	if len(issue.CustomFields) != 0 {
+		t.Fatalf("CustomFields = %#v, want empty — Linear GraphQL does not expose Issue custom fields (#326)", issue.CustomFields)
 	}
 }
 
@@ -371,10 +378,25 @@ func TestParseLinearIssueTimeErrorsOnMalformedTimestamp(t *testing.T) {
 	}
 }
 
-func TestListIssuesByStatesMapsNonStringCustomFieldValues(t *testing.T) {
+// TestListIssuesByStatesUsesLinearSupportedQueryShape pins #326: the query
+// must not ask Linear for `customFieldValues` (the GraphQL schema does not
+// expose that field on Issue; every poll 400'd with GRAPHQL_VALIDATION_FAILED
+// before this regression was caught). Verified against live Linear
+// introspection 2026-05-23.
+func TestListIssuesByStatesUsesLinearSupportedQueryShape(t *testing.T) {
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		for _, banned := range []string{"customFieldValues", "customField {"} {
+			if strings.Contains(payload.Query, banned) {
+				t.Fatalf("ListIssues query must not request %q (Linear schema rejects it): %s", banned, payload.Query)
+			}
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[]},"customFieldValues":{"nodes":[{"customField":{"name":"Risk"},"value":3},{"customField":{"name":"CustomerFacing"},"value":true},{"customField":{"name":"Option"},"value":{"name":"gold"}}]},"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","project":{"slugId":"api-platform"},"team":{"key":"ENG"},"labels":{"nodes":[]},"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
 	}))
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "api-platform"})
@@ -386,9 +408,8 @@ func TestListIssuesByStatesMapsNonStringCustomFieldValues(t *testing.T) {
 	if len(issues) != 1 {
 		t.Fatalf("issues = %d, want 1", len(issues))
 	}
-	fields := issues[0].CustomFields
-	if fields["Risk"] != "3" || fields["CustomerFacing"] != "true" || fields["Option"] != `{"name":"gold"}` {
-		t.Fatalf("custom fields = %#v, want stringified non-string values", fields)
+	if len(issues[0].CustomFields) != 0 {
+		t.Fatalf("CustomFields = %#v, want empty — Linear GraphQL does not expose Issue custom fields (#326)", issues[0].CustomFields)
 	}
 }
 

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -299,8 +299,7 @@ var supportedSandboxNetworks = map[string]struct{}{
 func hasExplicitServiceRoute(route ServiceTrackerRouteConfig) bool {
 	return strings.TrimSpace(route.ProjectSlug) != "" ||
 		strings.TrimSpace(route.TeamKey) != "" ||
-		len(route.Labels) > 0 ||
-		len(route.CustomFields) > 0
+		len(route.Labels) > 0
 }
 
 func validateConfig(path string, cfg Config) error {
@@ -335,7 +334,17 @@ func validateConfig(path string, cfg Config) error {
 				return fmt.Errorf("%s: services[%d].tracker.project_slug or tracker.project_slug is required for Linear service routing", path, i)
 			}
 			if !hasExplicitServiceRoute(service.Tracker) {
-				return fmt.Errorf("%s: services[%d].tracker must define at least one Linear route predicate (project_slug, team_key, labels, or custom_fields)", path, i)
+				return fmt.Errorf("%s: services[%d].tracker must define at least one Linear route predicate (project_slug, team_key, or labels)", path, i)
+			}
+			// Linear's GraphQL schema does not expose any custom-field data
+			// on Issue (introspection: only `customerTicketCount` matches
+			// `custom*`); the upstream Elixir reference omits the fragment
+			// for the same reason. A `custom_fields:` predicate can never
+			// match a polled issue and would silently drop work, so reject
+			// it at load time per AGENTS.md "Failures are configuration
+			// problems". See #326.
+			if len(service.Tracker.CustomFields) > 0 {
+				return fmt.Errorf("%s: services[%d].tracker.custom_fields is not supported — Linear's GraphQL schema does not expose Issue custom fields (see #326)", path, i)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #326 — Linear tracker polling is non-functional today; every poll returns HTTP 400 `GRAPHQL_VALIDATION_FAILED` because `internal/tracker/linear.go:158` requests `customFieldValues(first: 50) { customField { name } value }`, which Linear's GraphQL schema does not expose.

## Authoritative API confirmation

Live introspection against `https://api.linear.app/graphql` on 2026-05-23 with a Pro-tier personal API key (`Yy B` / `aishuode` org):

```
Issue type has 83 fields total.
Fields containing 'custom' (case-insensitive):
  - customerTicketCount : Int
Fields containing 'field' (case-insensitive):
  (none)
Types containing 'custom' (Schema-wide):
  - CustomView*, Customer*, IssueTitleSuggestionFromCustomerRequestPayload, ...
  (no IssueCustomField* anywhere)
Query root fields containing custom/field:
  - customViews, customView, customViewDetailsSuggestion, customViewHasSubscribers,
    customerNeeds, customerNeed, issueTitleSuggestionFromCustomerRequest,
    customers, customer, customerStatuses, customerStatus, customerTiers, customerTier
  (no issueCustomFields* root either)
```

No `customField*`, no `*FieldValue`, no `*FieldValues` exists on Issue or its connections. Renaming to `custom_fields` does not help either — the schema does not expose any custom-field surface on Issue under any name.

The upstream Elixir reference [`elixir/lib/symphony_elixir/linear/client.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/linear/client.ex) (the SPEC tiebreaker per AGENTS.md) **also omits any custom-field fragment** for the same reason.

## Changes

- Remove `customFieldValues` GraphQL fragment + matching Go struct from `ListIssuesByStates`. Comment in `linear.go` documents the introspection result.
- `Issue.CustomFields` stays in the type (consumed by `services[]` routing predicate matching in `worker/reconcile.go` and `orchestrator/poller.go`). Linear always returns nil; the matching loops handle nil safely.
- `workflow/loader.go` now rejects `services[].tracker.custom_fields:` at workflow load time with a clear error pointing to #326 (the predicate can never match a Linear-polled issue). Removes `custom_fields` from the predicate list in the "must define at least one predicate" error.
- Replace `TestListIssuesByStatesMapsNonStringCustomFieldValues` with `TestListIssuesByStatesUsesLinearSupportedQueryShape` that pins the regression by asserting the query MUST NOT request `customFieldValues` or `customField {`.
- Update `TestListIssuesByStatesMapsSpecDomainFields` to drop the customFieldValues fragment from the assertion and add the same negative assertion.

## Verification

- ✅ `gofmt -l .` clean
- ✅ `go test -race -count=1 -timeout 5m ./...` — 14/14 packages green
- ✅ Mutation test: re-introducing `customFieldValues` into the query (one-line `sed` patch) makes the new test fail with the exact `customFieldValues` negative-assertion message; restoring the fix makes it pass again. Confirms the new test catches the regression.
- ✅ Live verified against `tracker.kind: linear` worker poll loop on org `aishuode` (project slug `01d2b95da4b2`, issue `AIS-10`): after this patch, `event=reconcile_end status=ok active_issues=1` followed by full workspace prep → mock runner → verify → `Succeeded` chain. Without the patch, every poll logs `linear request failed: 400 Bad Request`.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 -timeout 5m ./...` all green
- [x] Mutation: re-inject `customFieldValues` → new tests FAIL; restore → PASS
- [x] Live Linear API tested end-to-end with patched binary