### PR TITLE
Add dashboard npm Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,21 @@ updates:
       - github-actions
     commit-message:
       prefix: deps
+
+  - package-ecosystem: npm
+    directory: "/cmd/worker/dashboard"
+    schedule:
+      interval: weekly
+      day: friday
+      time: "09:30"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - area:observability
+    commit-message:
+      prefix: deps
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"

--- a/dependabot_test.go
+++ b/dependabot_test.go
@@ -1,0 +1,87 @@
+package aiopsplatform_test
+
+import (
+	"os"
+	"slices"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type dependabotConfig struct {
+	Updates []dependabotUpdate `yaml:"updates"`
+}
+
+type dependabotUpdate struct {
+	PackageEcosystem      string                     `yaml:"package-ecosystem"`
+	Directory             string                     `yaml:"directory"`
+	Schedule              dependabotSchedule         `yaml:"schedule"`
+	OpenPullRequestsLimit int                        `yaml:"open-pull-requests-limit"`
+	Labels                []string                   `yaml:"labels"`
+	CommitMessage         dependabotCommitMessage    `yaml:"commit-message"`
+	Groups                map[string]dependabotGroup `yaml:"groups"`
+}
+
+type dependabotSchedule struct {
+	Interval string `yaml:"interval"`
+	Day      string `yaml:"day"`
+	Time     string `yaml:"time"`
+	Timezone string `yaml:"timezone"`
+}
+
+type dependabotCommitMessage struct {
+	Prefix string `yaml:"prefix"`
+}
+
+type dependabotGroup struct {
+	Patterns []string `yaml:"patterns"`
+}
+
+func TestDependabotCoversDashboardNPMDependencies(t *testing.T) {
+	body, err := os.ReadFile(".github/dependabot.yml")
+	if err != nil {
+		t.Fatalf("read dependabot config: %v", err)
+	}
+
+	var config dependabotConfig
+	if err := yaml.Unmarshal(body, &config); err != nil {
+		t.Fatalf("parse dependabot config: %v", err)
+	}
+
+	var dashboardNPM *dependabotUpdate
+	for i := range config.Updates {
+		update := &config.Updates[i]
+		if update.PackageEcosystem == "npm" && update.Directory == "/cmd/worker/dashboard" {
+			dashboardNPM = update
+			break
+		}
+	}
+	if dashboardNPM == nil {
+		t.Fatal("dependabot config must cover dashboard npm dependencies")
+	}
+
+	if dashboardNPM.Schedule.Interval != "weekly" ||
+		dashboardNPM.Schedule.Day != "friday" ||
+		dashboardNPM.Schedule.Time != "09:30" ||
+		dashboardNPM.Schedule.Timezone != "America/Los_Angeles" {
+		t.Fatalf("unexpected dashboard npm schedule: %+v", dashboardNPM.Schedule)
+	}
+	if dashboardNPM.OpenPullRequestsLimit != 5 {
+		t.Fatalf("unexpected dashboard npm open PR limit: %d", dashboardNPM.OpenPullRequestsLimit)
+	}
+	for _, label := range []string{"dependencies", "area:observability"} {
+		if !slices.Contains(dashboardNPM.Labels, label) {
+			t.Fatalf("dashboard npm config missing label %q in %v", label, dashboardNPM.Labels)
+		}
+	}
+	if dashboardNPM.CommitMessage.Prefix != "deps" {
+		t.Fatalf("unexpected dashboard npm commit prefix: %q", dashboardNPM.CommitMessage.Prefix)
+	}
+	group, ok := dashboardNPM.Groups["npm-dependencies"]
+	if !ok {
+		t.Fatalf("dashboard npm config missing npm-dependencies group: %v", dashboardNPM.Groups)
+	}
+	if !slices.Contains(group.Patterns, "*") {
+		t.Fatalf("dashboard npm group must cover all packages, got %v", group.Patterns)
+	}
+}

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -115,8 +115,10 @@ Dependabot is configured for:
 
 - Go modules
 - GitHub Actions
+- dashboard npm dependencies in `cmd/worker/dashboard`
 
-It runs weekly and groups Go dependency updates to reduce pull request noise.
+It runs weekly and groups Go and dashboard npm dependency updates to reduce
+pull request noise.
 
 ## Security posture
 


### PR DESCRIPTION
Closes #408

## Acceptance
- Adds a Dependabot npm ecosystem entry for `cmd/worker/dashboard`, where `package.json` and `package-lock.json` live.
- Groups dashboard npm dependency updates to reduce PR noise.
- Routes Dependabot PRs with existing repository labels: `dependencies` and `area:observability`.
- Updates the CI runbook Dependabot coverage list.
- Adds a regression test that parses `.github/dependabot.yml` and asserts the dashboard npm coverage stays present.

## Validation
- SPEC/upstream check: `rg -n "dependabot|npm|dashboard|package-lock|supply|dependency" /tmp/symphony-upstream/SPEC.md /tmp/symphony-upstream/elixir/lib/symphony_elixir || true`; no Dependabot/npm package-manager protocol behavior applies.
- RED: `go test . -run TestDependabotCoversDashboardNPMDependencies -count=1` failed before the npm entry existed.
- GREEN: `go test . -run TestDependabotCoversDashboardNPMDependencies -count=1` passed after the config change.
- Mutation check: removing the `area:observability` label made `TestDependabotCoversDashboardNPMDependencies` fail; restoring it passed.
- Label check: `gh label list --search "area:observability" --json name --jq .[].name` returned `area:observability`.
- Direct dependency check: `rg -n "^\s*gopkg.in/yaml.v3" go.mod` shows `gopkg.in/yaml.v3 v3.0.1` as a direct requirement.
- Dashboard manifest check: `test -f cmd/worker/dashboard/package.json && test -f cmd/worker/dashboard/package-lock.json` passed.
- Full local gate after rebase onto latest `origin/main`: `git fetch origin main && test -z "$(gofmt -l $(git ls-files '*.go'))" && go mod tidy && git diff --exit-code -- go.mod go.sum && go vet ./... && go test -race -covermode=atomic ./... && go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`.
- Pre-push Codex diff-only reviewer on `fa6f7b7533d5b0458f853bd835a55bc8f7dac4ec`: MERGE-READY, no Critical/HIGH/MEDIUM findings; LOW note about schedule assertions in the regression test.
- Pre-push Claude diff-only reviewer on `fa6f7b7533d5b0458f853bd835a55bc8f7dac4ec`: no Critical/HIGH findings; one MEDIUM verification item for `gopkg.in/yaml.v3` directness was resolved by the direct dependency check and full tidy-clean gate.
- GitHub CI: green on run `26426699071` (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`).
- CI warning audit: `gh run view 26426699071 --log | rg '::warning|warning:' || true` returned no matches.
- Fresh `@codex review`: clean on trigger `4538737816`; eye reaction appeared then cleared, and Codex posted “Didn't find any major issues” on head `fa6f7b7533d5b0458f853bd835a55bc8f7dac4ec`.
- GraphQL reviewThreads: 0 threads.

## Live ledger
- Head: `fa6f7b7533d5b0458f853bd835a55bc8f7dac4ec`.
- CI: green.
- Fresh `@codex review`: clean.
- Review threads: clean.
- Deferrals: none.
- Size gate: within default budget, 3 files and 108 insertions / 1 deletion.

## Risk
- The issue suggested `area:dashboard`, but that label does not exist in this repo. GitHub Dependabot ignores missing custom labels, so this PR uses the existing `area:observability` label for the dashboard surface instead.
