### PR TITLE
fix(orchestrator): SPEC §13.1 stderr line for non-retryable terminal failures

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -1780,6 +1780,10 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 			}
 			msg := "clean continuation budget exhausted after " + strconv.Itoa(f.o.maxTurns) + " turns while tracker issue remained active"
 			st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: msg})
+			// SPEC §13.1: the failed outcome must be expressible on stderr,
+			// not only in the in-memory recent_events ring. Operators tailing
+			// stderr otherwise see a run of "Succeeded" lines then silence.
+			log.Printf("event=run_failed issue_id=%s issue_identifier=%s reason=continuation_budget_exhausted budget=%d", f.id, f.identifier, f.o.maxTurns)
 			close(f.done)
 			return nil
 		}
@@ -1812,6 +1816,8 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 			return nil
 		}
 		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: f.result.Err.Error()})
+		// SPEC §13.1 failed outcome on stderr (see continuation-budget site).
+		log.Printf("event=run_failed issue_id=%s issue_identifier=%s reason=non_retryable_runner_error error=%q", f.id, f.identifier, f.result.Err.Error())
 		close(f.done)
 		return nil
 	}
@@ -1854,6 +1860,8 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		}
 		msg := "failure retry budget exhausted after " + strconv.Itoa(f.o.maxFailureRetries) + " retries: " + runErr
 		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: msg})
+		// SPEC §13.1 failed outcome on stderr (see continuation-budget site).
+		log.Printf("event=run_failed issue_id=%s issue_identifier=%s reason=failure_retry_budget_exhausted attempts=%d error=%q", f.id, f.identifier, f.o.maxFailureRetries, runErr)
 		close(f.done)
 		return nil
 	}

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -1199,6 +1199,135 @@ func TestFinalize_NormalExitStopsAfterMaxTurns(t *testing.T) {
 	}
 }
 
