### PR TITLE
chore: remove last_codex_at back-compat alias (#342)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ tmp/
 *.out
 *.pid
 *.tmp
+# Go binaries built at repo root (e.g. `go build ./cmd/worker/`)
+/worker
+/linear-poller
+/gitea-poller
 
 # Go test artifacts
 coverage.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,41 @@ go run ./cmd/worker --print-config /path/to/repo/clone
 
 Go toolchain: pinned via `go.mod` (Go 1.25). Don't edit `go.mod`'s `go` directive opportunistically.
 
+## Clean code (Robert C. Martin)
+
+These rules apply to every PR. The project is pre-release — the cost of doing
+it right is at its minimum now.
+
+1. **No technical debt by default.** "We'll clean it up later" is rarely true.
+   If a decision produces debt (duplicate fields, back-compat shims, dead code
+   paths), fix it before merging or open a tracking issue tagged
+   `area:tech-debt` with a concrete acceptance criteria. Do not merge both in
+   the same PR.
+
+2. **No unnecessary backward compatibility.** Pre-release means no external
+   users to protect. Remove old wire names, deprecated fields, and legacy code
+   paths outright rather than aliasing or dual-emitting. If a consumer inside
+   this repo uses an old name, update the consumer in the same PR.
+
+3. **One source of truth per concept.** Never emit the same data under two
+   keys or store the same value in two fields. When SPEC renames a concept
+   (e.g. `last_codex_at` → `last_event_at`), rename it everywhere — struct
+   field, JSON tag, dashboard, runbook, test — in a single atomic change.
+
+4. **Names must match the domain.** Internal Go identifiers should mirror the
+   SPEC vocabulary, not a historical implementation artefact. If SPEC says
+   `last_event_at`, the struct field is `LastEventAt`, not `LastCodexAt`.
+
+5. **Every comment explains *why*, not *what*.** A comment that restates what
+   the code already says is noise. Back-compat comments ("retained for
+   §13.7…") that outlive the back-compat code are doubly harmful — delete
+   both together.
+
+6. **Tests must assert the new code path.** A test that would pass even if the
+   feature were deleted is a placebo. After writing a test, do a quick mental
+   mutation (or literal sed) to confirm the test fails when the production code
+   is broken.
+
 ## Conventions
 
 - **gofmt is non-negotiable**: CI fails on any diff. Always run before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,40 +259,49 @@ go run ./cmd/worker --print-config /path/to/repo/clone
 
 Go toolchain: pinned via `go.mod` (Go 1.25). Don't edit `go.mod`'s `go` directive opportunistically.
 
-## Clean code (Robert C. Martin)
+## Clean code
 
 These rules apply to every PR. The project is pre-release — the cost of doing
-it right is at its minimum now.
+it right is at its minimum now. Each rule is earned by a specific observed
+failure per the "Earned rules" principle above.
 
-1. **No technical debt by default.** "We'll clean it up later" is rarely true.
-   If a decision produces debt (duplicate fields, back-compat shims, dead code
-   paths), fix it before merging or open a tracking issue tagged
-   `area:tech-debt` with a concrete acceptance criteria. Do not merge both in
-   the same PR.
+1. **No technical debt by default.** If a decision produces debt (duplicate
+   fields, back-compat shims, dead code paths), fix it before merging or open
+   a tracking issue tagged `area:tech-debt` with concrete acceptance criteria.
+   Do not merge both in the same PR. **Earned by:** PR #338 dual-emitting
+   `last_codex_at` + `last_event_at` and deferring removal; required a
+   separate cleanup PR #342.
 
 2. **No unnecessary backward compatibility.** Pre-release means no external
    users to protect. Remove old wire names, deprecated fields, and legacy code
    paths outright rather than aliasing or dual-emitting. If a consumer inside
-   this repo uses an old name, update the consumer in the same PR.
+   this repo uses an old name, update the consumer in the same PR. **Earned
+   by:** same as rule 1 (#338 / #342).
 
 3. **One source of truth per concept.** Never emit the same data under two
    keys or store the same value in two fields. When SPEC renames a concept
    (e.g. `last_codex_at` → `last_event_at`), rename it everywhere — struct
    field, JSON tag, dashboard, runbook, test — in a single atomic change.
+   **Earned by:** PR #342 audit found that the wire rename in #338 left the
+   internal `LastCodexAt` field untouched across four files, violating the
+   rule the PR itself introduced.
 
 4. **Names must match the domain.** Internal Go identifiers should mirror the
    SPEC vocabulary, not a historical implementation artefact. If SPEC says
    `last_event_at`, the struct field is `LastEventAt`, not `LastCodexAt`.
+   **Earned by:** same as rule 3 (#342 audit finding HIGH).
 
 5. **Every comment explains *why*, not *what*.** A comment that restates what
-   the code already says is noise. Back-compat comments ("retained for
-   §13.7…") that outlive the back-compat code are doubly harmful — delete
-   both together.
+   the code already says is noise. Back-compat comments ("retained for §13.7…")
+   that outlive the back-compat code are doubly harmful — delete both together.
+   **Earned by:** PR #338 left a five-line comment block explaining a
+   dual-field strategy that PR #342 then deleted.
 
 6. **Tests must assert the new code path.** A test that would pass even if the
-   feature were deleted is a placebo. After writing a test, do a quick mental
-   mutation (or literal sed) to confirm the test fails when the production code
-   is broken.
+   feature were deleted is a placebo. After writing a test, verify it fails
+   when the production code is broken (mutation or negative assertion). **Earned
+   by:** PR #342 audit (LOW) noted the back-compat test asserted `last_codex_at`
+   presence but not its absence after removal.
 
 ## Conventions
 

--- a/cmd/worker/dashboard/src/main.jsx
+++ b/cmd/worker/dashboard/src/main.jsx
@@ -132,7 +132,7 @@ function App() {
                 <td>{row.state || 'running'}</td>
                 <td><code>{row.session_id || 'n/a'}</code></td>
                 <td>{formatRuntime(row.started_at ? (Date.now() - new Date(row.started_at).getTime()) / 1000 : 0)} / {formatInt(row.turn_count)}</td>
-                <td>{row.last_message || row.last_event || 'n/a'}<br /><small>{formatDate(row.last_codex_at)}</small></td>
+                <td>{row.last_message || row.last_event || 'n/a'}<br /><small>{formatDate(row.last_event_at)}</small></td>
                 <td>Total {formatInt(row.tokens?.total_tokens)}<br /><small>In {formatInt(row.tokens?.input_tokens)} / Out {formatInt(row.tokens?.output_tokens)}</small></td>
               </tr>
             ))}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -959,8 +959,8 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 		startedAt = &v
 	}
 	var lastEventAt *time.Time
-	if !row.LastCodexAt.IsZero() {
-		v := row.LastCodexAt
+	if !row.LastEventAt.IsZero() {
+		v := row.LastEventAt
 		lastEventAt = &v
 	}
 	return apiStateRunning{
@@ -1044,8 +1044,8 @@ func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 			blockedAt = &v
 		}
 		var lastEventAt *time.Time
-		if !row.LastCodexAt.IsZero() {
-			v := row.LastCodexAt
+		if !row.LastEventAt.IsZero() {
+			v := row.LastEventAt
 			lastEventAt = &v
 		}
 		blocked = append(blocked, apiStateBlocked{

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -670,20 +670,12 @@ type apiStateRunning struct {
 	// `"last_message": ""` and `"turn_count": 7`, so a freshly-dispatched
 	// run with zero/empty values must still emit the keys. omitempty would
 	// let consumers confuse "known zero/empty" with "field missing".
-	State       string     `json:"state"`
-	SessionID   string     `json:"session_id"`
-	TurnCount   int        `json:"turn_count"`
-	LastEvent   string     `json:"last_event"`
-	LastMessage string     `json:"last_message"`
-	StartedAt   *time.Time `json:"started_at,omitempty"`
-	// LastCodexAt is the SPEC §13.7.2 `last_event_at` value; the wire name
-	// `last_codex_at` is preserved for back-compat with existing dashboards
-	// (no fields removed per §13.7 "SHOULD avoid breaking existing fields").
-	// LastEventAt carries the same timestamp under the SPEC §13.7.2-canonical
-	// key so consumers reading the spec name find it (#328); both are emitted
-	// from the one source and are omitempty so a freshly-dispatched run with
-	// no observed event yet emits neither.
-	LastCodexAt       *time.Time       `json:"last_codex_at,omitempty"`
+	State             string           `json:"state"`
+	SessionID         string           `json:"session_id"`
+	TurnCount         int              `json:"turn_count"`
+	LastEvent         string           `json:"last_event"`
+	LastMessage       string           `json:"last_message"`
+	StartedAt         *time.Time       `json:"started_at,omitempty"`
 	LastEventAt       *time.Time       `json:"last_event_at,omitempty"`
 	RetryAttempt      *int             `json:"retry_attempt,omitempty"`
 	WorkspacePath     string           `json:"workspace_path,omitempty"`
@@ -705,7 +697,7 @@ type apiStateBlocked struct {
 	BlockedAt         *time.Time           `json:"blocked_at,omitempty"`
 	WorkspacePath     string               `json:"workspace_path,omitempty"`
 	SessionID         string               `json:"session_id,omitempty"`
-	LastCodexAt       *time.Time           `json:"last_codex_at,omitempty"`
+	LastEventAt       *time.Time           `json:"last_event_at,omitempty"`
 	Method            string               `json:"method,omitempty"`
 	Error             string               `json:"error,omitempty"`
 	CodexAppServerPID int                  `json:"codex_app_server_pid,omitempty"`
@@ -966,17 +958,9 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 		v := row.StartedAt
 		startedAt = &v
 	}
-	var lastCodexAt *time.Time
+	var lastEventAt *time.Time
 	if !row.LastCodexAt.IsZero() {
 		v := row.LastCodexAt
-		lastCodexAt = &v
-	}
-	// last_event_at carries the same instant as last_codex_at under the
-	// SPEC §13.7.2-canonical key. Use a distinct pointer so a consumer
-	// mutating one decoded field cannot reach the other (#328).
-	var lastEventAt *time.Time
-	if lastCodexAt != nil {
-		v := *lastCodexAt
 		lastEventAt = &v
 	}
 	return apiStateRunning{
@@ -988,7 +972,6 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 		LastEvent:     row.LastEvent,
 		LastMessage:   redactStateAPILastMessage(row.LastMessage),
 		StartedAt:     startedAt,
-		LastCodexAt:   lastCodexAt,
 		LastEventAt:   lastEventAt,
 		RetryAttempt:  copyIntPointer(row.RetryAttempt),
 		WorkspacePath: row.WorkspacePath,
@@ -1060,10 +1043,10 @@ func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 			v := row.BlockedAt
 			blockedAt = &v
 		}
-		var lastCodexAt *time.Time
+		var lastEventAt *time.Time
 		if !row.LastCodexAt.IsZero() {
 			v := row.LastCodexAt
-			lastCodexAt = &v
+			lastEventAt = &v
 		}
 		blocked = append(blocked, apiStateBlocked{
 			IssueID:           row.IssueID,
@@ -1072,7 +1055,7 @@ func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 			BlockedAt:         blockedAt,
 			WorkspacePath:     row.WorkspacePath,
 			SessionID:         row.SessionID,
-			LastCodexAt:       lastCodexAt,
+			LastEventAt:       lastEventAt,
 			Method:            row.Method,
 			Error:             row.Error,
 			CodexAppServerPID: row.CodexAppServerPID,

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -78,12 +78,10 @@ func TestApiRunningRowAlwaysEmitsSpec13_7_2StatusKeys(t *testing.T) {
 	}
 }
 
-// TestApiRunningRowEmitsLastEventAtAliasingLastCodexAt pins the SPEC §13.7.2
-// running-row contract from #328: once a runtime event has been observed the
-// row exposes the spec-canonical `last_event_at` key carrying the same instant
-// as the back-compat `last_codex_at` key. Both share one source so they can
-// never disagree.
-func TestApiRunningRowEmitsLastEventAtAliasingLastCodexAt(t *testing.T) {
+// TestApiRunningRowEmitsLastEventAt pins the SPEC §13.7.2 running-row
+// contract: once a runtime event has been observed the row exposes
+// last_event_at as an RFC3339 string; no back-compat alias is emitted.
+func TestApiRunningRowEmitsLastEventAt(t *testing.T) {
 	lastEvent := time.Date(2026, 5, 20, 9, 5, 30, 0, time.UTC)
 	row := apiRunningFromView(orchestrator.RunningView{
 		IssueID:     "issue-1",
@@ -102,12 +100,8 @@ func TestApiRunningRowEmitsLastEventAtAliasingLastCodexAt(t *testing.T) {
 	if !ok {
 		t.Fatalf("last_event_at must be present once an event is observed: %s", raw)
 	}
-	lastCodexAt, ok := got["last_codex_at"].(string)
-	if !ok {
-		t.Fatalf("last_codex_at must remain present for back-compat: %s", raw)
-	}
-	if lastEventAt != lastCodexAt {
-		t.Fatalf("last_event_at = %q, last_codex_at = %q, want identical instants", lastEventAt, lastCodexAt)
+	if _, exists := got["last_codex_at"]; exists {
+		t.Fatalf("last_codex_at must not be emitted (removed in #342): %s", raw)
 	}
 	if want := lastEvent.Format(time.RFC3339); lastEventAt != want {
 		t.Fatalf("last_event_at = %q, want %q (RFC3339 of source)", lastEventAt, want)
@@ -294,9 +288,6 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 		if _, ok := rowObject["started_at"]; ok {
 			t.Fatalf("zero started_at should be omitted from running row: %#v", rowObject)
 		}
-		if _, ok := rowObject["last_codex_at"]; ok {
-			t.Fatalf("zero last_codex_at should be omitted from running row: %#v", rowObject)
-		}
 		if _, ok := rowObject["last_event_at"]; ok {
 			t.Fatalf("zero last_event_at should be omitted from running row: %#v", rowObject)
 		}
@@ -313,8 +304,8 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 		if _, ok := rowObject["blocked_at"]; ok {
 			t.Fatalf("zero blocked_at should be omitted from blocked row: %#v", rowObject)
 		}
-		if _, ok := rowObject["last_codex_at"]; ok {
-			t.Fatalf("zero last_codex_at should be omitted from blocked row: %#v", rowObject)
+		if _, ok := rowObject["last_event_at"]; ok {
+			t.Fatalf("zero last_event_at should be omitted from blocked row: %#v", rowObject)
 		}
 	}
 	rawRetrying, ok := raw["retrying"].([]any)

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -86,7 +86,7 @@ func TestApiRunningRowEmitsLastEventAt(t *testing.T) {
 	row := apiRunningFromView(orchestrator.RunningView{
 		IssueID:     "issue-1",
 		Identifier:  "ENG-1",
-		LastCodexAt: lastEvent,
+		LastEventAt: lastEvent,
 	})
 	raw, err := json.Marshal(row)
 	if err != nil {

--- a/cmd/worker/runbook_drift_test.go
+++ b/cmd/worker/runbook_drift_test.go
@@ -86,7 +86,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 	t.Helper()
 	startedAt := time.Date(2026, 5, 21, 9, 9, 55, 0, time.UTC)
 	blockedAt := time.Date(2026, 5, 20, 6, 5, 38, 0, time.UTC)
-	lastCodexAt := time.Date(2026, 5, 21, 9, 10, 0, 0, time.UTC)
+	lastEventAt := time.Date(2026, 5, 21, 9, 10, 0, 0, time.UTC)
 	dueAt := time.Date(2026, 5, 21, 9, 11, 0, 0, time.UTC)
 	retryAttempt := 1
 	resp := apiStateResponse{
@@ -112,7 +112,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 			LastEvent:     "turn_completed",
 			LastMessage:   "Working on it...",
 			StartedAt:     &startedAt,
-			LastCodexAt:   &lastCodexAt,
+			LastEventAt:   &lastEventAt,
 			RetryAttempt:  &retryAttempt,
 			WorkspacePath: "/var/aiops/workspaces/acme/repo/issue-1",
 			Tokens: apiRunningTokens{
@@ -129,7 +129,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 			BlockedAt:         &blockedAt,
 			WorkspacePath:     "/var/aiops/workspaces/acme/repo/issue-2",
 			SessionID:         "thread-1-turn-1",
-			LastCodexAt:       &lastCodexAt,
+			LastEventAt:       &lastEventAt,
 			Method:            "mcpServer/elicitation/request",
 			Error:             "input required: mcpServer/elicitation/request",
 			CodexAppServerPID: 67890,

--- a/docs/design/d21-d6-orchestrator-state.md
+++ b/docs/design/d21-d6-orchestrator-state.md
@@ -120,7 +120,7 @@ type RunningEntry struct {
 
     // §4.1.6 live-session fields, populated by D1's app-server client.
     Session     LiveSession
-    LastCodexAt time.Time                              // §8.5 Part A input (D14)
+    LastEventAt time.Time                              // §8.5 Part A input (D14)
 
     // Handles for reconciliation termination (§8.5 Part B).
     CancelWorker context.CancelFunc
@@ -156,7 +156,7 @@ client can fill them without another type churn.
 | Reconciliation: tracker state terminal (§8.5 Part B) | `CancelWorker()`; workspace cleanup queued; `Claimed[id]` + `RetryAttempts[id]` removed |
 | Reconciliation: tracker state non-active, non-terminal (§8.5 Part B) | `CancelWorker()` without workspace cleanup; `Claimed[id]` removed |
 | Stall detected (§8.5 Part A) | `CancelWorker()`; treated as abnormal exit. **Deferred to D14**; hook is no-op here. |
-| Codex update event (§7.3) | `Running[id].LastCodexAt = now()`; tokens / rate-limit updated. **Deferred to D1**; channel exists, no producer yet. |
+| Codex update event (§7.3) | `Running[id].LastEventAt = now()`; tokens / rate-limit updated. **Deferred to D1**; channel exists, no producer yet. |
 
 `Completed` is bookkeeping only per §4.1.8 — never read for dispatch gating.
 

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -120,7 +120,6 @@ the shape here without updating the handler — or vice versa — fails the buil
       "last_event": "turn_completed",
       "last_message": "Working on it...",
       "started_at": "2026-05-21T09:09:55Z",
-      "last_codex_at": "2026-05-21T09:10:00Z",
       "last_event_at": "2026-05-21T09:10:00Z",
       "retry_attempt": 1,
       "workspace_path": "/var/aiops/workspaces/acme/repo/issue-1",
@@ -140,7 +139,7 @@ the shape here without updating the handler — or vice versa — fails the buil
       "blocked_at": "2026-05-20T06:05:38Z",
       "workspace_path": "/var/aiops/workspaces/acme/repo/issue-2",
       "session_id": "thread-1-turn-1",
-      "last_codex_at": "2026-05-20T06:05:30Z",
+      "last_event_at": "2026-05-20T06:05:30Z",
       "method": "mcpServer/elicitation/request",
       "error": "input required: mcpServer/elicitation/request",
       "codex_app_server_pid": 67890
@@ -231,12 +230,8 @@ Each entry in the `running` array follows SPEC §13.7.2:
 - `last_message` — the most-recent `payload.message` string from a runtime
   event; sticky across later events that do not include one.
 - `started_at` — RFC3339 timestamp the worker spawned at.
-- `last_codex_at` — RFC3339 timestamp of the last observed runtime event,
-  semantically the SPEC §13.7.2 `last_event_at`. The wire name `last_codex_at`
-  is kept for back-compat with existing dashboards.
-- `last_event_at` — the same timestamp under the SPEC §13.7.2-canonical key,
-  emitted alongside `last_codex_at` for spec parity (#328). Like `last_codex_at`
-  it is absent until the runner emits its first event.
+- `last_event_at` — RFC3339 timestamp of the last observed runtime event
+  (SPEC §13.7.2). Absent until the runner emits its first event.
 - `retry_attempt` — retry attempt number when the dispatch is a retry; absent
   on the first run (SPEC §4.1.5 first-run semantic).
 - `workspace_path` — absolute path of the per-issue workspace.

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -649,7 +649,7 @@ func (o *Orchestrator) ReconcileTrackerIssues(ctx context.Context, issuesByID ma
 
 // ReconcileStalledRuns implements SPEC §8.5 Part A / §16.3
 // reconcile_stalled_runs: for each running issue compute elapsed time
-// since the last observed runtime event (RunningEntry.LastCodexAt,
+// since the last observed runtime event (RunningEntry.LastEventAt,
 // falling back to StartedAt before any event has been seen) and, if it
 // exceeds stallTimeoutMs, cancel the worker so the finalize path
 // schedules a retry. stallTimeoutMs <= 0 skips detection entirely (SPEC
@@ -658,7 +658,7 @@ func (o *Orchestrator) ReconcileTrackerIssues(ctx context.Context, issuesByID ma
 // The Codex app-server runner has its own self-stall detection; this
 // orchestrator-side path closes the gap when the runner goroutine itself
 // wedges or when a non-Codex runner (mock, codex exec) produces no
-// StallError. Without this an issue with `LastCodexAt` long in the past
+// StallError. Without this an issue with `LastEventAt` long in the past
 // would stay claimed forever.
 //
 // wait is the per-tick budget for waiting on cancelled worker
@@ -921,7 +921,7 @@ func (r *runningRetryingAndBlockedIssueIDsOp) apply(st *OrchestratorState) func(
 }
 
 // reconcileStalledRunsOp is the actor-side handler for SPEC §8.5 Part A.
-// It scans st.Running for entries whose LastCodexAt (or StartedAt when no
+// It scans st.Running for entries whose LastEventAt (or StartedAt when no
 // runtime event has been observed yet) is older than the configured
 // stall budget and cancels the worker. The entry stays Claimed: the
 // finalize op observes the canceled ctx as a worker failure and schedules
@@ -936,7 +936,7 @@ type reconcileStalledRunsOp struct {
 func (r *reconcileStalledRunsOp) apply(st *OrchestratorState) func() {
 	var canceled []*RunningEntry
 	for id, run := range st.Running {
-		ref := run.LastCodexAt
+		ref := run.LastEventAt
 		if ref.IsZero() {
 			ref = run.StartedAt
 		}

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -326,7 +326,7 @@ func TestScheduleRetry_TimerFireProducesExactlyOneReDispatch(t *testing.T) {
 }
 
 // TestReconcileStalledRunsCancelsWorkerPastTimeout pins SPEC §8.5 Part A:
-// a running entry whose LastCodexAt is older than the configured stall
+// a running entry whose LastEventAt is older than the configured stall
 // budget gets its worker context cancelled, and the finalize path treats
 // the resulting context.Canceled as a normal worker failure (claim
 // retained, retry scheduled), NOT as a reconciled cancel.
@@ -341,10 +341,10 @@ func TestReconcileStalledRunsCancelsWorkerPastTimeout(t *testing.T) {
 	}
 	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
 
-	// Force the running entry's LastCodexAt into the past so the stall
+	// Force the running entry's LastEventAt into the past so the stall
 	// budget (100ms) is comfortably exceeded.
 	o.WithStateForTest(func(st *OrchestratorState) {
-		st.Running["STALL-1"].LastCodexAt = time.Now().Add(-10 * time.Second)
+		st.Running["STALL-1"].LastEventAt = time.Now().Add(-10 * time.Second)
 	})
 
 	if err := o.ReconcileStalledRuns(context.Background(), 100, 0); err != nil {
@@ -359,7 +359,7 @@ func TestReconcileStalledRunsCancelsWorkerPastTimeout(t *testing.T) {
 }
 
 // TestReconcileStalledRunsLeavesActiveRunsAlone pins the no-false-positive
-// invariant: an entry with a recent LastCodexAt must not be cancelled
+// invariant: an entry with a recent LastEventAt must not be cancelled
 // even when the stall budget is small.
 func TestReconcileStalledRunsLeavesActiveRunsAlone(t *testing.T) {
 	disp := &fakeDispatcher{}
@@ -373,7 +373,7 @@ func TestReconcileStalledRunsLeavesActiveRunsAlone(t *testing.T) {
 	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
 
 	o.WithStateForTest(func(st *OrchestratorState) {
-		st.Running["ACTIVE-1"].LastCodexAt = time.Now()
+		st.Running["ACTIVE-1"].LastEventAt = time.Now()
 	})
 
 	if err := o.ReconcileStalledRuns(context.Background(), 5_000, 0); err != nil {
@@ -382,7 +382,7 @@ func TestReconcileStalledRunsLeavesActiveRunsAlone(t *testing.T) {
 
 	select {
 	case <-disp.contextAt(0).Done():
-		t.Fatal("active worker context was cancelled even though LastCodexAt is recent")
+		t.Fatal("active worker context was cancelled even though LastEventAt is recent")
 	case <-time.After(100 * time.Millisecond):
 		// Expected — context still live.
 	}
@@ -401,10 +401,10 @@ func TestReconcileStalledRunsSkipsWhenTimeoutDisabled(t *testing.T) {
 	}
 	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
 
-	// Even with an ancient LastCodexAt, stall detection is a no-op when
+	// Even with an ancient LastEventAt, stall detection is a no-op when
 	// the budget is 0.
 	o.WithStateForTest(func(st *OrchestratorState) {
-		st.Running["OFF-1"].LastCodexAt = time.Now().Add(-10 * time.Second)
+		st.Running["OFF-1"].LastEventAt = time.Now().Add(-10 * time.Second)
 	})
 	if err := o.ReconcileStalledRuns(context.Background(), 0, 0); err != nil {
 		t.Fatalf("ReconcileStalledRuns: %v", err)
@@ -935,8 +935,8 @@ func TestRecordRuntimeEventUpdatesCodexTotalsAndRateLimits(t *testing.T) {
 	if view.CodexTotals.InputTokens != 11 || view.CodexTotals.OutputTokens != 13 || view.CodexTotals.TotalTokens != 24 {
 		t.Fatalf("CodexTotals = %+v, want cumulative absolute telemetry totals", view.CodexTotals)
 	}
-	if len(view.Running) != 1 || view.Running[0].LastCodexAt.IsZero() {
-		t.Fatalf("Running LastCodexAt not updated from runtime event: %+v", view.Running)
+	if len(view.Running) != 1 || view.Running[0].LastEventAt.IsZero() {
+		t.Fatalf("Running LastEventAt not updated from runtime event: %+v", view.Running)
 	}
 	if view.CodexRateLimits == nil {
 		t.Fatal("CodexRateLimits = nil, want latest rate_limits payload")

--- a/internal/orchestrator/export_test.go
+++ b/internal/orchestrator/export_test.go
@@ -3,7 +3,7 @@ package orchestrator
 import "context"
 
 // WithStateForTest runs fn against OrchestratorState on the actor goroutine.
-// Test-only helper for surgical mutations (e.g. backdating LastCodexAt to
+// Test-only helper for surgical mutations (e.g. backdating LastEventAt to
 // trigger a stall reconciliation without sleeping for the full budget).
 // Production code must go through the typed op surface.
 func (o *Orchestrator) WithStateForTest(fn func(*OrchestratorState)) {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -988,7 +988,7 @@ func TestPollOnceContinuesReconciliationWhenStalledRunCleanupTimesOut(t *testing
 	// dispatcher never closes its done channel, so the cancel-wait times
 	// out with context.DeadlineExceeded.
 	orch.WithStateForTest(func(st *OrchestratorState) {
-		st.Running["wedged"].LastCodexAt = time.Now().Add(-10 * time.Second)
+		st.Running["wedged"].LastEventAt = time.Now().Add(-10 * time.Second)
 	})
 
 	// Move the unrelated "movable" run to Cancelled. Part B must still

--- a/internal/orchestrator/runtime_events.go
+++ b/internal/orchestrator/runtime_events.go
@@ -63,7 +63,7 @@ func (s *OrchestratorState) recordRuntimeEvent(run *RunningEntry, event task.Run
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	run.LastCodexAt = now
+	run.LastEventAt = now
 	run.LastCodexEvent = event.Event
 	if payload, ok := asStringMap(event.Payload); ok {
 		if msg, ok := stringField(payload, "message"); ok {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -112,7 +112,7 @@ type RunningEntry struct {
 	Workspace           Workspace
 
 	Session     LiveSession
-	LastCodexAt time.Time // SPEC §8.5 Part A input (D14)
+	LastEventAt time.Time // SPEC §8.5 Part A input (D14)
 	// LastCodexEvent is the most-recent runtime event kind (e.g.
 	// "turn_completed", "notification") folded from the worker's runtime
 	// event stream; SPEC §13.7.2 surfaces it as `last_event`.
@@ -153,7 +153,7 @@ type BlockedEntry struct {
 	BlockedAt   time.Time
 	Workspace   Workspace
 	Session     LiveSession
-	LastCodexAt time.Time
+	LastEventAt time.Time
 	Method      string
 	Error       string
 }
@@ -544,7 +544,7 @@ func (s *OrchestratorState) BlockRun(id IssueID, run *RunningEntry, blockedAt ti
 		BlockedAt:   blockedAt,
 		Workspace:   run.Workspace,
 		Session:     run.Session,
-		LastCodexAt: run.LastCodexAt,
+		LastEventAt: run.LastEventAt,
 		Method:      run.InputRequiredMethod,
 		Error:       runErr,
 	}
@@ -684,7 +684,7 @@ type RunningView struct {
 	LastEvent         string
 	LastMessage       string
 	StartedAt         time.Time
-	LastCodexAt       time.Time
+	LastEventAt       time.Time
 	RetryAttempt      *int
 	WorkspacePath     string
 	Tokens            TokensView
@@ -708,7 +708,7 @@ type BlockedView struct {
 	BlockedAt         time.Time
 	WorkspacePath     string
 	SessionID         string
-	LastCodexAt       time.Time
+	LastEventAt       time.Time
 	Method            string
 	Error             string
 	CodexAppServerPID int
@@ -794,7 +794,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 			LastEvent:     r.LastCodexEvent,
 			LastMessage:   r.LastCodexMessage,
 			StartedAt:     r.StartedAt,
-			LastCodexAt:   r.LastCodexAt,
+			LastEventAt:   r.LastEventAt,
 			RetryAttempt:  retryAttempt,
 			WorkspacePath: r.Workspace.Path,
 			Tokens: TokensView{
@@ -813,7 +813,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 			BlockedAt:         b.BlockedAt,
 			WorkspacePath:     b.Workspace.Path,
 			SessionID:         b.Session.SessionID,
-			LastCodexAt:       b.LastCodexAt,
+			LastEventAt:       b.LastEventAt,
 			Method:            b.Method,
 			Error:             b.Error,
 			CodexAppServerPID: b.Session.CodexAppServerPID,


### PR DESCRIPTION
Closes #342.

## Problem

PR #338 added `last_event_at` (SPEC §13.7.2-canonical) but retained `last_codex_at` as a back-compat alias for the React dashboard. This produced two wire fields always carrying the same value — a DRY violation the PR itself flagged as technical debt.

The project is pre-release (AGENTS.md: "there are no users to migrate, so the cost of aligning with SPEC is at its minimum right now"). There is no valid reason to keep the alias.

## Change

- **`apiStateRunning`**: `LastCodexAt` field and `last_codex_at` JSON key removed. `LastEventAt` / `last_event_at` is the sole field.
- **`apiStateBlocked`**: same — `LastCodexAt` → `LastEventAt` (json: `last_event_at`).
- **`apiRunningFromView`**: collapse the two-pointer dance into a single `lastEventAt` populated directly from `row.LastCodexAt`; remove back-compat comment.
- **`apiStateFromView`** (blocked loop): same rename.
- **Dashboard** (`cmd/worker/dashboard/src/main.jsx`): reads `last_event_at`.
- **Runbook** (`docs/runbooks/runtime-status.md`): example and field table cleaned to `last_event_at` only.
- **`AGENTS.md`**: new "Clean code" section (Robert C. Martin) — no tech debt, no unnecessary back-compat, one source of truth per concept, names must match the domain, comments explain why not what, tests must not be placebos.

## Tests

- `TestApiRunningRowEmitsLastEventAt` (renamed from `…AliasingLastCodexAt`): asserts `last_event_at` is present and `last_codex_at` is absent.
- `TestStateHTTPHandlerReturnsRuntimeStateSnapshot`: back-compat `last_codex_at` assertion removed from running and blocked rows; `last_event_at` zero-omit check retained.
- `TestRuntimeStatusRunbookExampleMatchesHandler`: drift test passes with `LastEventAt` in `fullyPopulatedAPIStateResponseJSON`.

`go build ./...`, `go vet ./cmd/worker/`, `go test -race ./...` all green; `gofmt` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoA7PJCKLh9H2EHePZXuju)_