### PR TITLE
feat: productize first-run doctor and smoke path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,16 @@
 GITEA_BASE_URL=http://gitea.local
 GITEA_TOKEN=replace-with-gitea-bot-token
 LINEAR_API_KEY=replace-with-linear-personal-key
+# Production-style Docker + Codex runs should use deploy/docker-compose.codex.yml
+# and put sensitive values in files that Compose mounts as secrets instead of
+# leaving long-lived tokens in this env file.
+# Compose secret and bind-mount paths should be absolute for multi-file
+# invocations such as `docker compose -f deploy/docker-compose.yml ...`.
+# LINEAR_API_KEY_FILE=/absolute/path/to/aiops-platform/.aiops/secrets/linear_api_key
+# Optional: only when this deployment still needs a Gitea API token.
+# GITEA_TOKEN_FILE=/absolute/path/to/aiops-platform/.aiops/secrets/gitea_token
+# AIOPS_STATE_API_TOKEN_FILE=/absolute/path/to/aiops-platform/.aiops/secrets/state_api_token
+# AIOPS_CODEX_HOME_PATH=/absolute/path/to/aiops-platform/.aiops/codex-home
 # AIOPS_WORKSPACE_ROOT is optional. When unset, the worker uses WORKFLOW.md
 # `workspace.root` (SPEC §6.4 default: `<system-temp>/symphony_workspaces`,
 # typically `/tmp/symphony_workspaces` on Linux). Set this only to override

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 !cmd/worker/dashboard/dist/
 !cmd/worker/dashboard/dist/**
 logs/
+docs/validation/smoke/
 tmp/
 *.log
 *.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -o /out/worker ./cmd/worker
 
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ca-certificates git openssh-client wget && rm -rf /var/lib/apt/lists/*
+FROM debian:bookworm-slim AS worker
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ca-certificates git openssh-client ripgrep wget && rm -rf /var/lib/apt/lists/*
 # Run as a dedicated unprivileged user. The worker prepares git workspaces and
 # runs agent/hook/verify/git commands, so root-in-container would widen the
 # blast radius of any compromised runner or hostile repository content (#365).
@@ -46,6 +46,8 @@ RUN set -eux; \
     chmod 700 /home/aiops/.ssh
 ENV HOME=/home/aiops
 COPY --from=build /out/worker /usr/local/bin/worker
+COPY deploy/aiops-secret-entrypoint.sh /usr/local/bin/aiops-secret-entrypoint
+RUN chmod 0755 /usr/local/bin/aiops-secret-entrypoint
 WORKDIR /app
 USER ${AIOPS_UID}:${AIOPS_GID}
 # Default to the worker so `docker run <image>` is useful out of the box (#370).
@@ -53,3 +55,28 @@ USER ${AIOPS_UID}:${AIOPS_GID}
 # duplication in Compose.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD wget -qO- "http://127.0.0.1:${AIOPS_HEALTHCHECK_PORT:-4000}/livez" >/dev/null 2>&1 || exit 1
 CMD ["worker"]
+
+FROM worker AS codex-worker
+ARG AIOPS_UID=1000
+ARG AIOPS_GID=1000
+USER root
+ARG CODEX_CLI_VERSION=0.133.0
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) codex_arch="x86_64-unknown-linux-musl"; codex_sha="cad5f38b92247186a532157111ea43edca77d3427eb6127e603b7887db484473" ;; \
+      arm64) codex_arch="aarch64-unknown-linux-musl"; codex_sha="7a77d416f9ce16f18e09fdc57622a15aab6ad131c34e078ab9d55a13bb3d9b05" ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}; supported: amd64, arm64" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/openai/codex/releases/download/rust-v${CODEX_CLI_VERSION}/codex-package-${codex_arch}.tar.gz"; \
+    wget -qO /tmp/codex.tar.gz "${url}"; \
+    echo "${codex_sha}  /tmp/codex.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/codex; \
+    tar -xzf /tmp/codex.tar.gz -C /opt/codex; \
+    ln -sf /opt/codex/bin/codex /usr/local/bin/codex; \
+    rm -f /tmp/codex.tar.gz; \
+    codex --version
+USER ${AIOPS_UID}:${AIOPS_GID}
+
+# Keep `docker build .` on the baseline worker image; codex-worker is opt-in.
+FROM worker AS default

--- a/README.md
+++ b/README.md
@@ -406,6 +406,10 @@ release flow, and local pre-push checks.
 For production-style Docker runs that execute real `codex app-server` inside
 the worker image, see the
 [Codex app-server Docker runbook](docs/runbooks/codex-app-server-docker.md).
+For a clean first install, start with the
+[Docker + Linear + Codex first-run runbook](docs/runbooks/first-run-docker-linear-codex.md);
+it covers the support matrix, Docker secret mounts, `worker --doctor`, and the
+todo smoke script.
 
 ## AI agent rules
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/doctor"
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
@@ -39,11 +40,65 @@ func main() {
 		}
 		os.Exit(worker.PrintConfig(workdir, portOverride, os.Stdout, os.Stderr))
 	}
+	if len(os.Args) >= 2 && os.Args[1] == "--doctor" {
+		opts, err := parseDoctorArgs(os.Args[2:])
+		if err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				os.Exit(0)
+			}
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(2)
+		}
+		os.Exit(doctor.Run(context.Background(), opts))
+	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	if err := normalizeRunError(run(ctx, os.Args[1:]), ctx.Err()); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func parseDoctorArgs(args []string) (doctor.Options, error) {
+	fs := flag.NewFlagSet("worker --doctor", flag.ContinueOnError)
+	mode := fs.String("mode", "mock", "preflight depth: mock or real")
+	dashboardURL := fs.String("dashboard-url", "", "optional worker dashboard base URL to verify /api/v1/state auth")
+	if err := fs.Parse(reorderDoctorFlags(args)); err != nil {
+		return doctor.Options{}, err
+	}
+	if *mode != "mock" && *mode != "real" {
+		return doctor.Options{}, fmt.Errorf("--mode must be mock or real")
+	}
+	if fs.NArg() > 1 {
+		return doctor.Options{}, fmt.Errorf("usage: worker --doctor [--mode=mock|real] [--dashboard-url=http://127.0.0.1:4000] [path-to-WORKFLOW.md]")
+	}
+	var path string
+	if fs.NArg() == 1 {
+		path = fs.Arg(0)
+	}
+	return doctor.Options{WorkflowPath: path, Mode: *mode, DashboardURL: *dashboardURL, Stdout: os.Stdout, Stderr: os.Stderr}, nil
+}
+
+func reorderDoctorFlags(args []string) []string {
+	flags, positional := make([]string, 0, len(args)), make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--":
+			positional = append(positional, append([]string{"--"}, args[i+1:]...)...)
+			i = len(args)
+		case a == "--mode" || a == "-mode" || a == "--dashboard-url" || a == "-dashboard-url":
+			flags = append(flags, a)
+			if i+1 < len(args) {
+				flags = append(flags, args[i+1])
+				i++
+			}
+		case strings.HasPrefix(a, "-"):
+			flags = append(flags, a)
+		default:
+			positional = append(positional, a)
+		}
+	}
+	return append(flags, positional...)
 }
 
 func normalizeRunError(err error, runCtxErr error) error {
@@ -1166,7 +1221,65 @@ func apiIssueFromView(view orchestrator.StateView, identifier string) (apiIssueR
 		payload.LastError = stringPointerIfNotEmpty(row.Error)
 		return payload, true
 	}
+	if payload, ok := apiTerminalIssueFromView(view, want); ok {
+		return payload, true
+	}
 	return apiIssueResponse{}, false
+}
+
+func apiTerminalIssueFromView(view orchestrator.StateView, normalizedWant string) (apiIssueResponse, bool) {
+	base := func(issueID orchestrator.IssueID, identifier, status string) apiIssueResponse {
+		return apiIssueResponse{
+			IssueIdentifier: identifier,
+			IssueID:         issueID,
+			Status:          status,
+			RecentEvents:    []map[string]any{},
+			Tracked:         map[string]any{},
+		}
+	}
+	for i := len(view.RecentEvents) - 1; i >= 0; i-- {
+		ev := view.RecentEvents[i]
+		if ev.Kind != orchestrator.RuntimeEventCompleted && ev.Kind != orchestrator.RuntimeEventFailed {
+			continue
+		}
+		if !matchesIssueLookup(ev.IssueID, ev.Identifier, normalizedWant) {
+			continue
+		}
+		payload := base(ev.IssueID, ev.Identifier, string(ev.Kind))
+		payload.RecentEvents = []map[string]any{apiRuntimeEventFromView(ev)}
+		if ev.Kind == orchestrator.RuntimeEventFailed {
+			payload.LastError = stringPointerIfNotEmpty(ev.Message)
+		}
+		return payload, true
+	}
+	for _, issueID := range view.Completed {
+		if matchesIssueLookup(issueID, "", normalizedWant) {
+			return base(issueID, string(issueID), "completed"), true
+		}
+	}
+	for _, issueID := range view.Failed {
+		if matchesIssueLookup(issueID, "", normalizedWant) {
+			return base(issueID, string(issueID), "failed"), true
+		}
+	}
+	return apiIssueResponse{}, false
+}
+
+func apiRuntimeEventFromView(ev orchestrator.RuntimeEvent) map[string]any {
+	out := map[string]any{
+		"kind":       ev.Kind,
+		"issue_id":   ev.IssueID,
+		"identifier": ev.Identifier,
+		"message":    ev.Message,
+		"at":         ev.At,
+	}
+	if ev.Branch != "" {
+		out["branch"] = ev.Branch
+	}
+	if ev.PRURL != "" {
+		out["pr_url"] = ev.PRURL
+	}
+	return out
 }
 
 // restartCountFromRetryAttempt mirrors the Symphony Elixir reference

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -84,6 +84,29 @@ func TestApiRunningRowAlwaysEmitsSpec13_7_2StatusKeys(t *testing.T) {
 	}
 }
 
+func TestApiIssueFromViewFindsRecentTerminalEventByIdentifier(t *testing.T) {
+	view := orchestrator.StateView{
+		Completed: []orchestrator.IssueID{"linear-global-id"},
+		RecentEvents: []orchestrator.RuntimeEvent{{
+			Kind:       orchestrator.RuntimeEventCompleted,
+			IssueID:    "linear-global-id",
+			Identifier: "ENG-1",
+			Message:    "worker exited cleanly",
+			At:         time.Unix(1700000000, 0).UTC(),
+		}},
+	}
+	got, ok := apiIssueFromView(view, "ENG-1")
+	if !ok {
+		t.Fatal("apiIssueFromView(ENG-1) ok = false; want true")
+	}
+	if got.Status != "completed" || got.IssueID != "linear-global-id" {
+		t.Fatalf("terminal issue = (%s, %s); want (completed, linear-global-id)", got.Status, got.IssueID)
+	}
+	if len(got.RecentEvents) != 1 {
+		t.Fatalf("recent event count = %d; want 1", len(got.RecentEvents))
+	}
+}
+
 // TestApiRunningRowEmitsLastEventAt pins the SPEC §13.7.2 running-row
 // contract: once a runtime event has been observed the row exposes
 // last_event_at as an RFC3339 string; no back-compat alias is emitted.
@@ -2339,6 +2362,26 @@ func TestParseRunArgs_PortAfterPositionalPathStillParses(t *testing.T) {
 // fatal error.
 func TestParseRunArgs_HelpReturnsFlagErrHelp(t *testing.T) {
 	_, _, err := parseRunArgs([]string{"--help"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("err = %v, want flag.ErrHelp", err)
+	}
+	if normalized := normalizeRunError(err, nil); normalized != nil {
+		t.Fatalf("normalizeRunError(flag.ErrHelp) = %v, want nil", normalized)
+	}
+}
+
+func TestParseDoctorArgs_AllowsTrailingFlags(t *testing.T) {
+	opts, err := parseDoctorArgs([]string{"/wf.md", "--mode", "real", "--dashboard-url", "http://127.0.0.1:4000"})
+	if err != nil {
+		t.Fatalf("parseDoctorArgs returned error: %v", err)
+	}
+	if opts.WorkflowPath != "/wf.md" || opts.Mode != "real" || opts.DashboardURL != "http://127.0.0.1:4000" {
+		t.Fatalf("parseDoctorArgs = %+v", opts)
+	}
+}
+
+func TestParseDoctorArgs_HelpReturnsFlagErrHelp(t *testing.T) {
+	_, err := parseDoctorArgs([]string{"--help"})
 	if !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("err = %v, want flag.ErrHelp", err)
 	}

--- a/deploy/aiops-secret-entrypoint.sh
+++ b/deploy/aiops-secret-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+if [ -s /run/secrets/linear_api_key ]; then
+  export LINEAR_API_KEY="$(cat /run/secrets/linear_api_key)"
+fi
+
+if [ -s /run/secrets/gitea_token ]; then
+  export GITEA_TOKEN="$(cat /run/secrets/gitea_token)"
+fi
+
+if [ -s /run/secrets/aiops_state_api_token ]; then
+  export AIOPS_STATE_API_TOKEN="$(cat /run/secrets/aiops_state_api_token)"
+fi
+
+if [ "$#" -eq 0 ]; then
+  set -- worker
+elif [ "${1#-}" != "$1" ]; then
+  set -- worker "$@"
+fi
+
+exec "$@"

--- a/deploy/docker-compose.codex.yml
+++ b/deploy/docker-compose.codex.yml
@@ -1,0 +1,44 @@
+# Opt-in Codex + secret-backed first-run overlay.
+#
+# Usage:
+#
+#   docker compose --env-file .env \
+#     -f deploy/docker-compose.yml \
+#     -f deploy/docker-compose.codex.yml \
+#     up --build worker
+#
+# The overlay builds the `codex-worker` Dockerfile target and feeds sensitive
+# values through Docker-supported secret files where possible. Codex auth/config
+# are mounted as a read-only host directory because Codex expects a CODEX_HOME
+# directory rather than one secret file.
+services:
+  worker:
+    build:
+      target: codex-worker
+    environment:
+      AIOPS_WORKFLOW_PATH: /app/WORKFLOW.md
+      CODEX_HOME: /home/aiops/.codex
+      # Clear plain-env tokens inherited from the base local-dev compose file;
+      # this production-style overlay feeds them through service secrets below.
+      AIOPS_STATE_API_TOKEN: ""
+      GITEA_TOKEN: ""
+      LINEAR_API_KEY: ""
+    entrypoint:
+      - /usr/local/bin/aiops-secret-entrypoint
+    command:
+      - worker
+    volumes:
+      - ${AIOPS_WORKFLOW_PATH:?set AIOPS_WORKFLOW_PATH to a workflow file}:/app/WORKFLOW.md:ro
+      - ${AIOPS_CODEX_HOME_PATH:?set AIOPS_CODEX_HOME_PATH to a Codex home directory}:/home/aiops/.codex:ro
+    secrets:
+      - linear_api_key
+      - gitea_token
+      - aiops_state_api_token
+
+secrets:
+  linear_api_key:
+    file: ${LINEAR_API_KEY_FILE:?set LINEAR_API_KEY_FILE to a file containing the Linear API key}
+  gitea_token:
+    file: ${GITEA_TOKEN_FILE:-/dev/null}
+  aiops_state_api_token:
+    file: ${AIOPS_STATE_API_TOKEN_FILE:?set AIOPS_STATE_API_TOKEN_FILE to a file containing the state API token}

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -4,6 +4,10 @@ This runbook documents the production-style worker image path for workflows
 that set `agent.default: codex-app-server` and run `codex app-server` inside the
 worker container.
 
+For the full new-operator path, including support matrix, Docker Compose
+secrets, `worker --doctor`, and the todo smoke test, start with
+[`first-run-docker-linear-codex.md`](first-run-docker-linear-codex.md).
+
 ## Current installer status
 
 On 2026-05-26, the online installer failed inside the Linux ARM64 worker image:
@@ -24,6 +28,15 @@ Could not find SHA-256 digest for codex-package-aarch64-unknown-linux-musl.tar.g
 
 Until the installer works for this platform, use a deterministic release-package
 install in the worker image.
+
+The repository Dockerfile now exposes this as the `codex-worker` target:
+
+```bash
+docker build --target codex-worker -t aiops-platform:codex-worker .
+```
+
+The target supports Linux `amd64` and `arm64`, pins Codex CLI `0.133.0`, checks
+the release artifact SHA-256, and runs `codex --version` during the build.
 
 ## Linux ARM64 fallback
 

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -1,0 +1,166 @@
+# First run: Docker + Linear + Codex
+
+This is the supported first-run path for a new operator who wants to validate
+aiops-platform with Docker, Linear, and `codex app-server`.
+
+## Support matrix
+
+| Area | Stable path | Fallback | Not supported yet / blocker |
+| --- | --- | --- | --- |
+| macOS host development | Run `go run ./cmd/worker --doctor --mode=mock` and `agent.default: mock` from source. | Use host Codex CLI for local `codex` / `codex-app-server` workflows after `codex --login`. | Host binary mounts into Linux containers are not supported; install Codex in the image. |
+| Linux amd64 Docker worker | Build `Dockerfile` target `codex-worker`; Codex CLI `0.133.0` is installed from a pinned release artifact and checksum. | Use base `worker` target for mock-only validation. | Online installer is not the promoted Docker path until Linux ARM64 checksum behavior is reliable. |
+| Linux arm64 Docker worker | Build `codex-worker`; uses the pinned `aarch64-unknown-linux-musl` release artifact and checksum. | Same as above. | `curl https://chatgpt.com/codex/install.sh \| sh` failed on 2026-05-26 because the installer could not find the ARM64 package checksum. |
+| Codex auth | Mount a read-only `CODEX_HOME` directory into `/home/aiops/.codex` for smoke validation; verify with `worker --doctor --mode=real`. | Local host development can use the normal host `~/.codex`; long-lived ChatGPT-login deployments should use a restricted writable Codex home so token refresh can persist. | Passing raw bearer tokens on command lines or in logs is not supported. |
+| Linear auth | Personal API key in a Docker Compose secret file. Linear expects `Authorization: <API_KEY>` for personal keys. | Local development may use `LINEAR_API_KEY` in `.env`; do not use this for production-style examples. | OAuth app-actor is documented by Linear and is the intended future service-account path, but aiops-platform still accepts a single `tracker.api_key` string today. |
+| Sandbox | Mock mode works under the base hardened container. Real Codex Docker validation uses a Docker-isolated profile and explicit `codex.thread_sandbox: danger-full-access` only inside that container boundary. | Enable kernel/user namespace support and keep Codex `workspace-write` if your container profile permits it. | Do not copy `danger-full-access` to a shared host run. |
+
+Official references checked for this path:
+
+- OpenAI Codex CLI getting started: npm install / upgrade, supported local CLI
+  behavior, approvals, and sandbox expectations.
+- OpenAI Codex CLI ChatGPT sign-in: `codex --login`, local credential storage,
+  and revocation behavior.
+- OpenAI Codex repository install docs: macOS/Linux/WSL requirements, DotSlash,
+  source builds, and release artifacts.
+- OpenAI Codex app-server README: prefer token/auth files over raw bearer
+  tokens on command lines for manual app-server startup.
+- Docker Compose secrets docs: service-scoped secrets are mounted under
+  `/run/secrets/<name>` and should be preferred for passwords/API keys.
+- Linear GraphQL docs: personal API keys use raw `Authorization: <API_KEY>`;
+  OAuth access tokens use `Authorization: Bearer <ACCESS_TOKEN>`.
+- Linear OAuth actor authorization docs: `actor=app` is the future
+  app/service-account style path for agent integrations.
+
+## 1. Prepare files
+
+```bash
+mkdir -p .aiops/secrets .aiops/codex-home
+cp examples/WORKFLOW.md .aiops/WORKFLOW.md
+printf '%s' 'replace-with-linear-personal-key' > .aiops/secrets/linear_api_key
+openssl rand -hex 24 > .aiops/secrets/state_api_token
+```
+
+Run `codex --login` on the host, then copy or provision the Codex home you
+want the container to read:
+
+```bash
+cp ~/.codex/auth.json .aiops/codex-home/auth.json
+cp ~/.codex/config.toml .aiops/codex-home/config.toml
+chmod 600 .aiops/secrets/* .aiops/codex-home/*
+```
+
+Edit `.aiops/WORKFLOW.md`:
+
+- set `repo.clone_url` to a disposable fixture repository for smoke tests;
+- set `tracker.project_slug` to the Linear project slug;
+- keep `agent.default: mock` for the first smoke;
+- switch to `agent.default: codex-app-server` only for the real Codex smoke;
+- in Docker real mode, set `codex.command: codex app-server` and make the
+  sandbox choice explicit.
+
+## 2. Configure Compose
+
+Use `.env` only for non-secret paths and build settings. Write absolute paths:
+the documented command merges Compose files from `deploy/`, and absolute
+bind/secret paths avoid project-directory ambiguity.
+
+```bash
+cat > .env <<EOF
+AIOPS_WORKFLOW_PATH=$PWD/.aiops/WORKFLOW.md
+AIOPS_CODEX_HOME_PATH=$PWD/.aiops/codex-home
+LINEAR_API_KEY_FILE=$PWD/.aiops/secrets/linear_api_key
+# Optional: only if this deployment still needs a Gitea API token.
+# GITEA_TOKEN_FILE=$PWD/.aiops/secrets/gitea_token
+AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token
+AIOPS_UID=$(id -u)
+AIOPS_GID=$(id -g)
+EOF
+```
+
+The Codex overlay reads Linear, optional Gitea, and dashboard tokens from Docker
+secret files. The Codex home is a read-only bind because Codex expects a
+directory.
+
+## 3. Run preflight
+
+Host mock preflight:
+
+```bash
+go run ./cmd/worker --doctor --mode=mock .aiops/WORKFLOW.md
+```
+
+Docker real preflight:
+
+```bash
+docker compose --env-file .env \
+  -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.codex.yml \
+  run --rm worker --doctor --mode=real
+```
+
+Expected output is action-oriented:
+
+```text
+PASS Linear auth: API key authenticated and project is visible
+FAIL Codex auth: ...
+     Fix: Run codex --login in the same CODEX_HOME/container user context.
+WARN Dashboard state API: not checked; no dashboard URL supplied
+     Fix: Pass --dashboard-url while the worker is running to verify state API auth.
+```
+
+`--mode=mock` fails on missing workflow, missing `repo.clone_url`, missing
+Linear key, and missing required host binaries. It warns, but does not fail, on
+Docker/Codex paths that are not needed by the mock runner. On the host,
+`--mode=real` also checks Docker Compose. Inside the Docker worker it skips the
+host Docker CLI check and validates live Linear auth/project visibility, Codex
+CLI version, Codex login status, and a minimal `codex app-server` JSON-RPC
+probe.
+
+## 4. Run a todo smoke
+
+Prepare or select one disposable Linear issue in an active state. For the first
+pass, keep `agent.default: mock`:
+
+```bash
+go build -o /tmp/aiops-worker ./cmd/worker
+AIOPS_SMOKE_WORKER_BIN=/tmp/aiops-worker \
+  scripts/aiops-todo-smoke.sh \
+  --mode mock \
+  --workflow .aiops/WORKFLOW.md \
+  --issue AIS-123
+```
+
+The smoke script:
+
+- runs `worker --doctor`;
+- starts a worker on `127.0.0.1:4010`;
+- triggers `/api/v1/refresh`;
+- waits for one lifecycle to increment `completed_total` or `failed_total`;
+- writes a timestamped report under `docs/validation/smoke/`;
+- records the state snapshot and worker log paths without printing secrets.
+
+For real Codex mode, switch the workflow to `agent.default: codex-app-server`,
+allow only the Linear mutations you need (`issueUpdate`, `commentCreate`), and
+run:
+
+```bash
+AIOPS_SMOKE_WORKER_BIN=/tmp/aiops-worker \
+  scripts/aiops-todo-smoke.sh \
+  --mode real \
+  --workflow .aiops/WORKFLOW.md \
+  --issue AIS-124
+```
+
+Verify the report, Linear comment, final Linear state, and workspace cleanup
+before considering the install validated.
+
+## Troubleshooting
+
+| Symptom | Next action |
+| --- | --- |
+| `FAIL Linear API key` | Make sure the workflow uses `api_key: $LINEAR_API_KEY`; for Docker, set `LINEAR_API_KEY_FILE` and merge `deploy/docker-compose.codex.yml`. |
+| `FAIL Linear auth` | Personal keys must be sent raw, not as `Bearer`; confirm the token can see `tracker.project_slug`. |
+| `FAIL Codex CLI` | Build the `codex-worker` target or install Codex on the host. |
+| `FAIL Codex auth` | Run `codex --login` for the same `CODEX_HOME` and container user context. |
+| `WARN Codex sandbox` | Either use the documented Docker-isolated profile for real smoke validation or enable the kernel/user namespace support required by Codex `workspace-write`. |
+| smoke timeout | Confirm a disposable issue is in an active state, `/readyz` is healthy, and `tracker.active_states` matches the Linear board. |

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -186,7 +186,16 @@ it as a bearer token when polling the overlay.
 
 ## 3. Smoke test
 
-The fastest way to verify local configuration is to print the
+For a first install, run the operator preflight before starting a worker:
+
+```bash
+go run ./cmd/worker --doctor --mode=mock "$AIOPS_WORKFLOW_PATH"
+```
+
+Use `--mode=real` only when the selected workflow should validate live Linear
+auth and a real Codex app-server setup.
+
+The fastest way to inspect the effective local configuration is to print the
 effective worker config. `--print-config <workdir>` resolves
 `<workdir>/WORKFLOW.md` directly and does **not** consult
 `AIOPS_WORKFLOW_PATH`, so pass the directory that holds the workflow

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,565 @@
+package doctor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+type Status string
+
+const (
+	Pass Status = "PASS"
+	Warn Status = "WARN"
+	Fail Status = "FAIL"
+)
+
+type Check struct {
+	Status Status
+	Name   string
+	Detail string
+	Fix    string
+}
+
+type Options struct {
+	WorkflowPath string
+	Mode         string
+	DashboardURL string
+	Stdout       io.Writer
+	Stderr       io.Writer
+	Runner       CommandRunner
+	HTTPClient   *http.Client
+}
+
+type CommandRunner func(context.Context, string, []string, []string, io.Reader) ([]byte, error)
+
+type Report struct {
+	Checks []Check
+}
+
+func Run(ctx context.Context, opts Options) int {
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	report := BuildReport(ctx, opts)
+	writeTextReport(opts.Stdout, report)
+	if report.HasFailures() {
+		return 1
+	}
+	return 0
+}
+
+func BuildReport(ctx context.Context, opts Options) Report {
+	r := &reportBuilder{opts: opts}
+	r.normalize()
+	wf, path := r.checkWorkflow()
+	r.checkHostBinaries(wf)
+	r.checkDockerCompose(ctx)
+	if wf != nil {
+		r.checkLinear(ctx, wf.Config)
+		r.checkCodex(ctx, wf.Config)
+		r.checkSandbox(wf.Config)
+	}
+	r.checkDashboard(ctx)
+	if wf != nil && path != "" {
+		r.pass("Workflow path", path)
+	}
+	return Report{Checks: r.checks}
+}
+
+func (r Report) HasFailures() bool {
+	for _, check := range r.Checks {
+		if check.Status == Fail {
+			return true
+		}
+	}
+	return false
+}
+
+type reportBuilder struct {
+	opts   Options
+	checks []Check
+}
+
+func (r *reportBuilder) normalize() {
+	if r.opts.Mode == "" {
+		r.opts.Mode = "mock"
+	}
+	if r.opts.Runner == nil {
+		r.opts.Runner = defaultRunner
+	}
+	if r.opts.HTTPClient == nil {
+		r.opts.HTTPClient = &http.Client{Timeout: 10 * time.Second}
+	}
+}
+
+func (r *reportBuilder) checkWorkflow() (*workflow.Workflow, string) {
+	path := strings.TrimSpace(r.opts.WorkflowPath)
+	if path == "" {
+		path = os.Getenv("AIOPS_WORKFLOW_PATH")
+	}
+	if path == "" {
+		if wd, err := os.Getwd(); err == nil {
+			path = filepath.Join(wd, "WORKFLOW.md")
+		}
+	}
+	if path == "" {
+		r.fail("Workflow", "no workflow path found", "Pass --doctor <path> or set AIOPS_WORKFLOW_PATH.")
+		return nil, ""
+	}
+	wf, err := workflow.Load(path)
+	if err != nil {
+		r.fail("Workflow", err.Error(), "Fix the WORKFLOW.md front matter, then rerun worker --doctor.")
+		return nil, path
+	}
+	if wf.Config.Repo.CloneURL == "" && len(wf.Config.Services) == 0 {
+		r.fail("Runtime config", "repo.clone_url is required for worker dispatch", "Set repo.clone_url or configure services[].repo.clone_url.")
+	} else {
+		r.pass("Runtime config", "repo/workflow config is dispatchable")
+	}
+	return wf, path
+}
+
+func (r *reportBuilder) checkHostBinaries(wf *workflow.Workflow) {
+	r.requiredBinary("git")
+	if wf != nil && workflowNeedsSSH(wf.Config) {
+		r.requiredBinary("ssh")
+	} else {
+		r.pass("ssh", "not required for configured repository clone URLs")
+	}
+	if _, err := exec.LookPath("rg"); err != nil {
+		r.warn("rg", "ripgrep not found on PATH", "Install rg in the worker image for faster agent code search.")
+	} else {
+		r.pass("rg", "found on PATH")
+	}
+}
+
+func (r *reportBuilder) checkDockerCompose(ctx context.Context) {
+	if runningInContainer() {
+		r.warn("Docker Compose", "host Docker Compose check skipped inside the worker container", "Run docker compose config --quiet on the host before docker compose run/up.")
+		return
+	}
+	out, err := r.run(ctx, "docker", []string{"compose", "version"})
+	if err != nil {
+		status := Warn
+		if r.realMode() {
+			status = Fail
+		}
+		r.add(status, "Docker Compose", trimOutput(out, err), "Install Docker with Compose v2 before running the Docker first-run path.")
+		return
+	}
+	r.pass("Docker Compose", strings.TrimSpace(string(out)))
+	if _, err := os.Stat("deploy/docker-compose.yml"); err == nil {
+		if out, err := r.run(ctx, "docker", []string{"compose", "-f", "deploy/docker-compose.yml", "config", "--quiet"}); err != nil {
+			r.fail("Compose config", trimOutput(out, err), "Fix deploy/docker-compose.yml or its required .env interpolation values.")
+		} else {
+			r.pass("Compose config", "deploy/docker-compose.yml renders")
+		}
+	}
+}
+
+func (r *reportBuilder) checkLinear(ctx context.Context, cfg workflow.Config) {
+	if strings.TrimSpace(cfg.Tracker.Kind) != "linear" {
+		r.warn("Linear", "tracker.kind is not linear; Linear smoke checks skipped", "Use a Linear workflow for the documented first-run path.")
+		return
+	}
+	if strings.TrimSpace(cfg.Tracker.APIKey) == "" {
+		r.fail("Linear API key", "tracker.api_key resolved empty", "Set LINEAR_API_KEY or mount it from a Docker secret into the workflow env.")
+		return
+	}
+	if !r.realMode() {
+		r.pass("Linear API key", "present; live auth skipped in mock mode")
+		return
+	}
+	if err := r.checkLinearGraphQL(ctx, cfg); err != nil {
+		r.fail("Linear auth", err.Error(), "Verify the token, project_slug, and Authorization header style.")
+		return
+	}
+	r.pass("Linear auth", "API key authenticated and configured projects are visible")
+}
+
+func (r *reportBuilder) checkCodex(ctx context.Context, cfg workflow.Config) {
+	if !requiresCodex(cfg) {
+		r.pass("Codex", "not required for mock runner")
+		return
+	}
+	if usesDefaultCodexCLI(cfg) {
+		if _, err := exec.LookPath("codex"); err != nil {
+			r.fail("Codex CLI", "codex binary not found on PATH", "Install Codex CLI in this host/container or set codex.command to a runnable app-server wrapper.")
+			return
+		}
+		if out, err := r.run(ctx, "codex", []string{"--version"}); err != nil {
+			r.fail("Codex version", trimOutput(out, err), "Fix the Codex installation before dispatching real agents.")
+		} else {
+			r.pass("Codex version", strings.TrimSpace(string(out)))
+		}
+		if out, err := r.run(ctx, "codex", []string{"login", "status"}); err != nil {
+			r.fail("Codex auth", trimOutput(out, err), "Run codex --login in the same CODEX_HOME/container user context.")
+		} else {
+			r.pass("Codex auth", firstLine(out))
+		}
+	} else {
+		r.warn("Codex CLI", "version/auth checks skipped for custom codex.command", "Ensure the wrapper uses an authenticated Codex context; the app-server probe validates launch.")
+	}
+	if cfg.Agent.Default != runner.NameCodexAppServer {
+		return
+	}
+	if err := r.probeCodexAppServer(ctx, cfg); err != nil {
+		r.fail("Codex app-server", err.Error(), "Check CODEX_HOME, codex.command, and app-server support in the installed Codex version.")
+	} else {
+		r.pass("Codex app-server", "started and answered a JSON-RPC probe")
+	}
+}
+
+func (r *reportBuilder) checkSandbox(cfg workflow.Config) {
+	if !requiresCodex(cfg) {
+		return
+	}
+	if runningInContainer() && cfg.Codex.ThreadSandbox != "danger-full-access" {
+		r.warn("Codex sandbox", "containerized Codex may not support workspace-write namespaces", "Use the documented Docker-isolated profile or enable the required kernel/userns support.")
+		return
+	}
+	r.pass("Codex sandbox", "selected profile is compatible with this preflight")
+}
+
+func (r *reportBuilder) checkDashboard(ctx context.Context) {
+	if strings.TrimSpace(r.opts.DashboardURL) == "" {
+		r.warn("Dashboard state API", "not checked; no dashboard URL supplied", "Pass --dashboard-url while the worker is running to verify state API auth.")
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(r.opts.DashboardURL, "/")+"/api/v1/state", nil)
+	if err != nil {
+		r.fail("Dashboard state API", err.Error(), "Pass a valid dashboard base URL.")
+		return
+	}
+	if tok := os.Getenv("AIOPS_STATE_API_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	resp, err := r.opts.HTTPClient.Do(req)
+	if err != nil {
+		r.fail("Dashboard state API", err.Error(), "Start the worker or fix the dashboard URL/network mapping.")
+		return
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		r.fail("Dashboard state API", resp.Status, "Set AIOPS_STATE_API_TOKEN or use the loopback-only URL.")
+		return
+	}
+	r.pass("Dashboard state API", resp.Status)
+}
+
+func (r *reportBuilder) checkLinearGraphQL(ctx context.Context, cfg workflow.Config) error {
+	query := `query Doctor($projectSlug: String!) { viewer { id name } projects(filter: { slugId: { eq: $projectSlug } }, first: 1) { nodes { id slugId name } } }`
+	projectSlugs := linearProjectSlugs(cfg)
+	if len(projectSlugs) == 0 {
+		return fmt.Errorf("linear project_slug is required at tracker.project_slug or services[].tracker.project_slug")
+	}
+	endpoint := strings.TrimSpace(cfg.Tracker.Endpoint)
+	if endpoint == "" {
+		endpoint = tracker.DefaultLinearEndpoint
+	}
+	for _, projectSlug := range projectSlugs {
+		var out struct {
+			Data struct {
+				Projects struct {
+					Nodes []struct {
+						ID string `json:"id"`
+					} `json:"nodes"`
+				} `json:"projects"`
+			} `json:"data"`
+			Errors []map[string]any `json:"errors"`
+		}
+		body, _ := json.Marshal(map[string]any{"query": query, "variables": map[string]any{"projectSlug": projectSlug}})
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", cfg.Tracker.APIKey)
+		resp, err := r.opts.HTTPClient.Do(req)
+		if err != nil {
+			return err
+		}
+		if err := decodeLinearProjectProbe(resp, &out); err != nil {
+			return err
+		}
+		if len(out.Errors) > 0 {
+			return fmt.Errorf("linear GraphQL errors for project_slug %q: %v", projectSlug, out.Errors)
+		}
+		if len(out.Data.Projects.Nodes) == 0 {
+			return fmt.Errorf("project_slug %q is not visible to the token", projectSlug)
+		}
+	}
+	return nil
+}
+
+func decodeLinearProjectProbe(resp *http.Response, out any) error {
+	defer closeBody(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("linear returned %s", resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (r *reportBuilder) probeCodexAppServer(ctx context.Context, cfg workflow.Config) error {
+	probe := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"aiops-doctor","title":"aiops doctor","version":"0.1.0"}}}` + "\n"
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	env := os.Environ()
+	cmd, _, err := runner.NewCodexAppServerCommand(probeCtx, cfg, env)
+	if err != nil {
+		return err
+	}
+	cmd.Env = env
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	defer func() {
+		terminate(cmd)
+		_ = cmd.Wait()
+	}()
+	if _, err := io.WriteString(stdin, probe); err != nil {
+		return err
+	}
+	_ = stdin.Close()
+	sc := bufio.NewScanner(stdout)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		ok, err := validateAppServerProbeLine(sc.Bytes())
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	if probeCtx.Err() != nil {
+		return probeCtx.Err()
+	}
+	return fmt.Errorf("no JSON-RPC response: %s", strings.TrimSpace(stderr.String()))
+}
+
+func validateAppServerProbeLine(line []byte) (bool, error) {
+	var msg struct {
+		ID     json.RawMessage `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return false, nil
+	}
+	if strings.TrimSpace(string(msg.ID)) != "1" {
+		return false, nil
+	}
+	if len(msg.Error) > 0 && strings.TrimSpace(string(msg.Error)) != "null" {
+		return false, fmt.Errorf("app-server initialize error: %s", strings.TrimSpace(string(msg.Error)))
+	}
+	if len(msg.Result) == 0 || strings.TrimSpace(string(msg.Result)) == "null" {
+		return false, fmt.Errorf("unexpected app-server response: %s", strings.TrimSpace(string(line)))
+	}
+	return true, nil
+}
+
+func terminate(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}
+
+func closeBody(body io.Closer) {
+	_ = body.Close()
+}
+
+func (r *reportBuilder) requiredBinary(name string) {
+	if _, err := exec.LookPath(name); err != nil {
+		r.fail(name, "not found on PATH", "Install "+name+" in the worker image.")
+		return
+	}
+	r.pass(name, "found on PATH")
+}
+
+func (r *reportBuilder) realMode() bool {
+	return r.opts.Mode == "real"
+}
+
+func (r *reportBuilder) run(ctx context.Context, name string, args []string) ([]byte, error) {
+	runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return r.opts.Runner(runCtx, name, args, nil, nil)
+}
+
+func (r *reportBuilder) pass(name, detail string) {
+	r.add(Pass, name, detail, "")
+}
+
+func (r *reportBuilder) warn(name, detail, fix string) {
+	r.add(Warn, name, detail, fix)
+}
+
+func (r *reportBuilder) fail(name, detail, fix string) {
+	r.add(Fail, name, detail, fix)
+}
+
+func (r *reportBuilder) add(status Status, name, detail, fix string) {
+	r.checks = append(r.checks, Check{Status: status, Name: name, Detail: redact(detail), Fix: redact(fix)})
+}
+
+func defaultRunner(ctx context.Context, name string, args []string, env []string, stdin io.Reader) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Stdin = stdin
+	out, err := cmd.CombinedOutput()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return out, ctx.Err()
+	}
+	return out, err
+}
+
+func requiresCodex(cfg workflow.Config) bool {
+	return cfg.Agent.Default == "codex" || cfg.Agent.Default == runner.NameCodexAppServer
+}
+
+func linearProjectSlugs(cfg workflow.Config) []string {
+	seen := map[string]bool{}
+	var slugs []string
+	add := func(raw string) {
+		slug := strings.TrimSpace(raw)
+		if slug == "" || seen[slug] {
+			return
+		}
+		seen[slug] = true
+		slugs = append(slugs, slug)
+	}
+	add(cfg.Tracker.ProjectSlug)
+	for _, service := range cfg.Services {
+		add(service.Tracker.ProjectSlug)
+	}
+	return slugs
+}
+
+func usesDefaultCodexCLI(cfg workflow.Config) bool {
+	command := strings.TrimSpace(cfg.Codex.Command)
+	return command == "" || command == "codex exec" || command == "codex app-server" || strings.HasPrefix(command, "codex app-server ")
+}
+
+func workflowNeedsSSH(cfg workflow.Config) bool {
+	for _, cloneURL := range workflowCloneURLs(cfg) {
+		if cloneURLNeedsSSH(cloneURL) {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowCloneURLs(cfg workflow.Config) []string {
+	urls := make([]string, 0, 1+len(cfg.Services))
+	if strings.TrimSpace(cfg.Repo.CloneURL) != "" {
+		urls = append(urls, cfg.Repo.CloneURL)
+	}
+	for _, service := range cfg.Services {
+		if strings.TrimSpace(service.Repo.CloneURL) != "" {
+			urls = append(urls, service.Repo.CloneURL)
+		}
+	}
+	return urls
+}
+
+func cloneURLNeedsSSH(raw string) bool {
+	cloneURL := strings.TrimSpace(raw)
+	if cloneURL == "" {
+		return false
+	}
+	if strings.Contains(cloneURL, "://") {
+		u, err := url.Parse(cloneURL)
+		if err != nil {
+			return false
+		}
+		switch strings.ToLower(u.Scheme) {
+		case "ssh", "git+ssh":
+			return true
+		default:
+			return false
+		}
+	}
+	at := strings.Index(cloneURL, "@")
+	colon := strings.Index(cloneURL, ":")
+	return at > 0 && colon > at
+}
+
+func writeTextReport(w io.Writer, report Report) {
+	for _, check := range report.Checks {
+		_, _ = fmt.Fprintf(w, "%s %s", check.Status, check.Name)
+		if check.Detail != "" {
+			_, _ = fmt.Fprintf(w, ": %s", check.Detail)
+		}
+		_, _ = fmt.Fprintln(w)
+		if check.Fix != "" && check.Status != Pass {
+			_, _ = fmt.Fprintf(w, "     Fix: %s\n", check.Fix)
+		}
+	}
+}
+
+func trimOutput(out []byte, err error) string {
+	msg := strings.TrimSpace(string(out))
+	if msg == "" && err != nil {
+		msg = err.Error()
+	}
+	return msg
+}
+
+func firstLine(out []byte) string {
+	line := strings.TrimSpace(string(out))
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	if line == "" {
+		return "ok"
+	}
+	return line
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func runningInContainer() bool {
+	return fileExists("/.dockerenv") || fileExists("/run/.containerenv")
+}
+
+func redact(s string) string {
+	for _, env := range []string{"LINEAR_API_KEY", "GITHUB_TOKEN", "GITEA_TOKEN", "OPENAI_API_KEY", "AIOPS_STATE_API_TOKEN"} {
+		if v := os.Getenv(env); v != "" {
+			s = strings.ReplaceAll(s, v, "***")
+		}
+	}
+	return s
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,454 @@
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildReportMockModeCatchesMissingLinearKeyDuringWorkflowLoad(t *testing.T) {
+	path := writeWorkflow(t, "linear", "$AIOPS_TEST_MISSING_LINEAR_KEY")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "mock",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "Workflow")
+	if check.Status != Fail {
+		t.Fatalf("Workflow status = %s; want FAIL", check.Status)
+	}
+	if !strings.Contains(check.Detail, "missing_tracker_api_key") {
+		t.Fatalf("detail = %q; want missing_tracker_api_key", check.Detail)
+	}
+}
+
+func TestBuildReportRealModeAuthenticatesLinearProject(t *testing.T) {
+	installFakeCodex(t)
+	linear := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "lin-test" {
+			t.Fatalf("Authorization = %q; want raw Linear API key", got)
+		}
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"id":"u","name":"Ada"},"projects":{"nodes":[{"id":"p","slugId":"platform","name":"Platform"}]}}}`))
+	}))
+	defer linear.Close()
+	path := writeWorkflowWithEndpoint(t, linear.URL, "codex-app-server")
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin-test")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Runner:       fakeRealRunner,
+	})
+
+	if got := findCheck(t, report, "Linear auth").Status; got != Pass {
+		t.Fatalf("Linear auth status = %s; want PASS", got)
+	}
+	if got := findCheck(t, report, "Codex auth").Status; got != Pass {
+		t.Fatalf("Codex auth status = %s; want PASS", got)
+	}
+}
+
+func TestBuildReportRealModeAuthenticatesServiceLinearProject(t *testing.T) {
+	installFakeCodex(t)
+	var gotSlugs []string
+	linear := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Variables map[string]string `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode Linear probe: %v", err)
+		}
+		gotSlugs = append(gotSlugs, body.Variables["projectSlug"])
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"id":"u","name":"Ada"},"projects":{"nodes":[{"id":"p","slugId":"api-platform","name":"API"}]}}}`))
+	}))
+	defer linear.Close()
+	path := writeServiceLinearWorkflow(t, linear.URL)
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin-test")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Runner:       fakeRealRunner,
+	})
+
+	if got := findCheck(t, report, "Linear auth").Status; got != Pass {
+		t.Fatalf("Linear auth status = %s; want PASS", got)
+	}
+	if len(gotSlugs) != 1 || gotSlugs[0] != "api-platform" {
+		t.Fatalf("Linear probe project slugs = %#v; want service project slug only", gotSlugs)
+	}
+}
+
+func TestBuildReportDoesNotRequireSSHForHTTPSCloneURLs(t *testing.T) {
+	installFakeGitOnly(t)
+	path := writeWorkflow(t, "linear", "$AIOPS_TEST_LINEAR_KEY")
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin-test")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "mock",
+		Runner:       passingRunner,
+	})
+
+	if got := findCheck(t, report, "ssh"); got.Status != Pass {
+		t.Fatalf("ssh check = %+v; want PASS for HTTPS clone URLs without ssh on PATH", got)
+	}
+	for _, check := range report.Checks {
+		if check.Status == Fail {
+			t.Fatalf("HTTPS workflow without ssh should not fail; got %+v", check)
+		}
+	}
+}
+
+func TestBuildReportRequiresSSHForSSHCloneURLs(t *testing.T) {
+	installFakeGitOnly(t)
+	path := writeWorkflowWithCloneURL(t, "git@example.com:o/r.git")
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin-test")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "mock",
+		Runner:       passingRunner,
+	})
+
+	if got := findCheck(t, report, "ssh"); got.Status != Fail {
+		t.Fatalf("ssh check = %+v; want FAIL for SSH clone URL without ssh on PATH", got)
+	}
+}
+
+func TestBuildReportRealModeUsesCustomCodexCommandForAppServerProbe(t *testing.T) {
+	wrapper := installFakeCodexWrapper(t)
+	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Runner:       dockerOnlyRunner,
+	})
+
+	if got := findCheck(t, report, "Codex CLI").Status; got != Warn {
+		t.Fatalf("Codex CLI status = %s; want WARN for custom codex.command", got)
+	}
+	if got := findCheck(t, report, "Codex app-server").Status; got != Pass {
+		t.Fatalf("Codex app-server status = %s; want PASS", got)
+	}
+	for _, check := range report.Checks {
+		if check.Status == Fail {
+			t.Fatalf("custom codex.command report has failure %+v", check)
+		}
+	}
+}
+
+func TestBuildReportRealModeSkipsCodexForMockAgent(t *testing.T) {
+	installFakeGitOnly(t)
+	path := writeWorkflow(t, "gitea", "token")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	if got := findCheck(t, report, "Codex").Status; got != Pass {
+		t.Fatalf("Codex status = %s; want PASS skip for mock agent", got)
+	}
+	if checkExists(report, "Codex CLI") {
+		t.Fatalf("Codex CLI check should be skipped for mock agent in real mode")
+	}
+}
+
+func TestBuildReportFailsCodexAppServerErrorResponse(t *testing.T) {
+	wrapper := installFakeCodexWrapperBody(t, `#!/bin/sh
+if [ "$1" = "app-server" ]; then
+  read line
+  echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"bad init"}}'
+  exit 0
+fi
+exit 1
+`)
+	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Runner:       dockerOnlyRunner,
+	})
+
+	check := findCheck(t, report, "Codex app-server")
+	if check.Status != Fail {
+		t.Fatalf("Codex app-server status = %s; want FAIL", check.Status)
+	}
+	if !strings.Contains(check.Detail, "app-server initialize error") || !strings.Contains(check.Detail, "bad init") {
+		t.Fatalf("Codex app-server detail = %q; want JSON-RPC initialize error message", check.Detail)
+	}
+}
+
+func TestBuildReportRealModeSkipsAppServerProbeForCodexExec(t *testing.T) {
+	installFakeCodexWithoutAppServer(t)
+	path := writeWorkflowWithAgent(t, "codex")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Runner:       fakeRealRunner,
+	})
+
+	if got := findCheck(t, report, "Codex auth").Status; got != Pass {
+		t.Fatalf("Codex auth status = %s; want PASS", got)
+	}
+	if checkExists(report, "Codex app-server") {
+		t.Fatalf("Codex app-server check should be skipped for agent.default codex")
+	}
+	for _, check := range report.Checks {
+		if check.Status == Fail {
+			t.Fatalf("codex exec workflow should not fail app-server preflight; got %+v", check)
+		}
+	}
+}
+
+func installFakeCodex(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex")
+	body := `#!/bin/sh
+case "$1" in
+  --version) echo "codex-cli 0.133.0"; exit 0 ;;
+  login) echo "Logged in"; exit 0 ;;
+  app-server) read line; echo '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}'; exit 0 ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func installFakeCodexWithoutAppServer(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex")
+	body := `#!/bin/sh
+case "$1" in
+  --version) echo "codex-cli 0.133.0"; exit 0 ;;
+  login) echo "Logged in"; exit 0 ;;
+  app-server) echo "app-server unavailable" >&2; exit 1 ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func installFakeGitOnly(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "git")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+func installFakeCodexWrapper(t *testing.T) string {
+	t.Helper()
+	body := `#!/bin/sh
+if [ "$1" = "app-server" ]; then
+  read line
+  echo '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}'
+  exit 0
+fi
+exit 1
+`
+	return installFakeCodexWrapperBody(t, body)
+}
+
+func installFakeCodexWrapperBody(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wrapped-codex")
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write fake codex wrapper: %v", err)
+	}
+	return path
+}
+
+func TestRunReturnsFailureWhenReportHasFailures(t *testing.T) {
+	path := writeWorkflow(t, "linear", "$AIOPS_TEST_MISSING_LINEAR_KEY")
+	var out strings.Builder
+	code := Run(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "mock",
+		Stdout:       &out,
+		Runner:       passingRunner,
+	})
+
+	if code != 1 {
+		t.Fatalf("Run exit code = %d; want 1", code)
+	}
+	if !strings.Contains(out.String(), "FAIL Workflow") || !strings.Contains(out.String(), "missing_tracker_api_key") {
+		t.Fatalf("doctor output missing workflow credential failure:\n%s", out.String())
+	}
+}
+
+func writeWorkflow(t *testing.T, trackerKind, apiKey string) string {
+	t.Helper()
+	return writeWorkflowBody(t, trackerKind, apiKey, "mock", "")
+}
+
+func writeWorkflowWithEndpoint(t *testing.T, endpoint, agent string) string {
+	t.Helper()
+	body := "\n  endpoint: " + endpoint
+	return writeWorkflowBody(t, "linear", "$AIOPS_TEST_LINEAR_KEY", agent, body)
+}
+
+func writeServiceLinearWorkflow(t *testing.T, endpoint string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+tracker:
+  kind: linear
+  api_key: $AIOPS_TEST_LINEAR_KEY
+  endpoint: ` + endpoint + `
+services:
+  - name: api
+    repo:
+      owner: o
+      name: r
+      clone_url: https://example.invalid/o/r.git
+    tracker:
+      project_slug: api-platform
+agent:
+  default: codex-app-server
+---
+prompt
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write service workflow: %v", err)
+	}
+	return path
+}
+
+func writeWorkflowWithCloneURL(t *testing.T, cloneURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: ` + cloneURL + `
+tracker:
+  kind: linear
+  api_key: $AIOPS_TEST_LINEAR_KEY
+  project_slug: platform
+agent:
+  default: mock
+---
+prompt
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	return path
+}
+
+func writeWorkflowWithAgent(t *testing.T, agent string) string {
+	t.Helper()
+	return writeWorkflowBody(t, "gitea", "token", agent, "")
+}
+
+func writeWorkflowWithCodexCommand(t *testing.T, command string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: https://example.invalid/o/r.git
+tracker:
+  kind: gitea
+agent:
+  default: codex-app-server
+codex:
+  command: ` + command + `
+---
+prompt
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	return path
+}
+
+func writeWorkflowBody(t *testing.T, trackerKind, apiKey, agent, extraTracker string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: https://example.invalid/o/r.git
+tracker:
+  kind: ` + trackerKind + `
+  api_key: ` + apiKey + `
+  project_slug: platform` + extraTracker + `
+agent:
+  default: ` + agent + `
+---
+prompt
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	return path
+}
+
+func passingRunner(context.Context, string, []string, []string, io.Reader) ([]byte, error) {
+	return []byte("ok\n"), nil
+}
+
+func fakeRealRunner(_ context.Context, name string, args []string, _ []string, _ io.Reader) ([]byte, error) {
+	if name != "docker" && name != "codex" {
+		return nil, errors.New("unexpected command")
+	}
+	if name == "codex" && len(args) > 0 && args[0] == "login" {
+		return []byte("Logged in\n"), nil
+	}
+	if name == "codex" && len(args) > 0 && args[0] == "--version" {
+		return []byte("codex-cli 0.133.0\n"), nil
+	}
+	return []byte("ok\n"), nil
+}
+
+func dockerOnlyRunner(_ context.Context, name string, _ []string, _ []string, _ io.Reader) ([]byte, error) {
+	if name != "docker" {
+		return nil, errors.New("unexpected command")
+	}
+	return []byte("ok\n"), nil
+}
+
+func findCheck(t *testing.T, report Report, name string) Check {
+	t.Helper()
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	t.Fatalf("missing check %q in %+v", name, report.Checks)
+	return Check{}
+}
+
+func checkExists(report Report, name string) bool {
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -187,7 +187,14 @@ func validateAppServerWorkdir(workdir string) error {
 // codex — see codex_app_server.go's session_started emit for the resulting
 // PID-emission guard.
 func buildCodexAppServerCmd(ctx context.Context, in RunInput, env []string) (*exec.Cmd, bool, error) {
-	command := strings.TrimSpace(in.Workflow.Config.Codex.Command)
+	return NewCodexAppServerCommand(ctx, in.Workflow.Config, env)
+}
+
+// NewCodexAppServerCommand returns the configured Codex app-server command plus
+// whether it directly execs the codex binary. Callers that preflight or run the
+// app-server must share this path so codex.command overrides behave identically.
+func NewCodexAppServerCommand(ctx context.Context, cfg workflow.Config, env []string) (*exec.Cmd, bool, error) {
+	command := strings.TrimSpace(cfg.Codex.Command)
 	if command == "" || command == "codex exec" {
 		command = "codex app-server"
 	}

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1175,7 +1175,7 @@ for line in sys.stdin:
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
 	in.Workflow.Config.Codex.StallTimeoutMs = 250
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	start := time.Now()

--- a/scripts/aiops-todo-smoke.sh
+++ b/scripts/aiops-todo-smoke.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="mock"
+workflow="${AIOPS_SMOKE_WORKFLOW:-${AIOPS_WORKFLOW_PATH:-}}"
+dashboard_url="${AIOPS_SMOKE_DASHBOARD_URL:-http://127.0.0.1:4010}"
+report_dir="${AIOPS_SMOKE_REPORT_DIR:-docs/validation/smoke}"
+issue="${AIOPS_SMOKE_ISSUE:-}"
+timeout_seconds="${AIOPS_SMOKE_TIMEOUT_SECONDS:-180}"
+worker_bin="${AIOPS_SMOKE_WORKER_BIN:-worker}"
+state_api_token="${AIOPS_STATE_API_TOKEN:-}"
+
+usage() {
+  printf 'usage: %s [--mode mock|real] --workflow PATH [--issue IDENTIFIER] [--dashboard-url URL] [--report-dir DIR]\n' "$0" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      mode="${2:-}"; shift 2 ;;
+    --workflow)
+      workflow="${2:-}"; shift 2 ;;
+    --issue)
+      issue="${2:-}"; shift 2 ;;
+    --dashboard-url)
+      dashboard_url="${2:-}"; shift 2 ;;
+    --report-dir)
+      report_dir="${2:-}"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      usage; exit 2 ;;
+  esac
+done
+
+if [ "$mode" != "mock" ] && [ "$mode" != "real" ]; then
+  printf 'mode must be mock or real\n' >&2
+  exit 2
+fi
+if [ -z "$workflow" ]; then
+  printf 'workflow is required\n' >&2
+  usage
+  exit 2
+fi
+dashboard_hostport="${dashboard_url#*://}"
+dashboard_hostport="${dashboard_hostport%%/*}"
+if [ "$dashboard_hostport" = "$dashboard_url" ] || [ "${dashboard_hostport##*:}" = "$dashboard_hostport" ] || [ -z "${dashboard_hostport##*:}" ]; then
+  printf 'dashboard-url must include an explicit host:port, got %s\n' "$dashboard_url" >&2
+  exit 2
+fi
+dashboard_port="${dashboard_hostport##*:}"
+case "$dashboard_port" in
+  *[!0-9]*)
+    printf 'dashboard-url port must be numeric, got %s\n' "$dashboard_port" >&2
+    exit 2 ;;
+esac
+
+api_curl() {
+  local args=(-fsS)
+  if [ -n "$state_api_token" ]; then
+    args+=(-H "Authorization: Bearer $state_api_token")
+  fi
+  curl "${args[@]}" "$@"
+}
+
+mkdir -p "$report_dir"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+report="$report_dir/${stamp}-todo-${mode}.md"
+workspace_root="${AIOPS_SMOKE_WORKSPACE_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/aiops-smoke-workspaces.XXXXXX")}"
+log_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-worker.XXXXXX.log")"
+state_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-state.XXXXXX.json")"
+
+cleanup() {
+  if [ "${worker_pid:-}" ]; then
+    kill "$worker_pid" >/dev/null 2>&1 || true
+    wait "$worker_pid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+{
+  printf '# aiops todo smoke report\n\n'
+  printf '- timestamp: `%s`\n' "$stamp"
+  printf '- mode: `%s`\n' "$mode"
+  printf '- workflow: `%s`\n' "$workflow"
+  printf '- dashboard_url: `%s`\n' "$dashboard_url"
+  printf '- issue: `%s`\n' "${issue:-not specified}"
+  printf '- workspace_root: `%s`\n\n' "$workspace_root"
+} >"$report"
+
+"$worker_bin" --doctor --mode="$mode" "$workflow" >>"$report"
+
+AIOPS_WORKFLOW_PATH="$workflow" \
+AIOPS_WORKSPACE_ROOT="$workspace_root" \
+AIOPS_SERVER_HOST=127.0.0.1 \
+"$worker_bin" --port="$dashboard_port" "$workflow" >"$log_file" 2>&1 &
+worker_pid="$!"
+
+deadline=$(( $(date +%s) + timeout_seconds ))
+ready="false"
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if ! kill -0 "$worker_pid" >/dev/null 2>&1; then
+    printf '\n## result\n\nFAIL worker exited before smoke completed\n\n' >>"$report"
+    printf 'Worker log: `%s`\n' "$log_file" >>"$report"
+    exit 1
+  fi
+  if curl -fsS "$dashboard_url/readyz" >/dev/null 2>&1; then
+    ready="true"
+    break
+  fi
+  sleep 2
+done
+
+if [ "$ready" != "true" ]; then
+  printf '\n## result\n\nFAIL timed out waiting for worker readiness.\n\n' >>"$report"
+  printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+  exit 1
+fi
+
+api_curl -X POST -H 'X-AIOPS-Refresh: true' "$dashboard_url/api/v1/refresh" >/dev/null
+
+completed_before="0"
+failed_before="0"
+selected_issue_id=""
+selected_observed="false"
+if api_curl "$dashboard_url/api/v1/state" >"$state_file"; then
+  completed_before="$(sed -n 's/.*"completed_total":[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$state_file" | head -1)"
+  failed_before="$(sed -n 's/.*"failed_total":[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$state_file" | head -1)"
+fi
+completed_before="${completed_before:-0}"
+failed_before="${failed_before:-0}"
+
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  api_curl "$dashboard_url/api/v1/state" >"$state_file"
+  if [ -n "$issue" ] && [ "$selected_observed" = "false" ]; then
+    issue_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-issue.XXXXXX.json")"
+    if api_curl "$dashboard_url/api/v1/$issue" >"$issue_file"; then
+      selected_observed="true"
+      selected_issue_id="$(sed -n 's/.*"issue_id":[[:space:]]*"\([^"]*\)".*/\1/p' "$issue_file" | head -1)"
+      printf '\n## selected issue\n\nObserved `%s` in runtime state as `%s`.\n\n' "$issue" "${selected_issue_id:-unknown}" >>"$report"
+    fi
+  fi
+  completed_now="$(sed -n 's/.*"completed_total":[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$state_file" | head -1)"
+  failed_now="$(sed -n 's/.*"failed_total":[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$state_file" | head -1)"
+  completed_now="${completed_now:-0}"
+  failed_now="${failed_now:-0}"
+  if [ -n "$selected_issue_id" ] && grep -q "\"completed\":[^]]*\"$selected_issue_id\"" "$state_file"; then
+    printf '\n## result\n\nPASS selected issue `%s` completed.\n\n' "$issue" >>"$report"
+    printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+    printf '%s\n' "$report"
+    exit 0
+  fi
+  if [ -n "$selected_issue_id" ] && grep -q "\"failed\":[^]]*\"$selected_issue_id\"" "$state_file"; then
+    printf '\n## result\n\nFAIL selected issue `%s` failed.\n\n' "$issue" >>"$report"
+    printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+    exit 1
+  fi
+  if [ -z "$issue" ] && [ "$completed_now" -gt "$completed_before" ]; then
+    printf '\n## result\n\nPASS completed_total advanced from `%s` to `%s`.\n\n' "$completed_before" "$completed_now" >>"$report"
+    printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+    printf '%s\n' "$report"
+    exit 0
+  fi
+  if [ -z "$issue" ] && [ "$failed_now" -gt "$failed_before" ]; then
+    printf '\n## result\n\nFAIL failed_total advanced from `%s` to `%s`.\n\n' "$failed_before" "$failed_now" >>"$report"
+    printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+    exit 1
+  fi
+  if [ -n "$issue" ]; then
+    if [ "$completed_now" -gt "$completed_before" ] && [ "$selected_observed" != "true" ]; then
+      printf '\n## result\n\nFAIL completed_total advanced, but selected issue `%s` was never observed in runtime state.\n\n' "$issue" >>"$report"
+      printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+      exit 1
+    fi
+  fi
+  sleep 3
+done
+
+printf '\n## result\n\nFAIL timed out waiting for one worker lifecycle.\n\n' >>"$report"
+printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+exit 1

