### PR TITLE
docs: batch issue processing runbook + wire skills to it

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -58,10 +58,11 @@ go vet ./... ; go test -race ./... ; go build ./...
 3. **并行本地审查提速**：同时派 Claude general-purpose subagent + Codex（`codex:codex-rescue`）审 `git diff origin/main...HEAD`，盲审、附 severity + verdict。两者抓不同缺陷类。（注：本环境 codex-rescue 沙箱可能被 bwrap/netns 限制；那就以 stop-time gate + GitHub @codex 为 Codex 信号。）
 4. 每条 finding 归入 ≥1 类（算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试），然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。
 5. **审查深度匹配 blast radius**：破坏性/并发路径要穷尽对抗式审查；纯增量序列化改动一轮即可。
-6. 收敛后交给 `gh-pr-follow-through` 盯 CI + 线程到 merge-ready。
+6. 收敛后交给 `gh-pr-follow-through`（来自私有 `xrf9268-hue/yy-skills`；本地开发机已装，**云端容器通常没装**）盯 CI + 线程到 merge-ready。**该 skill 不可用时（如当前云端环境）就地内联这步**：`gh pr checks <pr> --watch --fail-fast` 等 CI 收敛 → 查 `reviewThreads` 解决所有未决 actionable thread → 直到 merge-ready，别因为缺 skill 而跳过这步。
 
 ### 7. 合并
 - **必须等用户明确许可**再合并。
+- 例外：用户给了**按批次、按 scope 的显式授权**时，可走 `docs/runbooks/batch-issue-processing.md` 的 opt-in 自动合并流程（全部放行门槛 + hard stops；优先 GitHub 原生 auto-merge）。授权不是长期的，批次外/scope 外仍要重新确认。
 - squash + 删分支；commit message 写**最终状态**，不要按轮次罗列。
 - 强推统一 `--force-with-lease=<branch>:<known-sha>`。
 
@@ -91,3 +92,4 @@ go vet ./... ; go test -race ./... ; go build ./...
 - 中文回复，简洁；每次只汇报变化，不复述。
 - worker 永不 push/合并 PR 或写 tracker 状态（D8/#76）。
 - Go 版本由 go.mod 锁定，别顺手改 `go` 指令。
+- **批处理多个 issue 时**（`/goal` over a set）：独立 issue **默认并行**开分支推进，只在有真实依赖（共享文件 / migration 顺序 / 后者消费前者的 API）时串行；决定某条 acceptance criterion 延后时**当场**告知用户并立即开 follow-up issue，别留到收尾汇报。完整批处理纪律见 `docs/runbooks/batch-issue-processing.md`。

--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -58,7 +58,7 @@ go vet ./... ; go test -race ./... ; go build ./...
 3. **并行本地审查提速**：同时派 Claude general-purpose subagent + Codex（`codex:codex-rescue`）审 `git diff origin/main...HEAD`，盲审、附 severity + verdict。两者抓不同缺陷类。（注：本环境 codex-rescue 沙箱可能被 bwrap/netns 限制；那就以 stop-time gate + GitHub @codex 为 Codex 信号。）
 4. 每条 finding 归入 ≥1 类（算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试），然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。
 5. **审查深度匹配 blast radius**：破坏性/并发路径要穷尽对抗式审查；纯增量序列化改动一轮即可。
-6. 收敛后交给 `gh-pr-follow-through`（来自私有 `xrf9268-hue/yy-skills`；本地开发机已装，**云端容器通常没装**）盯 CI + 线程到 merge-ready。**该 skill 不可用时（如当前云端环境）就地内联这步**：`gh pr checks <pr> --watch --fail-fast` 等 CI 收敛 → 查 `reviewThreads` 解决所有未决 actionable thread → 直到 merge-ready，别因为缺 skill 而跳过这步。
+6. 收敛后交给 `gh-pr-follow-through`（来自私有 `xrf9268-hue/yy-skills`；本地开发机已装，**云端容器通常没装**）盯 CI + 线程到 merge-ready。**该 skill 不可用时（如当前云端环境）就地内联这步**：`gh pr checks <pr> --watch --fail-fast` 等 CI 收敛 → 查 `reviewThreads` 解决所有未决 actionable thread → 直到 merge-ready，别因为缺 skill 而跳过这步。follow-through 期间若推了修复，按 step 2 对新 head 重跑 `@codex review` 环（新 push 会重开审查轮）。
 
 ### 7. 合并
 - **必须等用户明确许可**再合并。

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -2,7 +2,7 @@
 description: Audit and ship a GitHub PR through SPEC-aligned review rounds against upstream openai/symphony. Manual invoke only.
 argument-hint: "[pr-number]"
 disable-model-invocation: true
-allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(gofmt *)
+allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(gofmt *) Bash(gh *)
 ---
 
 # Handle PR #$ARGUMENTS

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -36,7 +36,7 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
 
 3. **Mutation test 验证新测试有效**：删掉新代码的关键行，跑新测试，确认 fail；恢复，确认 pass。安慰剂测试是最隐蔽的陷阱。
 
-4. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria。AGENTS.md rule 2 要求。
+4. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria。AGENTS.md rule 2 要求。决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
 
 5. **Scope 分离**：治理 / 文档改动从 main 开新分支单独 PR，不要塞进 fix PR。
 
@@ -45,5 +45,6 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
 - 工作分支：系统会告诉你具体名字
 - 合并方式：squash（本仓库惯例），commit_message 写最终状态不要按轮次罗列
 - 强推统一 `--force-with-lease=<branch>:<known-sha>`
-- merge 前必须等用户明确许可
+- merge 前必须等用户明确许可；例外：用户给了**按批次、按 scope 的显式授权**时，走 `docs/runbooks/batch-issue-processing.md` 的 opt-in 自动合并流程（全门槛 + hard stops，优先 GitHub 原生 auto-merge），授权不跨批次/scope 沿用
+- 批处理多个 PR 时的并行与状态清单纪律见 `docs/runbooks/batch-issue-processing.md`
 - 中文回复，简洁；每次只汇报变化不复述

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,6 +339,7 @@ searched or reported as normal shadow sources.
 - `docs/runbooks/ci.md` — CI behavior, release flow, pre-push checks
 - `docs/runbooks/secret-scanning.md` — opt-in pre-push leak scan
 - `docs/runbooks/workspace-cache.md` — workspace lifecycle and cleanup
+- `docs/runbooks/batch-issue-processing.md` — running a `/goal` over a set of issues: one-issue-per-PR, parallelism, deferral protocol, and the authorized auto-merge flow
 - `docs/adr/0001-symphony-style-personal-orchestrator.md` — the "why"
 
 ## Safety posture for agents

