### PR TITLE
Block fixed high severity image vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,10 +223,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           vuln-type: os,library
-          # Report-only for now (incremental rollout, #372): findings surface in
-          # the job log without blocking. Tighten exit-code once the image
-          # baseline is clean and the team agrees to gate on it.
-          exit-code: "0"
+          exit-code: "1"
 
       - name: Generate SBOM (Trivy, CycloneDX)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go build -o /out/linear-poller ./cmd/linear-poller
 RUN go build -o /out/gitea-poller ./cmd/gitea-poller
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git openssh-client && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ca-certificates git openssh-client && rm -rf /var/lib/apt/lists/*
 # Run as a dedicated unprivileged user. The worker prepares git workspaces and
 # runs agent/hook/verify/git commands, so root-in-container would widen the
 # blast radius of any compromised runner or hostile repository content (#365).

--- a/README.md
+++ b/README.md
@@ -421,7 +421,8 @@ all changes; PRs should not merge while it is red. It runs three jobs:
 - **`e2e`** — the end-to-end Gitea mock loop (`go test -tags e2e ./test/e2e/...`)
   against real `postgres:16` and `gitea` containers.
 - **`docker`** — a Docker image build of the repository `Dockerfile` (depends on
-  `go`).
+  `go`), plus a blocking Trivy scan for fixed CRITICAL/HIGH image
+  vulnerabilities.
 
 See the [CI/CD runbook](docs/runbooks/ci.md) for triggers, security posture,
 release flow, and local pre-push checks.

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -32,7 +32,17 @@ Checks:
 - govulncheck
 - e2e Gitea mock loop
 - Docker image build validation
-- Trivy image scan and CycloneDX SBOM upload
+- blocking Trivy image scan for fixed CRITICAL/HIGH vulnerabilities
+- CycloneDX SBOM upload
+
+The Trivy image scan uses `ignore-unfixed: true` and `exit-code: "1"`, so it
+blocks only CRITICAL/HIGH findings that already have an upstream fix. If this
+gate fails on a package inherited from the Debian base image, first rebuild with
+`docker build --pull --no-cache --tag aiops-platform:local .` to force a fresh
+`apt-get update && apt-get upgrade` layer. Update the Dockerfile or base image
+only if the rebuilt image still contains a fixed finding. Do not add a
+`.trivyignore` entry for a vulnerability that the package manager can already
+fix.
 
 ### Release
 

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -1,0 +1,35 @@
+package scripts
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestCITrivyImageScanBlocksHighAndCriticalVulnerabilities(t *testing.T) {
+	body, err := os.ReadFile("../.github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("ReadFile(ci.yml): %v", err)
+	}
+
+	text := string(body)
+	if strings.Contains(text, "Report-only for now") {
+		t.Fatal("CI Trivy scan still documents report-only mode")
+	}
+
+	step := regexp.MustCompile(`(?s)- name: Scan image for vulnerabilities \(Trivy\).*?(?:\n\n|$)`).FindString(text)
+	if step == "" {
+		t.Fatal("CI workflow missing Trivy image scan step")
+	}
+	for _, want := range []string{
+		"severity: CRITICAL,HIGH",
+		"ignore-unfixed: true",
+		"vuln-type: os,library",
+		`exit-code: "1"`,
+	} {
+		if !strings.Contains(step, want) {
+			t.Fatalf("Trivy image scan step missing %q:\n%s", want, step)
+		}
+	}
+}

--- a/test/e2e/fixtures/dockerfile_buildlayer_test.go
+++ b/test/e2e/fixtures/dockerfile_buildlayer_test.go
@@ -39,3 +39,23 @@ func TestDockerfileCopiesGoSumBeforeDownload(t *testing.T) {
 		t.Errorf("`go mod download` (at %d) must run before `COPY . .` (at %d) to keep the cached dependency layer", download, copyAll)
 	}
 }
+
+func TestDockerfileAppliesRuntimeSecurityUpdatesBeforeInstallingTools(t *testing.T) {
+	df := dockerfileContents(t)
+
+	runtimeStage := strings.Index(df, "FROM debian:bookworm-slim")
+	if runtimeStage < 0 {
+		t.Fatal("Dockerfile missing debian runtime stage")
+	}
+	upgrade := strings.Index(df[runtimeStage:], "apt-get upgrade -y")
+	if upgrade < 0 {
+		t.Fatal("runtime stage must apply Debian security updates before installing tools")
+	}
+	install := strings.Index(df[runtimeStage:], "apt-get install -y --no-install-recommends ca-certificates git openssh-client")
+	if install < 0 {
+		t.Fatal("runtime stage missing expected tool installation command")
+	}
+	if upgrade > install {
+		t.Fatalf("runtime apt-get upgrade must precede tool installation: upgrade=%d install=%d", upgrade, install)
+	}
+}


### PR DESCRIPTION
Closes #409

## Acceptance
- Docker image Trivy scan now uses `exit-code: "1"` for fixed `CRITICAL,HIGH` findings while keeping `ignore-unfixed: true`.
- Removed the report-only / incremental-rollout comment from the CI Trivy scan.
- Baseline remediation is handled by applying Debian runtime security updates before installing runtime tools in the Dockerfile.
- No `.trivyignore` entries are needed for this baseline because the known fixed findings are remediated by package upgrades.
- README and CI runbook document the blocking scan and the base-image remediation workflow.

## Validation
- SPEC/upstream check: no Symphony runtime protocol behavior applies; this is CI/supply-chain policy only.
- Official action syntax check: `aquasecurity/trivy-action` supports `exit-code`; actionlint passed for `.github/workflows/ci.yml` and `.github/workflows/release.yml`.
- Existing report-only baseline evidence from CI run `26425375420`: Trivy found fixed `libgnutls30` CRITICAL/HIGH entries on `3.7.9-2+deb12u6`, fixed in `3.7.9-2+deb12u7`.
- Local Docker build after this change: `docker build --pull --tag aiops-platform:ci .` passed.
- Local image package check: `docker run --rm aiops-platform:ci dpkg-query -W -f=${Package}\\ ${Version}\\n libgnutls30 libgcrypt20` showed `libgnutls30 3.7.9-2+deb12u7` and `libgcrypt20 1.10.1-3+deb12u1`.
- RED: `go test ./scripts -run TestCITrivyImageScanBlocksHighAndCriticalVulnerabilities -count=1` failed before the CI change.
- RED: `go test ./test/e2e/fixtures -run TestDockerfileAppliesRuntimeSecurityUpdatesBeforeInstallingTools -count=1` failed before the Dockerfile change.
- GREEN: both focused tests passed after implementation.
- Mutation checks: changing `exit-code` back to `"0"` failed the CI workflow test; removing `apt-get upgrade -y` failed the Dockerfile test; restoring both passed.
- Full local gate: `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml && git fetch origin main && test -z "$(gofmt -l $(git ls-files '*.go'))" && go mod tidy && git diff --exit-code -- go.mod go.sum && go vet ./... && go test -race -covermode=atomic ./... && go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`.
- Pre-push Codex diff-only reviewer: MERGE-READY, no Critical/HIGH/MEDIUM findings.
- Pre-push Claude diff-only reviewer: MERGE-READY after reclassifying the inherent Trivy-DB moving-baseline behavior as a documented LOW operational tradeoff, no fix-required Critical/HIGH/MEDIUM findings.
- GitHub CI: green on run `26426247931` (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`).
- CI warning audit: `gh run view 26426247931 --log | rg '::warning|warning:'` returned no matches.
- GraphQL reviewThreads: 0 threads.
- Fresh `@codex review`: clean. Trigger `4538679877` now has `reactions.eyes == 0`; Codex posted “Didn't find any major issues” on head `3c9ff7a294aad2dbe0452054d7329d9452711a77`.

## Live ledger
- Head: `3c9ff7a294aad2dbe0452054d7329d9452711a77`.
- CI: green.
- Fresh `@codex review`: clean.
- Review threads: clean.
- Deferrals: none.
- Size gate: within default budget, 6 files and 70 insertions / 7 deletions.

## Risk
- Blocking Trivy means future fixed CRITICAL/HIGH findings in Debian base layers can turn unrelated PRs red. The runbook now says to rebuild with `--pull --no-cache` first and not to ignore vulnerabilities the package manager can fix.
- If the blocking scan fails, downstream SBOM upload in the same job will not run; Trivy still prints the actionable vulnerability table in the job log. This is recorded as a LOW reviewer observation, not a blocker for #409.
- Auto-merge gates satisfied on this head.
