### PR TITLE
fix(tracker): fail ListIssuesByStates loud on pagination cap

### DIFF
--- a/cmd/gitea-poller/main_test.go
+++ b/cmd/gitea-poller/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -119,8 +120,11 @@ func TestGiteaMetricsHandlerExposesPaginationCapHits(t *testing.T) {
 	client := gitea.NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 	client.Logf = func(string, ...any) {}
-	if _, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"}); err != nil {
-		t.Fatalf("ListIssuesByStates: %v", err)
+	// Listing intentionally overflows pagination to drive the cap metric;
+	// per #401/#402, ListIssuesByStates surfaces ErrIssueListingCapped on
+	// partial results so reconcile does not treat them as authoritative.
+	if _, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"}); !errors.Is(err, tracker.ErrIssueListingCapped) {
+		t.Fatalf("ListIssuesByStates err = %v, want tracker.ErrIssueListingCapped", err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -96,21 +96,40 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	var out []tracker.Issue
 	seenIssues := map[string]struct{}{}
 	if len(labelNames) == 0 {
-		issues, _, err := c.listIssuesByStateLabel(ctx, "", issueState, wantedStates, seenIssues)
-		return issues, err
+		issues, capped, err := c.listIssuesByStateLabel(ctx, "", issueState, wantedStates, seenIssues)
+		if err != nil {
+			return nil, err
+		}
+		if capped {
+			return nil, tracker.NewError(
+				tracker.CategoryIssueListingCapped,
+				fmt.Sprintf("gitea issue listing partial: capped state %q", issueState),
+				nil,
+			)
+		}
+		return issues, nil
 	}
+	var cappedLabels []string
 	for _, labelName := range labelNames {
 		issues, capped, err := c.listIssuesByStateLabel(ctx, labelName, issueState, wantedStates, seenIssues)
 		if err != nil {
 			return nil, err
 		}
 		if capped {
+			cappedLabels = append(cappedLabels, labelName)
 			continue
 		}
 		for _, issue := range issues {
 			seenIssues[issue.ID] = struct{}{}
 		}
 		out = append(out, issues...)
+	}
+	if len(cappedLabels) > 0 {
+		return nil, tracker.NewError(
+			tracker.CategoryIssueListingCapped,
+			fmt.Sprintf("gitea issue listing partial: capped labels %v", cappedLabels),
+			nil,
+		)
 	}
 	return out, nil
 }
@@ -238,7 +257,7 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 func (c *TrackerClient) recordPaginationCapHit(labelName string, maxPages int) {
 	c.paginationCapHits.Add(1)
 	if c.Logf != nil {
-		c.Logf("gitea issue pagination exceeded %d pages for label %q; skipping that label and continuing this tracker poll", maxPages, labelName)
+		c.Logf("gitea issue pagination exceeded %d pages for label %q; failing this tracker listing so reconcile does not treat partial results as authoritative", maxPages, labelName)
 	}
 }
 

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -3,6 +3,7 @@ package gitea
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -321,7 +322,13 @@ func TestTrackerClientListIssuesByStatesAllowsExactlyFullMaxPages(t *testing.T) 
 	}
 }
 
