### PR TITLE
fix(worker): honor gitea tracker endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ export LINEAR_API_KEY=your-linear-personal-key
 # uses project_slug: aiops-platform-abc123.
 
 # For tracker.kind: gitea
+# Set tracker.endpoint in WORKFLOW.md to the Gitea base URL.
 export GITEA_BASE_URL=https://gitea.example.com
 export GITEA_TOKEN=your-gitea-bot-token
 
@@ -258,6 +259,7 @@ from SPEC are called out and tracked in [`DEVIATIONS.md`](DEVIATIONS.md):
 | `policy.max_changed_files` | `12` | implementation |
 | `policy.max_changed_loc` | `300` | implementation |
 | `tracker.kind` | none — REQUIRED per SPEC §6.4; the loader rejects an empty value with an error that names the field and the allowed set (`gitea`, `github`, `linear`) | SPEC §6.4 |
+| `tracker.endpoint` | Linear defaults to `https://api.linear.app/graphql`; Gitea/GitHub use this as the REST API base URL, with env fallbacks only when omitted | SPEC §6.4 / implementation |
 | `tracker.project_slug` | required for `tracker.kind: linear` unless `services[]` routes define per-service project slugs | SPEC §6.4 |
 | `tracker.active_states` | `[Todo, In Progress]` | SPEC §6.4 |
 | `tracker.terminal_states` | `[Closed, Cancelled, Canceled, Duplicate, Done]` | SPEC §6.4 |

--- a/cmd/gitea-poller/main.go
+++ b/cmd/gitea-poller/main.go
@@ -158,10 +158,7 @@ func writeMetrics(w http.ResponseWriter, _ *http.Request, client *gitea.TrackerC
 }
 
 func giteaBaseURL(cfg workflow.TrackerConfig) string {
-	if cfg.ProjectSlug != "" {
-		return strings.TrimRight(cfg.ProjectSlug, "/")
-	}
-	return env("GITEA_BASE_URL", "http://localhost:3000")
+	return gitea.BaseURLFromTrackerConfig(cfg, env("GITEA_BASE_URL", "http://localhost:3000"))
 }
 
 func databaseURL() string {

--- a/cmd/gitea-poller/main_test.go
+++ b/cmd/gitea-poller/main_test.go
@@ -34,6 +34,36 @@ func TestDefaultDatabaseURLIsUsablePostgresDSN(t *testing.T) {
 	}
 }
 
+func TestGiteaBaseURLUsesEndpointBeforeProjectSlugAndEnv(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "https://gitea-env.example.test/")
+
+	got := giteaBaseURL(workflow.TrackerConfig{
+		Endpoint:    "https://gitea-endpoint.example.test/",
+		ProjectSlug: "https://gitea-legacy.example.test/",
+	})
+	if got != "https://gitea-endpoint.example.test" {
+		t.Fatalf("giteaBaseURL = %q, want tracker.endpoint without trailing slash", got)
+	}
+}
+
+func TestGiteaBaseURLUsesDeprecatedProjectSlugBeforeEnv(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "https://gitea-env.example.test/")
+
+	got := giteaBaseURL(workflow.TrackerConfig{ProjectSlug: "https://gitea-legacy.example.test/"})
+	if got != "https://gitea-legacy.example.test" {
+		t.Fatalf("giteaBaseURL = %q, want legacy tracker.project_slug without trailing slash", got)
+	}
+}
+
+func TestGiteaBaseURLUsesEnvFallbackWhenEndpointEmpty(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "https://gitea-env.example.test/")
+
+	got := giteaBaseURL(workflow.TrackerConfig{})
+	if got != "https://gitea-env.example.test" {
+		t.Fatalf("giteaBaseURL = %q, want GITEA_BASE_URL without trailing slash", got)
+	}
+}
+
 func TestProcessIssuesEnqueuesGiteaIssueTasks(t *testing.T) {
 	store := &fakeStore{}
 	cfg := &workflow.Config{

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1350,10 +1350,7 @@ func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error)
 		}
 		return multiTrackerRuntimeClient{trackers: clients}, nil
 	case "gitea":
