### PR TITLE
Preserve custom codex app-server commands

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -181,24 +181,124 @@ func validateAppServerWorkdir(workdir string) error {
 
 // buildCodexAppServerCmd returns the codex app-server *exec.Cmd plus a
 // directCodexExec flag. The flag is true only when the command launches the
-// `codex` binary directly (so `cmd.Process.Pid` after Start() is the actual
-// app-server pid). Custom `codex.command` configurations route through
-// `sh -c <command>`, in which case `cmd.Process.Pid` is the shell wrapper,
-// not codex — see codex_app_server.go's session_started emit for the resulting
+// `codex app-server` binary directly (so `cmd.Process.Pid` after Start() is
+// the actual app-server pid). Custom wrapper commands route through
+// `sh -c <command>`, in which case `cmd.Process.Pid` is the shell wrapper, not
+// codex — see codex_app_server.go's session_started emit for the resulting
 // PID-emission guard.
 func buildCodexAppServerCmd(ctx context.Context, in RunInput, env []string) (*exec.Cmd, bool, error) {
 	command := strings.TrimSpace(in.Workflow.Config.Codex.Command)
 	if command == "" || command == "codex exec" {
 		command = "codex app-server"
 	}
-	if command == "codex app-server" {
+	args, err := splitAppServerCommand(command)
+	if err == nil && len(args) >= 2 && args[0] == "codex" && args[1] == "app-server" && !hasShellSyntax(command) {
 		codexPath, err := lookPathInEnv("codex", env)
 		if err != nil {
 			return nil, false, NewError(CategoryCodexNotFound, "codex binary not found in PATH; install codex CLI or set agent.default to claude/mock", err)
 		}
-		return exec.CommandContext(ctx, codexPath, "app-server"), true, nil
+		return exec.CommandContext(ctx, codexPath, args[1:]...), true, nil
 	}
 	return exec.CommandContext(ctx, "sh", "-c", command), false, nil
+}
+
+func splitAppServerCommand(command string) ([]string, error) {
+	var args []string
+	var current strings.Builder
+	var quote rune
+	tokenStarted := false
+	runes := []rune(command)
+
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+				tokenStarted = true
+			} else if quote == '"' && r == '\\' && i+1 < len(runes) && strings.ContainsRune("$`\"\\\n", runes[i+1]) {
+				i++
+				current.WriteRune(runes[i])
+				tokenStarted = true
+			} else {
+				current.WriteRune(r)
+				tokenStarted = true
+			}
+		case r == '\\':
+			current.WriteRune(r)
+			tokenStarted = true
+		case r == '\'' || r == '"':
+			quote = r
+			tokenStarted = true
+		case isCommandSpace(r):
+			if tokenStarted {
+				args = append(args, current.String())
+				current.Reset()
+				tokenStarted = false
+			}
+		default:
+			current.WriteRune(r)
+			tokenStarted = true
+		}
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("parse codex.command")
+	}
+	if tokenStarted {
+		args = append(args, current.String())
+	}
+	return args, nil
+}
+
+func hasShellSyntax(command string) bool {
+	var quote rune
+	tokenBoundary := true
+	runes := []rune(command)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		switch {
+		case quote == '\'':
+			if r == '\'' {
+				quote = 0
+			}
+		case quote == '"':
+			switch r {
+			case '"':
+				quote = 0
+			case '$', '`', '\n':
+				return true
+			case '\\':
+				if i+1 < len(runes) && runes[i+1] == '\n' {
+					return true
+				}
+				i++
+			}
+		case r == '\'' || r == '"':
+			quote = r
+			tokenBoundary = false
+		case r == '\n' || r == '\r':
+			return true
+		case r == '#':
+			if tokenBoundary {
+				return true
+			}
+			tokenBoundary = false
+		case isCommandSpace(r):
+			tokenBoundary = true
+			continue
+		case r == '\\':
+			return true
+		case strings.ContainsRune("|&;<>$()`{}[]*?~", r):
+			return true
+		default:
+			tokenBoundary = false
+		}
+	}
+	return quote != 0
+}
+
+func isCommandSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
 }
 
 type appServerClient struct {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1457,13 +1457,8 @@ func TestBuildCodexAppServerCmdResolvesCodexFromAgentEnvPATH(t *testing.T) {
 	}
 }
 
-// TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect pins the
-// directCodexExec flag's negative case: when `codex.command` is anything other
-// than the built-in `codex app-server` invocation, the cmd runs through `sh -c`.
-// The runner
-// uses this signal to suppress codex_app_server_pid emission, since
-// cmd.Process.Pid would be the shell wrapper rather than the actual codex
-// process.
+// TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect pins the direct exec
+// flag's negative case: wrapper commands still run through `sh -c`.
 func TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect(t *testing.T) {
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
@@ -1482,19 +1477,129 @@ func TestBuildCodexAppServerCmdReportsCustomCommandAsIndirect(t *testing.T) {
 }
 
 func TestBuildCodexAppServerCmdPreservesQuotedCustomCodexCommand(t *testing.T) {
+	binDir := t.TempDir()
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.Command = `codex app-server --config "model = gpt-5"`
 
-	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + os.Getenv("PATH")})
+	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + binDir})
 	if err != nil {
 		t.Fatalf("buildCodexAppServerCmd: %v", err)
 	}
