### PR TITLE
fix(tracker): refresh issue states without cache

### DIFF
--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -135,19 +135,23 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 }
 
 func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+	return c.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(issueIDs))
+}
+
+func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]string, error) {
 	if c.BaseURL == "" || c.Token == "" {
 		return nil, fmt.Errorf("GITEA_BASE_URL and Gitea tracker api_key are required")
 	}
 	if c.Owner == "" || c.Repo == "" {
 		return nil, fmt.Errorf("repo.owner and repo.name are required for Gitea tracker polling")
 	}
-	if len(issueIDs) == 0 {
+	if len(issueRefs) == 0 {
 		return map[string]string{}, nil
 	}
-	states := make(map[string]string, len(issueIDs))
+	states := make(map[string]string, len(issueRefs))
 	seen := map[string]struct{}{}
-	for _, issueID := range issueIDs {
-		issueID = strings.TrimSpace(issueID)
+	for _, issueRef := range issueRefs {
+		issueID := strings.TrimSpace(issueRef.ID)
 		if issueID == "" {
 			continue
 		}
@@ -155,8 +159,9 @@ func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []st
 			continue
 		}
 		seen[issueID] = struct{}{}
-		issueNumber, ok := c.cachedIssueNumber(issueID)
+		issueNumber, ok := c.issueNumberForStateRefresh(issueRef)
 		if !ok {
+			c.logStateRefreshCacheMiss(issueRef)
 			continue
 		}
 		issue, found, err := c.getIssueByNumber(ctx, issueNumber)
@@ -166,7 +171,7 @@ func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []st
 		if !found {
 			continue
 		}
-		if refreshedID := giteaIssueID(issue); refreshedID != issueID {
+		if !giteaIssueMatchesRef(issueID, issueRef.Identifier, issue) {
 			c.cacheIssueNumber(issue)
 			continue
 		}
@@ -179,6 +184,66 @@ func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []st
 		states[issueID] = state
 	}
 	return states, nil
+}
+
+func giteaIssueMatchesRef(issueID, identifier string, issue Issue) bool {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == giteaIssueID(issue) {
+		return true
+	}
+	if !giteaIdentifierMatchesIssueNumber(identifier, issue.Number) {
+		return false
+	}
+	if strings.HasPrefix(issueID, "#") {
+		return issueID == fmt.Sprintf("#%d", issue.Number)
+	}
+	return issueID == giteaIssueNumberID(issue.Number)
+}
+
+func giteaIdentifierMatchesIssueNumber(identifier string, issueNumber int) bool {
+	if identifierNumber, ok := giteaIssueNumberFromIdentifier(identifier); ok {
+		return identifierNumber == issueNumber
+	}
+	return true
+}
+
+func giteaIssueNumberID(issueNumber int) string {
+	if issueNumber <= 0 {
+		return ""
+	}
+	return strconv.Itoa(issueNumber)
+}
+
+func (c *TrackerClient) issueNumberForStateRefresh(ref tracker.IssueRef) (int, bool) {
+	if issueNumber, ok := c.cachedIssueNumber(ref.ID); ok {
+		return issueNumber, true
+	}
+	if issueNumber, ok := giteaIssueNumberFromIdentifier(ref.Identifier); ok {
+		return issueNumber, true
+	}
+	if strings.HasPrefix(strings.TrimSpace(ref.ID), "#") {
+		return giteaIssueNumberFromIdentifier(ref.ID)
+	}
+	return 0, false
+}
+
+func (c *TrackerClient) logStateRefreshCacheMiss(ref tracker.IssueRef) {
+	if c.Logf == nil {
+		return
+	}
+	c.Logf("gitea issue state refresh skipped uncached issue_id=%q issue_identifier=%q; no repo issue-number fallback available", strings.TrimSpace(ref.ID), strings.TrimSpace(ref.Identifier))
+}
+
+func giteaIssueNumberFromIdentifier(identifier string) (int, bool) {
+	identifier = strings.TrimSpace(identifier)
+	if !strings.HasPrefix(identifier, "#") {
+		return 0, false
+	}
+	number, err := strconv.Atoi(strings.TrimPrefix(identifier, "#"))
+	if err != nil || number <= 0 {
+		return 0, false
+	}
+	return number, true
 }
 
 func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, issueState string, wantedStates map[string]struct{}, seenIssues map[string]struct{}) ([]tracker.Issue, bool, error) {

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -151,6 +151,118 @@ func TestTrackerClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) 
 	}
 }
 
