### PR TITLE
fix(orchestrator): repair crossed cleanup var names that break the build on main

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -1304,7 +1304,7 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 		}
 		st.ReleaseClaim(id)
 	}
-	return r.o.reconcileCancelFollowup(cancelEntries, blockedCleanups, r.result)
+	return r.o.reconcileCancelFollowup(cancelEntries, terminalCleanups, r.result)
 }
 
 // reconcileCancelFollowup builds the off-actor followup both reconcile passes
@@ -1319,7 +1319,7 @@ func (o *Orchestrator) reconcileCancelFollowup(cancelEntries []*RunningEntry, bl
 				entry.CancelWorker()
 			}
 		}
-		for _, w := range terminalCleanups {
+		for _, w := range blockedCleanups {
 			o.runReconciledWorkspaceCleanup(w)
 		}
 		if result != nil {


### PR DESCRIPTION
## Summary
`main` currently does not compile. `internal/orchestrator/actor.go` references two undefined identifiers:

```
internal/orchestrator/actor.go:1307:52: undefined: blockedCleanups
internal/orchestrator/actor.go:1322:21: undefined: terminalCleanups
```

The merge of #353 and #355 crossed two locals:
- `reconcileInactiveTrackerIssuesOp.apply` builds a `terminalCleanups` slice but passed `blockedCleanups` (undefined in that scope) to `reconcileCancelFollowup` — **L1307**.
- `reconcileCancelFollowup`'s parameter is `blockedCleanups`, but its body ranged over `terminalCleanups` (undefined in that scope) — **L1322**.

This binds each reference to the name in scope (2 lines). The helper is generic over "workspaces to clean", so both callers (`blockedCleanups` from the cancel pass, `terminalCleanups` from the inactive-tracker pass) now type-check and behave as intended.

## Impact
- Unblocks CI for every open PR (e.g. #354), since `pull_request` CI builds the merge with `main`.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l` clean
- [x] `go test -race ./internal/orchestrator/... ./internal/worker/...`

https://claude.ai/code/session_019SpaCdG5NMYogF1imDiCTU

---
_Generated by [Claude Code](https://claude.ai/code/session_019SpaCdG5NMYogF1imDiCTU)_