-func TestTrackerClientListIssuesByStatesSkipsOverflowingLabelAndContinues(t *testing.T) {
+// TestTrackerClientListIssuesByStatesErrorsWhenLabelOverflows pins the
+// fail-safe contract for #402: if any state-label collection overflows
+// pagination, ListIssuesByStates must surface tracker.ErrIssueListingCapped
+// (with nil issues) so startup reconciliation does not treat the partial
+// result as authoritative and delete workspaces for active issues that fell
+// past the page cap.
+func TestTrackerClientListIssuesByStatesErrorsWhenLabelOverflows(t *testing.T) {
 	var logs []string
 	todoPages := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -352,17 +359,17 @@ func TestTrackerClientListIssuesByStatesSkipsOverflowingLabelAndContinues(t *tes
 		t.Fatalf("initial PaginationCapHits = %d, want 0", got)
 	}
 	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready", "Rework"})
-	if err != nil {
-		t.Fatalf("ListIssuesByStates: %v", err)
+	if !errors.Is(err, tracker.ErrIssueListingCapped) {
+		t.Fatalf("ListIssuesByStates err = %v, want tracker.ErrIssueListingCapped", err)
 	}
-	if len(issues) != 1 || issues[0].Identifier != "#9001" || issues[0].State != "Rework" {
-		t.Fatalf("issues = %#v, want only non-overflowing Rework label", issues)
+	if issues != nil {
+		t.Fatalf("issues = %#v, want nil when listing is partial", issues)
 	}
 	if todoPages != 2 {
 		t.Fatalf("aiops/todo pages = %d, want configured max page plus probe", todoPages)
 	}
-	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "gitea issue pagination exceeded") {
-		t.Fatalf("logs = %#v, want pagination cap diagnostic", logs)
+	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "failing this tracker listing") {
+		t.Fatalf("logs = %#v, want fail-loud diagnostic", logs)
 	}
 	if got := client.PaginationCapHits(); got != 1 {
 		t.Fatalf("PaginationCapHits = %d, want 1", got)

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -140,6 +140,7 @@ func (c *GitHubClient) ListIssuesByStates(ctx context.Context, states []string) 
 	}
 	seen := map[string]struct{}{}
 	var out []Issue
+	var cappedScopes []string
 	for _, state := range stateFilters {
 		issueState, label, mappedState := githubIssueQueryForState(state)
 		scope := githubIssueCollectionScope(issueState, label)
@@ -147,6 +148,7 @@ func (c *GitHubClient) ListIssuesByStates(ctx context.Context, states []string) 
 			if c.Logf != nil {
 				c.Logf("github open pull request pagination exceeded configured cap; skipping issue collection %q to avoid dispatching already-claimed issues", scope)
 			}
+			cappedScopes = append(cappedScopes, scope)
 			continue
 		}
 		issues, capped, err := c.listIssuesForState(ctx, issueState, label, mappedState, seen, claimedIssueNumbers)
@@ -154,12 +156,20 @@ func (c *GitHubClient) ListIssuesByStates(ctx context.Context, states []string) 
 			return nil, err
 		}
 		if capped {
+			cappedScopes = append(cappedScopes, scope)
 			continue
 		}
 		for _, issue := range issues {
 			seen[issue.ID] = struct{}{}
 		}
 		out = append(out, issues...)
+	}
+	if len(cappedScopes) > 0 {
+		return nil, NewError(
+			CategoryIssueListingCapped,
+			fmt.Sprintf("github issue listing partial: capped collections %v", cappedScopes),
+			nil,
+		)
 	}
 	return out, nil
 }
@@ -458,7 +468,7 @@ func githubHasNextPage(linkHeaders []string) bool {
 func (c *GitHubClient) recordPaginationCapHit(label string, maxPages int) {
 	c.paginationCapHits.Add(1)
 	if c.Logf != nil {
-		c.Logf("github pagination exceeded %d pages for label/state %q; skipping that collection and continuing this tracker poll", maxPages, label)
+		c.Logf("github pagination exceeded %d pages for label/state %q; failing this tracker listing so reconcile does not treat partial results as authoritative", maxPages, label)
 	}
 }
 

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -195,7 +196,12 @@ func TestGitHubClaimedIssueNumbersMatchesPRContract(t *testing.T) {
 	}
 }
 
