### PR TITLE
fix(worker): unify env var naming on the AIOPS_ prefix with deprecated aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,17 @@
 # Configuration for cmd/worker and the transitional pollers.
-# Variable names are inconsistent: cmd/worker reads both prefixed
-# (AIOPS_WORKFLOW_PATH, see cmd/worker/main.go) and bare names
-# (WORKSPACE_ROOT, see internal/worker/config.go). Use the names exactly
-# as written here — adding an AIOPS_ prefix to a bare name (or removing
-# it from a prefixed one) without changing the matching reader will
-# silently fall back to the code default.
+# Worker-owned variables use the AIOPS_ prefix (AIOPS_WORKFLOW_PATH,
+# AIOPS_WORKSPACE_ROOT, AIOPS_MIRROR_ROOT). The legacy unprefixed forms
+# (WORKSPACE_ROOT, MIRROR_ROOT, WORKFLOW_PATH) are still honored as
+# deprecated aliases, but using one logs a warning at startup; prefer the
+# prefixed names. External-service credentials keep their conventional
+# names (DATABASE_URL, GITEA_*, LINEAR_API_KEY, GITHUB_TOKEN).
 DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
 GITEA_BASE_URL=http://gitea.local
 GITEA_TOKEN=replace-with-gitea-bot-token
 LINEAR_API_KEY=replace-with-linear-personal-key
-# WORKSPACE_ROOT is optional. When unset, the worker uses WORKFLOW.md
+# AIOPS_WORKSPACE_ROOT is optional. When unset, the worker uses WORKFLOW.md
 # `workspace.root` (SPEC §6.4 default: `<system-temp>/symphony_workspaces`,
 # typically `/tmp/symphony_workspaces` on Linux). Set this only to override
 # the workflow value from outside WORKFLOW.md — e.g. a project-local path:
