### PR TITLE
Fix Codex app-server schema alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,20 @@ specific observed failure per the "Earned rules" principle.
    PR #304 had to retrofit `recoverPanic` across actor + timer
    goroutines after a panic in one path crashed the whole worker.
 
-3. **Run an adversarial pass on your own diff before asking a human
+3. **Treat generated downstream protocol schemas as separate authorities.**
+   Symphony's Elixir config schema is the reference for workflow/config shape,
+   but it is not the authority for every downstream agent wire protocol. When
+   touching `internal/runner` paths that speak to `codex app-server`, validate
+   the request structs against the current OpenAI Codex app-server protocol
+   schema for that Codex version. Do not hand-build `turn/start` payloads with
+   free `map[string]any`, do not translate legacy sandbox shapes such as
+   `mode: workspace-write`, and keep local schema contract tests in step with
+   any Codex CLI upgrade. **Earned by:** Codex CLI 0.133 rejected the old
+   aiops-platform `turn/start` payload because `UserInput.Text` required
+   `text_elements` and `SandboxPolicy` required typed variants such as
+   `type: workspaceWrite`.
+
+4. **Run an adversarial pass on your own diff before asking a human
    to look.** `@codex review` reads SPEC + the Elixir reference +
    this file, and surfaces precisely the gaps that human review
    tends to miss. Trigger it on the head commit before marking the

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -61,6 +61,32 @@ codex-cli 0.133.0
 Keep the version and checksum together in any derived Dockerfile so future
 upgrades are reviewable.
 
+## Protocol schema upgrades
+
+`codex app-server` has its own versioned wire protocol. The Symphony Elixir
+config schema is useful for organizing workflow settings, but it is not the
+authority for the Codex `turn/start` JSON shape. For each Codex CLI upgrade,
+refresh the local minimal schema snapshot from the matching upstream Codex
+app-server protocol schema before running live Linear validation.
+
+The runner-side contract currently covers the fields aiops-platform emits:
+
+- `TurnStartParams.sandboxPolicy`
+- `UserInput.Text` with `text_elements`
+- `SandboxPolicy` variants such as `workspaceWrite`
+
+Run the schema contract tests before any real issue run:
+
+```bash
+go test ./internal/workflow -run 'Codex.*Sandbox|Schema' -count=1
+go test ./internal/runner -run 'CodexAppServer.*TurnStart|Schema' -count=1
+```
+
+If either test fails after a Codex upgrade, update the typed Go structs and the
+schema snapshot first. Do not add fallback translation for old sandbox fields
+such as `mode`, `access`, or `readOnlyAccess`; this project is pre-release and
+should fail fast on stale workflow shape.
+
 ## Authentication mount
 
 `codex app-server` must be authenticated before the worker starts it. For a
@@ -88,6 +114,9 @@ codex app-server
 
 `codex login status` should report a logged-in account, and `codex app-server`
 should remain running on stdio until the worker speaks JSON-RPC to it.
+`worker --doctor --mode=real` performs that stdio probe by keeping stdin open,
+sending `initialize`, and waiting for a JSON-RPC response. A probe that only
+starts the process and closes stdin is not a valid app-server check.
 
 ## Sandbox note
 

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -154,6 +154,27 @@ AIOPS_SMOKE_WORKER_BIN=/tmp/aiops-worker \
 Verify the report, Linear comment, final Linear state, and workspace cleanup
 before considering the install validated.
 
+When validating writeback behavior, the disposable issue must exercise the real
+agent-side tracker tool path. A validation-only prompt can prove that
+`codex app-server` accepts the schema, but it does not prove the full Symphony
+contract where the agent performs tracker writes through advertised tools.
+
+For a production-style writeback check, use a fresh disposable issue and require
+the agent to:
+
+- write `.aiops/PLAN.md` and `.aiops/RUN_SUMMARY.md`;
+- call the advertised `linear_graphql` tool for `commentCreate`;
+- call the advertised `linear_graphql` tool for `issueUpdate` to move the issue
+  to a terminal state;
+- avoid shell `curl`, source edits, pushes, and pull requests.
+
+After the run, verify Linear independently with the API or UI: the expected
+comment must exist, the issue must be in the expected terminal state, the worker
+must report `runner_end ok:true` and `verify_end status:ok`, and the issue
+workspace should be cleaned up on the next reconciliation. If you rerun the same
+disposable issue id, clean the previous temporary worktree first; workspace
+branch names are derived from issue ids and can collide.
+
 ## Troubleshooting
 
 | Symptom | Next action |

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -346,7 +346,7 @@ func (r *reportBuilder) probeCodexAppServer(ctx context.Context, cfg workflow.Co
 	if _, err := io.WriteString(stdin, probe); err != nil {
 		return err
 	}
-	_ = stdin.Close()
+	defer closeBody(stdin)
 	sc := bufio.NewScanner(stdout)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for sc.Scan() {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -184,6 +184,34 @@ exit 1
 	}
 }
 
