### PR TITLE
fix(orchestrator): §18.1 workspace cleanup on the §16.5 self-stop + failure retry terminal paths (#341)

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -935,14 +935,18 @@ func (o *Orchestrator) ReconcileInactiveTrackerIssuesAndWait(ctx context.Context
 // The 1-based attempt counter is the attempt number this retry will
 // run as (i.e. the prior run was attempt-1, or 0 for first-run).
 func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string) error {
-	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindFailure, Attempt: attempt}, attempt, runErr)
+	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindFailure, Attempt: attempt}, attempt, runErr, Workspace{})
 }
 
-func (o *Orchestrator) scheduleContinuationRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int) error {
-	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindContinuation, Attempt: attempt}, attempt, "")
+// scheduleContinuationRetry queues the short SPEC §16.6 wake after a clean
+// turn. workspace carries the finalized run's directory so a continuation
+// whose issue is later seen terminal can be cleaned through the §18.1 seam
+// (#341); pass the finalized RunningEntry.Workspace.
+func (o *Orchestrator) scheduleContinuationRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, workspace Workspace) error {
+	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindContinuation, Attempt: attempt}, attempt, "", workspace)
 }
 
-func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, req RetryRequest, attempt int, runErr string) error {
+func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, req RetryRequest, attempt int, runErr string, workspace Workspace) error {
 	op := &scheduleRetryOp{
 		o:          o,
 		issue:      issue,
@@ -951,6 +955,7 @@ func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, i
 		runErr:     runErr,
 		kind:       req.Kind,
 		req:        req,
+		workspace:  workspace,
 	}
 	return o.submit(ctx, op)
 }