+func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t *testing.T) {
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		if r.Header.Get("Authorization") != "token secret" {
+			t.Fatalf("Authorization = %q, want token secret", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/5":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID:      555,
+				Number:  5,
+				Title:   "done",
+				HTMLURL: "https://gitea.local/o/r/issues/5",
+				Labels:  []Label{{Name: "aiops/done"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/7":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID:      987654,
+				Number:  7,
+				Title:   "done",
+				HTMLURL: "https://gitea.local/o/r/issues/7",
+				Labels:  []Label{{Name: "aiops/done"}},
+			})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "987654", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs: %v", err)
+	}
+	if got, want := states, map[string]string{"987654": "Done"}; len(got) != len(want) || got["987654"] != want["987654"] {
+		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	if got, want := strings.Join(requestedPaths, ","), "/api/v1/repos/owner/repo/issues/7"; got != want {
+		t.Fatalf("requested paths = %s, want %s", got, want)
+	}
+	states, err = client.FetchIssueStatesByIDs(context.Background(), []string{"987654"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs after successful ref refresh: %v", err)
+	}
+	if got := states["987654"]; got != "Done" {
+		t.Fatalf("successful ref refresh cache state = %q, want Done", got)
+	}
+
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "other-global-id", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs wrong ID: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states for mismatched issue id = %#v, want empty", states)
+	}
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs #number ID: %v", err)
+	}
+	if got := states["#7"]; got != "Done" {
+		t.Fatalf("#number fallback state = %q, want Done", got)
+	}
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "#8", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs mismatched #number ID: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states for mismatched #number ID = %#v, want empty", states)
+	}
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "7", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs numeric fallback ID: %v", err)
+	}
+	if got := states["7"]; got != "Done" {
+		t.Fatalf("numeric fallback ID state = %q, want Done", got)
+	}
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "5", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs mismatched numeric fallback ID: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states for mismatched numeric fallback ID = %#v, want empty", states)
+	}
+	client.cacheIssueNumber(Issue{ID: 5, Number: 5})
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "5", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs cached mismatched numeric fallback ID: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states for cached mismatched numeric fallback ID = %#v, want empty", states)
+	}
+	client.cacheIssueNumber(Issue{ID: 555, Number: 5})
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "555", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs cached global ID with stale identifier: %v", err)
+	}
+	if got := states["555"]; got != "Done" {
+		t.Fatalf("cached global ID state = %q, want Done", got)
+	}
+	states, err = client.FetchIssueStatesByIDs(context.Background(), []string{"987654"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs after fallback cache: %v", err)
+	}
+	if got := states["987654"]; got != "Done" {
+		t.Fatalf("cached fallback state = %q, want Done", got)
+	}
+}
+
 func TestParseGiteaIssueTimeErrorsOnMalformedTimestamp(t *testing.T) {
 	_, err := parseGiteaIssueTime("updated_at", "not-a-timestamp")
 	if err == nil {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -874,6 +874,37 @@ func (o *Orchestrator) RunningRetryingAndBlockedIssueIDs(ctx context.Context) []
 	}
 }
 
+func (o *Orchestrator) RunningRetryingAndBlockedIssueRefs(ctx context.Context) []tracker.IssueRef {
+	view, err := o.Snapshot(ctx)
+	if err != nil {
+		return nil
+	}
+	refs := make([]tracker.IssueRef, 0, len(view.Running)+len(view.Retrying)+len(view.Blocked))
+	seen := map[string]struct{}{}
+	add := func(issueID IssueID, identifier string) {
+		id := strings.TrimSpace(string(issueID))
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		refs = append(refs, tracker.IssueRef{ID: id, Identifier: strings.TrimSpace(identifier)})
+	}
+	for _, run := range view.Running {
+		add(run.IssueID, run.Identifier)
+	}
+	for _, retry := range view.Retrying {
+		add(retry.IssueID, retry.Identifier)
+	}
+	for _, blocked := range view.Blocked {
+		add(blocked.IssueID, blocked.Identifier)
+	}
+	sort.Slice(refs, func(i, j int) bool { return refs[i].ID < refs[j].ID })
+	return refs
+}
+
 func (o *Orchestrator) RunningAndRetryingIssueIDs(ctx context.Context) []string {
 	return o.RunningRetryingAndBlockedIssueIDs(ctx)
 }
@@ -1656,7 +1687,10 @@ func (r *retryFireOp) apply(st *OrchestratorState) func() {
 					// leaking its workspace — the exact leak this resolves (Codex
 					// P2). Derived from runCtx so actor shutdown still cancels it.
 					resolveCtx, resolveCancel := context.WithTimeout(o.runCtx, retryFetchTimeout)
-					statesByID, rerr := resolver.FetchIssueStatesByIDs(resolveCtx, []string{string(id)})
+					statesByID, rerr := fetchIssueStates(resolveCtx, resolver, []tracker.IssueRef{{
+						ID:         string(id),
+						Identifier: entry.Identifier,
+					}})
 					resolveCancel()
 					if rerr == nil {
 						if s := strings.TrimSpace(statesByID[string(id)]); s != "" && isTerminalTrackerState(s, terminalStates) {

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -3120,6 +3120,26 @@ func (s staticStateRefresher) FetchIssueStatesByIDs(_ context.Context, ids []str
 	return out, nil
 }
 
+type recordingRefStateRefresher struct {
+	states map[string]string
+	refs   [][]tracker.IssueRef
+}
+
+func (r *recordingRefStateRefresher) FetchIssueStatesByIDs(context.Context, []string) (map[string]string, error) {
+	return nil, errors.New("legacy ID-only retry terminal refresh should not be used")
+}
+
+func (r *recordingRefStateRefresher) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+	r.refs = append(r.refs, append([]tracker.IssueRef(nil), refs...))
+	out := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		if state, ok := r.states[ref.ID]; ok {
+			out[ref.ID] = state
+		}
+	}
+	return out, nil
+}
+
 // TestRetryFire_TerminalIssueFiresWorkspaceCleanup is the failure-retry half of
 // #341: a failure retry whose issue has since gone terminal must clean its
 // workspace when the SPEC §16.6 retry timer fires. The active-only candidate
@@ -3138,10 +3158,11 @@ func TestRetryFire_TerminalIssueFiresWorkspaceCleanup(t *testing.T) {
 		WorkspaceCleaner: cleaner,
 	})
 	defer cancel()
