### PR TITLE
fix(runner): scope agent environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ from SPEC are called out and tracked in [`DEVIATIONS.md`](DEVIATIONS.md):
 | `agent.max_timeout_retries` | unbounded (SPEC §8.4 backoff-only); explicit positive integer opts into the §15.5 cap, explicit `0` disables runner-timeout re-queues | SPEC §8.4 default; opt-in cap tracked under DEVIATIONS D29 |
 | `agent.policy_violation_budget` | `2` policy-violation feedback entries per issue before non-retryable fail (`0` disables suppression) | implementation (#230) |
 | `codex.command` | `codex app-server` | SPEC §6.4 |
+| `codex.env_passthrough` / `claude.env_passthrough` | none beyond runner baseline (`PATH`, `HOME`, `USER`, locale, `TZ`, `TERM`); use for model CLI auth/proxy/CA vars, not tracker/repo API tokens | implementation (#384) |
 | `pr.draft` | `false` | implementation |
 | `pr.labels` | `[ai-generated, needs-review]` | implementation |
 | `server.port` | `4000` (`-1` disables the HTTP state server + dashboard) | implementation |

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -423,9 +423,10 @@ PR creation lives **agent-side**, not in the worker. The worker no
 longer holds Gitea credentials. If the agent (Codex, Claude, etc.)
 needs to push:
 
-- The agent invocation environment must carry credentials matching
-  the configured remote (SSH key, deploy key, or
-  `GITEA_TOKEN`/`GITHUB_TOKEN` exported to the agent process).
+- Prefer file-backed Git credentials such as a dedicated SSH deploy key. Agent
+  subprocesses do not inherit the worker's full environment, and
+  `codex.env_passthrough` / `claude.env_passthrough` reject tracker/repo token
+  names such as `LINEAR_API_KEY`, `GITEA_TOKEN`, and `GITHUB_TOKEN`.
 - For Docker Compose, the worker container mounts a **dedicated** SSH
   keypair at `/home/aiops/.ssh/id_ed25519` — not your entire `~/.ssh`. Set
   it up once:

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -86,7 +86,7 @@ agent:
 
 ### `codex`
 
-Profile-driven runner (`internal/runner/codex.go`) that invokes the codex CLI with sandbox/approval flags chosen by `codex.profile`. PROMPT.md is piped on stdin; output is captured to `.aiops/CODEX_OUTPUT.txt`. The `custom` profile falls back to `sh -lc <codex.command>` (still stdin-fed).
+Profile-driven runner (`internal/runner/codex.go`) that invokes the codex CLI with sandbox/approval flags chosen by `codex.profile`. PROMPT.md is piped on stdin; output is captured to `.aiops/CODEX_OUTPUT.txt`. The `custom` profile falls back to `sh -c <codex.command>` (still stdin-fed).
 
 Use when:
 
@@ -105,7 +105,7 @@ codex:
 
 - `safe` (default): builds `codex exec --sandbox workspace-write --skip-git-repo-check --cd <workdir> -o <workdir>/.aiops/CODEX_LAST_MESSAGE.md` from argv (no shell). PROMPT.md is piped on stdin. This avoids the deprecated `--full-auto` shorthand while preserving the workspace-write sandbox behavior.
 - `bypass`: same shape but with `--dangerously-bypass-approvals-and-sandbox`. Use only when the worker host is already isolated (container, dedicated VM); the flag turns codex's own sandbox off.
-- `custom`: runs the literal `codex.command` via `sh -lc` with PROMPT.md on stdin. Note the change from earlier versions: the runner no longer appends `< .aiops/PROMPT.md` to the command — your command must consume stdin (which `codex exec` does by default when no positional prompt is given).
+- `custom`: runs the literal `codex.command` via `sh -c` with PROMPT.md on stdin. Note the change from earlier versions: the runner no longer appends `< .aiops/PROMPT.md` to the command — your command must consume stdin (which `codex exec` does by default when no positional prompt is given).
 
 ### Reading codex output after a run
 
@@ -167,7 +167,7 @@ For legacy queue runs, `/events` is the most useful endpoint. Look for `enqueued
 - `repo.clone_url missing in WORKFLOW.md`: poller log line. Fix `WORKFLOW.md`, restart the poller.
 - Verification command failed (`go test ./...` non-zero): read `.aiops/RUN_SUMMARY.md` in the work branch if the runner produced one. Reproduce locally on the same branch.
 - Policy violation (deny path or size cap): re-scope the task into a smaller issue, or do it manually.
-- Runner command not found: confirm `codex.command` or `claude.command` resolves on the worker host. The codex/claude shell runner uses `sh -lc`, so PATH must be set in the worker's login shell. Workspace hooks (`hooks.after_create`, `hooks.before_run`, etc.) and `verify.commands` run under plain `sh -c` with the PATH captured once from the worker's login shell at startup — the same login-shell PATH that resolves `codex` also resolves hook/verify commands, but `/etc/profile.d/*` and `~/.profile` are not re-sourced per command, so their stdout cannot leak into hook/verify output buffers (#314).
+- Runner command not found: confirm `codex.command` or `claude.command` resolves in the worker's scoped `PATH`. The codex/claude shell runner uses plain `sh -c`, so `/etc/profile.d/*` and `~/.profile` are not re-sourced per command; pass any required non-secret env explicitly with `codex.env_passthrough` or `claude.env_passthrough`.
 - Empty diff: agent decided nothing to do. Tighten the issue body, then move it to `Rework` (or the equivalent active Gitea `aiops/*` state label).
 
 ### Re-running a failed task

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -36,6 +36,8 @@ Supported enforcement today:
 - the agent working directory must remain under `workspace.root` before the
   sandbox wrapper is applied;
 - the child process environment is reduced to `sandbox.env_allowlist`;
+- the agent executable must live under a path the sandbox backend exposes
+  (for example `/usr` or `/bin` with the current bubblewrap/firejail profile);
 - explicitly listed credential files are checked for readability and bound into
   the sandbox read-only;
 - `network: none` disables network access for supported backends;
@@ -129,16 +131,16 @@ The current Go implementation provides these safety controls:
 - operator-visible blocked state for Codex input-required and MCP elicitation
   requests, so non-interactive runs stop and remain claimed instead of burning
   retries silently;
-- allow-listed environment for hook and verify subprocesses: by default
-  hook scripts (`after_create`, `before_run`, `after_run`,
-  `before_remove`) and verify commands run with only a small POSIX
-  baseline env (`PATH`, `HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`,
-  `TZ`, `TERM`). Tracker tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`,
-  `GITEA_TOKEN`), `SSH_AUTH_SOCK`, and any other secret in the worker's
-  `.env` are excluded — a malicious or buggy WORKFLOW.md cannot `env >
-  /tmp/dump` and exfiltrate. Operators opt specific extra vars back in
-  per workflow with `hooks.env_passthrough: [VAR_NAME, ...]` and
-  `verify.env_passthrough: [VAR_NAME, ...]`. See
+- allow-listed environment for agent, hook, and verify subprocesses: by
+  default these children run with only a small POSIX baseline env (`PATH`,
+  `HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TZ`, `TERM`). Tracker/repo
+  tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`, `GITEA_TOKEN`) and any other secret
+  in the worker's `.env` are excluded — a malicious or buggy WORKFLOW.md cannot
+  `env > /tmp/dump` and exfiltrate them. Operators opt non-tracker vars back in
+  per workflow with `codex.env_passthrough`, `claude.env_passthrough`,
+  `hooks.env_passthrough`, or `verify.env_passthrough`; agent passthrough
+  rejects tracker/repo API token names so those credentials stay behind
+  orchestrator-owned tools. See
   [`docs/design/hook-verify-env-allowlist.md`](design/hook-verify-env-allowlist.md);
 - allow-listed redaction of Codex `turn/failed`, `turn/cancelled`, and failed
   `turn/completed` protocol payloads: returned error strings and

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -82,7 +82,7 @@ codex:
   #   bypass           - codex exec --dangerously-bypass-approvals-and-sandbox ...
   #                      (only when the worker host is already isolated, e.g. a
   #                      container; codex bypasses its own sandbox + approval gates)
-  #   custom           - run the literal codex.command via sh -lc; PROMPT.md
+  #   custom           - run the literal codex.command via sh -c; PROMPT.md
   #                      is piped on stdin. Escape hatch for bespoke wrappers.
   profile: safe
   # linear_graphql narrows the agent-visible Linear GraphQL tool to the
@@ -137,7 +137,8 @@ safety:
 
 # Optional worker-enforced process hardening. Disabled by default so personal
 # workflows continue to rely on the selected coding agent's own sandbox. Enable
-# only after installing and validating the backend on the worker host.
+# only after installing and validating the backend on the worker host. The
+# selected agent binary must live under a path exposed by that backend profile.
 sandbox:
   enabled: false
   backend: none      # none, bubblewrap, or firejail

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -36,11 +36,13 @@ func (CodexRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 		return Result{}, fmt.Errorf("read %s: %w", PromptPath, err)
 	}
 
-	cmd, err := buildCodexCmd(ctx, in)
+	env := agentEnv(in.Workflow.Config.Codex.EnvPassthrough, in.Workflow.Config)
+	cmd, err := buildCodexCmd(ctx, in, env)
 	if err != nil {
 		return Result{}, err
 	}
 	cmd.Dir = in.Workdir
+	cmd.Env = env
 	if err := validateAgentCommandWorkdir(in, cmd); err != nil {
 		return Result{}, err
 	}
@@ -94,7 +96,7 @@ func (CodexRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 
 // buildCodexCmd assembles the *exec.Cmd for the requested profile. PROMPT.md
 // is always provided via stdin, never via shell redirection.
-func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
+func buildCodexCmd(ctx context.Context, in RunInput, env []string) (*exec.Cmd, error) {
 	profile := in.Workflow.Config.Codex.Profile
 	if profile == "" {
 		profile = "safe"
@@ -106,7 +108,8 @@ func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
 	lastMessageAbs := filepath.Join(in.Workdir, CodexLastMessagePath)
 	switch profile {
 	case "safe":
-		if _, err := exec.LookPath("codex"); err != nil {
+		codexPath, err := lookPathInEnv("codex", env)
+		if err != nil {
 			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
 		}
 		// `--sandbox workspace-write` replaces the deprecated `--full-auto`.
@@ -119,18 +122,19 @@ func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
 		// resolve to the same sandbox mode; the new spelling is forward-
 		// compatible if codex eventually removes the alias.
 		return exec.CommandContext(ctx,
-			"codex", "exec",
+			codexPath, "exec",
 			"--sandbox", "workspace-write",
 			"--skip-git-repo-check",
 			"--cd", in.Workdir,
 			"-o", lastMessageAbs,
 		), nil
 	case "bypass":
-		if _, err := exec.LookPath("codex"); err != nil {
+		codexPath, err := lookPathInEnv("codex", env)
+		if err != nil {
 			return nil, fmt.Errorf("codex binary not found in PATH; install codex CLI or set agent.default to claude/mock")
 		}
 		return exec.CommandContext(ctx,
-			"codex", "exec",
+			codexPath, "exec",
 			"--dangerously-bypass-approvals-and-sandbox",
 			"--skip-git-repo-check",
 			"--cd", in.Workdir,
@@ -141,7 +145,7 @@ func buildCodexCmd(ctx context.Context, in RunInput) (*exec.Cmd, error) {
 		if command == "" {
 			return nil, fmt.Errorf("codex.profile=custom requires codex.command to be non-empty")
 		}
-		return exec.CommandContext(ctx, "sh", "-lc", command), nil
+		return exec.CommandContext(ctx, "sh", "-c", command), nil
 	default:
 		return nil, fmt.Errorf("codex.profile %q is not supported", profile)
 	}

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -49,11 +49,13 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		return Result{}, fmt.Errorf("read %s: %w", PromptPath, err)
 	}
 
-	cmd, directCodexExec, err := buildCodexAppServerCmd(ctx, in)
+	env := agentEnv(in.Workflow.Config.Codex.EnvPassthrough, in.Workflow.Config)
+	cmd, directCodexExec, err := buildCodexAppServerCmd(ctx, in, env)
 	if err != nil {
 		return Result{}, err
 	}
 	cmd.Dir = in.Workdir
+	cmd.Env = env
 	if err := validateAgentCommandWorkdir(in, cmd); err != nil {
 		return Result{}, err
 	}
@@ -97,7 +99,7 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
 	// Only emit codex_app_server_pid when we can guarantee cmd.Process.Pid is
 	// the actual codex process: the command must launch the codex binary
-	// directly (no `sh -lc` wrapper from a custom codex.command), and the
+	// directly (no `sh -c` wrapper from a custom codex.command), and the
 	// sandbox must not have wrapped cmd in firejail/bwrap. In any wrapper
 	// scenario the PID belongs to the wrapper, which would mislead operators
 	// trying to map `/api/v1/state` rows to a host process. omitempty makes
@@ -180,10 +182,10 @@ func validateAppServerWorkdir(workdir string) error {
 // directCodexExec flag. The flag is true only when the command launches the
 // `codex` binary directly (so `cmd.Process.Pid` after Start() is the actual
 // app-server pid). Custom `codex.command` configurations route through
-// `sh -lc <command>`, in which case `cmd.Process.Pid` is the shell wrapper,
+// `sh -c <command>`, in which case `cmd.Process.Pid` is the shell wrapper,
 // not codex — see codex_app_server.go's session_started emit for the resulting
 // PID-emission guard.
-func buildCodexAppServerCmd(ctx context.Context, in RunInput) (*exec.Cmd, bool, error) {
+func buildCodexAppServerCmd(ctx context.Context, in RunInput, env []string) (*exec.Cmd, bool, error) {
 	command := strings.TrimSpace(in.Workflow.Config.Codex.Command)
 	if command == "" || command == "codex exec" {
 		command = "codex app-server"
@@ -193,12 +195,13 @@ func buildCodexAppServerCmd(ctx context.Context, in RunInput) (*exec.Cmd, bool, 
 		return nil, false, fmt.Errorf("codex app-server command is empty")
 	}
 	if fields[0] == "codex" {
-		if _, err := exec.LookPath("codex"); err != nil {
+		codexPath, err := lookPathInEnv("codex", env)
+		if err != nil {
 			return nil, false, NewError(CategoryCodexNotFound, "codex binary not found in PATH; install codex CLI or set agent.default to claude/mock", err)
 		}
-		return exec.CommandContext(ctx, fields[0], fields[1:]...), true, nil
+		return exec.CommandContext(ctx, codexPath, fields[1:]...), true, nil
 	}
-	return exec.CommandContext(ctx, "sh", "-lc", command), false, nil
+	return exec.CommandContext(ctx, "sh", "-c", command), false, nil
 }
 
 type appServerClient struct {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -32,6 +32,11 @@ func appServerInput(workdir string) RunInput {
 				TurnSandboxPolicy: map[string]any{
 					"mode": "workspace-write",
 				},
+				EnvPassthrough: []string{
+					"CODEX_ARGV_LOG",
+					"CODEX_STDIN_LOG",
+					"CODEX_STARTED_LOG",
+				},
 				TurnTimeoutMs:  3000,
 				ReadTimeoutMs:  3000,
 				StallTimeoutMs: 3000,
@@ -55,9 +60,31 @@ with open(os.environ['CODEX_ARGV_LOG'], 'w') as f:
 	if err := os.WriteFile(scriptPath, []byte(header+body), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	path := dir + string(os.PathListSeparator) + os.Getenv("PATH")
+	t.Setenv("PATH", path)
+	useAgentLoginPATH(t, path)
 	t.Setenv("CODEX_ARGV_LOG", filepath.Join(dir, "argv.txt"))
 	t.Setenv("CODEX_STDIN_LOG", filepath.Join(dir, "stdin.txt"))
+	return dir
+}
+
+func codexAppServerEnvStubScript(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "codex")
+	header := `#!/usr/bin/env python3
+import os, sys
+with open("env.txt", "w") as f:
+    for name in ("LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN", "PATH"):
+        if name in os.environ:
+            f.write(f"{name}={os.environ[name]}\n")
+`
+	if err := os.WriteFile(scriptPath, []byte(header+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := dir + string(os.PathListSeparator) + os.Getenv("PATH")
+	t.Setenv("PATH", path)
+	useAgentLoginPATH(t, path)
 	return dir
 }
 
@@ -171,6 +198,46 @@ for line in sys.stdin:
 	}
 	if turnParams["title"] != "AIOPS-64: Wire Codex app-server" {
 		t.Fatalf("turn title = %#v", turnParams["title"])
+	}
+}
+
+func TestCodexAppServerRunnerDoesNotInheritWorkerSecretsByDefault(t *testing.T) {
+	codexAppServerEnvStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {'protocolVersion': '0.1.0'}}), flush=True)
+    elif method == 'initialized':
+        pass
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'turnId': 'turn-1', 'lastAssistantMessage': 'done'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "app-server env")
+	t.Setenv("LINEAR_API_KEY", "linear-secret")
+	t.Setenv("GITEA_TOKEN", "gitea-secret")
+	t.Setenv("GITHUB_TOKEN", "github-secret")
+
+	if _, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(wd, "env.txt"))
+	if err != nil {
+		t.Fatalf("read env.txt: %v", err)
+	}
+	for _, secretName := range []string{"LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN"} {
+		if strings.Contains(string(body), secretName+"=") {
+			t.Fatalf("codex app-server env leaked %s:\n%s", secretName, body)
+		}
+	}
+	if !strings.Contains(string(body), "PATH=") {
+		t.Fatalf("codex app-server env lost baseline PATH:\n%s", body)
 	}
 }
 
@@ -1350,21 +1417,44 @@ func TestBuildCodexAppServerCmdUsesAppServerWhenDefaultCodexExecCommandIsUnchang
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.Command = "codex exec"
 
-	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in)
+	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + os.Getenv("PATH")})
 	if err != nil {
 		t.Fatalf("buildCodexAppServerCmd: %v", err)
 	}
 	if !directExec {
 		t.Fatalf("directCodexExec = false for default codex command, want true")
 	}
-	if len(cmd.Args) < 2 || cmd.Args[0] != "codex" || cmd.Args[1] != "app-server" {
+	if len(cmd.Args) < 2 || filepath.Base(cmd.Args[0]) != "codex" || cmd.Args[1] != "app-server" {
 		t.Fatalf("cmd.Args = %#v, want codex app-server", cmd.Args)
+	}
+}
+
+func TestBuildCodexAppServerCmdResolvesCodexFromAgentEnvPATH(t *testing.T) {
+	rawPathDir := t.TempDir()
+	t.Setenv("PATH", rawPathDir)
+	binDir := t.TempDir()
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+
+	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + binDir})
+	if err != nil {
+		t.Fatalf("buildCodexAppServerCmd: %v", err)
+	}
+	if !directExec {
+		t.Fatalf("directCodexExec = false, want true")
+	}
+	if cmd.Path != codex {
+		t.Fatalf("cmd.Path = %q, want codex from agent env PATH %q", cmd.Path, codex)
 	}
 }
 
 // TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect pins the
 // directCodexExec flag's negative case: when `codex.command` is anything other
-// than a `codex ...` invocation, the cmd runs through `sh -lc`. The runner
+// than a `codex ...` invocation, the cmd runs through `sh -c`. The runner
 // uses this signal to suppress codex_app_server_pid emission, since
 // cmd.Process.Pid would be the shell wrapper rather than the actual codex
 // process.
@@ -1373,15 +1463,15 @@ func TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect(t *testing.T) {
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.Command = "/usr/local/bin/my-codex-wrapper --foo"
 
-	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in)
+	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + os.Getenv("PATH")})
 	if err != nil {
 		t.Fatalf("buildCodexAppServerCmd: %v", err)
 	}
 	if directExec {
-		t.Fatalf("directCodexExec = true for custom command %q, want false (sh -lc wrapper)", in.Workflow.Config.Codex.Command)
+		t.Fatalf("directCodexExec = true for custom command %q, want false (sh -c wrapper)", in.Workflow.Config.Codex.Command)
 	}
-	if len(cmd.Args) == 0 || cmd.Args[0] != "sh" {
-		t.Fatalf("cmd.Args = %#v, want sh -lc wrapper", cmd.Args)
+	if len(cmd.Args) < 3 || cmd.Args[0] != "sh" || cmd.Args[1] != "-c" || cmd.Args[2] != in.Workflow.Config.Codex.Command {
+		t.Fatalf("cmd.Args = %#v, want sh -c wrapper", cmd.Args)
 	}
 }
 

--- a/internal/runner/codex_test.go
+++ b/internal/runner/codex_test.go
@@ -34,8 +34,19 @@ cat > "` + dir + `/stdin.txt"
 	if err := os.WriteFile(scriptPath, []byte(header+body), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	path := dir + string(os.PathListSeparator) + os.Getenv("PATH")
+	t.Setenv("PATH", path)
+	useAgentLoginPATH(t, path)
 	return dir
+}
+
+func useAgentLoginPATH(t *testing.T, path string) {
+	t.Helper()
+	old := agentLoginPATH
+	agentLoginPATH = func() string { return path }
+	t.Cleanup(func() {
+		agentLoginPATH = old
+	})
 }
 
 // codexWorkdir creates a per-test workdir with a populated .aiops/PROMPT.md.
@@ -106,6 +117,25 @@ func TestCodexRunner_SafeProfileBuildsExpectedArgv(t *testing.T) {
 		if line == "--full-auto" {
 			t.Fatalf("safe profile must not emit --full-auto; codex deprecated it (see #330): argv=%q", gotLines)
 		}
+	}
+}
+
+func TestBuildCodexCmdResolvesCodexFromAgentEnvPATH(t *testing.T) {
+	rawPathDir := t.TempDir()
+	t.Setenv("PATH", rawPathDir)
+	binDir := t.TempDir()
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd := codexWorkdir(t, "x")
+
+	cmd, err := buildCodexCmd(context.Background(), codexInput(wd), []string{"PATH=" + binDir})
+	if err != nil {
+		t.Fatalf("buildCodexCmd: %v", err)
+	}
+	if cmd.Path != codex {
+		t.Fatalf("cmd.Path = %q, want codex from agent env PATH %q", cmd.Path, codex)
 	}
 }
 
@@ -228,7 +258,9 @@ func TestCodexRunner_MissingPromptReturnsWrappedError(t *testing.T) {
 
 func TestCodexRunner_MissingBinaryReturnsClearError(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv — sequential only.
-	t.Setenv("PATH", "") // no codex anywhere
+	emptyPath := t.TempDir()
+	t.Setenv("PATH", emptyPath) // no codex anywhere
+	useAgentLoginPATH(t, emptyPath)
 	wd := codexWorkdir(t, "x")
 	_, err := (CodexRunner{}).Run(context.Background(), codexInput(wd))
 	if err == nil {
@@ -307,6 +339,34 @@ func TestCodexRunner_CustomProfileUsesShellWithStdin(t *testing.T) {
 	}
 }
 
+func TestCodexRunner_CustomProfileDoesNotSourceProfile(t *testing.T) {
+	wd := codexWorkdir(t, "custom-profile-canary")
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".profile"), []byte("export PROFILE_CANARY=from-profile\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	in := RunInput{
+		Task: task.Task{ID: "tsk_custom_profile", Model: "codex"},
+		Workflow: workflow.Workflow{Config: workflow.Config{
+			Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(wd)},
+			Codex:     workflow.CommandConfig{Command: `printf '%s' "${PROFILE_CANARY:-}"`, Profile: "custom"},
+		}},
+		Workdir: wd,
+	}
+	if _, err := (CodexRunner{}).Run(context.Background(), in); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(wd, ".aiops/CODEX_OUTPUT.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(body); got != "" {
+		t.Fatalf("custom codex profile sourced HOME profile; canary=%q", got)
+	}
+}
+
 func TestCodexRunner_CustomProfileEmptyCommandRejected(t *testing.T) {
 	wd := codexWorkdir(t, "x")
 	in := RunInput{
@@ -323,5 +383,30 @@ func TestCodexRunner_CustomProfileEmptyCommandRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "codex.command") {
 		t.Fatalf("error %q should mention codex.command", err)
+	}
+}
+
+func TestCodexRunnerDoesNotInheritWorkerSecretsByDefault(t *testing.T) {
+	codexStubScript(t, `env > env.txt ; exit 0`)
+	wd := codexWorkdir(t, "x")
+	t.Setenv("LINEAR_API_KEY", "linear-secret")
+	t.Setenv("GITEA_TOKEN", "gitea-secret")
+	t.Setenv("GITHUB_TOKEN", "github-secret")
+
+	if _, err := (CodexRunner{}).Run(context.Background(), codexInput(wd)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(wd, "env.txt"))
+	if err != nil {
+		t.Fatalf("read env.txt: %v", err)
+	}
+	for _, secretName := range []string{"LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN"} {
+		if strings.Contains(string(body), secretName+"=") {
+			t.Fatalf("codex env leaked %s:\n%s", secretName, body)
+		}
+	}
+	if !strings.Contains(string(body), "PATH=") {
+		t.Fatalf("codex env lost baseline PATH:\n%s", body)
 	}
 }

--- a/internal/runner/command_path.go
+++ b/internal/runner/command_path.go
@@ -1,0 +1,53 @@
+package runner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func lookPathInEnv(file string, env []string) (string, error) {
+	return lookPathInPATH(file, envPATH(env))
+}
+
+func envPATH(env []string) string {
+	for _, envPair := range env {
+		name, value, ok := strings.Cut(envPair, "=")
+		if ok && name == "PATH" {
+			return value
+		}
+	}
+	return ""
+}
+
+func lookPathInPATH(file, pathValue string) (string, error) {
+	if strings.ContainsAny(file, `/\`) || pathValue == "" {
+		return exec.LookPath(file)
+	}
+	for _, dir := range filepath.SplitList(pathValue) {
+		if dir == "" {
+			dir = "."
+		}
+		path := filepath.Join(dir, file)
+		if err := executableFile(path); err == nil {
+			return path, nil
+		}
+	}
+	return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
+}
+
+func executableFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return exec.ErrNotFound
+	}
+	if runtime.GOOS == "windows" || info.Mode()&0o111 != 0 {
+		return nil
+	}
+	return os.ErrPermission
+}

--- a/internal/runner/env.go
+++ b/internal/runner/env.go
@@ -1,0 +1,60 @@
+package runner
+
+import (
+	"os"
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
+)
+
+var baselineAgentEnvAllowlist = []string{
+	"PATH",
+	"HOME",
+	"USER",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"TZ",
+	"TERM",
+}
+
+var agentLoginPATH = workspace.LoginPATH
+
+func agentEnv(passthrough []string, cfg workflow.Config) []string {
+	return agentEnvWithLookup(passthrough, cfg, os.LookupEnv, agentLoginPATH)
+}
+
+func agentEnvWithLookup(passthrough []string, cfg workflow.Config, lookup func(string) (string, bool), loginPath func() string) []string {
+	seen := make(map[string]struct{}, len(baselineAgentEnvAllowlist)+len(passthrough))
+	env := make([]string, 0, len(baselineAgentEnvAllowlist)+len(passthrough))
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || strings.Contains(name, "=") {
+			return
+		}
+		if workflow.AgentEnvPassthroughDenyReasonForConfig(name, cfg) != "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		if name == "PATH" {
+			if value := loginPath(); value != "" {
+				env = append(env, "PATH="+value)
+				return
+			}
+		}
+		if value, ok := lookup(name); ok {
+			env = append(env, name+"="+value)
+		}
+	}
+	for _, name := range baselineAgentEnvAllowlist {
+		add(name)
+	}
+	for _, name := range passthrough {
+		add(name)
+	}
+	return env
+}

--- a/internal/runner/errors_test.go
+++ b/internal/runner/errors_test.go
@@ -38,8 +38,7 @@ func TestRunnerSentinelsCoverSpecCategories(t *testing.T) {
 
 func TestCodexAppServerRunnerSurfacesRunnerErrorCategories(t *testing.T) {
 	t.Run("codex not found", func(t *testing.T) {
-		t.Setenv("PATH", t.TempDir())
-		_, _, err := buildCodexAppServerCmd(context.Background(), appServerInput(t.TempDir()))
+		_, _, err := buildCodexAppServerCmd(context.Background(), appServerInput(t.TempDir()), []string{"PATH=" + t.TempDir()})
 		if !errors.Is(err, ErrCodexNotFound) {
 			t.Fatalf("buildCodexAppServerCmd error = %T %[1]v, want ErrCodexNotFound", err)
 		}
@@ -76,7 +75,9 @@ func TestCodexAppServerRunnerStillReadsPromptForValidWorkspace(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(wd, PromptPath), []byte("prompt"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("PATH", t.TempDir())
+	emptyPath := t.TempDir()
+	t.Setenv("PATH", emptyPath)
+	useAgentLoginPATH(t, emptyPath)
 	_, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
 	if err == nil || !strings.Contains(err.Error(), "codex binary not found") {
 		t.Fatalf("Run valid workdir error = %T %[1]v, want codex lookup after prompt read", err)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -153,6 +154,160 @@ func TestShellRunnerNonTimeoutErrorNotMisclassified(t *testing.T) {
 	}
 	if IsTimeout(err) {
 		t.Fatalf("non-zero exit must not be classified as timeout: %v", err)
+	}
+}
+
+func TestShellRunnerDoesNotInheritWorkerSecretsByDefault(t *testing.T) {
+	workdir := shellTestWorkdir(t)
+	t.Setenv("LINEAR_API_KEY", "linear-secret")
+	t.Setenv("GITEA_TOKEN", "gitea-secret")
+	t.Setenv("GITHUB_TOKEN", "github-secret")
+
+	wf := workflow.Workflow{Config: workflow.Config{
+		Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
+		Claude: workflow.CommandConfig{
+			Command: "env > shell-env.txt",
+		},
+	}}
+
+	if _, err := (ShellRunner{Name: "claude"}).Run(context.Background(), RunInput{
+		Task:     task.Task{ID: "tsk_shell_env"},
+		Workflow: wf,
+		Workdir:  workdir,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(workdir, "shell-env.txt"))
+	if err != nil {
+		t.Fatalf("read shell-env.txt: %v", err)
+	}
+	for _, secretName := range []string{"LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN"} {
+		if strings.Contains(string(body), secretName+"=") {
+			t.Fatalf("runner env leaked %s:\n%s", secretName, body)
+		}
+	}
+	if !strings.Contains(string(body), "PATH=") {
+		t.Fatalf("runner env lost baseline PATH:\n%s", body)
+	}
+}
+
+func TestShellRunnerDoesNotSourceProfileByDefault(t *testing.T) {
+	workdir := shellTestWorkdir(t)
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".profile"), []byte("export PROFILE_CANARY=from-profile\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	wf := workflow.Workflow{Config: workflow.Config{
+		Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
+		Claude: workflow.CommandConfig{
+			Command: `printf '%s' "${PROFILE_CANARY:-}" > profile-canary.txt`,
+		},
+	}}
+
+	if _, err := (ShellRunner{Name: "claude"}).Run(context.Background(), RunInput{
+		Task:     task.Task{ID: "tsk_shell_profile"},
+		Workflow: wf,
+		Workdir:  workdir,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(workdir, "profile-canary.txt"))
+	if err != nil {
+		t.Fatalf("read profile-canary.txt: %v", err)
+	}
+	if got := string(body); got != "" {
+		t.Fatalf("shell runner sourced HOME profile; canary=%q", got)
+	}
+}
+
+func TestShellRunnerHonorsExplicitEnvPassthrough(t *testing.T) {
+	workdir := shellTestWorkdir(t)
+	t.Setenv("AIOPS_RUNNER_CANARY", "allowed-value")
+	t.Setenv("LINEAR_API_KEY", "linear-secret")
+
+	wf := workflow.Workflow{Config: workflow.Config{
+		Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
+		Claude: workflow.CommandConfig{
+			Command:        "env > shell-env.txt",
+			EnvPassthrough: []string{"AIOPS_RUNNER_CANARY"},
+		},
+	}}
+
+	if _, err := (ShellRunner{Name: "claude"}).Run(context.Background(), RunInput{
+		Task:     task.Task{ID: "tsk_shell_env_allow"},
+		Workflow: wf,
+		Workdir:  workdir,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(workdir, "shell-env.txt"))
+	if err != nil {
+		t.Fatalf("read shell-env.txt: %v", err)
+	}
+	if !strings.Contains(string(body), "AIOPS_RUNNER_CANARY=allowed-value") {
+		t.Fatalf("runner env missing explicit passthrough:\n%s", body)
+	}
+	if strings.Contains(string(body), "LINEAR_API_KEY=") {
+		t.Fatalf("runner env leaked token outside explicit passthrough:\n%s", body)
+	}
+}
+
+func TestAgentEnvRejectsTrackerTokenPassthrough(t *testing.T) {
+	t.Setenv("AIOPS_RUNNER_CANARY", "allowed-value")
+	t.Setenv("LINEAR_API_KEY", "linear-secret")
+	t.Setenv("GITEA_TOKEN", "gitea-secret")
+	t.Setenv("GITHUB_TOKEN", "github-secret")
+
+	body := strings.Join(agentEnv([]string{"AIOPS_RUNNER_CANARY", "LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN"}, workflow.Config{}), "\n")
+	if !strings.Contains(body, "AIOPS_RUNNER_CANARY=allowed-value") {
+		t.Fatalf("agent env missing non-secret passthrough:\n%s", body)
+	}
+	for _, secretName := range []string{"LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN"} {
+		if strings.Contains(body, secretName+"=") {
+			t.Fatalf("agent env leaked denied passthrough %s:\n%s", secretName, body)
+		}
+	}
+}
+
+func TestAgentEnvRejectsTrackerAPIKeyValuePassthrough(t *testing.T) {
+	t.Setenv("AIOPS_RUNNER_CANARY", "allowed-value")
+	t.Setenv("AIOPS_TEST_TRACKER_TOKEN", "tracker-secret")
+
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{APIKey: "tracker-secret"},
+	}
+	body := strings.Join(agentEnv([]string{"AIOPS_RUNNER_CANARY", "AIOPS_TEST_TRACKER_TOKEN"}, cfg), "\n")
+	if !strings.Contains(body, "AIOPS_RUNNER_CANARY=allowed-value") {
+		t.Fatalf("agent env missing non-secret passthrough:\n%s", body)
+	}
+	if strings.Contains(body, "AIOPS_TEST_TRACKER_TOKEN=") {
+		t.Fatalf("agent env leaked tracker API key value:\n%s", body)
+	}
+}
+
+func TestAgentEnvUsesLoginShellPATHSnapshot(t *testing.T) {
+	env := agentEnvWithLookup(
+		nil,
+		workflow.Config{},
+		func(name string) (string, bool) {
+			if name == "PATH" {
+				return "/worker/path", true
+			}
+			return "", false
+		},
+		func() string { return "/login/path" },
+	)
+	body := strings.Join(env, "\n")
+	if !strings.Contains(body, "PATH=/login/path") {
+		t.Fatalf("agent env did not use login-shell PATH snapshot:\n%s", body)
+	}
+	if strings.Contains(body, "PATH=/worker/path") {
+		t.Fatalf("agent env used raw worker PATH instead of login-shell snapshot:\n%s", body)
 	}
 }
 

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -52,7 +52,7 @@ func applySandbox(ctx context.Context, in RunInput, cmd *exec.Cmd) (*exec.Cmd, e
 	if len(childArgs) == 0 {
 		return nil, fmt.Errorf("sandbox cannot wrap empty command")
 	}
-	env := scopedEnv(cfg.EnvAllowlist)
+	env := sandboxEnv(cmd.Env, cfg.EnvAllowlist, in.Workflow.Config)
 
 	switch cfg.Backend {
 	case "bubblewrap":
@@ -86,9 +86,20 @@ func ensurePathWithinRoot(path, root string) error {
 	return fmt.Errorf("workspace path %q is outside workspace root %q", path, root)
 }
 
-func scopedEnv(allow []string) []string {
+func scopedEnv(allow []string, cfg workflow.Config) []string {
+	return sandboxEnv(nil, allow, cfg)
+}
+
+func sandboxEnv(primary []string, allow []string, cfg workflow.Config) []string {
 	if len(allow) == 0 {
 		return []string{}
+	}
+	primaryByName := make(map[string]string, len(primary))
+	for _, envPair := range primary {
+		name, value, ok := strings.Cut(envPair, "=")
+		if ok && name != "" {
+			primaryByName[name] = value
+		}
 	}
 	seen := map[string]struct{}{}
 	var env []string
@@ -97,10 +108,17 @@ func scopedEnv(allow []string) []string {
 		if name == "" || strings.Contains(name, "=") {
 			continue
 		}
+		if workflow.AgentEnvPassthroughDenyReasonForConfig(name, cfg) != "" {
+			continue
+		}
 		if _, ok := seen[name]; ok {
 			continue
 		}
 		seen[name] = struct{}{}
+		if value, ok := primaryByName[name]; ok {
+			env = append(env, name+"="+value)
+			continue
+		}
 		if value, ok := os.LookupEnv(name); ok {
 			env = append(env, name+"="+value)
 		}

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -74,7 +74,7 @@ func TestSandboxBubblewrapBuildsWrappedCommandAndScopesEnvironment(t *testing.T)
 		Enabled:      true,
 		Backend:      "bubblewrap",
 		NetworkMode:  "none",
-		EnvAllowlist: []string{"AIOPS_RUN_TOKEN"},
+		EnvAllowlist: []string{"AIOPS_RUN_TOKEN", "GITHUB_TOKEN"},
 	}), base)
 	if err != nil {
 		t.Fatalf("applySandbox: %v", err)
@@ -88,11 +88,124 @@ func TestSandboxBubblewrapBuildsWrappedCommandAndScopesEnvironment(t *testing.T)
 			t.Fatalf("wrapped args missing %q in %#v", want, wrapped.Args)
 		}
 	}
+	if strings.Contains(joined, "GITHUB_TOKEN") {
+		t.Fatalf("wrapped args leaked denied credential: %#v", wrapped.Args)
+	}
 	for _, env := range wrapped.Env {
 		if strings.HasPrefix(env, "GITHUB_TOKEN=") {
 			t.Fatalf("sandbox env leaked non-allowlisted credential: %q", wrapped.Env)
 		}
 	}
+}
+
+func TestScopedEnvRejectsTrackerTokenNames(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "must-not-leak")
+	t.Setenv("AIOPS_RUN_TOKEN", "allowed-secret")
+
+	env := scopedEnv([]string{"AIOPS_RUN_TOKEN", "GITHUB_TOKEN"}, workflow.Config{})
+	if !envContains(env, "AIOPS_RUN_TOKEN=allowed-secret") {
+		t.Fatalf("scoped env missing allowed value: %q", env)
+	}
+	if envContains(env, "GITHUB_TOKEN=must-not-leak") {
+		t.Fatalf("scoped env leaked denied token name: %q", env)
+	}
+}
+
+func TestScopedEnvRejectsTrackerAPIKeyValue(t *testing.T) {
+	t.Setenv("AIOPS_TEST_TRACKER_TOKEN", "tracker-secret")
+
+	env := scopedEnv([]string{"AIOPS_TEST_TRACKER_TOKEN"}, workflow.Config{
+		Tracker: workflow.TrackerConfig{APIKey: "tracker-secret"},
+	})
+	if envContains(env, "AIOPS_TEST_TRACKER_TOKEN=tracker-secret") {
+		t.Fatalf("scoped env leaked tracker API key value: %q", env)
+	}
+}
+
+func TestSandboxEnvTreatsAllowlistAsFinalBoundary(t *testing.T) {
+	t.Setenv("AIOPS_RUNNER_CANARY", "from-worker-env")
+	t.Setenv("AIOPS_SANDBOX_CANARY", "from-sandbox-allowlist")
+
+	env := sandboxEnv(
+		[]string{"AIOPS_RUNNER_CANARY=from-runner-env", "AIOPS_BLOCKED_CANARY=blocked", "PATH=/agent/bin"},
+		[]string{"AIOPS_RUNNER_CANARY", "AIOPS_SANDBOX_CANARY"},
+		workflow.Config{},
+	)
+	if !envContains(env, "AIOPS_RUNNER_CANARY=from-runner-env") {
+		t.Fatalf("sandbox env missing allowlisted runner value: %q", env)
+	}
+	if envContains(env, "AIOPS_RUNNER_CANARY=from-worker-env") {
+		t.Fatalf("sandbox env used worker env instead of runner-scoped value: %q", env)
+	}
+	if !envContains(env, "AIOPS_SANDBOX_CANARY=from-sandbox-allowlist") {
+		t.Fatalf("sandbox env missing allowlisted worker value: %q", env)
+	}
+	if envContains(env, "AIOPS_BLOCKED_CANARY=blocked") || envContains(env, "PATH=/agent/bin") {
+		t.Fatalf("sandbox env leaked non-allowlisted runner values: %q", env)
+	}
+}
+
+func TestSandboxBubblewrapTreatsEnvAllowlistAsFinalBoundary(t *testing.T) {
+	requireLinuxSandboxHost(t)
+	binDir := t.TempDir()
+	bwrap := filepath.Join(binDir, "bwrap")
+	if err := os.WriteFile(bwrap, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AIOPS_SANDBOX_CANARY", "from-sandbox-allowlist")
+	t.Setenv("AIOPS_RUNNER_CANARY", "from-worker-env")
+
+	workdir := t.TempDir()
+	base := exec.CommandContext(context.Background(), "codex", "exec", "--cd", workdir)
+	base.Dir = workdir
+	base.Env = []string{"AIOPS_RUNNER_CANARY=from-runner-env", "AIOPS_BLOCKED_CANARY=blocked", "PATH=" + os.Getenv("PATH")}
+
+	wrapped, err := applySandbox(context.Background(), sandboxInput(t, workdir, workflow.SandboxConfig{
+		Enabled:      true,
+		Backend:      "bubblewrap",
+		NetworkMode:  "none",
+		EnvAllowlist: []string{"AIOPS_RUNNER_CANARY", "AIOPS_SANDBOX_CANARY"},
+	}), base)
+	if err != nil {
+		t.Fatalf("applySandbox: %v", err)
+	}
+	joined := strings.Join(wrapped.Args, "\x00")
+	for _, want := range []string{"--setenv", "AIOPS_RUNNER_CANARY", "from-runner-env", "AIOPS_SANDBOX_CANARY", "from-sandbox-allowlist"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("wrapped args missing %q in %#v", want, wrapped.Args)
+		}
+	}
+	for _, denied := range []string{"AIOPS_BLOCKED_CANARY", "PATH=" + os.Getenv("PATH")} {
+		if strings.Contains(joined, denied) {
+			t.Fatalf("wrapped args leaked non-allowlisted runner env %q in %#v", denied, wrapped.Args)
+		}
+	}
+	if !envContains(wrapped.Env, "AIOPS_RUNNER_CANARY=from-runner-env") {
+		t.Fatalf("wrapped Env missing runner-scoped env: %q", wrapped.Env)
+	}
+	if envContains(wrapped.Env, "AIOPS_RUNNER_CANARY=from-worker-env") {
+		t.Fatalf("wrapped Env used worker env instead of runner-scoped env: %q", wrapped.Env)
+	}
+	if envContains(wrapped.Env, "AIOPS_BLOCKED_CANARY=blocked") {
+		t.Fatalf("wrapped Env leaked non-allowlisted runner env: %q", wrapped.Env)
+	}
+	if !envContains(wrapped.Env, "AIOPS_SANDBOX_CANARY=from-sandbox-allowlist") {
+		t.Fatalf("wrapped Env missing sandbox allowlist env: %q", wrapped.Env)
+	}
+}
+
+func envContains(env []string, want string) bool {
+	for _, got := range env {
+		if got == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSandboxBubblewrapSkipsMissingLib64Bind(t *testing.T) {

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -32,8 +32,16 @@ func (r ShellRunner) Run(ctx context.Context, in RunInput) (Result, error) {
 	}
 
 	start := time.Now()
-	cmd := exec.CommandContext(ctx, "sh", "-lc", command+" < .aiops/PROMPT.md")
+	cmd := exec.CommandContext(ctx, "sh", "-c", command+" < .aiops/PROMPT.md")
 	cmd.Dir = in.Workdir
+	switch r.Name {
+	case "codex":
+		cmd.Env = agentEnv(in.Workflow.Config.Codex.EnvPassthrough, in.Workflow.Config)
+	case "claude":
+		cmd.Env = agentEnv(in.Workflow.Config.Claude.EnvPassthrough, in.Workflow.Config)
+	default:
+		cmd.Env = agentEnv(nil, in.Workflow.Config)
+	}
 	if err := validateAgentCommandWorkdir(in, cmd); err != nil {
 		return Result{}, err
 	}

--- a/internal/runner/shell_unix.go
+++ b/internal/runner/shell_unix.go
@@ -9,7 +9,7 @@ import (
 )
 
 // configurePlatformKill makes the shell runner survive SIGTERM-resistant
-// children (e.g. `sleep` under `sh -lc`). The runner runs in its own
+// children (e.g. `sleep` under `sh -c`). The runner runs in its own
 // process group so we can deliver signals to the entire group on
 // context cancel; otherwise WaitDelay would only kill `sh` and leave
 // grandchildren orphaned, blocking workspace cleanup.

--- a/internal/workflow/agent_env_policy.go
+++ b/internal/workflow/agent_env_policy.go
@@ -1,0 +1,44 @@
+package workflow
+
+import (
+	"os"
+	"strings"
+)
+
+var deniedAgentEnvPassthroughNames = map[string]struct{}{
+	"GH_TOKEN":        {},
+	"GITEA_API_TOKEN": {},
+	"GITEA_TOKEN":     {},
+	"GITHUB_PAT":      {},
+	"GITHUB_TOKEN":    {},
+	"LINEAR_API_KEY":  {},
+	"LINEAR_TOKEN":    {},
+}
+
+// AgentEnvPassthroughDenyReason returns a non-empty reason when an environment
+// variable name must not be exposed to agent subprocesses. Model-runtime
+// credentials such as OPENAI_API_KEY remain opt-in; tracker/repo API tokens
+// stay behind the orchestrator-owned tool/proxy boundary.
+func AgentEnvPassthroughDenyReason(name string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(name))
+	if _, denied := deniedAgentEnvPassthroughNames[normalized]; denied {
+		return "tracker/API token must stay behind orchestrator tools"
+	}
+	return ""
+}
+
+func AgentEnvPassthroughDenyReasonForConfig(name string, cfg Config) string {
+	name = strings.TrimSpace(name)
+	if reason := AgentEnvPassthroughDenyReason(name); reason != "" {
+		return reason
+	}
+	if cfg.Tracker.apiKeyEnvVar != "" && strings.EqualFold(name, cfg.Tracker.apiKeyEnvVar) {
+		return "tracker.api_key environment variable must stay behind orchestrator tools"
+	}
+	if cfg.Tracker.APIKey != "" {
+		if value, ok := os.LookupEnv(name); ok && value == cfg.Tracker.APIKey {
+			return "tracker.api_key value must stay behind orchestrator tools"
+		}
+	}
+	return ""
+}

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -93,8 +93,9 @@ type ServiceTrackerRouteConfig struct {
 }
 
 type TrackerConfig struct {
-	Kind   string `yaml:"kind" json:"kind"`
-	APIKey string `yaml:"api_key" json:"api_key"`
+	Kind         string `yaml:"kind" json:"kind"`
+	APIKey       string `yaml:"api_key" json:"api_key"`
+	apiKeyEnvVar string
 	// Endpoint is the tracker base/GraphQL URL (SPEC §5.3.1). For
 	// `kind: linear` the default is `https://api.linear.app/graphql`;
 	// GitHub Enterprise / Gitea installs name their REST root here.
@@ -360,6 +361,10 @@ func (a AgentConfig) PolicyViolationBudgetValue() int {
 
 type CommandConfig struct {
 	Command string `yaml:"command" json:"command"`
+	// EnvPassthrough names worker environment variables the agent subprocess may
+	// inherit in addition to the runner baseline. Tracker/repo API tokens stay
+	// behind orchestrator-owned tools and are rejected here.
+	EnvPassthrough []string `yaml:"env_passthrough,omitempty" json:"env_passthrough,omitempty"`
 	// Profile is consulted only by the codex runner. Allowed values: "safe"
 	// (default), "bypass", "custom". The field lives on the shared
 	// CommandConfig type to avoid splitting CodexConfig out for one field;

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -2542,3 +2542,132 @@ prompt
 		}
 	}
 }
+
+func TestLoadRejectsAgentEnvPassthroughTrackerTokens(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		envName    string
+		envValue   string
+		body       string
+		want       string
+		wantReason string
+	}{
+		{
+			name: "codex_linear_api_key",
+			body: `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+tracker:
+  kind: gitea
+codex:
+  env_passthrough:
+    - LINEAR_API_KEY
+---
+hello
+`,
+			want:       "codex.env_passthrough[0]",
+			wantReason: "tracker/API token",
+		},
+		{
+			name: "claude_github_token",
+			body: `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+tracker:
+  kind: gitea
+claude:
+  env_passthrough:
+    - GITHUB_TOKEN
+---
+hello
+`,
+			want:       "claude.env_passthrough[0]",
+			wantReason: "tracker/API token",
+		},
+		{
+			name:     "codex_tracker_api_key_source_env",
+			envName:  "AIOPS_TEST_TRACKER_TOKEN",
+			envValue: "tracker-secret",
+			body: `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+tracker:
+  kind: gitea
+  api_key: $AIOPS_TEST_TRACKER_TOKEN
+codex:
+  env_passthrough:
+    - AIOPS_TEST_TRACKER_TOKEN
+---
+hello
+`,
+			want:       "codex.env_passthrough[0]",
+			wantReason: "tracker.api_key environment variable",
+		},
+		{
+			name:     "sandbox_tracker_api_key_source_env",
+			envName:  "AIOPS_TEST_TRACKER_TOKEN",
+			envValue: "tracker-secret",
+			body: `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+tracker:
+  kind: gitea
+  api_key: $AIOPS_TEST_TRACKER_TOKEN
+sandbox:
+  enabled: true
+  backend: bubblewrap
+  env_allowlist:
+    - AIOPS_TEST_TRACKER_TOKEN
+---
+hello
+`,
+			want:       "sandbox.env_allowlist[0]",
+			wantReason: "tracker.api_key environment variable",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envName != "" {
+				t.Setenv(tc.envName, tc.envValue)
+			}
+			_, err := Load(writeTempWorkflow(t, tc.body))
+			if err == nil {
+				t.Fatal("Load succeeded, want denied env_passthrough error")
+			}
+			if !strings.Contains(err.Error(), tc.want) || !strings.Contains(err.Error(), tc.wantReason) {
+				t.Fatalf("Load error = %q, want %s %s guidance", err, tc.want, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestLoadedConfigRetainsTrackerAPIKeySourceEnv(t *testing.T) {
+	t.Setenv("AIOPS_TEST_TRACKER_TOKEN", "tracker-secret")
+	wf, err := Load(writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: n
+  clone_url: git@example.com:o/n.git
+tracker:
+  kind: gitea
+  api_key: $AIOPS_TEST_TRACKER_TOKEN
+---
+hello
+`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	t.Setenv("AIOPS_TEST_TRACKER_TOKEN", "rotated-secret")
+	reason := AgentEnvPassthroughDenyReasonForConfig("AIOPS_TEST_TRACKER_TOKEN", wf.Config)
+	if !strings.Contains(reason, "tracker.api_key environment variable") {
+		t.Fatalf("deny reason = %q, want tracker.api_key source env protection", reason)
+	}
+}

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -293,7 +293,7 @@ var supportedAgentDefaults = map[string]struct{}{
 // runner package knows how to dispatch. "safe" injects --sandbox
 // workspace-write + --skip-git-repo-check; "bypass" swaps in
 // --dangerously-bypass-approvals-and-sandbox for already-isolated hosts;
-// "custom" falls back to the operator-supplied codex.command via sh -lc.
+// "custom" falls back to the operator-supplied codex.command via sh -c.
 var supportedCodexProfiles = map[string]struct{}{
 	"safe":   {},
 	"bypass": {},
@@ -393,6 +393,12 @@ func validateConfig(path string, cfg Config) error {
 	if _, ok := supportedCodexProfiles[cfg.Codex.Profile]; !ok {
 		return fmt.Errorf("%s: codex.profile %q is not supported (allowed: safe, bypass, custom)", path, cfg.Codex.Profile)
 	}
+	if err := validateAgentEnvPassthrough(path, "codex", cfg.Codex.EnvPassthrough, cfg); err != nil {
+		return err
+	}
+	if err := validateAgentEnvPassthrough(path, "claude", cfg.Claude.EnvPassthrough, cfg); err != nil {
+		return err
+	}
 	if _, ok := supportedSandboxBackends[cfg.Sandbox.Backend]; !ok {
 		return fmt.Errorf("%s: sandbox.backend %q is not supported (allowed: none, bubblewrap, firejail)", path, cfg.Sandbox.Backend)
 	}
@@ -401,6 +407,9 @@ func validateConfig(path string, cfg Config) error {
 	}
 	if cfg.Sandbox.Enabled && len(cfg.Sandbox.EnvAllowlist) == 0 {
 		return fmt.Errorf("%s: sandbox.enabled requires sandbox.env_allowlist to explicitly scope child environment", path)
+	}
+	if err := validateAgentEnvExposure(path, "sandbox.env_allowlist", cfg.Sandbox.EnvAllowlist, cfg); err != nil {
+		return err
 	}
 	if _, ok := supportedSandboxNetworks[cfg.Sandbox.NetworkMode]; !ok {
 		return fmt.Errorf("%s: sandbox.network %q is not supported (allowed: none, allowlist)", path, cfg.Sandbox.NetworkMode)
@@ -494,6 +503,19 @@ func validateConfig(path string, cfg Config) error {
 	}
 	if len(invalid) > 0 {
 		return fmt.Errorf("%s: invalid codex app-server timeout settings: %s", path, strings.Join(invalid, ", "))
+	}
+	return nil
+}
+
+func validateAgentEnvPassthrough(path, section string, names []string, cfg Config) error {
+	return validateAgentEnvExposure(path, section+".env_passthrough", names, cfg)
+}
+
+func validateAgentEnvExposure(path, field string, names []string, cfg Config) error {
+	for i, name := range names {
+		if reason := AgentEnvPassthroughDenyReasonForConfig(name, cfg); reason != "" {
+			return fmt.Errorf("%s: %s[%d] %q is not allowed: %s", path, field, i, name, reason)
+		}
 	}
 	return nil
 }
@@ -643,6 +665,11 @@ func expandConfig(cfg *Config) error {
 
 func expandConfigForWorkflowPath(workflowPath string, cfg *Config) error {
 	var err error
+	if envName, ok := explicitEnvReferenceName(cfg.Tracker.APIKey); ok {
+		cfg.Tracker.apiKeyEnvVar = envName
+	} else {
+		cfg.Tracker.apiKeyEnvVar = ""
+	}
 	if cfg.Tracker.APIKey, err = resolveExplicitEnv("tracker.api_key", cfg.Tracker.APIKey); err != nil {
 		return err
 	}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -402,7 +402,7 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 	// Hook commands run under `sh -c` (not `-lc`) so the user's login
 	// profile is not re-sourced per command. The PATH that a login shell
 	// would build is captured once at startup and propagated via cmd.Env
-	// (see loginPATH in path_snapshot.go and #314). Without this split,
+	// (see LoginPATH in path_snapshot.go and #314). Without this split,
 	// every hook command captured the stdout of /etc/profile.d/* into
 	// HookResult.Output — surfaced to operators in runtime events and
 	// consumed by policy-feedback parsers.
@@ -498,7 +498,7 @@ func RunVerify(ctx context.Context, workdir string, wf workflow.Config) ([]Verif
 		buf := &cappedBuffer{Cap: VerifyOutputCap}
 		// `sh -c` (no `-l`): see runWorkspaceHookCommand and #314 for why
 		// the login flag was dropped. PATH inheritance is preserved via the
-		// loginPATH snapshot threaded through cmd.Env.
+		// LoginPATH snapshot threaded through cmd.Env.
 		cmd := exec.CommandContext(runCtx, "sh", "-c", command)
 		cmd.Dir = workdir
 		cmd.Env = env

--- a/internal/workspace/path_snapshot.go
+++ b/internal/workspace/path_snapshot.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// loginPATH returns the PATH value a login shell would expose to a subprocess,
+// LoginPATH returns the PATH value a login shell would expose to a subprocess,
 // captured once per process. Hooks and verify commands use it so they inherit
 // version-manager additions (nvm, rustup, pyenv, etc.) without paying the cost
 // — or the stdout-capture cost — of sourcing the login profile on every command.
@@ -20,7 +20,7 @@ import (
 // VerifyResult.Output. Snapshotting PATH once and running per-command shells
 // without `-l` keeps the PATH-inheritance contract while removing the per-command
 // profile-source side-effect.
-func loginPATH() string {
+func LoginPATH() string {
 	loginPATHOnce.Do(func() {
 		loginPATHCached = captureLoginPATH()
 	})

--- a/internal/workspace/subprocess_env.go
+++ b/internal/workspace/subprocess_env.go
@@ -41,7 +41,7 @@ func subprocessEnv(passthrough []string) []string {
 			// inherits version-manager additions (nvm, rustup, etc.) without
 			// sourcing the login profile per command — which would otherwise
 			// echo profile stdout into the hook/verify output buffer (#314).
-			if v := loginPATH(); v != "" {
+			if v := LoginPATH(); v != "" {
 				env = append(env, "PATH="+v)
 				return
 			}


### PR DESCRIPTION
Closes #384

## Acceptance
- Scope Codex, Codex app-server, and Claude/shell agent subprocess environments to a non-inheriting baseline plus explicit `codex.env_passthrough` / `claude.env_passthrough`.
- Reject tracker/repo token passthrough by static name, by the configured `tracker.api_key` source env var, and by matching the resolved tracker API key value.
- Apply the same deny policy to sandbox env allowlists while preserving runner-scoped env through bubblewrap/firejail wrappers.
- Remove login-shell execution for custom runner commands so `~/.profile` cannot reintroduce host env, and update docs/examples for the new explicit env contract.

## Validation
- `go test ./internal/runner ./internal/workflow`
- Mutation: disabling `agentEnv` deny logic made `TestAgentEnvRejectsTrackerAPIKeyValuePassthrough` fail; restored and passed.
- Mutation: disabling sandbox `scopedEnv` deny logic made token-deny sandbox tests fail; restored and passed.
- Mutation: removing loaded `tracker.api_key` source capture made `TestLoadedConfigRetainsTrackerAPIKeySourceEnv` fail; restored and passed.
- Mutation: reverting shell execution to `sh -lc` made `TestShellRunnerDoesNotSourceProfileByDefault` fail; restored and passed.
- `gofmt -l $(git ls-files '*.go')`\n- `go mod tidy && git diff --exit-code -- go.mod go.sum`\n- `go test -race -covermode=atomic ./...`\n- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`\n- Post-commit/pre-push review: Codex review clean; Claude Code review clean after verifying the safe-profile docs/code item against current/base `codex.go` and local `codex exec --help`.\n\n## Risk / Deferral\n- No deferrals. Existing deployments that depended on environment-based model credentials must opt in with the new env passthrough settings; tracker/repo API tokens remain denied.\n