@@ -1139,13 +1144,16 @@ type reconcileInactiveTrackerIssuesOp struct {
 
 func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	var cancelEntries []*RunningEntry
-	// blockedCleanups collects terminal-state blocked entries whose workspace
-	// must be removed now (no live worker holds them, unlike running entries
-	// which defer cleanup to the finalize path). Both paths go through the
+	// terminalCleanups collects terminal-state entries that hold no live worker
+	// — blocked (input-required, stopped executing) and retry-queued (a clean
+	// SPEC §16.5 self-stop finalized the run before scheduling the continuation
+	// retry) — whose workspace must be removed now rather than deferred to the
+	// finalize path the way running entries are. Every path goes through the
 	// same WorkspaceCleaner so before_remove fires and a reconcile_workspace
-	// event is emitted — mirroring upstream reconcile_blocked_issue_state,
-	// which cleans the workspace only on a terminal transition.
-	var blockedCleanups []ReconciledWorkspace
+	// event is emitted — mirroring upstream reconcile_blocked_issue_state and
+	// handle_retry_issue_lookup, which clean the workspace only on a terminal
+	// transition.
+	var terminalCleanups []ReconciledWorkspace
 	for id, run := range st.Running {
 		issue, ok := r.issuesByID[string(id)]
 		if !ok {
@@ -1167,9 +1175,21 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 		run.ReconcileCleanupWorkspace = isTerminalTrackerState(issue.State, r.terminalStates)
 		cancelEntries = append(cancelEntries, run)
 	}
-	for id := range st.RetryAttempts {
-		if _, ok := r.issuesByID[string(id)]; !ok {
+	for id, retry := range st.RetryAttempts {
+		issue, ok := r.issuesByID[string(id)]
+		if !ok {
 			continue
+		}
+		// Mirror upstream handle_retry_issue_lookup (orchestrator.ex:1082-1100):
+		// a retry whose issue is now terminal cleans its workspace + releases;
+		// a merely-inactive (non-terminal) one releases only, keeping the
+		// directory for possible reuse. The continuation retry carries the
+		// finalized run's workspace (#341); a failure retry without one yields
+		// no path and is released only.
+		if isTerminalTrackerState(issue.State, r.terminalStates) {
+			if w, okw := terminalWorkspaceForCleanup(id, retry.Identifier, retry.Workspace.Path, retry.Workspace.Root, issue.State); okw {
+				terminalCleanups = append(terminalCleanups, w)
+			}
 		}
 		st.ReleaseClaim(id)
 	}
@@ -1180,7 +1200,7 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 		}
 		if isTerminalTrackerState(issue.State, r.terminalStates) {
 			if w, okw := terminalWorkspaceForCleanup(id, blocked.Identifier, blocked.Workspace.Path, blocked.Workspace.Root, issue.State); okw {
-				blockedCleanups = append(blockedCleanups, w)
+				terminalCleanups = append(terminalCleanups, w)
 			}
 		}
 		st.ReleaseClaim(id)
@@ -1193,7 +1213,7 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 				entry.CancelWorker()
 			}
 		}
-		for _, w := range blockedCleanups {
+		for _, w := range terminalCleanups {
 			o.runReconciledWorkspaceCleanup(w)
 		}
 		if result != nil {
@@ -1433,6 +1453,7 @@ type scheduleRetryOp struct {
 	runErr     string
 	kind       RetryKind
 	req        RetryRequest
+	workspace  Workspace
 }
 
 func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
@@ -1454,6 +1475,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 		DueAt:      time.Now().Add(delay),
 		Error:      s.runErr,
 		Kind:       s.kind,
+		Workspace:  s.workspace,
 	}
 	entry.Timer = time.AfterFunc(delay, func() {
 		defer recoverPanic("orchestrator.retry_timer")
@@ -1792,6 +1814,13 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		// the tracker state mid-run, and per-state capacity gates must see
 		// the live state, not the dispatch-time snapshot.
 		issue := f.entry.Issue
+		// Carry the finalized run's workspace onto the continuation retry. A
+		// clean exit can be a SPEC §16.5 self-stop (the per-turn refresher saw
+		// the issue leave the active set); if the issue is later observed
+		// terminal while this continuation is queued, the reconcile pass uses
+		// this path to clean the directory through the §18.1 seam instead of
+		// leaking it until the next startup sweep (#341).
+		workspace := f.entry.Workspace
 		st.Claimed[f.id] = struct{}{}
 		st.ClaimedIssues[f.id] = issue
 		close(f.done)
@@ -1803,7 +1832,7 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		o := f.o
 		identifier := f.identifier
 		return func() {
-			_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt)
+			_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt, workspace)
 		}
 	}
 	if f.result.NonRetryable {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -1630,7 +1630,17 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 			terminalState := ""
 			if found == nil {
 				if resolver, terminalStates := o.currentRetryTerminalResolver(); resolver != nil && len(terminalStates) > 0 {
-					if statesByID, rerr := resolver.FetchIssueStatesByIDs(fetchCtx, []string{string(id)}); rerr == nil {
+					// Give the terminal-state lookup its own timeout budget rather
+					// than the already-consumed fetchCtx: a slow-but-successful
+					// ListActiveIssues near the deadline would otherwise leave this
+					// call to fail immediately with context-deadline-exceeded,
+					// dropping a terminal issue onto the release-only path and
+					// leaking its workspace — the exact leak this resolves (Codex
+					// P2). Derived from runCtx so actor shutdown still cancels it.
+					resolveCtx, resolveCancel := context.WithTimeout(o.runCtx, retryFetchTimeout)
+					statesByID, rerr := resolver.FetchIssueStatesByIDs(resolveCtx, []string{string(id)})
+					resolveCancel()
+					if rerr == nil {
 						if s := strings.TrimSpace(statesByID[string(id)]); s != "" && isTerminalTrackerState(s, terminalStates) {
 							terminal = true
 							terminalState = s

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -258,6 +258,18 @@ type Orchestrator struct {
 	candidateListerMu sync.Mutex
 	candidateLister   ActiveIssueLister
 
+	// retryTerminalResolver lets the SPEC §16.6 retry-fire path tell a
+	// terminal issue from a merely-absent one when the active-candidate fetch
+	// returns nothing for it. The candidate lister is active-only, so a
+	// terminal issue is indistinguishable from a deleted one there; resolving
+	// the actual state (the way the reconcile pass does) lets the found==nil
+	// branch clean a terminal workspace through the §18.1 seam instead of
+	// leaking it (#341). nil leaves the legacy release-only behavior. Guarded
+	// by the same swap discipline as candidateLister.
+	retryTerminalResolverMu sync.Mutex
+	retryTerminalResolver   IssueStateRefresher
+	retryTerminalStates     map[string]struct{}
+
 	// runCtx is captured by Run so followup goroutines can cancel
 	// their work when the actor stops. Set once at the top of Run
 	// before close(started); reads from outside the actor synchronize
@@ -395,6 +407,32 @@ func (o *Orchestrator) currentCandidateLister() ActiveIssueLister {
 	o.candidateListerMu.Lock()
 	defer o.candidateListerMu.Unlock()
 	return o.candidateLister
+}
+
+// SetRetryTerminalStateResolver installs (or swaps) the reader the §16.6
+// retry-fire found==nil branch uses to tell a terminal issue from a
+// merely-absent one (#341), along with the lowercased terminal-state set used
+// to classify the resolved state. Production wires the same multi-tracker
+// state reader and terminal_states the reconcile pass uses. nil/empty leaves
+// the legacy release-only behavior (no workspace cleanup on retry-fire). Safe
+// to call before or after Run.
+func (o *Orchestrator) SetRetryTerminalStateResolver(refresher IssueStateRefresher, terminalStates []string) {
+	if o == nil {
+		return
+	}
+	o.retryTerminalResolverMu.Lock()
+	o.retryTerminalResolver = refresher
+	o.retryTerminalStates = normalizedStates(terminalStates)
+	o.retryTerminalResolverMu.Unlock()
+}
+
+func (o *Orchestrator) currentRetryTerminalResolver() (IssueStateRefresher, map[string]struct{}) {
+	if o == nil {
+		return nil, nil
+	}
+	o.retryTerminalResolverMu.Lock()
+	defer o.retryTerminalResolverMu.Unlock()
+	return o.retryTerminalResolver, o.retryTerminalStates
 }
 
 func (o *Orchestrator) queuePollWake() bool {
@@ -935,7 +973,18 @@ func (o *Orchestrator) ReconcileInactiveTrackerIssuesAndWait(ctx context.Context
 // The 1-based attempt counter is the attempt number this retry will
 // run as (i.e. the prior run was attempt-1, or 0 for first-run).
 func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string) error {
-	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindFailure, Attempt: attempt}, attempt, runErr, Workspace{})
+	return o.scheduleFailureRetry(ctx, issue, identifier, attempt, runErr, Workspace{})
+}
+
+// scheduleFailureRetry is the internal failure-retry entry point that also
+// carries the prior run's workspace forward. A failure retry whose issue is
+// later observed terminal (by the reconcile pass or the SPEC §16.6 retry-fire
+// resolution) cleans this directory through the §18.1 seam rather than leaking
+// it until the next startup sweep (#341). The reschedule paths (capacity defer,
+// retry-poll-failed) thread the existing entry's workspace through so it
+// survives across attempts.
+func (o *Orchestrator) scheduleFailureRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string, workspace Workspace) error {
+	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindFailure, Attempt: attempt}, attempt, runErr, workspace)
 }
 
 // scheduleContinuationRetry queues the short SPEC §16.6 wake after a clean
@@ -1570,12 +1619,33 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 				})
 				return
 			}
+			// found==nil means the issue is not in the active candidate set:
+			// terminal, merely-inactive, or deleted. The active-only fetch
+			// cannot tell them apart, so resolve the actual state (the way the
+			// reconcile pass does) to recover upstream handle_retry_issue_lookup's
+			// terminal branch — terminal → clean the workspace + release, every
+			// other absence → release only (#341). Resolver errors / unknown
+			// states leave terminal=false, preserving the release-only default.
+			terminal := false
+			terminalState := ""
+			if found == nil {
+				if resolver, terminalStates := o.currentRetryTerminalResolver(); resolver != nil && len(terminalStates) > 0 {
+					if statesByID, rerr := resolver.FetchIssueStatesByIDs(fetchCtx, []string{string(id)}); rerr == nil {
+						if s := strings.TrimSpace(statesByID[string(id)]); s != "" && isTerminalTrackerState(s, terminalStates) {
+							terminal = true
+							terminalState = s
+						}
+					}
+				}
+			}
 			_ = o.submit(o.runCtx, &retryFireAfterFetchOp{
-				o:       o,
-				id:      id,
-				attempt: attempt,
-				kind:    kind,
-				found:   found,
+				o:             o,
+				id:            id,
+				attempt:       attempt,
+				kind:          kind,
+				found:         found,
+				terminal:      terminal,
+				terminalState: terminalState,
 			})
 		}
 	}