--- a/scripts/aiops_todo_smoke_test.go
+++ b/scripts/aiops_todo_smoke_test.go
@@ -1,0 +1,46 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTodoSmokeScriptRunsDoctorAndWritesReport(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "aiops-todo-smoke.sh")
+	body, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("read %s: %v", script, err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"\"$worker_bin\" --doctor --mode=\"$mode\" \"$workflow\"",
+		"Authorization: Bearer $state_api_token",
+		"api_curl -X POST -H 'X-AIOPS-Refresh: true'",
+		"dashboard-url must include an explicit host:port",
+		"dashboard_port=\"${dashboard_hostport##*:}\"",
+		"ready=\"false\"",
+		"FAIL timed out waiting for worker readiness.",
+		"\"$worker_bin\" --port=\"$dashboard_port\" \"$workflow\"",
+		"X-AIOPS-Refresh: true",
+		"selected issue",
+		"[ -z \"$issue\" ] && [ \"$completed_now\" -gt \"$completed_before\" ]",
+		"completed_total advanced",
+		"docs/validation/smoke",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("smoke script missing %q", want)
+		}
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Dir(wd)
+}

--- a/test/e2e/fixtures/compose_config_test.go
+++ b/test/e2e/fixtures/compose_config_test.go
@@ -2,6 +2,7 @@ package fixtures_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,6 +59,89 @@ func TestWorkerComposeDefinesHealthcheck(t *testing.T) {
 	}
 }
 
