### PR TITLE
fix(worker): reject oversized refresh bodies

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -741,7 +741,10 @@ type stateRefreshFunc func(context.Context) (orchestrator.RefreshRequestResult, 
 const (
 	refreshRequestHeader      = "X-AIOPS-Refresh"
 	refreshRequestHeaderValue = "true"
+	refreshBodyLimitBytes     = 1 << 20
 )
+
+var errRefreshBodyTooLarge = errors.New("refresh request body exceeds 1 MiB")
 
 func optionalStateRefreshFunc(refresh []stateRefreshFunc) stateRefreshFunc {
 	if len(refresh) == 0 {
@@ -950,6 +953,10 @@ func refreshHTTPHandler(refresh stateRefreshFunc) http.Handler {
 			return
 		}
 		if err := validateRefreshBody(r); err != nil {
+			if errors.Is(err, errRefreshBodyTooLarge) {
+				writeAPIError(w, http.StatusRequestEntityTooLarge, "refresh_body_too_large", err.Error())
+				return
+			}
 			writeAPIError(w, http.StatusBadRequest, "invalid_refresh_body", err.Error())
 			return
 		}
@@ -1005,9 +1012,15 @@ func validateRefreshBody(r *http.Request) error {
 	if r.Body == nil {
 		return nil
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if r.ContentLength > refreshBodyLimitBytes {
+		return errRefreshBodyTooLarge
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, refreshBodyLimitBytes+1))
 	if err != nil {
 		return err
+	}
+	if len(body) > refreshBodyLimitBytes {
+		return errRefreshBodyTooLarge
 	}
 	bodyText := strings.TrimSpace(string(body))
 	if bodyText == "" {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -772,6 +772,105 @@ func TestRefreshHTTPHandlerRejectsUnsupportedBodies(t *testing.T) {
 	}
 }
 
+func TestRefreshHTTPHandlerAcceptsLimitSizedBodies(t *testing.T) {
+	calls := 0
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, nil
+	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
+		calls++
+		return orchestrator.RefreshRequestResult{Queued: true, RequestedAt: time.Date(2026, 5, 25, 12, 30, 0, 0, time.UTC)}, nil
+	})
+
+	for _, tc := range []struct {
+		name               string
+		body               string
+		forceUnknownLength bool
+		wantContentLength  int64
+	}{
+		{
+			name:              "known length",
+			body:              "{}" + strings.Repeat(" ", refreshBodyLimitBytes-2),
+			wantContentLength: int64(refreshBodyLimitBytes),
+		},
+		{
+			name:               "unknown length",
+			body:               "{}" + strings.Repeat(" ", refreshBodyLimitBytes-2),
+			forceUnknownLength: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", strings.NewReader(tc.body))
+			req.Header.Set(refreshRequestHeader, refreshRequestHeaderValue)
+			if tc.forceUnknownLength {
+				req.ContentLength = -1
+			} else if req.ContentLength != tc.wantContentLength {
+				t.Fatalf("ContentLength = %d, want %d", req.ContentLength, tc.wantContentLength)
+			}
+			resp := httptest.NewRecorder()
+			server.Handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusAccepted {
+				t.Fatalf("status code = %d, want %d; response=%s", resp.Code, http.StatusAccepted, resp.Body.String())
+			}
+		})
+	}
+	if calls != 2 {
+		t.Fatalf("refresh calls = %d, want 2", calls)
+	}
+}
+
+func TestRefreshHTTPHandlerRejectsOversizedBodies(t *testing.T) {
+	called := false
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, nil
+	}, func(context.Context) (orchestrator.RefreshRequestResult, error) {
+		called = true
+		return orchestrator.RefreshRequestResult{}, nil
+	})
+
+	for _, tc := range []struct {
+		name               string
+		body               string
+		forceUnknownLength bool
+		wantContentLength  int64
+	}{
+		{
+			name:              "known length",
+			body:              "{}" + strings.Repeat(" ", refreshBodyLimitBytes-1),
+			wantContentLength: int64(refreshBodyLimitBytes + 1),
+		},
+		{
+			name:               "unknown length",
+			body:               "{}" + strings.Repeat(" ", refreshBodyLimitBytes-1),
+			forceUnknownLength: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000/api/v1/refresh", strings.NewReader(tc.body))
+			req.Header.Set(refreshRequestHeader, refreshRequestHeaderValue)
+			if tc.forceUnknownLength {
+				req.ContentLength = -1
+			} else if req.ContentLength != tc.wantContentLength {
+				t.Fatalf("ContentLength = %d, want %d", req.ContentLength, tc.wantContentLength)
+			}
+			resp := httptest.NewRecorder()
+			server.Handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("status code = %d, want %d; response=%s", resp.Code, http.StatusRequestEntityTooLarge, resp.Body.String())
+			}
+			var payload apiErrorResponse
+			if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("decode error response: %v; body=%s", err, resp.Body.String())
+			}
+			if payload.Error.Code != "refresh_body_too_large" {
+				t.Fatalf("error code = %q, want refresh_body_too_large", payload.Error.Code)
+			}
+		})
+	}
+	if called {
+		t.Fatal("refresh function should not be called for oversized bodies")
+	}
+}
+
 func TestStateHTTPServerRejectsNonLoopbackHost(t *testing.T) {
 	called := false
 	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {


### PR DESCRIPTION
Closes #393

## Acceptance
- /api/v1/refresh now rejects request bodies larger than 1 MiB with HTTP 413 and error code refresh_body_too_large.
- Known Content-Length bodies over the limit are rejected before body parsing; unknown/chunked bodies read at most limit+1 bytes before returning 413.
- Empty bodies, valid `{}`, and exactly-1MiB padded `{}` bodies still follow the existing accepted refresh path.
- Added regression coverage for N and N+1 boundaries across known and unknown Content-Length requests.

## Validation
- go test ./cmd/worker -run 'TestRefreshHTTPHandler(AcceptsLimitSizedBodies|RejectsOversizedBodies)' -count=1
- Mutation check: changed the boundary comparisons to >=; TestRefreshHTTPHandlerAcceptsLimitSizedBodies failed; restored and passed.
- Mutation check: changed LimitReader(limit+1) back to LimitReader(limit); TestRefreshHTTPHandlerRejectsOversizedBodies/unknown_length failed; restored and passed.
- gofmt -l $(git ls-files '*.go')
- go mod tidy && git diff --exit-code -- go.mod go.sum
- go test -race -covermode=atomic ./...
- go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller
- Post-commit/pre-push Claude Code review: clean (LOW non-blocking message/constant duplication note only).
- Post-commit/pre-push Codex review: clean.

## Risk / Deferral
- No deferrals. This is scoped to the worker state HTTP refresh endpoint; no tracker or runner behavior changes.