-func TestGitHubClientListIssuesByStatesSkipsOverflowingStateAndContinues(t *testing.T) {
+// TestGitHubClientListIssuesByStatesErrorsWhenStateCollectionOverflows pins
+// the fail-safe contract for #401: if any state collection overflows pagination,
+// ListIssuesByStates must surface ErrIssueListingCapped (with nil issues) so
+// startup reconciliation does not treat the partial result as authoritative and
+// delete workspaces for active issues that fell past the page cap.
+func TestGitHubClientListIssuesByStatesErrorsWhenStateCollectionOverflows(t *testing.T) {
 	var logs []string
 	openIssuePages := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -231,11 +237,11 @@ func TestGitHubClientListIssuesByStatesSkipsOverflowingStateAndContinues(t *test
 		logs = append(logs, fmt.Sprintf(format, args...))
 	}
 	issues, err := client.ListIssuesByStates(context.Background(), []string{"open", "closed"})
-	if err != nil {
-		t.Fatalf("ListIssuesByStates: %v", err)
+	if !errors.Is(err, ErrIssueListingCapped) {
+		t.Fatalf("ListIssuesByStates err = %v, want ErrIssueListingCapped", err)
 	}
-	if len(issues) != 1 || issues[0].Identifier != "#42" || issues[0].State != "closed" {
-		t.Fatalf("issues = %#v, want only non-overflowing closed state", issues)
+	if issues != nil {
+		t.Fatalf("issues = %#v, want nil when listing is partial", issues)
 	}
 	if openIssuePages != 2 {
 		t.Fatalf("open issue pages = %d, want configured max page plus probe", openIssuePages)
@@ -243,12 +249,17 @@ func TestGitHubClientListIssuesByStatesSkipsOverflowingStateAndContinues(t *test
 	if got := client.PaginationCapHits(); got != 1 {
 		t.Fatalf("PaginationCapHits = %d, want 1", got)
 	}
-	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "skipping that collection") {
-		t.Fatalf("logs = %#v, want skip diagnostic", logs)
+	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "failing this tracker listing") {
+		t.Fatalf("logs = %#v, want fail-loud diagnostic", logs)
 	}
 }
 
-func TestGitHubClientListIssuesByStatesSkipsOpenWhenOpenPRPaginationOverflows(t *testing.T) {
+// TestGitHubClientListIssuesByStatesErrorsWhenOpenPRPaginationOverflows pins
+// the fail-safe contract for #401 on the open-PR-claim-cap path: if the open PR
+// listing overflows, any state collection that depends on a complete claim set
+// is skipped AND ListIssuesByStates returns ErrIssueListingCapped so reconcile
+// does not treat the resulting partial issue set as authoritative.
+func TestGitHubClientListIssuesByStatesErrorsWhenOpenPRPaginationOverflows(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
 		states            []string
@@ -292,11 +303,11 @@ func TestGitHubClientListIssuesByStatesSkipsOpenWhenOpenPRPaginationOverflows(t 
 			client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", PaginationMaxPages: 1}, srv.URL, "acme", "api")
 			client.HTTP = srv.Client()
 			issues, err := client.ListIssuesByStates(context.Background(), tc.states)
-			if err != nil {
-				t.Fatalf("ListIssuesByStates: %v", err)
+			if !errors.Is(err, ErrIssueListingCapped) {
+				t.Fatalf("ListIssuesByStates err = %v, want ErrIssueListingCapped", err)
 			}
-			if len(issues) != 1 || issues[0].Identifier != "#45" || issues[0].State != "closed" {
-				t.Fatalf("issues = %#v, want only closed issue after incomplete open-PR claim scan", issues)
+			if issues != nil {
+				t.Fatalf("issues = %#v, want nil when listing is partial", issues)
 			}
 			if pullPages != 2 {
 				t.Fatalf("open pull request pages = %d, want configured max page plus cap probe", pullPages)

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -29,6 +29,7 @@ const (
 	CategoryLinearGraphQLErrors       Category = "linear_graphql_errors"
 	CategoryLinearUnknownPayload      Category = "linear_unknown_payload"
 	CategoryLinearMissingEndCursor    Category = "linear_missing_end_cursor"
+	CategoryIssueListingCapped        Category = "issue_listing_capped"
 )
 
 var (
@@ -40,6 +41,12 @@ var (
 	ErrLinearGraphQLErrors       = &Error{Category: CategoryLinearGraphQLErrors}
 	ErrLinearUnknownPayload      = &Error{Category: CategoryLinearUnknownPayload}
 	ErrLinearMissingEndCursor    = &Error{Category: CategoryLinearMissingEndCursor}
+	// ErrIssueListingCapped is returned by ListIssuesByStates when pagination
+	// cap is hit on any collection, so the returned issue set would be partial.
+	// Callers that rely on listing completeness (e.g. startup reconciliation,
+	// which deletes workspaces not seen in the active list) must treat this as
+	// a fetch failure and skip cleanup.
+	ErrIssueListingCapped = &Error{Category: CategoryIssueListingCapped}
 )
 
 type Error struct {

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -218,6 +218,63 @@ func TestReconcileStartupTolerantOfActiveFetchFailure(t *testing.T) {
 	}
 }
 
+// TestReconcileStartupSafeWhenActiveListingCapped pins #401/#402: a partial
+// active list (signaled by tracker.ErrIssueListingCapped) MUST be treated as a
+// fetch failure so reconcile skips cleanup. Otherwise an active workspace that
+// fell past the page cap would be deleted as "unknown" on restart whenever
+// terminal issues are present.
+func TestReconcileStartupSafeWhenActiveListingCapped(t *testing.T) {
+	root := t.TempDir()
+	activePath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1")
+	maybeTerminalPath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-2")
+	for _, path := range []string{activePath, maybeTerminalPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	emitter := &fakeEmitter{}
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:  root,
+		ActiveStates:   []string{"AI Ready"},
+		TerminalStates: []string{"Done"},
+		Tracker: &fakeReconcileTrackerByCall{
+			// Active fetch returns capped error; terminal fetch would have
+			// terminal issues, which is what would normally arm canRemoveUnknown.
+			errByCall:    []error{tracker.ErrIssueListingCapped, nil},
+			issuesByCall: [][]tracker.Issue{nil, {{ID: "issue-2", Identifier: "LIN-2", State: "Done"}}},
+		},
+		Emitter:         emitter,
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup must not fail when active listing is capped: %v", err)
+	}
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("active workspace must remain when active listing is capped: %v", err)
+	}
+	if _, err := os.Stat(maybeTerminalPath); err != nil {
+		t.Fatalf("any workspace must remain when active listing is capped (safety): %v", err)
+	}
+	endEvents := emitter.byKind(task.EventReconcileEnd)
+	if len(endEvents) != 1 {
+		t.Fatalf("reconcile_end events = %d, want 1", len(endEvents))
+	}
+	payload, ok := endEvents[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("reconcile_end payload = %T, want map", endEvents[0].Payload)
+	}
+	if status, _ := payload["status"].(string); status != "skipped" {
+		t.Fatalf("reconcile_end status = %q, want \"skipped\"", status)
+	}
+	if reason, _ := payload["reason"].(string); reason != "active_fetch_failed" {
+		t.Fatalf("reconcile_end reason = %q, want \"active_fetch_failed\"", reason)
+	}
+	if errMsg, _ := payload["error"].(string); !strings.Contains(errMsg, "issue_listing_capped") {
+		t.Fatalf("reconcile_end error = %q, want issue_listing_capped category surfaced", errMsg)
+	}
+}
+
 // TestReconcileStartupTolerantOfTerminalFetchFailure: terminal-fetch failure
 // is non-fatal. Active workspaces are still kept; terminal/unknown removal is
 // skipped because terminalKeys is empty and canRemoveUnknown stays false.


### PR DESCRIPTION
## Why

PR #400 (`fix(tracker): degrade pagination cap hits by collection`) made GitHub/Gitea trackers skip overflowing collections silently and return success with a partial issue set. The merged-PR review threads (#401, #402) caught that this is unsafe:

> Startup reconciliation (`internal/worker/reconcile.go`) treats successful `ListIssuesByStates` calls as complete and can remove unknown workspaces whenever terminal issues are present, so an omitted active issue from a capped collection can have its workspace deleted on restart.

The same risk applies to the orchestrator runtime poller's inactive-reconciliation path — both paths gate destructive cleanup on a successful active listing.

## What

Surface a typed `tracker.ErrIssueListingCapped` (category `issue_listing_capped`) from `ListIssuesByStates` whenever any state/label collection hits the pagination cap. Both trackers:

- `internal/tracker/github.go`: when `listIssuesForState` reports `capped` OR the open-PR claim scan caps a dependent collection, accumulate the scope and return `nil, ErrIssueListingCapped` instead of partial results.
- `internal/gitea/tracker_client.go`: same treatment for the label-loop and the no-label fallback path that previously discarded `capped`.

Existing handlers are already safe under errors:

- `internal/worker/reconcile.go` — active-fetch err ⇒ emit `reconcile_end{status:skipped, reason:active_fetch_failed}` and return nil (no cleanup). Terminal-fetch err ⇒ keep `canRemoveUnknown=false`.
- `internal/orchestrator/poller.go:129` — `activeErr != nil && len(issues) == 0` ⇒ return early; `reconcileTick` is gated on `activeErr == nil`.

Metric (`paginationCapHits`) and log line are preserved; only the return contract tightens.

## Pins (regression + mutation)

- `internal/tracker/github_test.go` — capped state collection AND capped open-PR claim scan both surface `ErrIssueListingCapped` with nil issues; mutation: removing the error return restored the old failure mode and tests caught it.
- `internal/gitea/tracker_client_test.go` — capped label surfaces the same error; mutation verified.
- `internal/worker/reconcile_test.go` — new `TestReconcileStartupSafeWhenActiveListingCapped`: when active listing returns `ErrIssueListingCapped` and terminal issues are present, all workspaces are kept and `reconcile_end{status:skipped, reason:active_fetch_failed, error: ...issue_listing_capped}` is emitted.
- `cmd/gitea-poller/main_test.go` — `TestGiteaMetricsHandlerExposesPaginationCapHits` now asserts `ErrIssueListingCapped` while still verifying the metric is exposed.

## Local gates

- `gofmt -l $(git ls-files '*.go')` — empty
- `go mod tidy && git diff --exit-code -- go.mod go.sum` — clean
- `go vet ./...` — clean
- `go test -race ./...` — all green
- `go build ./...` — clean

Closes #401
Closes #402

---
_Generated by [Claude Code](https://claude.ai/code/session_011ofvSTsG4nb58iGv57jzkt)_