### PR TITLE
feat(worker): configurable dashboard bind host + Compose dashboard overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,12 @@ docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dashboard.y
 
 The overlay sets `AIOPS_SERVER_HOST=0.0.0.0` (bind all interfaces *inside* the
 container) but publishes only to host loopback (`127.0.0.1:4000:4000`), so the
-trust boundary stays the host loopback. The Host-header guard is spoofable and
-the surface is unauthenticated, so do **not** publish on a routable host
-interface without adding authentication first.
+host trust boundary stays the loopback. It also moves the worker onto a
+dedicated `dashboard` bridge network — off the project default network — so
+sibling containers (e.g. the legacy-queue services) cannot reach `worker:4000`
+and spoof the loopback Host guard. The surface is still unauthenticated, so do
+**not** publish on a routable host interface or attach untrusted containers to
+the dashboard network without adding authentication first.
 
 **Treat the status surface as live agent text even though it binds to loopback.**
 Per SPEC §15.3, each running row's `last_message` is a passthrough of the most

--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ README ever diverge, **this README is canonical**.
 
 ## Operator surfaces
 
-The worker binds a private-loopback HTTP server at `127.0.0.1:<server.port>`
-(default `4000`). The same listener serves the JSON state API and the web
-dashboard:
+The worker binds an HTTP server at `<server.host>:<server.port>`, defaulting to
+the private loopback `127.0.0.1:4000`. Override the bind host with `server.host`
+in `WORKFLOW.md` or the `AIOPS_SERVER_HOST` environment variable (a blank value
+keeps the loopback default). The same listener serves the JSON state API and the
+web dashboard:
 
 | Path | Purpose |
 |------|---------|
@@ -144,6 +146,20 @@ listener entirely (e.g. when you provide your own state bridge). If the
 configured listener cannot start, the worker logs the failure, continues without
 the HTTP surface, and retries on later workflow-reload checks until the bind
 succeeds or `server.port` changes.
+
+Under Docker Compose the default loopback bind is unreachable from the host
+(Docker publishes ports to the container interface, not its loopback). Merge the
+opt-in overlay to reach the dashboard from the host:
+
+```bash
+docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dashboard.yml up worker
+```
+
+The overlay sets `AIOPS_SERVER_HOST=0.0.0.0` (bind all interfaces *inside* the
+container) but publishes only to host loopback (`127.0.0.1:4000:4000`), so the
+trust boundary stays the host loopback. The Host-header guard is spoofable and
+the surface is unauthenticated, so do **not** publish on a routable host
+interface without adding authentication first.
 
 **Treat the status surface as live agent text even though it binds to loopback.**
 Per SPEC §15.3, each running row's `last_message` is a passthrough of the most

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -170,11 +170,13 @@ func desiredHostForLoop(opts stateHTTPServerLoopOptions, wf *workflow.Workflow) 
 }
 
 // serverHostOverrideFromEnv returns the AIOPS_SERVER_HOST override, or nil when
