### PR TITLE
fix(tracker): degrade pagination cap hits by collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ from SPEC are called out and tracked in [`DEVIATIONS.md`](DEVIATIONS.md):
 | `tracker.project_slug` | required for `tracker.kind: linear` unless `services[]` routes define per-service project slugs | SPEC §6.4 |
 | `tracker.active_states` | `[Todo, In Progress]` | SPEC §6.4 |
 | `tracker.terminal_states` | `[Closed, Cancelled, Canceled, Duplicate, Done]` | SPEC §6.4 |
+| `tracker.pagination_max_pages` | adapter default (`github`: 10 pages; `gitea`: 20 pages; `linear`: uncapped cursor walk) | implementation |
 | `workspace.root` | `<system-temp>/symphony_workspaces` (resolved via `os.TempDir()` at startup, typically `/tmp/symphony_workspaces` on Linux; per-boot — set explicitly to a long-lived path for persistence) | SPEC §6.4 |
 | `verify.commands` | none | implementation |
 

--- a/cmd/gitea-poller/main.go
+++ b/cmd/gitea-poller/main.go
@@ -152,7 +152,7 @@ func startMetricsServer(addr string, client *gitea.TrackerClient) {
 
 func writeMetrics(w http.ResponseWriter, _ *http.Request, client *gitea.TrackerClient) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	fmt.Fprintf(w, "# HELP aiops_gitea_issue_pagination_cap_hits_total Gitea issue listings capped after %d pages.\n", gitea.ListIssuesMaxPages())
+	fmt.Fprintf(w, "# HELP aiops_gitea_issue_pagination_cap_hits_total Gitea issue listings capped after %d pages.\n", client.IssueMaxPages())
 	fmt.Fprintln(w, "# TYPE aiops_gitea_issue_pagination_cap_hits_total counter")
 	fmt.Fprintf(w, "aiops_gitea_issue_pagination_cap_hits_total %d\n", client.PaginationCapHits())
 }

--- a/cmd/gitea-poller/main_test.go
+++ b/cmd/gitea-poller/main_test.go
@@ -119,8 +119,8 @@ func TestGiteaMetricsHandlerExposesPaginationCapHits(t *testing.T) {
 	client := gitea.NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 	client.Logf = func(string, ...any) {}
-	if _, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"}); err == nil || !strings.Contains(err.Error(), "gitea issue pagination exceeded") {
-		t.Fatalf("ListIssuesByStates err = %v, want pagination overflow error", err)
+	if _, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"}); err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1364,13 +1364,17 @@ func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error)
 		return multiTrackerRuntimeClient{trackers: clients}, nil
 	case "gitea":
 		baseURL := gitea.BaseURLFromTrackerConfig(cfg.Tracker, env("GITEA_BASE_URL", "http://localhost:3000"))
-		return gitea.NewTrackerClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name), nil
+		client := gitea.NewTrackerClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name)
+		client.Logf = log.Printf
+		return client, nil
 	case "github":
 		baseURL := cfg.Tracker.Endpoint
 		if baseURL == "" {
 			baseURL = env("GITHUB_API_BASE_URL", "https://api.github.com")
 		}
-		return tracker.NewGitHubClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name), nil
+		client := tracker.NewGitHubClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name)
+		client.Logf = log.Printf
+		return client, nil
 	default:
 		return nil, tracker.NewError(tracker.CategoryUnsupportedTrackerKind, fmt.Sprintf("unsupported tracker.kind %q", cfg.Tracker.Kind), nil)
 	}

--- a/docs/runbooks/github-local-automation.md
+++ b/docs/runbooks/github-local-automation.md
@@ -179,9 +179,12 @@ The local state roots are:
   Read or write errors for these files are also non-retryable, because failing
   open would disable the stop-after counter.
 
-GitHub tracker pagination is fail-closed: if issue or open-PR pagination
-exceeds the configured scan cap, the poll returns an error instead of acting on
-a truncated issue set.
+GitHub tracker pagination is label/state-scoped: if issue pagination exceeds
+`tracker.pagination_max_pages`, that label/state scan is skipped, a cap-hit
+diagnostic is logged, and the remaining configured states continue. If the
+open-PR claim scan exceeds the same cap, the worker logs the cap hit and skips
+open/all issue collections for that tick so it does not dispatch issues that
+may already be claimed by a PR beyond the scan window.
 
 Per-tick state refresh (SPEC §8.5 Part B) for already-running GitHub issues
 issues one `GET /repos/{owner}/{repo}/issues/{number}` per running issue,

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -316,9 +316,11 @@ the agent tool surface, not the poller. Default state labels:
 | `Done` | `aiops/done` |
 | `Canceled` | `aiops/canceled` |
 