-# WORKSPACE_ROOT=/tmp/symphony_workspaces
+# AIOPS_WORKSPACE_ROOT=/tmp/symphony_workspaces
 AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ orchestrator state:
 
 ```bash
 export AIOPS_WORKFLOW_PATH=$PWD/examples/WORKFLOW.md
-export WORKSPACE_ROOT=$PWD/.aiops/workspaces
+export AIOPS_WORKSPACE_ROOT=$PWD/.aiops/workspaces
 
 # For tracker.kind: linear
 export LINEAR_API_KEY=your-linear-personal-key
@@ -103,8 +103,9 @@ go run ./cmd/worker
 
 `WORKFLOW.md` front matter is the source of truth for runtime workspace
 placement: when `workspace.root` is set in the selected workflow, the worker
-creates and reconciles task workspaces under that path. `WORKSPACE_ROOT` is only
-the fallback for workflows that omit `workspace.root`.
+creates and reconciles task workspaces under that path. `AIOPS_WORKSPACE_ROOT`
+(legacy alias: `WORKSPACE_ROOT`) is only the fallback for workflows that omit
+`workspace.root`.
 
 No `DATABASE_URL` or Postgres service is required for `cmd/worker`. Restart
 recovery follows SPEC §14.3: the worker starts with fresh runtime state, cleans

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -194,8 +194,9 @@ func startupWorkflowPath(args []string) (string, error) {
 	if len(args) == 1 {
 		return args[0], nil
 	}
-	if path := os.Getenv("AIOPS_WORKFLOW_PATH"); path != "" {
-		return path, nil
+	if res := worker.ResolveEnv("AIOPS_WORKFLOW_PATH", "WORKFLOW_PATH"); res.Value != "" {
+		res.LogWarning()
+		return res.Value, nil
 	}
 	workdir, err := os.Getwd()
 	if err != nil {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -194,9 +194,8 @@ func startupWorkflowPath(args []string) (string, error) {
 	if len(args) == 1 {
 		return args[0], nil
 	}
-	if res := worker.ResolveEnv("AIOPS_WORKFLOW_PATH", "WORKFLOW_PATH"); res.Value != "" {
-		res.LogWarning()
-		return res.Value, nil
+	if path := worker.WorkflowPathEnv().Value; path != "" {
+		return path, nil
 	}
 	workdir, err := os.Getwd()
 	if err != nil {
@@ -257,6 +256,9 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Emit deprecated-alias warnings exactly once per startup; the env loaders
+	// below are pure and run more than once.
+	worker.WarnDeprecatedEnv()
 	var resolveArgs []string
 	if workflowPath != "" {
 		resolveArgs = []string{workflowPath}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       GITEA_BASE_URL: ${GITEA_BASE_URL}
       GITEA_TOKEN: ${GITEA_TOKEN}
-      WORKSPACE_ROOT: /workspaces
+      AIOPS_WORKSPACE_ROOT: /workspaces
       AIOPS_WORKFLOW_PATH: /app/examples/WORKFLOW.md
       LINEAR_API_KEY: ${LINEAR_API_KEY}
     volumes:

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -40,7 +40,8 @@ needs Postgres, it is stale — file an issue.
   - `tracker.kind: gitea` → a Gitea base URL and bot token.
   - `tracker.kind: github` → a GitHub token (`gh auth token` works).
 - A scratch workspace root. `workspace.root` in `WORKFLOW.md` is the
-  source of truth; `WORKSPACE_ROOT` is the fallback when omitted.
+  source of truth; `AIOPS_WORKSPACE_ROOT` (legacy alias `WORKSPACE_ROOT`)
+  is the fallback when omitted.
 - Optional: Docker and Docker Compose v2, only if you want the
   containerized worker or the legacy compose path.
 - Optional: the Codex CLI installed and on `PATH`, only if you set
@@ -64,10 +65,11 @@ Edit `.env` to fill in only the variables the worker actually reads for
 your tracker kind (see [Prerequisites](#prerequisites)). Never commit
 a real `.env`.
 
-The worker resolves its workflow source from `AIOPS_WORKFLOW_PATH`
-(prefixed) and its fallback workspace root from `WORKSPACE_ROOT`
-(unprefixed). The `.env.example` file documents this naming
-inconsistency; use the names as written there.
+The worker resolves its workflow source from `AIOPS_WORKFLOW_PATH` and
+its fallback workspace root from `AIOPS_WORKSPACE_ROOT`. Worker env vars
+share the `AIOPS_` prefix; the legacy unprefixed forms (`WORKSPACE_ROOT`,
+`MIRROR_ROOT`, `WORKFLOW_PATH`) are still honored as deprecated aliases
+but log a warning at startup. See `.env.example`.
 
 For first-time local testing keep `agent.default: mock` in the
 selected `WORKFLOW.md`. The mock runner produces a deterministic change
@@ -96,7 +98,7 @@ Option A: from source.
 
 ```bash
 export AIOPS_WORKFLOW_PATH=$PWD/.aiops/WORKFLOW.md
-export WORKSPACE_ROOT=$PWD/.aiops/workspaces
+export AIOPS_WORKSPACE_ROOT=$PWD/.aiops/workspaces
 
 # For tracker.kind: linear  (consumed by WORKFLOW.md "api_key: $LINEAR_API_KEY")
 export LINEAR_API_KEY=your-linear-personal-key
@@ -410,7 +412,8 @@ The worker keeps a per-repo bare mirror under `AIOPS_MIRROR_ROOT`
 (default `os.UserCacheDir()/aiops-platform/mirrors`) and creates a
 per-task worktree under the selected workflow's `workspace.root` for
 every claimed task. If `workspace.root` is omitted from `WORKFLOW.md`,
-the worker falls back to `WORKSPACE_ROOT`. This avoids re-cloning on
+the worker falls back to `AIOPS_WORKSPACE_ROOT` (legacy alias
+`WORKSPACE_ROOT`). This avoids re-cloning on
 every retry and lets two tasks run concurrently without sharing a
 working tree. See the dedicated
 [workspace cache runbook](workspace-cache.md) for the on-disk layout,

--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -11,7 +11,7 @@ how to prune the cache on a long-running host.
 ```text
 $AIOPS_MIRROR_ROOT/                 # bare mirror cache (one per repo)
   <host>/<owner>/<repo>.git/        # populated by `git clone --bare`
-$WORKSPACE_ROOT/                    # per-task worktrees
+$AIOPS_WORKSPACE_ROOT/                    # per-task worktrees
   <owner>_<repo>/<task-id>/         # populated by `git worktree add`
 ```
 
