### PR TITLE
feat(worker): report config value provenance in --print-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ To inspect the effective configuration for a workdir without consuming a task:
 
 ```bash
 worker --print-config /path/to/repo/clone
+# pass --port to see how a CLI override is attributed:
+worker --print-config /path/to/repo/clone --port=4001
 ```
 
 The output is JSON. `tracker.api_key` is masked as `***`; the prompt template is
@@ -299,6 +301,15 @@ summarized (length + first line) rather than printed verbatim — `cat
 <resolution.path>` to see the full body. For post-hoc inspection, the
 `workflow_resolved` task event records the source and path of every run;
 `shadowed_by` is omitted unless future non-legacy resolution metadata is added.
+
+A `provenance` block reports where each multi-layer value resolved from —
+`default`, `env` (with the env var name and whether it was a deprecated
+unprefixed alias), `workflow`, or `cli`. It currently covers the workspace root
+(`AIOPS_WORKSPACE_ROOT` / legacy `WORKSPACE_ROOT` / `workspace.root`), the mirror
+root (`AIOPS_MIRROR_ROOT`), `server.port` (including the `--port` override), and
+the workflow path source. The `provenance` values are the effective ones the
+worker would actually use, so they reflect env/CLI overrides that the masked
+`config` block (the raw WORKFLOW.md/default values) does not.
 
 ## Runner modes and first safe mode
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -30,11 +30,12 @@ import (
 
 func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "--print-config" {
-		if len(os.Args) < 3 {
-			fmt.Fprintln(os.Stderr, "usage: worker --print-config <workdir>")
+		workdir, portOverride, err := parsePrintConfigArgs(os.Args[2:])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(2)
 		}
-		os.Exit(worker.PrintConfig(os.Args[2], os.Stdout, os.Stderr))
+		os.Exit(worker.PrintConfig(workdir, portOverride, os.Stdout, os.Stderr))
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -82,24 +83,57 @@ func parseRunArgs(args []string) (string, *int, error) {
 	if fs.NArg() == 1 {
 		path = fs.Arg(0)
 	}
-	// Use fs.Visit to distinguish "flag explicitly provided" from "flag
-	// at its default value". A naked sentinel int has no safe pick: any
-	// reserved value would conflict with a real --port=N for that N.
+	override, err := portOverrideFromFlagSet(fs, portFlag)
+	if err != nil {
+		return "", nil, err
+	}
+	return path, override, nil
+}
+
+// parsePrintConfigArgs parses the args after the `--print-config`
+// subcommand token. It requires exactly one positional (the workdir to
+// inspect) and accepts the same `--port` override as run mode, so
+// `worker --print-config /repo --port=4001` attributes server.port to a
+// `cli` source in the provenance block (#375, SPEC §13.7). The override is
+// nil when --port is not passed.
+func parsePrintConfigArgs(args []string) (string, *int, error) {
+	fs := flag.NewFlagSet("worker --print-config", flag.ContinueOnError)
+	portFlag := fs.Int("port", 0, "override server.port for provenance reporting: -1 disables the HTTP server, 0 binds an ephemeral port, 1..65535 binds explicitly. SPEC §13.7.")
+	if err := fs.Parse(reorderForFlagParse(args)); err != nil {
+		return "", nil, err
+	}
+	if fs.NArg() != 1 {
+		return "", nil, fmt.Errorf("usage: worker --print-config [--port=N] <workdir>")
+	}
+	override, err := portOverrideFromFlagSet(fs, portFlag)
+	if err != nil {
+		return "", nil, err
+	}
+	return fs.Arg(0), override, nil
+}
+
+// portOverrideFromFlagSet extracts the --port override from a parsed flag
+// set shared by run mode and --print-config, so the two paths can never
+// diverge on the accepted range or the set-vs-default detection. It uses
+// fs.Visit to distinguish "flag explicitly provided" from "flag at its
+// default value": a naked sentinel int has no safe pick, since any
+// reserved value would conflict with a real --port=N for that N. Returns
+// nil when --port was not passed.
+func portOverrideFromFlagSet(fs *flag.FlagSet, portFlag *int) (*int, error) {
 	var portSet bool
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "port" {
 			portSet = true
 		}
 	})
-	var override *int
-	if portSet {
-		p := *portFlag
-		if p < -1 || p > 65535 {
-			return "", nil, fmt.Errorf("--port %d out of range: pass -1 to disable the HTTP server, 0 for an ephemeral port, or 1..65535", p)
-		}
-		override = &p
+	if !portSet {
+		return nil, nil
 	}
-	return path, override, nil
+	p := *portFlag
+	if p < -1 || p > 65535 {
+		return nil, fmt.Errorf("--port %d out of range: pass -1 to disable the HTTP server, 0 for an ephemeral port, or 1..65535", p)
+	}
+	return &p, nil
 }
 
 // reorderForFlagParse pulls flag tokens to the front of args so the

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -2019,6 +2019,50 @@ func TestParseRunArgs_WorkflowPathStillSupported(t *testing.T) {
 	}
 }
 