-Gitea issue listing is capped at 20 pages of 50 issues per state label
-(1000 issues). When the `+1` probe page proves more issues exist, the
-poller keeps running with the capped result set and increments
+Gitea issue listing is capped at 20 pages of 50 issues per state label by
+default (1000 issues). Override the page budget with
+`tracker.pagination_max_pages` when a repository legitimately needs more. When
+the `+1` probe page proves more issues exist, the poller skips that state label,
+continues the remaining labels, and increments
 `aiops_gitea_issue_pagination_cap_hits_total`. Expose the counter via
 `GITEA_POLLER_METRICS_ADDR`:
 

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -249,35 +249,42 @@ Each entry in the `running` array follows SPEC §13.7.2:
 Both the GitHub adapter (`internal/tracker/github.go`) and the Gitea adapter
 (`internal/gitea/tracker_client.go`) cap label-scoped issue listing at a
 small number of pages so a pathological repository cannot spend the worker
-on a single tracker call. When the cap is reached and the next page is
-still non-empty (or carries a `Link: rel="next"` header), the adapter:
+on a single tracker call. The cap is configurable with
+`tracker.pagination_max_pages`; `0` or an omitted value keeps the adapter
+default. When the cap is reached and the next page is still non-empty (or
+carries a `Link: rel="next"` header), the adapter:
 
 1. increments `PaginationCapHits()` so the metric surfaces in operator
    dashboards;
 2. logs `… issue pagination exceeded N pages for label "<label>" …`;
-3. returns an error from `ListIssuesByStates` / `ListActiveIssues`.
+3. skips the overflowing label/state collection and continues the rest of the
+   tracker poll.
+
+For GitHub, an overflowing open-PR claim scan makes open/all issue collections
+unsafe for that tick because later PR pages may already claim those issues. The
+adapter logs the cap hit, skips those open/all collections, and still returns
+any complete collections that do not depend on open-PR claim suppression.
 
 The worker's multi-tracker aggregator (`cmd/worker/main.go`,
 `multiTrackerRuntimeClient`) joins per-tracker errors via `errors.Join` and
-continues with the other trackers' results, so an overflow on one tracker
-does not stop a Linear/GitHub tracker on the same poll tick — but the
-per-tick error is still reported and the affected tracker's candidate set
-is empty for that tick.
+continues with the other trackers' results. Pagination cap hits are now
+handled inside the GitHub/Gitea adapters before they reach the aggregator, so
+one oversized state label no longer empties the whole tracker result set.
 
 ### Triage
 
-If you see this error in a poll tick:
+If you see this diagnostic in a poll tick log:
 
-- Identify the label from the error message (`label "<label>"`).
+- Identify the label from the log line (`label "<label>"`).
 - Check the tracker for the count of issues currently carrying that label.
   If it exceeds the cap (Gitea: 1000 = 20 pages × 50/page; GitHub:
   similarly bounded), the project genuinely has too many active issues for
   the worker's cap to enumerate in one tick.
 - Either reduce the active set on the tracker (move terminal issues out of
-  active states) or, if the cap is wrong for your scale, raise the
-  constant (`listIssuesMaxPages` / `githubMaxIssuePages`) in a follow-up
-  PR — do not silence the error.
+  active states) or raise `tracker.pagination_max_pages` after estimating the
+  API cost for your repository size.
 
 Gitea previously returned a silently capped slice in this scenario, so
 workers missed dispatchable issues beyond the cap. #225 aligned Gitea with
-the GitHub adapter's fail-loud semantics.
+the GitHub adapter's observable cap-hit semantics; #387 keeps the signal but
+limits the blast radius to the overflowing label/state.

--- a/examples/gitea-WORKFLOW.md
+++ b/examples/gitea-WORKFLOW.md
@@ -8,6 +8,9 @@ repo:
 tracker:
   kind: gitea
   endpoint: http://gitea.local
+  # Optional: raise this for large Gitea repositories. A cap hit skips only the
+  # overflowing aiops/* state label and logs the diagnostic.
+  # pagination_max_pages: 25
   active_states:
     - AI Ready
     - Rework

--- a/examples/github-local-WORKFLOW.md
+++ b/examples/github-local-WORKFLOW.md
@@ -11,6 +11,9 @@ tracker:
   # GitHub tracker states map to issue labels unless the state is open/closed/all.
   # This queue processes priority-labeled open issues first, then any remaining
   # open issues that have not been triaged with a priority label yet.
+  # Optional: raise this for very large repositories. A cap hit skips only the
+  # overflowing state/label scan and logs the diagnostic.
+  # pagination_max_pages: 25
   active_states:
     - priority:p1
     - priority:p2

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -22,10 +22,6 @@ const (
 	listIssuesMaxPages = 20
 )
 