-		baseURL := cfg.Tracker.ProjectSlug
-		if baseURL == "" {
-			baseURL = env("GITEA_BASE_URL", "http://localhost:3000")
-		}
+		baseURL := gitea.BaseURLFromTrackerConfig(cfg.Tracker, env("GITEA_BASE_URL", "http://localhost:3000"))
 		return gitea.NewTrackerClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name), nil
 	case "github":
 		baseURL := cfg.Tracker.Endpoint

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1543,11 +1543,12 @@ func TestTrackerClientForWorkflowBuildsMultiProjectLinearClientForServiceRoutes(
 	}
 }
 
-func TestTrackerClientForWorkflowUsesGiteaProjectSlugBeforeEnvBaseURL(t *testing.T) {
+func TestTrackerClientForWorkflowUsesGiteaEndpointBeforeProjectSlugAndEnvBaseURL(t *testing.T) {
 	t.Setenv("GITEA_BASE_URL", "https://gitea-env.example.test/")
 	cfg := workflow.DefaultConfig()
 	cfg.Tracker.Kind = "gitea"
-	cfg.Tracker.ProjectSlug = "https://gitea-workflow.example.test/"
+	cfg.Tracker.Endpoint = "https://gitea-endpoint.example.test/"
+	cfg.Tracker.ProjectSlug = "https://gitea-legacy.example.test/"
 	cfg.Repo.Owner = "owner"
 	cfg.Repo.Name = "repo"
 
@@ -1559,8 +1560,49 @@ func TestTrackerClientForWorkflowUsesGiteaProjectSlugBeforeEnvBaseURL(t *testing
 	if !ok {
 		t.Fatalf("client type = %T, want *gitea.TrackerClient", client)
 	}
-	if giteaClient.BaseURL != "https://gitea-workflow.example.test" {
-		t.Fatalf("base URL = %q, want tracker.project_slug without trailing slash", giteaClient.BaseURL)
+	if giteaClient.BaseURL != "https://gitea-endpoint.example.test" {
+		t.Fatalf("base URL = %q, want tracker.endpoint without trailing slash", giteaClient.BaseURL)
+	}
+}
+
+func TestTrackerClientForWorkflowUsesDeprecatedGiteaProjectSlugBeforeEnvBaseURL(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "https://gitea-env.example.test/")
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "gitea"
+	cfg.Tracker.ProjectSlug = "https://gitea-legacy.example.test/"
+	cfg.Repo.Owner = "owner"
+	cfg.Repo.Name = "repo"
+
+	client, err := trackerClientForWorkflow(cfg)
+	if err != nil {
+		t.Fatalf("tracker client: %v", err)
+	}
+	giteaClient, ok := client.(*gitea.TrackerClient)
+	if !ok {
+		t.Fatalf("client type = %T, want *gitea.TrackerClient", client)
+	}
+	if giteaClient.BaseURL != "https://gitea-legacy.example.test" {
+		t.Fatalf("base URL = %q, want legacy tracker.project_slug without trailing slash", giteaClient.BaseURL)
+	}
+}
+
+func TestTrackerClientForWorkflowUsesGiteaEnvFallbackWhenEndpointEmpty(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "https://gitea-env.example.test/")
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "gitea"
+	cfg.Repo.Owner = "owner"
+	cfg.Repo.Name = "repo"
+
+	client, err := trackerClientForWorkflow(cfg)
+	if err != nil {
+		t.Fatalf("tracker client: %v", err)
+	}
+	giteaClient, ok := client.(*gitea.TrackerClient)
+	if !ok {
+		t.Fatalf("client type = %T, want *gitea.TrackerClient", client)
+	}
+	if giteaClient.BaseURL != "https://gitea-env.example.test" {
+		t.Fatalf("base URL = %q, want GITEA_BASE_URL without trailing slash", giteaClient.BaseURL)
 	}
 }
 

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -37,7 +37,8 @@ needs Postgres, it is stale — file an issue.
 - `git` and `curl`.
 - Tracker credentials matching the workflow you're running:
   - `tracker.kind: linear` → a Linear personal API key.
-  - `tracker.kind: gitea` → a Gitea base URL and bot token.
+  - `tracker.kind: gitea` → a Gitea base URL in `tracker.endpoint`
+    and a bot token.
   - `tracker.kind: github` → a GitHub token (`gh auth token` works).
 - A scratch workspace root. `workspace.root` in `WORKFLOW.md` is the
   source of truth; `AIOPS_WORKSPACE_ROOT` (legacy alias `WORKSPACE_ROOT`)
@@ -104,9 +105,9 @@ export AIOPS_WORKSPACE_ROOT=$PWD/.aiops/workspaces
 export LINEAR_API_KEY=your-linear-personal-key
 
 # For tracker.kind: gitea
-# GITEA_BASE_URL is consumed at runtime as a base-URL fallback when
-# tracker.project_slug is empty; GITEA_TOKEN must be wired through
-# "api_key: $GITEA_TOKEN" in WORKFLOW.md to actually authenticate.
+# Prefer tracker.endpoint in WORKFLOW.md. GITEA_BASE_URL is only a runtime
+# base-URL fallback when tracker.endpoint is empty; GITEA_TOKEN must be wired
+# through "api_key: $GITEA_TOKEN" in WORKFLOW.md to actually authenticate.
 export GITEA_BASE_URL=https://gitea.example.com
 export GITEA_TOKEN=your-gitea-bot-token
 
@@ -367,7 +368,7 @@ config field is empty).
 | `tracker.kind` | `WORKFLOW.md` token reference | Base-URL env fallback |
 | --- | --- | --- |
 | `linear` | `tracker.api_key: $LINEAR_API_KEY` (or any `$VAR`) | n/a |
