### PR TITLE
chore: add earned Go lint baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,12 @@ jobs:
             exit 1
           fi
 
+      - name: Run golangci-lint (report only)
+        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+        with:
+          version: v2.12.2
+          args: --config=.golangci.yml --issues-exit-code=0
+
       - name: Verify Dockerfile Go version matches go.mod
         shell: bash
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,37 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - contextcheck
+    - errcheck
+    - errorlint
+    - funlen
+    - gocognit
+    - gocritic
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck
+    - unparam
+    - unused
+  settings:
+    funlen:
+      lines: 80
+      statements: 50
+      ignore-comments: true
+    gocognit:
+      min-complexity: 10
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - ["ID", "API", "HTTP", "HTTPS", "URL", "JSON", "SQL", "UUID"]
+            - []
+
+formatters:
+  enable:
+    - gofmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,8 @@ The CI gate is the authoritative checklist — match it locally before pushing:
 ```bash
 gofmt -l $(git ls-files '*.go')         # must be empty
 go mod tidy && git diff --exit-code -- go.mod go.sum
+go vet ./...
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0
 go test -race -covermode=atomic ./...
 go build ./cmd/worker
 ```
@@ -302,10 +304,52 @@ failure per the "Earned rules" principle above.
    by:** PR #342 audit (LOW) noted the back-compat test asserted `last_codex_at`
    presence but not its absence after removal.
 
+7. **Function and file size budgets.** New code must keep single functions at
+   or below 80 lines and single files at or below 800 lines, excluding test
+   files and generated code. When porting from Elixir, split oversized upstream
+   modules on the Go side instead of preserving a monolith. The current
+   `golangci-lint` gate reports `funlen` and `gocognit` findings without
+   blocking while the baseline is burned down; do not add new violations.
+   **Earned by:** #410 found `RunTask` at 244 lines, `validateConfig` at 186
+   lines, and `actor.go` at 2138 lines; PR #342 showed that one concept rename
+   had to touch four files partly because large files hid the domain boundary.
+
+8. **Errors are wrapped and classified, not string-matched.** Wrap underlying
+   errors with `%w`, classify them with `errors.Is` / `errors.As`, and keep
+   sentinel errors in the package that owns the failure mode. Error strings
+   are lowercase unless they begin with a proper noun or acronym. Never compare
+   error text with `strings.Contains`. **Earned by:** mixed `%w` / `%s` /
+   `errors.New` styles made review-time reasoning about `errors.Is` /
+   `errors.As` unreliable.
+
+9. **Test failures must print the input, actual value, and expected value.**
+   Prefer the Go review-comment shape `Foo(%q) = %v; want %v` over
+   assertion-only text like `"expected X"`. A regression test whose failure
+   message omits the actual state slows down every future investigation.
+   **Earned by:** repository tests using `t.Errorf("expected ...")` without the
+   actual value left reviewers guessing which state transition regressed.
+
 ## Conventions
 
 - **gofmt is non-negotiable**: CI fails on any diff. Always run before committing. A PostToolUse hook (`.claude/scripts/format-go.sh`) auto-runs `gofmt -w` on `.go` files edited via the Edit/Write tools; files changed through Bash (e.g. `sed`, heredocs) are not covered, so always verify with `gofmt -l` before pushing — CI's `gofmt -l` gate is the backstop.
 - **`go mod tidy` must leave `go.mod`/`go.sum` clean**: don't add deps you don't use.
+- **All external I/O is timeout-bounded**: every function that talks to a
+  tracker, repository service, agent runner, subprocess, or network API must
+  enforce a per-request deadline with `context.WithTimeout`, even if the
+  underlying client claims to honor `ctx`. This applies to new code, not only
+  Elixir ports. **Earned by:** #287 retry-fire fetch had no timeout on an
+  Elixir-port path, and #405 found the same failure class in the non-port Gitea
+  tracker client.
+- **Goroutine lifetimes are explicit**: every `go func` / `time.AfterFunc`
+  outside of `package main` boot code must use `safeGo` or install
+  `defer recoverPanic("site")`, and the code must make the exit condition
+  obvious. `package main` boot goroutines that intentionally share process
+  lifetime are exempt, but the call site must say so. Direct async launch
+  without panic recovery or a clear stop condition is a stuck-state bug, not
+  style drift. **Earned by:** PR #304 retrofitted panic recovery after one path
+  could crash the worker; #413's audit found most production goroutine launch
+  sites still lacked that guard, so this needs a machine-checkable follow-up
+  rather than reviewer memory.
 - **Prefer the `gh` CLI over the GitHub MCP server** for GitHub interactions (PRs, issues, CI status, reviews). The SessionStart hook installs `gh` in remote/cloud/web sessions (`.claude/scripts/session-start.sh`); fall back to the GitHub MCP server only when `gh` is unavailable.
 - **Task events**: when adding a new lifecycle event, add the kind as a constant in `internal/task` rather than inlining the string at the call site.
 - **Secrets**: never commit real credentials. `.env`, `.env.*`, `*.key`, `*.pem` are gitignored; `.env.example` is the only sanctioned env template.

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -25,6 +25,7 @@ Checks:
 - setup Go from `go.mod`
 - Go module download
 - `gofmt` check
