### PR TITLE
Add SessionStart gh installer + gofmt PostToolUse hook for web sessions

### DIFF
--- a/.claude/scripts/format-go.sh
+++ b/.claude/scripts/format-go.sh
@@ -17,7 +17,8 @@ if ! command -v jq > /dev/null 2>&1; then
 fi
 
 # PostToolUse delivers {"tool_name":...,"tool_input":{"file_path":...},...} on stdin.
-file="$(cat | jq -r '.tool_input.file_path // empty')"
+# Tolerate unexpected/non-JSON stdin: stay silent and exit 0 rather than erroring.
+file="$(cat | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
 
 # Only touch existing .go files; anything else is none of gofmt's business.
 [[ -n "${file}" && "${file}" == *.go && -f "${file}" ]] || exit 0

--- a/.claude/scripts/format-go.sh
+++ b/.claude/scripts/format-go.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+##
+# PostToolUse Hook: gofmt edited Go files
+#
+# Official docs: https://code.claude.com/docs/en/hooks#posttooluse
+#
+# Triggered after Edit/Write. Runs `gofmt -w` on the edited file so it always
+# matches the CI gate (`gofmt -l` must be empty; see AGENTS.md "Build, test,
+# lint"). Silent and non-blocking: always exits 0 so it never nags or blocks.
+##
+
+set -euo pipefail
+
+# jq parses the hook's stdin JSON; without it we can't find the file, so skip.
+if ! command -v jq > /dev/null 2>&1; then
+  exit 0
+fi
+
+# PostToolUse delivers {"tool_name":...,"tool_input":{"file_path":...},...} on stdin.
+file="$(cat | jq -r '.tool_input.file_path // empty')"
+
+# Only touch existing .go files; anything else is none of gofmt's business.
+[[ -n "${file}" && "${file}" == *.go && -f "${file}" ]] || exit 0
+
+if command -v gofmt > /dev/null 2>&1; then
+  # Swallow errors: a mid-edit syntax error is surfaced later by build/test,
+  # not something this formatting hook should block on.
+  gofmt -w "${file}" > /dev/null 2>&1 || true
+fi
+
+exit 0

