### PR TITLE
Add worker health probes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go build -o /out/linear-poller ./cmd/linear-poller
 RUN go build -o /out/gitea-poller ./cmd/gitea-poller
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ca-certificates git openssh-client && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ca-certificates git openssh-client wget && rm -rf /var/lib/apt/lists/*
 # Run as a dedicated unprivileged user. The worker prepares git workspaces and
 # runs agent/hook/verify/git commands, so root-in-container would widen the
 # blast radius of any compromised runner or hostile repository content (#365).
@@ -56,4 +56,7 @@ USER ${AIOPS_UID}:${AIOPS_GID}
 # CMD (not ENTRYPOINT) keeps it overridable: Compose's `command: ["worker"]`
 # and the poller services' `command: ["linear-poller", ...]` replace it without
 # argument duplication, and `docker run <image> linear-poller ...` still works.
+# The image healthcheck probes only when PID 1 is worker; poller command
+# overrides no-op here, and adding an init wrapper requires revisiting this.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD cmd="$(tr '\0' '\n' </proc/1/cmdline | head -n1)"; case "$cmd" in */worker|worker) wget -qO- "http://127.0.0.1:${AIOPS_HEALTHCHECK_PORT:-4000}/livez" >/dev/null 2>&1 || exit 1 ;; *) exit 0 ;; esac
 CMD ["worker"]

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ web dashboard:
 | `GET /api/v1/{issue}` | Per-issue debug snapshot — see the [task debugging API runbook](docs/runbooks/task-api.md). |
 | `GET /` | The embedded web dashboard (HTML). |
 | `GET /assets/…` | Static dashboard assets. |
+| `GET /livez` | Unauthenticated liveness probe. Returns `ok` when the HTTP listener can serve requests. |
+| `GET /readyz` | Unauthenticated readiness probe. Returns `ok` once the worker has loaded workflow config, constructed the tracker client, and completed startup reconciliation. |
 
 When `AIOPS_STATE_API_TOKEN` is set, every request must authenticate with either
 `Authorization: Bearer <token>` or HTTP Basic auth user `aiops` and the token as
@@ -173,6 +175,14 @@ fail closed. Set `server.port: -1` to disable the listener entirely (e.g. when
 you provide your own state bridge). If the configured listener cannot start, the
 worker logs the failure, continues without the HTTP surface, and retries on
 later workflow-reload checks until the bind succeeds or `server.port` changes.
+The `/livez` and `/readyz` probes intentionally bypass this auth guard and
+return no runtime state or agent text, so Docker and Compose can use them
+without a dashboard token. `/readyz` returns `503` until startup readiness has
+been marked after workflow load, tracker client construction, and startup
+reconciliation. The default container health check probes `/livez`; use
+`/readyz` for orchestrators that distinguish startup/readiness from liveness.
+If you change the worker port in Compose, set `AIOPS_HEALTHCHECK_PORT` to match;
+if you set `server.port: -1`, disable the container health check as well.
 
 Under Docker Compose the default loopback bind is unreachable from the host
 (Docker publishes ports to the container interface, not its loopback). Merge the

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -336,15 +337,10 @@ func run(ctx context.Context, args []string) error {
 		return err
 	}
 	cfg.Workflow = wf
+	readiness := &stateHTTPReadiness{}
 
 	trackerClient, err := trackerClientForWorkflow(wf.Config)
 	if err != nil {
-		return err
-	}
-	reconcileCfg := startupReconcileConfigForWorkflow(wf.Config, trackerClient)
-	reconcileCfg.WorkspaceRoot = worker.EffectiveWorkspaceRoot(cfg, wf.Config)
-	if err := worker.ReconcileStartup(ctx, reconcileCfg); err != nil {
-		worker.LogReconcileError(err)
 		return err
 	}
 