+- report-only `golangci-lint` baseline for earned Go engineering rules
 - `go mod tidy` check
 - `go test -race -covermode=atomic ./...`
 - build `worker`
@@ -43,6 +44,13 @@ gate fails on a package inherited from the Debian base image, first rebuild with
 only if the rebuilt image still contains a fixed finding. Do not add a
 `.trivyignore` entry for a vulnerability that the package manager can already
 fix.
+
+The `golangci-lint` step is intentionally report-only for lint findings during
+the initial baseline. It runs with `--issues-exit-code=0` so CI surfaces
+`errorlint`, `contextcheck`, `funlen`, `gocognit`, and related findings without
+blocking existing debt. Configuration, action, or runtime failures still fail
+the workflow. New PRs should avoid adding reported violations; follow-up cleanup
+PRs can later tighten the gate once the baseline is below the agreed threshold.
 
 ### Release
 
@@ -80,6 +88,7 @@ Run:
 ```bash
 go mod tidy
 gofmt -w cmd internal
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0
 go test ./...
 docker build --pull --tag aiops-platform:local .
 ```

--- a/test/e2e/fixtures/ci_security_test.go
+++ b/test/e2e/fixtures/ci_security_test.go
@@ -35,6 +35,36 @@ func TestCIRunsSecurityScanning(t *testing.T) {
 	}
 }
 
+// TestCIRunsReportOnlyGoLint guards #413's rollout model: newly earned Go
+// engineering rules need a machine-visible golangci-lint gate, but the initial
+// baseline must be report-only so existing violations can be burned down in
+// follow-up PRs.
+func TestCIRunsReportOnlyGoLint(t *testing.T) {
+	ci := readCIWorkflow(t)
+	const stepName = "      - name: Run golangci-lint (report only)"
+	stepStart := strings.Index(ci, stepName)
+	if stepStart < 0 {
+		t.Fatalf("ci.yml is missing %q", stepName)
+	}
+	step := ci[stepStart:]
+	if next := strings.Index(step[len(stepName):], "\n      - name:"); next >= 0 {
+		step = step[:len(stepName)+next]
+	}
+	for _, want := range []string{
+		"golangci/golangci-lint-action@",
+		"version: v2.",
+		"--config=.golangci.yml",
+		"--issues-exit-code=0",
+	} {
+		if !strings.Contains(step, want) {
+			t.Errorf("golangci-lint step is missing report-only marker %q", want)
+		}
+	}
+	if strings.Contains(step, "continue-on-error") {
+		t.Errorf("golangci-lint step must not mask configuration or action failures with continue-on-error")
+	}
+}
+
 // TestCIActionsArePinnedToSHA guards supply-chain hardening (#372): every
 // third-party action `uses:` must reference a 40-hex commit SHA, not a movable
 // tag like @v6. A reverted pin re-introduces the mutable-tag risk and fails.


### PR DESCRIPTION
## Summary
- Add `.golangci.yml` as the initial Go engineering-rule lint baseline with `contextcheck`, `errorlint`, `funlen`, `gocognit`, `revive`, and related linters.
- Wire `golangci-lint-action` into CI as report-only for lint findings via `--issues-exit-code=0`; config/action/runtime failures still fail because the step intentionally does not use `continue-on-error`.
- Add the earned AGENTS.md rules for function/file budgets, external I/O timeouts, error wrapping/classification, goroutine lifetimes, and useful test failures; update the CI runbook and fixture guard.

Closes #413

## Acceptance criteria
- [x] AGENTS.md captures already-earned Go engineering rules without broad style-guide creep.
- [x] CI has an initial report-only golangci-lint baseline.
- [x] The report-only semantics are fixture-tested on the exact lint step and prevent `continue-on-error` from hiding config/action failures.
- [x] Current baseline is listed: local golangci-lint reported 113 issues (contextcheck 1, errcheck 27, errorlint 1, funlen 1, gocognit 50, gocritic 2, ineffassign 1, staticcheck 14, unparam 14, unused 2).

## Verification
- `go test ./test/e2e/fixtures` (red first before CI step, then green)
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 config verify --config=.golangci.yml`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker`
- `go test -tags e2e -race -timeout 15m ./test/e2e/...`

## Review
- Codex diff reviewer on `ea267d5`: approve / no findings.
- Claude diff reviewer on `ea267d5`: no blocking bug / approve; noted only non-blocking follow-up considerations for future gate tightening.