--- a/docs/runbooks/batch-issue-processing.md
+++ b/docs/runbooks/batch-issue-processing.md
@@ -1,0 +1,127 @@
+# Batch issue processing
+
+How an agent should run a batch of issues (a `/goal` over a set of tracker
+issues) so the work stays reviewable, parallel where it can be, and safe to
+merge.
+
+Every rule below is earned by a specific failure or friction observed in the
+**2026-05 eight-issue sequential batch** (#365–#372 → PRs #373–#381; one
+acceptance-criterion deferral tracked as #375). Per the "Earned rules"
+principle in [`AGENTS.md`](../../AGENTS.md), do not generalize beyond what that
+run actually taught.
+
+## The unit of work: one issue → one PR
+
+1. **One issue per branch, one branch per PR.** Never bundle multiple issues
+   into a single PR. Small blast radius is what makes a batch reviewable: CI
+   failures localize to one issue, the human can merge at their own cadence,
+   and a revert touches exactly one concern. **Earned by:** the eight-issue
+   batch shipped as eight independent PRs and every one was reviewable in
+   isolation; the value was in the isolation, not the volume.
+2. **Each PR is self-contained and self-verifying.** It includes the fix plus
+   regression tests, and the test must fail when the production code is broken
+   (mutation or negative assertion — see "Clean code" rule 6 in `AGENTS.md`). A
+   PR whose tests would pass with the fix reverted does not count as done.
+3. **Run the local CI gate before pushing**, then confirm CI green and run the
+   adversarial pass (`@codex review`) on the head commit. Resolve or
+   explicitly defer every finding before marking ready. This is the
+   cross-cutting checklist in `AGENTS.md`, applied per PR.
+
+## Parallelize independent issues by default
+
+Sequential execution was the single biggest throughput cost of the 2026-05
+run: eight independent issues were processed one after another when most had no
+ordering dependency.
+
+1. **Map dependencies before starting.** For the issue set, sketch which issues
+   touch overlapping paths or have a real ordering constraint (one's fix
+   depends on another's merge). Issues touching disjoint paths are independent.
+2. **Default to parallel for independent issues.** Open a branch per
+   independent issue and progress them concurrently rather than draining them
+   in series. Serialize **only** where a dependency is real — a shared file, a
+   migration ordering, or an API a later issue consumes.
+3. **Cap concurrency to what you can keep green.** Each in-flight PR still owes
+   the full per-PR gate (local CI, CI green, `@codex review` triage). Do not
+   open more parallel work than you can drive to mergeable without letting
+   reviews rot.
+4. **Respect the size budget per PR regardless of parallelism**
+   (`policy.max_changed_files: 12`, `policy.max_changed_loc: 300`). Parallelism
+   is about more small PRs, never bigger ones.
+
+## Surface deferrals at the moment you defer, not at the end
+
+In the 2026-05 run, one acceptance criterion that could not be met was carried
+silently and only disclosed in the final summary, tracked late as #375. That
+robbed the human of the chance to weigh in while the context was fresh.
+
+1. **The instant you decide an acceptance criterion cannot be met in this PR,
+   say so** — in the PR body and to the human — with the reason and the
+   proposed follow-up.
+2. **File the follow-up issue immediately** (tagged `area:tech-debt` or
+   `area:spec-alignment` as appropriate, per `AGENTS.md`) and link it from the
+   PR. A deferral without a tracked issue is just a silent gap.
+3. **Never let "done" hide a deferral.** The end-of-batch summary should
+   restate deferrals already raised, not introduce them.
+
+## Keep a live status checklist
+
+Mid-batch, the only way the human could reconstruct state was by reading the PR
+list. Maintain a running checklist instead and refresh it on every meaningful
+transition:
+
+```text
+issue → branch → PR → state (draft | CI green | review clean | mergeable | merged | deferred→#NNN)
+```
+
+This is the same discipline `AGENTS.md` requires for PR-activity events; apply
+it to the batch as a whole.
+
+## Merge and goal-clear are human actions by default
+
+The 2026-05 run deliberately left every merge to the human and could not clear
+its own `/goal` at the end (the Stop hook released only after the human ran
+`/goal clear`). That is the safe default and it is intentional:
+
+1. **The agent drives each PR to *mergeable*, then stops.** It does not merge,
+   it does not force-push `main`, and it does not change `go.mod`'s `go`
+   directive (see `AGENTS.md`). These are durable guardrails, not per-session
+   reminders.
+2. **The batch's terminal state depends on human actions** — merging the PRs
+   and clearing the goal. Plan for PRs to queue waiting for a human; that is
+   expected, not a stall.
+
+## Authorized auto-merge flow (opt-in, scope-bounded)
+
+The default above (human merges) stands unless the human grants explicit,
+scope-bounded authorization for the agent to merge. Authorization is per-batch
+and per-scope — "you may merge the PRs for issues #365–#372 once they pass the
+gate" — never a standing grant. Approving one merge does not authorize the
+next.
+
+When auto-merge **is** authorized, a PR may be merged only when **all** of
+these hold:
+
+1. **CI is green** on the head commit (not a stale run).
+2. **`@codex review` is clean** — no unresolved HIGH/MEDIUM findings — and
+   there are **zero unresolved, non-outdated review threads**.
+3. **Every acceptance criterion is met, or each gap is deferred to a tracked,
+   linked issue** (per the deferral protocol above).
+4. **The PR is within the policy size budget** and changes no `policy.deny_paths`
+   (`infra/**`, `deploy/**`, `db/migrations/**`, `secrets/**`).
+5. **The merge uses the agreed method** (default: squash) into the agreed base.
+
+Prefer GitHub's native auto-merge so the platform enforces required checks:
+enable auto-merge on the PR rather than issuing an immediate merge, so a
+later-arriving failing check still blocks the merge.
+
+Hard stops — **always require human sign-off even under an auto-merge grant:**
+
+- Force-pushing or merging into `main` out of band, or any history rewrite.
+- Editing `go.mod`'s `go` directive, or touching `policy.deny_paths`.
+- A PR that breached its scope (size budget, unrelated refactors) — flag, don't
+  merge.
+- Anything the human's instructions for this batch put off-limits. When a PR
+  sits at the edge of the grant, use `AskUserQuestion` rather than assuming the
+  grant covers it.
+
+Stop the moment the human revokes the grant or asks you to stop.

--- a/docs/runbooks/batch-issue-processing.md
+++ b/docs/runbooks/batch-issue-processing.md
@@ -5,10 +5,11 @@ issues) so the work stays reviewable, parallel where it can be, and safe to
 merge.
 
 Every rule below is earned by a specific failure or friction observed in the
-**2026-05 eight-issue sequential batch** (#365–#372 → PRs #373–#381; one
-acceptance-criterion deferral tracked as #375). Per the "Earned rules"
-principle in [`AGENTS.md`](../../AGENTS.md), do not generalize beyond what that
-run actually taught.
+**2026-05 eight-issue sequential batch** (issues #365–#372 → 8 PRs #373, #374,
+#376–#381; the one acceptance-criterion deferral was filed as a separate
+follow-up, issue #375 — which is why the PR numbers skip it). Per the "Earned
+rules" principle in [`AGENTS.md`](../../AGENTS.md), do not generalize beyond
+what that run actually taught.
 
 ## The unit of work: one issue → one PR
 
@@ -35,15 +36,20 @@ ordering dependency.
 
 1. **Map dependencies before starting.** For the issue set, sketch which issues
    touch overlapping paths or have a real ordering constraint (one's fix
-   depends on another's merge). Issues touching disjoint paths are independent.
+   depends on another's merge). Issues touching disjoint paths are independent
+   — but "disjoint" means more than different files: two issues in the same Go
+   package can still collide through shared types, an atomic rename (Clean-code
+   rule 3 in `AGENTS.md`), or `go.mod`/`go.sum`. Treat shared package/module
+   surface as a dependency, not as independent.
 2. **Default to parallel for independent issues.** Open a branch per
    independent issue and progress them concurrently rather than draining them
    in series. Serialize **only** where a dependency is real — a shared file, a
    migration ordering, or an API a later issue consumes.
 3. **Cap concurrency to what you can keep green.** Each in-flight PR still owes
-   the full per-PR gate (local CI, CI green, `@codex review` triage). Do not
-   open more parallel work than you can drive to mergeable without letting
-   reviews rot.
+   the full per-PR gate (local CI, CI green, `@codex review` triage). The
+   worker's per-state capacity caps are the hard ceiling; your review bandwidth
+   is the practical one. Do not open more parallel work than you can drive to
+   mergeable without letting reviews rot.
 4. **Respect the size budget per PR regardless of parallelism**
    (`policy.max_changed_files: 12`, `policy.max_changed_loc: 300`). Parallelism
    is about more small PRs, never bigger ones.
@@ -73,8 +79,8 @@ transition:
 issue → branch → PR → state (draft | CI green | review clean | mergeable | merged | deferred→#NNN)
 ```
 
-This is the same discipline `AGENTS.md` requires for PR-activity events; apply
-it to the batch as a whole.
+This mirrors the per-event status-checklist discipline the harness expects when
+watching PR activity; apply it to the batch as a whole.
 
 ## Merge and goal-clear are human actions by default
 
@@ -106,18 +112,30 @@ these hold:
    there are **zero unresolved, non-outdated review threads**.
 3. **Every acceptance criterion is met, or each gap is deferred to a tracked,
    linked issue** (per the deferral protocol above).
-4. **The PR is within the policy size budget** and changes no `policy.deny_paths`
-   (`infra/**`, `deploy/**`, `db/migrations/**`, `secrets/**`).
-5. **The merge uses the agreed method** (default: squash) into the agreed base.
+4. **The PR is within this repo's effective size budget and changes no
+   `policy.deny_paths`.** Read both from the repo's `WORKFLOW.md`; do not trust
+   a hardcoded list — workflows differ (defaults are 12 files / 300 LOC and
+   deny `infra/**`, `deploy/**`, `db/migrations/**`, `secrets/**`, but e.g. the
+   `github-local` example uses 20 / 600).
+5. **Branch protection's required reviews are satisfied.**
+6. **The merge uses the agreed method** (default: squash) into the agreed base.
 
-Prefer GitHub's native auto-merge so the platform enforces required checks:
-enable auto-merge on the PR rather than issuing an immediate merge, so a
-later-arriving failing check still blocks the merge.
+**Native auto-merge enforces only required status checks (CI) and branch
+protection's required reviews — not gates 2–4.** `gh pr merge --auto` merges the
+instant required CI passes, regardless of an open `@codex` finding, an
+unresolved review thread, an unmet acceptance criterion, or a size-budget
+breach. So:
+
+- Confirm gates 2–4 **yourself, immediately before** enabling auto-merge.
+- A new commit re-opens them — any push restarts the `@codex` round, so
+  re-confirm before re-enabling.
+- Prefer native auto-merge over an immediate merge only to win the CI race, not
+  as a substitute for checking the policy gates.
 
 Hard stops — **always require human sign-off even under an auto-merge grant:**
 
 - Force-pushing or merging into `main` out of band, or any history rewrite.
-- Editing `go.mod`'s `go` directive, or touching `policy.deny_paths`.
+- Editing `go.mod`'s `go` directive opportunistically, or touching `policy.deny_paths`.
 - A PR that breached its scope (size budget, unrelated refactors) — flag, don't
   merge.
 - Anything the human's instructions for this batch put off-limits. When a PR


### PR DESCRIPTION
## Summary

Captures the retrospective from the 2026-05 eight-issue `/goal` batch
(#365–#372 → PRs #373–#381; one acceptance-criterion deferral tracked as #375)
as durable process docs, and wires the existing skills to it. All changes are
docs/governance — no code paths touched.

### New runbook — `docs/runbooks/batch-issue-processing.md` (linked from `AGENTS.md`)

Every rule framed as **earned by** that batch, matching the repo's "Earned
rules" philosophy:
- **One issue → one PR**, self-contained and self-verifying (regression +
  mutation tests).
- **Parallelize independent issues by default** — map dependencies first,
  serialize only on a real dependency, cap concurrency to what stays green.
  (Direct fix for the biggest throughput cost of the serial run.)
- **Surface deferrals the moment you defer**, with an immediately-filed linked
  follow-up — not at the end-of-batch summary.
- **Keep a live status checklist** (issue → branch → PR → state).
- **Merge and goal-clear are human actions by default** — drive to *mergeable*,
  never force-push `main`, never touch `go.mod`'s `go` directive.
- **Authorized auto-merge flow (opt-in, scope-bounded)** — explicit per-batch
  grant, full release gates (CI green, `@codex review` clean, zero unresolved
  threads, acceptance met or tracked-deferred, within size budget, no
  `deny_paths`), prefer GitHub native auto-merge, plus hard stops that always
  require human sign-off.

### Skill edits — `handle-issue` / `handle-pr`

- **Cloud fallback for the `gh-pr-follow-through` handoff.** That skill lives in
  the private `xrf9268-hue/yy-skills` and is installed on the local dev box but
  absent in cloud containers. `handle-issue` now says so and inlines the
  CI-watch + thread-resolution step when it's unavailable, so the handoff never
  silently dead-ends.
- **Cross-references to the runbook** from both skills for parallelism,
  deferral-at-decision-time, and the opt-in authorized auto-merge flow.

## Test plan

- [ ] `AGENTS.md` link resolves to the new runbook
- [ ] Runbook and skill files render correctly on GitHub

https://claude.ai/code/session_01RzVFgBxHyDqvqGpQRqqzuK