### PR TITLE
Translate approval policy once so harness decisions match codex wire value

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -241,7 +241,14 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	c.turnTimeoutMs = in.Workflow.Config.Codex.TurnTimeoutMs
 	c.readTimeoutMs = in.Workflow.Config.Codex.ReadTimeoutMs
 	c.stallTimeoutMs = in.Workflow.Config.Codex.StallTimeoutMs
-	c.approvalPolicy = in.Workflow.Config.Codex.ApprovalPolicy
+	// Translate once at this boundary and reuse the same value for both the
+	// codex wire payload (thread/start, turn/start) and the harness-side
+	// auto-approve decisions (autoApproveRequest). Storing the raw workflow
+	// value here while sending the translated one to codex desyncs the two:
+	// a legacy reject:{...} config would reach codex as granular:{...} (codex
+	// emits approval prompts) but autoApproveRequest, which no longer handles
+	// reject:, would decline them unconditionally and flip behavior (#335).
+	c.approvalPolicy = codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
 	if _, err := c.request(ctx, "initialize", map[string]any{
 		"capabilities": map[string]any{"experimentalApi": true},
 		"clientInfo": map[string]any{
@@ -259,7 +266,7 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	}
 
 	threadResult, err := c.request(ctx, "thread/start", map[string]any{
-		"approvalPolicy": codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy),
+		"approvalPolicy": c.approvalPolicy,
 		"sandbox":        in.Workflow.Config.Codex.ThreadSandbox,
 		"cwd":            in.Workdir,
 		"dynamicTools":   appServerDynamicToolSpecs(in.Workflow.Config),
@@ -296,7 +303,7 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 			"input":          input,
 			"cwd":            in.Workdir,
 			"title":          appServerTurnTitle(in),
-			"approvalPolicy": codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy),
+			"approvalPolicy": c.approvalPolicy,
 			"sandboxPolicy":  in.Workflow.Config.Codex.TurnSandboxPolicy,
 		})
 		if err != nil {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1648,6 +1648,73 @@ for line in sys.stdin:
 	}
 }
 
+// TestCodexAppServerRunnerTranslatesLegacyRejectPolicyForApprovalDecisions
+// pins the boundary contract from #335: the approval policy is translated to
+// codex's `granular` wire shape exactly once (codexWireApprovalPolicy) and the
+// SAME translated value drives both the wire payload and the harness-side
+// auto-approve decision (autoApproveRequest).
+//
+// The config below is the obsolete reject:{...} shape with every flag false —
+// legacy operator intent "don't reject, allow these approval flows". Codex
+// receives the translated granular:{...true} (so it emits approval prompts),
+// and autoApproveRequest — which no longer special-cases reject: since #334 —
+// only produces the right ALLOW decision if it is fed the translated value.
+// If c.approvalPolicy were instead the raw reject:{...} map, autoApproveRequest
+// would fall through to its safe-fallback decline, the runner would emit
+// turn_input_required + InputRequiredError, and Run would error here.
+func TestCodexAppServerRunnerTranslatesLegacyRejectPolicyForApprovalDecisions(t *testing.T) {
+	binDir := codexAppServerStubScript(t, `
+import json
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'jsonrpc': '2.0', 'id': 'approval-command', 'method': 'item/commandExecution/requestApproval', 'params': {'command': 'go test ./...'}}), flush=True)
+    elif msg.get('id') == 'approval-command':
+        if msg.get('result') == {'decision': 'acceptForSession'}:
+            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'approvals handled'}}), flush=True)
+        else:
+            print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'unexpected approval response', 'got': msg.get('result')}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	// Obsolete reject:{flag:false} == "don't reject; allow these prompts".
+	in.Workflow.Config.Codex.ApprovalPolicy = map[string]any{"reject": map[string]any{"sandbox_approval": false, "rules": false, "mcp_elicitations": false}}
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v (legacy reject:{false} must auto-approve, not decline)", err)
+	}
+	if res.Summary != "approvals handled" {
+		t.Fatalf("Summary = %q, want approvals handled", res.Summary)
+	}
+	if events := runtimeEventsNamed(res.RuntimeEvents, task.EventApprovalAutoApproved); len(events) != 1 {
+		t.Fatalf("approval_auto_approved events = %d, want 1; events=%#v", len(events), res.RuntimeEvents)
+	}
+	stdin, err := os.ReadFile(filepath.Join(binDir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stdin), `"decision":"acceptForSession"`) {
+		t.Fatalf("stdin missing acceptForSession in approval response: %s", stdin)
+	}
+	// The translated granular payload — not the raw reject: shape — must be
+	// what reached codex on the wire.
+	if strings.Contains(string(stdin), `"reject"`) {
+		t.Fatalf("raw reject: shape leaked onto the wire: %s", stdin)
+	}
+	if !strings.Contains(string(stdin), `"granular"`) {
+		t.Fatalf("stdin missing translated granular policy on the wire: %s", stdin)
+	}
+}
+
 // Replaced by TestCodexAppServerRunnerEmitsTurnInputRequiredOnDeclinedApproval:
 // the previous TestCodexAppServerRunnerDeclinesApprovalsWhenPolicyRequiresReview
 // pinned the SPEC §10.4-non-compliant silent-decline behavior (decline sent


### PR DESCRIPTION
## Summary

Follow-up to the unresolved review thread on merged PR #334 (`internal/runner/codex_app_server.go:936`).

`c.approvalPolicy` was populated from the **raw** workflow `ApprovalPolicy`, while `thread/start` / `turn/start` sent `codexWireApprovalPolicy(...)` — the **translated** value. PR #334 deliberately dropped the `reject:` branch from `autoApproveRequest` on the premise that the harness never observes a raw `reject:` shape, but the raw field assignment broke that premise:

- A legacy `reject:{...}` config with **false** flags (operator intent: "don't reject, allow these prompts") reaches codex as the translated `granular:{...true}`, so codex emits approval prompts.
- `autoApproveRequest`, fed the untranslated `reject:` map, finds no `granular` key and falls through to its safe-fallback **decline**.
- Result: the harness declines those prompts unconditionally — a behavior flip that can deny command / file / permissions requests mid-turn.

This translates the policy **once** at the field-assignment boundary and reuses that single value for both the wire payloads (`thread/start`, `turn/start`) and the harness-side auto-approve decisions (`autoApproveRequest`), so codex and the harness always interpret the same canonical policy shape.

## Test plan

- [x] New regression test `TestCodexAppServerRunnerTranslatesLegacyRejectPolicyForApprovalDecisions`: a legacy `reject:{false}` config must auto-approve (not decline) via the integration stub, and the wire payload must carry the translated `granular:` shape (not raw `reject:`).
- [x] Mutation-verified: reverting the field assignment to the raw value makes the new test FAIL with `input required: item/commandExecution/requestApproval`; restoring it PASSes.
- [x] `gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test -race ./...` all green, `go mod tidy` no diff.

Closes #335

https://claude.ai/code/session_015DDssZjxyadBstj216iWQf

---
_Generated by [Claude Code](https://claude.ai/code/session_015DDssZjxyadBstj216iWQf)_