### PR TITLE
harden(deploy): legacy Postgres needs an explicit password, loopback-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,11 @@
 # Legacy-queue pollers only (not needed by cmd/worker). Set a strong
 # POSTGRES_PASSWORD before starting the `legacy-queue` Compose profile — the
 # postgres service has no default password and refuses to start without one
-# (#371). Use the same value in DATABASE_URL for native poller runs.
+# (#371). Compose passes it to the pollers via PGPASSWORD (not embedded in the
+# DSN, so reserved characters are safe). For native poller runs, export
+# PGPASSWORD="$POSTGRES_PASSWORD" alongside the password-less DATABASE_URL.
 POSTGRES_PASSWORD=replace-with-a-strong-postgres-password
-DATABASE_URL=postgres://aiops:replace-with-a-strong-postgres-password@localhost:5432/aiops?sslmode=disable
+DATABASE_URL=postgres://aiops@localhost:5432/aiops?sslmode=disable
 GITEA_BASE_URL=http://gitea.local
 GITEA_TOKEN=replace-with-gitea-bot-token
 LINEAR_API_KEY=replace-with-linear-personal-key

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,12 @@
 # as written here — adding an AIOPS_ prefix to a bare name (or removing
 # it from a prefixed one) without changing the matching reader will
 # silently fall back to the code default.
-DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
+# Legacy-queue pollers only (not needed by cmd/worker). Set a strong
+# POSTGRES_PASSWORD before starting the `legacy-queue` Compose profile — the
+# postgres service has no default password and refuses to start without one
+# (#371). Use the same value in DATABASE_URL for native poller runs.
+POSTGRES_PASSWORD=replace-with-a-strong-postgres-password
+DATABASE_URL=postgres://aiops:replace-with-a-strong-postgres-password@localhost:5432/aiops?sslmode=disable
 GITEA_BASE_URL=http://gitea.local
 GITEA_TOKEN=replace-with-gitea-bot-token
 LINEAR_API_KEY=replace-with-linear-personal-key

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -45,7 +45,10 @@ services:
     depends_on:
       - postgres
     environment:
-      DATABASE_URL: postgres://aiops:${POSTGRES_PASSWORD:-}@postgres:5432/aiops?sslmode=disable
+      # Password is passed via PGPASSWORD (libpq env), not embedded in the
+      # DSN, so a strong password with URL-reserved characters is not mangled.
+      DATABASE_URL: postgres://aiops@postgres:5432/aiops?sslmode=disable
+      PGPASSWORD: ${POSTGRES_PASSWORD:-}
       LINEAR_API_KEY: ${LINEAR_API_KEY}
     volumes:
       - ../examples:/app/examples:ro
@@ -59,7 +62,10 @@ services:
     depends_on:
       - postgres
     environment:
-      DATABASE_URL: postgres://aiops:${POSTGRES_PASSWORD:-}@postgres:5432/aiops?sslmode=disable
+      # Password is passed via PGPASSWORD (libpq env), not embedded in the
+      # DSN, so a strong password with URL-reserved characters is not mangled.
+      DATABASE_URL: postgres://aiops@postgres:5432/aiops?sslmode=disable
+      PGPASSWORD: ${POSTGRES_PASSWORD:-}
       GITEA_BASE_URL: ${GITEA_BASE_URL}
       GITEA_TOKEN: ${GITEA_TOKEN}
     volumes:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -24,10 +24,14 @@ services:
     image: postgres:16
     environment:
       POSTGRES_USER: aiops
-      POSTGRES_PASSWORD: aiops
+      # No hardcoded password (#371). Operators using the legacy-queue profile
+      # must set POSTGRES_PASSWORD in .env; left empty the postgres image
+      # refuses to initialize, so there is no weak default to leak.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: aiops
+    # Bind to host loopback only — never expose Postgres on all interfaces.
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ../migrations:/docker-entrypoint-initdb.d:ro
@@ -41,7 +45,7 @@ services:
     depends_on:
       - postgres
     environment:
-      DATABASE_URL: postgres://aiops:aiops@postgres:5432/aiops?sslmode=disable
+      DATABASE_URL: postgres://aiops:${POSTGRES_PASSWORD:-}@postgres:5432/aiops?sslmode=disable
       LINEAR_API_KEY: ${LINEAR_API_KEY}
     volumes:
       - ../examples:/app/examples:ro
@@ -55,7 +59,7 @@ services:
     depends_on:
       - postgres
     environment:
-      DATABASE_URL: postgres://aiops:aiops@postgres:5432/aiops?sslmode=disable
+      DATABASE_URL: postgres://aiops:${POSTGRES_PASSWORD:-}@postgres:5432/aiops?sslmode=disable
       GITEA_BASE_URL: ${GITEA_BASE_URL}
       GITEA_TOKEN: ${GITEA_TOKEN}
     volumes:

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -236,7 +236,8 @@ docker compose --env-file .env -f deploy/docker-compose.yml down -v
 ### 4.2 Linear legacy poller
 
 ```bash
-export DATABASE_URL=postgres://aiops:${POSTGRES_PASSWORD}@localhost:5432/aiops?sslmode=disable
+export DATABASE_URL=postgres://aiops@localhost:5432/aiops?sslmode=disable
+export PGPASSWORD="$POSTGRES_PASSWORD"
 export LINEAR_API_KEY=your-linear-personal-key
 go run ./cmd/linear-poller examples/WORKFLOW.md
 ```
@@ -252,7 +253,8 @@ For Linear workflows, `tracker.project_slug` in the selected
 ### 4.3 Gitea legacy poller
 
 ```bash
-export DATABASE_URL=postgres://aiops:${POSTGRES_PASSWORD}@localhost:5432/aiops?sslmode=disable
+export DATABASE_URL=postgres://aiops@localhost:5432/aiops?sslmode=disable
+export PGPASSWORD="$POSTGRES_PASSWORD"
 export GITEA_BASE_URL=http://localhost:3000
 export GITEA_TOKEN=your-gitea-bot-token
 go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -204,6 +204,10 @@ poller produces are never claimed.
 
 ### 4.1 Postgres for the legacy pollers
 
+Set a strong `POSTGRES_PASSWORD` in `.env` first — the postgres service
+has no default password and refuses to start without one (#371), and it
+publishes only on host loopback (`127.0.0.1:5432`).
+
 ```bash
 docker compose --env-file .env -f deploy/docker-compose.yml up -d postgres
 docker compose --env-file .env -f deploy/docker-compose.yml \
@@ -232,7 +236,7 @@ docker compose --env-file .env -f deploy/docker-compose.yml down -v
 ### 4.2 Linear legacy poller
 
 ```bash
-export DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
+export DATABASE_URL=postgres://aiops:${POSTGRES_PASSWORD}@localhost:5432/aiops?sslmode=disable
 export LINEAR_API_KEY=your-linear-personal-key
 go run ./cmd/linear-poller examples/WORKFLOW.md
 ```
@@ -248,7 +252,7 @@ For Linear workflows, `tracker.project_slug` in the selected
 ### 4.3 Gitea legacy poller
 
 ```bash
-export DATABASE_URL=postgres://aiops:aiops@localhost:5432/aiops?sslmode=disable
+export DATABASE_URL=postgres://aiops:${POSTGRES_PASSWORD}@localhost:5432/aiops?sslmode=disable
 export GITEA_BASE_URL=http://localhost:3000
 export GITEA_TOKEN=your-gitea-bot-token
 go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -278,7 +278,7 @@ docker compose --env-file .env -f deploy/docker-compose.yml down -v
 
 ```bash
 export DATABASE_URL=postgres://aiops@localhost:5432/aiops?sslmode=disable
-export PGPASSWORD="$POSTGRES_PASSWORD"
+export PGPASSWORD=your-postgres-password   # same value as POSTGRES_PASSWORD in .env
 export LINEAR_API_KEY=your-linear-personal-key
 go run ./cmd/linear-poller examples/WORKFLOW.md
 ```
@@ -295,7 +295,7 @@ For Linear workflows, `tracker.project_slug` in the selected
 
 ```bash
 export DATABASE_URL=postgres://aiops@localhost:5432/aiops?sslmode=disable
