### PR TITLE
docs: support Docker dashboard exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ Under Docker Compose the default loopback bind is unreachable from the host
 opt-in overlay to reach the dashboard from the host:
 
 ```bash
-export AIOPS_STATE_API_TOKEN=$(openssl rand -hex 24)
+mkdir -p .aiops/secrets
+openssl rand -hex 24 > .aiops/secrets/state_api_token
+AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token \
 docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dashboard.yml up worker
 ```
 
@@ -185,7 +187,7 @@ The overlay sets `AIOPS_SERVER_HOST=0.0.0.0` (bind all interfaces *inside* the
 container) but publishes only to host loopback (`127.0.0.1:4000:4000`), so the
 host trust boundary stays the loopback. Docker port publishing reaches the
 container from a bridge peer rather than container loopback, so the overlay
-requires `AIOPS_STATE_API_TOKEN`; browsers will receive a Basic-auth challenge
+requires `AIOPS_STATE_API_TOKEN_FILE`; browsers will receive a Basic-auth challenge
 and should use username `aiops` plus that token. Open the plain dashboard URL
 (`http://127.0.0.1:4000/`) and let the browser prompt for credentials; avoid
 sharing or bookmarking URLs with embedded credentials. The dashboard strips URL

--- a/deploy/docker-compose.dashboard.yml
+++ b/deploy/docker-compose.dashboard.yml
@@ -11,7 +11,7 @@
 # published port reaches it, while the port mapping publishes ONLY to host
 # loopback (127.0.0.1). The effective host trust boundary therefore stays the
 # loopback (SPEC §15.3). Docker forwards from a bridge peer rather than
-# container loopback, so the overlay also requires AIOPS_STATE_API_TOKEN; use
+# container loopback, so the overlay also requires a state API token secret; use
 # HTTP Basic user `aiops` and that token as the browser password.
 #
 # Because a 0.0.0.0 bind is reachable by any sibling container on the same
@@ -23,13 +23,16 @@
 # unless they should be able to use the token-protected status surface.
 services:
   worker:
+    entrypoint:
+      - /usr/local/bin/aiops-secret-entrypoint
     environment:
       AIOPS_SERVER_HOST: 0.0.0.0
-      AIOPS_STATE_API_TOKEN: ${AIOPS_STATE_API_TOKEN:?set AIOPS_STATE_API_TOKEN for the dashboard overlay}
     ports:
       - "127.0.0.1:4000:4000"
     networks:
       - dashboard
+    secrets:
+      - aiops_state_api_token
 
 # No explicit `name:` — Compose scopes the network to the project
 # (<project>_dashboard). A fixed global name would be shared across separate
@@ -37,3 +40,7 @@ services:
 # worker:4000, which would defeat the sibling isolation above.
 networks:
   dashboard: {}
+
+secrets:
+  aiops_state_api_token:
+    file: ${AIOPS_STATE_API_TOKEN_FILE:?set AIOPS_STATE_API_TOKEN_FILE to a file containing the state API token}

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -116,7 +116,77 @@ host Docker CLI check and validates live Linear auth/project visibility, Codex
 CLI version, Codex login status, and a minimal `codex app-server` JSON-RPC
 probe.
 