@@ -1599,12 +1669,12 @@ func retryFireDispatchTail(st *OrchestratorState, entry *RetryEntry, id IssueID,
 		// reschedule through the configured backoff with attempt+1 and a
 		// typed "no available orchestrator slots" error instead of arming a
 		// short 100ms re-fire timer.
-		return capacityDeferRetry(st, id, issue, identifier, attempt, o)
+		return capacityDeferRetry(st, id, issue, identifier, attempt, entry.Workspace, o)
 	}
 	if st.StateCapacityFull(issue.State) {
 		// Retry timers must also obey per-state capacity gates. Same
 		// upstream-aligned reschedule shape as the global-cap branch.
-		return capacityDeferRetry(st, id, issue, identifier, attempt, o)
+		return capacityDeferRetry(st, id, issue, identifier, attempt, entry.Workspace, o)
 	}
 	// Consume the retry entry but keep Claimed: the re-dispatch
 	// immediately re-adds Running, and dropping Claimed in between
@@ -1626,7 +1696,7 @@ func retryFireDispatchTail(st *OrchestratorState, entry *RetryEntry, id IssueID,
 // 100ms re-fire loop bypassed the backoff formula, left the attempt
 // counter frozen across thousands of re-fires, and produced no runtime
 // event for the cap-pressure case.
-func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, identifier string, attempt int, o *Orchestrator) func() {
+func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, identifier string, attempt int, workspace Workspace, o *Orchestrator) func() {
 	if o.runCtx.Err() != nil {
 		// Mirror retryPollFailedOp's shutdown guard (actor.go above):
 		// the followup's ScheduleRetry would fail submit anyway, so
@@ -1643,7 +1713,9 @@ func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, 
 		Message:    runErr,
 	})
 	return func() {
-		_ = o.ScheduleRetry(o.runCtx, issue, identifier, nextAttempt, runErr)
+		// Carry the workspace across the reschedule so the §18.1 terminal
+		// cleanup gate still has a path on a later attempt (#341).
+		_ = o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace)
 	}
 }
 