@@ -384,6 +380,21 @@ func run(ctx context.Context, args []string) error {
 	if err := orch.WaitStarted(ctx); err != nil {
 		return err
 	}
+	// Start the listener before startup reconciliation so /readyz can report
+	// 503 while reconciliation is still running; the poll loop below still
+	// starts only after ReconcileStartup succeeds.
+	go func() {
+		if err := runStateHTTPServerLoop(ctx, runtime, orch.Snapshot, stateHTTPServerLoopOptions{Refresh: orch.RequestRefresh, Readiness: readiness.Status, PortOverride: portOverride, HostOverride: serverHostOverrideFromEnv()}); err != nil && ctx.Err() == nil {
+			log.Printf("state HTTP server loop exited: %v", err)
+		}
+	}()
+	reconcileCfg := startupReconcileConfigForWorkflow(wf.Config, trackerClient)
+	reconcileCfg.WorkspaceRoot = worker.EffectiveWorkspaceRoot(cfg, wf.Config)
+	if err := worker.ReconcileStartup(ctx, reconcileCfg); err != nil {
+		worker.LogReconcileError(err)
+		return err
+	}
+	readiness.MarkReady()
 	poller, err := orchestrator.NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (orchestrator.IssueStateLister, error) {
 		return trackerClientForWorkflow(cfg)
 	}, orch, runtime, cfg, worker.LogEventEmitter{})
@@ -407,17 +418,28 @@ func run(ctx context.Context, args []string) error {
 			log.Printf("workflow reload loop exited: %v", err)
 		}
 	}()
-	go func() {
-		if err := runStateHTTPServerLoop(ctx, runtime, orch.Snapshot, stateHTTPServerLoopOptions{Refresh: orch.RequestRefresh, PortOverride: portOverride, HostOverride: serverHostOverrideFromEnv()}); err != nil && ctx.Err() == nil {
-			log.Printf("state HTTP server loop exited: %v", err)
-		}
-	}()
 	return orchestrator.RunPollLoopWithRuntime(ctx, poller, runtime, orchestrator.PollLoopRuntimeOptions{})
 }
 
