### PR TITLE
fix(tui): query live terminal width first, mirroring :io.columns()

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -250,7 +250,16 @@ func run(ctx context.Context, scr *screen, fetch func(context.Context) (*stateRe
 	var lastTPS float64
 	var lastTPSSec int64
 
-	drawOnce := func() {
+	// Last rendered snapshot, reused by redraw() so a resize reflows the table
+	// at the new width without issuing another fetch.
+	var (
+		haveSnapshot bool
+		lastState    *stateResponse
+		lastErr      error
+		lastNow      time.Time
+	)
+
+	poll := func() {
 		// Bound each fetch to the poll interval so a slow/hung worker can't
 		// outlive its tick and stall the next refresh (#356). A fetch that
 		// cannot finish within the interval is surfaced as an "unavailable"
@@ -274,14 +283,29 @@ func run(ctx context.Context, scr *screen, fetch func(context.Context) (*stateRe
 			}
 		}
 
-		content := safeRenderFrame(state, fetchErr, now, lastTPS, baseURL, interval)
-		scr.draw(content)
+		lastState, lastErr, lastNow, haveSnapshot = state, fetchErr, now, true
+		scr.draw(safeRenderFrame(state, fetchErr, now, lastTPS, baseURL, interval))
 	}
 
-	drawOnce()
+	// redraw re-renders the last snapshot at the current terminal width (the
+	// width is re-evaluated inside renderFrame via terminalColumns), so a live
+	// SIGWINCH resize reflows immediately instead of waiting for the next tick.
+	redraw := func() {
+		if !haveSnapshot {
+			return
+		}
+		scr.draw(safeRenderFrame(lastState, lastErr, lastNow, lastTPS, baseURL, interval))
+	}
+
+	poll()
 	if ctx.Err() != nil {
 		return
 	}
+
+	// Reflow on terminal resize (SIGWINCH on unix; a no-op where unavailable).
+	winch := make(chan os.Signal, 1)
+	stopResize := notifyResize(winch)
+	defer stopResize()
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -290,7 +314,9 @@ func run(ctx context.Context, scr *screen, fetch func(context.Context) (*stateRe
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			drawOnce()
+			poll()
+		case <-winch:
+			redraw()
 		}
 	}
 }
@@ -756,10 +782,25 @@ func statusDotColor(event string) string {
 	}
 }
 
-// terminalColumns mirrors terminal_columns/0 + terminal_columns_from_env/0.
+// liveTerminalWidth resolves the dashboard output's live terminal width. It is a
+// package var so tests can stub the tty query — which can't be forced from a
+// non-tty test process — to exercise the terminalColumns precedence.
+var liveTerminalWidth = func() (int, bool) { return terminalWidth(os.Stdout) }
+
+// terminalColumns mirrors terminal_columns/0: query the live terminal width
+// first (TIOCGWINSZ, the :io.columns() equivalent), then fall back to the
+// COLUMNS-env precedence of terminal_columns_from_env/0.
+func terminalColumns() int {
+	if cols, ok := liveTerminalWidth(); ok {
+		return cols
+	}
+	return terminalColumnsFromEnv()
+}
+
+// terminalColumnsFromEnv mirrors terminal_columns_from_env/0.
 // When COLUMNS is absent: Elixir computes fixed_running_width + chrome + event_default.
 // When COLUMNS is present but invalid: Elixir falls back to @default_terminal_columns (115).
-func terminalColumns() int {
+func terminalColumnsFromEnv() int {
 	s := os.Getenv("COLUMNS")
 	if s == "" {
 		return fixedRunningWidth() + chromeWidth + colEventDef

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -224,6 +224,49 @@ func TestFormatResetValue_IntegerGetsSuffix(t *testing.T) {
 	}
 }
 
+// ── terminalColumns precedence (live tty width → COLUMNS → default) ────────────
+// Mirrors :io.columns() precedence: the live terminal width wins, then COLUMNS,
+// then the @default_terminal_columns / computed-default fallbacks. The live
+// width is stubbed because a non-tty test process can't be forced to report one.
+
+func TestTerminalColumns_Precedence(t *testing.T) {
+	orig := liveTerminalWidth
+	t.Cleanup(func() { liveTerminalWidth = orig })
+
+	t.Run("live width preferred over COLUMNS", func(t *testing.T) {
+		t.Setenv("COLUMNS", "200")
+		liveTerminalWidth = func() (int, bool) { return 137, true }
+		if got := terminalColumns(); got != 137 {
+			t.Errorf("terminalColumns() = %d, want 137 (live tty width must win over COLUMNS)", got)
+		}
+	})
+
+	t.Run("COLUMNS used when live width unavailable", func(t *testing.T) {
+		liveTerminalWidth = func() (int, bool) { return 0, false }
+		t.Setenv("COLUMNS", "200")
+		if got := terminalColumns(); got != 200 {
+			t.Errorf("terminalColumns() = %d, want 200 (COLUMNS fallback)", got)
+		}
+	})
+
+	t.Run("invalid COLUMNS falls back to default", func(t *testing.T) {
+		liveTerminalWidth = func() (int, bool) { return 0, false }
+		t.Setenv("COLUMNS", "not-a-number")
+		if got := terminalColumns(); got != defaultTermCols {
+			t.Errorf("terminalColumns() = %d, want %d (@default_terminal_columns)", got, defaultTermCols)
+		}
+	})
+
+	t.Run("computed default when neither live width nor COLUMNS", func(t *testing.T) {
+		liveTerminalWidth = func() (int, bool) { return 0, false }
+		t.Setenv("COLUMNS", "")
+		want := fixedRunningWidth() + chromeWidth + colEventDef
+		if got := terminalColumns(); got != want {
+			t.Errorf("terminalColumns() = %d, want %d (computed default)", got, want)
+		}
+	})
+}
+
 // ── screen lifecycle (alt-screen / cursor / non-TTY degrade) ──────────────────
 
 // On a TTY the per-frame output must stay byte-for-byte identical to upstream:

--- a/cmd/tui/resize_unix_test.go
+++ b/cmd/tui/resize_unix_test.go
@@ -1,0 +1,87 @@
+//go:build unix
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// lockedBuffer is a goroutine-safe io.Writer so the test can read frames while
+// run() writes them from its own goroutine (keeps -race quiet).
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// A SIGWINCH must reflow the dashboard by redrawing the last snapshot — without
+// issuing another fetch — so a live terminal resize is reflected immediately.
+func TestRun_RedrawsOnSIGWINCH(t *testing.T) {
+	lb := &lockedBuffer{}
+	scr := newScreen(lb, true /* isTTY */, false /* raw */)
+
+	var fetches int32
+	fetch := func(context.Context) (*stateResponse, error) {
+		atomic.AddInt32(&fetches, 1)
+		return &stateResponse{MaxConcurrentAgents: 3}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		// A long interval keeps the ticker silent: the only frames are the
+		// initial poll and the SIGWINCH-driven redraw.
+		run(ctx, scr, fetch, time.Hour, "http://example")
+		close(done)
+	}()
+
+	frames := func() int { return strings.Count(lb.String(), "AIOPS STATUS") }
+	waitUntil(t, "initial frame", func() bool { return frames() >= 1 })
+	before := frames()
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGWINCH); err != nil {
+		t.Fatalf("raise SIGWINCH: %v", err)
+	}
+	waitUntil(t, "redraw after SIGWINCH", func() bool { return frames() > before })
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return after cancellation")
+	}
+
+	if got := atomic.LoadInt32(&fetches); got != 1 {
+		t.Errorf("fetch called %d times, want 1 (SIGWINCH redraw must not refetch)", got)
+	}
+}
+
+func waitUntil(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/cmd/tui/tty_other.go
+++ b/cmd/tui/tty_other.go
@@ -17,3 +17,15 @@ func isTerminal(f *os.File) bool {
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
 }
+
+// terminalWidth has no portable live-width query without the TIOCGWINSZ ioctl,
+// so it reports ok=false and callers fall back to the COLUMNS env.
+func terminalWidth(*os.File) (int, bool) {
+	return 0, false
+}
+
+// notifyResize is a no-op where SIGWINCH is unavailable (e.g. Windows): there
+// are no resize events to deliver, so the returned stop function does nothing.
+func notifyResize(chan os.Signal) func() {
+	return func() {}
+}

--- a/cmd/tui/tty_unix.go
+++ b/cmd/tui/tty_unix.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os"
+	"os/signal"
 	"syscall"
 	"unsafe"
 )
@@ -26,4 +27,36 @@ func isTerminal(f *os.File) bool {
 		0, 0, 0,
 	)
 	return errno == 0
+}
+
+// terminalWidth reports the live column width of f via a TIOCGWINSZ ioctl — the
+// portable equivalent of the BEAM's :io.columns(). It reports ok=false when f is
+// nil, not a tty, or the kernel reports a zero width, so callers fall back to the
+// COLUMNS env. TIOCGWINSZ is the same constant across the unix targets (unlike
+// the termios "get" request), so no per-platform constant is needed. No external
+// module dependency (golang.org/x/term) is used.
+func terminalWidth(f *os.File) (int, bool) {
+	if f == nil {
+		return 0, false
+	}
+	var ws struct{ Row, Col, Xpixel, Ypixel uint16 }
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		f.Fd(),
+		uintptr(syscall.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(&ws)),
+		0, 0, 0,
+	)
+	if errno != 0 || ws.Col == 0 {
+		return 0, false
+	}
+	return int(ws.Col), true
+}
+
+// notifyResize delivers terminal-resize events (SIGWINCH) to ch and returns a
+// stop function. Resize is a unix signal; tty_other.go provides a no-op so the
+// render loop stays portable.
+func notifyResize(ch chan os.Signal) func() {
+	signal.Notify(ch, syscall.SIGWINCH)
+	return func() { signal.Stop(ch) }
 }


