### PR TITLE
docs(config): correct DefaultConfig retry comments to say unbounded

### DIFF
--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -532,12 +532,14 @@ func DefaultConfig() Config {
 		hooksTimeoutDefaulted: true,
 		Workspace:             WorkspaceConfig{Root: defaultWorkspaceRoot()},
 		// Agent.MaxRetryAttempts is intentionally left nil here so the
-		// "absent" signal survives YAML overlay. The effective default of
-		// one failure retry is supplied by MaxRetryAttemptsValue().
+		// "absent" signal survives YAML overlay. The effective default is
+		// unbounded failure retries (UnboundedRetryBudget), supplied by
+		// MaxRetryAttemptsValue() per SPEC §8.4 / §16.6 (README "unbounded";
+		// DEVIATIONS D29).
 		// Agent.MaxTimeoutRetries is intentionally left nil here so the
 		// "absent" signal survives a YAML unmarshal that overlays this
-		// default. The effective default of 1 retry is supplied by
-		// MaxTimeoutRetriesValue().
+		// default. The effective default is likewise unbounded timeout
+		// requeues (UnboundedRetryBudget), supplied by MaxTimeoutRetriesValue().
 		Agent: AgentConfig{
 			Default:             "mock",
 			MaxConcurrentAgents: 10,


### PR DESCRIPTION
## Summary
The `DefaultConfig` comments in `internal/workflow/config.go` claimed the effective default was "one failure retry" / "1 retry", which directly contradicts the accessors they reference (`MaxRetryAttemptsValue()` / `MaxTimeoutRetriesValue()` return `UnboundedRetryBudget` for a nil pointer), the README, and DEVIATIONS D29.

This is a **comment-only** fix — the intended unbounded behavior (SPEC §8.4 / §16.6) is unchanged. Per the issue, this is not a request to change retry behavior.

## Acceptance criteria (#367)
- [x] Update the two `DefaultConfig` comments to say the effective default is unbounded, matching the accessors / README.

## Tests
No behavior change. The unbounded default the corrected comment now describes is already pinned by `TestDefaultConfigAgentTimeout` (asserts both accessors return `UnboundedRetryBudget` for `DefaultConfig`); mutation-verified that a finite default fails it.

Closes #367