-	o.SetRetryTerminalStateResolver(staticStateRefresher{"ENG-FR-T": "Done"}, []string{"Done"})
+	resolver := &recordingRefStateRefresher{states: map[string]string{"global-101": "Done"}}
+	o.SetRetryTerminalStateResolver(resolver, []string{"Done"})
 
-	issue := tracker.Issue{ID: "ENG-FR-T", Identifier: "ENG-FR-T", State: "In Progress", Title: "fail then terminal"}
-	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-FR-T"
+	issue := tracker.Issue{ID: "global-101", Identifier: "#7", State: "In Progress", Title: "fail then terminal"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/github_issue/7"
 	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
 
 	// Abnormal (retryable) exit → failure retry that carries the run's workspace.
@@ -3169,6 +3190,9 @@ func TestRetryFire_TerminalIssueFiresWorkspaceCleanup(t *testing.T) {
 	}
 
 	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, 2*time.Second)
+	if len(resolver.refs) != 1 || len(resolver.refs[0]) != 1 || resolver.refs[0][0].ID != "global-101" || resolver.refs[0][0].Identifier != "#7" {
+		t.Fatalf("terminal resolver refs = %#v, want global-101 with identifier #7", resolver.refs)
+	}
 	got := cleaner.snapshot()[0]
 	if got.IssueID != IssueID(issue.ID) || got.Path != wsPath || got.Reason != "terminal" || got.State != "Done" {
 		t.Fatalf("cleanup = %+v, want terminal cleanup for %s at %q reason=terminal state=Done", got, issue.ID, wsPath)

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -37,6 +37,24 @@ type IssueStateRefresher interface {
 	FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error)
 }
 
+type issueStateRefresherByRefs interface {
+	FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]string, error)
+}
+
+func fetchIssueStates(ctx context.Context, refresher IssueStateRefresher, refs []tracker.IssueRef) (map[string]string, error) {
+	if refresher == nil || len(refs) == 0 {
+		return map[string]string{}, nil
+	}
+	if refRefresher, ok := refresher.(issueStateRefresherByRefs); ok {
+		return refRefresher.FetchIssueStatesByRefs(ctx, refs)
+	}
+	issueIDs := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		issueIDs = append(issueIDs, ref.ID)
+	}
+	return refresher.FetchIssueStatesByIDs(ctx, issueIDs)
+}
+
 // ReconciliationConfig names the workflow states the poller uses to decide
 // whether in-process work is still eligible to run. A running issue absent from
 // active states is canceled once it is observed in either terminal states or in
@@ -277,11 +295,15 @@ func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID
 	if !ok {
 		return nil, nil
 	}
