### PR TITLE
fix(runner/codex): use codex `granular:` policy instead of obsolete `reject:` (#329)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -259,7 +259,7 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	}
 
 	threadResult, err := c.request(ctx, "thread/start", map[string]any{
-		"approvalPolicy": in.Workflow.Config.Codex.ApprovalPolicy,
+		"approvalPolicy": codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy),
 		"sandbox":        in.Workflow.Config.Codex.ThreadSandbox,
 		"cwd":            in.Workdir,
 		"dynamicTools":   appServerDynamicToolSpecs(in.Workflow.Config),
@@ -296,7 +296,7 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 			"input":          input,
 			"cwd":            in.Workdir,
 			"title":          appServerTurnTitle(in),
-			"approvalPolicy": in.Workflow.Config.Codex.ApprovalPolicy,
+			"approvalPolicy": codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy),
 			"sandboxPolicy":  in.Workflow.Config.Codex.TurnSandboxPolicy,
 		})
 		if err != nil {
@@ -904,6 +904,19 @@ func protocolServerRequestAutoApproved(method string, approvalPolicy any) bool {
 	}
 }
 
+// autoApproveRequest reports whether protocolServerRequestResult should
+// auto-approve a server-side approval prompt that codex sent the harness.
+// The decision tracks codex's own `AskForApproval` semantics (codex-rs
+// protocol/src/protocol.rs):
+//
+//   - "never"                     — codex never asks; if a prompt still
+//     surfaces, auto-approve it (matches codex's "failures returned to the
+//     model" intent).
+//   - "on-failure"                — codex asks only on failure; the harness
+//     auto-approves to keep the unattended loop moving.
+//   - "untrusted" / "on-request"  — operator-supervised modes; decline.
+//   - {"granular": {...}}         — per-method bool flags where TRUE means
+//     ALLOW (codex semantics since #14516, b7dba72db, 2026-03-12).
 func autoApproveRequest(method string, approvalPolicy any) bool {
 	if policy, ok := approvalPolicy.(string); ok {
 		switch strings.ToLower(strings.TrimSpace(policy)) {
@@ -920,19 +933,7 @@ func autoApproveRequest(method string, approvalPolicy any) bool {
 	if granular, ok := policy["granular"].(map[string]any); ok {
 		return approvalRuleAllowsRequest(granular, method)
 	}
-	if reject, ok := policy["reject"].(map[string]any); ok {
-		return !approvalRuleRequiresReview(reject, method)
-	}
 	return false
-}
-
-func approvalRuleRequiresReview(rules map[string]any, method string) bool {
-	if method == "item/permissions/requestApproval" {
-		return approvalRuleEnabled(rules, "request_permissions") ||
-			approvalRuleEnabled(rules, "sandbox_approval") ||
-			approvalRuleEnabled(rules, "rules")
-	}
-	return approvalRuleEnabled(rules, "sandbox_approval") || approvalRuleEnabled(rules, "rules")
 }
 
 func approvalRuleAllowsRequest(rules map[string]any, method string) bool {
@@ -945,6 +946,58 @@ func approvalRuleAllowsRequest(rules map[string]any, method string) bool {
 func approvalRuleEnabled(rules map[string]any, key string) bool {
 	enabled, _ := rules[key].(bool)
 	return enabled
+}
+
+// codexWireApprovalPolicy maps aiops-platform's ApprovalPolicy value to the
+// codex app-server JSON-RPC wire format. Codex's `AskForApproval` enum
+// (codex-rs/protocol/src/protocol.rs and
+// codex-rs/app-server-protocol/src/protocol/v2/shared.rs) accepts exactly
+// {"untrusted", "on-failure", "on-request", "granular": {...}, "never"}.
+// Sending anything else makes thread/start return JSON-RPC -32600
+// `Invalid request: unknown variant ...` and breaks startup (#329).
+//
+// The obsolete `{"reject": {...}}` shape — which used to be valid in codex
+// up to PR #14516 (commit b7dba72db, renamed to `granular` and field
+// polarity inverted on 2026-03-12) — is translated here for back-compat
+// with WORKFLOW.md files written against the old protocol. The polarity
+// flip (`reject.sandbox_approval=true` meant "reject"; the new
+// `granular.sandbox_approval=true` means "allow") is preserved so the
+// translated payload retains the operator's original intent.
+//
+// All codex-recognized values (`"untrusted"`/`"on-failure"`/`"on-request"`/
+// `"never"` strings, and the `{"granular": {...}}` map) pass through
+// unchanged. Unrecognized shapes also pass through so codex's own
+// validation error reaches the operator verbatim rather than getting
+// masked behind a translator silently rewriting their payload.
+func codexWireApprovalPolicy(internal any) any {
+	policy, ok := internal.(map[string]any)
+	if !ok {
+		return internal
+	}
+	rejectShape, hasReject := policy["reject"].(map[string]any)
+	if !hasReject {
+		return internal
+	}
+	// Translate obsolete reject:{flag:true} → granular:{flag:false} per the
+	// codex #14516 polarity flip. Pass through any extra keys verbatim so a
+	// future codex addition doesn't get lost.
+	granular := make(map[string]any, len(rejectShape))
+	for k, v := range rejectShape {
+		if b, ok := v.(bool); ok {
+			granular[k] = !b
+			continue
+		}
+		granular[k] = v
+	}
+	translated := make(map[string]any, len(policy))
+	for k, v := range policy {
+		if k == "reject" {
+			continue
+		}
+		translated[k] = v
+	}
+	translated["granular"] = granular
+	return translated
 }
 
 func protocolUserInputResult(msg map[string]any) map[string]any {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1696,7 +1696,13 @@ func TestProtocolServerRequestResultApprovalPolicyMatrix(t *testing.T) {
 		{name: "on-request", policy: "on-request", wantModernDecision: "decline"},
 		{name: "untrusted", policy: "untrusted", wantModernDecision: "decline"},
 		{name: "on-failure", policy: "on-failure", wantModernDecision: "acceptForSession", wantPermissions: true},
-		{name: "reject legacy map", policy: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true}}, wantModernDecision: "decline"},
+		// `reject:` is the obsolete codex variant renamed to `granular:` in
+		// PR #14516 (b7dba72db). Harness no longer special-cases it — the
+		// codexWireApprovalPolicy boundary translates it to granular before
+		// going to codex, so by the time protocolServerRequestResult sees a
+		// payload it should never observe a raw reject:. The case below
+		// pins the safe fallback: unknown shapes don't auto-approve.
+		{name: "reject legacy map (unknown to harness)", policy: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true}}, wantModernDecision: "decline"},
 		{name: "granular denies all disabled allowances", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": false}}, wantModernDecision: "decline"},
 		{name: "granular allows sandbox only", policy: map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "request_permissions": false}}, wantModernDecision: "acceptForSession"},
 		{name: "granular allows permissions only", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": true}}, wantModernDecision: "decline", wantPermissions: true},
@@ -1731,6 +1737,84 @@ func TestProtocolServerRequestResultApprovalPolicyMatrix(t *testing.T) {
 	}
 	if _, ok := elicitationResult["content"]; !ok || elicitationResult["content"] != nil {
 		t.Fatalf("elicitation content = %#v, present %v; want explicit null content", elicitationResult["content"], ok)
+	}
+}
+
+// TestCodexWireApprovalPolicy pins the translation contract between
+// aiops-platform's ApprovalPolicy value and codex's `AskForApproval` wire
+// format (codex-rs/protocol/src/protocol.rs `AskForApproval`).
+//
+// The codex enum is the source of truth: codex commit b7dba72db (PR #14516,
+// 2026-03-12) renamed the `Reject` variant to `Granular` and inverted the
+// field polarity (true = ALLOW, was true = REJECT). Sending the obsolete
+// `{"reject": {...}}` payload to a current codex returns
+// `-32600 unknown variant ` and breaks startup (#329).
+//
+// Future maintainers: do NOT "fix" this by reverting to `reject:` — the
+// rename is a deliberate codex protocol change. Check
+// codex-rs/protocol/src/protocol.rs `pub enum AskForApproval` first.
+func TestCodexWireApprovalPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{
+			name: "never string passes through",
+			in:   "never",
+			want: "never",
+		},
+		{
+			name: "untrusted string passes through",
+			in:   "untrusted",
+			want: "untrusted",
+		},
+		{
+			name: "on-failure string passes through",
+			in:   "on-failure",
+			want: "on-failure",
+		},
+		{
+			name: "on-request string passes through",
+			in:   "on-request",
+			want: "on-request",
+		},
+		{
+			name: "granular map passes through unchanged",
+			in:   map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "mcp_elicitations": true}},
+			want: map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "mcp_elicitations": true}},
+		},
+		{
+			name: "legacy reject:{true} translates to granular:{false}",
+			// Operator intent: reject sandbox+rules+mcp prompts.
+			in: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true, "mcp_elicitations": true}},
+			// Codex equivalent: granular flags ALL false (none allowed).
+			want: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "mcp_elicitations": false}},
+		},
+		{
+			name: "legacy reject:{false} translates to granular:{true}",
+			// Operator intent: don't reject; allow sandbox approvals.
+			in:   map[string]any{"reject": map[string]any{"sandbox_approval": false, "rules": true, "mcp_elicitations": true}},
+			want: map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "mcp_elicitations": false}},
+		},
+		{
+			name: "unrecognized shape passes through so codex surfaces its own validation error",
+			in:   map[string]any{"future_variant": map[string]any{"x": 1}},
+			want: map[string]any{"future_variant": map[string]any{"x": 1}},
+		},
+		{
+			name: "nil passes through",
+			in:   nil,
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := codexWireApprovalPolicy(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("codexWireApprovalPolicy(%#v) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -546,9 +546,17 @@ func DefaultConfig() Config {
 			Timeout:             30 * time.Minute,
 		},
 		Codex: CommandConfig{
-			Command:        "codex app-server",
-			Profile:        "safe",
-			ApprovalPolicy: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true, "mcp_elicitations": true}},
+			Command: "codex app-server",
+			Profile: "safe",
+			// See loader.go for why this is `granular:` with all flags
+			// false instead of the obsolete `reject:` shape (#329).
+			ApprovalPolicy: map[string]any{"granular": map[string]any{
+				"sandbox_approval":    false,
+				"rules":               false,
+				"skill_approval":      false,
+				"request_permissions": false,
+				"mcp_elicitations":    false,
+			}},
 			ThreadSandbox:  "workspace-write",
 			TurnTimeoutMs:  3600000,
 			ReadTimeoutMs:  5000,

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -707,7 +707,20 @@ func expandConfigForWorkflowPath(workflowPath string, cfg *Config) error {
 		cfg.Codex.ThreadSandbox = "workspace-write"
 	}
 	if cfg.Codex.ApprovalPolicy == nil {
-		cfg.Codex.ApprovalPolicy = map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true, "mcp_elicitations": true}}
+		// Default mirrors codex's `granular` policy with every flag set to
+		// false, i.e. "auto-reject every approval / elicitation prompt".
+		// Codex renamed the variant from `reject` → `granular` and flipped
+		// the field polarity (true = allow) in
+		// codex commit b7dba72db (#14516); aiops-platform had been sending
+		// the obsolete `reject:` payload, which made every thread/start
+		// return `-32600 unknown variant ` (#329).
+		cfg.Codex.ApprovalPolicy = map[string]any{"granular": map[string]any{
+			"sandbox_approval":    false,
+			"rules":               false,
+			"skill_approval":      false,
+			"request_permissions": false,
+			"mcp_elicitations":    false,
+		}}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #329 — `agent.default: codex-app-server` is unusable with default config: every `thread/start` returns `-32600 Invalid request: unknown variant \`reject\`, expected one of \`untrusted\`, \`on-failure\`, \`on-request\`, \`granular\`, \`never\``.

