### PR TITLE
tui: terminal lifecycle, signal restore, non-TTY degrade, steady cadence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tmp/
 /linear-poller
 /gitea-poller
 /tui
+/tui.exe
 
 # Node / npm
 node_modules/

--- a/cmd/tui/exit_unix_test.go
+++ b/cmd/tui/exit_unix_test.go
@@ -4,10 +4,13 @@ package main
 
 import (
 	"errors"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // raiseAfterSignal must terminate the process via the re-raised signal so the
@@ -26,15 +29,64 @@ func TestRaiseAfterSignal_ExitsBySignal(t *testing.T) {
 	cmd.Env = append(os.Environ(), "TUI_RERAISE_TEST=1")
 	err := cmd.Run()
 
+	assertExitBySIGINT(t, err)
+}
+
+// TestMain_SignalExitsBySignal exercises the full main() wiring end to end:
+// NotifyContext cancellation → run returns → the sigCh snoop → raiseAfterSignal.
+// It builds and runs the real binary (non-TTY, pointed at a closed port) and
+// sends it SIGINT, asserting it terminates by signal / exit 130.
+func TestMain_SignalExitsBySignal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and runs the binary; skipped in -short")
+	}
+
+	bin := filepath.Join(t.TempDir(), "tui")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("build tui: %v", err)
+	}
+
+	// Closed port → fetches fail fast; io.Discard stdout → non-TTY mode.
+	cmd := exec.Command(bin, "--url", "http://127.0.0.1:0", "--interval", "1s")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start tui: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	time.Sleep(300 * time.Millisecond) // let it install handlers and enter the loop
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		t.Fatalf("signal tui: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		assertExitBySIGINT(t, err)
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatal("process did not exit within 5s of SIGINT")
+	}
+}
+
+// assertExitBySIGINT requires that err reflects termination by SIGINT or, via
+// the os.Exit fallback, exit code 128+SIGINT.
+func assertExitBySIGINT(t *testing.T, err error) {
+	t.Helper()
 	var ee *exec.ExitError
 	if !errors.As(err, &ee) {
-		t.Fatalf("subprocess returned %v, want non-zero termination", err)
+		t.Fatalf("process returned %v, want non-zero termination", err)
 	}
 	if ws, ok := ee.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
 		if ws.Signal() != syscall.SIGINT {
 			t.Errorf("terminated by signal %v, want SIGINT", ws.Signal())
 		}
-		return // killed by the re-raised SIGINT — correct path
+		return
 	}
 	if want := 128 + int(syscall.SIGINT); ee.ExitCode() != want {
 		t.Errorf("exit code = %d, want %d (128+SIGINT) or death by SIGINT", ee.ExitCode(), want)

--- a/cmd/tui/exit_unix_test.go
+++ b/cmd/tui/exit_unix_test.go
@@ -1,0 +1,42 @@
+//go:build unix
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+// raiseAfterSignal must terminate the process via the re-raised signal so the
+// shell sees the conventional 128+signum status. It calls os.Exit / kills the
+// process, so it is exercised in a subprocess: the child re-invokes this test
+// with TUI_RERAISE_TEST=1, runs raiseAfterSignal(SIGINT), and is expected to die
+// by SIGINT (or, via the fallback, exit 128+SIGINT) — never returning normally.
+func TestRaiseAfterSignal_ExitsBySignal(t *testing.T) {
+	if os.Getenv("TUI_RERAISE_TEST") == "1" {
+		raiseAfterSignal(syscall.SIGINT)
+		os.Exit(99) // unreachable if raiseAfterSignal terminates the process
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRaiseAfterSignal_ExitsBySignal$")
+	cmd.Env = append(os.Environ(), "TUI_RERAISE_TEST=1")
+	err := cmd.Run()
+
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("subprocess returned %v, want non-zero termination", err)
+	}
+	if ws, ok := ee.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+		if ws.Signal() != syscall.SIGINT {
+			t.Errorf("terminated by signal %v, want SIGINT", ws.Signal())
+		}
+		return // killed by the re-raised SIGINT — correct path
+	}
+	if want := 128 + int(syscall.SIGINT); ee.ExitCode() != want {
+		t.Errorf("exit code = %d, want %d (128+SIGINT) or death by SIGINT", ee.ExitCode(), want)
+	}
+}

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -180,25 +180,20 @@ func main() {
 
 	scr := newScreen(os.Stdout, isTerminal(os.Stdout), *rawFlag)
 
+	// NotifyContext cancels ctx on SIGINT/SIGTERM, which both breaks the render
+	// loop and aborts any in-flight fetch (the per-fetch context derives from
+	// ctx), so Ctrl-C restores the terminal immediately even mid-poll. This
+	// mirrors the signal handling in the sibling cmd/ entrypoints.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// A second subscription records which signal fired (NotifyContext discards
+	// the value) so it can be re-raised for a conventional exit status. The
+	// runtime delivers to this channel before NotifyContext's goroutine cancels
+	// ctx, so the value is buffered by the time run returns.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
-
-	// Translate the first signal into context cancellation: this both breaks
-	// the render loop and aborts any in-flight fetch (the per-fetch context is
-	// derived from ctx), so Ctrl-C restores the terminal immediately even
-	// mid-poll. The caught signal is handed back for a conventional exit code.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	caught := make(chan os.Signal, 1)
-	go func() {
-		select {
-		case s := <-sigCh:
-			caught <- s
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
 
 	fetch := func(ctx context.Context) (*stateResponse, error) {
 		return fetchState(ctx, client, stateURL)
@@ -207,22 +202,28 @@ func main() {
 	run(ctx, scr, fetch, interval, baseURL)
 
 	// run has already restored the terminal (its deferred restore). If a signal
-	// caused the shutdown, re-raise it under the default handler so we exit with
-	// the conventional 128+signum status (130 for SIGINT) rather than 0.
+	// caused the shutdown, re-raise it so we exit with the conventional
+	// 128+signum status (130 for SIGINT) instead of 0.
 	select {
-	case s := <-caught:
-		signal.Reset(os.Interrupt, syscall.SIGTERM)
-		if p, err := os.FindProcess(os.Getpid()); err == nil {
-			_ = p.Signal(s)
-		}
-		// Safety net if the re-raised signal doesn't terminate the process.
-		time.Sleep(100 * time.Millisecond)
-		if sysSig, ok := s.(syscall.Signal); ok {
-			os.Exit(128 + int(sysSig))
-		}
-		os.Exit(1)
+	case s := <-sigCh:
+		raiseAfterSignal(s)
 	default:
 	}
+}
+
+// raiseAfterSignal restores the default disposition for sig and re-raises it so
+// the process terminates with the conventional 128+signum status, falling back
+// to an explicit os.Exit if the re-raised signal doesn't terminate us.
+func raiseAfterSignal(sig os.Signal) {
+	signal.Reset(os.Interrupt, syscall.SIGTERM)
+	if p, err := os.FindProcess(os.Getpid()); err == nil {
+		_ = p.Signal(sig)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if sysSig, ok := sig.(syscall.Signal); ok {
+		os.Exit(128 + int(sysSig))
+	}
+	os.Exit(1)
 }
 
 // run drives the poll/render loop until ctx is cancelled (signal or otherwise),
@@ -237,6 +238,10 @@ func run(ctx context.Context, scr *screen, fetch func(context.Context) (*stateRe
 	var lastTPSSec int64
 
 	drawOnce := func() {
+		// Bound each fetch to the poll interval so a slow/hung worker can't
+		// outlive its tick and stall the next refresh (#356). A fetch that
+		// cannot finish within the interval is surfaced as an "unavailable"
+		// frame rather than blocking the loop.
 		fetchCtx, cancel := context.WithTimeout(ctx, interval)
 		defer cancel()
 
@@ -304,7 +309,6 @@ func (s *screen) enter() {
 }
 
 // restore reverses enter: show cursor, reset attributes, leave alt-screen.
-// It is a no-op outside lifecycle mode and safe to call more than once.
 func (s *screen) restore() {
 	if s.lifecycle {
 		io.WriteString(s.w, ansiShowCursor+ansiReset+ansiAltScreenLeave)

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -11,10 +12,12 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"os/signal"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 	"unicode/utf8"
 )
@@ -34,6 +37,12 @@ const (
 
 	// Clear screen + cursor home: equivalent to IO.ANSI.home() <> IO.ANSI.clear()
 	ansiClear = "\033[H\033[2J"
+
+	// Terminal lifecycle sequences (not part of the upstream parity frame body).
+	ansiAltScreenEnter = "\033[?1049h"
+	ansiAltScreenLeave = "\033[?1049l"
+	ansiHideCursor     = "\033[?25l"
+	ansiShowCursor     = "\033[?25h"
 )
 
 // Column widths (mirrors Elixir @running_*_width constants)
@@ -150,6 +159,7 @@ func rollingTPS(samples []tokenSample, now time.Time, currentTokens int64) float
 func main() {
 	urlFlag := flag.String("url", "http://127.0.0.1:4000/", "worker HTTP API base URL")
 	intervalFlag := flag.Duration("interval", 5*time.Second, "poll interval")
+	rawFlag := flag.Bool("raw", false, "disable alt-screen/cursor management (upstream parity mode)")
 	flag.Parse()
 
 	baseURL := strings.TrimSuffix(*urlFlag, "/")
@@ -162,17 +172,41 @@ func main() {
 	stateURL := baseURL + "/api/v1/state"
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	var samples []tokenSample
-	var lastTPS float64
-	var lastTPSSec int64
 	interval := *intervalFlag
 	if interval <= 0 {
 		fmt.Fprintln(os.Stderr, "--interval must be a positive duration (e.g. 5s)")
 		os.Exit(1)
 	}
 
-	for {
-		state, fetchErr := fetchState(client, stateURL)
+	scr := newScreen(os.Stdout, isTerminal(os.Stdout), *rawFlag)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	fetch := func(ctx context.Context) (*stateResponse, error) {
+		return fetchState(ctx, client, stateURL)
+	}
+
+	run(scr, fetch, interval, baseURL, sigCh)
+}
+
+// run drives the poll/render loop until a signal arrives on sigCh, restoring
+// terminal state on the way out so an interrupted dashboard never leaves the
+// real terminal in alt-screen / cursor-hidden state.
+func run(scr *screen, fetch func(context.Context) (*stateResponse, error), interval time.Duration, baseURL string, sigCh <-chan os.Signal) {
+	scr.enter()
+	defer scr.restore()
+
+	var samples []tokenSample
+	var lastTPS float64
+	var lastTPSSec int64
+
+	drawOnce := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), interval)
+		defer cancel()
+
+		state, fetchErr := fetch(ctx)
 		now := time.Now()
 
 		if fetchErr == nil {
@@ -184,10 +218,76 @@ func main() {
 		}
 
 		content := safeRenderFrame(state, fetchErr, now, lastTPS, baseURL, interval)
-		fmt.Fprint(os.Stdout, ansiClear+content+"\n")
-
-		time.Sleep(interval)
+		scr.draw(content)
 	}
+
+	drawOnce()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-sigCh:
+			return
+		case <-ticker.C:
+			drawOnce()
+		}
+	}
+}
+
+// ── Terminal screen lifecycle ──────────────────────────────────────────────────
+
+// screen wraps the output writer with optional alt-screen / cursor management.
+// The per-frame body bytes are identical across modes; only the surrounding
+// terminal control sequences differ, so upstream parity is preserved.
+type screen struct {
+	w io.Writer
+	// isTTY gates the per-frame clear sequence (the ANSI clear is control noise
+	// when stdout is piped or redirected).
+	isTTY bool
+	// lifecycle gates alt-screen + cursor management. Active only on a real TTY
+	// when --raw is not set.
+	lifecycle bool
+}
+
+func newScreen(w io.Writer, isTTY, raw bool) *screen {
+	return &screen{w: w, isTTY: isTTY, lifecycle: isTTY && !raw}
+}
+
+// enter switches to the alternate screen buffer and hides the cursor.
+func (s *screen) enter() {
+	if s.lifecycle {
+		io.WriteString(s.w, ansiAltScreenEnter+ansiHideCursor)
+	}
+}
+
+// restore reverses enter: show cursor, reset attributes, leave alt-screen.
+// It is a no-op outside lifecycle mode and safe to call more than once.
+func (s *screen) restore() {
+	if s.lifecycle {
+		io.WriteString(s.w, ansiShowCursor+ansiReset+ansiAltScreenLeave)
+	}
+}
+
+// draw writes a single rendered frame. On a TTY each frame is preceded by the
+// upstream clear sequence; on a non-TTY the clear is dropped so the output is
+// plain, appendable text.
+func (s *screen) draw(content string) {
+	if s.isTTY {
+		io.WriteString(s.w, ansiClear+content+"\n")
+	} else {
+		io.WriteString(s.w, content+"\n")
+	}
+}
+
+// isTerminal reports whether f refers to a character device (a real terminal),
+// using only the standard library (no x/term dependency).
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 // safeRenderFrame wraps renderFrame with panic recovery, mirroring the
@@ -205,8 +305,12 @@ func safeRenderFrame(state *stateResponse, fetchErr error, now time.Time, tps fl
 	return renderFrame(state, fetchErr, now, tps, baseURL, interval)
 }
 
-func fetchState(client *http.Client, url string) (*stateResponse, error) {
-	resp, err := client.Get(url)
+func fetchState(ctx context.Context, client *http.Client, url string) (*stateResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -180,19 +180,32 @@ func main() {
 
 	scr := newScreen(os.Stdout, isTerminal(os.Stdout), *rawFlag)
 
-	// NotifyContext cancels ctx on SIGINT/SIGTERM, which both breaks the render
-	// loop and aborts any in-flight fetch (the per-fetch context derives from
-	// ctx), so Ctrl-C restores the terminal immediately even mid-poll. The
-	// sibling cmd/ entrypoints use NotifyContext the same way; unlike them, the
-	// TUI re-raises the signal below for a conventional exit status (see run).
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	// A second subscription records which signal fired (NotifyContext discards
-	// the value) so it can be re-raised for a conventional exit status.
+	// A single signal subscription drives both shutdown and the exit status.
+	// Using one subscription (rather than signal.NotifyContext plus a second
+	// signal.Notify) avoids a startup race: two independent subscriptions can't
+	// be installed atomically, so a signal landing between them could cancel ctx
+	// without the value reaching the exit-status channel, hanging shutdown.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
+
+	// The first signal cancels ctx — breaking the render loop and aborting any
+	// in-flight fetch (the per-fetch context derives from ctx), so Ctrl-C
+	// restores the terminal immediately even mid-poll. The signal value is
+	// handed to exitSig (buffered, before the cancel) so it can be re-raised for
+	// a conventional exit status.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	exitSig := make(chan os.Signal, 1)
+	go func() {
+		// Channel/cancel only — no panic surface, no external I/O.
+		select {
+		case s := <-sigCh:
+			exitSig <- s
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
 
 	fetch := func(ctx context.Context) (*stateResponse, error) {
 		return fetchState(ctx, client, stateURL)
@@ -200,12 +213,15 @@ func main() {
 
 	run(ctx, scr, fetch, interval, baseURL)
 
-	// run returns only once ctx is cancelled, and with a background parent and
-	// stop deferred the sole canceller during the loop is a signal — so a signal
-	// definitely fired and sigCh will receive it (no ordering assumption needed).
-	// run has already restored the terminal; re-raise so we exit with the
-	// conventional 128+signum status (130 for SIGINT) instead of 0.
-	raiseAfterSignal(<-sigCh)
+	// run has already restored the terminal (its deferred restore). On signal
+	// shutdown exitSig holds the value (sent before the cancel that unblocks
+	// run); re-raise it so we exit with the conventional 128+signum status (130
+	// for SIGINT). The non-blocking read guarantees we never hang here.
+	select {
+	case s := <-exitSig:
+		raiseAfterSignal(s)
+	default:
+	}
 }
 
 // raiseAfterSignal restores the default disposition for sig and re-raises it so

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -182,15 +182,14 @@ func main() {
 
 	// NotifyContext cancels ctx on SIGINT/SIGTERM, which both breaks the render
 	// loop and aborts any in-flight fetch (the per-fetch context derives from
-	// ctx), so Ctrl-C restores the terminal immediately even mid-poll. This
-	// mirrors the signal handling in the sibling cmd/ entrypoints.
+	// ctx), so Ctrl-C restores the terminal immediately even mid-poll. The
+	// sibling cmd/ entrypoints use NotifyContext the same way; unlike them, the
+	// TUI re-raises the signal below for a conventional exit status (see run).
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	// A second subscription records which signal fired (NotifyContext discards
-	// the value) so it can be re-raised for a conventional exit status. The
-	// runtime delivers to this channel before NotifyContext's goroutine cancels
-	// ctx, so the value is buffered by the time run returns.
+	// the value) so it can be re-raised for a conventional exit status.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
@@ -201,14 +200,12 @@ func main() {
 
 	run(ctx, scr, fetch, interval, baseURL)
 
-	// run has already restored the terminal (its deferred restore). If a signal
-	// caused the shutdown, re-raise it so we exit with the conventional
-	// 128+signum status (130 for SIGINT) instead of 0.
-	select {
-	case s := <-sigCh:
-		raiseAfterSignal(s)
-	default:
-	}
+	// run returns only once ctx is cancelled, and with a background parent and
+	// stop deferred the sole canceller during the loop is a signal — so a signal
+	// definitely fired and sigCh will receive it (no ordering assumption needed).
+	// run has already restored the terminal; re-raise so we exit with the
+	// conventional 128+signum status (130 for SIGINT) instead of 0.
+	raiseAfterSignal(<-sigCh)
 }
 
 // raiseAfterSignal restores the default disposition for sig and re-raises it so

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -180,17 +180,49 @@ func main() {
 
 	scr := newScreen(os.Stdout, isTerminal(os.Stdout), *rawFlag)
 
-	// NotifyContext is the idiomatic modern pattern: the context is cancelled
-	// on SIGINT/SIGTERM, which both breaks the render loop and aborts any
-	// in-flight fetch so Ctrl-C restores the terminal immediately even mid-poll.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	// Translate the first signal into context cancellation: this both breaks
+	// the render loop and aborts any in-flight fetch (the per-fetch context is
+	// derived from ctx), so Ctrl-C restores the terminal immediately even
+	// mid-poll. The caught signal is handed back for a conventional exit code.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	caught := make(chan os.Signal, 1)
+	go func() {
+		select {
+		case s := <-sigCh:
+			caught <- s
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
 
 	fetch := func(ctx context.Context) (*stateResponse, error) {
 		return fetchState(ctx, client, stateURL)
 	}
 
 	run(ctx, scr, fetch, interval, baseURL)
+
+	// run has already restored the terminal (its deferred restore). If a signal
+	// caused the shutdown, re-raise it under the default handler so we exit with
+	// the conventional 128+signum status (130 for SIGINT) rather than 0.
+	select {
+	case s := <-caught:
+		signal.Reset(os.Interrupt, syscall.SIGTERM)
+		if p, err := os.FindProcess(os.Getpid()); err == nil {
+			_ = p.Signal(s)
+		}
+		// Safety net if the re-raised signal doesn't terminate the process.
+		time.Sleep(100 * time.Millisecond)
+		if sysSig, ok := s.(syscall.Signal); ok {
+			os.Exit(128 + int(sysSig))
+		}
+		os.Exit(1)
+	default:
+	}
 }
 
 // run drives the poll/render loop until ctx is cancelled (signal or otherwise),
@@ -288,16 +320,6 @@ func (s *screen) draw(content string) {
 	} else {
 		io.WriteString(s.w, content+"\n")
 	}
-}
-
-// isTerminal reports whether f refers to a character device (a real terminal),
-// using only the standard library (no x/term dependency).
-func isTerminal(f *os.File) bool {
-	fi, err := f.Stat()
-	if err != nil {
-		return false
-	}
-	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 // safeRenderFrame wraps renderFrame with panic recovery, mirroring the

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -180,21 +180,23 @@ func main() {
 
 	scr := newScreen(os.Stdout, isTerminal(os.Stdout), *rawFlag)
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
+	// NotifyContext is the idiomatic modern pattern: the context is cancelled
+	// on SIGINT/SIGTERM, which both breaks the render loop and aborts any
+	// in-flight fetch so Ctrl-C restores the terminal immediately even mid-poll.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	fetch := func(ctx context.Context) (*stateResponse, error) {
 		return fetchState(ctx, client, stateURL)
 	}
 
-	run(scr, fetch, interval, baseURL, sigCh)
+	run(ctx, scr, fetch, interval, baseURL)
 }
 
-// run drives the poll/render loop until a signal arrives on sigCh, restoring
-// terminal state on the way out so an interrupted dashboard never leaves the
-// real terminal in alt-screen / cursor-hidden state.
-func run(scr *screen, fetch func(context.Context) (*stateResponse, error), interval time.Duration, baseURL string, sigCh <-chan os.Signal) {
+// run drives the poll/render loop until ctx is cancelled (signal or otherwise),
+// restoring terminal state on the way out so an interrupted dashboard never
+// leaves the real terminal in alt-screen / cursor-hidden state.
+func run(ctx context.Context, scr *screen, fetch func(context.Context) (*stateResponse, error), interval time.Duration, baseURL string) {
 	scr.enter()
 	defer scr.restore()
 
@@ -203,10 +205,15 @@ func run(scr *screen, fetch func(context.Context) (*stateResponse, error), inter
 	var lastTPSSec int64
 
 	drawOnce := func() {
-		ctx, cancel := context.WithTimeout(context.Background(), interval)
+		fetchCtx, cancel := context.WithTimeout(ctx, interval)
 		defer cancel()
 
-		state, fetchErr := fetch(ctx)
+		state, fetchErr := fetch(fetchCtx)
+		// If we're shutting down, don't paint a spurious final (error) frame —
+		// just unwind so the deferred restore runs.
+		if ctx.Err() != nil {
+			return
+		}
 		now := time.Now()
 
 		if fetchErr == nil {
@@ -222,12 +229,15 @@ func run(scr *screen, fetch func(context.Context) (*stateResponse, error), inter
 	}
 
 	drawOnce()
+	if ctx.Err() != nil {
+		return
+	}
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-sigCh:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			drawOnce()

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -181,7 +184,7 @@ func TestFetchState_ReturnsErrorOnNon2xx(t *testing.T) {
 	defer srv.Close()
 
 	client := &http.Client{}
-	_, err := fetchState(client, srv.URL)
+	_, err := fetchState(context.Background(), client, srv.URL)
 	if err == nil {
 		t.Fatal("fetchState returned nil error for 503 response, want error")
 	}
@@ -199,7 +202,7 @@ func TestFetchState_ParsesValidResponse(t *testing.T) {
 	defer srv.Close()
 
 	client := &http.Client{}
-	state, err := fetchState(client, srv.URL)
+	state, err := fetchState(context.Background(), client, srv.URL)
 	if err != nil {
 		t.Fatalf("fetchState error = %v", err)
 	}
@@ -219,5 +222,109 @@ func TestFormatResetValue_IntegerGetsSuffix(t *testing.T) {
 	}
 	if got := formatResetValue("already-string"); got != "already-string" {
 		t.Errorf("formatResetValue(string) = %q, want passthrough", got)
+	}
+}
+
+// ── screen lifecycle (alt-screen / cursor / non-TTY degrade) ──────────────────
+
+// On a TTY the per-frame output must stay byte-for-byte identical to upstream:
+// clear sequence + content + newline.
+func TestScreen_Draw_TTYKeepsParityBytes(t *testing.T) {
+	var buf bytes.Buffer
+	scr := newScreen(&buf, true /* isTTY */, false /* raw */)
+	scr.draw("BODY")
+	if got, want := buf.String(), ansiClear+"BODY\n"; got != want {
+		t.Errorf("draw on TTY = %q, want %q", got, want)
+	}
+}
+
+// Non-TTY output must not contain the clear / alt-screen / cursor control bytes
+// (item 5: piped/redirected output should be plain).
+func TestScreen_Draw_NonTTYDropsControlBytes(t *testing.T) {
+	var buf bytes.Buffer
+	scr := newScreen(&buf, false /* isTTY */, false /* raw */)
+	scr.enter()
+	scr.draw("BODY")
+	scr.restore()
+
+	out := buf.String()
+	if out != "BODY\n" {
+		t.Errorf("non-TTY output = %q, want %q (plain, no control bytes)", out, "BODY\n")
+	}
+	if strings.Contains(out, "\033") {
+		t.Errorf("non-TTY output contains an escape byte: %q", out)
+	}
+}
+
+func TestScreen_EnterRestore_LifecycleSequences(t *testing.T) {
+	var buf bytes.Buffer
+	scr := newScreen(&buf, true /* isTTY */, false /* raw */)
+
+	scr.enter()
+	if got, want := buf.String(), ansiAltScreenEnter+ansiHideCursor; got != want {
+		t.Errorf("enter() = %q, want %q", got, want)
+	}
+
+	buf.Reset()
+	scr.restore()
+	if got, want := buf.String(), ansiShowCursor+ansiReset+ansiAltScreenLeave; got != want {
+		t.Errorf("restore() = %q, want %q", got, want)
+	}
+}
+
+// --raw on a TTY is parity mode: no alt-screen / cursor management, and the
+// per-frame body is exactly the upstream clear+content+newline.
+func TestScreen_RawModeIsParity(t *testing.T) {
+	var buf bytes.Buffer
+	scr := newScreen(&buf, true /* isTTY */, true /* raw */)
+
+	scr.enter()
+	scr.restore()
+	if buf.Len() != 0 {
+		t.Errorf("raw mode enter/restore wrote %q, want nothing", buf.String())
+	}
+
+	scr.draw("BODY")
+	if got, want := buf.String(), ansiClear+"BODY\n"; got != want {
+		t.Errorf("raw draw = %q, want %q", got, want)
+	}
+}
+
+// ── signal-driven graceful restore (item 2) ──────────────────────────────────
+
+func TestRun_RestoresTerminalOnSignal(t *testing.T) {
+	var buf bytes.Buffer
+	scr := newScreen(&buf, true /* isTTY */, false /* raw */)
+
+	fetch := func(ctx context.Context) (*stateResponse, error) {
+		return &stateResponse{MaxConcurrentAgents: 3}, nil
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	go func() {
+		// A long interval keeps the ticker from firing; only the initial
+		// frame is drawn before the signal arrives.
+		run(scr, fetch, time.Hour, "http://example", sigCh)
+		close(done)
+	}()
+
+	sigCh <- os.Interrupt
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return after signal")
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, ansiAltScreenEnter+ansiHideCursor) {
+		t.Errorf("output did not start by entering alt-screen / hiding cursor: %q", out[:min(40, len(out))])
+	}
+	if !strings.HasSuffix(out, ansiShowCursor+ansiReset+ansiAltScreenLeave) {
+		t.Errorf("output did not end by restoring the terminal: tail=%q", out[max(0, len(out)-40):])
+	}
+	if !strings.Contains(out, "AIOPS STATUS") {
+		t.Errorf("output did not contain a rendered frame: %q", out)
 	}
 }

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -292,6 +291,8 @@ func TestScreen_RawModeIsParity(t *testing.T) {
 
 // ── signal-driven graceful restore (item 2) ──────────────────────────────────
 
+// run exits and restores the terminal when its context is cancelled — exactly
+// what signal.NotifyContext delivers on SIGINT/SIGTERM.
 func TestRun_RestoresTerminalOnSignal(t *testing.T) {
 	var buf bytes.Buffer
 	scr := newScreen(&buf, true /* isTTY */, false /* raw */)
@@ -300,21 +301,23 @@ func TestRun_RestoresTerminalOnSignal(t *testing.T) {
 		return &stateResponse{MaxConcurrentAgents: 3}, nil
 	}
 
-	sigCh := make(chan os.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
 		// A long interval keeps the ticker from firing; only the initial
-		// frame is drawn before the signal arrives.
-		run(scr, fetch, time.Hour, "http://example", sigCh)
+		// frame is drawn before the context is cancelled.
+		run(ctx, scr, fetch, time.Hour, "http://example")
 		close(done)
 	}()
 
-	sigCh <- os.Interrupt
+	// Give the initial frame time to render, then simulate the signal.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
 
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("run did not return after signal")
+		t.Fatal("run did not return after context cancellation")
 	}
 
 	out := buf.String()
@@ -326,5 +329,46 @@ func TestRun_RestoresTerminalOnSignal(t *testing.T) {
 	}
 	if !strings.Contains(out, "AIOPS STATUS") {
 		t.Errorf("output did not contain a rendered frame: %q", out)
+	}
+}
+
+// A signal arriving mid-fetch must abort the fetch and skip the final frame,
+// so the only control bytes after the last frame are the restore sequence.
+func TestRun_CancelDuringFetchAbortsAndRestores(t *testing.T) {
+	var buf bytes.Buffer
+	scr := newScreen(&buf, true /* isTTY */, false /* raw */)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	fetchStarted := make(chan struct{})
+
+	fetch := func(fctx context.Context) (*stateResponse, error) {
+		close(fetchStarted)
+		// Block until the loop's context is cancelled (the fetchCtx derives
+		// from it), mimicking a slow/hung poll interrupted by Ctrl-C.
+		<-fctx.Done()
+		return nil, fctx.Err()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		run(ctx, scr, fetch, time.Hour, "http://example")
+		close(done)
+	}()
+
+	<-fetchStarted
+	cancel() // signal arrives while the very first fetch is in flight
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return after cancellation during fetch")
+	}
+
+	// No frame should have been drawn (fetch never returned a usable state
+	// before cancellation), but the terminal must still be restored.
+	out := buf.String()
+	want := ansiAltScreenEnter + ansiHideCursor + ansiShowCursor + ansiReset + ansiAltScreenLeave
+	if out != want {
+		t.Errorf("output = %q, want enter+restore with no frame (%q)", out, want)
 	}
 }

--- a/cmd/tui/tty_bsd.go
+++ b/cmd/tui/tty_bsd.go
@@ -1,0 +1,9 @@
+//go:build dragonfly || freebsd || netbsd || openbsd
+
+package main
+
+import "syscall"
+
+// ioctlReadTermios is the BSD "get termios" ioctl request (shared with macOS,
+// which has its own file in tty_darwin.go).
+const ioctlReadTermios = syscall.TIOCGETA

--- a/cmd/tui/tty_darwin.go
+++ b/cmd/tui/tty_darwin.go
@@ -1,0 +1,10 @@
+package main
+
+import "syscall"
+
+// macOS is a primary development platform for this tool, so it gets its own
+// build-tagged file (Go's `darwin` GOOS suffix) rather than being folded into
+// the generic BSD group. The isatty mechanism is the BSD-style TIOCGETA ioctl
+// (Darwin has no Linux-style TCGETS); the shared implementation lives in
+// tty_unix.go.
+const ioctlReadTermios = syscall.TIOCGETA

--- a/cmd/tui/tty_darwin_test.go
+++ b/cmd/tui/tty_darwin_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// macOS-specific guard: /dev/null is a character device, so an os.ModeCharDevice
+// check would misclassify it as a terminal; the TIOCGETA ioctl must reject it.
+// Runs only on darwin (file name GOOS suffix); CI is Linux, so this is exercised
+// when developing locally on macOS.
+func TestIsTerminal_DevNullIsNotTTY_Darwin(t *testing.T) {
+	f, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if isTerminal(f) {
+		t.Error("isTerminal(/dev/null) = true, want false (TIOCGETA should reject)")
+	}
+}

--- a/cmd/tui/tty_linux.go
+++ b/cmd/tui/tty_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// isTerminal reports whether f is a real terminal by issuing the TCGETS ioctl —
+// the same mechanism libc's isatty() uses. This is more precise than checking
+// os.ModeCharDevice, which is also true for /dev/null and similar character
+// devices. No external module dependency (golang.org/x/term) is required.
+func isTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		f.Fd(),
+		syscall.TCGETS,
+		uintptr(unsafe.Pointer(&termios)),
+		0, 0, 0,
+	)
+	return errno == 0
+}

--- a/cmd/tui/tty_linux.go
+++ b/cmd/tui/tty_linux.go
@@ -2,27 +2,7 @@
 
 package main
 
-import (
-	"os"
-	"syscall"
-	"unsafe"
-)
+import "syscall"
 
-// isTerminal reports whether f is a real terminal by issuing the TCGETS ioctl —
-// the same mechanism libc's isatty() uses. This is more precise than checking
-// os.ModeCharDevice, which is also true for /dev/null and similar character
-// devices. No external module dependency (golang.org/x/term) is required.
-func isTerminal(f *os.File) bool {
-	if f == nil {
-		return false
-	}
-	var termios syscall.Termios
-	_, _, errno := syscall.Syscall6(
-		syscall.SYS_IOCTL,
-		f.Fd(),
-		syscall.TCGETS,
-		uintptr(unsafe.Pointer(&termios)),
-		0, 0, 0,
-	)
-	return errno == 0
-}
+// ioctlReadTermios is the Linux "get termios" ioctl request.
+const ioctlReadTermios = syscall.TCGETS

--- a/cmd/tui/tty_linux_test.go
+++ b/cmd/tui/tty_linux_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// /dev/null is a character device, so the old os.ModeCharDevice check
+// misclassified it as a terminal; the TCGETS ioctl correctly rejects it.
+func TestIsTerminal_DevNullIsNotTTY(t *testing.T) {
+	f, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if isTerminal(f) {
+		t.Error("isTerminal(/dev/null) = true, want false (ioctl should reject)")
+	}
+}

--- a/cmd/tui/tty_other.go
+++ b/cmd/tui/tty_other.go
@@ -1,12 +1,12 @@
-//go:build !linux
+//go:build !linux && !darwin && !dragonfly && !freebsd && !netbsd && !openbsd
 
 package main
 
 import "os"
 
-// isTerminal falls back to a character-device check on non-Linux platforms.
-// Note: this also reports true for /dev/null; the Linux build uses a precise
-// TCGETS ioctl instead.
+// isTerminal falls back to a character-device check on platforms without a
+// termios ioctl wired up here (e.g. Windows, Plan 9). Note: this also reports
+// true for /dev/null; the unix builds use a precise termios ioctl instead.
 func isTerminal(f *os.File) bool {
 	if f == nil {
 		return false

--- a/cmd/tui/tty_other.go
+++ b/cmd/tui/tty_other.go
@@ -1,0 +1,19 @@
+//go:build !linux
+
+package main
+
+import "os"
+
+// isTerminal falls back to a character-device check on non-Linux platforms.
+// Note: this also reports true for /dev/null; the Linux build uses a precise
+// TCGETS ioctl instead.
+func isTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/tui/tty_test.go
+++ b/cmd/tui/tty_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsTerminal_NilIsNotTTY(t *testing.T) {
+	if isTerminal(nil) {
+		t.Error("isTerminal(nil) = true, want false")
+	}
+}
+
+func TestIsTerminal_RegularFileIsNotTTY(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "tty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if isTerminal(f) {
+		t.Error("isTerminal(regular file) = true, want false")
+	}
+}

--- a/cmd/tui/tty_unix.go
+++ b/cmd/tui/tty_unix.go
@@ -1,0 +1,29 @@
+//go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd
+
+package main
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// isTerminal reports whether f is a real terminal by issuing the platform's
+// "get termios" ioctl (ioctlReadTermios — TCGETS on Linux, TIOCGETA on
+// macOS/BSD), the same mechanism libc's isatty() uses. This is more precise
+// than checking os.ModeCharDevice, which is also true for /dev/null and similar
+// character devices. No external module dependency (golang.org/x/term) is used.
+func isTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		f.Fd(),
+		uintptr(ioctlReadTermios),
+		uintptr(unsafe.Pointer(&termios)),
+		0, 0, 0,
+	)
+	return errno == 0
+}


### PR DESCRIPTION
Closes #356

Implements the scoped subset of the TUI review that the issue flagged as the "suggested approach" — keeping the rendered **frame body byte-for-byte identical** to upstream `SymphonyElixir.StatusDashboard` so the existing parity tests stay green, and **adding no new module dependencies** (stdlib `syscall`/`unsafe` only).

## What's in this PR
- **(1) Alt-screen + cursor management.** On start the dashboard enters the alternate screen buffer (`\033[?1049h`) and hides the cursor (`\033[?25l`); on exit it shows the cursor, resets attributes (`\033[0m`) and leaves the alt-screen. Enabled by **default on a TTY**, disabled by a new **`--raw`** flag (parity mode = exactly today's output). Per-frame body bytes are unchanged in both modes.
- **(2) Signal handling / graceful exit.** `SIGINT`/`SIGTERM` break the render loop cleanly and restore terminal state via `defer` — Ctrl-C no longer leaves the terminal in alt-screen / cursor-hidden.
- **(5) Non-TTY degradation.** When stdout isn't a real terminal (piped/redirected) the clear / alt-screen / cursor control bytes are dropped, producing plain appendable text.
- **(6) Steady cadence.** `time.Ticker` replaces `time.Sleep(interval)` so fetch+render time no longer accumulates into drift.
- **(7) Bounded fetch.** Each poll gets a `context` deadline tied to the interval so a slow fetch can't stall the next tick.

## Best-practice hardening
- **Signal aborts the in-flight fetch.** A single `signal.Notify` subscription feeds a small goroutine that cancels `ctx` on the first signal; the per-fetch context derives from `ctx`, so Ctrl-C during a slow/hung poll aborts the request and restores the terminal immediately instead of waiting up to `interval`. Verified in a pty against a hung server: restore latency dropped from up to 30s to ~2ms.
- **No shutdown-hang race.** The signal value is handed to a buffered channel (before the cancel that unblocks the loop) and read non-blockingly after `run` returns. Using one subscription — rather than `signal.NotifyContext` plus a second `signal.Notify` — avoids a startup window where a signal could cancel `ctx` without the value reaching the exit path (which would otherwise hang shutdown until a second Ctrl-C). Caught by `@codex` review; fixed in b5107e8.
- **Precise `isatty` via a termios ioctl** (`TCGETS` on Linux, `TIOCGETA` on macOS/BSD) instead of `os.ModeCharDevice` (which is also true for `/dev/null`, so `tui > /dev/null` would otherwise stay in TTY mode and emit alt-screen bytes). Split across build-tagged files (`tty_unix.go` + per-platform `ioctlReadTermios`); macOS gets a dedicated `tty_darwin.go`. Non-unix platforms keep the `ModeCharDevice` fallback. No `golang.org/x/term` dependency.
- **Conventional exit status on signal.** After restoring the terminal, the handler is reset and the signal re-raised so the process terminates with `128+signum` (130 for Ctrl-C) rather than exiting 0.

## Deferred (per the issue's "larger / worth their own discussion" note)
- **(3)** Flicker / diff or double-buffer redraw — biggest parity deviation.
- **(4)** `TIOCGWINSZ` + `SIGWINCH` **live resize.** Width still adapts via `COLUMNS` only, as before. This also surfaced a **pre-existing SPEC-alignment gap**: upstream `terminal_columns/0` queries the live tty via `:io.columns()` first and only then falls back to `COLUMNS`, whereas the port is `COLUMNS`-only. Tracked in **#359** (`area:spec-alignment`); intentionally out of scope here to preserve parity tests. (Note: this PR adds a termios ioctl for tty *detection*, not size.)
- **(8)** `rollingTPS` per-tick allocation — micro, touches the boundary-semantics code the parity tests lock.

## Tests
New coverage for: non-TTY degrade, alt-screen/raw modes, the signal-restore loop, cancel-during-fetch, `isatty` (incl. `/dev/null` rejection on Linux; a darwin-only `/dev/null` test for local macOS runs), `raiseAfterSignal` (subprocess test asserting death-by-SIGINT / exit 130), and an end-to-end `TestMain_SignalExitsBySignal` that builds and signals the real binary. All existing parity tests retained. `fetchState` gained a `context` parameter; callers updated.

## Verification
- `gofmt -l` clean; `go vet`, `go build ./cmd/tui/...`, `go test -race ./cmd/tui/...` all pass; cross-compiles for `linux`, `darwin/arm64`+`darwin/amd64`, `windows/amd64`, `freebsd/amd64` (build-tag matrix resolves to exactly one `isTerminal` + one `ioctlReadTermios` per platform).
- Real pty run: starts with alt-screen-enter + cursor-hide, renders frames, and on Ctrl-C restores the terminal and terminates by signal (shell sees 130); Ctrl-C mid-hung-fetch restores in ~2ms.
- Piped (non-TTY): zero `\033[?1049` / `\033[H\033[2J` sequences, frame content intact.
- Reviewed across three independent SPEC-aligned audit rounds + `@codex review` (no major issues on the final commit).