### PR TITLE
fix(worker): guard state api peers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ LINEAR_API_KEY=replace-with-linear-personal-key
 # the workflow value from outside WORKFLOW.md — e.g. a project-local path:
 # AIOPS_WORKSPACE_ROOT=/tmp/symphony_workspaces
 AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md
+# Required only when exposing the state API beyond in-process loopback, such as
+# the opt-in dashboard Compose overlay. Browsers use Basic auth user `aiops`
+# with this token as the password; cmd/tui sends it as a bearer token.
+# AIOPS_STATE_API_TOKEN=replace-with-random-state-api-token
 # The worker container runs as an unprivileged user (#365). Its UID/GID must
 # match the host owner of the bind-mounted deploy key (mounted read-only,
 # 0600), or git-over-SSH cannot read the key. Default is 1000; override only if

--- a/README.md
+++ b/README.md
@@ -160,29 +160,35 @@ web dashboard:
 | `GET /` | The embedded web dashboard (HTML). |
 | `GET /assets/…` | Static dashboard assets. |
 
-The server accepts only `localhost` / `127.0.0.1` Host headers and assumes local
-host users and processes are trusted. Set `server.port: -1` to disable the
-listener entirely (e.g. when you provide your own state bridge). If the
-configured listener cannot start, the worker logs the failure, continues without
-the HTTP surface, and retries on later workflow-reload checks until the bind
-succeeds or `server.port` changes.
+When `AIOPS_STATE_API_TOKEN` is set, every request must authenticate with either
+`Authorization: Bearer <token>` or HTTP Basic auth user `aiops` and the token as
+the password. Without that token, the server accepts unauthenticated requests
+only when both the Host header and TCP peer are loopback; non-loopback peers
+fail closed. Set `server.port: -1` to disable the listener entirely (e.g. when
+you provide your own state bridge). If the configured listener cannot start, the
+worker logs the failure, continues without the HTTP surface, and retries on
+later workflow-reload checks until the bind succeeds or `server.port` changes.
 
 Under Docker Compose the default loopback bind is unreachable from the host
 (Docker publishes ports to the container interface, not its loopback). Merge the
 opt-in overlay to reach the dashboard from the host:
 
 ```bash
+export AIOPS_STATE_API_TOKEN=$(openssl rand -hex 24)
 docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dashboard.yml up worker
 ```
 
 The overlay sets `AIOPS_SERVER_HOST=0.0.0.0` (bind all interfaces *inside* the
 container) but publishes only to host loopback (`127.0.0.1:4000:4000`), so the
-host trust boundary stays the loopback. It also moves the worker onto a
-dedicated `dashboard` bridge network — off the project default network — so
-sibling containers (e.g. the legacy-queue services) cannot reach `worker:4000`
-and spoof the loopback Host guard. The surface is still unauthenticated, so do
-**not** publish on a routable host interface or attach untrusted containers to
-the dashboard network without adding authentication first.
+host trust boundary stays the loopback. Docker port publishing reaches the
+container from a bridge peer rather than container loopback, so the overlay
+requires `AIOPS_STATE_API_TOKEN`; browsers will receive a Basic-auth challenge
+and should use username `aiops` plus that token. The overlay also moves the
+worker onto a dedicated `dashboard` bridge network — off the project default
+network — so sibling containers (e.g. the legacy-queue services) cannot reach
+`worker:4000` and attempt to spoof loopback access. Do **not** publish on a
+routable host interface or attach untrusted containers to the dashboard network
+unless they should be able to use the token-protected status surface.
 
 **Treat the status surface as live agent text even though it binds to loopback.**
 Per SPEC §15.3, each running row's `last_message` is a passthrough of the most