@@ -25,7 +25,7 @@ $WORKSPACE_ROOT/                    # per-task worktrees
   `git worktree add -B <work-branch> <task-dir> origin/<base-branch>`.
   The worktree shares objects with the mirror via `gitdir` linkage, so
   disk usage is roughly `O(repo)` rather than `O(repo) * O(tasks)`.
-- Each task gets its own directory under `WORKSPACE_ROOT`, so two
+- Each task gets its own directory under `AIOPS_WORKSPACE_ROOT`, so two
   concurrent workers never share a working tree.
 
 ## Workspace reuse across runs (SPEC §9.1 + §9.4)
@@ -109,7 +109,7 @@ just `<workdir>/.git`) — the worker recovers on the next prepare.
 
 | Env var               | Default                                                                 | Purpose                                                  |
 | --------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------- |
-| `WORKSPACE_ROOT`      | _unset_ — falls back to WORKFLOW.md `workspace.root` (SPEC §6.4 default `<system-temp>/symphony_workspaces`) | Where per-task worktrees live.                           |
+| `AIOPS_WORKSPACE_ROOT` (legacy alias `WORKSPACE_ROOT`) | _unset_ — falls back to WORKFLOW.md `workspace.root` (SPEC §6.4 default `<system-temp>/symphony_workspaces`) | Where per-task worktrees live.                           |
 | `AIOPS_MIRROR_ROOT`   | `os.UserCacheDir()/aiops-platform/mirrors` (fallback `$TMPDIR/...`)     | Where bare mirror clones are cached.                     |
 
 On Linux containers `os.UserCacheDir()` resolves to `$XDG_CACHE_HOME` or
@@ -190,12 +190,12 @@ events on the next worker boot:
 ```sh
 # Audit (no removals): list workspace components that contain old-style
 # dash separators or lowercase identifiers under the per-issue subtree.
-find "$WORKSPACE_ROOT" -mindepth 4 -maxdepth 4 -type d
+find "$AIOPS_WORKSPACE_ROOT" -mindepth 4 -maxdepth 4 -type d
 
 # Migrate by wiping the workspace root entirely. The bare mirror cache
 # under $AIOPS_MIRROR_ROOT is untouched, so the next task pays only a
 # fresh worktree-add, not a fresh clone.
-rm -rf "$WORKSPACE_ROOT"/*
+rm -rf "$AIOPS_WORKSPACE_ROOT"/*
 ```
 
 The wipe also removes the `<owner>/<repo>/.aiops-policy-feedback`
@@ -237,7 +237,7 @@ not back-compat-matched and will be reconciled away.
 The worker does **not** automatically delete old worktrees. The
 recommended strategy is age-based pruning, gated on operator preference:
 
-- **Per-task worktrees** (`$WORKSPACE_ROOT/...`): safe to delete once
+- **Per-task worktrees** (`$AIOPS_WORKSPACE_ROOT/...`): safe to delete once
   the corresponding task is `succeeded` or `failed`. Use a 24h-72h
   window for personal use; pick something larger if you frequently
   inspect old runs.
@@ -247,7 +247,7 @@ recommended strategy is age-based pruning, gated on operator preference:
   mirror when you change its upstream URL or the cache disk fills up.
 
 The Go API for cleanup is `(*workspace.Manager).Cleanup(ctx, maxAge)`.
-It walks `$WORKSPACE_ROOT`, deletes each task directory whose mtime
+It walks `$AIOPS_WORKSPACE_ROOT`, deletes each task directory whose mtime
 predates `now - maxAge`, and returns a `CleanupReport` with counts of
 removed/skipped/failed entries. It never touches the mirror cache.
 
@@ -260,7 +260,7 @@ the worker is deployed:
    `workspace.New(root).Cleanup(ctx, 48*time.Hour)`. Suitable for the
    personal daily workflow described in
    [personal-daily-workflow.md](personal-daily-workflow.md).