-export PGPASSWORD="$POSTGRES_PASSWORD"
+export PGPASSWORD=your-postgres-password   # same value as POSTGRES_PASSWORD in .env
 export GITEA_BASE_URL=http://localhost:3000
 export GITEA_TOKEN=your-gitea-bot-token
 go run ./cmd/gitea-poller examples/gitea-WORKFLOW.md

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -242,6 +242,19 @@ docker compose --env-file .env -f deploy/docker-compose.yml \
   exec postgres psql -U aiops -d aiops -c '\dt'
 ```
 
+> **Migrating an existing volume.** Postgres only applies `POSTGRES_PASSWORD`
+> when it first initializes an empty data directory. A `pgdata` volume created
+> under the old default `aiops` keeps that password, so the pollers' new
+> `PGPASSWORD` would fail to authenticate. The queue volume is disposable, so
+> the simplest path is to recreate it once:
+>
+> ```bash
+> docker compose --env-file .env -f deploy/docker-compose.yml down -v
+> ```
+>
+> To preserve the data instead, rotate the role password in place:
+> `ALTER USER aiops PASSWORD '<new>';` to match the new `POSTGRES_PASSWORD`.
+
 You should see `tasks` and `task_events`. The compose file mounts
 `migrations/` into Postgres's `/docker-entrypoint-initdb.d`, so the
 schema is applied automatically on first startup.

--- a/test/e2e/fixtures/postgres_hardening_test.go
+++ b/test/e2e/fixtures/postgres_hardening_test.go
@@ -1,9 +1,13 @@
 package fixtures_test
 
 import (
+	"net"
 	"strings"
 	"testing"
 )
+
+// publishedHostIP (Compose port-mapping host-IP parser) is shared from
+// dashboard_overlay_test.go in this package.
 
 // TestLegacyPostgresHasNoHardcodedPassword guards #371: the legacy-queue
 // postgres service must not ship a hardcoded password and must source it from
@@ -39,13 +43,15 @@ func TestLegacyPostgresBindsLoopbackOnly(t *testing.T) {
 		if !ok {
 			t.Fatalf("port mapping %#v is not a string", raw)
 		}
-		parts := strings.Split(mapping, ":")
-		if len(parts) != 3 {
-			t.Errorf("port mapping %q must pin a host IP (HOST_IP:HOST_PORT:CONTAINER_PORT)", mapping)
-			continue
+		hostIP, parsed := publishedHostIP(mapping)
+		if !parsed {
+			t.Fatalf("could not parse port mapping %q", mapping)
 		}
-		if parts[0] != "127.0.0.1" && parts[0] != "::1" {
-			t.Errorf("postgres port %q publishes on %q; expected loopback", mapping, parts[0])
+		// An empty host IP means the bare HOST_PORT:CONTAINER_PORT form, which
+		// publishes on every host interface — exactly what we must forbid.
+		ip := net.ParseIP(hostIP)
+		if ip == nil || !ip.IsLoopback() {
+			t.Errorf("postgres port %q publishes on host IP %q; expected a loopback address", mapping, hostIP)
 		}
 	}
 }

--- a/test/e2e/fixtures/postgres_hardening_test.go
+++ b/test/e2e/fixtures/postgres_hardening_test.go
@@ -50,9 +50,11 @@ func TestLegacyPostgresBindsLoopbackOnly(t *testing.T) {
 	}
 }
 
-// TestLegacyPollerDBURLsHaveNoHardcodedPassword guards that the poller
-// DATABASE_URLs no longer embed the weak aiops:aiops credentials (#371).
-func TestLegacyPollerDBURLsHaveNoHardcodedPassword(t *testing.T) {
+// TestLegacyPollerDBURLsHaveNoEmbeddedPassword guards that the pollers no
+// longer embed a password in the DSN (#371): the weak aiops password is gone,
+// and the password is supplied via PGPASSWORD (libpq env) so URL-reserved
+// characters in a strong secret are not mangled.
+func TestLegacyPollerDBURLsHaveNoEmbeddedPassword(t *testing.T) {
 	compose := readCompose(t)
 	for _, name := range []string{"linear-poller", "gitea-poller"} {
 		env, ok := service(t, compose, name)["environment"].(map[string]any)
@@ -60,11 +62,18 @@ func TestLegacyPollerDBURLsHaveNoHardcodedPassword(t *testing.T) {
 			t.Fatalf("%s.environment = %#v, want map", name, service(t, compose, name)["environment"])
 		}
 		url, _ := env["DATABASE_URL"].(string)
+		// userinfo must be the bare user with no ":password@" component.
 		if strings.Contains(url, ":aiops@") {
 			t.Errorf("%s DATABASE_URL embeds the hardcoded aiops password: %q", name, url)
 		}
-		if !strings.Contains(url, "POSTGRES_PASSWORD") {
-			t.Errorf("%s DATABASE_URL = %q, want the password sourced from ${POSTGRES_PASSWORD...}", name, url)
+		if at := strings.Index(url, "@"); at >= 0 {
+			if scheme := strings.Index(url, "://"); scheme >= 0 && strings.Contains(url[scheme+3:at], ":") {
+				t.Errorf("%s DATABASE_URL embeds a password in the DSN: %q (use PGPASSWORD)", name, url)
+			}
+		}
+		pgpw, _ := env["PGPASSWORD"].(string)
+		if !strings.Contains(pgpw, "POSTGRES_PASSWORD") {
+			t.Errorf("%s PGPASSWORD = %q, want the password sourced from ${POSTGRES_PASSWORD...}", name, pgpw)
 		}
 	}
 }

--- a/test/e2e/fixtures/postgres_hardening_test.go
+++ b/test/e2e/fixtures/postgres_hardening_test.go
@@ -1,0 +1,70 @@
+package fixtures_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLegacyPostgresHasNoHardcodedPassword guards #371: the legacy-queue
+// postgres service must not ship a hardcoded password and must source it from
+// the environment, so there is no weak default to leak.
+func TestLegacyPostgresHasNoHardcodedPassword(t *testing.T) {
+	pg := service(t, readCompose(t), "postgres")
+	env, ok := pg["environment"].(map[string]any)
+	if !ok {
+		t.Fatalf("postgres.environment = %#v, want map", pg["environment"])
+	}
+	pw, _ := env["POSTGRES_PASSWORD"].(string)
+	if pw == "" {
+		t.Fatal("postgres has no POSTGRES_PASSWORD entry")
+	}
+	if pw == "aiops" {
+		t.Error("postgres POSTGRES_PASSWORD is the hardcoded default 'aiops'")
+	}
+	if !strings.Contains(pw, "POSTGRES_PASSWORD") {
+		t.Errorf("postgres POSTGRES_PASSWORD = %q, want an env-sourced ${POSTGRES_PASSWORD...} value", pw)
+	}
+}
+
+// TestLegacyPostgresBindsLoopbackOnly guards that the postgres host port is
+// published only on loopback, never all interfaces (#371).
+func TestLegacyPostgresBindsLoopbackOnly(t *testing.T) {
+	pg := service(t, readCompose(t), "postgres")
+	ports, ok := pg["ports"].([]any)
+	if !ok || len(ports) == 0 {
+		t.Fatalf("postgres.ports = %#v, want non-empty list", pg["ports"])
+	}
+	for _, raw := range ports {
+		mapping, ok := raw.(string)
+		if !ok {
+			t.Fatalf("port mapping %#v is not a string", raw)
+		}
+		parts := strings.Split(mapping, ":")
+		if len(parts) != 3 {
+			t.Errorf("port mapping %q must pin a host IP (HOST_IP:HOST_PORT:CONTAINER_PORT)", mapping)
+			continue
+		}
+		if parts[0] != "127.0.0.1" && parts[0] != "::1" {
+			t.Errorf("postgres port %q publishes on %q; expected loopback", mapping, parts[0])
+		}
+	}
+}
+
+// TestLegacyPollerDBURLsHaveNoHardcodedPassword guards that the poller
+// DATABASE_URLs no longer embed the weak aiops:aiops credentials (#371).
+func TestLegacyPollerDBURLsHaveNoHardcodedPassword(t *testing.T) {
+	compose := readCompose(t)
+	for _, name := range []string{"linear-poller", "gitea-poller"} {
+		env, ok := service(t, compose, name)["environment"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s.environment = %#v, want map", name, service(t, compose, name)["environment"])
+		}
+		url, _ := env["DATABASE_URL"].(string)
+		if strings.Contains(url, ":aiops@") {
+			t.Errorf("%s DATABASE_URL embeds the hardcoded aiops password: %q", name, url)
+		}
+		if !strings.Contains(url, "POSTGRES_PASSWORD") {
+			t.Errorf("%s DATABASE_URL = %q, want the password sourced from ${POSTGRES_PASSWORD...}", name, url)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
The `legacy-queue` Postgres service used the weak default password `aiops` and mapped `5432:5432` on all host interfaces.

- **No hardcoded password**: `POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}` (no default). Left unset, the postgres image refuses to initialize, so there's no weak default to leak; operators set it in `.env`.
- **Loopback-only**: `ports: ["127.0.0.1:5432:5432"]`.
- Poller `DATABASE_URL`s now source the password from `${POSTGRES_PASSWORD:-}` instead of embedding `aiops:aiops`.
- `.env.example` + runbook updated (set a strong `POSTGRES_PASSWORD`).

Note: a required-variable form (`${POSTGRES_PASSWORD:?...}`) is intentionally **not** used — Compose interpolates the whole file at parse time regardless of profiles, so it would break the default `docker compose up worker` (verified with `docker compose config`). The empty default keeps the default path parsing while still failing the legacy profile loudly when no password is set.

## Acceptance criteria (#371)
- [x] Bind to `127.0.0.1:5432:5432` (loopback)
- [x] Require a user-provided password via `.env` instead of the hardcoded default

## Tests (mutation-verified)
`test/e2e/fixtures/postgres_hardening_test.go`: postgres has no hardcoded `aiops` password and sources it from the env; the host port binds loopback only; poller `DATABASE_URL`s don't embed `:aiops@`. Reverting any of these fails the corresponding guard.

Closes #371