+// TestParsePrintConfigArgs covers the #375 dispatch contract: a required
+// workdir positional plus an optional --port override that shares run
+// mode's accepted range, in either token order.
+func TestParsePrintConfigArgs(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		wantWorkdir string
+		wantPort    *int
+		wantErr     string // substring, "" = no error
+	}{
+		{name: "workdir_only", args: []string{"/repo"}, wantWorkdir: "/repo", wantPort: nil},
+		{name: "workdir_then_port_equals", args: []string{"/repo", "--port=4001"}, wantWorkdir: "/repo", wantPort: intPtr(4001)},
+		{name: "port_then_workdir", args: []string{"--port=4001", "/repo"}, wantWorkdir: "/repo", wantPort: intPtr(4001)},
+		{name: "port_split_then_workdir", args: []string{"--port", "4001", "/repo"}, wantWorkdir: "/repo", wantPort: intPtr(4001)},
+		{name: "port_disable", args: []string{"/repo", "--port=-1"}, wantWorkdir: "/repo", wantPort: intPtr(-1)},
+		{name: "port_out_of_range", args: []string{"/repo", "--port=65536"}, wantErr: "--port"},
+		{name: "missing_workdir", args: []string{}, wantErr: "usage"},
+		{name: "missing_workdir_with_port", args: []string{"--port=4001"}, wantErr: "usage"},
+		{name: "too_many_positionals", args: []string{"/repo", "/other"}, wantErr: "usage"},
+		{name: "dash_dash_protects_dash_prefixed_workdir", args: []string{"--", "-repo"}, wantWorkdir: "-repo", wantPort: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			workdir, port, err := parsePrintConfigArgs(tc.args)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePrintConfigArgs(%v): %v", tc.args, err)
+			}
+			if workdir != tc.wantWorkdir {
+				t.Fatalf("workdir = %q, want %q", workdir, tc.wantWorkdir)
+			}
+			if !reflect.DeepEqual(port, tc.wantPort) {
+				t.Fatalf("port = %v, want %v", port, tc.wantPort)
+			}
+		})
+	}
+}
+
 // TestDesiredPortForLoop_OverrideWinsOverWorkflow pins SPEC §13.7's
 // "CLI --port overrides server.port when both are present" against the
 // runStateHTTPServerLoop port-selection step.

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -55,6 +55,8 @@ func LoadConfigFromEnv() Config {
 }
 
 // PrintConfig dispatches the `worker --print-config <workdir>` subcommand.
-func PrintConfig(workdir string, stdout, stderr io.Writer) int {
-	return printConfig(workdir, stdout, stderr)
+// portOverride carries the CLI --port flag (nil when not passed) so the
+// provenance block can attribute server.port to a `cli` source.
+func PrintConfig(workdir string, portOverride *int, stdout, stderr io.Writer) int {
+	return printConfig(workdir, portOverride, stdout, stderr)
 }

--- a/internal/worker/print_config.go
+++ b/internal/worker/print_config.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
 )
 
 // printConfigOutput is the JSON shape of `worker --print-config <dir>`.