+func TestBuildReportRealModeKeepsCodexAppServerProbeStdinOpen(t *testing.T) {
+	wrapper := installFakeCodexWrapperBody(t, `#!/usr/bin/env python3
+import json, select, sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "app-server":
+    _ = sys.stdin.readline()
+    ready, _, _ = select.select([sys.stdin], [], [], 0.2)
+    if ready and sys.stdin.readline() == "":
+        print(json.dumps({"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"stdin closed during probe"}}), flush=True)
+        sys.exit(0)
+    print(json.dumps({"jsonrpc":"2.0","id":1,"result":{"ok":True}}), flush=True)
+    sys.exit(0)
+
+sys.exit(1)
+`)
+	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Runner:       dockerOnlyRunner,
+	})
+
+	check := findCheck(t, report, "Codex app-server")
+	if check.Status != Pass {
+		t.Fatalf("Codex app-server check = %+v; want PASS with stdin held open", check)
+	}
+}
+
 func TestBuildReportRealModeSkipsAppServerProbeForCodexExec(t *testing.T) {
 	installFakeCodexWithoutAppServer(t)
 	path := writeWorkflowWithAgent(t, "codex")

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -338,6 +338,21 @@ type appServerClient struct {
 	lastTerminal      time.Time
 }
 
+type codexAppServerTextInput struct {
+	Type         string `json:"type"`
+	Text         string `json:"text"`
+	TextElements []any  `json:"text_elements"`
+}
+
+type codexAppServerTurnStartParams struct {
+	ThreadID       string                      `json:"threadId"`
+	Input          []codexAppServerTextInput   `json:"input"`
+	CWD            string                      `json:"cwd,omitempty"`
+	Title          string                      `json:"title,omitempty"`
+	ApprovalPolicy any                         `json:"approvalPolicy,omitempty"`
+	SandboxPolicy  workflow.CodexSandboxPolicy `json:"sandboxPolicy"`
+}
+
 func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) error {
 	c.runtimeEventSink = in.RuntimeEventSink
 	c.phaseTransitionSink = in.PhaseTransitionSink
@@ -395,23 +410,25 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 		maxTurns = 20
 	}
 	for turn := 1; turn <= maxTurns; turn++ {
-		input := []map[string]any{{
-			"type": "text",
-			"text": appServerContinuationPrompt(in, turn),
+		input := []codexAppServerTextInput{{
+			Type:         "text",
+			Text:         appServerContinuationPrompt(in, turn),
+			TextElements: []any{},
 		}}
 		if turn == 1 {
-			input = []map[string]any{{
-				"type": "text",
-				"text": prompt,
+			input = []codexAppServerTextInput{{
+				Type:         "text",
+				Text:         prompt,
+				TextElements: []any{},
 			}}
 		}
-		turnResult, err := c.request(ctx, "turn/start", map[string]any{
-			"threadId":       threadID,
-			"input":          input,
-			"cwd":            in.Workdir,
-			"title":          appServerTurnTitle(in),
-			"approvalPolicy": c.approvalPolicy,
-			"sandboxPolicy":  in.Workflow.Config.Codex.TurnSandboxPolicy,
+		turnResult, err := c.request(ctx, "turn/start", codexAppServerTurnStartParams{
+			ThreadID:       threadID,
+			Input:          input,
+			CWD:            in.Workdir,
+			Title:          appServerTurnTitle(in),
+			ApprovalPolicy: c.approvalPolicy,
+			SandboxPolicy:  in.Workflow.Config.Codex.TurnSandboxPolicy,
 		})
 		if err != nil {
 			if turn == 1 {
@@ -483,7 +500,7 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	return fmt.Errorf("codex app-server exceeded agent.max_turns=%d", maxTurns)
 }
 
-func (c *appServerClient) request(ctx context.Context, method string, params map[string]any) (map[string]any, error) {
+func (c *appServerClient) request(ctx context.Context, method string, params any) (map[string]any, error) {
 	id := c.nextID
 	c.nextID++
 	if err := c.send(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params}); err != nil {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -26,12 +26,10 @@ func appServerInput(workdir string) RunInput {
 			Agent:     workflow.AgentConfig{MaxTurns: 8},
 			Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
 			Codex: workflow.CommandConfig{
-				Command:        "codex app-server",
-				ApprovalPolicy: "never",
-				ThreadSandbox:  "workspace-write",
-				TurnSandboxPolicy: map[string]any{
-					"mode": "workspace-write",
-				},
+				Command:           "codex app-server",
+				ApprovalPolicy:    "never",
+				ThreadSandbox:     "workspace-write",
+				TurnSandboxPolicy: workflow.DefaultCodexSandboxPolicy(),
 				EnvPassthrough: []string{
 					"CODEX_ARGV_LOG",
 					"CODEX_STDIN_LOG",
@@ -198,12 +196,90 @@ for line in sys.stdin:
 	}
 	turnParams := messages[3]["params"].(map[string]any)
 	input := turnParams["input"].([]any)[0].(map[string]any)
+	if input["type"] != "text" {
+		t.Fatalf("turn input type = %#v, want text", input["type"])
+	}
 	if input["text"] != "app-server prompt canary" {
 		t.Fatalf("turn prompt text = %#v, want prompt file contents", input["text"])
+	}
+	if textElements, ok := input["text_elements"].([]any); !ok || len(textElements) != 0 {
+		t.Fatalf("turn input text_elements = %#v, want empty array", input["text_elements"])
 	}
 	if turnParams["title"] != "AIOPS-64: Wire Codex app-server" {
 		t.Fatalf("turn title = %#v", turnParams["title"])
 	}
+	sandboxPolicy := turnParams["sandboxPolicy"].(map[string]any)
+	if sandboxPolicy["type"] != "workspaceWrite" {
+		t.Fatalf("sandboxPolicy.type = %#v, want workspaceWrite", sandboxPolicy["type"])
+	}
+	if writableRoots, ok := sandboxPolicy["writableRoots"].([]any); !ok || len(writableRoots) != 0 {
+		t.Fatalf("sandboxPolicy.writableRoots = %#v, want empty array", sandboxPolicy["writableRoots"])
+	}
+	if sandboxPolicy["networkAccess"] != false {
+		t.Fatalf("sandboxPolicy.networkAccess = %#v, want false", sandboxPolicy["networkAccess"])
+	}
+	for _, forbidden := range []string{"mode", "access", "readOnlyAccess"} {
+		if _, ok := sandboxPolicy[forbidden]; ok {
+			t.Fatalf("sandboxPolicy contains legacy field %q: %#v", forbidden, sandboxPolicy)
+		}
+	}
+}
+
+func TestCodexAppServerTurnStartPayloadMatchesSchemaSnapshot(t *testing.T) {
+	snapshotBytes, err := os.ReadFile(filepath.Join("testdata", "codex_app_server_v0_133_turn_start_schema.json"))
+	if err != nil {
+		t.Fatalf("read schema snapshot: %v", err)
+	}
+	var snapshot struct {
+		UserInputTextRequired []string `json:"user_input_text_required"`
+		SandboxPolicyTypes    []string `json:"sandbox_policy_types"`
+		ForbiddenLegacyFields []string `json:"forbidden_legacy_fields"`
+	}
+	if err := json.Unmarshal(snapshotBytes, &snapshot); err != nil {
+		t.Fatalf("decode schema snapshot: %v", err)
+	}
+
+	payload := codexAppServerTurnStartParams{
+		ThreadID: "thread-1",
+		Input: []codexAppServerTextInput{{
+			Type:         "text",
+			Text:         "hello",
+			TextElements: []any{},
+		}},
+		SandboxPolicy: workflow.DefaultCodexSandboxPolicy(),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal turn/start payload: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decode turn/start payload: %v", err)
+	}
+	input := decoded["input"].([]any)[0].(map[string]any)
+	for _, key := range snapshot.UserInputTextRequired {
+		if _, ok := input[key]; !ok {
+			t.Fatalf("turn/start text input missing schema-required key %q: %s", key, raw)
+		}
+	}
+	sandboxPolicy := decoded["sandboxPolicy"].(map[string]any)
+	if !containsString(snapshot.SandboxPolicyTypes, sandboxPolicy["type"].(string)) {
+		t.Fatalf("sandboxPolicy.type = %#v, want one of %#v", sandboxPolicy["type"], snapshot.SandboxPolicyTypes)
+	}
+	for _, key := range snapshot.ForbiddenLegacyFields {
+		if _, ok := sandboxPolicy[key]; ok {
+			t.Fatalf("turn/start sandboxPolicy contains legacy key %q: %s", key, raw)
+		}
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCodexAppServerRunnerDoesNotInheritWorkerSecretsByDefault(t *testing.T) {

--- a/internal/runner/testdata/codex_app_server_v0_133_turn_start_schema.json
+++ b/internal/runner/testdata/codex_app_server_v0_133_turn_start_schema.json
@@ -1,0 +1,6 @@
+{
+  "source": "openai/codex rust-v0.133.0 codex-rs/app-server-protocol/schema/typescript/v2",
+  "user_input_text_required": ["type", "text", "text_elements"],
+  "sandbox_policy_types": ["dangerFullAccess", "readOnly", "externalSandbox", "workspaceWrite"],
+  "forbidden_legacy_fields": ["mode", "access", "readOnlyAccess"]
+}

--- a/internal/workflow/codex_schema.go
+++ b/internal/workflow/codex_schema.go
@@ -1,0 +1,234 @@
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	CodexSandboxDangerFullAccess = "dangerFullAccess"
+	CodexSandboxReadOnly         = "readOnly"
+	CodexSandboxExternalSandbox  = "externalSandbox"
+	CodexSandboxWorkspaceWrite   = "workspaceWrite"
+)
+
+type CodexSandboxPolicy struct {
+	Type                  string
+	WritableRoots         []string
+	NetworkAccess         bool
+	ExternalNetworkAccess string
+	ExcludeTmpdirEnvVar   bool
+	ExcludeSlashTmp       bool
+}
+
+func DefaultCodexSandboxPolicy() CodexSandboxPolicy {
+	return CodexSandboxPolicy{
+		Type:                CodexSandboxWorkspaceWrite,
+		WritableRoots:       []string{},
+		NetworkAccess:       false,
+		ExcludeTmpdirEnvVar: false,
+		ExcludeSlashTmp:     false,
+	}
+}
+
+func (p CodexSandboxPolicy) IsZero() bool {
+	return p.Type == "" &&
+		len(p.WritableRoots) == 0 &&
+		!p.NetworkAccess &&
+		p.ExternalNetworkAccess == "" &&
+		!p.ExcludeTmpdirEnvVar &&
+		!p.ExcludeSlashTmp
+}
+
+func (p *CodexSandboxPolicy) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil || node.Tag == "!!null" {
+		*p = CodexSandboxPolicy{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("codex.turn_sandbox_policy must be a map with a type field")
+	}
+
+	fields := map[string]*yaml.Node{}
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		if _, ok := fields[key]; ok {
+			return fmt.Errorf("codex.turn_sandbox_policy.%s is duplicated", key)
+		}
+		fields[key] = node.Content[i+1]
+	}
+	for _, legacy := range []string{"mode", "readOnlyAccess", "access"} {
+		if _, ok := fields[legacy]; ok {
+			return fmt.Errorf("codex.turn_sandbox_policy.%s is not supported; use the current Codex app-server typed sandboxPolicy schema", legacy)
+		}
+	}
+
+	typeNode, ok := fields["type"]
+	if !ok || strings.TrimSpace(typeNode.Value) == "" {
+		return fmt.Errorf("codex.turn_sandbox_policy.type is required")
+	}
+	policy := CodexSandboxPolicy{Type: typeNode.Value}
+	if err := rejectUnknownCodexSandboxFields(policy.Type, fields); err != nil {
+		return err
+	}
+
+	switch policy.Type {
+	case CodexSandboxDangerFullAccess:
+	case CodexSandboxReadOnly:
+		if err := requireBoolCodexSandboxField(fields, "networkAccess", &policy.NetworkAccess); err != nil {
+			return err
+		}
+	case CodexSandboxExternalSandbox:
+		network, err := requireStringCodexSandboxField(fields, "networkAccess")
+		if err != nil {
+			return err
+		}
+		if network != "restricted" && network != "enabled" {
+			return fmt.Errorf("codex.turn_sandbox_policy.networkAccess = %q, want restricted or enabled", network)
+		}
+		policy.ExternalNetworkAccess = network
+	case CodexSandboxWorkspaceWrite:
+		if err := requireStringSliceCodexSandboxField(fields, "writableRoots", &policy.WritableRoots); err != nil {
+			return err
+		}
+		if err := requireBoolCodexSandboxField(fields, "networkAccess", &policy.NetworkAccess); err != nil {
+			return err
+		}
+		if err := requireBoolCodexSandboxField(fields, "excludeTmpdirEnvVar", &policy.ExcludeTmpdirEnvVar); err != nil {
+			return err
+		}
+		if err := requireBoolCodexSandboxField(fields, "excludeSlashTmp", &policy.ExcludeSlashTmp); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("codex.turn_sandbox_policy.type %q is not supported (allowed: dangerFullAccess, readOnly, externalSandbox, workspaceWrite)", policy.Type)
+	}
+	*p = policy
+	return nil
+}
+
+func (p CodexSandboxPolicy) MarshalJSON() ([]byte, error) {
+	switch p.Type {
+	case "":
+		return []byte("null"), nil
+	case CodexSandboxDangerFullAccess:
+		return json.Marshal(struct {
+			Type string `json:"type"`
+		}{Type: p.Type})
+	case CodexSandboxReadOnly:
+		return json.Marshal(struct {
+			Type          string `json:"type"`
+			NetworkAccess bool   `json:"networkAccess"`
+		}{Type: p.Type, NetworkAccess: p.NetworkAccess})
+	case CodexSandboxExternalSandbox:
+		return json.Marshal(struct {
+			Type          string `json:"type"`
+			NetworkAccess string `json:"networkAccess"`
+		}{Type: p.Type, NetworkAccess: p.ExternalNetworkAccess})
+	case CodexSandboxWorkspaceWrite:
+		roots := p.WritableRoots
+		if roots == nil {
+			roots = []string{}
+		}
+		return json.Marshal(struct {
+			Type                string   `json:"type"`
+			WritableRoots       []string `json:"writableRoots"`
+			NetworkAccess       bool     `json:"networkAccess"`
+			ExcludeTmpdirEnvVar bool     `json:"excludeTmpdirEnvVar"`
+			ExcludeSlashTmp     bool     `json:"excludeSlashTmp"`
+		}{
+			Type:                p.Type,
+			WritableRoots:       roots,
+			NetworkAccess:       p.NetworkAccess,
+			ExcludeTmpdirEnvVar: p.ExcludeTmpdirEnvVar,
+			ExcludeSlashTmp:     p.ExcludeSlashTmp,
+		})
+	default:
+		return nil, fmt.Errorf("unsupported Codex sandbox policy type %q", p.Type)
+	}
+}
+
+func (p CodexSandboxPolicy) Validate(field string) error {
+	if p.IsZero() {
+		return fmt.Errorf("%s.type is required", field)
+	}
+	switch p.Type {
+	case CodexSandboxDangerFullAccess, CodexSandboxReadOnly, CodexSandboxWorkspaceWrite:
+		return nil
+	case CodexSandboxExternalSandbox:
+		if p.ExternalNetworkAccess != "restricted" && p.ExternalNetworkAccess != "enabled" {
+			return fmt.Errorf("%s.networkAccess = %q, want restricted or enabled", field, p.ExternalNetworkAccess)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s.type %q is not supported", field, p.Type)
+	}
+}
+
+func rejectUnknownCodexSandboxFields(policyType string, fields map[string]*yaml.Node) error {
+	allowed := map[string]bool{"type": true}
+	switch policyType {
+	case CodexSandboxDangerFullAccess:
+	case CodexSandboxReadOnly, CodexSandboxExternalSandbox:
+		allowed["networkAccess"] = true
+	case CodexSandboxWorkspaceWrite:
+		allowed["writableRoots"] = true
+		allowed["networkAccess"] = true
+		allowed["excludeTmpdirEnvVar"] = true
+		allowed["excludeSlashTmp"] = true
+	default:
+		return nil
+	}
+	var unknown []string
+	for key := range fields {
+		if !allowed[key] {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("codex.turn_sandbox_policy has unsupported field(s): %s", strings.Join(unknown, ", "))
+}
+
+func requireBoolCodexSandboxField(fields map[string]*yaml.Node, key string, out *bool) error {
+	node, ok := fields[key]
+	if !ok {
+		return fmt.Errorf("codex.turn_sandbox_policy.%s is required", key)
+	}
+	if err := node.Decode(out); err != nil {
+		return fmt.Errorf("codex.turn_sandbox_policy.%s must be a boolean: %w", key, err)
+	}
+	return nil
+}
+
+func requireStringCodexSandboxField(fields map[string]*yaml.Node, key string) (string, error) {
+	node, ok := fields[key]
+	if !ok {
+		return "", fmt.Errorf("codex.turn_sandbox_policy.%s is required", key)
+	}
+	var out string
+	if err := node.Decode(&out); err != nil {
+		return "", fmt.Errorf("codex.turn_sandbox_policy.%s must be a string: %w", key, err)
+	}
+	return out, nil
+}
+
+func requireStringSliceCodexSandboxField(fields map[string]*yaml.Node, key string, out *[]string) error {
+	node, ok := fields[key]
+	if !ok {
+		return fmt.Errorf("codex.turn_sandbox_policy.%s is required", key)
+	}
+	if err := node.Decode(out); err != nil {
+		return fmt.Errorf("codex.turn_sandbox_policy.%s must be a string array: %w", key, err)
+	}
+	if *out == nil {
+		*out = []string{}
+	}
+	return nil
+}

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -375,15 +375,14 @@ type CommandConfig struct {
 	// nothing.
 	Profile string `yaml:"profile,omitempty" json:"profile,omitempty"`
 	// App-server runtime settings mirror the Symphony/Codex app-server
-	// protocol fields. They are pass-through values for the Codex runtime,
-	// so the loader validates only presence/timeout bounds rather than
-	// maintaining Codex-owned enums.
-	ApprovalPolicy    any            `yaml:"approval_policy,omitempty" json:"approval_policy,omitempty"`
-	ThreadSandbox     string         `yaml:"thread_sandbox,omitempty" json:"thread_sandbox,omitempty"`
-	TurnSandboxPolicy map[string]any `yaml:"turn_sandbox_policy,omitempty" json:"turn_sandbox_policy,omitempty"`
-	TurnTimeoutMs     int            `yaml:"turn_timeout_ms,omitempty" json:"turn_timeout_ms,omitempty"`
-	ReadTimeoutMs     int            `yaml:"read_timeout_ms,omitempty" json:"read_timeout_ms,omitempty"`
-	StallTimeoutMs    int            `yaml:"stall_timeout_ms,omitempty" json:"stall_timeout_ms,omitempty"`
+	// protocol fields. Keep Codex-owned wire shapes typed here so schema
+	// drift fails at workflow load or runner tests instead of in a live run.
+	ApprovalPolicy    any                `yaml:"approval_policy,omitempty" json:"approval_policy,omitempty"`
+	ThreadSandbox     string             `yaml:"thread_sandbox,omitempty" json:"thread_sandbox,omitempty"`
+	TurnSandboxPolicy CodexSandboxPolicy `yaml:"turn_sandbox_policy,omitempty" json:"turn_sandbox_policy,omitempty"`
+	TurnTimeoutMs     int                `yaml:"turn_timeout_ms,omitempty" json:"turn_timeout_ms,omitempty"`
+	ReadTimeoutMs     int                `yaml:"read_timeout_ms,omitempty" json:"read_timeout_ms,omitempty"`
+	StallTimeoutMs    int                `yaml:"stall_timeout_ms,omitempty" json:"stall_timeout_ms,omitempty"`
 	// LinearGraphQL narrows the agent-visible linear_graphql client-side tool
 	// (SPEC §15.5 harness hardening). The field lives on the shared
 	// CommandConfig type for the same pragmatic reason as Profile above; the
@@ -587,10 +586,11 @@ func DefaultConfig() Config {
 				"request_permissions": false,
 				"mcp_elicitations":    false,
 			}},
-			ThreadSandbox:  "workspace-write",
-			TurnTimeoutMs:  3600000,
-			ReadTimeoutMs:  5000,
-			StallTimeoutMs: 300000,
+			ThreadSandbox:     "workspace-write",
+			TurnSandboxPolicy: DefaultCodexSandboxPolicy(),
+			TurnTimeoutMs:     3600000,
+			ReadTimeoutMs:     5000,
+			StallTimeoutMs:    300000,
 		},
 		Claude:  CommandConfig{Command: "claude"},
 		Policy:  PolicyConfig{Mode: "draft_pr", MaxChangedFiles: 12, MaxChangedLOC: 300},

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -2388,7 +2388,11 @@ codex:
   approval_policy: never
   thread_sandbox: workspace-write
   turn_sandbox_policy:
-    mode: workspace-write
+    type: workspaceWrite
+    writableRoots: []
+    networkAccess: false
+    excludeTmpdirEnvVar: false
+    excludeSlashTmp: false
   turn_timeout_ms: 120000
   read_timeout_ms: 250
   stall_timeout_ms: 0
@@ -2411,11 +2415,109 @@ prompt
 	if wf.Config.Codex.ThreadSandbox != "workspace-write" {
 		t.Fatalf("Codex.ThreadSandbox = %q, want workspace-write", wf.Config.Codex.ThreadSandbox)
 	}
-	if got := wf.Config.Codex.TurnSandboxPolicy["mode"]; got != "workspace-write" {
-		t.Fatalf("Codex.TurnSandboxPolicy[mode] = %#v, want workspace-write", got)
+	if got := wf.Config.Codex.TurnSandboxPolicy.Type; got != CodexSandboxWorkspaceWrite {
+		t.Fatalf("Codex.TurnSandboxPolicy.Type = %#v, want workspaceWrite", got)
 	}
 	if wf.Config.Codex.TurnTimeoutMs != 120000 || wf.Config.Codex.ReadTimeoutMs != 250 || wf.Config.Codex.StallTimeoutMs != 0 {
 		t.Fatalf("Codex timeouts = turn %d read %d stall %d, want 120000/250/0", wf.Config.Codex.TurnTimeoutMs, wf.Config.Codex.ReadTimeoutMs, wf.Config.Codex.StallTimeoutMs)
+	}
+}
+
+func TestLoadRejectsLegacyCodexTurnSandboxPolicyFields(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "mode",
+			body: "mode: workspace-write",
+			want: "codex.turn_sandbox_policy.mode",
+		},
+		{
+			name: "read_only_access",
+			body: "type: workspaceWrite\n    readOnlyAccess: restricted",
+			want: "codex.turn_sandbox_policy.readOnlyAccess",
+		},
+		{
+			name: "access",
+			body: "type: readOnly\n    access: restricted",
+			want: "codex.turn_sandbox_policy.access",
+		},
+		{
+			name: "unknown_field",
+			body: "type: workspaceWrite\n    writableRoots: []\n    networkAccess: false\n    excludeTmpdirEnvVar: false\n    excludeSlashTmp: false\n    extra: nope",
+			want: "unsupported field",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+  project_slug: platform
+agent:
+  default: codex-app-server
+codex:
+  turn_sandbox_policy:
+    `+tc.body+`
+---
+prompt
+`)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("Load(%q) succeeded; want codex.turn_sandbox_policy rejection", path)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Load(%q) error = %q; want %q", path, err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadAcceptsTypedCodexWorkspaceWriteSandboxPolicy(t *testing.T) {
+	t.Parallel()
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: file:///tmp/repo
+tracker:
+  kind: linear
+  project_slug: platform
+agent:
+  default: codex-app-server
+codex:
+  turn_sandbox_policy:
+    type: workspaceWrite
+    writableRoots:
+      - /tmp/aiops-workspace
+    networkAccess: false
+    excludeTmpdirEnvVar: true
+    excludeSlashTmp: false
+---
+prompt
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(%q): %v", path, err)
+	}
+	policy := wf.Config.Codex.TurnSandboxPolicy
+	if policy.Type != CodexSandboxWorkspaceWrite {
+		t.Fatalf("Codex.TurnSandboxPolicy.Type = %#v, want workspaceWrite", policy.Type)
+	}
+	if got, want := policy.WritableRoots, []string{"/tmp/aiops-workspace"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Codex.TurnSandboxPolicy.WritableRoots = %#v, want %#v", got, want)
+	}
+	if policy.NetworkAccess != false {
+		t.Fatalf("Codex.TurnSandboxPolicy.NetworkAccess = %#v, want false", policy.NetworkAccess)
+	}
+	if policy.ExcludeTmpdirEnvVar != true {
+		t.Fatalf("Codex.TurnSandboxPolicy.ExcludeTmpdirEnvVar = %#v, want true", policy.ExcludeTmpdirEnvVar)
+	}
+	if policy.ExcludeSlashTmp != false {
+		t.Fatalf("Codex.TurnSandboxPolicy.ExcludeSlashTmp = %#v, want false", policy.ExcludeSlashTmp)
 	}
 }
 

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -440,6 +440,9 @@ func validateConfig(path string, cfg Config) error {
 	if cfg.Server.Port < -1 || cfg.Server.Port == 0 || cfg.Server.Port > 65535 {
 		return fmt.Errorf("%s: server.port must be -1 to disable the local state server or between 1 and 65535", path)
 	}
+	if err := cfg.Codex.TurnSandboxPolicy.Validate("codex.turn_sandbox_policy"); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
 	if strings.TrimSpace(cfg.Claude.Profile) != "" {
 		return fmt.Errorf("%s: claude.profile is not supported (only codex has profiles)", path)
 	}
@@ -755,6 +758,9 @@ func expandConfigForWorkflowPath(workflowPath string, cfg *Config) error {
 	}
 	if cfg.Codex.ThreadSandbox == "" {
 		cfg.Codex.ThreadSandbox = "workspace-write"
+	}
+	if cfg.Codex.TurnSandboxPolicy.IsZero() {
+		cfg.Codex.TurnSandboxPolicy = DefaultCodexSandboxPolicy()
 	}
 	if cfg.Codex.ApprovalPolicy == nil {
 		// Default mirrors codex's `granular` policy with every flag set to

--- a/scripts/aiops-todo-smoke.sh
+++ b/scripts/aiops-todo-smoke.sh
@@ -63,12 +63,19 @@ api_curl() {
   curl "${args[@]}" "$@"
 }
 
+state_array_contains_issue() {
+  local field="$1"
+  local issue_id="$2"
+  local file="$3"
+  grep -q "\"$field\":[[:space:]]*\[[^]]*\"$issue_id\"" "$file"
+}
+
 mkdir -p "$report_dir"
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 report="$report_dir/${stamp}-todo-${mode}.md"
 workspace_root="${AIOPS_SMOKE_WORKSPACE_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/aiops-smoke-workspaces.XXXXXX")}"
-log_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-worker.XXXXXX.log")"
-state_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-state.XXXXXX.json")"
+log_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-worker.log.XXXXXX")"
+state_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-state.json.XXXXXX")"
 
 cleanup() {
   if [ "${worker_pid:-}" ]; then
@@ -80,12 +87,12 @@ trap cleanup EXIT
 
 {
   printf '# aiops todo smoke report\n\n'
-  printf '- timestamp: `%s`\n' "$stamp"
-  printf '- mode: `%s`\n' "$mode"
-  printf '- workflow: `%s`\n' "$workflow"
-  printf '- dashboard_url: `%s`\n' "$dashboard_url"
-  printf '- issue: `%s`\n' "${issue:-not specified}"
-  printf '- workspace_root: `%s`\n\n' "$workspace_root"
+  printf -- '- timestamp: `%s`\n' "$stamp"
+  printf -- '- mode: `%s`\n' "$mode"
+  printf -- '- workflow: `%s`\n' "$workflow"
+  printf -- '- dashboard_url: `%s`\n' "$dashboard_url"
+  printf -- '- issue: `%s`\n' "${issue:-not specified}"
+  printf -- '- workspace_root: `%s`\n\n' "$workspace_root"
 } >"$report"
 
 "$worker_bin" --doctor --mode="$mode" "$workflow" >>"$report"
@@ -133,7 +140,7 @@ failed_before="${failed_before:-0}"
 while [ "$(date +%s)" -lt "$deadline" ]; do
   api_curl "$dashboard_url/api/v1/state" >"$state_file"
   if [ -n "$issue" ] && [ "$selected_observed" = "false" ]; then
-    issue_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-issue.XXXXXX.json")"
+    issue_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-issue.json.XXXXXX")"
     if api_curl "$dashboard_url/api/v1/$issue" >"$issue_file"; then
       selected_observed="true"
       selected_issue_id="$(sed -n 's/.*"issue_id":[[:space:]]*"\([^"]*\)".*/\1/p' "$issue_file" | head -1)"
@@ -144,13 +151,13 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   failed_now="$(sed -n 's/.*"failed_total":[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$state_file" | head -1)"
   completed_now="${completed_now:-0}"
   failed_now="${failed_now:-0}"
-  if [ -n "$selected_issue_id" ] && grep -q "\"completed\":[^]]*\"$selected_issue_id\"" "$state_file"; then
+  if [ -n "$selected_issue_id" ] && state_array_contains_issue completed "$selected_issue_id" "$state_file"; then
     printf '\n## result\n\nPASS selected issue `%s` completed.\n\n' "$issue" >>"$report"
     printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
     printf '%s\n' "$report"
     exit 0
   fi
-  if [ -n "$selected_issue_id" ] && grep -q "\"failed\":[^]]*\"$selected_issue_id\"" "$state_file"; then
+  if [ -n "$selected_issue_id" ] && state_array_contains_issue failed "$selected_issue_id" "$state_file"; then
     printf '\n## result\n\nFAIL selected issue `%s` failed.\n\n' "$issue" >>"$report"
     printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
     exit 1

--- a/scripts/aiops_todo_smoke_test.go
+++ b/scripts/aiops_todo_smoke_test.go
@@ -36,6 +36,82 @@ func TestTodoSmokeScriptRunsDoctorAndWritesReport(t *testing.T) {
 	}
 }
 
+func TestTodoSmokeScriptUsesPrintfOptionSeparatorForMarkdownLists(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "aiops-todo-smoke.sh")
+	body, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("read %s: %v", script, err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		`printf -- '- timestamp:`,
+		`printf -- '- mode:`,
+		`printf -- '- workflow:`,
+		`printf -- '- dashboard_url:`,
+		`printf -- '- issue:`,
+		`printf -- '- workspace_root:`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("smoke script missing %q", want)
+		}
+	}
+}
+
+func TestTodoSmokeScriptUsesPortableMktempTemplates(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "aiops-todo-smoke.sh")
+	body, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("read %s: %v", script, err)
+	}
+	text := string(body)
+	for _, forbidden := range []string{
+		`XXXXXX.log`,
+		`XXXXXX.json`,
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("smoke script contains non-portable mktemp template %q", forbidden)
+		}
+	}
+	for _, want := range []string{
+		`aiops-smoke-worker.log.XXXXXX`,
+		`aiops-smoke-state.json.XXXXXX`,
+		`aiops-smoke-issue.json.XXXXXX`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("smoke script missing portable mktemp template %q", want)
+		}
+	}
+}
+
+func TestTodoSmokeScriptRequiresIssueIDInsideTerminalArrays(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "aiops-todo-smoke.sh")
+	body, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("read %s: %v", script, err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		`state_array_contains_issue completed "$selected_issue_id" "$state_file"`,
+		`state_array_contains_issue failed "$selected_issue_id" "$state_file"`,
+		`"\"$field\":[[:space:]]*\[[^]]*\"$issue_id\""`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("smoke script missing selected-issue array check %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		`"\"completed\":[^]]*\"$selected_issue_id\""`,
+		`"\"failed\":[^]]*\"$selected_issue_id\""`,
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("smoke script contains false-positive selected-issue grep %q", forbidden)
+		}
+	}
+}
+
 func repoRoot(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()


### PR DESCRIPTION
## Summary

- add a typed workflow schema for `codex.turn_sandbox_policy` and fail fast on legacy sandbox fields
- build Codex app-server `turn/start` requests with typed structs, including `text_elements: []` and current `sandboxPolicy` variants
- fix `worker --doctor --mode=real` so the stdio probe keeps stdin open while waiting for `initialize`
- keep the macOS smoke script fixes and document the learned schema/E2E rules in the runbooks

## Root Cause

aiops-platform was hand-building Codex app-server JSON with free `map[string]any`, so the local runner could drift from the current Codex 0.133 app-server protocol. Codex 0.133 requires `UserInput.Text.text_elements` and typed sandbox variants such as `type: workspaceWrite`; the old local shape used stale sandbox fields.

## Validation

- `gofmt -l $(git ls-files '*.go')`
- `git diff --check`
- `go build ./cmd/worker ./cmd/tui`
- `go test ./...`
- independent staged diff review via `codex exec --skip-git-repo-check --sandbox read-only -` returned `LGTM`
- real E2E: disposable Linear issue `AIS-24` ran through real `codex app-server --listen stdio://`; observed `session_started`, `sandbox_policy.type: workspaceWrite`, `text_elements: []`, `turn_completed`, `runner_end ok:true`, `verify_end status:ok`, and `Succeeded`
- real Linear writeback: agent-side `linear_graphql` created the AIS-24 completion comment and moved AIS-24 to `Done`; external Linear API recheck confirmed both

Fixes #443.
Fixes #444.
