### PR TITLE
feat(docker): add default CMD ["worker"] so docker run is useful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,8 @@ COPY --from=build /out/worker /usr/local/bin/worker
 COPY --from=build /out/linear-poller /usr/local/bin/linear-poller
 COPY --from=build /out/gitea-poller /usr/local/bin/gitea-poller
 WORKDIR /app
+# Default to the worker so `docker run <image>` is useful out of the box (#370).
+# CMD (not ENTRYPOINT) keeps it overridable: Compose's `command: ["worker"]`
+# and the poller services' `command: ["linear-poller", ...]` replace it without
+# argument duplication, and `docker run <image> linear-poller ...` still works.
+CMD ["worker"]

--- a/README.md
+++ b/README.md
@@ -120,12 +120,22 @@ docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
 ```
 
 The image defaults to the worker (`CMD ["worker"]`), so a plain `docker run`
-starts it; pass a different binary to run a poller instead:
+starts it; override the command to run a poller instead. The runtime image
+ships only the binaries, so mount your workflow file in (as Compose does):
 
 ```bash
 docker build -t aiops-platform .
-docker run --rm --env-file .env aiops-platform                      # runs worker
-docker run --rm --env-file .env aiops-platform linear-poller /app/examples/WORKFLOW.md
+
+# Worker (default CMD); mount a workflow and point the worker at it:
+docker run --rm --env-file .env \
+  -v "$PWD/examples:/app/examples:ro" \
+  -e AIOPS_WORKFLOW_PATH=/app/examples/WORKFLOW.md \
+  aiops-platform
+
+# Poller (overrides the default CMD with its own binary + workflow path):
+docker run --rm --env-file .env \
+  -v "$PWD/examples:/app/examples:ro" \
+  aiops-platform linear-poller /app/examples/WORKFLOW.md
 ```
 
 For an operator walkthrough — workflow file layout, the `/api/v1/state` and

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ requested:
 docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
 ```
 
+The image defaults to the worker (`CMD ["worker"]`), so a plain `docker run`
+starts it; pass a different binary to run a poller instead:
+
+```bash
+docker build -t aiops-platform .
+docker run --rm --env-file .env aiops-platform                      # runs worker
+docker run --rm --env-file .env aiops-platform linear-poller /app/examples/WORKFLOW.md
+```
+
 For an operator walkthrough — workflow file layout, the `/api/v1/state` and
 `--print-config` smoke checks, and the legacy queue-driven pollers — see the
 [local development runbook](docs/runbooks/local-dev.md). If the runbook and this

--- a/test/e2e/fixtures/dockerfile_cmd_test.go
+++ b/test/e2e/fixtures/dockerfile_cmd_test.go
@@ -1,0 +1,32 @@
+package fixtures_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// TestDockerfileDefaultsToWorkerCmd guards #370: the runtime image must define
+// a default `CMD ["worker"]` so `docker run <image>` is useful. CMD (not
+// ENTRYPOINT) is required so Compose's `command:` overrides replace it cleanly
+// without argument duplication.
+func TestDockerfileDefaultsToWorkerCmd(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "Dockerfile")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	df := string(data)
+
+	cmdRE := regexp.MustCompile(`(?m)^CMD \["worker"\]`)
+	if !cmdRE.MatchString(df) {
+		t.Error(`Dockerfile is missing a default CMD ["worker"]`)
+	}
+	// ENTRYPOINT ["worker"] would make Compose's `command: ["worker"]` run
+	// `worker worker`; guard against that regression.
+	entryRE := regexp.MustCompile(`(?m)^ENTRYPOINT \["worker"\]`)
+	if entryRE.MatchString(df) {
+		t.Error(`Dockerfile uses ENTRYPOINT ["worker"]; use CMD so Compose command overrides do not duplicate the argument`)
+	}
+}


### PR DESCRIPTION
## Summary
The runtime image defined no default `CMD`/`ENTRYPOINT`, so `docker run aiops-platform` did nothing useful — only Compose worked, via its explicit `command: ["worker"]`.

- Add `CMD ["worker"]`. **CMD, not ENTRYPOINT**, on purpose: Compose's `command: ["worker"]` and the poller services' `command: ["linear-poller", ...]` cleanly *override* CMD (an ENTRYPOINT would make Compose run `worker worker`), and `docker run <image> linear-poller ...` still works.
- README: add a `docker run` example.

## Acceptance criteria (#370)
- [x] Add default `CMD ["worker"]`
- [x] `docker run` example in the README

## Tests (mutation-verified)
`test/e2e/fixtures/dockerfile_cmd_test.go`: asserts a default `CMD ["worker"]` is present and that `ENTRYPOINT ["worker"]` is **not** used (which would break Compose overrides). Removing the CMD or switching to ENTRYPOINT fails it. The CI `Docker image build` job builds the image.

Closes #370