-## 4. Run a todo smoke
+## 4. Start the long-lived worker
+
+Start production-style workers with the dashboard overlay from the first
+long-lived `up`. The base Compose service binds the worker HTTP listener to
+container loopback, and Docker cannot add a new published port to an already
+running container without recreating it. The overlay binds all interfaces inside
+the worker container, publishes only to host loopback, and keeps the state API
+token loaded from the secret file configured above.
+
+```bash
+docker compose --env-file .env \
+  -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.codex.yml \
+  -f deploy/docker-compose.dashboard.yml \
+  up -d --build worker
+```
+
+After the worker is healthy, smoke-check host reachability without printing the
+state API token:
+
+```bash
+docker compose --env-file .env \
+  -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.codex.yml \
+  -f deploy/docker-compose.dashboard.yml \
+  ps worker
+
+curl_cfg="$(mktemp)"
+chmod 600 "$curl_cfg"
+printf 'header = "Authorization: Bearer %s"\n' \
+  "$(cat .aiops/secrets/state_api_token)" > "$curl_cfg"
+curl --fail --silent --show-error --config "$curl_cfg" \
+  http://127.0.0.1:4000/ >/tmp/aiops-dashboard.html
+curl --fail --silent --show-error --config "$curl_cfg" \
+  http://127.0.0.1:4000/api/v1/state >/tmp/aiops-state.json
+rm -f "$curl_cfg"
+
+timeout 15s env AIOPS_STATE_API_TOKEN="$(cat .aiops/secrets/state_api_token)" \
+  go run ./cmd/tui --url http://127.0.0.1:4000/ --raw >/tmp/aiops-tui.txt \
+  || test "$?" -eq 124
+```
+
+`cmd/tui` keeps polling until interrupted; the `timeout` command is expected to
+stop it after a frame has been written.
+
+Open `http://127.0.0.1:4000/` in a browser and let the Basic-auth prompt ask
+for credentials. Use username `aiops` and the contents of
+`.aiops/secrets/state_api_token` as the password. Do not put credentials in the
+URL.
+
+If a worker is already running without the dashboard overlay and cannot be
+recreated yet, use a host-local tunnel as a low-downtime bridge until the next
+planned restart. This keeps the host listener on loopback and preserves the
+worker's existing state API authentication; it requires `socat` on the host and
+`bash` in the worker image.
+
+```bash
+worker_container="$(docker compose --env-file .env \
+  -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.codex.yml \
+  ps -q worker)"
+
+socat TCP-LISTEN:4000,bind=127.0.0.1,reuseaddr,fork \
+  EXEC:"docker exec -i $worker_container bash -lc 'exec 3<>/dev/tcp/127.0.0.1/4000; cat <&0 >&3 & cat <&3 >&1; wait'",nofork
+```
+
+Run the same `curl` and `cmd/tui --raw` smoke checks through the tunnel. Treat
+the tunnel as temporary operational access; keep the dashboard overlay in the
+normal long-lived Compose command so future restarts do not need it.
+
+## 5. Run a todo smoke
 
 Prepare or select one disposable Linear issue in an active state. For the first
 pass, keep `agent.default: mock`:

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -160,17 +160,21 @@ base Compose file. To reach it, merge the opt-in overlay, which binds
 container loopback, so the overlay requires a state API token:
 
 ```bash
-export AIOPS_STATE_API_TOKEN=$(openssl rand -hex 24)
+mkdir -p .aiops/secrets
+openssl rand -hex 24 > .aiops/secrets/state_api_token
+AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token \
 docker compose -f deploy/docker-compose.yml \
   -f deploy/docker-compose.dashboard.yml up worker
 ```
 
 See README "Operator surfaces" for the trust-boundary caveats; the
 overlay requires auth on every request. The browser Basic-auth username is
-`aiops` and the password is `$AIOPS_STATE_API_TOKEN`. Open
+`aiops` and the password is the contents of
+`.aiops/secrets/state_api_token`. Open
 `http://127.0.0.1:4000/` and let the browser show its Basic-auth prompt instead
-of embedding credentials in the URL. `cmd/tui` reads the same env var and sends
-it as a bearer token when polling the overlay.
+of embedding credentials in the URL. For `cmd/tui`, set
+`AIOPS_STATE_API_TOKEN` from the same secret file; the client sends it as a
+bearer token when polling the overlay.
 
 > **Upgrading from a root-running worker image.** The worker now runs as the
 > unprivileged `aiops` user (#365). A `workspaces` named volume created by an

--- a/test/e2e/fixtures/compose_config_test.go
+++ b/test/e2e/fixtures/compose_config_test.go
@@ -133,6 +133,31 @@ func TestFirstRunRunbookWritesAbsoluteComposePaths(t *testing.T) {
 	}
 }
 
