### PR TITLE
fix: make Docker Codex home writable

### DIFF
--- a/deploy/docker-compose.codex.yml
+++ b/deploy/docker-compose.codex.yml
@@ -9,8 +9,8 @@
 #
 # The overlay builds the `codex-worker` Dockerfile target and feeds sensitive
 # values through Docker-supported secret files where possible. Codex auth/config
-# are mounted as a read-only host directory because Codex expects a CODEX_HOME
-# directory rather than one secret file.
+# live in a CODEX_HOME directory, which Codex CLI 0.133 writes while loading
+# configuration and refreshing auth state.
 services:
   worker:
     build:
@@ -29,7 +29,7 @@ services:
       - worker
     volumes:
       - ${AIOPS_WORKFLOW_PATH:?set AIOPS_WORKFLOW_PATH to a workflow file}:/app/WORKFLOW.md:ro
-      - ${AIOPS_CODEX_HOME_PATH:?set AIOPS_CODEX_HOME_PATH to a Codex home directory}:/home/aiops/.codex:ro
+      - ${AIOPS_CODEX_HOME_PATH:?set AIOPS_CODEX_HOME_PATH to a Codex home directory}:/home/aiops/.codex
     secrets:
       - linear_api_key
       - gitea_token

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -98,7 +98,7 @@ cp ~/.codex/auth.json /tmp/aiops-codex-home/.codex/auth.json
 cp ~/.codex/config.toml /tmp/aiops-codex-home/.codex/config.toml
 ```
 
-Mount that directory read-only or from a secret store at `/home/aiops/.codex`
+For Codex CLI 0.133, mount that directory writable at `/home/aiops/.codex`
 for the default non-root worker image, and set:
 
 ```text
@@ -117,6 +117,13 @@ should remain running on stdio until the worker speaks JSON-RPC to it.
 `worker --doctor --mode=real` performs that stdio probe by keeping stdin open,
 sending `initialize`, and waiting for a JSON-RPC response. A probe that only
 starts the process and closes stdin is not a valid app-server check.
+
+The supported Compose overlay uses a writable bind for `CODEX_HOME` because
+Codex 0.133 writes while loading configuration and may refresh auth state.
+Use a restricted directory owned by the worker UID/GID. A read-only copy is
+only suitable for archival inspection or a future Codex version that documents
+a no-write startup mode; it is not a valid `worker --doctor --mode=real`
+preflight mount for 0.133.
 
 ## Sandbox note
 

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -10,7 +10,7 @@ aiops-platform with Docker, Linear, and `codex app-server`.
 | macOS host development | Run `go run ./cmd/worker --doctor --mode=mock` and `agent.default: mock` from source. | Use host Codex CLI for local `codex` / `codex-app-server` workflows after `codex --login`. | Host binary mounts into Linux containers are not supported; install Codex in the image. |
 | Linux amd64 Docker worker | Build `Dockerfile` target `codex-worker`; Codex CLI `0.133.0` is installed from a pinned release artifact and checksum. | Use base `worker` target for mock-only validation. | Online installer is not the promoted Docker path until Linux ARM64 checksum behavior is reliable. |
 | Linux arm64 Docker worker | Build `codex-worker`; uses the pinned `aarch64-unknown-linux-musl` release artifact and checksum. | Same as above. | `curl https://chatgpt.com/codex/install.sh \| sh` failed on 2026-05-26 because the installer could not find the ARM64 package checksum. |
-| Codex auth | Mount a read-only `CODEX_HOME` directory into `/home/aiops/.codex` for smoke validation; verify with `worker --doctor --mode=real`. | Local host development can use the normal host `~/.codex`; long-lived ChatGPT-login deployments should use a restricted writable Codex home so token refresh can persist. | Passing raw bearer tokens on command lines or in logs is not supported. |
+| Codex auth | Mount a restricted writable `CODEX_HOME` directory into `/home/aiops/.codex` for Codex CLI 0.133; verify with `worker --doctor --mode=real`. | Local host development can use the normal host `~/.codex`; read-only copies are only suitable for archival inspection or future no-write smoke modes. | Passing raw bearer tokens on command lines or in logs is not supported. |
 | Linear auth | Personal API key in a Docker Compose secret file. Linear expects `Authorization: <API_KEY>` for personal keys. | Local development may use `LINEAR_API_KEY` in `.env`; do not use this for production-style examples. | OAuth app-actor is documented by Linear and is the intended future service-account path, but aiops-platform still accepts a single `tracker.api_key` string today. |
 | Sandbox | Mock mode works under the base hardened container. Real Codex Docker validation uses a Docker-isolated profile and explicit `codex.thread_sandbox: danger-full-access` only inside that container boundary. | Enable kernel/user namespace support and keep Codex `workspace-write` if your container profile permits it. | Do not copy `danger-full-access` to a shared host run. |
 