@@ -1691,6 +1763,9 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 	}
 	issue := entry.Issue
 	identifier := entry.Identifier
+	// Carry the workspace across the reschedule so the §18.1 terminal cleanup
+	// gate still has a path on a later attempt (#341).
+	workspace := entry.Workspace
 	nextAttempt := r.attempt + 1
 	runErr := "retry poll failed"
 	if r.fetchErr != nil {
@@ -1703,7 +1778,7 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 		Message:    runErr,
 	})
 	return func() {
-		_ = o.ScheduleRetry(o.runCtx, issue, identifier, nextAttempt, runErr)
+		_ = o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace)
 	}
 }
 
@@ -1712,12 +1787,19 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 // from the active candidate set (step 3 / step 5: release the claim);
 // otherwise refresh entry.Issue with the live tracker state and proceed
 // to capacity check + dispatch.
+//
+// terminal/terminalState are resolved by the followup only when found == nil:
+// they recover upstream handle_retry_issue_lookup's terminal branch that the
+// active-only candidate fetch collapses into plain absence, so a terminal
+// issue's workspace is cleaned through the §18.1 seam rather than leaked (#341).
 type retryFireAfterFetchOp struct {
-	o       *Orchestrator
-	id      IssueID
-	attempt int
-	kind    RetryKind
-	found   *tracker.Issue
+	o             *Orchestrator
+	id            IssueID
+	attempt       int
+	kind          RetryKind
+	found         *tracker.Issue
+	terminal      bool
+	terminalState string
 }
 
 func (r *retryFireAfterFetchOp) apply(st *OrchestratorState) func() {
@@ -1733,6 +1815,27 @@ func (r *retryFireAfterFetchOp) apply(st *OrchestratorState) func() {
 		// set (either absent or moved to a non-active state). Drop the
 		// retry and release the claim.
 		identifier := entry.Identifier
+		if r.terminal {
+			// Upstream handle_retry_issue_lookup's terminal branch
+			// (orchestrator.ex:1082-1090): a retry whose issue went terminal
+			// cleans its workspace + releases. The worker already exited before
+			// the retry was scheduled, so no live worker holds the directory —
+			// route the removal through the same WorkspaceCleaner seam the
+			// running/blocked terminal paths use (#341). The actor-serialized
+			// re-claim guard inside runReconciledWorkspaceCleanup prevents a
+			// re-dispatch from racing the removal onto the same path.
+			if w, okw := terminalWorkspaceForCleanup(r.id, identifier, entry.Workspace.Path, entry.Workspace.Root, r.terminalState); okw {
+				st.ReleaseClaim(r.id)
+				st.RecordEvent(RuntimeEvent{
+					Kind:       RuntimeEventFailed,
+					IssueID:    r.id,
+					Identifier: identifier,
+					Message:    "retry released: issue terminal, removing workspace",
+				})
+				o := r.o
+				return func() { o.runReconciledWorkspaceCleanup(w) }
+			}
+		}
 		st.ReleaseClaim(r.id)
 		st.RecordEvent(RuntimeEvent{
 			Kind:       RuntimeEventFailed,
@@ -1903,13 +2006,16 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 	// Use f.entry.Issue, not f.issue: reconciliation may have refreshed
 	// the tracker state mid-run, and the retry must carry the live state.
 	issue := f.entry.Issue
+	// Carry the workspace so a failure retry whose issue later goes terminal
+	// is cleaned through the §18.1 seam instead of leaking (#341).
+	workspace := f.entry.Workspace
 	st.Claimed[f.id] = struct{}{}
 	st.ClaimedIssues[f.id] = issue
 	close(f.done)
 	o := f.o
 	identifier := f.identifier
 	return func() {
-		_ = o.ScheduleRetry(o.runCtx, issue, identifier, nextAttempt, runErr)
+		_ = o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace)
 	}
 }
 

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -868,7 +868,7 @@ func TestContinuationRetryRecheckedDispatchKeepsRetryWhenCapacityFull(t *testing
 	}
 	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
 
-	if err := o.scheduleContinuationRetry(context.Background(), issueA, issueA.Identifier, 1); err != nil {
+	if err := o.scheduleContinuationRetry(context.Background(), issueA, issueA.Identifier, 1, Workspace{}); err != nil {
 		t.Fatalf("schedule continuation retry: %v", err)
 	}
 	waitFor(t, func() bool {
@@ -1659,6 +1659,116 @@ func TestReconcileInactiveNonTerminalRunKeepsWorkspace(t *testing.T) {
 	view, _ := o.Snapshot(context.Background())
 	if len(view.Running) != 0 {
 		t.Fatalf("running not cleared after reconcile: %+v", view.Running)
+	}
+}
+
+// TestReconcileTerminalContinuationRetryFiresWorkspaceCleanup is the
+// regression for #341: a run that self-stops via the SPEC §16.5 per-turn
+// refresher exits cleanly and schedules a continuation retry. If the issue is
+// then observed terminal while that continuation is queued, the reconcile pass
+// must clean its workspace through the WorkspaceCleaner (before_remove hook /
+// reconcile_workspace reason=terminal) once the retry resolves, instead of
+// leaking the directory until the next startup sweep. Mirrors upstream
+// handle_retry_issue_lookup's terminal branch (orchestrator.ex:1082-1090).
+func TestReconcileTerminalContinuationRetryFiresWorkspaceCleanup(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-CR1", Identifier: "ENG-CR1", State: "In Progress", Title: "self-stop"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-CR1"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+
+	// Clean exit (the §16.5 refresher observed the issue leave the active set)
+	// → finalize finishes the run and schedules a continuation retry that
+	// carries the finalized run's workspace.
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && len(view.Running) == 0
+	}, time.Second)
+
+	// The continuation is still queued when the issue is observed terminal.
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, time.Second)
+	got := cleaner.snapshot()[0]
+	if got.IssueID != IssueID(issue.ID) || got.Path != wsPath || got.Reason != "terminal" || got.State != "Done" {
+		t.Fatalf("cleanup = %+v, want terminal cleanup for %s at %q reason=terminal state=Done", got, issue.ID, wsPath)
+	}
+	// The dispatch-time root recorded for the run must reach the cleaner so
+	// removal is checked against the root the path was created under.
+	if got.Root != testWorkspaceRoot {
+		t.Fatalf("cleanup root = %q, want recorded dispatch-time root %q", got.Root, testWorkspaceRoot)
+	}
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 0 {
+		t.Fatalf("retry not released after terminal reconcile: %+v", view.Retrying)
+	}
+}
+
+// TestReconcileInactiveContinuationRetryKeepsWorkspace pins the other branch of
+// the retry-fire release path (#341): a continuation retry whose issue went to
+// a merely-inactive (non-terminal) state must be released WITHOUT removing its
+// workspace — the issue may return to active work and reuse it. A terminal
+// sibling reconciled in the same pass is the progress barrier that makes the
+// negative observable: its cleanup fires from a fire-and-forget followup, so we
+// wait for it to land, then assert it is the ONLY call. A reverted terminal
+// gate would push the count to 2.
+func TestReconcileInactiveContinuationRetryKeepsWorkspace(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	inactive := tracker.Issue{ID: "ENG-CR-I", Identifier: "ENG-CR-I", State: "In Progress", Title: "inactive self-stop"}
+	terminal := tracker.Issue{ID: "ENG-CR-T", Identifier: "ENG-CR-T", State: "In Progress", Title: "terminal self-stop"}
+	const inactivePath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-CR-I"
+	const terminalPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-CR-T"
+	dispatchRunningIssue(t, o, disp, inactive, inactivePath, 1)
+	dispatchRunningIssue(t, o, disp, terminal, terminalPath, 2)
+
+	// Both self-stop cleanly → two queued continuation retries.
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	disp.finishAt(1, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 2 && len(view.Running) == 0
+	}, time.Second)
+
+	// One reconcile pass: ENG-CR-I → Backlog (non-terminal inactive),
+	// ENG-CR-T → Done (terminal). Only the terminal one may be cleaned.
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		inactive.ID: {ID: inactive.ID, Identifier: inactive.Identifier, State: "Backlog"},
+		terminal.ID: {ID: terminal.ID, Identifier: terminal.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, time.Second)
+	calls := cleaner.snapshot()
+	if len(calls) != 1 || calls[0].IssueID != IssueID(terminal.ID) || calls[0].Path != terminalPath {
+		t.Fatalf("only the terminal sibling may be cleaned, got %+v", calls)
+	}
+	view, _ := o.Snapshot(context.Background())
+	if len(view.Retrying) != 0 {
+		t.Fatalf("retries not released after reconcile: %+v", view.Retrying)
 	}
 }
 

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -2774,6 +2774,155 @@ func TestRetryFire_ReleasesClaimWhenIssueAbsentFromCandidates(t *testing.T) {
 	}
 }
 