-| `gitea`  | `tracker.api_key: $GITEA_TOKEN`  (or any `$VAR`) | `GITEA_BASE_URL` when `tracker.project_slug` is empty |
+| `gitea`  | `tracker.api_key: $GITEA_TOKEN`  (or any `$VAR`) | `GITEA_BASE_URL` when `tracker.endpoint` is empty |
 | `github` | `tracker.api_key: $GITHUB_TOKEN` (or any `$VAR`) | `GITHUB_API_BASE_URL` when `tracker.endpoint` is empty |
 
 When the failure surfaces depends on how `tracker.api_key` is encoded

--- a/examples/gitea-WORKFLOW.md
+++ b/examples/gitea-WORKFLOW.md
@@ -7,7 +7,7 @@ repo:
 
 tracker:
   kind: gitea
-  project_slug: http://gitea.local
+  endpoint: http://gitea.local
   active_states:
     - AI Ready
     - Rework

--- a/internal/gitea/config.go
+++ b/internal/gitea/config.go
@@ -1,0 +1,19 @@
+package gitea
+
+import (
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// BaseURLFromTrackerConfig applies the Gitea tracker base URL precedence used
+// by the worker, legacy poller, and agent-side Gitea tools.
+func BaseURLFromTrackerConfig(cfg workflow.TrackerConfig, fallback string) string {
+	if endpoint := strings.TrimSpace(cfg.Endpoint); endpoint != "" {
+		return strings.TrimRight(endpoint, "/")
+	}
+	if legacy := strings.TrimSpace(cfg.ProjectSlug); legacy != "" {
+		return strings.TrimRight(legacy, "/")
+	}
+	return strings.TrimRight(strings.TrimSpace(fallback), "/")
+}

--- a/internal/gitea/config_test.go
+++ b/internal/gitea/config_test.go
@@ -1,0 +1,33 @@
+package gitea
+
+import (
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestBaseURLFromTrackerConfigUsesEndpointBeforeProjectSlugAndFallback(t *testing.T) {
+	got := BaseURLFromTrackerConfig(workflow.TrackerConfig{
+		Endpoint:    " https://gitea-endpoint.example.test/ ",
+		ProjectSlug: "https://gitea-legacy.example.test/",
+	}, "https://gitea-env.example.test/")
+	if got != "https://gitea-endpoint.example.test" {
+		t.Fatalf("BaseURLFromTrackerConfig = %q, want tracker.endpoint without trailing slash", got)
+	}
+}
+
+func TestBaseURLFromTrackerConfigUsesLegacyProjectSlugBeforeFallback(t *testing.T) {
+	got := BaseURLFromTrackerConfig(workflow.TrackerConfig{
+		ProjectSlug: " https://gitea-legacy.example.test/ ",
+	}, "https://gitea-env.example.test/")
+	if got != "https://gitea-legacy.example.test" {
+		t.Fatalf("BaseURLFromTrackerConfig = %q, want legacy tracker.project_slug without trailing slash", got)
+	}
+}
+
+func TestBaseURLFromTrackerConfigUsesFallbackWhenTrackerURLIsEmpty(t *testing.T) {
+	got := BaseURLFromTrackerConfig(workflow.TrackerConfig{}, " https://gitea-env.example.test/ ")
+	if got != "https://gitea-env.example.test" {
+		t.Fatalf("BaseURLFromTrackerConfig = %q, want fallback without trailing slash", got)
+	}
+}

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -567,7 +567,7 @@ func TestRuntimePollerCancelsHealthyProjectIssueDuringPartialPoll(t *testing.T) 
 func TestRuntimePollerDoesNotFanOutServiceProjectsForGitea(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Tracker.Kind = "gitea"
-	cfg.Tracker.ProjectSlug = "https://gitea.example.com"
+	cfg.Tracker.Endpoint = "https://gitea.example.com"
 	cfg.Services = []workflow.ServiceConfig{
 		{Name: "api", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "api-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "api", CloneURL: "git@example.com:acme/api.git", DefaultBranch: "main"}},
 		{Name: "web", Tracker: workflow.ServiceTrackerRouteConfig{ProjectSlug: "web-platform"}, Repo: workflow.RepoConfig{Owner: "acme", Name: "web", CloneURL: "git@example.com:acme/web.git", DefaultBranch: "main"}},
@@ -577,8 +577,8 @@ func TestRuntimePollerDoesNotFanOutServiceProjectsForGitea(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("tracker configs = %d, want one non-Linear tracker config", len(got))
 	}
-	if got[0].Tracker.ProjectSlug != "https://gitea.example.com" {
-		t.Fatalf("tracker project slug = %q, want original Gitea base URL", got[0].Tracker.ProjectSlug)
+	if got[0].Tracker.Endpoint != "https://gitea.example.com" {
+		t.Fatalf("tracker endpoint = %q, want original Gitea base URL", got[0].Tracker.Endpoint)
 	}
 }
 

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
@@ -274,8 +275,5 @@ func containsIssueLabelFold(labels []giteaIssueLabel, label string) bool {
 }
 
 func giteaBaseURLFromTracker(cfg workflow.TrackerConfig) string {
-	if cfg.ProjectSlug != "" {
-		return strings.TrimRight(cfg.ProjectSlug, "/")
-	}
-	return strings.TrimRight(os.Getenv("GITEA_BASE_URL"), "/")
+	return gitea.BaseURLFromTrackerConfig(cfg, os.Getenv("GITEA_BASE_URL"))
 }

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -74,9 +74,9 @@ func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
 	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
 		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo"},
 		Tracker: workflow.TrackerConfig{
-			Kind:        "gitea",
-			APIKey:      token,
-			ProjectSlug: "https://gitea.example.test/",
+			Kind:     "gitea",
+			APIKey:   token,
+			Endpoint: "https://gitea.example.test/",
 		},
 	}})
 
@@ -127,6 +127,42 @@ func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
 	body = bodies[1]
 	if strings.Contains(body, token) || !strings.Contains(body, "aiops/in-progress") {
 		t.Fatalf("unexpected request body: %s", body)
+	}
+}
+
+func TestDynamicToolsUseGiteaEndpointBeforeProjectSlugAndEnvBaseURL(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "http://127.0.0.1:1")
+	server := &fakeGiteaLabelServer{}
+	httpServer := httptest.NewServer(server.handler())
+	defer httpServer.Close()
+
+	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo"},
+		Tracker: workflow.TrackerConfig{
+			Kind:        "gitea",
+			APIKey:      "token",
+			Endpoint:    httpServer.URL + "/",
+			ProjectSlug: "http://127.0.0.1:1",
+		},
+	}})
+	tool, ok := tools.Lookup("gitea_issue_labels")
+	if !ok {
+		t.Fatalf("gitea_issue_labels tool not advertised; tools=%#v", tools.Names())
+	}
+
+	result, err := tool.Call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/in-progress"}})
+	if err != nil {
+		t.Fatalf("gitea_issue_labels call: %v", err)
+	}
+	if !strings.Contains(result, `"success":true`) {
+		t.Fatalf("result = %q, want success from endpoint-backed Gitea server", result)
+	}
+	_, _, path, _, requests := server.recorded()
+	if requests != 3 {
+		t.Fatalf("requests = %d, want endpoint server to receive GET, POST, DELETE", requests)
+	}
+	if !strings.HasPrefix(path, "/api/v1/repos/owner/repo/issues/7/labels") {
+		t.Fatalf("path = %q, want endpoint-backed Gitea label request", path)
 	}
 }
 

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -168,10 +168,11 @@ func DynamicToolsForWorkflow(wf workflow.Workflow) DynamicToolSet {
 		}
 		tools.tools["linear_ai_workpad"] = NewLinearWorkpadTool(harnessTool)
 	}
