### PR TITLE
chore(docker): copy go.sum before go mod download for a verifiable layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}-bookworm AS build
 WORKDIR /src
-COPY go.mod ./
-RUN go mod download
+# Copy go.sum alongside go.mod so `go mod download` can verify module
+# checksums, and so the cached dependency layer is keyed on both files
+# (matching the CI cache key) — a go.sum-only change now invalidates it (#369).
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
 COPY . .
 RUN go build -o /out/worker ./cmd/worker
 RUN go build -o /out/linear-poller ./cmd/linear-poller

--- a/test/e2e/fixtures/dockerfile_buildlayer_test.go
+++ b/test/e2e/fixtures/dockerfile_buildlayer_test.go
@@ -1,0 +1,41 @@
+package fixtures_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func dockerfileContents(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "Dockerfile")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// TestDockerfileCopiesGoSumBeforeDownload guards the reproducible dependency
+// layer (#369): go.sum must be copied alongside go.mod before `go mod
+// download`, so module checksums are verifiable and the cache layer is keyed on
+// both files. A go.mod-only copy regresses this.
+func TestDockerfileCopiesGoSumBeforeDownload(t *testing.T) {
+	df := dockerfileContents(t)
+
+	copyGoSum := strings.Index(df, "COPY go.mod go.sum")
+	if copyGoSum < 0 {
+		t.Fatal("Dockerfile does not COPY go.sum alongside go.mod before downloading modules")
+	}
+	download := strings.Index(df, "RUN go mod download")
+	if download < 0 {
+		t.Fatal("Dockerfile has no `RUN go mod download`")
+	}
+	if copyGoSum > download {
+		t.Errorf("`COPY go.mod go.sum` (at %d) must precede `go mod download` (at %d)", copyGoSum, download)
+	}
+	if copyAll := strings.Index(df, "COPY . ."); copyAll >= 0 && download > copyAll {
+		t.Errorf("`go mod download` (at %d) must run before `COPY . .` (at %d) to keep the cached dependency layer", download, copyAll)
+	}
+}


### PR DESCRIPTION
## Summary
The build stage copied only `go.mod` before `go mod download`; `go.sum` arrived later via `COPY . .`. Without `go.sum` present at download time the dependency layer couldn't verify module checksums, and its Docker cache was keyed only on `go.mod`, so `go.sum`-only changes didn't invalidate it.

- `COPY go.mod go.sum ./` before `RUN go mod download && go mod verify`.

## Acceptance criteria (#369)
- [x] `COPY go.mod go.sum ./` then `RUN go mod download`
- [x] `go mod verify` added

## Tests (mutation-verified)
`test/e2e/fixtures/dockerfile_buildlayer_test.go`: asserts `COPY go.mod go.sum` precedes `RUN go mod download`, which precedes `COPY . .`. Reverting to a go.mod-only copy fails it. The CI `Docker image build` job exercises the real build.

Closes #369