--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+##
+# SessionStart Hook for aiops-platform
+#
+# Runs automatically when a Claude Code session starts. In the remote/cloud/web
+# container environment it installs the GitHub CLI (gh), which the project
+# prefers over the GitHub MCP server for GitHub interactions (see AGENTS.md).
+#
+# Trigger: Only on 'startup' events (matcher configured in .claude/settings.json).
+#
+# Environment Detection:
+# - CLAUDE_CODE_REMOTE=true: web/cloud/mobile container -> auto-install gh
+# - CLAUDE_CODE_REMOTE=false or unset: local desktop -> skip auto-install
+##
+
+set -euo pipefail
+
+echo "[SessionStart] Initializing environment..." >&2
+
+# Detect the Claude Code remote/cloud/web container environment.
+is_remote_environment() {
+  [[ "${CLAUDE_CODE_REMOTE:-false}" == "true" ]]
+}
+
+# Only auto-install in the remote container; never touch a local desktop machine.
+if ! is_remote_environment; then
+  echo "[SessionStart] Local environment detected, skipping gh auto-installation" >&2
+  echo "[SessionStart] To install gh manually: https://github.com/cli/cli#installation" >&2
+  exit 0
+fi
+
+echo "[SessionStart] Remote/cloud environment detected, ensuring gh is available..." >&2
+
+# Ensure ~/.local/bin exists and is on PATH for this and subsequent commands.
+mkdir -p "${HOME}/.local/bin"
+export PATH="${HOME}/.local/bin:${PATH}"
+
+# Persist PATH for subsequent commands in the session via CLAUDE_ENV_FILE.
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+  echo "export PATH=\"\${HOME}/.local/bin:\${PATH}\"" >> "${CLAUDE_ENV_FILE}"
+  echo "[SessionStart] PATH persisted to CLAUDE_ENV_FILE" >&2
+fi
+
+# Install GitHub CLI (gh) - official precompiled binary.
+# Ref: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+# Using the official binary release (not a distro package, which can lag behind).
+install_gh() {
+  local target="${HOME}/.local/bin/gh"
+
+  # Skip if already installed.
+  if command -v gh > /dev/null 2>&1; then
+    echo "[SessionStart] gh already installed ($(gh --version 2>&1 | head -1 || echo 'unknown'))" >&2
+    return 0
+  fi
+
+  # Resolve the latest release tag from the GitHub API.
+  local gh_version
+  gh_version="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest \
+    | grep -o '"tag_name":\s*"v[^"]*"' | head -1 | grep -o 'v[^"]*')"
+
+  if [[ -z "${gh_version}" ]]; then
+    echo "[SessionStart] Failed to determine latest gh version" >&2
+    return 1
+  fi
+
+  # Strip the leading 'v' for the download URL path.
+  local ver="${gh_version#v}"
+
+  # Map host architecture to gh's release naming.
+  local arch
+  case "$(uname -m)" in
+    x86_64) arch="amd64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    armv6*) arch="armv6" ;;
+    i386 | i686) arch="386" ;;
+    *)
+      echo "[SessionStart] Unsupported architecture: $(uname -m)" >&2
+      return 1
+      ;;
+  esac
+
+  echo "[SessionStart] Installing gh ${gh_version} (latest, linux/${arch})..." >&2
+
+  local tmp_dir="/tmp/gh-$$"
+  mkdir -p "${tmp_dir}"
+
+  if curl -fsSL -o "${tmp_dir}/gh.tar.gz" \
+    "https://github.com/cli/cli/releases/download/${gh_version}/gh_${ver}_linux_${arch}.tar.gz"; then
+    tar -xzf "${tmp_dir}/gh.tar.gz" -C "${tmp_dir}"
+    mv "${tmp_dir}/gh_${ver}_linux_${arch}/bin/gh" "${target}"
+    chmod +x "${target}"
+    rm -rf "${tmp_dir}"
+    echo "[SessionStart] gh ${gh_version} installed successfully" >&2
+
+    # Report auth status; gh picks up GH_TOKEN / GITHUB_TOKEN from the environment.
+    if gh auth status > /dev/null 2>&1; then
+      echo "[SessionStart] gh already authenticated" >&2
+    elif [[ -n "${GH_TOKEN:-}" ]] || [[ -n "${GITHUB_TOKEN:-}" ]]; then
+      echo "[SessionStart] gh authenticated via environment token" >&2
+    else
+      echo "[SessionStart] gh installed but no token found for authentication" >&2
+    fi
+    return 0
+  else
+    echo "[SessionStart] Failed to install gh" >&2
+    rm -rf "${tmp_dir}"
+    return 1
+  fi
+}
+
+install_gh
+
+# Verify installation.
+echo "[SessionStart] Tooling ready:" >&2
+command -v gh > /dev/null 2>&1 && echo "  ✓ gh $(gh --version 2>&1 | head -1)" >&2
+
+echo "[SessionStart] Environment initialized successfully" >&2