+// staticStateRefresher is a read-only IssueStateRefresher for the §16.6
+// retry-fire terminal-resolution tests (#341). Concurrent reads of the
+// underlying map from multiple followup goroutines are safe because nothing
+// mutates it after construction.
+type staticStateRefresher map[string]string
+
+func (s staticStateRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]string, error) {
+	out := make(map[string]string, len(ids))
+	for _, id := range ids {
+		if state, ok := s[id]; ok {
+			out[id] = state
+		}
+	}
+	return out, nil
+}
+
+// TestRetryFire_TerminalIssueFiresWorkspaceCleanup is the failure-retry half of
+// #341: a failure retry whose issue has since gone terminal must clean its
+// workspace when the SPEC §16.6 retry timer fires. The active-only candidate
+// fetch returns found==nil for a terminal issue, indistinguishable from a
+// deleted one; the terminal-state resolver recovers upstream
+// handle_retry_issue_lookup's terminal branch so the directory is removed
+// through the WorkspaceCleaner seam (reason=terminal) instead of leaking.
+func TestRetryFire_TerminalIssueFiresWorkspaceCleanup(t *testing.T) {
+	disp := &fakeDispatcher{}
+	lister := &fakeCandidateLister{} // empty active set → found==nil
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        &sequenceScheduler{delays: []time.Duration{time.Hour}},
+		CandidateLister:  lister,
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+	o.SetRetryTerminalStateResolver(staticStateRefresher{"ENG-FR-T": "Done"}, []string{"Done"})
+
+	issue := tracker.Issue{ID: "ENG-FR-T", Identifier: "ENG-FR-T", State: "In Progress", Title: "fail then terminal"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-FR-T"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+
+	// Abnormal (retryable) exit → failure retry that carries the run's workspace.
+	disp.finishAt(0, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	var attempt int
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		if len(v.Retrying) == 1 && len(v.Running) == 0 {
+			attempt = v.Retrying[0].Attempt
+			return true
+		}
+		return false
+	}, time.Second)
+
+	// Fire the retry timer: candidate fetch is empty (issue not active), the
+	// resolver reports the terminal state → clean + release.
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(issue.ID),
+		issue:   issue,
+		attempt: attempt,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, 2*time.Second)
+	got := cleaner.snapshot()[0]
+	if got.IssueID != IssueID(issue.ID) || got.Path != wsPath || got.Reason != "terminal" || got.State != "Done" {
+		t.Fatalf("cleanup = %+v, want terminal cleanup for %s at %q reason=terminal state=Done", got, issue.ID, wsPath)
+	}
+	if got.Root != testWorkspaceRoot {
+		t.Fatalf("cleanup root = %q, want recorded dispatch-time root %q", got.Root, testWorkspaceRoot)
+	}
+	v, _ := o.Snapshot(context.Background())
+	if len(v.Retrying) != 0 {
+		t.Fatalf("retry not released after terminal fire: %+v", v.Retrying)
+	}
+}
+
+// TestRetryFire_InactiveIssueKeepsWorkspace pins the other branch of the
+// failure-retry §16.6 resolution (#341): a retry whose issue went to a
+// merely-inactive (non-terminal) state is released WITHOUT removing its
+// workspace. The assertion is deterministic: retryFireAfterFetchOp records the
+// release reason in the SAME apply that releases the claim, so observing the
+// "absent from active candidates" event (not the "issue terminal" one) proves
+// the terminal branch was not taken — and that branch is the only path that
+// schedules a cleanup. A reverted terminal gate (classifying Backlog as
+// terminal) would record the "issue terminal" message and fail this assertion.
+func TestRetryFire_InactiveIssueKeepsWorkspace(t *testing.T) {
+	disp := &fakeDispatcher{}
+	lister := &fakeCandidateLister{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        &sequenceScheduler{delays: []time.Duration{time.Hour}},
+		CandidateLister:  lister,
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+	o.SetRetryTerminalStateResolver(staticStateRefresher{"ENG-FR-I": "Backlog"}, []string{"Done"})
+
+	issue := tracker.Issue{ID: "ENG-FR-I", Identifier: "ENG-FR-I", State: "In Progress", Title: "fail then inactive"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-FR-I"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+
+	disp.finishAt(0, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	var attempt int
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		if len(v.Retrying) == 1 {
+			attempt = v.Retrying[0].Attempt
+			return true
+		}
+		return false
+	}, time.Second)
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(issue.ID),
+		issue:   issue,
+		attempt: attempt,
+		kind:    RetryKindFailure,
+	}); err != nil {
+		t.Fatalf("submit retry fire: %v", err)
+	}
+
+	// The resolver reports Backlog (non-terminal) → release only. Wait for the
+	// release event, which apply records synchronously with the ReleaseClaim.
+	var msg string
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		if len(v.Retrying) != 0 {
+			return false
+		}
+		for _, ev := range v.RecentEvents {
+			if ev.IssueID == IssueID(issue.ID) && strings.HasPrefix(ev.Message, "retry released:") {
+				msg = ev.Message
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second)
+	if msg != "retry released: issue absent from active candidates" {
+		t.Fatalf("release event = %q, want the non-terminal release-only message (no workspace cleanup)", msg)
+	}
+	if got := cleaner.snapshot(); len(got) != 0 {
+		t.Fatalf("non-terminal retry must not clean its workspace, got %+v", got)
+	}
+}
+
 // TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError is the SPEC §16.6
 // step 1 alt conformance check: when the candidate fetch fails, the retry is
 // rescheduled with a typed "retry poll failed" error so the next backoff

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -34,6 +34,15 @@ type RetryEntry struct {
 	Timer      *time.Timer
 	Error      string
 	Kind       RetryKind
+	// Workspace is the on-disk workspace the prior turn used, carried forward
+	// from the finalized RunningEntry so a continuation retry whose issue is
+	// later observed terminal can route the removal through the same
+	// WorkspaceCleaner seam as the running/blocked paths (SPEC §18.1) instead
+	// of leaking the directory until the next startup sweep (#341). It is empty
+	// for retries scheduled without a recorded workspace (failure retries, or a
+	// run that never recorded one); terminalWorkspaceForCleanup then reports no
+	// path and the entry is released only.
+	Workspace Workspace
 }
 
 // IsDue reports whether the retry's DueAt has passed relative to now.

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -166,6 +166,12 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	}
 	retryLister = eligibleActiveIssueLister{inner: retryLister, terminalStates: snap.Reconciliation.TerminalStates}
 	p.orchestrator.SetCandidateLister(retryLister)