@@ -24,7 +26,130 @@ type printConfigOutput struct {
 	ShadowedBy     []string              `json:"shadowed_by,omitempty"`
 	Resolution     printConfigResolution `json:"resolution"`
 	Config         configView            `json:"config"`
+	Provenance     configProvenance      `json:"provenance"`
 	PromptTemplate promptSummary         `json:"prompt_template"`
+}
+
+// Provenance source tokens (#375). Every effective value annotated by
+// --print-config carries exactly one of these, naming the resolution
+// layer that won:
+//   - sourceDefault:  the built-in schema default (no override took effect)
+//   - sourceEnv:      a worker environment variable (the field's EnvVar
+//     names which one; EnvVarDeprecated flags a legacy
+//     unprefixed alias per #368)
+//   - sourceWorkflow: an explicit value in WORKFLOW.md front matter
+//   - sourceCLI:      a command-line override (currently only --port)
+const (
+	sourceDefault  = "default"
+	sourceEnv      = "env"
+	sourceWorkflow = "workflow"
+	sourceCLI      = "cli"
+)
+
+// configProvenance annotates the effective value and origin of the
+// config fields whose value can come from more than one resolution layer
+// (env / WORKFLOW.md / CLI / default). It is a debug aid layered on top of
+// the masked Config block, which alone cannot show that e.g. the effective
+// workspace root came from AIOPS_WORKSPACE_ROOT rather than the file.
+//
+// None of these fields is secret-bearing (filesystem paths, a port, a
+// workflow path), so they are reported verbatim; the maskSecrets contract
+// for Config is unchanged (#375).
+type configProvenance struct {
+	WorkspaceRoot fieldProvenance `json:"workspace_root"`
+	MirrorRoot    fieldProvenance `json:"mirror_root"`
+	ServerPort    fieldProvenance `json:"server_port"`
+	WorkflowPath  fieldProvenance `json:"workflow_path"`
+}
+
+// fieldProvenance is the effective value of one field plus where it came
+// from. Value is rendered as a string for a uniform shape across a path, a
+// port, and a workflow path. EnvVar/EnvVarDeprecated are populated only
+// when Source == sourceEnv.
+type fieldProvenance struct {
+	Value            string `json:"value"`
+	Source           string `json:"source"`
+	EnvVar           string `json:"env_var,omitempty"`
+	EnvVarDeprecated bool   `json:"env_var_deprecated,omitempty"`
+}
+
+// resolveProvenance derives the per-field provenance for --print-config.
+// workerCfg carries the env-layer values (LoadConfigFromEnv); wcfg is the
+// resolved workflow config; res is how the workflow file itself resolved;
+// portOverride is the CLI --port flag (nil when not passed).
+func resolveProvenance(workerCfg Config, wcfg workflow.Config, res workflow.Resolution, portOverride *int) configProvenance {
+	return configProvenance{
+		WorkspaceRoot: workspaceRootProvenance(workerCfg, wcfg),
+		MirrorRoot:    mirrorRootProvenance(),
+		ServerPort:    serverPortProvenance(wcfg, portOverride),
+		WorkflowPath:  workflowPathProvenance(res),
+	}
+}
+
+// workspaceRootProvenance mirrors EffectiveWorkspaceRoot's SPEC §6.4
+// precedence (workflow > env > default) and labels the winning layer. The
+// effective Value always comes from EffectiveWorkspaceRoot so the reported
+// value cannot drift from the value the worker actually uses.
+func workspaceRootProvenance(workerCfg Config, wcfg workflow.Config) fieldProvenance {
+	effective := EffectiveWorkspaceRoot(workerCfg, wcfg)
+	if wcfg.Workspace.RootSet() && strings.TrimSpace(wcfg.Workspace.Root) != "" {
+		return fieldProvenance{Value: effective, Source: sourceWorkflow}
+	}
+	envRes := ResolveEnv(workspaceRootEnv, workspaceRootEnvLegacy)
+	if strings.TrimSpace(envRes.Value) != "" {
+		return envProvenance(effective, envRes)
+	}
+	return fieldProvenance{Value: effective, Source: sourceDefault}
+}
+
+// mirrorRootProvenance reports where the bare-mirror cache root resolves
+// from. There is no WORKFLOW.md field for it, so the only layers are the
+// AIOPS_MIRROR_ROOT env (with its legacy alias) and the computed default.
+func mirrorRootProvenance() fieldProvenance {
+	envRes := ResolveEnv(mirrorRootEnv, mirrorRootEnvLegacy)
+	if strings.TrimSpace(envRes.Value) != "" {
+		return envProvenance(workspace.MirrorRoot(envRes.Value), envRes)
+	}
+	return fieldProvenance{Value: workspace.MirrorRoot(""), Source: sourceDefault}
+}
+
+// serverPortProvenance mirrors desiredPortForLoop's precedence: the CLI
+// --port override wins over the workflow snapshot, which wins over the
+// DefaultConfig port. PortSet() distinguishes a WORKFLOW.md value from the
+// inherited default.
+func serverPortProvenance(wcfg workflow.Config, portOverride *int) fieldProvenance {
+	if portOverride != nil {
+		return fieldProvenance{Value: strconv.Itoa(*portOverride), Source: sourceCLI}
+	}
+	if wcfg.Server.PortSet() {
+		return fieldProvenance{Value: strconv.Itoa(wcfg.Server.Port), Source: sourceWorkflow}
+	}
+	return fieldProvenance{Value: strconv.Itoa(wcfg.Server.Port), Source: sourceDefault}
+}
+
+// workflowPathProvenance reports whether the effective config came from a
+// resolved WORKFLOW.md (sourceWorkflow, with the repo-relative path) or
+// from the built-in defaults (sourceDefault, no path). The file-vs-prompt
+// distinction is preserved by the top-level `source`/`resolution` fields.
+func workflowPathProvenance(res workflow.Resolution) fieldProvenance {
+	switch res.Source {
+	case workflow.SourceFile, workflow.SourcePromptOnly:
+		return fieldProvenance{Value: res.Path, Source: sourceWorkflow}
+	default:
+		return fieldProvenance{Value: "", Source: sourceDefault}
+	}
+}
+
+// envProvenance builds an env-sourced fieldProvenance, flagging the used
+// name as deprecated when it is a legacy alias rather than the canonical
+// AIOPS_-prefixed name (#368).
+func envProvenance(value string, res EnvResolution) fieldProvenance {
+	return fieldProvenance{
+		Value:            value,
+		Source:           sourceEnv,
+		EnvVar:           res.UsedName,
+		EnvVarDeprecated: res.UsedName != res.Canonical,
+	}
 }
 
 // configView mirrors workflow.Config for --print-config output, but
