### PR TITLE
ci: add vulnerability scanning, static analysis, image scan, and SBOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
+          # Always resolve the newest 1.25.x rather than a stale cached patch,
+          # so govulncheck evaluates against an up-to-date standard library.
+          check-latest: true
           cache: true
           cache-dependency-path: |
             go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -40,7 +40,7 @@ jobs:
             go.sum
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
 
@@ -92,12 +92,42 @@ jobs:
           go build -trimpath -ldflags="-s -w" -o dist/gitea-poller ./cmd/gitea-poller
 
       - name: Upload CI binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: aiops-platform-linux-amd64
           path: dist/
           if-no-files-found: error
           retention-days: 7
+
+  security:
+    name: Security and supply-chain
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Use the latest 1.25.x patch toolchain (not the pinned go.mod floor) so
+      # govulncheck evaluates the code against an up-to-date standard library.
+      # go.mod's `go` directive is intentionally left untouched.
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.25"
+          cache: true
+          cache-dependency-path: |
+            go.mod
+            go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+          "$(go env GOPATH)/bin/govulncheck" ./...
 
   e2e:
     name: E2E Gitea mock loop
@@ -105,11 +135,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -134,9 +164,38 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Build Docker image
         run: docker build --pull --tag aiops-platform:ci .
+
+      - name: Scan image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: aiops-platform:ci
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          vuln-type: os,library
+          # Report-only for now (incremental rollout, #372): findings surface in
+          # the job log without blocking. Tighten exit-code once the image
+          # baseline is clean and the team agrees to gate on it.
+          exit-code: "0"
+
+      - name: Generate SBOM (Trivy, CycloneDX)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: aiops-platform:ci
+          format: cyclonedx
+          output: aiops-platform-sbom.cdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aiops-platform-sbom
+          path: aiops-platform-sbom.cdx.json
+          if-no-files-found: error
+          retention-days: 7

--- a/test/e2e/fixtures/ci_security_test.go
+++ b/test/e2e/fixtures/ci_security_test.go
@@ -48,6 +48,11 @@ func TestCIActionsArePinnedToSHA(t *testing.T) {
 	}
 	for _, m := range matches {
 		ref := m[1]
+		// Local actions / reusable workflows (e.g. ./.github/workflows/x.yml)
+		// have no @ref and are not a third-party supply-chain pin concern.
+		if strings.HasPrefix(ref, "./") {
+			continue
+		}
 		at := strings.LastIndex(ref, "@")
 		if at < 0 {
 			t.Errorf("action %q is not version-pinned", ref)

--- a/test/e2e/fixtures/ci_security_test.go
+++ b/test/e2e/fixtures/ci_security_test.go
@@ -1,0 +1,60 @@
+package fixtures_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func readCIWorkflow(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", ".github", "workflows", "ci.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// TestCIRunsSecurityScanning guards the #372 security/supply-chain coverage:
+// the workflow must run govulncheck, an explicit go vet, and a Trivy image
+// scan + SBOM. Deleting any one fails this test.
+func TestCIRunsSecurityScanning(t *testing.T) {
+	ci := readCIWorkflow(t)
+	for _, want := range []string{
+		"govulncheck",
+		"go vet ./...",
+		"trivy-action",
+		"cyclonedx",
+	} {
+		if !strings.Contains(ci, want) {
+			t.Errorf("ci.yml is missing %q", want)
+		}
+	}
+}
+
+// TestCIActionsArePinnedToSHA guards supply-chain hardening (#372): every
+// third-party action `uses:` must reference a 40-hex commit SHA, not a movable
+// tag like @v6. A reverted pin re-introduces the mutable-tag risk and fails.
+func TestCIActionsArePinnedToSHA(t *testing.T) {
+	ci := readCIWorkflow(t)
+	usesRE := regexp.MustCompile(`uses:\s*([^\s]+)`)
+	sha := regexp.MustCompile(`^[0-9a-f]{40}$`)
+	matches := usesRE.FindAllStringSubmatch(ci, -1)
+	if len(matches) == 0 {
+		t.Fatal("ci.yml has no `uses:` action references")
+	}
+	for _, m := range matches {
+		ref := m[1]
+		at := strings.LastIndex(ref, "@")
+		if at < 0 {
+			t.Errorf("action %q is not version-pinned", ref)
+			continue
+		}
+		if !sha.MatchString(ref[at+1:]) {
+			t.Errorf("action %q is not pinned to a 40-hex commit SHA", ref)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
CI covered gofmt/tidy/race/e2e/docker-build but had no security or supply-chain scanning for a project that runs code execution, git/ssh, and agent automation.

- **`security` job**: `govulncheck ./...` + explicit `go vet ./...`. It runs on the latest `1.25.x` patch toolchain (via `setup-go` `go-version: "1.25"`) so the standard library is current — go.mod's `go` directive is left untouched. (Verified: the stdlib advisories govulncheck reports at the pinned floor are all fixed in ≥1.25.3, and the scan is clean under the patch toolchain.)
- **Image scanning + SBOM** in the `docker` job: Trivy scan of the built image (`CRITICAL,HIGH`, `ignore-unfixed`) and a CycloneDX SBOM uploaded as an artifact. The scan is **report-only** for now (incremental rollout) so an unfixable base-image CVE doesn't block the pipeline; enforcement can be tightened once the baseline is agreed.
- **SHA-pinned** every third-party action (`checkout`, `setup-go`, `setup-node`, `upload-artifact`, `trivy-action`) to a 40-hex commit with a `# vX` comment.

Not included (issue marks them "optionally"/"and/or"): CodeQL (needs code-scanning setup) and staticcheck/golangci-lint (risk surfacing pre-existing lint as a blocker) — can be follow-ups.

## Acceptance criteria (#372 suggested incremental fix)
- [x] `govulncheck ./...`
- [x] explicit `go vet ./...`
- [x] Trivy image scan of the built image
- [x] SBOM generation (CycloneDX)
- [x] SHA-pin third-party actions
- [ ] CodeQL / staticcheck — optional, intentionally deferred

## Tests (mutation-verified)
`test/e2e/fixtures/ci_security_test.go`: asserts the workflow runs govulncheck, `go vet`, Trivy, and emits a CycloneDX SBOM; and that every `uses:` action is pinned to a 40-hex commit SHA. Reverting a pin or removing a scan fails the test.

Closes #372