+	// The candidate lister above is active-only, so a fired failure-retry whose
+	// issue moved to a terminal state sees found==nil — indistinguishable there
+	// from a deleted issue. Give the retry-fire path the same state reader and
+	// terminal set the reconcile pass uses so its found==nil branch can clean a
+	// terminal workspace through the §18.1 seam instead of leaking it (#341).
+	p.orchestrator.SetRetryTerminalStateResolver(multiLister, snap.Reconciliation.TerminalStates)
 	return poller, nil
 }
 


### PR DESCRIPTION
## Summary

Closes #341.

A run that leaves the active set mid-run reaches a terminal-mid-run outcome via a continuation/failure retry, but the retry release path released the claim **without cleaning the workspace** — leaking the directory until the next startup sweep. #339 closed this for the reconcile-poll path on running issues; this PR closes it for the retry-queued substate.

Root cause: `RetryEntry` did not carry the run's workspace (the finalized `RunningEntry` that held it is gone by the time the retry is scheduled), and the retry release sites released claim-only. Fix mirrors upstream `handle_retry_issue_lookup` (`orchestrator.ex:1082-1100`): **terminal → clean workspace + release; merely-inactive → release only.**

### Changes

1. **`RetryEntry.Workspace`** — carried from the finalized run when scheduling a continuation retry (clean §16.5 self-stop) and a failure retry (abnormal exit), and preserved across the capacity-defer / retry-poll-failed reschedules.
2. **Reconcile-inactive pass** (`reconcileInactiveTrackerIssuesOp`) — the `RetryAttempts` release now branches on terminal and routes terminal entries through the same `WorkspaceCleaner` seam + `terminalWorkspaceForCleanup` helper the running/blocked paths use (`before_remove` → remove → `reconcile_workspace reason=terminal`). This is the path a §16.5 continuation retry actually resolves through.
3. **SPEC §16.6 retry-timer fire** (`retryFireAfterFetchOp` `found==nil`) — the active-only candidate fetch can't tell a terminal issue from a deleted one, so a new terminal-state resolver (the same multi-tracker state reader + `terminal_states` the reconcile pass uses) resolves the actual state and branches terminal vs. release-only.