## Authoritative source — codex protocol

Codex's `AskForApproval` enum is the source of truth. The current shape lives at:

- [`codex-rs/protocol/src/protocol.rs` `pub enum AskForApproval`](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs)
- [`codex-rs/app-server-protocol/src/protocol/v2/shared.rs`](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/src/protocol/v2/shared.rs)

The variant **`Reject` was renamed to `Granular`** with field polarity inverted in [codex commit b7dba72db (PR openai/codex#14516, 2026-03-12)](https://github.com/openai/codex/commit/b7dba72db). The rename diff:

```rust
-    /// Fine-grained rejection controls for approval prompts.
-    ///
-    /// When a field is `true`, prompts of that category are automatically
-    /// rejected instead of shown to the user.
-    Reject(RejectConfig),
+    /// Fine-grained controls for individual approval flows.
+    ///
+    /// When a field is `true`, commands in that category are allowed. When it
+    /// is `false`, those requests are automatically rejected instead of shown
+    /// to the user.
+    #[strum(serialize = "granular")]
+    Granular(GranularApprovalConfig),
```

That is: the same JSON shape `{"sandbox_approval": true}` used to mean **reject**, now means **allow**. Sending the obsolete `reject:` wrapper makes codex emit `unknown variant`.

The upstream Elixir Symphony reference still ships the pre-rename default ([`elixir/lib/symphony_elixir/config/schema.ex:162-170`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/config/schema.ex#L162)); aiops-platform inherited the bug by porting from it. Treating codex's source as canonical (AGENTS.md "When SPEC text is ambiguous, the reference's behavior is the tiebreaker" — extended here because the protocol contract itself moved).

## Changes

- **`internal/workflow/config.go` + `internal/workflow/loader.go`**: default `ApprovalPolicy` is now
  ```yaml
  granular:
    sandbox_approval: false
    rules: false
    skill_approval: false
    request_permissions: false
    mcp_elicitations: false
  ```
  Semantically equivalent to the old `reject: all-true` intent (refuse every approval category), expressed in the codex-accepted enum variant.
- **`internal/runner/codex_app_server.go`**:
  - Add `codexWireApprovalPolicy()` wrapping both `thread/start` and `turn/start`. Pass-through for strings (`"never"`/`"untrusted"`/`"on-failure"`/`"on-request"`) and `{"granular": {...}}`. Migrate legacy `{"reject": {flag:bool}}` to `{"granular": {flag:!bool}}` so pre-rename WORKFLOW.md files keep their original intent across the polarity flip. Unknown shapes pass through verbatim so codex's own validation error reaches the operator.
  - Drop the now-dead `approvalRuleRequiresReview` helper and the `reject:` branch from `autoApproveRequest`. The harness handler now mirrors codex's enum exactly.
- **`internal/runner/codex_app_server_test.go`**: new `TestCodexWireApprovalPolicy` pinning every translation case with a long doc comment that names the codex commit + PR. Existing matrix label updated to document that the harness no longer special-cases `reject:` — the boundary translator handles back-compat.

## Why this won't be reverted

Long doc comments on `codexWireApprovalPolicy` and the test explain the codex commit (`b7dba72db`), the PR (`openai/codex#14516`), the date (2026-03-12), the polarity flip, and warn future maintainers to check codex's enum definition before "fixing" the translation back. Codex source is best-practice; the upstream Elixir reference is downstream of it and currently lags this change.

## Verification

- ✅ `gofmt -l .` clean.
- ✅ `go vet ./...` clean.
- ✅ `go test -race -count=1 -timeout 5m ./...` 14/14 green.
- ✅ Mutation: replacing `codexWireApprovalPolicy` with identity makes the legacy-translation cases of `TestCodexWireApprovalPolicy` fail with the exact polarity-flip diff; restoring makes them pass.
- ✅ Live verified end-to-end against `agent.default: codex-app-server` + real Linear API. Before the patch: `thread/start` returns `-32600 unknown variant \`reject\``. After the patch (default config, no operator override): `event=session_started thread_id=… turn_id=… session_id=…` fires, the codex session enters real turns.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 -timeout 5m ./...` all green
- [x] Mutation: revert translator to identity → translation tests FAIL; restore → PASS
- [x] Live `codex-app-server` runner test against real Linear issue (`event=session_started` confirmed)