### PR TITLE
fix(examples): start WORKFLOW.md front matter on line 1 so it parses

### DIFF
--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -1,9 +1,9 @@
+---
 # This is the service-level WORKFLOW.md selected when the worker process starts:
 # pass it explicitly as `worker /path/to/WORKFLOW.md`, or run the worker from a
 # directory containing `WORKFLOW.md`. Per Symphony SPEC §5.1, the worker loads
 # this single file for the service and reuses it for every task; per-task
 # repository checkouts do not override it.
----
 repo:
   owner: your-gitea-user
   name: your-repo


### PR DESCRIPTION
## Summary

Found during an end-to-end installation test of the documented quick-start.

`examples/WORKFLOW.md` — the file the README quick-start and the local-dev runbook both tell operators to copy and run — opened with five `#` comment lines **before** the `---` fence. `splitFrontMatter` (`internal/workflow/loader.go:601`) only recognizes front matter when the file begins with `---\n`, so the entire file (YAML included) was parsed as the prompt body:

- resolves as `source=prompt_only` with empty `tracker.kind` and `repo.clone_url`
- worker refuses to boot: `repo.clone_url is required for poll-based worker runtime` — **even when `clone_url` is set in the YAML**, because the YAML is never read

This fix moves the `---` opening fence to line 1 and keeps the explanatory text as YAML comments inside the front matter (one-line diff). The sibling examples (`gitea-WORKFLOW.md`, `github-local-WORKFLOW.md`) already start with `---` on line 1 and were unaffected.

## Verification

- `worker --print-config` on the fixed file now resolves `source=file`, `tracker.kind=linear`, populated `clone_url`, `api_key` masked, `policy.mode=draft_pr`.
- Worker boot now parses the front matter, reads the configured `active_states`/`workspace.root`, and binds the §13.7 state endpoint on `127.0.0.1:4000` (a 401 from a dummy `LINEAR_API_KEY` is the expected stopping point — previously it died at `repo.clone_url is required`).
- `gofmt` clean; `go test ./...` green (16/16 packages); all four binaries build.

The underlying loader footgun (silent `prompt_only` fallthrough when a `---…---` block exists but not on line 1) is tracked separately in #362.

## Test plan

- [ ] `go run ./cmd/worker --print-config examples` reports `source: file` and `tracker.kind: linear`
- [ ] CI green

https://claude.ai/code/session_01AkYgszT4YNBBTTHHbDPPYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkYgszT4YNBBTTHHbDPPYM)_