-	if strings.EqualFold(trackerCfg.Kind, "gitea") && trackerCfg.APIKey != "" && wf.Config.Repo.Owner != "" && wf.Config.Repo.Name != "" && giteaBaseURLFromTracker(trackerCfg) != "" {
+	giteaBaseURL := giteaBaseURLFromTracker(trackerCfg)
+	if strings.EqualFold(trackerCfg.Kind, "gitea") && trackerCfg.APIKey != "" && wf.Config.Repo.Owner != "" && wf.Config.Repo.Name != "" && giteaBaseURL != "" {
 		client := giteaIssueLabelsProxy{
 			token:   trackerCfg.APIKey,
-			baseURL: giteaBaseURLFromTracker(trackerCfg),
+			baseURL: giteaBaseURL,
 			owner:   wf.Config.Repo.Owner,
 			repo:    wf.Config.Repo.Name,
 			http:    http.DefaultClient,

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -168,6 +168,7 @@ func Load(path string) (*Workflow, error) {
 		}
 		migratePollingInterval(frontBytes, &cfg)
 		migrateTrackerEndpoint(frontBytes, &cfg)
+		migrateGiteaTrackerProjectSlug(frontBytes, &cfg)
 	}
 	var rawStateCaps map[string]int
 	if hasFrontMatter && len(cfg.Agent.MaxConcurrentAgentsByState) > 0 {
@@ -229,6 +230,24 @@ func migrateTrackerEndpoint(frontBytes []byte, cfg *Config) {
 		cfg.Tracker.Endpoint = cfg.Tracker.BaseURL
 	}
 	cfg.Tracker.BaseURL = ""
+}
+
+func migrateGiteaTrackerProjectSlug(frontBytes []byte, cfg *Config) {
+	if !strings.EqualFold(cfg.Tracker.Kind, "gitea") {
+		return
+	}
+	legacyPresent := hasNestedKey(frontBytes, "tracker", "project_slug")
+	if !legacyPresent {
+		return
+	}
+	switch {
+	case strings.TrimSpace(cfg.Tracker.Endpoint) != "":
+		log.Printf("workflow: tracker.project_slug is ignored for Gitea because tracker.endpoint is already set")
+	case strings.TrimSpace(cfg.Tracker.ProjectSlug) != "":
+		log.Printf("workflow: tracker.project_slug is deprecated as a Gitea base URL; use tracker.endpoint")
+		cfg.Tracker.Endpoint = cfg.Tracker.ProjectSlug
+	}
+	cfg.Tracker.ProjectSlug = ""
 }
 
 func migratePollingInterval(frontBytes []byte, cfg *Config) {

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -198,6 +198,80 @@ prompt body
 	}
 }
 
+func TestLoadMigratesGiteaProjectSlugBaseURLToEndpoint(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  kind: gitea
+  project_slug: https://gitea.example/legacy
+---
+prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Tracker.Endpoint; got != "https://gitea.example/legacy" {
+		t.Fatalf("Tracker.Endpoint = %q, want legacy Gitea project_slug migrated to endpoint", got)
+	}
+	if wf.Config.Tracker.ProjectSlug != "" {
+		t.Fatalf("Tracker.ProjectSlug = %q, want cleared after Gitea migration", wf.Config.Tracker.ProjectSlug)
+	}
+}
+
+func TestLoadPrefersGiteaEndpointOverProjectSlugBaseURL(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  kind: gitea
+  endpoint: https://gitea.example/canonical
+  project_slug: https://gitea.example/legacy
+---
+prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Tracker.Endpoint; got != "https://gitea.example/canonical" {
+		t.Fatalf("Tracker.Endpoint = %q, want tracker.endpoint to win over legacy Gitea project_slug", got)
+	}
+	if wf.Config.Tracker.ProjectSlug != "" {
+		t.Fatalf("Tracker.ProjectSlug = %q, want cleared after Gitea migration", wf.Config.Tracker.ProjectSlug)
+	}
+}
+
+func TestLoadPrefersLegacyBaseURLOverGiteaProjectSlugBaseURL(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+tracker:
+  kind: gitea
+  base_url: https://gitea.example/base-url
+  project_slug: https://gitea.example/project-slug
+---
+prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Tracker.Endpoint; got != "https://gitea.example/base-url" {
+		t.Fatalf("Tracker.Endpoint = %q, want legacy base_url to win over legacy Gitea project_slug", got)
+	}
+	if wf.Config.Tracker.ProjectSlug != "" {
+		t.Fatalf("Tracker.ProjectSlug = %q, want cleared after Gitea migration", wf.Config.Tracker.ProjectSlug)
+	}
+}
+
 func TestLoadResolvesExactEnvironmentReferences(t *testing.T) {
 	workspaceRoot := filepath.Join(t.TempDir(), "workspaces")
 	credentialPath := filepath.Join(t.TempDir(), "token")


### PR DESCRIPTION
Closes #386

## Acceptance
- Gitea worker tracker runtime now resolves the base URL from `tracker.endpoint` first, then legacy Gitea `tracker.project_slug`, then `GITEA_BASE_URL` fallback.
- The legacy `cmd/gitea-poller` path and agent-side `gitea_issue_labels` dynamic tool use the same shared Gitea base URL helper.
- WORKFLOW loading migrates legacy Gitea `tracker.project_slug` into `tracker.endpoint`, preserves migrated `tracker.base_url` over `project_slug`, and clears the Gitea `ProjectSlug` field so print-config shows one source of truth.
- README, local-dev runbook, and `examples/gitea-WORKFLOW.md` now document `tracker.endpoint` for Gitea.

## Validation
- `go test ./internal/workflow ./internal/gitea ./cmd/gitea-poller ./cmd/worker ./internal/runner ./internal/orchestrator`
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- Mutation check: reversing shared endpoint/project_slug precedence fails `internal/gitea`, `cmd/gitea-poller`, `cmd/worker`, and `internal/runner` endpoint tests; restored implementation passes.
- Mutation check: reintroducing the `base_url` + Gitea `project_slug` clobber fails `TestLoadPrefersLegacyBaseURLOverGiteaProjectSlugBaseURL`; restored implementation passes.
- Post-commit/pre-push Codex review: clean after P2 fix.
- Post-commit/pre-push Claude Code review: approve, no HIGH/MEDIUM blockers after P2 fix.

## Risk / Deferral
- No deferrals. Legacy Gitea `tracker.project_slug` remains as a direct-construction fallback for compatibility, but loaded Gitea workflows normalize to `tracker.endpoint`.
