### PR TITLE
fix(runner): preserve custom app-server command quoting

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -99,7 +99,7 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
 	// Only emit codex_app_server_pid when we can guarantee cmd.Process.Pid is
 	// the actual codex process: the command must launch the codex binary
-	// directly (no `sh -c` wrapper from a custom codex.command), and the
+	// directly (no shell wrapper from a custom codex.command), and the
 	// sandbox must not have wrapped cmd in firejail/bwrap. In any wrapper
 	// scenario the PID belongs to the wrapper, which would mislead operators
 	// trying to map `/api/v1/state` rows to a host process. omitempty makes
@@ -190,16 +190,12 @@ func buildCodexAppServerCmd(ctx context.Context, in RunInput, env []string) (*ex
 	if command == "" || command == "codex exec" {
 		command = "codex app-server"
 	}
-	fields := strings.Fields(command)
-	if len(fields) == 0 {
-		return nil, false, fmt.Errorf("codex app-server command is empty")
-	}
-	if fields[0] == "codex" {
+	if command == "codex app-server" {
 		codexPath, err := lookPathInEnv("codex", env)
 		if err != nil {
 			return nil, false, NewError(CategoryCodexNotFound, "codex binary not found in PATH; install codex CLI or set agent.default to claude/mock", err)
 		}
-		return exec.CommandContext(ctx, codexPath, fields[1:]...), true, nil
+		return exec.CommandContext(ctx, codexPath, "app-server"), true, nil
 	}
 	return exec.CommandContext(ctx, "sh", "-c", command), false, nil
 }

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1454,7 +1454,8 @@ func TestBuildCodexAppServerCmdResolvesCodexFromAgentEnvPATH(t *testing.T) {
 
 // TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect pins the
 // directCodexExec flag's negative case: when `codex.command` is anything other
-// than a `codex ...` invocation, the cmd runs through `sh -c`. The runner
+// than the built-in `codex app-server` invocation, the cmd runs through `sh -c`.
+// The runner
 // uses this signal to suppress codex_app_server_pid emission, since
 // cmd.Process.Pid would be the shell wrapper rather than the actual codex
 // process.
@@ -1472,6 +1473,23 @@ func TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect(t *testing.T) {
 	}
 	if len(cmd.Args) < 3 || cmd.Args[0] != "sh" || cmd.Args[1] != "-c" || cmd.Args[2] != in.Workflow.Config.Codex.Command {
 		t.Fatalf("cmd.Args = %#v, want sh -c wrapper", cmd.Args)
+	}
+}
+
+func TestBuildCodexAppServerCmdPreservesQuotedCustomCodexCommand(t *testing.T) {
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.Command = `codex app-server --config "model = gpt-5"`
+
+	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + os.Getenv("PATH")})
+	if err != nil {
+		t.Fatalf("buildCodexAppServerCmd: %v", err)
+	}
+	if directExec {
+		t.Fatalf("directCodexExec = true for custom command %q, want false (shell wrapper)", in.Workflow.Config.Codex.Command)
+	}
+	if len(cmd.Args) < 3 || cmd.Args[0] != "sh" || cmd.Args[1] != "-c" || cmd.Args[2] != in.Workflow.Config.Codex.Command {
+		t.Fatalf("cmd.Args = %#v, want shell wrapper preserving quoted command", cmd.Args)
 	}
 }
 


### PR DESCRIPTION
Closes #389

## Acceptance
- Preserves quoted `codex.command` strings by routing custom app-server commands through plain `sh -c` instead of splitting with `strings.Fields`.
- Keeps the built-in/legacy `codex app-server` path as direct exec so `codex_app_server_pid` is emitted only when it is the real Codex process.
- Avoids login-shell/profile re-sourcing for custom commands, preserving the #314 stdout-pollution guardrail.

## Validation
- `go test ./internal/runner -run 'TestBuildCodexAppServerCmdUsesAppServerWhenDefaultCodexExecCommandIsUnchanged|TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect|TestBuildCodexAppServerCmdPreservesQuotedCustomCodexCommand' -count=1`
- Mutation check: temporarily routing any `codex...` command through `strings.Fields` direct exec made `TestBuildCodexAppServerCmdPreservesQuotedCustomCodexCommand` fail; restored code passes.
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- `go vet ./...`
- Pre-push Codex review on `2222116`: LGTM, no HIGH/MEDIUM blockers.
- Pre-push Claude Code review on `2222116`: no HIGH/MEDIUM blockers.

## Risk / Deferral
- No deferrals.
- Custom `codex ...` commands that are not exactly the built-in default now run behind a shell wrapper and therefore suppress `codex_app_server_pid`; this is intentional because the PID would otherwise identify the wrapper, not Codex.