+type stateHTTPReadiness struct {
+	ready atomic.Bool
+}
+
+func (r *stateHTTPReadiness) MarkReady() {
+	r.ready.Store(true)
+}
+
+func (r *stateHTTPReadiness) Status() (bool, string) {
+	if r.ready.Load() {
+		return true, ""
+	}
+	return false, "startup reconciliation has not completed"
+}
+
 type stateHTTPServerController struct {
-	snapshot stateSnapshotFunc
-	refresh  stateRefreshFunc
+	snapshot  stateSnapshotFunc
+	refresh   stateRefreshFunc
+	readiness stateReadinessFunc
 
 	desiredSet  bool
 	desiredHost string
@@ -428,7 +450,7 @@ type stateHTTPServerController struct {
 }
 
 func newStateHTTPServerController(snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *stateHTTPServerController {
-	return &stateHTTPServerController{snapshot: snapshot, refresh: optionalStateRefreshFunc(refresh)}
+	return &stateHTTPServerController{snapshot: snapshot, refresh: optionalStateRefreshFunc(refresh), readiness: stateHTTPAlwaysReady}
 }
 
 func (c *stateHTTPServerController) apply(ctx context.Context, host string, port int) error {
@@ -445,7 +467,7 @@ func (c *stateHTTPServerController) apply(ctx context.Context, host string, port
 		return nil
 	}
 	serverCtx, cancel := context.WithCancel(ctx)
-	handle, err := startStateHTTPServer(serverCtx, host, port, c.snapshot, c.refresh)
+	handle, err := startStateHTTPServer(serverCtx, host, port, c.snapshot, c.readiness, c.refresh)
 	if err != nil {
 		cancel()
 		return err
@@ -504,6 +526,7 @@ type stateHTTPServerLoopOptions struct {
 	Sleep           func(context.Context, time.Duration) error
 	StopAfterChecks int
 	Refresh         stateRefreshFunc
+	Readiness       stateReadinessFunc
 	// PortOverride, when non-nil, replaces the workflow snapshot's
 	// `server.port` for every tick of the loop. SPEC §13.7 defines this
 	// as the CLI `--port` precedence rule. -1 disables the HTTP server,
@@ -521,6 +544,9 @@ func runStateHTTPServerLoop(ctx context.Context, runtime *orchestrator.WorkflowR
 		return errors.New("state HTTP server loop requires workflow runtime")
 	}
 	controller := newStateHTTPServerController(snapshot, opts.Refresh)
+	if opts.Readiness != nil {
+		controller.readiness = opts.Readiness
+	}
 	defer controller.stop()
 	sleep := opts.Sleep
 	if sleep == nil {
@@ -568,12 +594,12 @@ type stateHTTPServerHandle struct {
 	Done <-chan struct{}
 }
 
-func startStateHTTPServer(ctx context.Context, host string, port int, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) (*stateHTTPServerHandle, error) {
+func startStateHTTPServer(ctx context.Context, host string, port int, snapshot stateSnapshotFunc, readiness stateReadinessFunc, refresh ...stateRefreshFunc) (*stateHTTPServerHandle, error) {
 	if port < 0 {
 		log.Printf("state HTTP server disabled by server.port=%d", port)
 		return nil, nil
 	}
-	server := newStateHTTPServerWithAuthToken(host, port, os.Getenv(stateHTTPAuthTokenEnv), snapshot, refresh...)
+	server := newStateHTTPServerWithAuthTokenAndReadiness(host, port, os.Getenv(stateHTTPAuthTokenEnv), readiness, snapshot, refresh...)
 	listener, err := net.Listen("tcp", server.Addr)
 	if err != nil {
 		log.Printf("state HTTP server disabled because listen on %s failed: %v", server.Addr, err)
@@ -619,6 +645,10 @@ func newStateHTTPServer(host string, port int, snapshot stateSnapshotFunc, refre
 }
 
 func newStateHTTPServerWithAuthToken(host string, port int, authToken string, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *http.Server {
+	return newStateHTTPServerWithAuthTokenAndReadiness(host, port, authToken, stateHTTPAlwaysReady, snapshot, refresh...)
+}
+
+func newStateHTTPServerWithAuthTokenAndReadiness(host string, port int, authToken string, readiness stateReadinessFunc, snapshot stateSnapshotFunc, refresh ...stateRefreshFunc) *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle("/api/v1/state", stateHTTPHandler(snapshot))
 	mux.Handle("/api/v1/refresh", refreshHTTPHandler(optionalStateRefreshFunc(refresh)))
@@ -632,9 +662,13 @@ func newStateHTTPServerWithAuthToken(host string, port int, authToken string, sn
 		dashboardHTMLHandler().ServeHTTP(w, r)
 	})
 	guard := stateHTTPAccessGuard{authToken: strings.TrimSpace(authToken)}
+	root := http.NewServeMux()
+	root.Handle("/livez", livenessHTTPHandler())
+	root.Handle("/readyz", readinessHTTPHandler(readiness))
+	root.Handle("/", guard.wrap(mux))
 	return &http.Server{
 		Addr:              net.JoinHostPort(normalizeServerHost(host), strconv.Itoa(port)),
-		Handler:           guard.wrap(mux),
+		Handler:           root,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,
 		WriteTimeout:      10 * time.Second,
@@ -647,6 +681,56 @@ func newStateHTTPServerWithAuthToken(host string, port int, authToken string, sn
 		// value when computing the actual reject threshold.
 		MaxHeaderBytes: 64 << 10,
 	}
+}
+
+type stateReadinessFunc func() (bool, string)
+
+func stateHTTPAlwaysReady() (bool, string) {
+	return true, ""
+}
+
+func livenessHTTPHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		if _, err := io.WriteString(w, "ok\n"); err != nil {
+			log.Printf("write /livez response: %v", err)
+		}
+	})
+}
+
+func readinessHTTPHandler(readiness stateReadinessFunc) http.Handler {
+	if readiness == nil {
+		readiness = stateHTTPAlwaysReady
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		ready, reason := readiness()
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if !ready {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			if reason == "" {
+				reason = "not ready"
+			}
+			if _, err := io.WriteString(w, reason+"\n"); err != nil {
+				log.Printf("write /readyz unavailable response: %v", err)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := io.WriteString(w, "ok\n"); err != nil {
+			log.Printf("write /readyz response: %v", err)
+		}
+	})
 }
 
 type stateHTTPAccessGuard struct {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -424,6 +424,46 @@ func TestRootDashboardRejectsUnsafeMethodsWithHeadInAllow(t *testing.T) {
 	}
 }
 
+func TestHealthProbeEndpointsBypassStateHTTPAccessGuard(t *testing.T) {
+	called := false
+	server := newStateHTTPServerWithAuthToken("0.0.0.0", 0, "state-token", func(context.Context) (orchestrator.StateView, error) {
+		called = true
+		return orchestrator.StateView{}, nil
+	})
+
+	for _, path := range []string{"/livez", "/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, "http://worker.example:4000"+path, nil)
+		req.RemoteAddr = "172.18.0.1:54321"
+		w := httptest.NewRecorder()
+		server.Handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s status code = %d, want %d; body=%s", path, w.Code, http.StatusOK, w.Body.String())
+		}
+		if got := w.Body.String(); got != "ok\n" {
+			t.Fatalf("%s body = %q, want ok newline", path, got)
+		}
+	}
+	if called {
+		t.Fatal("snapshot function should not be called for health probes")
+	}
+}
+
+func TestHealthProbeEndpointsRejectUnsafeMethods(t *testing.T) {
+	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
+		t.Fatal("snapshot function should not be called for health probes")
+		return orchestrator.StateView{}, nil
+	})
+	for _, path := range []string{"/livez", "/readyz"} {
+		req := newLoopbackRequest(http.MethodPost, "http://127.0.0.1:4000"+path, nil)
+		w := httptest.NewRecorder()
+		server.Handler.ServeHTTP(w, req)
+		if w.Code != http.StatusMethodNotAllowed || w.Header().Get("Allow") != http.MethodGet {
+			t.Fatalf("POST %s status/Allow = %d/%q, want 405/GET; body=%s", path, w.Code, w.Header().Get("Allow"), w.Body.String())
+		}
+	}
+}
+
 func TestStateHTTPHandlerPropagatesRequestCancellation(t *testing.T) {
 	requestErr := context.Canceled
 	handler := stateHTTPHandler(func(context.Context) (orchestrator.StateView, error) {
@@ -1088,7 +1128,7 @@ func TestStartStateHTTPServerSkipsDisabledPort(t *testing.T) {
 	handle, err := startStateHTTPServer(context.Background(), "127.0.0.1", -1, func(context.Context) (orchestrator.StateView, error) {
 		t.Fatal("disabled state server must not evaluate snapshot")
 		return orchestrator.StateView{}, nil
-	})
+	}, stateHTTPAlwaysReady)
 	if err != nil {
 		t.Fatalf("startStateHTTPServer disabled: %v", err)
 	}
@@ -1107,7 +1147,7 @@ func TestStartStateHTTPServerDoesNotFailWorkerWhenPortInUse(t *testing.T) {
 
 	handle, err := startStateHTTPServer(context.Background(), "127.0.0.1", port, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
-	})
+	}, stateHTTPAlwaysReady)
 	if err != nil {
 		t.Fatalf("startStateHTTPServer occupied port: %v", err)
 	}
@@ -1122,7 +1162,7 @@ func TestStartStateHTTPServerBindsPrivateLoopback(t *testing.T) {
 
 	handle, err := startStateHTTPServer(ctx, "127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
-	})
+	}, stateHTTPAlwaysReady)
 	if err != nil {
 		t.Fatalf("startStateHTTPServer: %v", err)
 	}
@@ -1159,6 +1199,53 @@ func TestStateHTTPServerControllerStopsOnDisabledReload(t *testing.T) {
 	}
 	if controller.cancel != nil || controller.addr != nil {
 		t.Fatalf("controller after disable = cancel:%v addr:%v, want stopped server", controller.cancel, controller.addr)
+	}
+}
+
+func TestStateHTTPServerControllerServesReadyzBeforeReadiness(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ready := &stateHTTPReadiness{}
+	controller := newStateHTTPServerController(func(context.Context) (orchestrator.StateView, error) {
+		return orchestrator.StateView{}, nil
+	})
+	controller.readiness = ready.Status
+
+	if err := controller.apply(ctx, "127.0.0.1", 0); err != nil {
+		t.Fatalf("start state HTTP server: %v", err)
+	}
+	defer controller.stop()
+	if controller.addr == nil {
+		t.Fatal("controller addr = nil, want running server")
+	}
+	client := http.Client{Timeout: 2 * time.Second}
+	url := "http://" + controller.addr.String() + "/readyz"
+
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET /readyz before readiness: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read /readyz before readiness: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("GET /readyz before readiness status = %d, want %d; body=%s", resp.StatusCode, http.StatusServiceUnavailable, string(body))
+	}
+
+	ready.MarkReady()
+	resp, err = client.Get(url)
+	if err != nil {
+		t.Fatalf("GET /readyz after readiness: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read /readyz after readiness: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK || string(body) != "ok\n" {
+		t.Fatalf("GET /readyz after readiness status/body = %d/%q, want 200/ok", resp.StatusCode, string(body))
 	}
 }
 
@@ -2468,7 +2555,7 @@ func TestStartStateHTTPServerHonorsWiderBind(t *testing.T) {
 	defer cancel()
 	handle, err := startStateHTTPServer(ctx, "0.0.0.0", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil
-	})
+	}, stateHTTPAlwaysReady)
 	if err != nil {
 		t.Fatalf("startStateHTTPServer: %v", err)
 	}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -20,7 +20,14 @@ services:
       GITEA_TOKEN: ${GITEA_TOKEN}
       AIOPS_WORKSPACE_ROOT: /workspaces
       AIOPS_WORKFLOW_PATH: /app/examples/WORKFLOW.md