-2. **Manual**: `rm -rf $WORKSPACE_ROOT/*` between long pauses works in
+2. **Manual**: `rm -rf $AIOPS_WORKSPACE_ROOT/*` between long pauses works in
    a pinch. The next task simply re-creates its worktree from the bare
    mirror, which is fast.
 3. **Future hook**: a follow-up issue may wire `Cleanup` into the
@@ -284,7 +284,7 @@ The two production call sites today are
 after `after_create` hook failure) and
 `internal/worker/reconcile.go::removeWorkspace` (reconcile-driven
 cleanup for closed/cancelled issues). Any new cleanup code that touches
-`$WORKSPACE_ROOT` should call `workspace.SafeRemove` rather than
+`$AIOPS_WORKSPACE_ROOT` should call `workspace.SafeRemove` rather than
 `os.RemoveAll` directly.
 
 ## Troubleshooting
@@ -292,7 +292,7 @@ cleanup for closed/cancelled issues). Any new cleanup code that touches
 - `fatal: '<dir>' is not a working tree` printed during task setup is
   expected on the first prepare for a brand-new task ID and is
   swallowed. If it shows up repeatedly for the same task ID, check
-  whether `$WORKSPACE_ROOT` is on a shared filesystem with a different
+  whether `$AIOPS_WORKSPACE_ROOT` is on a shared filesystem with a different
   worker writing to the same path.
 - If you see `error: cannot lock ref 'refs/heads/<work>'` during
   `worktree add`, run `git -C $AIOPS_MIRROR_ROOT/<host>/<repo>.git

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -48,13 +48,9 @@ type IssueStateRefresherFactory func(t task.Task, cfg workflow.Config) runner.Is
 // `/tmp/aiops-workspaces` fallback silently shadowed that SPEC default
 // regardless of WORKFLOW.md content; see #319.
 func LoadConfigFromEnv() Config {
-	workspace := ResolveEnv("AIOPS_WORKSPACE_ROOT", "WORKSPACE_ROOT")
-	workspace.LogWarning()
-	mirror := ResolveEnv("AIOPS_MIRROR_ROOT", "MIRROR_ROOT")
-	mirror.LogWarning()
 	return Config{
-		WorkspaceRoot: workspace.Value,
-		MirrorRoot:    mirror.Value,
+		WorkspaceRoot: ResolveEnv(workspaceRootEnv, workspaceRootEnvLegacy).Value,
+		MirrorRoot:    ResolveEnv(mirrorRootEnv, mirrorRootEnvLegacy).Value,
 	}
 }
 

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"io"
-	"os"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
@@ -36,16 +35,26 @@ type IssueStateRefresherFactory func(t task.Task, cfg workflow.Config) runner.Is
 
 // LoadConfigFromEnv reads the worker configuration from the environment.
 //
-// WorkspaceRoot intentionally has no literal default here — when
-// WORKSPACE_ROOT is unset, Config.WorkspaceRoot stays empty and
+// Worker env vars use the AIOPS_ prefix as the single naming convention
+// (#368). The legacy unprefixed WORKSPACE_ROOT is still honored as a
+// deprecated alias for AIOPS_WORKSPACE_ROOT (with a warning) so existing
+// deployments keep working; using the wrong form no longer silently falls back
+// to the code default.
+//
+// WorkspaceRoot intentionally has no literal default here — when the workspace
+// root env is unset, Config.WorkspaceRoot stays empty and
 // EffectiveWorkspaceRoot falls back to the workflow's `Workspace.Root`
 // (the SPEC §6.4 default seeded by workflow.DefaultConfig). The previous
 // `/tmp/aiops-workspaces` fallback silently shadowed that SPEC default
 // regardless of WORKFLOW.md content; see #319.
 func LoadConfigFromEnv() Config {
+	workspace := ResolveEnv("AIOPS_WORKSPACE_ROOT", "WORKSPACE_ROOT")
+	workspace.LogWarning()
+	mirror := ResolveEnv("AIOPS_MIRROR_ROOT", "MIRROR_ROOT")
+	mirror.LogWarning()
 	return Config{
-		WorkspaceRoot: os.Getenv("WORKSPACE_ROOT"),
-		MirrorRoot:    os.Getenv("AIOPS_MIRROR_ROOT"),
+		WorkspaceRoot: workspace.Value,
+		MirrorRoot:    mirror.Value,
 	}
 }
 

--- a/internal/worker/env.go
+++ b/internal/worker/env.go
@@ -6,6 +6,36 @@ import (
 	"os"
 )
 
+// Worker env var names. The AIOPS_ prefix is the single convention (#368); the
+// *Legacy unprefixed forms are deprecated aliases kept for back-compat.
+const (
+	workspaceRootEnv       = "AIOPS_WORKSPACE_ROOT"
+	workspaceRootEnvLegacy = "WORKSPACE_ROOT"
+	mirrorRootEnv          = "AIOPS_MIRROR_ROOT"
+	mirrorRootEnvLegacy    = "MIRROR_ROOT"
+	workflowPathEnv        = "AIOPS_WORKFLOW_PATH"
+	workflowPathEnvLegacy  = "WORKFLOW_PATH"
+)
+
+// WorkflowPathEnv resolves the workflow-path env var (canonical AIOPS_WORKFLOW_PATH,
+// deprecated alias WORKFLOW_PATH). It is exported because cmd/worker resolves
+// this one outside LoadConfigFromEnv. The resolution is pure; deprecation
+// warnings are emitted once per startup via WarnDeprecatedEnv.
+func WorkflowPathEnv() EnvResolution {
+	return ResolveEnv(workflowPathEnv, workflowPathEnvLegacy)
+}
+
+// WarnDeprecatedEnv logs a one-time structured deprecation warning for every
+// worker env var supplied under its legacy unprefixed alias. Call it exactly
+// once per process startup: the value loaders (LoadConfigFromEnv,
+// WorkflowPathEnv) are pure and may run multiple times, so logging there would
+// duplicate the warning (#368, PR review).
+func WarnDeprecatedEnv() {
+	ResolveEnv(workspaceRootEnv, workspaceRootEnvLegacy).LogWarning()
+	ResolveEnv(mirrorRootEnv, mirrorRootEnvLegacy).LogWarning()
+	ResolveEnv(workflowPathEnv, workflowPathEnvLegacy).LogWarning()
+}
+
 // EnvResolution records which environment variable supplied a worker
 // configuration value, so callers can both read the value and surface a
 // deprecation/misconfiguration warning when it came from a non-canonical name.

--- a/internal/worker/env.go
+++ b/internal/worker/env.go
@@ -1,0 +1,59 @@
+package worker
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+// EnvResolution records which environment variable supplied a worker
+// configuration value, so callers can both read the value and surface a
+// deprecation/misconfiguration warning when it came from a non-canonical name.
+//
+// Worker-owned operational env vars use the AIOPS_ prefix as the single
+// convention (AIOPS_WORKSPACE_ROOT / AIOPS_MIRROR_ROOT / AIOPS_WORKFLOW_PATH).
+// The legacy unprefixed forms are still honored as deprecated aliases so
+// existing deployments do not break, but using one emits a warning instead of
+// silently falling back to the code default (#368).
+type EnvResolution struct {
+	// Canonical is the preferred (AIOPS_-prefixed) variable name.
+	Canonical string
+	// Value is the resolved value; empty when none of the names is set.
+	Value string
+	// UsedName is the variable actually read; empty when nothing was set.
+	UsedName string
+}
+
+// Warning returns a deprecation notice when the value came from a non-canonical
+// alias, or the empty string when the canonical name (or nothing) was used.
+func (r EnvResolution) Warning() string {
+	if r.UsedName == "" || r.UsedName == r.Canonical {
+		return ""
+	}
+	return fmt.Sprintf("env %s is deprecated; rename it to %s (its value is being honored for now)", r.UsedName, r.Canonical)
+}
+
+// LogWarning emits a structured deprecation warning (SPEC §13.1) when the
+// value came from a non-canonical alias.
+func (r EnvResolution) LogWarning() {
+	if r.Warning() == "" {
+		return
+	}
+	log.Printf("event=config_env_deprecated_alias used=%s canonical=%s", r.UsedName, r.Canonical)
+}
+
+// ResolveEnv reads canonical first, then each alias in declaration order; the
+// first non-empty value wins. An unset or empty variable is skipped so an
+// explicitly blank alias never masks a later non-empty one — and, crucially, a
+// wrong-prefix variant is honored with a warning rather than silently dropped.
+func ResolveEnv(canonical string, aliases ...string) EnvResolution {
+	if v := os.Getenv(canonical); v != "" {
+		return EnvResolution{Canonical: canonical, Value: v, UsedName: canonical}
+	}
+	for _, alias := range aliases {
+		if v := os.Getenv(alias); v != "" {
+			return EnvResolution{Canonical: canonical, Value: v, UsedName: alias}
+		}
+	}
+	return EnvResolution{Canonical: canonical}
+}

--- a/internal/worker/env_test.go
+++ b/internal/worker/env_test.go
@@ -1,0 +1,45 @@
+package worker_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
+)
+
+func TestResolveEnv_CanonicalWins(t *testing.T) {
+	t.Setenv("AIOPS_WORKSPACE_ROOT", "/canonical")
+	t.Setenv("WORKSPACE_ROOT", "/legacy")
+	res := worker.ResolveEnv("AIOPS_WORKSPACE_ROOT", "WORKSPACE_ROOT")
+	if res.Value != "/canonical" || res.UsedName != "AIOPS_WORKSPACE_ROOT" {
+		t.Fatalf("ResolveEnv = %+v, want canonical value", res)
+	}
+	if w := res.Warning(); w != "" {
+		t.Fatalf("Warning() = %q, want empty when canonical is used", w)
+	}
+}
+
+func TestResolveEnv_AliasHonoredWithWarning(t *testing.T) {
+	t.Setenv("AIOPS_WORKSPACE_ROOT", "")
+	t.Setenv("WORKSPACE_ROOT", "/legacy")
+	res := worker.ResolveEnv("AIOPS_WORKSPACE_ROOT", "WORKSPACE_ROOT")
+	if res.Value != "/legacy" || res.UsedName != "WORKSPACE_ROOT" {
+		t.Fatalf("ResolveEnv = %+v, want legacy alias value (not a silent default fallback)", res)
+	}
+	w := res.Warning()
+	if !strings.Contains(w, "WORKSPACE_ROOT") || !strings.Contains(w, "AIOPS_WORKSPACE_ROOT") {
+		t.Fatalf("Warning() = %q, want a deprecation notice naming both the alias and canonical", w)
+	}
+}
+
+func TestResolveEnv_UnsetYieldsEmptyNoWarning(t *testing.T) {
+	t.Setenv("AIOPS_WORKSPACE_ROOT", "")
+	t.Setenv("WORKSPACE_ROOT", "")
+	res := worker.ResolveEnv("AIOPS_WORKSPACE_ROOT", "WORKSPACE_ROOT")
+	if res.Value != "" || res.UsedName != "" {
+		t.Fatalf("ResolveEnv = %+v, want empty resolution", res)
+	}
+	if w := res.Warning(); w != "" {
+		t.Fatalf("Warning() = %q, want empty when nothing is set", w)
+	}
+}

--- a/internal/worker/env_test.go
+++ b/internal/worker/env_test.go
@@ -1,11 +1,65 @@
 package worker_test
 
 import (
+	"bytes"
+	"log"
 	"strings"
 	"testing"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 )
+
+// captureLog redirects the stdlib logger for the duration of fn and returns
+// everything written.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	})
+	fn()
+	return buf.String()
+}
+
+// TestWarnDeprecatedEnv_EmitsOncePerAlias guards that the single warning site
+// logs exactly one structured deprecation line per legacy alias in use (#368
+// PR review: the warning must not be duplicated across repeated loader calls).
+func TestWarnDeprecatedEnv_EmitsOncePerAlias(t *testing.T) {
+	t.Setenv("AIOPS_WORKSPACE_ROOT", "")
+	t.Setenv("WORKSPACE_ROOT", "/legacy")
+	t.Setenv("AIOPS_MIRROR_ROOT", "")
+	t.Setenv("MIRROR_ROOT", "")
+	t.Setenv("AIOPS_WORKFLOW_PATH", "")
+	t.Setenv("WORKFLOW_PATH", "")
+
+	out := captureLog(t, worker.WarnDeprecatedEnv)
+	if got := strings.Count(out, "used=WORKSPACE_ROOT"); got != 1 {
+		t.Fatalf("WORKSPACE_ROOT deprecation logged %d times, want 1\n%s", got, out)
+	}
+	if !strings.Contains(out, "event=config_env_deprecated_alias") {
+		t.Fatalf("warning is not structured (missing event=): %s", out)
+	}
+}
+
+// TestLoadConfigFromEnv_DoesNotLog locks in loader purity: resolving config
+// must not emit warnings, so calling it multiple times during startup cannot
+// duplicate the deprecation notice (the single site is WarnDeprecatedEnv).
+func TestLoadConfigFromEnv_DoesNotLog(t *testing.T) {
+	t.Setenv("AIOPS_WORKSPACE_ROOT", "")
+	t.Setenv("WORKSPACE_ROOT", "/legacy")
+
+	out := captureLog(t, func() {
+		worker.LoadConfigFromEnv()
+		worker.LoadConfigFromEnv()
+	})
+	if out != "" {
+		t.Fatalf("LoadConfigFromEnv logged %q, want no output (warnings belong to WarnDeprecatedEnv)", out)
+	}
+}
 
 func TestResolveEnv_CanonicalWins(t *testing.T) {
 	t.Setenv("AIOPS_WORKSPACE_ROOT", "/canonical")

--- a/internal/worker/workspace_root_test.go
+++ b/internal/worker/workspace_root_test.go
@@ -100,6 +100,7 @@ tracker:
 // fall through to the workflow's SPEC default. Pre-#319 the loader
 // returned the literal `/tmp/aiops-workspaces`.
 func TestLoadConfigFromEnv_NoLiteralWorkspaceRootDefault(t *testing.T) {
+	t.Setenv("AIOPS_WORKSPACE_ROOT", "")
 	t.Setenv("WORKSPACE_ROOT", "")
 
 	cfg := worker.LoadConfigFromEnv()
@@ -109,14 +110,42 @@ func TestLoadConfigFromEnv_NoLiteralWorkspaceRootDefault(t *testing.T) {
 }
 
 // TestLoadConfigFromEnv_HonorsWorkspaceRootEnv covers the still-supported
-// override path: an explicit WORKSPACE_ROOT flows through to
-// Config.WorkspaceRoot verbatim.
+// legacy alias path: an explicit WORKSPACE_ROOT flows through to
+// Config.WorkspaceRoot verbatim (now as a deprecated alias; see #368).
 func TestLoadConfigFromEnv_HonorsWorkspaceRootEnv(t *testing.T) {
 	want := filepath.Join(t.TempDir(), "operator-root")
+	t.Setenv("AIOPS_WORKSPACE_ROOT", "")
 	t.Setenv("WORKSPACE_ROOT", want)
 
 	cfg := worker.LoadConfigFromEnv()
 	if cfg.WorkspaceRoot != want {
 		t.Fatalf("LoadConfigFromEnv().WorkspaceRoot = %q, want %q", cfg.WorkspaceRoot, want)
+	}
+}
+
+// TestLoadConfigFromEnv_HonorsAIOPSWorkspaceRoot is the #368 regression: the
+// AIOPS_-prefixed canonical name a user naturally tries is no longer silently
+// ignored in favor of the code default.
+func TestLoadConfigFromEnv_HonorsAIOPSWorkspaceRoot(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "prefixed-root")
+	t.Setenv("WORKSPACE_ROOT", "")
+	t.Setenv("AIOPS_WORKSPACE_ROOT", want)
+
+	cfg := worker.LoadConfigFromEnv()
+	if cfg.WorkspaceRoot != want {
+		t.Fatalf("LoadConfigFromEnv().WorkspaceRoot = %q, want %q (AIOPS_WORKSPACE_ROOT must be honored)", cfg.WorkspaceRoot, want)
+	}
+}
+
+// TestLoadConfigFromEnv_CanonicalWorkspaceRootWinsOverLegacy pins precedence
+// when both the canonical and the deprecated alias are set.
+func TestLoadConfigFromEnv_CanonicalWorkspaceRootWinsOverLegacy(t *testing.T) {
+	canonical := filepath.Join(t.TempDir(), "canonical")
+	t.Setenv("AIOPS_WORKSPACE_ROOT", canonical)
+	t.Setenv("WORKSPACE_ROOT", filepath.Join(t.TempDir(), "legacy"))
+
+	cfg := worker.LoadConfigFromEnv()
+	if cfg.WorkspaceRoot != canonical {
+		t.Fatalf("LoadConfigFromEnv().WorkspaceRoot = %q, want canonical %q", cfg.WorkspaceRoot, canonical)
 	}
 }

--- a/test/e2e/fixtures/worker_env_test.go
+++ b/test/e2e/fixtures/worker_env_test.go
@@ -1,0 +1,20 @@
+package fixtures_test
+
+import "testing"
+
+// TestWorkerComposeUsesCanonicalWorkspaceRootEnv guards that the shipped
+// Compose worker uses the canonical AIOPS_WORKSPACE_ROOT name (#368), so the
+// default deployment never trips the deprecated-alias warning.
+func TestWorkerComposeUsesCanonicalWorkspaceRootEnv(t *testing.T) {
+	worker := service(t, readCompose(t), "worker")
+	env, ok := worker["environment"].(map[string]any)
+	if !ok {
+		t.Fatalf("worker.environment = %#v, want map", worker["environment"])
+	}
+	if _, ok := env["WORKSPACE_ROOT"]; ok {
+		t.Error("worker uses deprecated WORKSPACE_ROOT; rename to AIOPS_WORKSPACE_ROOT")
+	}
+	if _, ok := env["AIOPS_WORKSPACE_ROOT"]; !ok {
+		t.Error("worker is missing AIOPS_WORKSPACE_ROOT")
+	}
+}


### PR DESCRIPTION
## Summary
Worker env vars mixed prefixed (`AIOPS_WORKFLOW_PATH`, `AIOPS_MIRROR_ROOT`) and bare (`WORKSPACE_ROOT`) forms. Using the wrong form (e.g. `AIOPS_WORKSPACE_ROOT`, which a user naturally tries) was **silently ignored** and the worker fell back to the code default — an invisible misconfiguration for an automated runner.

- **Centralized env loading** (`internal/worker/env.go`): `ResolveEnv(canonical, aliases...)` reads the canonical AIOPS_-prefixed name, then deprecated aliases, first non-empty wins.
- **One convention**: `AIOPS_WORKSPACE_ROOT` / `AIOPS_MIRROR_ROOT` / `AIOPS_WORKFLOW_PATH` are canonical. The legacy unprefixed forms (`WORKSPACE_ROOT`, `MIRROR_ROOT`, `WORKFLOW_PATH`) are still honored as **deprecated aliases** but emit a structured startup warning (`event=config_env_deprecated_alias`, SPEC §13.1) instead of being silently dropped. Back-compatible.
- Updated `.env.example`, `deploy/docker-compose.yml`, and the runbooks/README to the canonical names.

## Acceptance criteria (#368 suggested fix)
- [x] Centralize env loading and pick one naming convention (aliases accepted with a deprecation warning)
- [x] Warn on likely prefix mistakes (the alias path is exactly that warning; `AIOPS_WORKSPACE_ROOT` is now honored)
- [ ] Extend `--print-config` to show each value's source → **deferred to #375** (`area:spec-alignment`): print-config does not currently read the env/CLI layers, so source provenance is a separable, larger feature.

## Tests (regression + mutation-verified)
- `internal/worker/env_test.go`: canonical wins; alias honored with a deprecation warning naming both names; unset → empty/no warning.
- `internal/worker/workspace_root_test.go`: `AIOPS_WORKSPACE_ROOT` is honored (the #368 regression); legacy `WORKSPACE_ROOT` still works; canonical wins over legacy when both set.
- `test/e2e/fixtures`: the shipped Compose worker uses the canonical `AIOPS_WORKSPACE_ROOT`.
- The SPEC §13.1 log-audit guard passes (warning routed through the structured `event=` form).

Closes #368