@@ -218,6 +224,10 @@ go run ./cmd/tui                          # defaults to http://127.0.0.1:4000/, 
 go run ./cmd/tui --url http://127.0.0.1:4000/ --interval 5s
 go run ./cmd/tui --raw                    # disable alt-screen/cursor mgmt (upstream parity)
 ```
+
+When the worker requires state API auth (for example the Docker dashboard
+overlay), set `AIOPS_STATE_API_TOKEN` in the TUI environment; the client sends
+it as a bearer token.
 
 ## WORKFLOW.md configuration
 

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -45,6 +45,8 @@ const (
 	ansiShowCursor     = "\033[?25h"
 )
 
+const stateAPIAuthTokenEnv = "AIOPS_STATE_API_TOKEN"
+
 // Column widths (mirrors Elixir @running_*_width constants)
 const (
 	colID       = 8
@@ -170,6 +172,7 @@ func main() {
 		}
 	}
 	stateURL := baseURL + "/api/v1/state"
+	authToken := stateAPIAuthTokenFromEnv()
 	client := &http.Client{Timeout: 10 * time.Second}
 
 	interval := *intervalFlag
@@ -208,7 +211,7 @@ func main() {
 	}()
 
 	fetch := func(ctx context.Context) (*stateResponse, error) {
-		return fetchState(ctx, client, stateURL)
+		return fetchStateWithAuth(ctx, client, stateURL, authToken)
 	}
 
 	run(ctx, scr, fetch, interval, baseURL)
@@ -381,9 +384,16 @@ func safeRenderFrame(state *stateResponse, fetchErr error, now time.Time, tps fl
 }
 
 func fetchState(ctx context.Context, client *http.Client, url string) (*stateResponse, error) {
+	return fetchStateWithAuth(ctx, client, url, "")
+}
+
+func fetchStateWithAuth(ctx context.Context, client *http.Client, url string, authToken string) (*stateResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
+	}
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -399,6 +409,10 @@ func fetchState(ctx context.Context, client *http.Client, url string) (*stateRes
 		return nil, err
 	}
 	return &s, nil
+}
+
+func stateAPIAuthTokenFromEnv() string {
+	return strings.TrimSpace(os.Getenv(stateAPIAuthTokenEnv))
 }
 
 // ── Rendering ────────────────────────────────────────────────────────────────

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -213,6 +213,30 @@ func TestFetchState_ParsesValidResponse(t *testing.T) {
 	}
 }
 
+func TestFetchStateWithAuthSendsBearerToken(t *testing.T) {
+	body := `{"poll_interval_ms":5000,"max_concurrent_agents":1,"counts":{},"running":[],"retrying":[],"codex_totals":{}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer state-token" {
+			t.Fatalf("Authorization = %q, want Bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{}
+	if _, err := fetchStateWithAuth(context.Background(), client, srv.URL, "state-token"); err != nil {
+		t.Fatalf("fetchStateWithAuth error = %v", err)
+	}
+}
+
+func TestStateAPIAuthTokenFromEnvTrimsWhitespace(t *testing.T) {
+	t.Setenv(stateAPIAuthTokenEnv, "  state-token\n")
+	if got := stateAPIAuthTokenFromEnv(); got != "state-token" {
+		t.Fatalf("stateAPIAuthTokenFromEnv() = %q, want trimmed token", got)
+	}
+}
+
 // ── formatResetValue ──────────────────────────────────────────────────────────
 
 func TestFormatResetValue_IntegerGetsSuffix(t *testing.T) {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -560,6 +561,7 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 }
 
 const stateHTTPServerShutdownTimeout = 10 * time.Second
+const stateHTTPAuthTokenEnv = "AIOPS_STATE_API_TOKEN"
 
 type stateHTTPServerHandle struct {
 	Addr net.Addr
@@ -571,7 +573,7 @@ func startStateHTTPServer(ctx context.Context, host string, port int, snapshot s
 		log.Printf("state HTTP server disabled by server.port=%d", port)
 		return nil, nil
 	}
-	server := newStateHTTPServer(host, port, snapshot, refresh...)
+	server := newStateHTTPServerWithAuthToken(host, port, os.Getenv(stateHTTPAuthTokenEnv), snapshot, refresh...)
 	listener, err := net.Listen("tcp", server.Addr)
 	if err != nil {
 		log.Printf("state HTTP server disabled because listen on %s failed: %v", server.Addr, err)
@@ -613,6 +615,10 @@ func normalizeServerHost(host string) string {
 }
 
 func newStateHTTPServer(host string, port int, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *http.Server {
+	return newStateHTTPServerWithAuthToken(host, port, "", snapshot, refresh...)
+}
+
+func newStateHTTPServerWithAuthToken(host string, port int, authToken string, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle("/api/v1/state", stateHTTPHandler(snapshot))
 	mux.Handle("/api/v1/refresh", refreshHTTPHandler(optionalStateRefreshFunc(refresh)))
@@ -625,9 +631,10 @@ func newStateHTTPServer(host string, port int, snapshot stateSnapshotFunc, refre
 		}
 		dashboardHTMLHandler().ServeHTTP(w, r)
 	})
+	guard := stateHTTPAccessGuard{authToken: strings.TrimSpace(authToken)}
 	return &http.Server{
 		Addr:              net.JoinHostPort(normalizeServerHost(host), strconv.Itoa(port)),
-		Handler:           loopbackHostOnly(mux),
+		Handler:           guard.wrap(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,
 		WriteTimeout:      10 * time.Second,
@@ -642,14 +649,53 @@ func newStateHTTPServer(host string, port int, snapshot stateSnapshotFunc, refre
 	}
 }
 
-func loopbackHostOnly(next http.Handler) http.Handler {
+type stateHTTPAccessGuard struct {
+	authToken string
+}
+
+func (g stateHTTPAccessGuard) wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if g.authToken != "" {
+			if stateHTTPAuthorized(r, g.authToken) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			requireStateHTTPAuth(w)
+			return
+		}
+		if isLoopbackHTTPHost(r.Host) && isLoopbackHTTPRemoteAddr(r.RemoteAddr) {
+			next.ServeHTTP(w, r)
+			return
+		}
 		if !isLoopbackHTTPHost(r.Host) {
 			http.Error(w, "misdirected request", http.StatusMisdirectedRequest)
 			return
 		}
-		next.ServeHTTP(w, r)
+		http.Error(w, "forbidden", http.StatusForbidden)
 	})
+}
+
+func requireStateHTTPAuth(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="aiops state API", charset="UTF-8"`)
+	http.Error(w, "authentication required", http.StatusUnauthorized)
+}
+
+func stateHTTPAuthorized(r *http.Request, token string) bool {
+	if user, password, ok := r.BasicAuth(); ok && user == "aiops" && stateHTTPTokenMatches(password, token) {
+		return true
+	}
+	scheme, credentials, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+	if ok && strings.EqualFold(scheme, "Bearer") && stateHTTPTokenMatches(strings.TrimSpace(credentials), token) {
+		return true
+	}
+	return false
+}
+
+func stateHTTPTokenMatches(got, want string) bool {
+	if got == "" || want == "" || len(got) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
 }
 
 func isLoopbackHTTPHost(hostport string) bool {
@@ -678,6 +724,15 @@ func isLoopbackHTTPHost(hostport string) bool {
 		return true
 	}
 	return false
+}
+
+func isLoopbackHTTPRemoteAddr(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 type stateSnapshotFunc func(context.Context) (orchestrator.StateView, error)

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -31,6 +31,12 @@ type fakeReconcileTracker struct {
 	issues []tracker.Issue
 }
 
+func newLoopbackRequest(method, target string, body io.Reader) *http.Request {
+	req := httptest.NewRequest(method, target, body)
+	req.RemoteAddr = "127.0.0.1:54321"
+	return req
+}
+
 func samePath(a, b string) bool {
 	eval := func(path string) string {
 		resolved, err := filepath.EvalSymlinks(path)
@@ -338,7 +344,7 @@ func TestRootDashboardServesStateDepictingReactApp(t *testing.T) {
 		return orchestrator.StateView{}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/", nil)
+	req := newLoopbackRequest(http.MethodGet, "http://127.0.0.1:4000/", nil)
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -359,7 +365,7 @@ func TestRootDashboardServesStateDepictingReactApp(t *testing.T) {
 	}
 
 	assetPath := firstScriptAssetPath(t, html)
-	assetReq := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000"+assetPath, nil)
+	assetReq := newLoopbackRequest(http.MethodGet, "http://127.0.0.1:4000"+assetPath, nil)
 	assetW := httptest.NewRecorder()
 	server.Handler.ServeHTTP(assetW, assetReq)
 	if assetW.Code != http.StatusOK {
@@ -388,7 +394,7 @@ func TestRootDashboardAllowsHeadProbes(t *testing.T) {
 		return orchestrator.StateView{}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodHead, "http://127.0.0.1:4000/", nil)
+	req := newLoopbackRequest(http.MethodHead, "http://127.0.0.1:4000/", nil)
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -406,7 +412,7 @@ func TestRootDashboardRejectsUnsafeMethodsWithHeadInAllow(t *testing.T) {
 		return orchestrator.StateView{}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/", nil)
+	req := newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000/", nil)
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -461,7 +467,7 @@ func TestIssueHTTPHandlerReturnsRunningIssueByIdentifier(t *testing.T) {
 		}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/mt-649", nil)
+	req := newLoopbackRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/mt-649", nil)
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -526,7 +532,7 @@ func TestIssueHTTPHandlerReturnsRestartCountForRetryingIssue(t *testing.T) {
 		}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/MT-650", nil)
+	req := newLoopbackRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/MT-650", nil)
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -570,7 +576,7 @@ func TestIssueHTTPHandlerOmitsRestartCountForFirstRun(t *testing.T) {
 		}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/MT-651", nil)
+	req := newLoopbackRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/MT-651", nil)
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -599,7 +605,7 @@ func TestIssueHTTPHandlerReturns404EnvelopeForUnknownIssue(t *testing.T) {
 		return orchestrator.StateView{}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/NOPE-1", nil)
+	req := newLoopbackRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/NOPE-1", nil)
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -627,7 +633,7 @@ func TestIssueHTTPHandlerRejectsNonGET(t *testing.T) {
 		return orchestrator.StateView{}, nil
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/MT-649", nil)
+	req := newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/MT-649", nil)
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -661,11 +667,11 @@ func TestRefreshHTTPHandlerQueuesAndCoalescesImmediatePoll(t *testing.T) {
 	})
 
 	first := httptest.NewRecorder()
-	firstReq := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", nil)
+	firstReq := newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", nil)
 	firstReq.Header.Set(refreshRequestHeader, refreshRequestHeaderValue)
 	server.Handler.ServeHTTP(first, firstReq)
 	second := httptest.NewRecorder()
-	secondReq := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", strings.NewReader("{}"))
+	secondReq := newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", strings.NewReader("{}"))
 	secondReq.Header.Set(refreshRequestHeader, refreshRequestHeaderValue)
 	server.Handler.ServeHTTP(second, secondReq)
 
@@ -711,7 +717,7 @@ func TestRefreshHTTPHandlerRequiresRefreshHeader(t *testing.T) {
 	})
 
 	resp := httptest.NewRecorder()
-	server.Handler.ServeHTTP(resp, httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", nil))
+	server.Handler.ServeHTTP(resp, newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", nil))
 
 	if resp.Code != http.StatusForbidden {
 		t.Fatalf("status code = %d, want %d; body=%s", resp.Code, http.StatusForbidden, resp.Body.String())
@@ -731,7 +737,7 @@ func TestRefreshHTTPHandlerRejectsUnsupportedMethods(t *testing.T) {
 	})
 
 	getResp := httptest.NewRecorder()
-	server.Handler.ServeHTTP(getResp, httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/refresh", nil))
+	server.Handler.ServeHTTP(getResp, newLoopbackRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/refresh", nil))
 	if getResp.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("GET status code = %d, want %d; body=%s", getResp.Code, http.StatusMethodNotAllowed, getResp.Body.String())
 	}
@@ -753,7 +759,7 @@ func TestRefreshHTTPHandlerRejectsUnsupportedBodies(t *testing.T) {
 	})
 
 	for _, body := range []string{`[]`, `null`, `"refresh"`, `{"force":true}`} {
-		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", strings.NewReader(body))
+		req := newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", strings.NewReader(body))
 		req.Header.Set(refreshRequestHeader, refreshRequestHeaderValue)
 		resp := httptest.NewRecorder()
 		server.Handler.ServeHTTP(resp, req)
@@ -785,6 +791,131 @@ func TestStateHTTPServerRejectsNonLoopbackHost(t *testing.T) {
 	}
 }
 
+func TestStateHTTPServerRejectsSpoofedLoopbackHostFromNonLoopbackPeer(t *testing.T) {
+	called := false
+	server := newStateHTTPServer("0.0.0.0", 0, func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/state", nil)
+	req.RemoteAddr = "203.0.113.10:54321"
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status code = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if called {
+		t.Fatal("snapshot function should not be called for spoofed loopback Host")
+	}
+}
+
+func TestStateHTTPServerRequiresAuthForNonLoopbackPeerWhenTokenConfigured(t *testing.T) {
+	called := false
+	server := newStateHTTPServerWithAuthToken("0.0.0.0", 0, "state-token", func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/state", nil)
+	req.RemoteAddr = "172.18.0.1:54321"
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+	if !strings.Contains(w.Header().Get("WWW-Authenticate"), "Basic") {
+		t.Fatalf("WWW-Authenticate = %q, want Basic challenge", w.Header().Get("WWW-Authenticate"))
+	}
+	if called {
+		t.Fatal("snapshot function should not be called without auth from non-loopback peer")
+	}
+}
+
+func TestStateHTTPServerRequiresAuthForLoopbackPeerWhenTokenConfigured(t *testing.T) {
+	called := false
+	server := newStateHTTPServerWithAuthToken("127.0.0.1", 0, "state-token", func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	req := newLoopbackRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+	if called {
+		t.Fatal("snapshot function should not be called without auth when token is configured")
+	}
+}
+
+func TestStateHTTPServerRejectsWrongToken(t *testing.T) {
+	called := false
+	server := newStateHTTPServerWithAuthToken("0.0.0.0", 0, "state-token", func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://worker.example:4000/api/v1/state", nil)
+	req.RemoteAddr = "172.18.0.1:54321"
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+	if called {
+		t.Fatal("snapshot function should not be called for wrong auth token")
+	}
+}
+
+func TestStateHTTPServerAllowsBearerAuthFromNonLoopbackPeer(t *testing.T) {
+	called := false
+	server := newStateHTTPServerWithAuthToken("0.0.0.0", 0, "state-token", func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://worker.example:4000/api/v1/state", nil)
+	req.RemoteAddr = "172.18.0.1:54321"
+	req.Header.Set("Authorization", "Bearer state-token")
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !called {
+		t.Fatal("snapshot function was not called for authenticated non-loopback peer")
+	}
+}
+
+func TestStateHTTPServerAllowsBasicAuthFromNonLoopbackPeer(t *testing.T) {
+	called := false
+	server := newStateHTTPServerWithAuthToken("0.0.0.0", 0, "state-token", func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/state", nil)
+	req.RemoteAddr = "172.18.0.1:54321"
+	req.SetBasicAuth("aiops", "state-token")
+	w := httptest.NewRecorder()
+	server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !called {
+		t.Fatal("snapshot function was not called for authenticated dashboard request")
+	}
+}
+
 func TestStateHTTPServerAllowsLoopbackHost(t *testing.T) {
 	called := false
 	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
@@ -793,6 +924,7 @@ func TestStateHTTPServerAllowsLoopbackHost(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:4000/api/v1/state", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 
@@ -812,6 +944,7 @@ func TestStateHTTPServerAllowsIPv6LoopbackHost(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "http://[::1]:4000/api/v1/state", nil)
+	req.RemoteAddr = "[::1]:54321"
 	w := httptest.NewRecorder()
 	server.Handler.ServeHTTP(w, req)
 

--- a/deploy/docker-compose.dashboard.yml
+++ b/deploy/docker-compose.dashboard.yml
@@ -10,7 +10,9 @@
 # AIOPS_SERVER_HOST=0.0.0.0 binds all interfaces *inside the container* so the
 # published port reaches it, while the port mapping publishes ONLY to host
 # loopback (127.0.0.1). The effective host trust boundary therefore stays the
-# loopback (SPEC §15.3).
+# loopback (SPEC §15.3). Docker forwards from a bridge peer rather than
+# container loopback, so the overlay also requires AIOPS_STATE_API_TOKEN; use
+# HTTP Basic user `aiops` and that token as the browser password.
 #
 # Because a 0.0.0.0 bind is reachable by any sibling container on the same
 # Compose network (which can spoof Host: localhost past the in-process guard),
@@ -18,13 +20,15 @@
 # removes it from the project default network, so the legacy-queue services
 # (postgres / pollers) — or any other co-located container — cannot reach
 # worker:4000. The network is a normal bridge (not `internal`), so the worker
-# keeps outbound egress for git/tracker traffic. The dashboard is still
-# unauthenticated, so do NOT widen the host side of the mapping to a routable
-# address or attach untrusted containers to the dashboard network.
+# keeps outbound egress for git/tracker traffic. Do NOT widen the host side of
+# the mapping to a routable address or attach untrusted containers to the
+# dashboard network unless they should be able to use the token-protected status
+# surface.
 services:
   worker:
     environment:
       AIOPS_SERVER_HOST: 0.0.0.0
+      AIOPS_STATE_API_TOKEN: ${AIOPS_STATE_API_TOKEN:?set AIOPS_STATE_API_TOKEN for the dashboard overlay}
     ports:
       - "127.0.0.1:4000:4000"
     networks:

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -153,16 +153,19 @@ profile is explicitly requested (see
 The worker's loopback dashboard is not reachable from the host under the
 base Compose file. To reach it, merge the opt-in overlay, which binds
 `0.0.0.0` inside the container and publishes only to host loopback
-(`127.0.0.1:4000:4000`):
+(`127.0.0.1:4000:4000`). Docker forwards from a bridge peer rather than
+container loopback, so the overlay requires a state API token:
 
 ```bash
+export AIOPS_STATE_API_TOKEN=$(openssl rand -hex 24)
 docker compose -f deploy/docker-compose.yml \
   -f deploy/docker-compose.dashboard.yml up worker
 ```
 
 See README "Operator surfaces" for the trust-boundary caveats; the
-surface is unauthenticated, so never publish it on a routable host
-interface.
+overlay requires auth on every request. The browser Basic-auth username is
+`aiops` and the password is `$AIOPS_STATE_API_TOKEN`; `cmd/tui` reads the same
+env var and sends it as a bearer token when polling the overlay.
 
 > **Upgrading from a root-running worker image.** The worker now runs as the
 > unprivileged `aiops` user (#365). A `workspaces` named volume created by an

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -45,7 +45,11 @@ created or owns them.
 ## HTTP endpoints
 
 When `server.port` is enabled, the worker binds the status API on
-`127.0.0.1:<port>` and accepts only `localhost` or `127.0.0.1` Host headers.
+`127.0.0.1:<port>` by default. When `AIOPS_STATE_API_TOKEN` is set, every
+request must present it as `Authorization: Bearer <token>` or HTTP Basic auth
+user `aiops` with the token as the password. Without a token, unauthenticated
+requests must have both a loopback Host header and a loopback TCP peer;
+non-loopback peers fail closed.
 
 The effective port is resolved in this order, per SPEC §13.7:
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -50,8 +50,8 @@ type ServerConfig struct {
 	// empty value is treated as the loopback default rather than a bind-all
 	// wildcard so a blank override never silently widens exposure. Set it to
 	// 0.0.0.0 only behind a loopback-scoped host port mapping (see the
-	// dashboard Compose overlay); the loopback Host-header guard is not
-	// authentication, so a routable bind needs auth that this server lacks.
+	// dashboard Compose overlay) with AIOPS_STATE_API_TOKEN requiring auth for
+	// every request.
 	Host string `yaml:"host" json:"host"`
 	Port int    `yaml:"port" json:"port"`
 	// portSet records whether server.port was explicitly present in the

--- a/test/e2e/fixtures/dashboard_overlay_test.go
+++ b/test/e2e/fixtures/dashboard_overlay_test.go
@@ -54,13 +54,16 @@ func TestDashboardOverlayBindsContainerWide(t *testing.T) {
 	if got := env["AIOPS_SERVER_HOST"]; got != "0.0.0.0" {
 		t.Fatalf("AIOPS_SERVER_HOST = %v, want 0.0.0.0", got)
 	}
+	if got := env["AIOPS_STATE_API_TOKEN"]; got != "${AIOPS_STATE_API_TOKEN:?set AIOPS_STATE_API_TOKEN for the dashboard overlay}" {
+		t.Fatalf("AIOPS_STATE_API_TOKEN = %v, want required Compose interpolation", got)
+	}
 }
 
 // TestDashboardOverlayIsolatesWorkerNetwork guards that the overlay moves the
 // worker onto a dedicated non-default network (#366). Because a 0.0.0.0 bind is
 // reachable by sibling containers on a shared Compose network (which can spoof
-// the loopback Host guard), the worker must leave the project default network
-// so co-located services cannot reach the unauthenticated dashboard.
+// the loopback Host guard and try the token-protected surface), the worker must
+// leave the project default network so co-located services cannot reach it.
 func TestDashboardOverlayIsolatesWorkerNetwork(t *testing.T) {
 	overlay := readDashboardOverlay(t)
 	worker := service(t, overlay, "worker")
@@ -87,8 +90,8 @@ func TestDashboardOverlayIsolatesWorkerNetwork(t *testing.T) {
 }
 
 // TestDashboardOverlayPublishesToHostLoopbackOnly guards the security property:
-// the host side of every published port must bind loopback, so the dashboard
-// (unauthenticated, SPEC §15.3) is never exposed on a routable host interface.
+// the host side of every published port must bind loopback, so the dashboard is
+// never exposed on a routable host interface.
 func TestDashboardOverlayPublishesToHostLoopbackOnly(t *testing.T) {
 	worker := service(t, readDashboardOverlay(t), "worker")
 	ports, ok := worker["ports"].([]any)


### PR DESCRIPTION
Closes #385

## Acceptance
- Guard unauthenticated state/refresh requests with both Host and TCP peer checks; spoofed loopback Host from a non-loopback peer now fails closed.
- Add optional `AIOPS_STATE_API_TOKEN` auth for the state API; when configured, Bearer and Basic auth are checked before any loopback allowance.
- Teach `cmd/tui` to send the Bearer token, require the token in the Docker dashboard overlay, and update `.env.example` plus runtime docs.

## Validation
- `go test ./cmd/worker ./internal/workflow ./test/e2e/fixtures`
- Mutation: disabling state API auth made Bearer/Basic tests fail; restored and passed.
- Mutation: removing TUI Authorization header made `TestFetchStateWithAuthSendsBearerToken` fail; restored and passed.
- Mutation: reintroducing a token-era loopback bypass made `TestStateHTTPServerRequiresAuthForLoopbackPeerWhenTokenConfigured` fail; restored and passed.
- `gofmt -l $(git ls-files '*.go')`\n- `go mod tidy && git diff --exit-code -- go.mod go.sum`\n- `go test -race -covermode=atomic ./...`\n- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller ./cmd/tui`\n- Post-commit/pre-push review: Codex review clean; Claude Code JSON review clean.\n\n## Risk / Deferral\n- No deferrals. Token auth remains opt-in for loopback-only local development; any configured token is required for all peers, including same-host reverse proxy paths.\n