+      AIOPS_HEALTHCHECK_PORT: ${AIOPS_HEALTHCHECK_PORT:-4000}
       LINEAR_API_KEY: ${LINEAR_API_KEY}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:$${AIOPS_HEALTHCHECK_PORT:-4000}/livez >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     volumes:
       - workspaces:/workspaces
       - ../examples:/app/examples:ro

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -150,6 +150,13 @@ container against your own workflow:
 The default Compose service starts only `worker` unless a legacy
 profile is explicitly requested (see
 [Section 4](#4-legacy-queue-driven-pollers-d6d7d8)).
+The worker image and Compose service include a health check against
+`http://127.0.0.1:${AIOPS_HEALTHCHECK_PORT:-4000}/livez` from inside the
+container. Use `/readyz` when a local orchestrator needs the startup-readiness
+signal instead of the liveness signal; both probes are unauthenticated, and
+`/readyz` returns `503` until startup reconciliation finishes. If you change the
+worker HTTP port, set `AIOPS_HEALTHCHECK_PORT` to match; if you disable the HTTP
+listener with `server.port: -1`, disable the container health check too.
 
 The worker's loopback dashboard is not reachable from the host under the
 base Compose file. To reach it, merge the opt-in overlay, which binds

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -51,6 +51,13 @@ user `aiops` with the token as the password. Without a token, unauthenticated
 requests must have both a loopback Host header and a loopback TCP peer;
 non-loopback peers fail closed.
 
+`GET /livez` and `GET /readyz` are the only unauthenticated endpoints on this
+listener. They bypass the state API guard and return only `ok`, with no runtime
+state or agent text, so container probes can use them without
+`AIOPS_STATE_API_TOKEN`. `/livez` proves the HTTP listener is serving requests.
+`/readyz` returns `503` until startup has loaded the workflow, constructed the
+tracker client, and completed startup reconciliation.
+
 The effective port is resolved in this order, per SPEC §13.7:
 
 1. The CLI flag `--port` if provided. `--port -1` disables the server,

--- a/test/e2e/fixtures/compose_config_test.go
+++ b/test/e2e/fixtures/compose_config_test.go
@@ -57,6 +57,54 @@ func TestGiteaPollerComposeUsesGiteaWorkflowFixture(t *testing.T) {
 	}
 }
 
+func TestWorkerComposeDefinesHealthcheck(t *testing.T) {
+	compose := readCompose(t)
+	worker := service(t, compose, "worker")
+	environment, ok := worker["environment"].(map[string]any)
+	if !ok {
+		t.Fatal("worker service missing environment map")
+	}
+	if got := environment["AIOPS_HEALTHCHECK_PORT"]; got != "${AIOPS_HEALTHCHECK_PORT:-4000}" {
+		t.Fatalf("worker AIOPS_HEALTHCHECK_PORT = %#v, want defaulted environment override", got)
+	}
+	workflowPath, ok := environment["AIOPS_WORKFLOW_PATH"].(string)
+	if !ok {
+		t.Fatalf("worker AIOPS_WORKFLOW_PATH = %#v, want string", environment["AIOPS_WORKFLOW_PATH"])
+	}
+	workflow := loadYAML(t, filepath.Join("..", "..", "..", strings.TrimPrefix(workflowPath, "/app/")))
+	server, ok := workflow["server"].(map[string]any)
+	if !ok || server["port"] != 4000 {
+		t.Fatalf("%s server.port = %#v, want 4000", workflowPath, server["port"])
+	}
+	healthcheck, ok := worker["healthcheck"].(map[string]any)
+	if !ok {
+		t.Fatal("worker service missing healthcheck")
+	}
+	testCommand, ok := healthcheck["test"].([]any)
+	if !ok || len(testCommand) != 2 {
+		t.Fatalf("worker healthcheck test = %#v, want CMD-SHELL command", healthcheck["test"])
+	}
+	if testCommand[0] != "CMD-SHELL" {
+		t.Fatalf("worker healthcheck test[0] = %#v, want CMD-SHELL", testCommand[0])
+	}
+	command, ok := testCommand[1].(string)
+	if !ok || !strings.Contains(command, "wget -qO- http://127.0.0.1:$${AIOPS_HEALTHCHECK_PORT:-4000}/livez") {
+		t.Fatalf("worker healthcheck command = %#v, want /livez wget probe", testCommand[1])
+	}
+	for key, want := range map[string]string{
+		"interval":     "30s",
+		"timeout":      "5s",
+		"start_period": "20s",
+	} {
+		if got := healthcheck[key]; got != want {
+			t.Fatalf("worker healthcheck %s = %#v, want %q", key, got, want)
+		}
+	}
+	if got := healthcheck["retries"]; got != 3 {
+		t.Fatalf("worker healthcheck retries = %#v, want 3", got)
+	}
+}
+
 func readCompose(t *testing.T) map[string]any {
 	t.Helper()
 	return loadYAML(t, filepath.Join("..", "..", "..", "deploy", "docker-compose.yml"))

--- a/test/e2e/fixtures/dockerfile_buildlayer_test.go
+++ b/test/e2e/fixtures/dockerfile_buildlayer_test.go
@@ -51,11 +51,25 @@ func TestDockerfileAppliesRuntimeSecurityUpdatesBeforeInstallingTools(t *testing
 	if upgrade < 0 {
 		t.Fatal("runtime stage must apply Debian security updates before installing tools")
 	}
-	install := strings.Index(df[runtimeStage:], "apt-get install -y --no-install-recommends ca-certificates git openssh-client")
+	install := strings.Index(df[runtimeStage:], "apt-get install -y --no-install-recommends ca-certificates git openssh-client wget")
 	if install < 0 {
 		t.Fatal("runtime stage missing expected tool installation command")
 	}
 	if upgrade > install {
 		t.Fatalf("runtime apt-get upgrade must precede tool installation: upgrade=%d install=%d", upgrade, install)
+	}
+}
+
+func TestDockerfileDefinesWorkerHealthcheck(t *testing.T) {
+	df := dockerfileContents(t)
+
+	if !strings.Contains(df, "HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3") {
+		t.Fatal("Dockerfile missing worker healthcheck timing")
+	}
+	if !strings.Contains(df, "</proc/1/cmdline") || !strings.Contains(df, "*/worker|worker)") {
+		t.Fatal("Dockerfile healthcheck must only probe when PID 1 is the worker command")
+	}
+	if !strings.Contains(df, `wget -qO- "http://127.0.0.1:${AIOPS_HEALTHCHECK_PORT:-4000}/livez"`) {
+		t.Fatal("Dockerfile healthcheck must probe the unauthenticated /livez endpoint on the configured healthcheck port")
 	}
 }


### PR DESCRIPTION
Closes #412

## Acceptance
- Adds unauthenticated `/livez` and `/readyz` probes that bypass the state API access guard while preserving guarded state/dashboard endpoints.
- `/livez` reports process liveness with `200 ok`; `/readyz` reports `503` until startup reconciliation completes, then `200 ok`.
- Adds worker container healthcheck wiring without breaking poller images that reuse the Dockerfile.
- Documents the probes in README, local dev, and runtime status docs.

## Validation
- `go test ./cmd/worker ./test/e2e/fixtures -count=1`
- `git fetch origin main && test -z "$(gofmt -l $(git ls-files '*.go'))" && go mod tidy && git diff --exit-code -- go.mod go.sum && go vet ./... && go test -race -covermode=atomic ./... && go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`\n- Mutation check: removing the `/livez` registration makes `TestHealthProbeEndpointsBypassStateHTTPAccessGuard` fail with a guarded `401`.\n- Mutation check: removing the `/readyz` registration makes readiness coverage fail instead of reaching the expected startup readiness behavior.\n\n## Independent Review\n- Codex diff-only reviewer on head `72a0b10d0b0ad2021d158d9b20028336d6addebf`: MERGE-READY; no Critical/HIGH/MEDIUM findings.\n- Claude diff-only reviewer on head `72a0b10d0b0ad2021d158d9b20028336d6addebf`: MERGE-READY; no Critical/HIGH/MEDIUM findings.\n\n## GitHub Review / CI\n- Fresh `@codex review` trigger: https://github.com/xrf9268-hue/aiops-platform/pull/430#issuecomment-4539003387\n- Bot result on head `72a0b10d0b0ad2021d158d9b20028336d6addebf`: clean review comment, no major issues.\n- GraphQL reviewThreads: 0 unresolved/non-outdated actionable threads.\n- CI run `26427829088`: green (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`).\n- Warning audit: clean (`gh run view 26427829088 --log | rg '::warning|warning:' || true`).\n\n## Risk / Deferral / Size\n- No deferrals.\n- Size gate: within budget, 9 files changed and 291 insertions.\n- Main operational risk is healthcheck coupling to the worker command; mitigated by a PID-1 guard so poller image commands no-op the inherited Dockerfile healthcheck.\n\n## Live Ledger\n- Head: `72a0b10d0b0ad2021d158d9b20028336d6addebf`\n- Local gate: passed\n- Fresh @codex review: clean\n- CI: green\n- Review threads: clean\n- State: mergeable\n