### PR TITLE
Harden release quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to check out for reusable CI callers"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -29,6 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -139,6 +146,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
 
       # Use the latest 1.25.x patch toolchain (not the pinned go.mod floor) so
       # govulncheck evaluates the code against an up-to-date standard library.
@@ -172,6 +180,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -201,6 +210,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Build Docker image
         run: docker build --pull --tag aiops-platform:ci .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,48 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve:
+    name: Resolve release ref
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      ref: ${{ steps.release.outputs.ref }}
+    steps:
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+            ref="refs/tags/${tag}"
+          else
+            tag="${GITHUB_REF_NAME}"
+            ref="${GITHUB_REF}"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+  ci:
+    name: Reuse CI quality gates
+    needs:
+      - resolve
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ needs.resolve.outputs.ref }}
+
   release:
     name: Build and publish release artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs:
+      - resolve
+      - ci
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -34,6 +70,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ needs.resolve.outputs.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -44,22 +81,8 @@ jobs:
             go.mod
             go.sum
 
-      - name: Resolve release tag
-        id: release
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag="${GITHUB_REF_NAME}"
-          fi
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-
       - name: Verify tag exists
-        run: git rev-parse --verify "refs/tags/${{ steps.release.outputs.tag }}"
-
-      - name: Test before release
-        run: go test ./...
+        run: git rev-parse --verify "refs/tags/${{ needs.resolve.outputs.tag }}"
 
       - name: Build release binaries
         shell: bash
@@ -75,21 +98,42 @@ jobs:
           )
           for target in "${targets[@]}"; do
             read -r goos goarch <<< "$target"
-            out="dist/aiops-platform_${{ steps.release.outputs.tag }}_${goos}_${goarch}"
+            out="dist/aiops-platform_${{ needs.resolve.outputs.tag }}_${goos}_${goarch}"
             for binary in "${binaries[@]}"; do
               GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 \
                 go build -trimpath -ldflags="-s -w" -o "${out}/${binary}" "./cmd/${binary}"
             done
+          done
+
+      - name: Generate release SBOM (Trivy, CycloneDX)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: dist
+          format: cyclonedx
+          output: dist/aiops-platform_${{ needs.resolve.outputs.tag }}_sbom.cdx.json
+
+      - name: Package release archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          for out in dist/aiops-platform_${{ needs.resolve.outputs.tag }}_*; do
+            [ -d "$out" ] || continue
             tar -C dist -czf "${out}.tar.gz" "$(basename "$out")"
             rm -rf "$out"
           done
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: dist/*
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ steps.release.outputs.tag }}" dist/*.tar.gz \
+          gh release create "${{ needs.resolve.outputs.tag }}" dist/*.tar.gz dist/*_sbom.cdx.json \
             --repo "$GITHUB_REPOSITORY" \
-            --title "${{ steps.release.outputs.tag }}" \
-            --notes "Automated aiops-platform release for ${{ steps.release.outputs.tag }}" \
+            --title "${{ needs.resolve.outputs.tag }}" \
+            --notes "Automated aiops-platform release for ${{ needs.resolve.outputs.tag }}" \
             --verify-tag

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -17,6 +17,7 @@ Triggers:
 - push to `main`
 - pull request targeting `main`
 - manual `workflow_dispatch`
+- reusable `workflow_call` from release publishing
 
 Checks:
 
@@ -28,7 +29,10 @@ Checks:
 - `go test -race -covermode=atomic ./...`
 - build `worker`, `linear-poller`, and `gitea-poller`
 - upload short-lived CI binaries
+- govulncheck
+- e2e Gitea mock loop
 - Docker image build validation
+- Trivy image scan and CycloneDX SBOM upload
 
 ### Release
 
@@ -49,8 +53,15 @@ Outputs:
 - Linux arm64
 - macOS amd64
 - macOS arm64
+- CycloneDX SBOM attached to the release
+- GitHub artifact attestations for release artifacts
 
-The release job uses `contents: write` only in the release job because publishing a GitHub release needs write access. CI remains read-only.
+Release publishing first resolves the exact tag ref and passes that ref to the
+CI workflow through `workflow_call`, so tag publishing inherits the same
+race-test, security, e2e, Docker, Trivy, and SBOM quality gates on the commit
+being released. The release job keeps `contents: write` scoped to publishing,
+and adds `id-token: write` plus `attestations: write` only for GitHub artifact
+provenance.
 
 ## Local checks before pushing
 
@@ -100,7 +111,9 @@ It runs weekly and groups Go dependency updates to reduce pull request noise.
 ## Security posture
 
 - CI uses top-level `permissions: contents: read`.
-- The release workflow uses `contents: write` only for the release job.
+- The release workflow uses read-only permissions for the reusable CI gate.
+- The release job uses `contents: write`, `id-token: write`, and
+  `attestations: write` only for release publication and provenance.
 - Workflows do not use `pull_request_target`.
 - No workflow stores or prints project secrets.
 - `persist-credentials: false` is used for checkout because the workflows do not need to push commits.


### PR DESCRIPTION
Closes #406

## Acceptance
- Release publishing reuses the repository CI quality gates through `workflow_call` before artifacts are built or published.
- Reusable CI checkouts honor an explicit release ref while normal push/PR/workflow_dispatch runs fall back to `github.ref`.
- Release workflow resolves the exact tag ref for both tag-push and manual dispatch paths.
- Release artifacts include a CycloneDX SBOM generated from expanded release outputs before packaging.
- Release artifacts receive GitHub build provenance attestations before `gh release create` uploads archives and the SBOM.
- CI runbook documents the reusable release gate, SBOM, and attestation behavior.

## Validation
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/release.yml` with Python `yaml.safe_load`.
- Workflow contract assertions checked `workflow_call`, exact ref checkout, inherited `go test -race -covermode=atomic ./...`, release CI reuse, SBOM ordering/upload, attestation action, and absence of duplicate release-job race test.
- Mutation checks: removing the inherited CI race-gate assertion and removing the attestation assertion were both detected.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml`.
- Full local gate: `git fetch origin main && test -z "$(gofmt -l $(git ls-files '*.go'))" && go mod tidy && git diff --exit-code -- go.mod go.sum && go vet ./... && go test -race -covermode=atomic ./... && go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`.
- Pre-push Codex diff-only reviewer: MERGE-READY, no Critical/HIGH/MEDIUM findings.
- Pre-push Claude diff-only reviewer: MERGE-READY, no Critical/HIGH/MEDIUM findings; noted one LOW manual-dispatch script interpolation observation.
- GitHub CI: green on run `26425375420` (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`).
- CI warning audit: `gh run view 26425375420 --log | rg '::warning|warning:'` returned no matches.
- Fresh `@codex review`: clean. Trigger comment `4538402677` had 👀 appear and now has `reactions.eyes == 0`; Codex posted “Didn't find any major issues” on head `8415d6755acbe3ce4fbd45727863c4e1c9dc661f`.
- GraphQL reviewThreads: 0 threads.

## Live ledger
- Head: `8415d6755acbe3ce4fbd45727863c4e1c9dc661f`.
- CI: green.
- Fresh `@codex review`: clean.
- Review threads: clean.
- Deferrals: none.
- Size gate: within default budget, 3 files and 88 insertions / 21 deletions.

## Risk
- Scope intentionally leaves Trivy vulnerability blocking policy to #409 and does not change the legacy release binary list beyond existing release behavior.
- Auto-merge gates satisfied on this head.
