### PR TITLE
fix(worker): SPEC §13.7.2 rate_limits always-present + running last_event_at (#328)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -607,18 +607,23 @@ func optionalStateRefreshFunc(refresh []stateRefreshFunc) stateRefreshFunc {
 }
 
 type apiStateResponse struct {
-	GeneratedAt                time.Time                       `json:"generated_at"`
-	PollIntervalMs             int64                           `json:"poll_interval_ms"`
-	MaxConcurrentAgents        int                             `json:"max_concurrent_agents"`
-	MaxConcurrentAgentsByState map[string]int                  `json:"max_concurrent_agents_by_state,omitempty"`
-	Counts                     apiStateCounts                  `json:"counts"`
-	Running                    []apiStateRunning               `json:"running"`
-	Blocked                    []apiStateBlocked               `json:"blocked"`
-	Retrying                   []apiStateRetry                 `json:"retrying"`
-	Completed                  []orchestrator.IssueID          `json:"completed"`
-	Failed                     []orchestrator.IssueID          `json:"failed"`
-	CodexTotals                apiCodexTotals                  `json:"codex_totals"`
-	RateLimits                 *orchestrator.RateLimitSnapshot `json:"rate_limits,omitempty"`
+	GeneratedAt                time.Time              `json:"generated_at"`
+	PollIntervalMs             int64                  `json:"poll_interval_ms"`
+	MaxConcurrentAgents        int                    `json:"max_concurrent_agents"`
+	MaxConcurrentAgentsByState map[string]int         `json:"max_concurrent_agents_by_state,omitempty"`
+	Counts                     apiStateCounts         `json:"counts"`
+	Running                    []apiStateRunning      `json:"running"`
+	Blocked                    []apiStateBlocked      `json:"blocked"`
+	Retrying                   []apiStateRetry        `json:"retrying"`
+	Completed                  []orchestrator.IssueID `json:"completed"`
+	Failed                     []orchestrator.IssueID `json:"failed"`
+	CodexTotals                apiCodexTotals         `json:"codex_totals"`
+	// RateLimits is the latest Codex rate-limit payload (SPEC §13.7.2). It
+	// is emitted unconditionally — `null` until a `rate_limit_updated`
+	// notification is observed — so operators can rely on the key always
+	// being present (upstream parity, #328). A nil snapshot marshals to
+	// JSON null, not an omitted key.
+	RateLimits *orchestrator.RateLimitSnapshot `json:"rate_limits"`
 }
 
 type apiCodexTotals struct {
@@ -674,7 +679,12 @@ type apiStateRunning struct {
 	// LastCodexAt is the SPEC §13.7.2 `last_event_at` value; the wire name
 	// `last_codex_at` is preserved for back-compat with existing dashboards
 	// (no fields removed per §13.7 "SHOULD avoid breaking existing fields").
+	// LastEventAt carries the same timestamp under the SPEC §13.7.2-canonical
+	// key so consumers reading the spec name find it (#328); both are emitted
+	// from the one source and are omitempty so a freshly-dispatched run with
+	// no observed event yet emits neither.
 	LastCodexAt       *time.Time       `json:"last_codex_at,omitempty"`
+	LastEventAt       *time.Time       `json:"last_event_at,omitempty"`
 	RetryAttempt      *int             `json:"retry_attempt,omitempty"`
 	WorkspacePath     string           `json:"workspace_path,omitempty"`
 	Tokens            apiRunningTokens `json:"tokens"`
@@ -961,6 +971,14 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 		v := row.LastCodexAt
 		lastCodexAt = &v
 	}
+	// last_event_at carries the same instant as last_codex_at under the
+	// SPEC §13.7.2-canonical key. Use a distinct pointer so a consumer
+	// mutating one decoded field cannot reach the other (#328).
+	var lastEventAt *time.Time
+	if lastCodexAt != nil {
+		v := *lastCodexAt
+		lastEventAt = &v
+	}
 	return apiStateRunning{
 		IssueID:       row.IssueID,
 		Identifier:    row.Identifier,
@@ -971,6 +989,7 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 		LastMessage:   redactStateAPILastMessage(row.LastMessage),
 		StartedAt:     startedAt,
 		LastCodexAt:   lastCodexAt,
+		LastEventAt:   lastEventAt,
 		RetryAttempt:  copyIntPointer(row.RetryAttempt),
 		WorkspacePath: row.WorkspacePath,
 		Tokens: apiRunningTokens{

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -78,6 +78,66 @@ func TestApiRunningRowAlwaysEmitsSpec13_7_2StatusKeys(t *testing.T) {
 	}
 }
 
+// TestApiRunningRowEmitsLastEventAtAliasingLastCodexAt pins the SPEC §13.7.2
+// running-row contract from #328: once a runtime event has been observed the
+// row exposes the spec-canonical `last_event_at` key carrying the same instant
+// as the back-compat `last_codex_at` key. Both share one source so they can
+// never disagree.
+func TestApiRunningRowEmitsLastEventAtAliasingLastCodexAt(t *testing.T) {
+	lastEvent := time.Date(2026, 5, 20, 9, 5, 30, 0, time.UTC)
+	row := apiRunningFromView(orchestrator.RunningView{
+		IssueID:     "issue-1",
+		Identifier:  "ENG-1",
+		LastCodexAt: lastEvent,
+	})
+	raw, err := json.Marshal(row)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	lastEventAt, ok := got["last_event_at"].(string)
+	if !ok {
+		t.Fatalf("last_event_at must be present once an event is observed: %s", raw)
+	}
+	lastCodexAt, ok := got["last_codex_at"].(string)
+	if !ok {
+		t.Fatalf("last_codex_at must remain present for back-compat: %s", raw)
+	}
+	if lastEventAt != lastCodexAt {
+		t.Fatalf("last_event_at = %q, last_codex_at = %q, want identical instants", lastEventAt, lastCodexAt)
+	}
+	if want := lastEvent.Format(time.RFC3339); lastEventAt != want {
+		t.Fatalf("last_event_at = %q, want %q (RFC3339 of source)", lastEventAt, want)
+	}
+}
+
+// TestStateResponseSurfacesObservedRateLimits pins the other half of #328:
+// once a rate_limit_updated payload has been recorded, /api/v1/state surfaces
+// it verbatim under the top-level rate_limits key.
+func TestStateResponseSurfacesObservedRateLimits(t *testing.T) {
+	snap := orchestrator.RateLimitSnapshot{"primary": map[string]any{"remaining": float64(42)}}
+	resp := apiStateFromView(orchestrator.StateView{CodexRateLimits: &snap})
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rateLimits, ok := got["rate_limits"].(map[string]any)
+	if !ok {
+		t.Fatalf("rate_limits = %#v, want observed payload object", got["rate_limits"])
+	}
+	primary, ok := rateLimits["primary"].(map[string]any)
+	if !ok || primary["remaining"] != float64(42) {
+		t.Fatalf("rate_limits = %#v, want primary.remaining surfaced verbatim", rateLimits)
+	}
+}
+
 func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 	generatedAt := time.Date(2026, 5, 20, 9, 30, 0, 0, time.UTC)
 	view := orchestrator.StateView{
@@ -237,6 +297,9 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 		if _, ok := rowObject["last_codex_at"]; ok {
 			t.Fatalf("zero last_codex_at should be omitted from running row: %#v", rowObject)
 		}
+		if _, ok := rowObject["last_event_at"]; ok {
+			t.Fatalf("zero last_event_at should be omitted from running row: %#v", rowObject)
+		}
 	}
 	rawBlocked, ok := raw["blocked"].([]any)
 	if !ok {
@@ -266,6 +329,16 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 		if _, ok := rowObject["due_at"]; ok {
 			t.Fatalf("zero due_at should be omitted from retry row: %#v", rowObject)
 		}
+	}
+	// rate_limits is emitted unconditionally per SPEC §13.7.2 (#328): the
+	// key must be present even when no rate-limit event has been observed,
+	// in which case it serializes to JSON null (not an omitted key).
+	rawRateLimits, ok := raw["rate_limits"]
+	if !ok {
+		t.Fatalf("rate_limits key must be present even when unobserved: %#v", raw)
+	}
+	if rawRateLimits != nil {
+		t.Fatalf("rate_limits = %#v, want null when no rate-limit event observed", rawRateLimits)
 	}
 }
 

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -121,6 +121,7 @@ the shape here without updating the handler — or vice versa — fails the buil
       "last_message": "Working on it...",
       "started_at": "2026-05-21T09:09:55Z",
       "last_codex_at": "2026-05-21T09:10:00Z",
+      "last_event_at": "2026-05-21T09:10:00Z",
       "retry_attempt": 1,
       "workspace_path": "/var/aiops/workspaces/acme/repo/issue-1",
       "tokens": {
@@ -162,7 +163,7 @@ the shape here without updating the handler — or vice versa — fails the buil
     "total_tokens": 0,
     "seconds_running": 0
   },
-  "rate_limits": {}
+  "rate_limits": null
 }
 ```
 
@@ -210,7 +211,10 @@ Two consequences for dashboard authors:
 - `poll_interval_ms` — current tracker poll interval (SPEC §13.7).
 - `max_concurrent_agents` — global concurrency cap.
 - `max_concurrent_agents_by_state` — optional per-tracker-state cap map; absent when no overrides set.
-- `rate_limits` — optional Codex rate-limit snapshot when one has been observed (omitted otherwise).
+- `rate_limits` — latest Codex rate-limit snapshot (SPEC §13.7.2). Always
+  present: `null` until a `rate_limit_updated` notification is observed, then
+  the payload verbatim. The key is never omitted, so dashboards can bind to it
+  unconditionally.
 
 ### Per-issue running row fields (SPEC §13.7.2)
 
@@ -230,6 +234,9 @@ Each entry in the `running` array follows SPEC §13.7.2:
 - `last_codex_at` — RFC3339 timestamp of the last observed runtime event,
   semantically the SPEC §13.7.2 `last_event_at`. The wire name `last_codex_at`
   is kept for back-compat with existing dashboards.
+- `last_event_at` — the same timestamp under the SPEC §13.7.2-canonical key,
+  emitted alongside `last_codex_at` for spec parity (#328). Like `last_codex_at`
+  it is absent until the runner emits its first event.
 - `retry_attempt` — retry attempt number when the dispatch is a retry; absent
   on the first run (SPEC §4.1.5 first-run semantic).
 - `workspace_path` — absolute path of the per-issue workspace.


### PR DESCRIPTION
Closes #328.

## Problem

`GET /api/v1/state` omits two SPEC §13.7.2 fields that upstream symphony/elixir exposes for the same orchestrator state:

1. **`rate_limits` (top-level)** — the field existed but was tagged `json:"rate_limits,omitempty"` on a `*RateLimitSnapshot`, so the key disappeared entirely until a `rate_limit_updated` notification had been observed. Operators couldn't bind to it to know when the coding agent is throttled.
2. **`last_event_at` (per running row)** — the last-event timestamp was emitted only under the back-compat wire name `last_codex_at`. The SPEC-canonical name `last_event_at` was absent, so consumers reading the spec name found nothing.

## Change

- Drop `omitempty` from `apiStateResponse.RateLimits` → the key is **always present**, serializing to `null` when no snapshot exists (matches upstream's behavior when no rate-limit event has been observed). When a payload is recorded it is surfaced verbatim.
- Add `LastEventAt *time.Time json:"last_event_at,omitempty"` to `apiStateRunning`, populated from the same source as `last_codex_at` (distinct pointer). `last_codex_at` is **retained** per §13.7 *"SHOULD avoid breaking existing fields"*. Both stay `omitempty`, so a freshly-dispatched run with no observed event yet emits neither (per the issue's no-event-yet note).

Scoped to the two fields the issue calls out; `worker_host` (shown in the issue's upstream diff but not requested) is out of scope.

## Tests
- Extended `TestStateHTTPHandlerReturnsRuntimeStateSnapshot`: asserts `rate_limits` is present-and-`null` with no snapshot, and `last_event_at` is omitted on a zero-timestamp running row.
- `TestApiRunningRowEmitsLastEventAtAliasingLastCodexAt`: once an event is observed, `last_event_at` == `last_codex_at` == RFC3339 of source.
- `TestStateResponseSurfacesObservedRateLimits`: a recorded snapshot is surfaced verbatim under `rate_limits`.

## Docs
`docs/runbooks/runtime-status.md` updated (example + field descriptions). The React dashboard (#337) already treats a falsy `rate_limits` as "no snapshot reported" and reads `last_codex_at`, so `null` is a no-op there.

`go build ./...`, `go vet ./cmd/worker/`, and `go test ./...` all green; `gofmt` clean.