+func TestCodexComposeOverlayUsesSecrets(t *testing.T) {
+	compose := loadYAML(t, filepath.Join("..", "..", "..", "deploy", "docker-compose.codex.yml"))
+	worker := service(t, compose, "worker")
+	build, ok := worker["build"].(map[string]any)
+	if !ok || build["target"] != "codex-worker" {
+		t.Fatalf("codex overlay build = %#v, want codex-worker target", worker["build"])
+	}
+	secrets, ok := worker["secrets"].([]any)
+	if !ok || len(secrets) == 0 {
+		t.Fatalf("codex overlay worker secrets = %#v, want service-scoped secrets", worker["secrets"])
+	}
+	environment := worker["environment"].(map[string]any)
+	if got := environment["AIOPS_WORKFLOW_PATH"]; got != "/app/WORKFLOW.md" {
+		t.Fatalf("codex overlay AIOPS_WORKFLOW_PATH = %#v, want /app/WORKFLOW.md", got)
+	}
+	for _, name := range []string{"AIOPS_STATE_API_TOKEN", "GITEA_TOKEN", "LINEAR_API_KEY"} {
+		if got := environment[name]; got != "" {
+			t.Fatalf("codex overlay %s = %#v, want blank because secret files feed production tokens", name, got)
+		}
+	}
+	volumes := worker["volumes"].([]any)
+	if !sliceContainsString(volumes, "/app/WORKFLOW.md:ro") {
+		t.Fatalf("codex overlay volumes = %#v, want mounted workflow file", volumes)
+	}
+	declared, ok := compose["secrets"].(map[string]any)
+	if !ok {
+		t.Fatal("codex overlay missing top-level secrets")
+	}
+	for _, name := range []string{"linear_api_key", "gitea_token", "aiops_state_api_token"} {
+		if _, ok := declared[name]; !ok {
+			t.Fatalf("codex overlay missing secret %s", name)
+		}
+	}
+	entrypoint := worker["entrypoint"].([]any)
+	if len(entrypoint) != 1 || entrypoint[0] != "/usr/local/bin/aiops-secret-entrypoint" {
+		t.Fatalf("codex overlay entrypoint = %#v, want aiops-secret-entrypoint", entrypoint)
+	}
+	command := worker["command"].([]any)
+	if len(command) != 1 || command[0] != "worker" {
+		t.Fatalf("codex overlay command = %#v, want worker default", command)
+	}
+	entrypointFile, err := os.ReadFile(filepath.Join("..", "..", "..", "deploy", "aiops-secret-entrypoint.sh"))
+	if err != nil {
+		t.Fatalf("read secret entrypoint: %v", err)
+	}
+	if !strings.Contains(string(entrypointFile), "/run/secrets/linear_api_key") {
+		t.Fatalf("secret entrypoint does not read Linear key from /run/secrets")
+	}
+	if !strings.Contains(string(entrypointFile), "/run/secrets/gitea_token") {
+		t.Fatalf("secret entrypoint does not read optional Gitea token from /run/secrets")
+	}
+	if !strings.Contains(string(entrypointFile), "set -- worker \"$@\"") {
+		t.Fatalf("secret entrypoint does not prepend worker for flag-only docker compose run commands")
+	}
+}
+
+func TestFirstRunRunbookWritesAbsoluteComposePaths(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "..", "docs", "runbooks", "first-run-docker-linear-codex.md"))
+	if err != nil {
+		t.Fatalf("read first-run runbook: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"AIOPS_WORKFLOW_PATH=$PWD/.aiops/WORKFLOW.md",
+		"AIOPS_CODEX_HOME_PATH=$PWD/.aiops/codex-home",
+		"LINEAR_API_KEY_FILE=$PWD/.aiops/secrets/linear_api_key",
+		"AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("first-run runbook missing absolute Compose path example %q", want)
+		}
+	}
+}
+
+func sliceContainsString(values []any, want string) bool {
+	for _, value := range values {
+		if strings.Contains(fmt.Sprint(value), want) {
+			return true
+		}
+	}
+	return false
+}
+
 func readCompose(t *testing.T) map[string]any {
 	t.Helper()
 	return loadYAML(t, filepath.Join("..", "..", "..", "deploy", "docker-compose.yml"))
@@ -82,6 +166,7 @@ func loadYAML(t *testing.T, path string) map[string]any {
 	return doc
 }
 
+//nolint:unparam // Shared test helper keeps call sites explicit about the service under inspection.
 func service(t *testing.T, compose map[string]any, name string) map[string]any {
 	t.Helper()
 	services, ok := compose["services"].(map[string]any)

--- a/test/e2e/fixtures/dockerfile_buildlayer_test.go
+++ b/test/e2e/fixtures/dockerfile_buildlayer_test.go
@@ -51,12 +51,48 @@ func TestDockerfileAppliesRuntimeSecurityUpdatesBeforeInstallingTools(t *testing
 	if upgrade < 0 {
 		t.Fatal("runtime stage must apply Debian security updates before installing tools")
 	}
-	install := strings.Index(df[runtimeStage:], "apt-get install -y --no-install-recommends ca-certificates git openssh-client wget")
+	install := strings.Index(df[runtimeStage:], "apt-get install -y --no-install-recommends ca-certificates git openssh-client ripgrep wget")
 	if install < 0 {
 		t.Fatal("runtime stage missing expected tool installation command")
 	}
 	if upgrade > install {
 		t.Fatalf("runtime apt-get upgrade must precede tool installation: upgrade=%d install=%d", upgrade, install)
+	}
+}
+
+func TestDockerfileDefinesCodexWorkerTarget(t *testing.T) {
+	df := dockerfileContents(t)
+
+	for _, want := range []string{
+		"FROM worker AS codex-worker",
+		"ARG CODEX_CLI_VERSION=0.133.0",
+		"x86_64-unknown-linux-musl",
+		"aarch64-unknown-linux-musl",
+		"sha256sum -c -",
+		"codex --version",
+	} {
+		if !strings.Contains(df, want) {
+			t.Fatalf("Dockerfile codex-worker target missing %q", want)
+		}
+	}
+}
+
+func TestDockerfileKeepsWorkerAsDefaultTarget(t *testing.T) {
+	df := dockerfileContents(t)
+
+	codexTarget := strings.Index(df, "FROM worker AS codex-worker")
+	if codexTarget < 0 {
+		t.Fatal("Dockerfile missing codex-worker target")
+	}
+	defaultTarget := strings.LastIndex(df, "FROM worker AS default")
+	if defaultTarget < 0 {
+		t.Fatal("Dockerfile must end with a worker default target so `docker build .` does not install Codex")
+	}
+	if defaultTarget < codexTarget {
+		t.Fatalf("Dockerfile default target must follow codex-worker: default=%d codex=%d", defaultTarget, codexTarget)
+	}
+	if strings.TrimSpace(df[defaultTarget:]) != "FROM worker AS default" {
+		t.Fatalf("Dockerfile final target must be the worker default alias; got trailing content %q", strings.TrimSpace(df[defaultTarget:]))
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #440.

Productizes the first-run path instead of adding prose-only docs:

- adds `worker --doctor` preflight with mock/real modes for workflow config, host/container tools, Linear auth, Codex CLI/login/app-server probe, sandbox posture, and optional dashboard auth
- adds a `codex-worker` Docker target with pinned Codex CLI 0.133.0 release artifacts/checksums for linux amd64/arm64
- adds a production-style Compose overlay using service secrets plus a secret entrypoint for Linear, optional Gitea, and state API tokens while clearing inherited plaintext env values
- adds `scripts/aiops-todo-smoke.sh` for one-command preflight + dashboard refresh + lifecycle smoke, with issue-specific terminal-state validation
- documents the supported first-run matrix and links it from README/local-dev/Codex Docker runbooks

## Research / Design Checked

- `.claude/skills/handle-issue`, `AGENTS.md`, `README.md`, local dev/Codex Docker runbooks
- Symphony SPEC and Elixir reference for scheduler/runner/tracker-reader boundaries
- official OpenAI Codex install/auth/app-server docs
- official Docker Compose secrets docs
- official Linear GraphQL/auth docs

## Validation

- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` filtered for new files: no new findings
- `go test ./...`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/tui`
- `bash -n scripts/aiops-todo-smoke.sh deploy/aiops-secret-entrypoint.sh`
- `LINEAR_API_KEY=lin_fake go run ./cmd/worker --doctor --mode=mock examples/WORKFLOW.md`
- `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.codex.yml config --quiet`
- `docker compose ... config` with plaintext env tokens set confirmed effective `LINEAR_API_KEY`, `GITEA_TOKEN`, and `AIOPS_STATE_API_TOKEN` are blanked by the overlay
- `docker build --target worker --tag aiops-platform:issue-440-worker .`
- `docker build --target codex-worker --tag aiops-platform:issue-440-codex-worker .` verified checksum and `codex-cli 0.133.0`
- `docker run --entrypoint /usr/local/bin/aiops-secret-entrypoint ... aiops-platform:issue-440-codex-worker --doctor --mode=mock`

## Review Notes

Fixed-head subagent/Claude review was run after committing, not against a floating worktree. Findings addressed in this branch:

- `docker compose run worker --doctor ...` now keeps secret export via entrypoint and handles flag-only commands
- container doctor skips host Docker CLI checks while preserving host `docker compose config` validation path
- operator workflow is mounted as `/app/WORKFLOW.md`
- plaintext env tokens inherited from base compose are blanked and rehydrated from secrets where supported
- `--issue` smoke no longer passes due to another issue advancing `completed_total`
## Latest Follow-through

- Head `d63e711c69df552e2597273a9b37fb882ddf27b2` fixes Codex review P2 by probing `codex app-server` only for `agent.default: codex-app-server`; `agent.default: codex` remains a one-shot `codex exec` path.
- Added `TestBuildReportRealModeSkipsAppServerProbeForCodexExec`; mutation check removing the runner gate failed the new test, then passed after restoration.
- Re-ran `bash -n scripts/aiops-todo-smoke.sh`, `gofmt -l $(git ls-files '*.go')`, `git diff --check`, `go test ./...`, `go vet ./...`, `go build ./cmd/worker ./cmd/tui`, `go test -race -covermode=atomic ./...`, and lint filtered for PR-touched areas; no new findings.
- Fixed-head incremental Codex diff-only review on `9f946175..d63e711c` returned `LGTM / MERGE-READY`; Claude diff-only review attempt hung with no output and was not counted.
- Resolved addressed thread `PRRT_kwDOSN-Foc6Ewn6i` and triggered fresh `@codex review`: https://github.com/xrf9268-hue/aiops-platform/pull/442#issuecomment-4543356873.