--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -53,13 +53,18 @@ install_gh() {
     return 0
   fi
 
-  # Resolve the latest release tag from the GitHub API.
-  local gh_version
-  gh_version="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest \
-    | grep -o '"tag_name":\s*"v[^"]*"' | head -1 | grep -o 'v[^"]*')"
+  # Resolve the latest release tag from the GitHub API. The trailing `|| true`
+  # keeps a transient failure (network, unauthenticated rate limit) from
+  # tripping `set -e` so the empty-check below can report it; `head` is last
+  # in the pipeline to avoid a SIGPIPE-induced non-zero status under pipefail.
+  local gh_version=""
+  gh_version="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null \
+    | grep -o '"tag_name":[[:space:]]*"v[^"]*"' \
+    | grep -o 'v[0-9][^"]*' \
+    | head -1)" || true
 
   if [[ -z "${gh_version}" ]]; then
-    echo "[SessionStart] Failed to determine latest gh version" >&2
+    echo "[SessionStart] Could not determine latest gh version (network or API rate limit); skipping gh install" >&2
     return 1
   fi
 
@@ -108,7 +113,12 @@ install_gh() {
   fi
 }
 
-install_gh
+# Run in a subshell so any failure inside install_gh (including a `set -e`
+# abort) degrades gracefully instead of failing the whole SessionStart hook.
+# Agents fall back to the GitHub MCP server when gh is unavailable (AGENTS.md).
+if ! ( install_gh ); then
+  echo "[SessionStart] gh not installed; agents will fall back to the GitHub MCP server" >&2
+fi
 
 # Verify installation.
 echo "[SessionStart] Tooling ready:" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/format-go.sh",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/session-start.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,12 @@ coverage.out
 # Local Claude Code state (worktrees, plugin cache, transcripts).
 # Project skills under .claude/skills/ are version-controlled per
 # https://code.claude.com/docs/en/skills "Share skills → Project skills".
+# Shared project hooks/settings are version-controlled so web sessions
+# pick them up; everything else under .claude/ stays local.
 .claude/*
 !.claude/skills/
+!.claude/scripts/
+!.claude/settings.json
 
 # Local Codex CLI config (machine/user-specific model + reasoning overrides);
 # never repo policy, so keep it out of version control.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,7 +305,7 @@ failure per the "Earned rules" principle above.
 
 ## Conventions
 
-- **gofmt is non-negotiable**: CI fails on any diff. Always run before committing. A PostToolUse hook (`.claude/scripts/format-go.sh`) auto-runs `gofmt -w` on every edited `.go` file, but still verify with `gofmt -l` before pushing.
+- **gofmt is non-negotiable**: CI fails on any diff. Always run before committing. A PostToolUse hook (`.claude/scripts/format-go.sh`) auto-runs `gofmt -w` on `.go` files edited via the Edit/Write tools; files changed through Bash (e.g. `sed`, heredocs) are not covered, so always verify with `gofmt -l` before pushing — CI's `gofmt -l` gate is the backstop.
 - **`go mod tidy` must leave `go.mod`/`go.sum` clean**: don't add deps you don't use.
 - **No `t.Parallel()` in tests that touch shared Postgres state** — the queue tests rely on serial execution to assert ordering.
 - **Prefer the `gh` CLI over the GitHub MCP server** for GitHub interactions (PRs, issues, CI status, reviews). The SessionStart hook installs `gh` in remote/cloud/web sessions (`.claude/scripts/session-start.sh`); fall back to the GitHub MCP server only when `gh` is unavailable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,7 @@ failure per the "Earned rules" principle above.
 - **gofmt is non-negotiable**: CI fails on any diff. Always run before committing.
 - **`go mod tidy` must leave `go.mod`/`go.sum` clean**: don't add deps you don't use.
 - **No `t.Parallel()` in tests that touch shared Postgres state** — the queue tests rely on serial execution to assert ordering.
+- **Prefer the `gh` CLI over the GitHub MCP server** for GitHub interactions (PRs, issues, CI status, reviews). The SessionStart hook installs `gh` in remote/cloud/web sessions (`.claude/scripts/session-start.sh`); fall back to the GitHub MCP server only when `gh` is unavailable.
 - **Task events**: when adding a new lifecycle event, add the kind as a constant in `internal/task` rather than inlining the string at the call site.
 - **Don't mock the database in integration tests** — hit real Postgres (testcontainers or the E2E harness).
 - **Secrets**: never commit real credentials. `.env`, `.env.*`, `*.key`, `*.pem` are gitignored; `.env.example` is the only sanctioned env template.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,7 +305,7 @@ failure per the "Earned rules" principle above.
 
 ## Conventions
 
-- **gofmt is non-negotiable**: CI fails on any diff. Always run before committing.
+- **gofmt is non-negotiable**: CI fails on any diff. Always run before committing. A PostToolUse hook (`.claude/scripts/format-go.sh`) auto-runs `gofmt -w` on every edited `.go` file, but still verify with `gofmt -l` before pushing.
 - **`go mod tidy` must leave `go.mod`/`go.sum` clean**: don't add deps you don't use.
 - **No `t.Parallel()` in tests that touch shared Postgres state** — the queue tests rely on serial execution to assert ordering.
 - **Prefer the `gh` CLI over the GitHub MCP server** for GitHub interactions (PRs, issues, CI status, reviews). The SessionStart hook installs `gh` in remote/cloud/web sessions (`.claude/scripts/session-start.sh`); fall back to the GitHub MCP server only when `gh` is unavailable.


### PR DESCRIPTION
## Summary

- **SessionStart hook (`.claude/scripts/session-start.sh`)** installs the GitHub CLI (`gh`) only when running in the remote/cloud/web container (`CLAUDE_CODE_REMOTE=true`); local desktop sessions are untouched. It fetches the latest official `gh` release binary into `~/.local/bin`, persists `PATH` via `CLAUDE_ENV_FILE`, and reports auth status (picks up `GH_TOKEN`/`GITHUB_TOKEN`). Adapted from the `xrf9268-hue/xray` reference, trimmed to `gh` only since this is a Go repo.
- **PostToolUse hook (`.claude/scripts/format-go.sh`)** auto-runs `gofmt -w` on every edited `.go` file, matching the CI gate (`gofmt -l` must be empty). Silent and non-blocking (always exits 0); filters to existing `.go` files.
- **`.claude/settings.json`** registers both hooks (`matcher: "startup"` and `"Edit|Write"`, both pathed via `$CLAUDE_PROJECT_DIR`).
- **`.gitignore`** un-ignores `.claude/scripts/` and `.claude/settings.json` (mirroring the existing `!.claude/skills/` exception) so web sessions pick up the shared config.
- **AGENTS.md** documents the auto-gofmt behavior and adds a convention to prefer `gh` over the GitHub MCP server, falling back to MCP when `gh` is unavailable.

Hook config was verified against the official Claude Code hooks docs (SessionStart/PostToolUse shape, `matcher` values, stdin `.tool_input.file_path` contract, exit-code semantics). `CLAUDE_CODE_REMOTE=true` confirmed as the live signal in the cloud container.

A self-review surfaced and fixed robustness issues in the shell hooks: under `set -euo pipefail` a failed `gh` version fetch (network/API rate limit) used to abort the whole SessionStart hook before its own error guard could run; it now degrades to a warning + MCP fallback and exits 0. The formatter now tolerates unexpected stdin and honors its always-exit-0 contract.

## Test plan

- [x] `bash -n` passes on both scripts; `settings.json` is valid JSON
- [x] Live run in the cloud container: installs `gh` v2.92.0 and authenticates via `GH_TOKEN`
- [x] Local-skip path (`CLAUDE_CODE_REMOTE` unset) exits 0 without installing
- [x] Graceful degrade: with `gh` absent and `curl` forced to fail, the hook prints the rate-limit diagnostic + MCP-fallback message and exits 0
- [x] `format-go.sh`: misformatted `.go` reformatted; non-Go path, missing file, and malformed stdin all exit 0 silently
- [ ] Confirm a fresh web session triggers the SessionStart hook end-to-end

https://claude.ai/code/session_017Zw1ctHDGSvWRTvAqJUYjU

---
_Generated by [Claude Code](https://claude.ai/code/session_017Zw1ctHDGSvWRTvAqJUYjU)_