-func ListIssuesMaxPages() int {
-	return listIssuesMaxPages
-}
-
 // Issue is the subset of Gitea's issue JSON used by the tracker reader.
 type Issue struct {
 	ID        int64   `json:"id"`
@@ -76,6 +72,13 @@ func (c *TrackerClient) PaginationCapHits() int64 {
 	return c.paginationCapHits.Load()
 }
 
+func (c *TrackerClient) IssueMaxPages() int {
+	if c != nil && c.Config.PaginationMaxPages > 0 {
+		return c.Config.PaginationMaxPages
+	}
+	return listIssuesMaxPages
+}
+
 func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string) ([]tracker.Issue, error) {
 	if c.BaseURL == "" || c.Token == "" {
 		return nil, fmt.Errorf("GITEA_BASE_URL and Gitea tracker api_key are required")
@@ -93,12 +96,19 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	var out []tracker.Issue
 	seenIssues := map[string]struct{}{}
 	if len(labelNames) == 0 {
-		return c.listIssuesByStateLabel(ctx, "", issueState, wantedStates, seenIssues)
+		issues, _, err := c.listIssuesByStateLabel(ctx, "", issueState, wantedStates, seenIssues)
+		return issues, err
 	}
 	for _, labelName := range labelNames {
-		issues, err := c.listIssuesByStateLabel(ctx, labelName, issueState, wantedStates, seenIssues)
+		issues, capped, err := c.listIssuesByStateLabel(ctx, labelName, issueState, wantedStates, seenIssues)
 		if err != nil {
 			return nil, err
+		}
+		if capped {
+			continue
+		}
+		for _, issue := range issues {
+			seenIssues[issue.ID] = struct{}{}
 		}
 		out = append(out, issues...)
 	}
@@ -152,23 +162,32 @@ func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []st
 	return states, nil
 }
 
-func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, issueState string, wantedStates map[string]struct{}, seenIssues map[string]struct{}) ([]tracker.Issue, error) {
+func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, issueState string, wantedStates map[string]struct{}, seenIssues map[string]struct{}) ([]tracker.Issue, bool, error) {
 	var out []tracker.Issue
-	for page := 1; page <= listIssuesMaxPages+1; page++ {
+	collectionSeen := make(map[string]struct{}, len(seenIssues))
+	for id := range seenIssues {
+		collectionSeen[id] = struct{}{}
+	}
+	maxPages := c.IssueMaxPages()
+	scope := labelName
+	if scope == "" {
+		scope = issueState
+	}
+	for page := 1; page <= maxPages+1; page++ {
 		batch, hasNext, err := c.listIssuesPage(ctx, labelName, issueState, page)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		if page > listIssuesMaxPages {
+		if page > maxPages {
 			if !hasNext && len(batch) == 0 {
-				return out, nil
+				return out, false, nil
 			}
-			c.recordPaginationCapHit(labelName)
-			return nil, fmt.Errorf("gitea issue pagination exceeded %d pages for label %q", listIssuesMaxPages, labelName)
+			c.recordPaginationCapHit(scope, maxPages)
+			return nil, true, nil
 		}
 		for _, issue := range batch {
 			issueKey := giteaIssueID(issue)
-			if _, ok := seenIssues[issueKey]; ok {
+			if _, ok := collectionSeen[issueKey]; ok {
 				continue
 			}
 			c.cacheIssueNumber(issue)
@@ -184,13 +203,13 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 			}
 			createdAt, err := parseGiteaIssueTime("created_at", issue.CreatedAt)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			updatedAt, err := parseGiteaIssueTime("updated_at", issue.UpdatedAt)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
-			seenIssues[issueKey] = struct{}{}
+			collectionSeen[issueKey] = struct{}{}
 			out = append(out, tracker.Issue{
 				ID:          issueKey,
 				Identifier:  fmt.Sprintf("#%d", issue.Number),
@@ -210,16 +229,16 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 			})
 		}
 		if !hasNext && len(batch) < listIssuesPageSize {
-			return out, nil
+			return out, false, nil
 		}
 	}
-	return nil, fmt.Errorf("gitea issue pagination exceeded %d pages", listIssuesMaxPages)
+	return nil, true, nil
 }
 
-func (c *TrackerClient) recordPaginationCapHit(labelName string) {
+func (c *TrackerClient) recordPaginationCapHit(labelName string, maxPages int) {
 	c.paginationCapHits.Add(1)
 	if c.Logf != nil {
-		c.Logf("gitea issue pagination exceeded %d pages for label %q; aborting this tracker poll to avoid acting on a truncated result set", listIssuesMaxPages, labelName)
+		c.Logf("gitea issue pagination exceeded %d pages for label %q; skipping that label and continuing this tracker poll", maxPages, labelName)
 	}
 }
 

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -321,25 +321,29 @@ func TestTrackerClientListIssuesByStatesAllowsExactlyFullMaxPages(t *testing.T) 
 	}
 }
 
-func TestTrackerClientListIssuesByStatesErrorsWhenIssuePaginationOverflows(t *testing.T) {
+func TestTrackerClientListIssuesByStatesSkipsOverflowingLabelAndContinues(t *testing.T) {
 	var logs []string
+	todoPages := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		page, err := strconv.Atoi(r.URL.Query().Get("page"))
 		if err != nil {
 			t.Fatalf("page query = %q: %v", r.URL.Query().Get("page"), err)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Add("Link", fmt.Sprintf(`<%s%s?page=%d>; rel="next"`, serverURL(r), r.URL.Path, page+1))
-		issues := make([]Issue, listIssuesPageSize)
-		for i := range issues {
-			number := (page-1)*listIssuesPageSize + i + 1
-			issues[i] = Issue{ID: int64(number), Number: number, Title: "todo", HTMLURL: fmt.Sprintf("https://gitea.local/o/r/issues/%d", number), Labels: []Label{{Name: "aiops/todo"}}}
+		switch r.URL.Query().Get("labels") {
+		case "aiops/todo":
+			todoPages++
+			w.Header().Add("Link", fmt.Sprintf(`<%s%s?page=%d>; rel="next"`, serverURL(r), r.URL.Path, page+1))
+			_ = json.NewEncoder(w).Encode([]Issue{{ID: 9001, Number: 9001, Labels: []Label{{Name: "aiops/todo"}}}})
+		case "aiops/rework":
+			_ = json.NewEncoder(w).Encode([]Issue{{ID: 9001, Number: 9001, Labels: []Label{{Name: "aiops/rework"}}}})
+		default:
+			t.Fatalf("unexpected labels query %q", r.URL.Query().Get("labels"))
 		}
-		_ = json.NewEncoder(w).Encode(issues)
 	}))
 	defer server.Close()
 
-	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", PaginationMaxPages: 1}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 	client.Logf = func(format string, args ...any) {
 		logs = append(logs, fmt.Sprintf(format, args...))
@@ -347,9 +351,15 @@ func TestTrackerClientListIssuesByStatesErrorsWhenIssuePaginationOverflows(t *te
 	if got := client.PaginationCapHits(); got != 0 {
 		t.Fatalf("initial PaginationCapHits = %d, want 0", got)
 	}
-	_, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
-	if err == nil || !strings.Contains(err.Error(), "gitea issue pagination exceeded") {
-		t.Fatalf("ListIssuesByStates err = %v, want pagination overflow error", err)
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready", "Rework"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Identifier != "#9001" || issues[0].State != "Rework" {
+		t.Fatalf("issues = %#v, want only non-overflowing Rework label", issues)
+	}
+	if todoPages != 2 {
+		t.Fatalf("aiops/todo pages = %d, want configured max page plus probe", todoPages)
 	}
 	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "gitea issue pagination exceeded") {
 		t.Fatalf("logs = %#v, want pagination cap diagnostic", logs)

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -111,6 +111,13 @@ func (c *GitHubClient) PaginationCapHits() int64 {
 	return c.paginationCapHits.Load()
 }
 
+func (c *GitHubClient) issueMaxPages() int {
+	if c != nil && c.Config.PaginationMaxPages > 0 {
+		return c.Config.PaginationMaxPages
+	}
+	return githubMaxIssuePages
+}
+
 func (c *GitHubClient) ListIssuesByStates(ctx context.Context, states []string) ([]Issue, error) {
 	if strings.TrimSpace(c.Token) == "" {
 		return nil, fmt.Errorf("GitHub tracker api_key is required")
@@ -123,9 +130,10 @@ func (c *GitHubClient) ListIssuesByStates(ctx context.Context, states []string) 
 		return nil, nil
 	}
 	claimedIssueNumbers := map[int]struct{}{}
+	claimsCapped := false
 	if githubStatesMayIncludeOpenIssues(stateFilters) {
 		var err error
-		claimedIssueNumbers, err = c.openPullRequestClaimedIssueNumbers(ctx)
+		claimedIssueNumbers, claimsCapped, err = c.openPullRequestClaimedIssueNumbers(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -134,28 +142,47 @@ func (c *GitHubClient) ListIssuesByStates(ctx context.Context, states []string) 
 	var out []Issue
 	for _, state := range stateFilters {
 		issueState, label, mappedState := githubIssueQueryForState(state)
-		issues, err := c.listIssuesForState(ctx, issueState, label, mappedState, seen, claimedIssueNumbers)
+		scope := githubIssueCollectionScope(issueState, label)
+		if claimsCapped && githubIssueQueryRequiresCompleteClaims(issueState) {
+			if c.Logf != nil {
+				c.Logf("github open pull request pagination exceeded configured cap; skipping issue collection %q to avoid dispatching already-claimed issues", scope)
+			}
+			continue
+		}
+		issues, capped, err := c.listIssuesForState(ctx, issueState, label, mappedState, seen, claimedIssueNumbers)
 		if err != nil {
 			return nil, err
+		}
+		if capped {
+			continue
+		}
+		for _, issue := range issues {
+			seen[issue.ID] = struct{}{}
 		}
 		out = append(out, issues...)
 	}
 	return out, nil
 }
 
-func (c *GitHubClient) listIssuesForState(ctx context.Context, issueState, label, mappedState string, seen map[string]struct{}, claimedIssueNumbers map[int]struct{}) ([]Issue, error) {
+func (c *GitHubClient) listIssuesForState(ctx context.Context, issueState, label, mappedState string, seen map[string]struct{}, claimedIssueNumbers map[int]struct{}) ([]Issue, bool, error) {
 	var out []Issue
-	for page := 1; page <= githubMaxIssuePages+1; page++ {
+	collectionSeen := make(map[string]struct{}, len(seen))
+	for id := range seen {
+		collectionSeen[id] = struct{}{}
+	}
+	maxPages := c.issueMaxPages()
+	scope := githubIssueCollectionScope(issueState, label)
+	for page := 1; page <= maxPages+1; page++ {
 		batch, hasNext, err := c.listIssuesPage(ctx, issueState, label, page)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		if page > githubMaxIssuePages {
+		if page > maxPages {
 			if !hasNext && len(batch) == 0 {
-				return out, nil
+				return out, false, nil
 			}
-			c.recordPaginationCapHit(label)
-			return nil, fmt.Errorf("github issue pagination exceeded %d pages for label/state %q", githubMaxIssuePages, label)
+			c.recordPaginationCapHit(scope, maxPages)
+			return nil, true, nil
 		}
 		for _, issue := range batch {
 			if issue.PullRequest != nil {
@@ -166,23 +193,23 @@ func (c *GitHubClient) listIssuesForState(ctx context.Context, issueState, label
 			}
 			mapped, err := mapGitHubIssue(issue, mappedState)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			if mapped.ID == "" {
 				continue
 			}
 			c.cacheIssueNumber(mapped.ID, issue.Number)
-			if _, ok := seen[mapped.ID]; ok {
+			if _, ok := collectionSeen[mapped.ID]; ok {
 				continue
 			}
-			seen[mapped.ID] = struct{}{}
+			collectionSeen[mapped.ID] = struct{}{}
 			out = append(out, mapped)
 		}
 		if !hasNext && len(batch) < githubIssuePageSize {
-			return out, nil
+			return out, false, nil
 		}
 	}
-	return nil, fmt.Errorf("github issue pagination exceeded %d pages", githubMaxIssuePages)
+	return nil, true, nil
 }
 
 func (c *GitHubClient) listIssuesPage(ctx context.Context, issueState, label string, page int) ([]githubIssue, bool, error) {
@@ -228,12 +255,20 @@ func (c *GitHubClient) listIssuesPage(ctx context.Context, issueState, label str
 	return issues, githubHasNextPage(resp.Header.Values("Link")), nil
 }
 
-func (c *GitHubClient) openPullRequestClaimedIssueNumbers(ctx context.Context) (map[int]struct{}, error) {
+func (c *GitHubClient) openPullRequestClaimedIssueNumbers(ctx context.Context) (map[int]struct{}, bool, error) {
 	out := map[int]struct{}{}
-	for page := 1; page <= githubMaxIssuePages; page++ {
+	maxPages := c.issueMaxPages()
+	for page := 1; page <= maxPages+1; page++ {
 		pulls, hasNext, err := c.listOpenPullRequestsPage(ctx, page)
 		if err != nil {
-			return nil, err
+			return nil, false, err
+		}
+		if page > maxPages {
+			if !hasNext && len(pulls) == 0 {
+				return out, false, nil
+			}
+			c.recordPaginationCapHit("open pull requests", maxPages)
+			return out, true, nil
 		}
 		for _, pull := range pulls {
 			if !strings.EqualFold(strings.TrimSpace(pull.State), "open") {
@@ -243,18 +278,11 @@ func (c *GitHubClient) openPullRequestClaimedIssueNumbers(ctx context.Context) (
 				out[issueNumber] = struct{}{}
 			}
 		}
-		if page == githubMaxIssuePages {
-			if hasNext {
-				c.recordPaginationCapHit("open pull requests")
-				return nil, fmt.Errorf("github open pull request pagination exceeded %d pages", githubMaxIssuePages)
-			}
-			return out, nil
-		}
 		if !hasNext && len(pulls) < githubIssuePageSize {
-			return out, nil
+			return out, false, nil
 		}
 	}
-	return out, nil
+	return out, false, nil
 }
 
 func (c *GitHubClient) listOpenPullRequestsPage(ctx context.Context, page int) ([]githubPullRequestSummary, bool, error) {
@@ -365,6 +393,18 @@ func githubStatesMayIncludeOpenIssues(states []string) bool {
 	return false
 }
 
+func githubIssueQueryRequiresCompleteClaims(issueState string) bool {
+	issueState = strings.ToLower(strings.TrimSpace(issueState))
+	return issueState == "open" || issueState == "all"
+}
+
+func githubIssueCollectionScope(issueState, label string) string {
+	if strings.TrimSpace(label) != "" {
+		return label
+	}
+	return issueState
+}
+
 func githubClaimedIssueNumbers(text string) []int {
 	matches := githubClaimedIssueRE.FindAllStringSubmatch(text, -1)
 	out := make([]int, 0, len(matches))
@@ -415,10 +455,10 @@ func githubHasNextPage(linkHeaders []string) bool {
 	return false
 }
 
-func (c *GitHubClient) recordPaginationCapHit(label string) {
+func (c *GitHubClient) recordPaginationCapHit(label string, maxPages int) {
 	c.paginationCapHits.Add(1)
 	if c.Logf != nil {
-		c.Logf("github pagination exceeded %d pages for label/state %q; aborting this tracker poll to avoid acting on a truncated result set", githubMaxIssuePages, label)
+		c.Logf("github pagination exceeded %d pages for label/state %q; skipping that collection and continuing this tracker poll", maxPages, label)
 	}
 }
 

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -194,7 +195,9 @@ func TestGitHubClaimedIssueNumbersMatchesPRContract(t *testing.T) {
 	}
 }
 
-func TestGitHubClientListIssuesByStatesErrorsWhenIssuePaginationOverflows(t *testing.T) {
+func TestGitHubClientListIssuesByStatesSkipsOverflowingStateAndContinues(t *testing.T) {
+	var logs []string
+	openIssuePages := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/repos/acme/api/pulls":
@@ -202,46 +205,156 @@ func TestGitHubClientListIssuesByStatesErrorsWhenIssuePaginationOverflows(t *tes
 			_, _ = io.WriteString(w, `[]`)
 		case "/repos/acme/api/issues":
 			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Link", `<`+r.URL.String()+`>; rel="next"`)
-			_, _ = io.WriteString(w, `[]`)
+			switch r.URL.Query().Get("state") {
+			case "open":
+				openIssuePages++
+				w.Header().Set("Link", `<`+r.URL.String()+`>; rel="next"`)
+				if r.URL.Query().Get("page") == "1" {
+					_ = json.NewEncoder(w).Encode([]githubIssue{{ID: 42, Number: 42, State: "open"}})
+					return
+				}
+				_, _ = io.WriteString(w, `[]`)
+			case "closed":
+				_ = json.NewEncoder(w).Encode([]githubIssue{{ID: 42, Number: 42, State: "closed"}})
+			default:
+				t.Fatalf("unexpected issue state query %q", r.URL.Query().Get("state"))
+			}
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
 	}))
 	defer srv.Close()
 
-	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, srv.URL, "acme", "api")
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", PaginationMaxPages: 1}, srv.URL, "acme", "api")
 	client.HTTP = srv.Client()
-	_, err := client.ListIssuesByStates(context.Background(), []string{"open"})
-	if err == nil || !strings.Contains(err.Error(), "github issue pagination exceeded") {
-		t.Fatalf("ListIssuesByStates error = %v, want pagination overflow", err)
+	client.Logf = func(format string, args ...any) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	}
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"open", "closed"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Identifier != "#42" || issues[0].State != "closed" {
+		t.Fatalf("issues = %#v, want only non-overflowing closed state", issues)
+	}
+	if openIssuePages != 2 {
+		t.Fatalf("open issue pages = %d, want configured max page plus probe", openIssuePages)
 	}
 	if got := client.PaginationCapHits(); got != 1 {
 		t.Fatalf("PaginationCapHits = %d, want 1", got)
+	}
+	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "skipping that collection") {
+		t.Fatalf("logs = %#v, want skip diagnostic", logs)
 	}
 }
 
-func TestGitHubClientListIssuesByStatesErrorsWhenOpenPRPaginationOverflows(t *testing.T) {
+func TestGitHubClientListIssuesByStatesSkipsOpenWhenOpenPRPaginationOverflows(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		states            []string
+		skippedIssueState string
+		skippedLabel      string
+	}{
+		{name: "open", states: []string{"open", "closed"}, skippedIssueState: "open"},
+		{name: "all", states: []string{"all", "closed"}, skippedIssueState: "all"},
+		{name: "label", states: []string{"priority:p2", "closed"}, skippedIssueState: "open", skippedLabel: "priority:p2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pullPages := 0
+			skippedCollectionRequests := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/acme/api/pulls":
+					pullPages++
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("Link", `<`+r.URL.String()+`>; rel="next"`)
+					_ = json.NewEncoder(w).Encode([]githubPullRequestSummary{{Number: 7, State: "open", Title: "claim", Body: "Closes #43"}})
+				case "/repos/acme/api/issues":
+					w.Header().Set("Content-Type", "application/json")
+					state := r.URL.Query().Get("state")
+					label := r.URL.Query().Get("labels")
+					if state == tc.skippedIssueState && label == tc.skippedLabel {
+						skippedCollectionRequests++
+						_ = json.NewEncoder(w).Encode([]githubIssue{{ID: 43, Number: 43, State: "open"}})
+						return
+					}
+					if state == "closed" && label == "" {
+						_ = json.NewEncoder(w).Encode([]githubIssue{{ID: 45, Number: 45, State: "closed"}})
+						return
+					}
+					t.Fatalf("unexpected issue query state=%q labels=%q", state, label)
+				default:
+					t.Fatalf("unexpected path %s", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", PaginationMaxPages: 1}, srv.URL, "acme", "api")
+			client.HTTP = srv.Client()
+			issues, err := client.ListIssuesByStates(context.Background(), tc.states)
+			if err != nil {
+				t.Fatalf("ListIssuesByStates: %v", err)
+			}
+			if len(issues) != 1 || issues[0].Identifier != "#45" || issues[0].State != "closed" {
+				t.Fatalf("issues = %#v, want only closed issue after incomplete open-PR claim scan", issues)
+			}
+			if pullPages != 2 {
+				t.Fatalf("open pull request pages = %d, want configured max page plus cap probe", pullPages)
+			}
+			if skippedCollectionRequests != 0 {
+				t.Fatalf("skipped collection requests = %d, want none when PR claims are incomplete", skippedCollectionRequests)
+			}
+			if got := client.PaginationCapHits(); got != 1 {
+				t.Fatalf("PaginationCapHits = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestGitHubClientOpenPRClaimScanAllowsEmptyProbePage(t *testing.T) {
+	pullPages := 0
+	openIssueRequests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/repos/acme/api/pulls":
+			pullPages++
 			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Link", `<`+r.URL.String()+`>; rel="next"`)
-			_, _ = io.WriteString(w, `[]`)
+			if r.URL.Query().Get("page") == "1" {
+				w.Header().Set("Link", `<`+r.URL.String()+`>; rel="next"`)
+				_ = json.NewEncoder(w).Encode([]githubPullRequestSummary{{Number: 7, State: "open", Title: "claim", Body: "Closes #43"}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]githubPullRequestSummary{})
+		case "/repos/acme/api/issues":
+			openIssueRequests++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]githubIssue{
+				{ID: 43, Number: 43, State: "open"},
+				{ID: 44, Number: 44, State: "open"},
+			})
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
 	}))
 	defer srv.Close()
 
-	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, srv.URL, "acme", "api")
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", PaginationMaxPages: 1}, srv.URL, "acme", "api")
 	client.HTTP = srv.Client()
-	_, err := client.ListIssuesByStates(context.Background(), []string{"open"})
-	if err == nil || !strings.Contains(err.Error(), "github open pull request pagination exceeded") {
-		t.Fatalf("ListIssuesByStates error = %v, want PR pagination overflow", err)
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"open"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
 	}
-	if got := client.PaginationCapHits(); got != 1 {
-		t.Fatalf("PaginationCapHits = %d, want 1", got)
+	if len(issues) != 1 || issues[0].Identifier != "#44" {
+		t.Fatalf("issues = %#v, want unclaimed open issue after empty PR probe page", issues)
+	}
+	if pullPages != 2 {
+		t.Fatalf("open pull request pages = %d, want max page plus empty probe", pullPages)
+	}
+	if openIssueRequests != 1 {
+		t.Fatalf("open issue requests = %d, want open collection to proceed after complete PR claim scan", openIssueRequests)
+	}
+	if got := client.PaginationCapHits(); got != 0 {
+		t.Fatalf("PaginationCapHits = %d, want 0", got)
 	}
 }
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -115,9 +115,12 @@ type TrackerConfig struct {
 	// running issue ineligible. Poll-tick reconciliation probes these states so
 	// operator pauses such as Backlog/Human Review cancel in-flight workers
 	// without treating issues missing from partial tracker listings as inactive.
-	InactiveStates []string            `yaml:"inactive_states" json:"inactive_states"`
-	PollIntervalMs int                 `yaml:"poll_interval_ms" json:"poll_interval_ms"`
-	Statuses       TrackerStatusConfig `yaml:"statuses" json:"statuses"`
+	InactiveStates []string `yaml:"inactive_states" json:"inactive_states"`
+	PollIntervalMs int      `yaml:"poll_interval_ms" json:"poll_interval_ms"`
+	// PaginationMaxPages caps one tracker pagination scan. Zero keeps the
+	// selected adapter's default budget.
+	PaginationMaxPages int                 `yaml:"pagination_max_pages" json:"pagination_max_pages,omitempty"`
+	Statuses           TrackerStatusConfig `yaml:"statuses" json:"statuses"`
 }
 
 type PollingConfig struct {

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -1915,6 +1915,48 @@ prompt
 	}
 }
 
+func TestLoad_AllowsTrackerPaginationMaxPages(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: xrf9268-hue
+  name: aiops-platform
+  clone_url: https://github.com/xrf9268-hue/aiops-platform.git
+tracker:
+  kind: github
+  api_key: github-token
+  pagination_max_pages: 42
+---
+prompt`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Tracker.PaginationMaxPages; got != 42 {
+		t.Fatalf("tracker.pagination_max_pages = %d, want 42", got)
+	}
+}
+
+func TestLoad_RejectsNegativeTrackerPaginationMaxPages(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  owner: xrf9268-hue
+  name: aiops-platform
+  clone_url: https://github.com/xrf9268-hue/aiops-platform.git
+tracker:
+  kind: github
+  api_key: github-token
+  pagination_max_pages: -1
+---
+prompt`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: expected error for negative tracker.pagination_max_pages")
+	}
+	if !strings.Contains(err.Error(), "tracker.pagination_max_pages") || !strings.Contains(err.Error(), "greater than zero") {
+		t.Fatalf("Load error = %q, want tracker.pagination_max_pages guidance", err)
+	}
+}
+
 // TestLoad_RejectsUnsupportedAgentDefault matches the runner registry in
 // internal/runner: only mock/codex/claude are wired up. Catching a typo
 // like `agent.default: codexx` at Load time prevents the worker from

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -387,6 +387,9 @@ func validateConfig(path string, cfg Config) error {
 	if _, ok := supportedTrackerKinds[cfg.Tracker.Kind]; !ok {
 		return fmt.Errorf("%s: tracker.kind %q is not supported (allowed: gitea, github, linear)", path, cfg.Tracker.Kind)
 	}
+	if cfg.Tracker.PaginationMaxPages < 0 {
+		return fmt.Errorf("%s: tracker.pagination_max_pages must be zero for the adapter default or greater than zero", path)
+	}
 	if _, ok := supportedAgentDefaults[cfg.Agent.Default]; !ok {
 		return fmt.Errorf("%s: agent.default %q is not supported (allowed: mock, codex, codex-app-server, claude)", path, cfg.Agent.Default)
 	}


### PR DESCRIPTION
Closes #387

## Acceptance
- Adds `tracker.pagination_max_pages` so GitHub/Gitea pagination caps can be raised per workflow while `0` keeps adapter defaults.
- GitHub state/label scans and Gitea label scans record/log cap hits, skip only the capped collection, and continue other complete collections.
- GitHub open-PR claim scans record/log cap hits, use a `+1` empty-page probe, and skip open/all/label-backed-open issue collections when PR claims are incomplete while still returning complete closed collections.
- Updates metrics/docs/examples for the configurable cap and degraded cap-hit behavior.

## Validation
- `go test ./internal/tracker ./internal/gitea ./internal/workflow ./cmd/gitea-poller -run 'TestGitHubClientListIssuesByStatesSkipsOverflowingStateAndContinues|TestGitHubClientListIssuesByStatesSkipsOpenWhenOpenPRPaginationOverflows|TestGitHubClientOpenPRClaimScanAllowsEmptyProbePage|TestTrackerClientListIssuesByStatesSkipsOverflowingLabelAndContinues|TestLoad_AllowsTrackerPaginationMaxPages|TestLoad_RejectsNegativeTrackerPaginationMaxPages|TestGiteaMetricsHandlerExposesPaginationCapHits' -count=1`
- Mutation checks: capped GitHub/Gitea collections returning truncated partial results fail; capped collection dedupe pollution fails; open/all/label-backed-open dispatch after incomplete PR claims fails; old PR-cap behavior without the empty probe fails; restored code passes.
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- `go vet ./...`
- Pre-push Codex review on `16647c9`: LGTM, no HIGH/MEDIUM blockers.
- Pre-push Claude Code review on `16647c9`: no HIGH/MEDIUM blockers.

## Risk / Deferral
- No functional deferrals.
- On cap hit, issues inside the capped collection are intentionally skipped for safety; operators should reduce active states/labels or raise `tracker.pagination_max_pages` after estimating API cost.
- Batch auto-merge note: this quality-preserving diff currently exceeds the default 12-file / 300-line size budget, so it needs explicit size-gate sign-off before I can auto-merge it.