-	issueIDs := p.orchestrator.RunningRetryingAndBlockedIssueIDs(ctx)
-	if len(issueIDs) == 0 {
+	issueRefs := p.orchestrator.RunningRetryingAndBlockedIssueRefs(ctx)
+	if len(issueRefs) == 0 {
 		return nil, nil
 	}
-	statesByID, err := refresher.FetchIssueStatesByIDs(ctx, issueIDs)
+	statesByID, err := fetchIssueStates(ctx, refresher, issueRefs)
+	refsByID := make(map[string]tracker.IssueRef, len(issueRefs))
+	for _, ref := range issueRefs {
+		refsByID[ref.ID] = ref
+	}
 	refreshed := make(map[string]tracker.Issue, len(statesByID))
 	for id, state := range statesByID {
 		if strings.TrimSpace(id) == "" || strings.TrimSpace(state) == "" {
@@ -289,7 +311,7 @@ func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID
 		}
 		issue, ok := activeIssuesByID[id]
 		if !ok {
-			issue = tracker.Issue{ID: id}
+			issue = tracker.Issue{ID: id, Identifier: refsByID[id].Identifier}
 		}
 		issue.ID = id
 		issue.State = state

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -200,7 +200,7 @@ type fakeIssueStateTracker struct {
 	issues        []tracker.Issue
 	err           error
 	fetchIDErr    error
-	fetchIDCalls  [][]string
+	fetchRefCalls [][]tracker.IssueRef
 	fetchIDStates map[string]string
 }
 
@@ -231,18 +231,22 @@ func (f *fakeIssueStateTracker) ListIssuesByStates(_ context.Context, states []s
 	return defaultTrackerIssueTitles(out), nil
 }
 
-func (f *fakeIssueStateTracker) FetchIssueStatesByIDs(_ context.Context, issueIDs []string) (map[string]string, error) {
+func (f *fakeIssueStateTracker) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+	return f.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(issueIDs))
+}
+
+func (f *fakeIssueStateTracker) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.fetchIDCalls = append(f.fetchIDCalls, append([]string(nil), issueIDs...))
+	f.fetchRefCalls = append(f.fetchRefCalls, append([]tracker.IssueRef(nil), refs...))
 	if f.err != nil {
 		return nil, f.err
 	}
 	wanted := map[string]struct{}{}
-	for _, id := range issueIDs {
-		wanted[id] = struct{}{}
+	for _, ref := range refs {
+		wanted[ref.ID] = struct{}{}
 	}
-	out := make(map[string]string, len(issueIDs))
+	out := make(map[string]string, len(refs))
 	if f.fetchIDStates != nil {
 		for id, state := range f.fetchIDStates {
 			if _, ok := wanted[id]; ok {
@@ -259,12 +263,12 @@ func (f *fakeIssueStateTracker) FetchIssueStatesByIDs(_ context.Context, issueID
 	return out, nil
 }
 
-func (f *fakeIssueStateTracker) fetchIssueStatesByIDsCalls() [][]string {
+func (f *fakeIssueStateTracker) fetchIssueStatesByRefsCalls() [][]tracker.IssueRef {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	out := make([][]string, len(f.fetchIDCalls))
-	for i, call := range f.fetchIDCalls {
-		out[i] = append([]string(nil), call...)
+	out := make([][]tracker.IssueRef, len(f.fetchRefCalls))
+	for i, call := range f.fetchRefCalls {
+		out[i] = append([]tracker.IssueRef(nil), call...)
 	}
 	return out
 }
@@ -284,7 +288,7 @@ func (f *fakeIssueStateTracker) setFetchIDErr(err error) {
 func (f *fakeIssueStateTracker) resetFetchIssueStatesByIDsCalls() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.fetchIDCalls = nil
+	f.fetchRefCalls = nil
 }
 
 func (f *fakeIssueStateTracker) setIssues(issues []tracker.Issue) {
@@ -435,21 +439,21 @@ func TestPollOnceUsesNarrowStateRefreshForRunningIssue(t *testing.T) {
 		t.Fatalf("narrow-refresh poll once: %v", err)
 	}
 
-	calls := trackerClient.fetchIssueStatesByIDsCalls()
+	calls := trackerClient.fetchIssueStatesByRefsCalls()
 	if len(calls) != 1 {
-		t.Fatalf("FetchIssueStatesByIDs calls = %d, want 1", len(calls))
+		t.Fatalf("FetchIssueStatesByRefs calls = %d, want 1", len(calls))
 	}
-	if got := calls[0]; len(got) != 1 || got[0] != "issue-1" {
-		t.Fatalf("FetchIssueStatesByIDs ids = %#v, want [issue-1]", got)
+	if got := calls[0]; len(got) != 1 || got[0].ID != "issue-1" || got[0].Identifier != "LIN-1" {
+		t.Fatalf("FetchIssueStatesByRefs refs = %#v, want issue-1 with identifier LIN-1", got)
 	}
 	waitForContextCanceled(t, dispatcher.contextAt(0))
 	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
 }
 
-func TestMultiIssueStateListerFetchesIssueStatesByIDsOnce(t *testing.T) {
+func TestMultiIssueStateListerFansOutIssueStateRefs(t *testing.T) {
 	ctx := context.Background()
-	linearA := &fakeIssueStateTracker{fetchIDStates: map[string]string{"issue-1": "Cancelled", "issue-2": "Done"}}
-	linearB := &fakeIssueStateTracker{fetchIDStates: map[string]string{"issue-1": "Cancelled", "issue-2": "Done"}}
+	linearA := &fakeIssueStateTracker{fetchIDStates: map[string]string{"issue-1": "Cancelled"}}
+	linearB := &fakeIssueStateTracker{fetchIDStates: map[string]string{"issue-2": "Done"}}
 	refresher := IssueStateRefresher(multiIssueStateLister{trackers: []IssueStateLister{linearA, linearB}})
 
 	states, err := refresher.FetchIssueStatesByIDs(ctx, []string{"issue-1", "issue-2"})
@@ -462,13 +466,15 @@ func TestMultiIssueStateListerFetchesIssueStatesByIDsOnce(t *testing.T) {
 	if got := states["issue-2"]; got != "Done" {
 		t.Fatalf("issue-2 state = %q, want Done", got)
 	}
-	if calls := linearA.fetchIssueStatesByIDsCalls(); len(calls) != 1 {
-		t.Fatalf("linearA FetchIssueStatesByIDs calls = %d, want 1", len(calls))
-	} else if got := calls[0]; len(got) != 2 || got[0] != "issue-1" || got[1] != "issue-2" {
-		t.Fatalf("linearA FetchIssueStatesByIDs ids = %#v, want [issue-1 issue-2]", got)
+	if calls := linearA.fetchIssueStatesByRefsCalls(); len(calls) != 1 {
+		t.Fatalf("linearA FetchIssueStatesByRefs calls = %d, want 1", len(calls))
+	} else if got := calls[0]; len(got) != 2 || got[0].ID != "issue-1" || got[1].ID != "issue-2" {
+		t.Fatalf("linearA FetchIssueStatesByRefs refs = %#v, want [issue-1 issue-2]", got)
 	}
-	if calls := linearB.fetchIssueStatesByIDsCalls(); len(calls) != 0 {
-		t.Fatalf("linearB FetchIssueStatesByIDs calls = %d, want 0 (single tracker fan-in)", len(calls))
+	if calls := linearB.fetchIssueStatesByRefsCalls(); len(calls) != 1 {
+		t.Fatalf("linearB FetchIssueStatesByRefs calls = %d, want 1", len(calls))
+	} else if got := calls[0]; len(got) != 1 || got[0].ID != "issue-2" {
+		t.Fatalf("linearB FetchIssueStatesByRefs refs = %#v, want unresolved issue-2 only", got)
 	}
 }
 
@@ -540,8 +546,8 @@ func TestPollOnceRoutingCancelsRunningIssueWhenNarrowRefreshLeavesActiveStates(t
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("refresh poll once: %v", err)
 	}
-	if got := trackerClient.fetchIssueStatesByIDsCalls(); len(got) != 1 {
-		t.Fatalf("FetchIssueStatesByIDs calls = %d, want 1", len(got))
+	if got := trackerClient.fetchIssueStatesByRefsCalls(); len(got) != 1 {
+		t.Fatalf("FetchIssueStatesByRefs calls = %d, want 1", len(got))
 	}
 	waitForContextCanceled(t, dispatcher.contextAt(0))
 	waitForNoRunningOrRetrying(t, ctx, orch, "issue-1")
@@ -825,12 +831,12 @@ func TestPollOnceAppliesPartialRunningIDRefreshWhenRefreshReturnsError(t *testin
 	if err := poller.PollOnce(ctx); err == nil || !strings.Contains(err.Error(), "secondary tracker state refresh failed") {
 		t.Fatalf("refresh poll error = %v, want partial refresh error", err)
 	}
-	calls := trackerClient.fetchIssueStatesByIDsCalls()
+	calls := trackerClient.fetchIssueStatesByRefsCalls()
 	if len(calls) != 1 {
-		t.Fatalf("FetchIssueStatesByIDs calls = %d, want 1", len(calls))
+		t.Fatalf("FetchIssueStatesByRefs calls = %d, want 1", len(calls))
 	}
-	if got := calls[0]; len(got) != 1 || got[0] != "issue-1" {
-		t.Fatalf("FetchIssueStatesByIDs ids = %#v, want [issue-1]", got)
+	if got := calls[0]; len(got) != 1 || got[0].ID != "issue-1" {
+		t.Fatalf("FetchIssueStatesByRefs refs = %#v, want [issue-1]", got)
 	}
 
 	select {

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -258,14 +258,39 @@ func (l multiIssueStateLister) ListIssuesByStates(ctx context.Context, states []
 }
 
 func (l multiIssueStateLister) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+	return l.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(issueIDs))
+}
+
+func (l multiIssueStateLister) FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]string, error) {
+	out := make(map[string]string, len(issueRefs))
+	remaining := append([]tracker.IssueRef(nil), issueRefs...)
+	var errOut error
 	for _, stateTracker := range l.trackers {
 		refresher, ok := stateTracker.(IssueStateRefresher)
 		if !ok {
 			continue
 		}
-		return refresher.FetchIssueStatesByIDs(ctx, issueIDs)
+		got, err := fetchIssueStates(ctx, refresher, remaining)
+		if err != nil {
+			errOut = errors.Join(errOut, err)
+		}
+		if len(got) == 0 {
+			continue
+		}
+		next := remaining[:0]
+		for _, ref := range remaining {
+			if state, ok := got[ref.ID]; ok {
+				out[ref.ID] = state
+				continue
+			}
+			next = append(next, ref)
+		}
+		remaining = next
+		if len(remaining) == 0 {
+			return out, nil
+		}
 	}
-	return map[string]string{}, nil
+	return out, errOut
 }
 
 // routedActiveIssueLister wraps an ActiveIssueLister with the same
@@ -444,8 +469,9 @@ func (d *RuntimeDispatcher) configForSnapshot(snap WorkflowSnapshot) worker.Conf
 			if len(activeStates) == 0 {
 				return nil
 			}
+			issueRef := tracker.IssueRef{ID: issueID, Identifier: taskIssueIdentifier(t)}
 			return func(ctx context.Context) (bool, error) {
-				statesByID, err := refresher.FetchIssueStatesByIDs(ctx, []string{issueID})
+				statesByID, err := fetchIssueStates(ctx, refresher, []tracker.IssueRef{issueRef})
 				if err != nil {
 					return false, err
 				}
@@ -463,6 +489,17 @@ func (d *RuntimeDispatcher) configForSnapshot(snap WorkflowSnapshot) worker.Conf
 		}
 	}
 	return cfg
+}
+
+func taskIssueIdentifier(t task.Task) string {
+	if identifier, ok := t.IssueRender["identifier"].(string); ok && strings.TrimSpace(identifier) != "" {
+		return strings.TrimSpace(identifier)
+	}
+	sourceEventID := strings.TrimSpace(t.SourceEventID)
+	if strings.Contains(sourceEventID, "|service|") {
+		return ""
+	}
+	return sourceEventID
 }
 
 func normalizedStateSet(states []string) map[string]struct{} {

--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -25,6 +26,26 @@ func (s *stubRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (
 	for _, id := range ids {
 		if state, ok := s.states[id]; ok {
 			out[id] = state
+		}
+	}
+	return out, nil
+}
+
+type stubRefAwareRefresher struct {
+	refs   [][]tracker.IssueRef
+	states map[string]string
+}
+
+func (s *stubRefAwareRefresher) FetchIssueStatesByIDs(context.Context, []string) (map[string]string, error) {
+	return nil, errors.New("legacy ID-only refresh should not be used")
+}
+
+func (s *stubRefAwareRefresher) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+	s.refs = append(s.refs, append([]tracker.IssueRef(nil), refs...))
+	out := map[string]string{}
+	for _, ref := range refs {
+		if state, ok := s.states[ref.ID]; ok {
+			out[ref.ID] = state
 		}
 	}
 	return out, nil
@@ -107,6 +128,36 @@ func TestRuntimeDispatcherConfigForSnapshotBuildsRefresherClosure(t *testing.T) 
 			t.Fatalf("err = %v, want wrapped tracker boom", err)
 		}
 	})
+}
+
+func TestRuntimeDispatcherIssueStateRefresherPassesIssueIdentifierFallback(t *testing.T) {
+	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
+	stub := &stubRefAwareRefresher{states: map[string]string{"global-101": "Done"}}
+	d.SetIssueStateRefresher(stub)
+
+	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
+		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress"}},
+	}}}
+	cfg := d.configForSnapshot(snap)
+	fn := cfg.IssueStateRefresher(task.Task{
+		ID:            "global-101",
+		SourceEventID: "global-101|service|api",
+		IssueRender:   map[string]any{"identifier": "#7"},
+	}, snap.Workflow.Config)
+
+	active, err := fn(context.Background())
+	if err != nil {
+		t.Fatalf("refresher err: %v", err)
+	}
+	if active {
+		t.Fatal("active = true, want false after ref-aware Done refresh")
+	}
+	if len(stub.refs) != 1 || len(stub.refs[0]) != 1 {
+		t.Fatalf("ref calls = %#v, want one issue ref", stub.refs)
+	}
+	if got := stub.refs[0][0]; got.ID != "global-101" || got.Identifier != "#7" {
+		t.Fatalf("issue ref = %+v, want ID global-101 with identifier #7", got)
+	}
 }
 
 // TestRuntimeDispatcherConfigForSnapshotReturnsNilWithoutRefresher pins the

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -475,15 +475,13 @@ func (c *GitHubClient) recordPaginationCapHit(label string, maxPages int) {
 // FetchIssueStatesByIDs implements SPEC §11.1 for the GitHub adapter. GitHub's
 // REST API has no `[ID!]` bulk endpoint, so this iterates one
 // `GET /repos/{owner}/{repo}/issues/{number}` per ID using the repo issue
-// number cached during prior list calls. Per-ID 404/410 responses are treated
-// as "issue removed" and silently skipped so a single deleted issue does not
-// abort reconciliation for the rest of the running set. Other HTTP errors
-// abort the whole call so a transient outage cannot silently degrade per-tick
-// state refresh.
-//
-// IDs without a cached number (e.g. issues we have never listed in this
-// process) are skipped because there is no way to address them by global
-// numeric ID via the REST API. They will be cached on the next list cycle.
+// number cached during prior list calls. Ref-aware callers can also provide
+// the human identifier (`#123`) so a rebuilt tracker client can query by repo
+// issue number before any list call repopulates the cache. Per-ID 404/410
+// responses are treated as "issue removed" and silently skipped so a single
+// deleted issue does not abort reconciliation for the rest of the running set.
+// Other HTTP errors abort the whole call so a transient outage cannot silently
+// degrade per-tick state refresh.
 //
 // State derivation: if any label on the issue matches a state configured in
 // active_states / terminal_states / inactive_states (case-insensitive), the
@@ -491,20 +489,24 @@ func (c *GitHubClient) recordPaginationCapHit(label string, maxPages int) {
 // normalization). Otherwise the issue's open/closed state is returned. This
 // matches the GitHub convention where workflow position is encoded as labels.
 func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+	return c.FetchIssueStatesByRefs(ctx, IssueRefsFromIDs(issueIDs))
+}
+
+func (c *GitHubClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef) (map[string]string, error) {
 	if strings.TrimSpace(c.Token) == "" {
 		return nil, fmt.Errorf("GitHub tracker api_key is required")
 	}
-	if len(issueIDs) == 0 {
+	if len(issueRefs) == 0 {
 		return map[string]string{}, nil
 	}
 	if strings.TrimSpace(c.Owner) == "" || strings.TrimSpace(c.Repo) == "" {
 		return nil, fmt.Errorf("repo.owner and repo.name are required for GitHub tracker polling")
 	}
 	configuredStates := githubConfiguredStates(c.Config)
-	states := make(map[string]string, len(issueIDs))
+	states := make(map[string]string, len(issueRefs))
 	seen := map[string]struct{}{}
-	for _, issueID := range issueIDs {
-		issueID = strings.TrimSpace(issueID)
+	for _, issueRef := range issueRefs {
+		issueID := strings.TrimSpace(issueRef.ID)
 		if issueID == "" {
 			continue
 		}
@@ -512,8 +514,9 @@ func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []str
 			continue
 		}
 		seen[issueID] = struct{}{}
-		issueNumber, ok := c.cachedIssueNumber(issueID)
+		issueNumber, ok := c.issueNumberForStateRefresh(issueRef)
 		if !ok {
+			c.logStateRefreshCacheMiss(issueRef)
 			continue
 		}
 		issue, found, err := c.getIssueByNumber(ctx, issueNumber)
@@ -523,7 +526,15 @@ func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []str
 		if !found {
 			continue
 		}
-		c.cacheIssueNumber(strconv.FormatInt(issue.ID, 10), issue.Number)
+		refreshedID := strconv.FormatInt(issue.ID, 10)
+		if !githubFetchedIssueMatchesRef(issueID, issueRef.Identifier, refreshedID, issue.Number) {
+			c.cacheIssueNumber(refreshedID, issue.Number)
+			continue
+		}
+		c.cacheIssueNumber(refreshedID, issue.Number)
+		if issueNumberID := githubIssueNumberID(issue.Number); issueID == issueNumberID {
+			c.cacheIssueNumber(issueID, issue.Number)
+		}
 		state := githubResolveState(issue, configuredStates)
 		if state == "" {
 			continue
@@ -531,6 +542,66 @@ func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []str
 		states[issueID] = state
 	}
 	return states, nil
+}
+
+func githubFetchedIssueMatchesRef(issueID, identifier, refreshedID string, issueNumber int) bool {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == refreshedID {
+		return true
+	}
+	if !githubIdentifierMatchesIssueNumber(identifier, issueNumber) {
+		return false
+	}
+	if strings.HasPrefix(issueID, "#") {
+		return issueID == fmt.Sprintf("#%d", issueNumber)
+	}
+	return issueID == githubIssueNumberID(issueNumber)
+}
+
+func githubIdentifierMatchesIssueNumber(identifier string, issueNumber int) bool {
+	if identifierNumber, ok := githubIssueNumberFromIdentifier(identifier); ok {
+		return identifierNumber == issueNumber
+	}
+	return true
+}
+
+func githubIssueNumberID(issueNumber int) string {
+	if issueNumber <= 0 {
+		return ""
+	}
+	return strconv.Itoa(issueNumber)
+}
+
+func (c *GitHubClient) issueNumberForStateRefresh(ref IssueRef) (int, bool) {
+	if issueNumber, ok := c.cachedIssueNumber(ref.ID); ok {
+		return issueNumber, true
+	}
+	if issueNumber, ok := githubIssueNumberFromIdentifier(ref.Identifier); ok {
+		return issueNumber, true
+	}
+	if strings.HasPrefix(strings.TrimSpace(ref.ID), "#") {
+		return githubIssueNumberFromIdentifier(ref.ID)
+	}
+	return 0, false
+}
+
+func (c *GitHubClient) logStateRefreshCacheMiss(ref IssueRef) {
+	if c.Logf == nil {
+		return
+	}
+	c.Logf("github issue state refresh skipped uncached issue_id=%q issue_identifier=%q; no repo issue-number fallback available", strings.TrimSpace(ref.ID), strings.TrimSpace(ref.Identifier))
+}
+
+func githubIssueNumberFromIdentifier(identifier string) (int, bool) {
+	identifier = strings.TrimSpace(identifier)
+	if !strings.HasPrefix(identifier, "#") {
+		return 0, false
+	}
+	number, err := strconv.Atoi(strings.TrimPrefix(identifier, "#"))
+	if err != nil || number <= 0 {
+		return 0, false
+	}
+	return number, true
 }
 
 func (c *GitHubClient) getIssueByNumber(ctx context.Context, issueNumber int) (githubIssue, bool, error) {

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -489,6 +489,113 @@ func TestGitHubClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) {
 	}
 }
 
+func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t *testing.T) {
+	var requestedPaths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/5":
+			_ = json.NewEncoder(w).Encode(githubIssue{
+				ID:        555,
+				Number:    5,
+				State:     "open",
+				CreatedAt: "2026-05-20T01:02:03Z",
+				UpdatedAt: "2026-05-20T02:03:04Z",
+				Labels:    []githubLabel{{Name: "Done"}},
+			})
+		case "/repos/acme/api/issues/7":
+			_ = json.NewEncoder(w).Encode(githubIssue{
+				ID:        987654,
+				Number:    7,
+				State:     "open",
+				CreatedAt: "2026-05-20T01:02:03Z",
+				UpdatedAt: "2026-05-20T02:03:04Z",
+				Labels:    []githubLabel{{Name: "Done"}},
+			})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{
+		APIKey:         "test-token",
+		TerminalStates: []string{"Done"},
+	}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "987654", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs: %v", err)
+	}
+	if got, want := states, map[string]string{"987654": "done"}; len(got) != len(want) || got["987654"] != want["987654"] {
+		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	if got, want := strings.Join(requestedPaths, ","), "/repos/acme/api/issues/7"; got != want {
+		t.Fatalf("requested paths = %s, want %s", got, want)
+	}
+
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "other-global-id", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs wrong ID: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states for mismatched issue id = %#v, want empty", states)
+	}
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs #number ID: %v", err)
+	}
+	if got := states["#7"]; got != "done" {
+		t.Fatalf("#number fallback state = %q, want done", got)
+	}
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "#8", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs mismatched #number ID: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states for mismatched #number ID = %#v, want empty", states)
+	}
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "7", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs numeric fallback ID: %v", err)
+	}
+	if got := states["7"]; got != "done" {
+		t.Fatalf("numeric fallback ID state = %q, want done", got)
+	}
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "5", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs mismatched numeric fallback ID: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states for mismatched numeric fallback ID = %#v, want empty", states)
+	}
+	client.cacheIssueNumber("5", 5)
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "5", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs cached mismatched numeric fallback ID: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states for cached mismatched numeric fallback ID = %#v, want empty", states)
+	}
+	client.cacheIssueNumber("555", 5)
+	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "555", Identifier: "#7"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs cached global ID with stale identifier: %v", err)
+	}
+	if got := states["555"]; got != "done" {
+		t.Fatalf("cached global ID state = %q, want done", got)
+	}
+	states, err = client.FetchIssueStatesByIDs(context.Background(), []string{"987654"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs after fallback cache: %v", err)
+	}
+	if got := states["987654"]; got != "done" {
+		t.Fatalf("cached fallback state = %q, want done", got)
+	}
+}
+
 func TestGitHubClientFetchIssueStatesByIDsRequiresToken(t *testing.T) {
 	client := NewGitHubClient(workflow.TrackerConfig{}, "https://api.github.test", "acme", "api")
 	if _, err := client.FetchIssueStatesByIDs(context.Background(), []string{"1"}); err == nil || !strings.Contains(err.Error(), "GitHub tracker api_key") {

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
@@ -22,6 +23,25 @@ type Issue struct {
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	BlockedBy    []BlockerRef
+}
+
+// IssueRef carries the stable tracker ID plus the human identifier captured at
+// dispatch time. GitHub and Gitea need the identifier as a repo issue-number
+// fallback because their REST state-refresh endpoints cannot address issues by
+// the normalized global ID directly.
+type IssueRef struct {
+	ID         string
+	Identifier string
+}
+
+func IssueRefsFromIDs(issueIDs []string) []IssueRef {
+	refs := make([]IssueRef, 0, len(issueIDs))
+	for _, id := range issueIDs {
+		if id = strings.TrimSpace(id); id != "" {
+			refs = append(refs, IssueRef{ID: id})
+		}
+	}
+	return refs
 }
 
 // BlockerRef is the minimal tracker dependency metadata the orchestrator needs

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -1,9 +1,18 @@
 package tracker
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
+
+func TestIssueRefsFromIDsTrimsAndSkipsEmptyIDs(t *testing.T) {
+	got := IssueRefsFromIDs([]string{" 123 ", "", " \t\n", "#7 "})
+	want := []IssueRef{{ID: "123"}, {ID: "#7"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("IssueRefsFromIDs = %#v, want %#v", got, want)
+	}
+}
 
 func TestTimeStringReturnsEmptyForZeroTime(t *testing.T) {
 	if got := TimeString(time.Time{}); got != "" {


### PR DESCRIPTION
Closes #388

## Acceptance
- GitHub/Gitea state refresh now accepts issue refs that carry the stable tracker ID plus the human `#number` identifier, so rebuilt clients can refresh state before list calls repopulate the in-memory ID -> number cache.
- Plain numeric fallback IDs like `"7"` with identifier `"#7"` remain eligible for refresh when adapters use issue-number fallback IDs.
- Mismatched refs are rejected: global-ID mismatches, numeric fallback mismatches like `"5"/"#7"`, cached numeric fallback mismatches like cached `"5" -> #5` with identifier `"#7"`, and `#number` mismatches like `"#8"/"#7"` all return no state.
- True global-ID matches still win even if the human identifier is stale, so a valid stable tracker ID does not get rejected by stale presentation metadata.
- `IssueRefsFromIDs` trims incidental whitespace and skips empty IDs, preserving the prior tolerant ID-only refresh behavior.
- Per-turn refresh, poll reconciliation, retry terminal lookup, and multi-tracker fan-out pass refs through the new path while preserving the legacy ID-only interface for Linear and tests.
- Cache misses without a usable issue number are logged when Logf is configured, and Gitea successful ref refresh warms the same ID -> number cache as GitHub.

## Validation
- `go test ./internal/tracker ./internal/gitea ./internal/orchestrator -run 'TestIssueRefsFromIDsTrimsAndSkipsEmptyIDs|TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache|TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache|TestMultiIssueStateListerFansOutIssueStateRefs|TestRuntimeDispatcherIssueStateRefresherPassesIssueIdentifierFallback|TestPollOnceUsesNarrowStateRefreshForRunningIssue|TestRetryFire_TerminalIssueFiresWorkspaceCleanup' -count=1`
- Mutation checks: removing numeric fallback acceptance makes GitHub/Gitea numeric fallback tests fail; restoring unconditional `#` acceptance makes `#8/#7` mismatch tests fail; ignoring identifier mismatch makes cached `5/#7` tests fail; removing Gitea success-path cache makes its cache assertion fail; removing orchestrator identifier propagation makes per-turn/poll/retry tests fail.
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`
- `go vet ./...`

## Review
- Pre-push Codex subagent review: LGTM on `0b41366`; only LOW size-gate reminder.
- Pre-push Claude Code review: LGTM on `0b41366`; LOW notes only.
- GitHub `@codex review`: pending fresh run for `0b41366`.

## Risk / gates
- Size gate: `12 files changed, 620 insertions(+), 62 deletions(-)`. This exceeds the default file/LOC budget; do not auto-merge without explicit size-gate sign-off.
- No acceptance deferrals.
