### PR TITLE
Bound Gitea tracker requests

### DIFF
--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -45,6 +45,9 @@ type TrackerClient struct {
 	Config  workflow.TrackerConfig
 	HTTP    *http.Client
 	Logf    func(format string, args ...any)
+	// RequestTimeout caps the wall-clock duration of a single Gitea tracker
+	// request. Zero falls back to defaultGiteaRequestTimeout.
+	RequestTimeout time.Duration
 
 	issueNumbers sync.Map
 
@@ -58,8 +61,21 @@ func NewTrackerClient(cfg workflow.TrackerConfig, baseURL, owner, repo string) *
 		Owner:   owner,
 		Repo:    repo,
 		Config:  cfg,
-		HTTP:    http.DefaultClient,
 	}
+}
+
+func (c *TrackerClient) requestTimeout() time.Duration {
+	if c != nil && c.RequestTimeout > 0 {
+		return c.RequestTimeout
+	}
+	return defaultGiteaRequestTimeout
+}
+
+func (c *TrackerClient) httpClient() *http.Client {
+	if c != nil && c.HTTP != nil {
+		return c.HTTP
+	}
+	return &http.Client{Timeout: c.requestTimeout()}
 }
 
 func (c *TrackerClient) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
@@ -340,15 +356,14 @@ func parseGiteaIssueTime(field, value string) (time.Time, error) {
 
 func (c *TrackerClient) getIssueByNumber(ctx context.Context, issueNumber int) (Issue, bool, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues/%d", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo), issueNumber)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return Issue{}, false, err
 	}
 	req.Header.Set("Authorization", "token "+c.Token)
-	client := c.HTTP
-	if client == nil {
-		client = http.DefaultClient
-	}
+	client := c.httpClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return Issue{}, false, err
@@ -400,15 +415,14 @@ func (c *TrackerClient) listIssuesPage(ctx context.Context, labelName string, is
 	}
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, false, err
 	}
 	req.Header.Set("Authorization", "token "+c.Token)
-	client := c.HTTP
-	if client == nil {
-		client = http.DefaultClient
-	}
+	client := c.httpClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, false, err

--- a/internal/gitea/tracker_client_timeout_test.go
+++ b/internal/gitea/tracker_client_timeout_test.go
@@ -1,0 +1,97 @@
+package gitea
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestTrackerClientRequestTimeoutFallsBackToDefault(t *testing.T) {
+	c := &TrackerClient{}
+	if got := c.requestTimeout(); got != defaultGiteaRequestTimeout {
+		t.Errorf("zero RequestTimeout: got %v, want %v", got, defaultGiteaRequestTimeout)
+	}
+}
+
+func TestTrackerClientRequestTimeoutHonorsExplicitOverride(t *testing.T) {
+	c := &TrackerClient{RequestTimeout: 250 * time.Millisecond}
+	if got := c.requestTimeout(); got != 250*time.Millisecond {
+		t.Errorf("explicit override: got %v, want 250ms", got)
+	}
+}
+
+func TestTrackerClientFallbackHTTPClientUsesRequestTimeout(t *testing.T) {
+	c := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, "https://gitea.example", "owner", "repo")
+	c.RequestTimeout = 250 * time.Millisecond
+	client := c.httpClient()
+	if client == nil {
+		t.Fatal("fallback HTTP client is nil")
+	}
+	if got := client.Timeout; got != 250*time.Millisecond {
+		t.Fatalf("HTTP.Timeout = %v, want 250ms", got)
+	}
+}
+
+func TestTrackerClientListIssuesAbortsHungServer(t *testing.T) {
+	srv := hungGiteaServer(t)
+	client := NewTrackerClient(workflow.TrackerConfig{
+		APIKey:       "secret",
+		ActiveStates: []string{"AI Ready"},
+	}, srv.URL, "owner", "repo")
+	client.HTTP = srv.Client()
+	client.RequestTimeout = 100 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	start := time.Now()
+	_, err := client.ListActiveIssues(ctx)
+	assertRequestTimeout(t, "ListActiveIssues", err, time.Since(start))
+}
+
+func TestTrackerClientFetchIssueStateAbortsHungServer(t *testing.T) {
+	srv := hungGiteaServer(t)
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, srv.URL, "owner", "repo")
+	client.HTTP = srv.Client()
+	client.RequestTimeout = 100 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	start := time.Now()
+	_, err := client.FetchIssueStatesByRefs(ctx, []tracker.IssueRef{{ID: "#1"}})
+	assertRequestTimeout(t, "FetchIssueStatesByRefs", err, time.Since(start))
+}
+
+func hungGiteaServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(3 * time.Second):
+		case <-r.Context().Done():
+		}
+	}))
+	srv.Config.SetKeepAlivesEnabled(false)
+	t.Cleanup(func() {
+		srv.CloseClientConnections()
+		srv.Close()
+	})
+	return srv
+}
+
+func assertRequestTimeout(t *testing.T, name string, err error, elapsed time.Duration) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected timeout error from hung server, got nil", name)
+	}
+	if !strings.Contains(err.Error(), "deadline exceeded") && !strings.Contains(err.Error(), "context") {
+		t.Fatalf("%s: expected context-deadline error, got %v", name, err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("%s blocked %v; RequestTimeout did not fire", name, elapsed)
+	}
+}


### PR DESCRIPTION
Closes #405

## Acceptance criteria
- [x] `TrackerClient` has a `RequestTimeout` override with `defaultGiteaRequestTimeout` fallback.
- [x] Gitea tracker list-page requests are wrapped in `context.WithTimeout`.
- [x] Gitea tracker issue-refresh requests are wrapped in `context.WithTimeout`.
- [x] Fallback HTTP client uses the effective request timeout only when no custom HTTP client is supplied.
- [x] Hung-server regression tests cover issue listing and state refresh paths.

## Validation
- `go test ./internal/gitea -run 'TestTrackerClient(RequestTimeout|ListIssuesAborts|FetchIssueStateAborts|FallbackHTTPClient)'`
- Mutation check: removing the list request timeout made `TestTrackerClientListIssuesAbortsHungServer` fail after the outer 2s context; restoring it passed.
- Mutation check: removing the issue-refresh request timeout made `TestTrackerClientFetchIssueStateAbortsHungServer` fail after the outer 2s context; restoring it passed.
- `git fetch origin main && test -z "$(gofmt -l $(git ls-files '*.go'))" && go mod tidy && git diff --exit-code -- go.mod go.sum && go vet ./... && go test -race -covermode=atomic ./... && go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`

## Review ledger
- Head: `52ccf78090ab691e984ba03bc603b7a414d4487b`
- Pre-push Codex diff-only reviewer: MERGE-READY, no blocking findings after timeout-source feedback was fixed.
- Pre-push Claude diff-only reviewer: MERGE-READY, no blocking findings.
- GitHub `@codex review`: trigger comment `4538061622`; completion comment `4538087282` said no major issues.
- GraphQL reviewThreads: 0 threads.
- CI: green, run `26424124342`.
- Warning audit: no `warning:` lines found in CI logs.

## Size gate
- Changed files: 2. Changed LOC: 133. Within default 12 files / 300 LOC size budget.
- Size-gated: no.

## Risk / deferral
- No deferrals.
- This is Go-side runtime hardening for tracker I/O; no SPEC deviation added.