+func TestFirstRunRunbookIncludesDashboardExposureSmoke(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "..", "docs", "runbooks", "first-run-docker-linear-codex.md"))
+	if err != nil {
+		t.Fatalf("read first-run runbook: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token",
+		"-f deploy/docker-compose.dashboard.yml",
+		"curl --fail --silent --show-error --config \"$curl_cfg\"",
+		"http://127.0.0.1:4000/api/v1/state >/tmp/aiops-state.json",
+		"timeout 15s env AIOPS_STATE_API_TOKEN=\"$(cat .aiops/secrets/state_api_token)\"",
+		"go run ./cmd/tui --url http://127.0.0.1:4000/ --raw >/tmp/aiops-tui.txt",
+		"test \"$?\" -eq 124",
+		"TCP-LISTEN:4000,bind=127.0.0.1",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("first-run runbook missing dashboard exposure smoke text %q", want)
+		}
+	}
+	if strings.Contains(text, "http://aiops:") {
+		t.Fatalf("first-run runbook embeds dashboard credentials in a URL")
+	}
+}
+
 func sliceContainsString(values []any, want string) bool {
 	for _, value := range values {
 		if strings.Contains(fmt.Sprint(value), want) {

--- a/test/e2e/fixtures/dashboard_overlay_test.go
+++ b/test/e2e/fixtures/dashboard_overlay_test.go
@@ -54,8 +54,27 @@ func TestDashboardOverlayBindsContainerWide(t *testing.T) {
 	if got := env["AIOPS_SERVER_HOST"]; got != "0.0.0.0" {
 		t.Fatalf("AIOPS_SERVER_HOST = %v, want 0.0.0.0", got)
 	}
-	if got := env["AIOPS_STATE_API_TOKEN"]; got != "${AIOPS_STATE_API_TOKEN:?set AIOPS_STATE_API_TOKEN for the dashboard overlay}" {
-		t.Fatalf("AIOPS_STATE_API_TOKEN = %v, want required Compose interpolation", got)
+	if _, ok := env["AIOPS_STATE_API_TOKEN"]; ok {
+		t.Fatalf("AIOPS_STATE_API_TOKEN is set in environment; want secret-file backed token")
+	}
+	entrypoint, ok := worker["entrypoint"].([]any)
+	if !ok || len(entrypoint) != 1 || entrypoint[0] != "/usr/local/bin/aiops-secret-entrypoint" {
+		t.Fatalf("worker.entrypoint = %#v, want aiops-secret-entrypoint", worker["entrypoint"])
+	}
+	secrets, ok := worker["secrets"].([]any)
+	if !ok || !sliceContainsString(secrets, "aiops_state_api_token") {
+		t.Fatalf("worker.secrets = %#v, want aiops_state_api_token", worker["secrets"])
+	}
+	declared, ok := readDashboardOverlay(t)["secrets"].(map[string]any)
+	if !ok {
+		t.Fatal("dashboard overlay missing top-level secrets")
+	}
+	secret, ok := declared["aiops_state_api_token"].(map[string]any)
+	if !ok {
+		t.Fatalf("aiops_state_api_token secret = %#v, want map", declared["aiops_state_api_token"])
+	}
+	if got := secret["file"]; got != "${AIOPS_STATE_API_TOKEN_FILE:?set AIOPS_STATE_API_TOKEN_FILE to a file containing the state API token}" {
+		t.Fatalf("aiops_state_api_token file = %v, want required file interpolation", got)
 	}
 }
 


### PR DESCRIPTION
Closes #449

Linear issue: 9cb92bf0-7fe0-4e82-87a9-697c3113cb79 (AIS-28)

## Summary
- Make the Docker dashboard overlay secret-file backed via `aiops-secret-entrypoint` and `AIOPS_STATE_API_TOKEN_FILE`, avoiding state API tokens in Compose environment metadata.
- Update README/local dev/production first-run docs so long-lived Docker workers start with dashboard exposure on host loopback by default.
- Document a temporary host-local tunnel for an already-running worker that cannot be recreated yet, plus Web UI and bounded TUI smoke checks.
- Add fixture coverage for the secret-backed dashboard overlay and production runbook smoke commands.

## Acceptance Criteria
- Supported zero/low-downtime or default path: met. Production runbook starts long-lived workers with `deploy/docker-compose.dashboard.yml`; already-running workers get a documented host-local tunnel until restart.
- Host bind remains loopback: met. Overlay continues publishing `127.0.0.1:4000:4000` and tests guard it.
- State API auth preserved: met. Overlay now requires `AIOPS_STATE_API_TOKEN_FILE` and loads auth through the existing secret entrypoint.
- Web UI/TUI commands without token logs: met. Curl uses a 0600 temp config; TUI reads token from env scoped to the command and is bounded with `timeout`.
- Smoke check added: met. Runbook includes Web UI/API/TUI smoke checks; fixture tests guard the documented commands.

## Verification
- `gofmt -w test/e2e/fixtures/compose_config_test.go test/e2e/fixtures/dashboard_overlay_test.go`
- `go test ./test/e2e/fixtures -run 'TestFirstRunRunbook|TestDashboardOverlay|TestCodexComposeOverlayUsesSecrets' -count=1`
- `go test ./test/e2e/fixtures`
- `go test ./scripts -run TestCodexSafeProfileDocsUseWorkspaceWriteSandbox -count=1`
- `git diff --check HEAD`
- CI on head `66710c2f9c08b2cdcfac97b63cf5e3ce9ff3068c`: Go build and test, Security and supply-chain, E2E Gitea mock loop, and Docker image build all passed.
- Not run locally: `docker compose config` smoke, because Docker is not installed in this container (`docker: command not found`).

## Local Reviews
- Codex review against `origin/main...HEAD`: clean on head `66710c2f9c08b2cdcfac97b63cf5e3ce9ff3068c` after fixing earlier P2 findings about Compose token interpolation, hanging TUI smoke command, and token exposure in Compose environment metadata.
- Claude Code review: unavailable; command failed with `claude: command not found`.

## GitHub Review / Threads
- Triggered `@codex review`: https://github.com/xrf9268-hue/aiops-platform/pull/454#issuecomment-4544492311.
- Status: pending at handoff; trigger still has eyes reaction, no completion signal yet.
- Review threads: GraphQL query currently returns zero threads.

## Size Budget
- 6 files changed, 138 insertions, 11 deletions. Within default 12-file / 300-LOC policy budget.

## Deferrals / Follow-ups
- None.

## Risks
- Live `docker compose config` could not be run in this container because Docker is unavailable; CI Docker image build passed.

## Current Head
- `66710c2f9c08b2cdcfac97b63cf5e3ce9ff3068c`