-// the variable is unset or empty so the workflow `server.host` (then the
-// loopback default) still applies.
+// the variable is unset so the workflow `server.host` (then the loopback
+// default) still applies. A set-but-empty value is an explicit override:
+// normalizeServerHost maps it to the safe loopback default, so
+// `AIOPS_SERVER_HOST=` forces loopback even over a workflow `server.host`.
 func serverHostOverrideFromEnv() *string {
 	host, ok := os.LookupEnv("AIOPS_SERVER_HOST")
-	if !ok || host == "" {
+	if !ok {
 		return nil
 	}
 	return &host

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -152,6 +153,31 @@ func desiredPortForLoop(opts stateHTTPServerLoopOptions, wf *workflow.Workflow) 
 		return wf.Config.Server.Port
 	}
 	return -1
+}
+
+// desiredHostForLoop selects the effective state-server bind host for one tick.
+// The AIOPS_SERVER_HOST env override wins, then the workflow snapshot's
+// `server.host`, then the loopback default. The empty string is returned as-is
+// and normalized to 127.0.0.1 at bind time (normalizeServerHost).
+func desiredHostForLoop(opts stateHTTPServerLoopOptions, wf *workflow.Workflow) string {
+	if opts.HostOverride != nil {
+		return *opts.HostOverride
+	}
+	if wf != nil {
+		return wf.Config.Server.Host
+	}
+	return ""
+}
+
+// serverHostOverrideFromEnv returns the AIOPS_SERVER_HOST override, or nil when
+// the variable is unset or empty so the workflow `server.host` (then the
+// loopback default) still applies.
+func serverHostOverrideFromEnv() *string {
+	host, ok := os.LookupEnv("AIOPS_SERVER_HOST")
+	if !ok || host == "" {
+		return nil
+	}
+	return &host
 }
 
 func loadWorkflowForStartupReconcile() (*workflow.Workflow, error) {
@@ -342,7 +368,7 @@ func run(ctx context.Context, args []string) error {
 		}
 	}()
 	go func() {
-		if err := runStateHTTPServerLoop(ctx, runtime, orch.Snapshot, stateHTTPServerLoopOptions{Refresh: orch.RequestRefresh, PortOverride: portOverride}); err != nil && ctx.Err() == nil {
+		if err := runStateHTTPServerLoop(ctx, runtime, orch.Snapshot, stateHTTPServerLoopOptions{Refresh: orch.RequestRefresh, PortOverride: portOverride, HostOverride: serverHostOverrideFromEnv()}); err != nil && ctx.Err() == nil {
 			log.Printf("state HTTP server loop exited: %v", err)
 		}
 	}()
@@ -354,6 +380,7 @@ type stateHTTPServerController struct {
 	refresh  stateRefreshFunc
 
 	desiredSet  bool
+	desiredHost string
 	desiredPort int
 	cancel      context.CancelFunc
 	addr        net.Addr
@@ -364,20 +391,21 @@ func newStateHTTPServerController(snapshot stateSnapshotFunc, refresh ...stateRe
 	return &stateHTTPServerController{snapshot: snapshot, refresh: optionalStateRefreshFunc(refresh)}
 }
 
-func (c *stateHTTPServerController) apply(ctx context.Context, port int) error {
+func (c *stateHTTPServerController) apply(ctx context.Context, host string, port int) error {
 	c.refreshStopped()
-	if c.desiredSet && c.desiredPort == port {
+	if c.desiredSet && c.desiredHost == host && c.desiredPort == port {
 		return nil
 	}
 	c.stop()
 	if port < 0 {
 		c.desiredSet = true
+		c.desiredHost = host
 		c.desiredPort = port
 		log.Printf("state HTTP server disabled by server.port=%d", port)
 		return nil
 	}
 	serverCtx, cancel := context.WithCancel(ctx)
-	handle, err := startStateHTTPServer(serverCtx, port, c.snapshot, c.refresh)
+	handle, err := startStateHTTPServer(serverCtx, host, port, c.snapshot, c.refresh)
 	if err != nil {
 		cancel()
 		return err
@@ -387,6 +415,7 @@ func (c *stateHTTPServerController) apply(ctx context.Context, port int) error {
 		return nil
 	}
 	c.desiredSet = true
+	c.desiredHost = host
 	c.desiredPort = port
 	c.cancel = cancel
 	c.addr = handle.Addr
@@ -424,6 +453,7 @@ func (c *stateHTTPServerController) stop() {
 
 func (c *stateHTTPServerController) clear() {
 	c.desiredSet = false
+	c.desiredHost = ""
 	c.desiredPort = 0
 	c.cancel = nil
 	c.addr = nil
@@ -439,6 +469,11 @@ type stateHTTPServerLoopOptions struct {
 	// as the CLI `--port` precedence rule. -1 disables the HTTP server,
 	// 0 binds an ephemeral port, 1..65535 binds explicitly.
 	PortOverride *int
+	// HostOverride, when non-nil, replaces the workflow snapshot's
+	// `server.host` for every tick of the loop. It carries the
+	// AIOPS_SERVER_HOST env override, mirroring PortOverride's role for the
+	// CLI --port flag. An empty string normalizes to the loopback default.
+	HostOverride *string
 }
 
 func runStateHTTPServerLoop(ctx context.Context, runtime *orchestrator.WorkflowRuntime, snapshot stateSnapshotFunc, opts stateHTTPServerLoopOptions) error {
@@ -461,8 +496,9 @@ func runStateHTTPServerLoop(ctx context.Context, runtime *orchestrator.WorkflowR
 		if snap := runtime.Current(); snap.Workflow != nil {
 			wf = snap.Workflow
 		}
+		host := desiredHostForLoop(opts, wf)
 		port := desiredPortForLoop(opts, wf)
-		if err := controller.apply(ctx, port); err != nil {
+		if err := controller.apply(ctx, host, port); err != nil {
 			return err
 		}
 		checks++
@@ -491,12 +527,12 @@ type stateHTTPServerHandle struct {
 	Done <-chan struct{}
 }
 
-func startStateHTTPServer(ctx context.Context, port int, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) (*stateHTTPServerHandle, error) {
+func startStateHTTPServer(ctx context.Context, host string, port int, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) (*stateHTTPServerHandle, error) {
 	if port < 0 {
 		log.Printf("state HTTP server disabled by server.port=%d", port)
 		return nil, nil
 	}
-	server := newStateHTTPServer(port, snapshot, refresh...)
+	server := newStateHTTPServer(host, port, snapshot, refresh...)
 	listener, err := net.Listen("tcp", server.Addr)
 	if err != nil {
 		log.Printf("state HTTP server disabled because listen on %s failed: %v", server.Addr, err)
@@ -527,7 +563,17 @@ func startStateHTTPServer(ctx context.Context, port int, snapshot stateSnapshotF
 	return &stateHTTPServerHandle{Addr: listener.Addr(), Done: done}, nil
 }
 
-func newStateHTTPServer(port int, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *http.Server {
+// normalizeServerHost maps an empty bind host to the loopback default so a
+// blank server.host / AIOPS_SERVER_HOST never resolves to net.Listen's
+// bind-all wildcard (SPEC §15.3 loopback-only trust boundary).
+func normalizeServerHost(host string) string {
+	if host == "" {
+		return "127.0.0.1"
+	}
+	return host
+}
+
+func newStateHTTPServer(host string, port int, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle("/api/v1/state", stateHTTPHandler(snapshot))
 	mux.Handle("/api/v1/refresh", refreshHTTPHandler(optionalStateRefreshFunc(refresh)))
@@ -541,7 +587,7 @@ func newStateHTTPServer(port int, snapshot stateSnapshotFunc, refresh ...stateRe
 		dashboardHTMLHandler().ServeHTTP(w, r)
 	})
 	return &http.Server{
-		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
+		Addr:              net.JoinHostPort(normalizeServerHost(host), strconv.Itoa(port)),
 		Handler:           loopbackHostOnly(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -2103,9 +2103,21 @@ func TestServerHostOverrideFromEnv(t *testing.T) {
 	if got := serverHostOverrideFromEnv(); got == nil || *got != "0.0.0.0" {
 		t.Fatalf("serverHostOverrideFromEnv() = %v, want 0.0.0.0", got)
 	}
+	// Set-but-empty is an explicit override: it must stay non-nil so
+	// `AIOPS_SERVER_HOST=` forces the loopback default over any workflow value.
 	t.Setenv("AIOPS_SERVER_HOST", "")
+	if got := serverHostOverrideFromEnv(); got == nil || *got != "" {
+		t.Fatalf("serverHostOverrideFromEnv() with empty env = %v, want non-nil empty override", got)
+	}
+}
+
+// TestServerHostOverrideUnsetYieldsNil — the unset case must fall through to the
+// workflow value (nil), distinct from the set-but-empty force-loopback case.
+func TestServerHostOverrideUnsetYieldsNil(t *testing.T) {
+	t.Setenv("AIOPS_SERVER_HOST", "x")
+	os.Unsetenv("AIOPS_SERVER_HOST")
 	if got := serverHostOverrideFromEnv(); got != nil {
-		t.Fatalf("serverHostOverrideFromEnv() with empty env = %v, want nil", got)
+		t.Fatalf("serverHostOverrideFromEnv() unset = %v, want nil", got)
 	}
 }
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -334,7 +334,7 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 }
 
 func TestRootDashboardServesStateDepictingReactApp(t *testing.T) {
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
 
@@ -384,7 +384,7 @@ func firstScriptAssetPath(t *testing.T, html string) string {
 }
 
 func TestRootDashboardAllowsHeadProbes(t *testing.T) {
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
 
@@ -401,7 +401,7 @@ func TestRootDashboardAllowsHeadProbes(t *testing.T) {
 }
 
 func TestRootDashboardRejectsUnsafeMethodsWithHeadInAllow(t *testing.T) {
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		t.Fatal("snapshot function should not be called for unsafe root methods")
 		return orchestrator.StateView{}, nil
 	})
@@ -449,7 +449,7 @@ func TestStateHTTPHandlerRejectsNonGET(t *testing.T) {
 func TestIssueHTTPHandlerReturnsRunningIssueByIdentifier(t *testing.T) {
 	startedAt := time.Date(2026, 5, 21, 9, 0, 0, 0, time.UTC)
 	retryAttempt := 2
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{
 			Running: []orchestrator.RunningView{{
 				IssueID:       "issue-1",
@@ -514,7 +514,7 @@ func TestIssueHTTPHandlerReturnsRunningIssueByIdentifier(t *testing.T) {
 
 func TestIssueHTTPHandlerReturnsRestartCountForRetryingIssue(t *testing.T) {
 	dueAt := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{
 			Retrying: []orchestrator.RetryView{{
 				IssueID:    "issue-2",
@@ -559,7 +559,7 @@ func TestIssueHTTPHandlerReturnsRestartCountForRetryingIssue(t *testing.T) {
 }
 
 func TestIssueHTTPHandlerOmitsRestartCountForFirstRun(t *testing.T) {
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{
 			Running: []orchestrator.RunningView{{
 				IssueID:    "issue-3",
@@ -595,7 +595,7 @@ func TestIssueHTTPHandlerOmitsRestartCountForFirstRun(t *testing.T) {
 }
 
 func TestIssueHTTPHandlerReturns404EnvelopeForUnknownIssue(t *testing.T) {
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
 
@@ -622,7 +622,7 @@ func TestIssueHTTPHandlerReturns404EnvelopeForUnknownIssue(t *testing.T) {
 
 func TestIssueHTTPHandlerRejectsNonGET(t *testing.T) {
 	called := false
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		called = true
 		return orchestrator.StateView{}, nil
 	})
@@ -648,7 +648,7 @@ func TestRefreshHTTPHandlerQueuesAndCoalescesImmediatePoll(t *testing.T) {
 		{Queued: true, Coalesced: true, RequestedAt: time.Date(2026, 5, 21, 9, 10, 1, 0, time.UTC), Operations: []string{"poll", "reconcile"}},
 	}
 	calls := 0
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		t.Fatal("snapshot function should not be called for refresh requests")
 		return orchestrator.StateView{}, nil
 	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
@@ -703,7 +703,7 @@ func TestRefreshHTTPHandlerQueuesAndCoalescesImmediatePoll(t *testing.T) {
 
 func TestRefreshHTTPHandlerRequiresRefreshHeader(t *testing.T) {
 	called := false
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
 		called = true
@@ -723,7 +723,7 @@ func TestRefreshHTTPHandlerRequiresRefreshHeader(t *testing.T) {
 
 func TestRefreshHTTPHandlerRejectsUnsupportedMethods(t *testing.T) {
 	called := false
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
 		called = true
@@ -745,7 +745,7 @@ func TestRefreshHTTPHandlerRejectsUnsupportedMethods(t *testing.T) {
 
 func TestRefreshHTTPHandlerRejectsUnsupportedBodies(t *testing.T) {
 	called := false
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
 		called = true
@@ -768,7 +768,7 @@ func TestRefreshHTTPHandlerRejectsUnsupportedBodies(t *testing.T) {
 
 func TestStateHTTPServerRejectsNonLoopbackHost(t *testing.T) {
 	called := false
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		called = true
 		return orchestrator.StateView{}, nil
 	})
@@ -787,7 +787,7 @@ func TestStateHTTPServerRejectsNonLoopbackHost(t *testing.T) {
 
 func TestStateHTTPServerAllowsLoopbackHost(t *testing.T) {
 	called := false
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		called = true
 		return orchestrator.StateView{}, nil
 	})
@@ -806,7 +806,7 @@ func TestStateHTTPServerAllowsLoopbackHost(t *testing.T) {
 
 func TestStateHTTPServerAllowsIPv6LoopbackHost(t *testing.T) {
 	called := false
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		called = true
 		return orchestrator.StateView{}, nil
 	})
@@ -853,7 +853,7 @@ func TestIsLoopbackHTTPHost(t *testing.T) {
 }
 
 func TestStartStateHTTPServerSkipsDisabledPort(t *testing.T) {
-	handle, err := startStateHTTPServer(context.Background(), -1, func(context.Context) (orchestrator.StateView, error) {
+	handle, err := startStateHTTPServer(context.Background(), "127.0.0.1", -1, func(context.Context) (orchestrator.StateView, error) {
 		t.Fatal("disabled state server must not evaluate snapshot")
 		return orchestrator.StateView{}, nil
 	})
@@ -873,7 +873,7 @@ func TestStartStateHTTPServerDoesNotFailWorkerWhenPortInUse(t *testing.T) {
 	defer listener.Close()
 	port := listener.Addr().(*net.TCPAddr).Port
 
-	handle, err := startStateHTTPServer(context.Background(), port, func(context.Context) (orchestrator.StateView, error) {
+	handle, err := startStateHTTPServer(context.Background(), "127.0.0.1", port, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
 	if err != nil {
@@ -888,7 +888,7 @@ func TestStartStateHTTPServerBindsPrivateLoopback(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	handle, err := startStateHTTPServer(ctx, 0, func(context.Context) (orchestrator.StateView, error) {
+	handle, err := startStateHTTPServer(ctx, "127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
 	if err != nil {
@@ -916,13 +916,13 @@ func TestStateHTTPServerControllerStopsOnDisabledReload(t *testing.T) {
 		return orchestrator.StateView{}, nil
 	})
 
-	if err := controller.apply(ctx, 0); err != nil {
+	if err := controller.apply(ctx, "127.0.0.1", 0); err != nil {
 		t.Fatalf("start state HTTP server: %v", err)
 	}
 	if controller.cancel == nil || controller.addr == nil {
 		t.Fatalf("controller after start = cancel:%v addr:%v, want running server", controller.cancel, controller.addr)
 	}
-	if err := controller.apply(ctx, -1); err != nil {
+	if err := controller.apply(ctx, "127.0.0.1", -1); err != nil {
 		t.Fatalf("disable state HTTP server: %v", err)
 	}
 	if controller.cancel != nil || controller.addr != nil {
@@ -942,7 +942,7 @@ func TestStateHTTPServerControllerRetriesSamePortAfterListenFailure(t *testing.T
 	controller := newStateHTTPServerController(func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
-	if err := controller.apply(ctx, port); err != nil {
+	if err := controller.apply(ctx, "127.0.0.1", port); err != nil {
 		t.Fatalf("apply occupied port: %v", err)
 	}
 	if controller.cancel != nil || controller.addr != nil || controller.desiredSet {
@@ -951,7 +951,7 @@ func TestStateHTTPServerControllerRetriesSamePortAfterListenFailure(t *testing.T
 	if err := listener.Close(); err != nil {
 		t.Fatalf("release port: %v", err)
 	}
-	if err := controller.apply(ctx, port); err != nil {
+	if err := controller.apply(ctx, "127.0.0.1", port); err != nil {
 		t.Fatalf("retry freed port: %v", err)
 	}
 	if controller.cancel == nil || controller.addr == nil {
@@ -974,19 +974,19 @@ func TestStateHTTPServerControllerRestartsPreviousPortAfterFailedReload(t *testi
 	controller := newStateHTTPServerController(func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
-	if err := controller.apply(ctx, oldPort); err != nil {
+	if err := controller.apply(ctx, "127.0.0.1", oldPort); err != nil {
 		t.Fatalf("start old port: %v", err)
 	}
 	if controller.cancel == nil || controller.addr == nil {
 		t.Fatalf("controller after old port start = cancel:%v addr:%v, want running server", controller.cancel, controller.addr)
 	}
-	if err := controller.apply(ctx, blockedPort); err != nil {
+	if err := controller.apply(ctx, "127.0.0.1", blockedPort); err != nil {
 		t.Fatalf("apply blocked port: %v", err)
 	}
 	if controller.cancel != nil || controller.addr != nil || controller.desiredSet {
 		t.Fatalf("controller after blocked reload = cancel:%v addr:%v desiredSet:%v, want retryable idle state", controller.cancel, controller.addr, controller.desiredSet)
 	}
-	if err := controller.apply(ctx, oldPort); err != nil {
+	if err := controller.apply(ctx, "127.0.0.1", oldPort); err != nil {
 		t.Fatalf("restart old port: %v", err)
 	}
 	if controller.cancel == nil || controller.addr == nil {
@@ -1009,7 +1009,7 @@ func TestStateHTTPServerControllerRestartsAfterServerExit(t *testing.T) {
 	controller.addr = &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 65535}
 	controller.serverDone = done
 
-	if err := controller.apply(ctx, 0); err != nil {
+	if err := controller.apply(ctx, "127.0.0.1", 0); err != nil {
 		t.Fatalf("restart after server exit: %v", err)
 	}
 	if controller.cancel == nil || controller.addr == nil {
@@ -1738,7 +1738,7 @@ func TestLoadWorkflowForStartupReconcileDefaultsWhenNoWorkflowExists(t *testing.
 // field is set, and TestNewStateHTTPServer_RejectsOversizedHeader
 // covers behavior on the over-cap side.
 func TestNewStateHTTPServer_SetsMaxHeaderBytes(t *testing.T) {
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
 	if got, want := server.MaxHeaderBytes, 64<<10; got != want {
@@ -1754,7 +1754,7 @@ func TestNewStateHTTPServer_SetsMaxHeaderBytes(t *testing.T) {
 // matrix is not a viable boundary for this field — see the comment on
 // SetsMaxHeaderBytes.)
 func TestNewStateHTTPServer_RejectsOversizedHeader(t *testing.T) {
-	server := newStateHTTPServer(0, func(context.Context) (orchestrator.StateView, error) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
 	})
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -2063,6 +2063,100 @@ func TestDesiredPortForLoop_NoWorkflowYieldsDisable(t *testing.T) {
 	got := desiredPortForLoop(stateHTTPServerLoopOptions{}, nil)
 	if got != -1 {
 		t.Fatalf("desiredPortForLoop(nil workflow) = %d, want -1", got)
+	}
+}
+
+// TestDesiredHostForLoop_OverrideWinsOverWorkflow pins AIOPS_SERVER_HOST
+// precedence over the workflow snapshot's server.host, mirroring the --port
+// override rule.
+func TestDesiredHostForLoop_OverrideWinsOverWorkflow(t *testing.T) {
+	override := "0.0.0.0"
+	got := desiredHostForLoop(stateHTTPServerLoopOptions{HostOverride: &override}, &workflow.Workflow{
+		Config: workflow.Config{Server: workflow.ServerConfig{Host: "127.0.0.1"}},
+	})
+	if got != "0.0.0.0" {
+		t.Fatalf("desiredHostForLoop = %q, want 0.0.0.0 (env override wins)", got)
+	}
+}
+
+// TestDesiredHostForLoop_FallsBackToWorkflow covers the no-override path: the
+// workflow server.host is used verbatim.
+func TestDesiredHostForLoop_FallsBackToWorkflow(t *testing.T) {
+	got := desiredHostForLoop(stateHTTPServerLoopOptions{}, &workflow.Workflow{
+		Config: workflow.Config{Server: workflow.ServerConfig{Host: "10.0.0.5"}},
+	})
+	if got != "10.0.0.5" {
+		t.Fatalf("desiredHostForLoop = %q, want 10.0.0.5", got)
+	}
+}
+
+// TestDesiredHostForLoop_NoWorkflowYieldsEmpty — no override and no snapshot
+// yields the empty string, which normalizeServerHost maps to loopback.
+func TestDesiredHostForLoop_NoWorkflowYieldsEmpty(t *testing.T) {
+	if got := desiredHostForLoop(stateHTTPServerLoopOptions{}, nil); got != "" {
+		t.Fatalf("desiredHostForLoop(nil) = %q, want empty", got)
+	}
+}
+
+func TestServerHostOverrideFromEnv(t *testing.T) {
+	t.Setenv("AIOPS_SERVER_HOST", "0.0.0.0")
+	if got := serverHostOverrideFromEnv(); got == nil || *got != "0.0.0.0" {
+		t.Fatalf("serverHostOverrideFromEnv() = %v, want 0.0.0.0", got)
+	}
+	t.Setenv("AIOPS_SERVER_HOST", "")
+	if got := serverHostOverrideFromEnv(); got != nil {
+		t.Fatalf("serverHostOverrideFromEnv() with empty env = %v, want nil", got)
+	}
+}
+
+// TestNewStateHTTPServerBindsConfiguredHost guards that the configured host
+// reaches the listen address, and that an empty host normalizes to loopback
+// rather than net.Listen's bind-all wildcard.
+func TestNewStateHTTPServerBindsConfiguredHost(t *testing.T) {
+	snap := func(context.Context) (orchestrator.StateView, error) { return orchestrator.StateView{}, nil }
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"0.0.0.0", "0.0.0.0:4000"},
+		{"127.0.0.1", "127.0.0.1:4000"},
+		{"", "127.0.0.1:4000"},
+		{"::1", "[::1]:4000"},
+	}
+	for _, c := range cases {
+		if got := newStateHTTPServer(c.host, 4000, snap).Addr; got != c.want {
+			t.Errorf("newStateHTTPServer(%q, 4000).Addr = %q, want %q", c.host, got, c.want)
+		}
+	}
+}
+
+// TestStartStateHTTPServerHonorsWiderBind proves AIOPS_SERVER_HOST=0.0.0.0
+// actually binds the unspecified address (the Compose reachability fix), while
+// the loopback Host-header guard still rejects non-loopback Hosts.
+func TestStartStateHTTPServerHonorsWiderBind(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle, err := startStateHTTPServer(ctx, "0.0.0.0", 0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, nil
+	})
+	if err != nil {
+		t.Fatalf("startStateHTTPServer: %v", err)
+	}
+	if handle == nil {
+		t.Fatal("handle = nil, want running server bound to 0.0.0.0")
+	}
+	tcpAddr, ok := handle.Addr.(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("addr = %T, want TCP", handle.Addr)
+	}
+	if !tcpAddr.IP.IsUnspecified() {
+		t.Fatalf("bind IP = %s, want unspecified (0.0.0.0)", tcpAddr.IP)
+	}
+	cancel()
+	select {
+	case <-handle.Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop after cancel")
 	}
 }
 

--- a/deploy/docker-compose.dashboard.yml
+++ b/deploy/docker-compose.dashboard.yml
@@ -1,0 +1,22 @@
+# Opt-in dashboard exposure overlay for Docker Compose.
+#
+# The base docker-compose.yml binds the worker's dashboard/state API to
+# container loopback, which Docker's published ports cannot reach (publishing
+# forwards to the container interface, not its loopback). Merge this overlay to
+# make the dashboard reachable from the host:
+#
+#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dashboard.yml up worker
+#
+# AIOPS_SERVER_HOST=0.0.0.0 binds all interfaces *inside the container* so the
+# published port reaches it, while the port mapping publishes ONLY to host
+# loopback (127.0.0.1). The effective trust boundary therefore stays the host
+# loopback (SPEC §15.3): the dashboard echoes live agent text and carries no
+# authentication, and the in-process loopback Host-header guard is spoofable, so
+# do NOT widen the host side of the mapping to 0.0.0.0 or a routable address
+# without adding real authentication first.
+services:
+  worker:
+    environment:
+      AIOPS_SERVER_HOST: 0.0.0.0
+    ports:
+      - "127.0.0.1:4000:4000"

--- a/deploy/docker-compose.dashboard.yml
+++ b/deploy/docker-compose.dashboard.yml
@@ -30,6 +30,9 @@ services:
     networks:
       - dashboard
 
+# No explicit `name:` — Compose scopes the network to the project
+# (<project>_dashboard). A fixed global name would be shared across separate
+# Compose projects on the same host, letting their containers attach and reach
+# worker:4000, which would defeat the sibling isolation above.
 networks:
-  dashboard:
-    name: aiops-dashboard
+  dashboard: {}

--- a/deploy/docker-compose.dashboard.yml
+++ b/deploy/docker-compose.dashboard.yml
@@ -9,14 +9,27 @@
 #
 # AIOPS_SERVER_HOST=0.0.0.0 binds all interfaces *inside the container* so the
 # published port reaches it, while the port mapping publishes ONLY to host
-# loopback (127.0.0.1). The effective trust boundary therefore stays the host
-# loopback (SPEC §15.3): the dashboard echoes live agent text and carries no
-# authentication, and the in-process loopback Host-header guard is spoofable, so
-# do NOT widen the host side of the mapping to 0.0.0.0 or a routable address
-# without adding real authentication first.
+# loopback (127.0.0.1). The effective host trust boundary therefore stays the
+# loopback (SPEC §15.3).
+#
+# Because a 0.0.0.0 bind is reachable by any sibling container on the same
+# Compose network (which can spoof Host: localhost past the in-process guard),
+# the overlay also moves the worker onto a dedicated `dashboard` network. This
+# removes it from the project default network, so the legacy-queue services
+# (postgres / pollers) — or any other co-located container — cannot reach
+# worker:4000. The network is a normal bridge (not `internal`), so the worker
+# keeps outbound egress for git/tracker traffic. The dashboard is still
+# unauthenticated, so do NOT widen the host side of the mapping to a routable
+# address or attach untrusted containers to the dashboard network.
 services:
   worker:
     environment:
       AIOPS_SERVER_HOST: 0.0.0.0
     ports:
       - "127.0.0.1:4000:4000"
+    networks:
+      - dashboard
+
+networks:
+  dashboard:
+    name: aiops-dashboard

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -148,6 +148,20 @@ The default Compose service starts only `worker` unless a legacy
 profile is explicitly requested (see
 [Section 4](#4-legacy-queue-driven-pollers-d6d7d8)).
 
+The worker's loopback dashboard is not reachable from the host under the
+base Compose file. To reach it, merge the opt-in overlay, which binds
+`0.0.0.0` inside the container and publishes only to host loopback
+(`127.0.0.1:4000:4000`):
+
+```bash
+docker compose -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.dashboard.yml up worker
+```
+
+See README "Operator surfaces" for the trust-boundary caveats; the
+surface is unauthenticated, so never publish it on a routable host
+interface.
+
 ## 3. Smoke test
 
 The fastest way to verify local configuration is to print the

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -45,7 +45,15 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	Port int `yaml:"port" json:"port"`
+	// Host is the bind address for the dashboard/state HTTP server. It
+	// defaults to 127.0.0.1 (SPEC §15.3 loopback-only trust boundary). An
+	// empty value is treated as the loopback default rather than a bind-all
+	// wildcard so a blank override never silently widens exposure. Set it to
+	// 0.0.0.0 only behind a loopback-scoped host port mapping (see the
+	// dashboard Compose overlay); the loopback Host-header guard is not
+	// authentication, so a routable bind needs auth that this server lacks.
+	Host string `yaml:"host" json:"host"`
+	Port int    `yaml:"port" json:"port"`
 }
 
 type RepoConfig struct {
@@ -505,7 +513,7 @@ type PRConfig struct {
 
 func DefaultConfig() Config {
 	return Config{
-		Server: ServerConfig{Port: 4000},
+		Server: ServerConfig{Host: "127.0.0.1", Port: 4000},
 		// Tracker.ActiveStates / TerminalStates mirror SPEC §6.4's
 		// cheat-sheet defaults (Todo/In Progress active; Closed,
 		// Cancelled, Canceled, Duplicate, Done terminal). Workflows that

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -53,6 +53,55 @@ func TestDefaultConfigEnablesStateServerOnPrivateLoopbackPort(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigBindsStateServerToLoopbackHost(t *testing.T) {
+	if got := DefaultConfig().Server.Host; got != "127.0.0.1" {
+		t.Fatalf("default server.host = %q, want 127.0.0.1", got)
+	}
+}
+
+func TestLoadParsesServerHost(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+server:
+  host: 0.0.0.0
+  port: 4000
+repo:
+  clone_url: git@example.com:owner/repo.git
+tracker:
+  kind: gitea
+---
+Prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Server.Host; got != "0.0.0.0" {
+		t.Fatalf("server.host = %q, want 0.0.0.0", got)
+	}
+}
+
+// TestLoadKeepsLoopbackHostWhenServerBlockOmitsHost guards that overlaying a
+// server block that sets only port does not zero out the loopback default.
+func TestLoadKeepsLoopbackHostWhenServerBlockOmitsHost(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+server:
+  port: 4567
+repo:
+  clone_url: git@example.com:owner/repo.git
+tracker:
+  kind: gitea
+---
+Prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Server.Host; got != "127.0.0.1" {
+		t.Fatalf("server.host = %q, want 127.0.0.1 (default survives partial server block)", got)
+	}
+}
+
 func TestLoadDefaultsServerPortWhenServerBlockIsOmitted(t *testing.T) {
 	path := writeTempWorkflow(t, `---
 repo:

--- a/test/e2e/fixtures/dashboard_overlay_test.go
+++ b/test/e2e/fixtures/dashboard_overlay_test.go
@@ -1,0 +1,54 @@
+package fixtures_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readDashboardOverlay(t *testing.T) map[string]any {
+	t.Helper()
+	return loadYAML(t, filepath.Join("..", "..", "..", "deploy", "docker-compose.dashboard.yml"))
+}
+
+// TestDashboardOverlayBindsContainerWide guards that the opt-in overlay sets
+// AIOPS_SERVER_HOST=0.0.0.0 so Docker's published port reaches the in-container
+// server (#366). Without it the dashboard stays unreachable under Compose.
+func TestDashboardOverlayBindsContainerWide(t *testing.T) {
+	worker := service(t, readDashboardOverlay(t), "worker")
+	env, ok := worker["environment"].(map[string]any)
+	if !ok {
+		t.Fatalf("worker.environment = %#v, want map", worker["environment"])
+	}
+	if got := env["AIOPS_SERVER_HOST"]; got != "0.0.0.0" {
+		t.Fatalf("AIOPS_SERVER_HOST = %v, want 0.0.0.0", got)
+	}
+}
+
+// TestDashboardOverlayPublishesToHostLoopbackOnly guards the security property:
+// the host side of every published port must bind loopback, so the dashboard
+// (unauthenticated, SPEC §15.3) is never exposed on a routable host interface.
+func TestDashboardOverlayPublishesToHostLoopbackOnly(t *testing.T) {
+	worker := service(t, readDashboardOverlay(t), "worker")
+	ports, ok := worker["ports"].([]any)
+	if !ok || len(ports) == 0 {
+		t.Fatalf("worker.ports = %#v, want non-empty list", worker["ports"])
+	}
+	for _, raw := range ports {
+		mapping, ok := raw.(string)
+		if !ok {
+			t.Fatalf("port mapping %#v is not a string", raw)
+		}
+		// Long-form "HOST_IP:HOST_PORT:CONTAINER_PORT". A two-field
+		// "HOST_PORT:CONTAINER_PORT" (no host IP) binds all host interfaces,
+		// which is exactly what we must forbid.
+		parts := strings.Split(mapping, ":")
+		if len(parts) != 3 {
+			t.Fatalf("port mapping %q must pin a host IP (HOST_IP:HOST_PORT:CONTAINER_PORT)", mapping)
+		}
+		hostIP := parts[0]
+		if hostIP != "127.0.0.1" && hostIP != "::1" {
+			t.Errorf("port mapping %q publishes on host IP %q; expected loopback (127.0.0.1)", mapping, hostIP)
+		}
+	}
+}

--- a/test/e2e/fixtures/dashboard_overlay_test.go
+++ b/test/e2e/fixtures/dashboard_overlay_test.go
@@ -1,10 +1,41 @@
 package fixtures_test
 
 import (
+	"net"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// publishedHostIP extracts the host-side IP of a Compose short-syntax port
+// mapping ("[HOST_IP:]HOST_PORT:CONTAINER_PORT[/proto]"). It returns ("", true)
+// for the bare "HOST_PORT:CONTAINER_PORT" form, which binds every host
+// interface, and handles bracketed/unbracketed IPv6 host IPs.
+func publishedHostIP(mapping string) (ip string, ok bool) {
+	m := mapping
+	if i := strings.IndexByte(m, '/'); i >= 0 {
+		m = m[:i]
+	}
+	if strings.HasPrefix(m, "[") {
+		end := strings.Index(m, "]")
+		if end < 0 {
+			return "", false
+		}
+		return m[1:end], true
+	}
+	parts := strings.Split(m, ":")
+	switch {
+	case len(parts) < 2:
+		return "", false
+	case len(parts) == 2:
+		// HOST_PORT:CONTAINER_PORT — no host IP pinned (binds all interfaces).
+		return "", true
+	default:
+		// HOST_IP:HOST_PORT:CONTAINER_PORT; the trailing two fields are ports,
+		// any leading fields are an unbracketed IPv6 host IP.
+		return strings.Join(parts[:len(parts)-2], ":"), true
+	}
+}
 
 func readDashboardOverlay(t *testing.T) map[string]any {
 	t.Helper()
@@ -39,16 +70,15 @@ func TestDashboardOverlayPublishesToHostLoopbackOnly(t *testing.T) {
 		if !ok {
 			t.Fatalf("port mapping %#v is not a string", raw)
 		}
-		// Long-form "HOST_IP:HOST_PORT:CONTAINER_PORT". A two-field
-		// "HOST_PORT:CONTAINER_PORT" (no host IP) binds all host interfaces,
-		// which is exactly what we must forbid.
-		parts := strings.Split(mapping, ":")
-		if len(parts) != 3 {
-			t.Fatalf("port mapping %q must pin a host IP (HOST_IP:HOST_PORT:CONTAINER_PORT)", mapping)
+		hostIP, parsed := publishedHostIP(mapping)
+		if !parsed {
+			t.Fatalf("could not parse port mapping %q", mapping)
 		}
-		hostIP := parts[0]
-		if hostIP != "127.0.0.1" && hostIP != "::1" {
-			t.Errorf("port mapping %q publishes on host IP %q; expected loopback (127.0.0.1)", mapping, hostIP)
+		// An empty host IP means the bare HOST_PORT:CONTAINER_PORT form, which
+		// publishes on every host interface — exactly what we must forbid.
+		ip := net.ParseIP(hostIP)
+		if ip == nil || !ip.IsLoopback() {
+			t.Errorf("port mapping %q publishes on host IP %q; expected a loopback address", mapping, hostIP)
 		}
 	}
 }

--- a/test/e2e/fixtures/dashboard_overlay_test.go
+++ b/test/e2e/fixtures/dashboard_overlay_test.go
@@ -56,6 +56,36 @@ func TestDashboardOverlayBindsContainerWide(t *testing.T) {
 	}
 }
 
+// TestDashboardOverlayIsolatesWorkerNetwork guards that the overlay moves the
+// worker onto a dedicated non-default network (#366). Because a 0.0.0.0 bind is
+// reachable by sibling containers on a shared Compose network (which can spoof
+// the loopback Host guard), the worker must leave the project default network
+// so co-located services cannot reach the unauthenticated dashboard.
+func TestDashboardOverlayIsolatesWorkerNetwork(t *testing.T) {
+	overlay := readDashboardOverlay(t)
+	worker := service(t, overlay, "worker")
+	nets, ok := worker["networks"].([]any)
+	if !ok || len(nets) == 0 {
+		t.Fatalf("worker.networks = %#v, want non-empty list pinning a dedicated network", worker["networks"])
+	}
+	declared, ok := overlay["networks"].(map[string]any)
+	if !ok || len(declared) == 0 {
+		t.Fatalf("overlay declares no top-level networks: %#v", overlay["networks"])
+	}
+	for _, raw := range nets {
+		name, ok := raw.(string)
+		if !ok {
+			t.Fatalf("network entry %#v is not a string", raw)
+		}
+		if name == "default" {
+			t.Errorf("worker is attached to the default network; a 0.0.0.0 bind would be reachable by sibling services")
+		}
+		if _, isDeclared := declared[name]; !isDeclared {
+			t.Errorf("worker network %q is not declared at the overlay top level", name)
+		}
+	}
+}
+
 // TestDashboardOverlayPublishesToHostLoopbackOnly guards the security property:
 // the host side of every published port must bind loopback, so the dashboard
 // (unauthenticated, SPEC §15.3) is never exposed on a routable host interface.


### PR DESCRIPTION
## Summary
Under Docker Compose the worker's dashboard/state API was unreachable: the server bound `127.0.0.1` *inside the container*, and Docker publishes ports to the container interface, not its loopback. There was also no knob to change the bind.

- **Configurable bind host**: `ServerConfig.Host` (`WORKFLOW.md` `server.host` / `AIOPS_SERVER_HOST` env), default `127.0.0.1`. An empty value normalizes to loopback at bind time, so a blank override never silently becomes a bind-all wildcard. Host is threaded through the server controller/loop with the same precedence model as the existing `--port` override (env > workflow > default).
- **Compose opt-in overlay** (`deploy/docker-compose.dashboard.yml`): binds `0.0.0.0` *inside* the container so the published port reaches it, but publishes **only to host loopback** (`127.0.0.1:4000:4000`). The effective trust boundary stays the host loopback (SPEC §15.3).
- The in-process `loopbackHostOnly` Host-header guard is unchanged.

## Security note
The Host-header guard is spoofable and the surface is unauthenticated, so the overlay deliberately publishes only to host loopback. Routable exposure would require real auth (out of scope) — documented in README "Operator surfaces" and the overlay header.

## Acceptance criteria (#366 "Pick one" → configurable host option)
- [x] Configurable bind host (`server.host` / `AIOPS_SERVER_HOST`) defaulting to `127.0.0.1`
- [x] Compose opt-in that binds `0.0.0.0` and maps `127.0.0.1:4000:4000`
- [x] No non-loopback host exposure without auth (overlay is loopback-scoped; docs warn against widening)

## Tests (regression + mutation-verified)
- `internal/workflow`: default host is `127.0.0.1`; `server.host` parses; partial `server:` block keeps the default.
- `cmd/worker`: `desiredHostForLoop` precedence; `serverHostOverrideFromEnv`; `newStateHTTPServer` builds the listen Addr from the host (empty → loopback); `startStateHTTPServer` actually binds `0.0.0.0` when configured.
- `test/e2e/fixtures`: overlay sets `AIOPS_SERVER_HOST=0.0.0.0` and publishes only to host loopback.

Closes #366