+// TestFinalize_ContinuationBudgetExhaustedEmitsStderrLine covers SPEC §13.1
+// (issue #332): the continuation-budget-exhausted terminal failure must emit
+// a structured stderr line, not only a RecordEvent into the in-memory ring.
+// Operators tailing stderr otherwise see a run of "Succeeded" lines followed
+// by silence when an issue is permanently suppressed.
+func TestFinalize_ContinuationBudgetExhaustedEmitsStderrLine(t *testing.T) {
+	disp := &fakeDispatcher{}
+	maxTurns := 2
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+		MaxTurns:   &maxTurns,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-CLEAN-BUDGET", Identifier: "ENG-CLEAN-BUDGET", Title: "clean budget"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, err := o.Snapshot(context.Background())
+		return err == nil && len(v.Retrying) == 1
+	}, time.Second)
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("tracker-rechecked continuation dispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+
+	// The Snapshot op is serviced strictly after the finalize apply returns,
+	// so observing Failed guarantees the in-apply log.Printf already ran.
+	got := captureOrchestratorLog(t, func() {
+		disp.finishAt(1, WorkerResult{Elapsed: time.Millisecond})
+		waitFor(t, func() bool {
+			v, err := o.Snapshot(context.Background())
+			return err == nil && len(v.Failed) == 1
+		}, time.Second)
+	})
+	for _, want := range []string{
+		"event=run_failed",
+		"issue_id=ENG-CLEAN-BUDGET",
+		"issue_identifier=ENG-CLEAN-BUDGET",
+		"reason=continuation_budget_exhausted",
+		"budget=2",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("continuation-budget stderr line missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestFinalize_NonRetryableErrorEmitsStderrLine covers SPEC §13.1 (issue #332)
+// for the explicit non-retryable runner-error terminal path.
+func TestFinalize_NonRetryableErrorEmitsStderrLine(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-NONRETRY", Identifier: "ENG-NONRETRY", Title: "non-retryable"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	got := captureOrchestratorLog(t, func() {
+		disp.finishAt(0, WorkerResult{Err: errors.New("repo.clone_url missing in WORKFLOW.md"), NonRetryable: true, Elapsed: time.Millisecond})
+		waitFor(t, func() bool {
+			v, err := o.Snapshot(context.Background())
+			return err == nil && len(v.Failed) == 1
+		}, time.Second)
+	})
+	for _, want := range []string{
+		"event=run_failed",
+		"issue_id=ENG-NONRETRY",
+		"issue_identifier=ENG-NONRETRY",
+		"reason=non_retryable_runner_error",
+		`error="repo.clone_url missing in WORKFLOW.md"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("non-retryable stderr line missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestFinalize_FailureRetryBudgetExhaustedEmitsStderrLine covers SPEC §13.1
+// (issue #332) for the opt-in failure-retry-budget-exhausted terminal path.
+func TestFinalize_FailureRetryBudgetExhaustedEmitsStderrLine(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cap := 1
+	o, cancel := startActor(t, Deps{
+		Dispatcher:        disp,
+		Scheduler:         RetryScheduler{MaxBackoff: time.Hour},
+		MaxFailureRetries: &cap,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-BUDGET", Identifier: "ENG-BUDGET", Title: "retry budget"}
+	attempt := 1
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, &attempt); err != nil {
+		t.Fatalf("RequestDispatchAfterTrackerRecheck: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	got := captureOrchestratorLog(t, func() {
+		disp.finishAt(0, WorkerResult{Err: errors.New("still failing"), Elapsed: 50 * time.Millisecond})
+		waitFor(t, func() bool {
+			v, err := o.Snapshot(context.Background())
+			return err == nil && len(v.Failed) == 1
+		}, time.Second)
+	})
+	for _, want := range []string{
+		"event=run_failed",
+		"issue_id=ENG-BUDGET",
+		"issue_identifier=ENG-BUDGET",
+		"reason=failure_retry_budget_exhausted",
+		"attempts=1",
+		`error="still failing"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("failure-retry-budget stderr line missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 // TestFinalize_RunnerEnforcedMaxTurnsSkipsContinuationSpawnCap covers SPEC
 // §7.1 + §5.3.5 (issue #216): when the agent runner enforces agent.max_turns
 // inside its own session loop (codex app-server), the orchestrator must not


### PR DESCRIPTION
## Summary

SPEC §13.1 requires the `failed` action outcome to be expressible on stderr with stable `key=value` phrasing (`issue_id`, `issue_identifier`, outcome, concise reason). Three non-retryable terminal paths in `finalizeRunOp.apply` recorded `RuntimeEventFailed` into the in-memory `recent_events` ring (surfaced in `/api/v1/state`) but emitted **no** stderr line. Operators tailing stderr saw a run of `Succeeded` lines then silence when an issue was permanently suppressed — the only signals were polling `/api/v1/state` for `failed_total` deltas or restarting the worker (which silently resets suppression).

This adds an `event=run_failed` structured line alongside each `RecordEvent`, keeping the in-memory `recent_events` semantics intact while adding the missing greppable stderr line:

- `internal/orchestrator/actor.go` — continuation budget exhausted: `event=run_failed issue_id=… issue_identifier=… reason=continuation_budget_exhausted budget=N`
- non-retryable runner error: `… reason=non_retryable_runner_error error="…"`
- failure retry budget exhausted: `… reason=failure_retry_budget_exhausted attempts=N error="…"`

Field naming follows SPEC §13.1's required `issue_id`/`issue_identifier` and the existing orchestrator-package `log.Printf("event=… ")` convention (e.g. `event=blocked_workspace_remove_failed`, `event=tracker_route_skipped`).

## Test plan

- [x] Added mutation-verified regression tests for all three paths (`TestFinalize_{ContinuationBudgetExhausted,NonRetryableError,FailureRetryBudgetExhausted}EmitsStderrLine`) — each asserts the stderr line via `captureOrchestratorLog`; deleting the corresponding `log.Printf` makes only that test FAIL, restoring makes it PASS.
- [x] `gofmt -l` clean; `go vet ./...`; `go build ./...`; `go mod tidy` no diff.
- [x] `go test -race ./...` green across the repo.

Closes #332

https://claude.ai/code/session_017XrGtXAoGCTLGw1MxxXVn9

---
_Generated by [Claude Code](https://claude.ai/code/session_017XrGtXAoGCTLGw1MxxXVn9)_