### PR TITLE
docs: add CLAUDE.md bridge so Claude Code loads AGENTS.md (#416)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,11 @@
 
 Project guide for AI coding agents (Codex CLI, Claude Code, etc.) working in this repo.
 
+**This file is the single source of truth for all engineering rules.** Other
+coding agents read it via thin bridge files: `CLAUDE.md` imports it with
+`@AGENTS.md` for Claude Code. Do not duplicate content in the bridge files —
+update only this file.
+
 ## What this project is
 
 `aiops-platform` is a Go-based, self-hostable AI coding orchestrator that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+@AGENTS.md
+
+## Claude Code specific
+
+<!-- This file is the Claude Code entrypoint. All engineering rules live in
+     AGENTS.md (the single source of truth); this file imports them via the
+     @AGENTS.md directive so Claude Code sessions load them automatically.
+     Do not duplicate content here — add Claude-Code-only guidance below. -->

--- a/README.md
+++ b/README.md
@@ -422,6 +422,15 @@ all changes; PRs should not merge while it is red. It runs three jobs:
 See the [CI/CD runbook](docs/runbooks/ci.md) for triggers, security posture,
 release flow, and local pre-push checks.
 
+## AI agent rules
+
+[`AGENTS.md`](AGENTS.md) is the canonical source for all engineering rules
+(SPEC alignment, clean code, harness engineering principles, Go runtime
+hardening). [`CLAUDE.md`](CLAUDE.md) is a thin bridge that imports it via
+`@AGENTS.md` so Claude Code sessions load the same rules automatically. If
+you add a coding agent that reads a different file (e.g. `.cursorrules`),
+add a bridge that imports `AGENTS.md` rather than duplicating content.
+
 ## Architecture notes
 
 - [SPEC deviations (D1–D24/D29)](DEVIATIONS.md)


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` at repo root with `@AGENTS.md` import — Claude Code's native import directive. AGENTS.md remains the single source of truth; CLAUDE.md is the entrypoint only, with no duplicated content.
- Add a header note to `AGENTS.md` explaining the bridging relationship so readers know not to duplicate content in bridge files.
- Add an "AI agent rules" section to `README.md` explaining the canonical-source / bridge-file pattern for future coding-agent additions.

## Problem

Claude Code reads `CLAUDE.md`, not `AGENTS.md`. Without this file every Claude Code session silently skips all earned rules, SPEC-alignment requirements, Go runtime hardening guidelines, and harness engineering principles in `AGENTS.md`. The [Claude Code memory docs](https://code.claude.com/docs/en/memory) explicitly recommend the `@AGENTS.md` import pattern to keep a single source of truth.

## Acceptance criteria

- [x] `CLAUDE.md` added at repo root with at least `@AGENTS.md` import
- [x] `README.md` updated with bridging explanation in new "AI agent rules" section
- [x] `AGENTS.md` header notes the bridging relationship
- [ ] Verify `/memory` lists both files in a fresh Claude Code session (requires local runtime; cannot be automated in CI)

## Design notes

Option A (import directive) chosen over Option B (symlink) per issue recommendation — leaves room for Claude-Code-specific additions and avoids symlink privilege issues on Windows.

No Go source files changed; `gofmt`, `go mod tidy`, and `go build ./...` all pass.

Closes #416

https://claude.ai/code/session_01Cd4L54oyDGNfvvEYmRGHd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cd4L54oyDGNfvvEYmRGHd3)_