### PR DESCRIPTION
## Summary
- **#359 (SPEC alignment):** `terminalColumns()` now queries the live terminal width first via a `TIOCGWINSZ` ioctl, then `COLUMNS`, then the default — matching upstream `StatusDashboard.terminal_columns/0` (`:io.columns()`) precedence. Previously it consulted only `COLUMNS`, so the dashboard rendered at the 115-col default unless `COLUMNS` was exported. Reuses #358's per-platform tty scaffolding (raw `syscall`, no `golang.org/x/term`); `terminalWidth` lives in `tty_unix.go` with a `(0,false)` fallback in `tty_other.go`. The `COLUMNS` / invalid-`COLUMNS` branches are unchanged (`terminalColumnsFromEnv`), preserving width parity when no tty is present.
- **SIGWINCH reflow:** the render loop's `select` gains a resize case that redraws the last snapshot at the new width without refetching (`notifyResize` is a unix wrapper, no-op elsewhere).

## Test plan
- [x] `gofmt -l` clean, `go vet`, `go build ./...`, `go test -race ./cmd/tui/...` green
- [x] `windows/amd64` cross-compile OK (build-tag fallback)
- [x] `go mod tidy` leaves go.mod/go.sum clean (zero new deps)
- [x] Precedence test (live width → COLUMNS → default) and SIGWINCH-redraw test, both mutation-verified

Closes #359

---
Scope note: the unrelated `gh` installer hook fix that originally rode along here has been split into #361.

https://claude.ai/code/session_01VhAMpsX6sEMtEp34HvYaMM