Removal goes through the existing actor-serialized re-claim guard (`beginReconcileWorkspaceCleanup`), so a re-dispatch cannot race the removal onto the same deterministic path.

### Note on the issue's line reference

The issue's "Path" step 3 points at `retryFireAfterFetchOp` `found==nil`. In this Go port a **clean §16.5 self-stop schedules a *continuation* retry, which only wakes the poll loop and resolves through the reconcile pass — it never reaches `retryFireAfterFetchOp`** (that op handles *failure* retries only). So the continuation acceptance criteria are met at the reconcile pass (change 2). The failure-retry timer-fire path (change 3) is the genuine sister-path gap and is fixed here too, so both triggers are covered.

## Acceptance criteria

- [x] §16.5 self-stop → terminal fires `before_remove` + `reconcile_workspace action=remove reason=terminal` once the continuation retry resolves.
- [x] §16.5 self-stop → non-terminal inactive keeps its workspace (release only).
- [x] Unit tests cover both branches of the retry release path (continuation via reconcile; failure via retry-timer fire), mutation-verified.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean, `go mod tidy` no-op
- [x] `go test -race ./...` green
- [x] New tests fail under targeted mutation (cleanup branch removed / workspace-carry removed / terminal gate broken), pass when restored

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y9X2zCvwUc9pXEZPpTmY5)_