### PR TITLE
fix(runner/codex): replace deprecated `--full-auto` with `--sandbox workspace-write` (#330)

### DIFF
--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -109,9 +109,18 @@ func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
 		if _, err := exec.LookPath("codex"); err != nil {
 			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
 		}
+		// `--sandbox workspace-write` replaces the deprecated `--full-auto`.
+		// Per codex commit 3d10ba9f3 (PR openai/codex#20133) `--full-auto`
+		// is now a deprecation alias whose migration target is
+		// `--sandbox workspace-write`; codex-rs/exec/src/lib.rs maps the
+		// removed flag to `SandboxMode::WorkspaceWrite` and prints
+		//   warning: `--full-auto` is deprecated; use `--sandbox workspace-write` instead.
+		// on every invocation, polluting stderr capture (#330). Both flags
+		// resolve to the same sandbox mode; the new spelling is forward-
+		// compatible if codex eventually removes the alias.
 		return exec.CommandContext(ctx,
 			"codex", "exec",
-			"--full-auto",
+			"--sandbox", "workspace-write",
 			"--skip-git-repo-check",
 			"--cd", in.Workdir,
 			"-o", lastMessageAbs,

--- a/internal/runner/codex_test.go
+++ b/internal/runner/codex_test.go
@@ -79,7 +79,8 @@ func TestCodexRunner_SafeProfileBuildsExpectedArgv(t *testing.T) {
 	}
 	want := []string{
 		"exec",
-		"--full-auto",
+		"--sandbox",
+		"workspace-write",
 		"--skip-git-repo-check",
 		"--cd",
 		wd,
@@ -93,6 +94,17 @@ func TestCodexRunner_SafeProfileBuildsExpectedArgv(t *testing.T) {
 	for i := range want {
 		if gotLines[i] != want[i] {
 			t.Fatalf("argv[%d] = %q, want %q", i, gotLines[i], want[i])
+		}
+	}
+	// Per #330, the safe profile MUST use `--sandbox workspace-write`
+	// rather than the deprecated `--full-auto` shorthand. Codex commit
+	// 3d10ba9f3 (openai/codex#20133) flagged `--full-auto` as deprecated
+	// in `codex exec`, prints a warning on every invocation, and codex-cli
+	// b7dba72db removed it at the top level entirely. Pin the new
+	// spelling here so a future "let's revert this one-liner" can't pass.
+	for _, line := range gotLines {
+		if line == "--full-auto" {
+			t.Fatalf("safe profile must not emit --full-auto; codex deprecated it (see #330): argv=%q", gotLines)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #330 — `codex exec --full-auto` is deprecated in codex CLI 0.133.0. Every safe-profile invocation prints `warning: --full-auto is deprecated; use --sandbox workspace-write instead.` to stderr, which then ends up in worker logs and the `runner_end output_head` payload.

## Authority confirmation

- **Codex CLI deprecation tests** ([`codex-rs/cli/src/main.rs:2574-2598`](https://github.com/openai/codex/blob/main/codex-rs/cli/src/main.rs)):
  - `full_auto_no_longer_parses_at_top_level` — top-level `--full-auto` is REMOVED entirely.
  - `exec_full_auto_reports_migration_path` — `codex exec --full-auto` still parses, only to emit `warning: --full-auto is deprecated; use --sandbox workspace-write instead.`
  - `sandbox_full_auto_no_longer_parses` — `codex sandbox --full-auto` is REMOVED.
- **Codex sandbox-mode resolution** ([`codex-rs/exec/src/lib.rs:285`](https://github.com/openai/codex/blob/main/codex-rs/exec/src/lib.rs)): `if removed_full_auto { Some(SandboxMode::WorkspaceWrite) }`. The new spelling and the deprecated flag resolve to **identical** sandbox semantics; this is a pure rename.
- **Deprecation commit**: `3d10ba9f3 chore(cli) deprecate --full-auto (openai/codex#20133)`.

## Changes

- `internal/runner/codex.go:107-119` — safe profile now invokes
  ```
  codex exec --sandbox workspace-write --skip-git-repo-check --cd <workdir> -o <last-message-path>
  ```
  instead of `--full-auto`. Doc-comment names the codex commit + PR + the resolving sandbox mode, so a future reader knows this isn't cosmetic.
- `bypass` profile uses `--dangerously-bypass-approvals-and-sandbox` and is unchanged.
- `internal/runner/codex_test.go` — update the expected argv in `TestCodexRunner_SafeProfileBuildsExpectedArgv`. Add a pinning assertion that explicitly rejects `--full-auto` in any argv slot so a future revert can't slip through.

## Verification

- ✅ `gofmt -l .` clean, `go vet ./...` clean.
- ✅ `go test -race -count=1 -timeout 5m ./...` 14/14 packages green.
- ✅ Mutation: re-injecting `--full-auto` (replace `--sandbox workspace-write` with `--full-auto` via `sed`) makes the safe-profile test fail with the exact argv-length diff (`7 want 8`) plus the new explicit `--full-auto must not appear` assertion. Both restore correctly.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 -timeout 5m ./...` all green
- [x] Mutation: revert flag → safe-profile test FAILS twice; restore → PASS
- [x] Authority-sourced doc comment cites codex commit `3d10ba9f3` + PR #20133 + the mapping at `codex-rs/exec/src/lib.rs:285`