@@ -173,10 +298,12 @@ func maskCloneURL(raw string) string {
 
 // printConfig writes the effective workflow for workdir as JSON to
 // stdout. Returns the process exit code (0 on success, 1 on schema
-// validation error). Used both by main()'s --print-config dispatch and
-// by tests; stdout/stderr are explicit io.Writer parameters so tests
-// can capture the output without subprocessing.
-func printConfig(workdir string, stdout, stderr io.Writer) int {
+// validation error). portOverride carries the CLI --port flag (nil when
+// not passed) so the provenance block can attribute server.port to `cli`.
+// Used both by main()'s --print-config dispatch and by tests;
+// stdout/stderr are explicit io.Writer parameters so tests can capture the
+// output without subprocessing.
+func printConfig(workdir string, portOverride *int, stdout, stderr io.Writer) int {
 	wf, res, err := workflow.Resolve(workdir)
 	if err != nil {
 		fmt.Fprintln(stderr, err.Error())
@@ -191,6 +318,7 @@ func printConfig(workdir string, stdout, stderr io.Writer) int {
 			ShadowedBy: res.ShadowedBy,
 		},
 		Config:         newConfigView(maskSecrets(wf.Config)),
+		Provenance:     resolveProvenance(LoadConfigFromEnv(), wf.Config, *res, portOverride),
 		PromptTemplate: summarizePrompt(wf.PromptTemplate),
 	}
 	enc := json.NewEncoder(stdout)

--- a/internal/worker/print_config_test.go
+++ b/internal/worker/print_config_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 // TestPrintConfig_MasksTrackerAPIKey verifies the secret-masking
@@ -24,7 +26,7 @@ func TestPrintConfig_MasksTrackerAPIKey(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 	got := stdout.String()
@@ -42,7 +44,7 @@ func TestPrintConfig_MasksTrackerAPIKey(t *testing.T) {
 func TestPrintConfig_DefaultSource(t *testing.T) {
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer
-	code := printConfig(dir, &stdout, &stderr)
+	code := printConfig(dir, nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
@@ -80,7 +82,7 @@ func TestPrintConfig_FileSourceWithPromptCanary(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 
@@ -126,7 +128,7 @@ func TestPrintConfig_FileSourceWithPromptCanary(t *testing.T) {
 func TestPrintConfig_RendersAgentTimeoutAsDurationString(t *testing.T) {
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 	var out struct {
@@ -162,7 +164,7 @@ func TestPrintConfig_AgentTimeoutFromYAMLOverride(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), `"timeout": "10m0s"`) {
@@ -181,7 +183,7 @@ func TestPrintConfig_ExposesMaxRetryBackoffMs(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 	var out struct {
@@ -206,7 +208,7 @@ func TestPrintConfig_ExposesMaxRetryAttempts(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 	var out struct {
@@ -242,7 +244,7 @@ func TestPrintConfig_TopLevelSourceOmitsLegacyShadowedBy(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 	if strings.Contains(stdout.String(), `"shadowed_by"`) {
@@ -276,7 +278,7 @@ func TestPrintConfig_TopLevelSourceOmitsLegacyShadowedBy(t *testing.T) {
 func TestPrintConfig_TopLevelOmitsEmptyShadowedBy(t *testing.T) {
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 	if strings.Contains(stdout.String(), `"shadowed_by"`) {
@@ -343,7 +345,7 @@ func TestPrintConfig_MasksRepoCloneURLUserinfo(t *testing.T) {
 				t.Fatalf("write: %v", err)
 			}
 			var stdout, stderr bytes.Buffer
-			if code := printConfig(dir, &stdout, &stderr); code != 0 {
+			if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 				t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 			}
 			got := stdout.String()
@@ -409,7 +411,7 @@ func TestPrintConfig_MasksSandboxCredentialFiles(t *testing.T) {
 				t.Fatalf("write: %v", err)
 			}
 			var stdout, stderr bytes.Buffer
-			if code := printConfig(dir, &stdout, &stderr); code != 0 {
+			if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 				t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 			}
 			got := stdout.String()
@@ -451,7 +453,7 @@ func TestPrintConfig_SandboxVisibleInConfigView(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	if code := printConfig(dir, &stdout, &stderr); code != 0 {
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
 	}
 	var out struct {
@@ -492,7 +494,7 @@ func TestPrintConfig_SchemaErrorReturnsExitOne(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	code := printConfig(dir, &stdout, &stderr)
+	code := printConfig(dir, nil, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
@@ -501,5 +503,321 @@ func TestPrintConfig_SchemaErrorReturnsExitOne(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "repo.clone_url") {
 		t.Fatalf("stderr missing field name: %s", stderr.String())
+	}
+}
+
+// clearWorkerEnv neutralizes every worker env var the provenance block
+// reads, so an ambient AIOPS_WORKSPACE_ROOT in the test runner's
+// environment cannot make a "default"/"workflow" assertion flap. ResolveEnv
+// treats an empty value as unset, so setting "" is equivalent to unset for
+// resolution while still being restored by t.Setenv's cleanup.
+func clearWorkerEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(workspaceRootEnv, "")
+	t.Setenv(workspaceRootEnvLegacy, "")
+	t.Setenv(mirrorRootEnv, "")
+	t.Setenv(mirrorRootEnvLegacy, "")
+}
+
+// runPrintConfigProvenance writes body (when non-empty) as WORKFLOW.md in a
+// fresh dir, runs printConfig with portOverride, and returns the decoded
+// provenance block. dir is returned so callers can cross-check against an
+// independent workflow.Resolve.
+func runPrintConfigProvenance(t *testing.T, body string, portOverride *int) (configProvenance, string) {
+	t.Helper()
+	dir := t.TempDir()
+	if body != "" {
+		if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, portOverride, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	var out struct {
+		Provenance configProvenance `json:"provenance"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode provenance: %v\nstdout: %s", err, stdout.String())
+	}
+	return out.Provenance, dir
+}
+
+// validFrontMatter wraps the minimal valid front matter (repo + linear
+// tracker) around the supplied extra block so loader validation passes.
+func validFrontMatter(extra string) string {
+	return "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n" + extra + "---\nprompt\n"
+}
+
+// TestPrintConfig_WorkspaceRootProvenance pins the #375 acceptance
+// criterion for workspace root: every SPEC §6.4 precedence layer
+// (workflow > env, canonical vs deprecated alias > default) is annotated
+// with the correct source, env var name, and deprecation flag.
+func TestPrintConfig_WorkspaceRootProvenance(t *testing.T) {
+	cases := []struct {
+		name           string
+		body           string
+		envCanonical   string
+		envLegacy      string
+		wantValue      string
+		wantSource     string
+		wantEnvVar     string
+		wantDeprecated bool
+	}{
+		{
+			// workflow.root wins even though an env var is also set.
+			name:         "workflow_wins_over_env",
+			body:         validFrontMatter("workspace:\n  root: /custom/ws\n"),
+			envCanonical: "/env/should-lose",
+			wantValue:    "/custom/ws",
+			wantSource:   sourceWorkflow,
+		},
+		{
+			name:         "env_canonical",
+			body:         "",
+			envCanonical: "/env/ws",
+			wantValue:    "/env/ws",
+			wantSource:   sourceEnv,
+			wantEnvVar:   workspaceRootEnv,
+		},
+		{
+			name:           "env_deprecated_alias",
+			body:           "",
+			envLegacy:      "/legacy/ws",
+			wantValue:      "/legacy/ws",
+			wantSource:     sourceEnv,
+			wantEnvVar:     workspaceRootEnvLegacy,
+			wantDeprecated: true,
+		},
+		{
+			name:       "default_no_file_no_env",
+			body:       "",
+			wantSource: sourceDefault,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearWorkerEnv(t)
+			if tc.envCanonical != "" {
+				t.Setenv(workspaceRootEnv, tc.envCanonical)
+			}
+			if tc.envLegacy != "" {
+				t.Setenv(workspaceRootEnvLegacy, tc.envLegacy)
+			}
+			prov, dir := runPrintConfigProvenance(t, tc.body, nil)
+			got := prov.WorkspaceRoot
+			if got.Source != tc.wantSource {
+				t.Fatalf("workspace_root.source = %q, want %q", got.Source, tc.wantSource)
+			}
+			if got.EnvVar != tc.wantEnvVar {
+				t.Fatalf("workspace_root.env_var = %q, want %q", got.EnvVar, tc.wantEnvVar)
+			}
+			if got.EnvVarDeprecated != tc.wantDeprecated {
+				t.Fatalf("workspace_root.env_var_deprecated = %v, want %v", got.EnvVarDeprecated, tc.wantDeprecated)
+			}
+			// The reported value must equal what the worker would actually
+			// use, so it cannot drift from EffectiveWorkspaceRoot.
+			wf, _, err := workflow.Resolve(dir)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			wantEffective := EffectiveWorkspaceRoot(LoadConfigFromEnv(), wf.Config)
+			if got.Value != wantEffective {
+				t.Fatalf("workspace_root.value = %q, want effective %q", got.Value, wantEffective)
+			}
+			if tc.wantValue != "" && got.Value != tc.wantValue {
+				t.Fatalf("workspace_root.value = %q, want %q", got.Value, tc.wantValue)
+			}
+			if tc.wantSource == sourceDefault && got.Value == "" {
+				t.Fatalf("default workspace_root.value must be the SPEC default, got empty")
+			}
+		})
+	}
+}
+
+// TestPrintConfig_MirrorRootProvenance pins the #375 acceptance criterion
+// for mirror root. There is no WORKFLOW.md field, so only env (canonical /
+// deprecated alias) and the computed default apply.
+func TestPrintConfig_MirrorRootProvenance(t *testing.T) {
+	cases := []struct {
+		name           string
+		envCanonical   string
+		envLegacy      string
+		wantSource     string
+		wantEnvVar     string
+		wantValue      string
+		wantDeprecated bool
+	}{
+		{
+			name:         "env_canonical",
+			envCanonical: "/env/mirror",
+			wantSource:   sourceEnv,
+			wantEnvVar:   mirrorRootEnv,
+			wantValue:    "/env/mirror",
+		},
+		{
+			name:           "env_deprecated_alias",
+			envLegacy:      "/legacy/mirror",
+			wantSource:     sourceEnv,
+			wantEnvVar:     mirrorRootEnvLegacy,
+			wantValue:      "/legacy/mirror",
+			wantDeprecated: true,
+		},
+		{
+			name:       "default_no_env",
+			wantSource: sourceDefault,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearWorkerEnv(t)
+			if tc.envCanonical != "" {
+				t.Setenv(mirrorRootEnv, tc.envCanonical)
+			}
+			if tc.envLegacy != "" {
+				t.Setenv(mirrorRootEnvLegacy, tc.envLegacy)
+			}
+			prov, _ := runPrintConfigProvenance(t, "", nil)
+			got := prov.MirrorRoot
+			if got.Source != tc.wantSource {
+				t.Fatalf("mirror_root.source = %q, want %q", got.Source, tc.wantSource)
+			}
+			if got.EnvVar != tc.wantEnvVar {
+				t.Fatalf("mirror_root.env_var = %q, want %q", got.EnvVar, tc.wantEnvVar)
+			}
+			if got.EnvVarDeprecated != tc.wantDeprecated {
+				t.Fatalf("mirror_root.env_var_deprecated = %v, want %v", got.EnvVarDeprecated, tc.wantDeprecated)
+			}
+			if tc.wantValue != "" && got.Value != tc.wantValue {
+				t.Fatalf("mirror_root.value = %q, want %q", got.Value, tc.wantValue)
+			}
+			if tc.wantSource == sourceDefault && got.Value == "" {
+				t.Fatalf("default mirror_root.value must be the computed default, got empty")
+			}
+		})
+	}
+}
+
+// TestPrintConfig_ServerPortProvenance pins the #375 acceptance criterion
+// for server.port, including the CLI --port override precedence over a
+// WORKFLOW.md value, and the workflow-vs-default distinction.
+func TestPrintConfig_ServerPortProvenance(t *testing.T) {
+	port := func(n int) *int { return &n }
+	cases := []struct {
+		name         string
+		body         string
+		portOverride *int
+		wantValue    string
+		wantSource   string
+	}{
+		{
+			// --port wins even when WORKFLOW.md sets server.port.
+			name:         "cli_wins_over_workflow",
+			body:         validFrontMatter("server:\n  port: 5000\n"),
+			portOverride: port(4001),
+			wantValue:    "4001",
+			wantSource:   sourceCLI,
+		},
+		{
+			name:       "workflow",
+			body:       validFrontMatter("server:\n  port: 5000\n"),
+			wantValue:  "5000",
+			wantSource: sourceWorkflow,
+		},
+		{
+			name:       "default_no_file",
+			body:       "",
+			wantValue:  "4000",
+			wantSource: sourceDefault,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearWorkerEnv(t)
+			prov, _ := runPrintConfigProvenance(t, tc.body, tc.portOverride)
+			got := prov.ServerPort
+			if got.Source != tc.wantSource {
+				t.Fatalf("server_port.source = %q, want %q", got.Source, tc.wantSource)
+			}
+			if got.Value != tc.wantValue {
+				t.Fatalf("server_port.value = %q, want %q", got.Value, tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestPrintConfig_WorkflowPathProvenance pins the #375 acceptance criterion
+// for the workflow path source: a resolved file (front-matter or
+// prompt-only) reports `workflow` with the repo-relative path, while no
+// file reports `default` with no path.
+func TestPrintConfig_WorkflowPathProvenance(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		wantValue  string
+		wantSource string
+	}{
+		{
+			name:       "file_front_matter",
+			body:       validFrontMatter(""),
+			wantValue:  "WORKFLOW.md",
+			wantSource: sourceWorkflow,
+		},
+		{
+			name:       "prompt_only_file",
+			body:       "just a prompt body, no front matter\n",
+			wantValue:  "WORKFLOW.md",
+			wantSource: sourceWorkflow,
+		},
+		{
+			name:       "default_no_file",
+			body:       "",
+			wantValue:  "",
+			wantSource: sourceDefault,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearWorkerEnv(t)
+			prov, _ := runPrintConfigProvenance(t, tc.body, nil)
+			got := prov.WorkflowPath
+			if got.Source != tc.wantSource {
+				t.Fatalf("workflow_path.source = %q, want %q", got.Source, tc.wantSource)
+			}
+			if got.Value != tc.wantValue {
+				t.Fatalf("workflow_path.value = %q, want %q", got.Value, tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestPrintConfig_ProvenanceDoesNotLeakSecrets keeps the #375 "secret
+// masking unchanged" criterion honest: adding the provenance block must
+// not echo the tracker API key even though provenance threads the env
+// layer into the print path.
+func TestPrintConfig_ProvenanceDoesNotLeakSecrets(t *testing.T) {
+	clearWorkerEnv(t)
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin_super_secret_value")
+	t.Setenv(workspaceRootEnv, "/env/ws")
+	dir := t.TempDir()
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n  api_key: $AIOPS_TEST_LINEAR_KEY\n---\nprompt\n"
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := printConfig(dir, nil, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	got := stdout.String()
+	if strings.Contains(got, "lin_super_secret_value") {
+		t.Fatalf("api_key leaked into stdout:\n%s", got)
+	}
+	if !strings.Contains(got, `"api_key": "***"`) {
+		t.Fatalf("api_key not masked; stdout:\n%s", got)
+	}
+	// The provenance block still reports the (non-secret) env workspace root.
+	if !strings.Contains(got, "/env/ws") {
+		t.Fatalf("expected env workspace root in provenance; stdout:\n%s", got)
 	}
 }

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -54,6 +54,19 @@ type ServerConfig struct {
 	// authentication, so a routable bind needs auth that this server lacks.
 	Host string `yaml:"host" json:"host"`
 	Port int    `yaml:"port" json:"port"`
+	// portSet records whether server.port was explicitly present in the
+	// WORKFLOW.md front matter (vs. inherited from DefaultConfig). It lets
+	// `worker --print-config` distinguish a `workflow` source from a
+	// `default` one without re-parsing the file. Unexported so YAML never
+	// populates it; the loader sets it after Unmarshal (mirrors
+	// WorkspaceConfig.rootSet).
+	portSet bool
+}
+
+// PortSet reports whether server.port was explicitly set in WORKFLOW.md
+// front matter. False means the effective Port came from DefaultConfig.
+func (s ServerConfig) PortSet() bool {
+	return s.portSet
 }
 
 type RepoConfig struct {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -155,12 +155,14 @@ func Load(path string) (*Workflow, error) {
 		hookFields := hookFieldPresence(frontBytes, "hooks")
 		legacyHookFields := hookFieldPresence(frontBytes, "workspace", "hooks")
 		workspaceRootSet := hasNestedKey(frontBytes, "workspace", "root")
+		serverPortSet := hasNestedKey(frontBytes, "server", "port")
 		if err := yaml.Unmarshal(frontBytes, &cfg); err != nil {
 			return nil, &Error{Category: CategoryWorkflowParseError, Path: path, Message: "parse workflow front matter", Err: err}
 		}
 		cfg.hookFields = hookFields
 		cfg.Workspace.hookFields = legacyHookFields
 		cfg.Workspace.rootSet = workspaceRootSet
+		cfg.Server.portSet = serverPortSet
 		if hookFields.TimeoutMs {
 			cfg.hooksTimeoutDefaulted = false
 		}

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -740,3 +740,66 @@ Prompt body
 		}
 	}
 }
+
+// TestServerPortSetTracksFrontMatterPresence pins the #375 enabler: the
+// loader must record whether server.port was explicitly present in the
+// front matter, so `worker --print-config` can label the port `workflow`
+// vs `default`. An explicit value sets PortSet; relying on the
+// DefaultConfig port (4000) leaves it false, even when the file carries
+// other server keys.
+func TestServerPortSetTracksFrontMatterPresence(t *testing.T) {
+	explicit := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+server:
+  port: 5000
+tracker:
+  kind: linear
+  project_slug: platform
+---
+Prompt body
+`)
+	wf, err := Load(explicit)
+	if err != nil {
+		t.Fatalf("Load(explicit server.port): %v", err)
+	}
+	if !wf.Config.Server.PortSet() {
+		t.Fatal("PortSet() = false for explicit server.port, want true")
+	}
+	if wf.Config.Server.Port != 5000 {
+		t.Fatalf("Server.Port = %d, want 5000", wf.Config.Server.Port)
+	}
+
+	// server.host present but server.port absent: PortSet must stay false
+	// so the inherited default port is labeled `default`, not `workflow`.
+	hostOnly := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+server:
+  host: 127.0.0.1
+tracker:
+  kind: linear
+  project_slug: platform
+---
+Prompt body
+`)
+	wf, err = Load(hostOnly)
+	if err != nil {
+		t.Fatalf("Load(host only): %v", err)
+	}
+	if wf.Config.Server.PortSet() {
+		t.Fatal("PortSet() = true when only server.host present, want false")
+	}
+	if wf.Config.Server.Port != 4000 {
+		t.Fatalf("Server.Port = %d, want DefaultConfig 4000", wf.Config.Server.Port)
+	}
+
+	// DefaultConfig (no file) must not report the port as workflow-sourced.
+	if DefaultConfig().Server.PortSet() {
+		t.Fatal("DefaultConfig().Server.PortSet() = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary

`worker --print-config` now emits a `provenance` block annotating each multi-layer config value with where its effective value came from: `default` / `env` (incl. which env var, and whether it was a deprecated unprefixed alias) / `workflow` / `cli`.

Follow-up split out from #368, which deferred this bullet. Closes #375.

Covered fields (acceptance criteria):
- **workspace root** — `AIOPS_WORKSPACE_ROOT` / legacy `WORKSPACE_ROOT` / `workspace.root` / default, mirroring `EffectiveWorkspaceRoot`'s SPEC §6.4 precedence.
- **mirror root** — `AIOPS_MIRROR_ROOT` (+ legacy alias) / computed default (no WORKFLOW.md field exists).
- **server.port** — CLI `--port` / `workflow` / `default`, mirroring `desiredPortForLoop`.
- **workflow path source** — `workflow` (resolved file, with path) / `default` (built-in).

## Implementation notes
- Threads the env layer (`LoadConfigFromEnv` / `EffectiveWorkspaceRoot`) and the CLI `--port` override into the print path. The reported workspace-root value comes straight from `EffectiveWorkspaceRoot`, so it cannot drift from what the worker actually uses.
- `--print-config` now accepts `--port` (shared parser with run mode via a new `portOverrideFromFlagSet`, so the accepted range can't diverge).
- Adds `ServerConfig.PortSet()` (set by the loader via `hasNestedKey`, mirroring `WorkspaceConfig.rootSet`) so a WORKFLOW.md port is distinguishable from the inherited `DefaultConfig` default.
- **Secret masking unchanged** — the provenance fields are non-secret (paths, a port, a workflow path); the `maskSecrets` contract for `config` is untouched, and a regression test pins that the API key still masks while provenance is present.

## Test plan
- [x] `gofmt -l` clean; `go vet ./...`; `go build ./...`; `go mod tidy` no diff
- [x] `go test -race ./...` green
- [x] New regression tests: workspace-root / mirror-root / server-port / workflow-path provenance tables (incl. canonical vs deprecated alias, CLI-wins-over-workflow, workflow-wins-over-env), `PortSet()` loader test, `parsePrintConfigArgs` table, no-secret-leak test
- [x] Mutation-verified: removing `cfg.Server.portSet = serverPortSet` and forcing `EnvVarDeprecated: false` each make the relevant new tests FAIL

https://claude.ai/code/session_015dC7sAei1KzVPDhPBmiojq

---
_Generated by [Claude Code](https://claude.ai/code/session_015dC7sAei1KzVPDhPBmiojq)_