-	if directExec {
-		t.Fatalf("directCodexExec = true for custom command %q, want false (shell wrapper)", in.Workflow.Config.Codex.Command)
+	if !directExec {
+		t.Fatalf("directCodexExec = false for custom codex app-server command %q, want true", in.Workflow.Config.Codex.Command)
 	}
-	if len(cmd.Args) < 3 || cmd.Args[0] != "sh" || cmd.Args[1] != "-c" || cmd.Args[2] != in.Workflow.Config.Codex.Command {
-		t.Fatalf("cmd.Args = %#v, want shell wrapper preserving quoted command", cmd.Args)
+	if cmd.Path != codex {
+		t.Fatalf("cmd.Path = %q, want codex from agent env PATH %q", cmd.Path, codex)
+	}
+	want := []string{codex, "app-server", "--config", "model = gpt-5"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("cmd.Args = %#v, want %#v", cmd.Args, want)
+	}
+}
+
+func TestBuildCodexAppServerCmdPreservesQuotedBackslashArgument(t *testing.T) {
+	binDir := t.TempDir()
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.Command = `codex app-server --cd "C:\proj"`
+
+	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + binDir})
+	if err != nil {
+		t.Fatalf("buildCodexAppServerCmd: %v", err)
+	}
+	if !directExec {
+		t.Fatalf("directCodexExec = false for quoted backslash command %q, want true", in.Workflow.Config.Codex.Command)
+	}
+	want := []string{codex, "app-server", "--cd", `C:\proj`}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("cmd.Args = %#v, want %#v", cmd.Args, want)
+	}
+}
+
+func TestBuildCodexAppServerCmdAllowsQuotedConfigMetacharacters(t *testing.T) {
+	binDir := t.TempDir()
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.Command = `codex app-server --config 'sandbox_permissions = ["read-only"]'`
+
+	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + binDir})
+	if err != nil {
+		t.Fatalf("buildCodexAppServerCmd: %v", err)
+	}
+	if !directExec {
+		t.Fatalf("directCodexExec = false for quoted config command %q, want true", in.Workflow.Config.Codex.Command)
+	}
+	want := []string{codex, "app-server", "--config", `sandbox_permissions = ["read-only"]`}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("cmd.Args = %#v, want %#v", cmd.Args, want)
+	}
+}
+
+func TestBuildCodexAppServerCmdAllowsHashInsideArgument(t *testing.T) {
+	binDir := t.TempDir()
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.Command = `codex app-server --config release#2026.toml`
+
+	cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + binDir})
+	if err != nil {
+		t.Fatalf("buildCodexAppServerCmd: %v", err)
+	}
+	if !directExec {
+		t.Fatalf("directCodexExec = false for hash inside argument %q, want true", in.Workflow.Config.Codex.Command)
+	}
+	want := []string{codex, "app-server", "--config", `release#2026.toml`}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("cmd.Args = %#v, want %#v", cmd.Args, want)
+	}
+}
+
+func TestBuildCodexAppServerCmdKeepsShellSyntaxCommandsIndirect(t *testing.T) {
+	for _, command := range []string{
+		`codex app-server && echo done`,
+		`codex app-server --config *.toml`,
+		`codex app-server --config "$(cat cfg)"`,
+		`codex app-server --config {a,b}.toml`,
+		"codex app-server --config x # note",
+		"codex app-server\nfoo",
+		`codex app-server --config foo\ bar`,
+		`codex app-server --config foo\z`,
+		`codex app-server --config C:\Users\agent\cfg.toml`,
+		`codex app-server --config "unterminated`,
+	} {
+		t.Run(command, func(t *testing.T) {
+			wd := codexWorkdir(t, "x")
+			in := appServerInput(wd)
+			in.Workflow.Config.Codex.Command = command
+
+			cmd, directExec, err := buildCodexAppServerCmd(context.Background(), in, []string{"PATH=" + os.Getenv("PATH")})
+			if err != nil {
+				t.Fatalf("buildCodexAppServerCmd: %v", err)
+			}
+			if directExec {
+				t.Fatalf("directCodexExec = true for shell syntax command %q, want false", in.Workflow.Config.Codex.Command)
+			}
+			if len(cmd.Args) < 3 || cmd.Args[0] != "sh" || cmd.Args[1] != "-c" || cmd.Args[2] != in.Workflow.Config.Codex.Command {
+				t.Fatalf("cmd.Args = %#v, want sh -c wrapper", cmd.Args)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #417

## Acceptance criteria
- [x] Custom `codex app-server ...` commands with argv-safe quoted arguments direct-exec the Codex binary.
- [x] Wrapper commands and shell syntax continue through `sh -c`.
- [x] `codex_app_server_pid` remains emitted only when the process PID is the real Codex app-server process.
- [x] Regression tests cover quoted configs, quoted Windows-style backslashes, shell metacharacters, comments, unquoted backslashes, and `#` inside an argv token.

## Validation
- `go test ./internal/runner -run 'TestBuildCodexAppServerCmd'`
- Mutation check: treating every `#` as shell syntax made `TestBuildCodexAppServerCmdAllowsHashInsideArgument` fail; restoring token-boundary handling passed.
- `git fetch origin main && test -z "$(gofmt -l $(git ls-files '*.go'))" && go mod tidy && git diff --exit-code -- go.mod go.sum && go vet ./... && go test -race -covermode=atomic ./... && go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`

## Review ledger
- Head: `9afc127b1419065565470568f7f49c5bb0c23d35`
- Pre-push Codex diff-only reviewer: MERGE-READY after the `#` token-boundary finding was fixed.
- Pre-push Claude diff-only reviewer: MERGE-READY after the `#` token-boundary finding was fixed.
- GitHub `@codex review`: trigger comment `4538180791`; completion comment `4538202376` said no major issues.
- GraphQL reviewThreads: no unresolved non-outdated actionable threads; the earlier P2 thread is outdated on the current head.
- CI: green, run `26424522342`.
- Warning audit: no `warning:` lines found in CI logs.

## Size gate
- Changed files: 2. Changed LOC: 223. Within default 12 files / 300 LOC size budget.
- Size-gated: no.

## Risk / deferral
- No deferrals.
- This is runner command construction only; no SPEC deviation added.