@@ -78,8 +78,10 @@ EOF
 ```
 
 The Codex overlay reads Linear, optional Gitea, and dashboard tokens from Docker
-secret files. The Codex home is a read-only bind because Codex expects a
-directory.
+secret files. The Codex home is a writable bind because Codex CLI 0.133 writes
+while loading configuration and may persist refreshed auth state. Keep this
+directory restricted to the worker UID/GID and do not point it at a shared host
+home unless that is your intended trust boundary.
 
 ## 3. Run preflight
 

--- a/test/e2e/fixtures/compose_config_test.go
+++ b/test/e2e/fixtures/compose_config_test.go
@@ -83,6 +83,12 @@ func TestCodexComposeOverlayUsesSecrets(t *testing.T) {
 	if !sliceContainsString(volumes, "/app/WORKFLOW.md:ro") {
 		t.Fatalf("codex overlay volumes = %#v, want mounted workflow file", volumes)
 	}
+	if !sliceContainsString(volumes, "/home/aiops/.codex") {
+		t.Fatalf("codex overlay volumes = %#v, want CODEX_HOME mounted", volumes)
+	}
+	if sliceContainsString(volumes, "/home/aiops/.codex:ro") {
+		t.Fatalf("codex overlay volumes = %#v, CODEX_HOME must be writable for Codex CLI 0.133", volumes)
+	}
 	declared, ok := compose["secrets"].(map[string]any)
 	if !ok {
 		t.Fatal("codex overlay missing top-level secrets")


### PR DESCRIPTION
Closes #447

Linear issue: a9ceed3d-e8c7-4af9-9d87-def3efbd2744 (AIS-30)

## Summary
- Mount the production-style Docker Codex `CODEX_HOME` bind writable instead of read-only.
- Update Codex Docker runbooks to document that Codex CLI 0.133 writes while loading config/auth and that `worker --doctor --mode=real` requires a writable home.
- Add a regression assertion to the existing Compose fixture test so the Codex overlay must not remount `/home/aiops/.codex` as `:ro`.

## Acceptance criteria
- Supported Docker Codex deployment path documents and implements a Codex home mount mode that works with Codex CLI 0.133: done.
- `worker --doctor --mode=real` passes in the documented Compose path with real Codex auth: not run locally because this container has no Docker, Go toolchain, or real Codex auth fixture; GitHub CI Docker image build is green and the config/docs now match the reported 0.133 write requirement.
- Runbook distinguishes read-only smoke/archive mounts from long-lived writable Codex homes when token/config refresh persistence is required: done.

## Verification
- `git diff --check`: pass.
- Targeted shell regression: pass. Verified the Codex overlay contains `${AIOPS_CODEX_HOME_PATH}: /home/aiops/.codex` without `:ro`, the fixture test asserts writable `CODEX_HOME`, and both runbooks mention Codex CLI 0.133 writable-home behavior.
- Mutation check: pass. Temporarily restored `:ro` on the Codex home bind and confirmed the shell assertion failed, then restored the fix.
- GitHub CI: pass (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`).
- `go test ./test/e2e/fixtures -run 'TestCodexComposeOverlayUsesSecrets|TestFirstRunRunbookWritesAbsoluteComposePaths' -count=1`: not run locally; `go` is not installed in this container (`/bin/bash: go: command not found`).
- `gofmt -w test/e2e/fixtures/compose_config_test.go`: not run locally; `gofmt` is not installed in this container (`/bin/bash: gofmt: command not found`).

## Local reviews
- Codex diff-only review on `origin/main...HEAD`: pass, no severity-tagged findings, verdict `MERGE-READY`.
- Claude Code diff-only review: unavailable; `claude` is not installed (`/bin/bash: claude: command not found`).

## GitHub Codex review
- Trigger comment: https://github.com/xrf9268-hue/aiops-platform/pull/453#issuecomment-4544375454
- Completion signal: clean Codex comment for current head at https://github.com/xrf9268-hue/aiops-platform/pull/453#issuecomment-4544403232
- Review threads: GraphQL check returned zero review threads.

## Size budget
- Files changed: 4 of 12.
- LOC changed: 29 total by git stat, under the 300 LOC default.
- No denied paths touched; no secrets or credential material touched.

## Deferrals / follow-ups
- None. Real Docker + Codex-auth doctor validation remains an operator environment check because this container lacks Docker and real auth material.

## Risks
- The writable bind means the configured Codex home can be modified by the worker container. The runbooks now call out using a restricted directory owned by the worker UID/GID and avoiding shared host homes unless intentional.

Current head SHA: 4ea3e4e1fd9b39a9972bf4f97aa1795d9d943999