### PR TITLE
ci(release): pin release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/scripts/release_workflow_test.go
+++ b/scripts/release_workflow_test.go
@@ -1,0 +1,37 @@
+package scripts
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestReleaseWorkflowPinsGitHubActionsBySHA(t *testing.T) {
+	body, err := os.ReadFile("../.github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("ReadFile(release.yml): %v", err)
+	}
+
+	actionUse := regexp.MustCompile(`uses:\s+(actions/[A-Za-z0-9_.-]+)@(.+)`)
+	pinned := regexp.MustCompile(`^[0-9a-f]{40}\s+#\s+v[0-9]+(?:\s|$)`)
+	seen := map[string]bool{}
+	for _, line := range strings.Split(string(body), "\n") {
+		match := actionUse.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		seen[match[1]] = true
+		if strings.HasPrefix(match[2], "v") {
+			t.Fatalf("release workflow uses floating action tag: %s", strings.TrimSpace(line))
+		}
+		if !pinned.MatchString(match[2]) {
+			t.Fatalf("release workflow action is not pinned to SHA with version comment: %s", strings.TrimSpace(line))
+		}
+	}
+	for _, name := range []string{"actions/checkout", "actions/setup-go"} {
+		if !seen[name] {
+			t.Fatalf("release workflow missing %s action", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #390

## Acceptance
- Release workflow now pins actions/checkout and actions/setup-go to full upstream SHAs with v6 comments, matching the CI pinning style.
- Dependabot already manages github-actions updates via .github/dependabot.yml.
- Added a scripts package regression test that fails if release workflow actions use floating tags instead of SHA pins.

## Validation
- go test ./scripts
- Mutation check: temporarily changed checkout back to actions/checkout@v6; go test ./scripts failed; restored and passed.
- gofmt -l $(git ls-files '*.go')
- go mod tidy && git diff --exit-code -- go.mod go.sum
- go test -race -covermode=atomic ./...
- go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller
- Post-commit/pre-push Claude Code review: clean.
- Post-commit/pre-push Codex review: clean.
- Verified upstream tags with git ls-remote: checkout v6 -> de0fac2e4500dabe0009e67214ff5f5447ce83dd; setup-go v6 -> 4a3601121dd01d1626a1e23e37211e3254c1c06c.

## Risk / Deferral
- No deferrals. Further release hardening such as checksums/SBOM/signing remains outside this PR unless a follow-up issue asks for it.