### PR TITLE
Fix terminal reconcile after app-server turn completion

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -140,6 +140,12 @@ const continuationRetryDelay = time.Second
 // bound; runtime callers must not mutate it.
 var retryFetchTimeout = 45 * time.Second
 
+// terminalCleanupStateFetchTimeout bounds the deletion-time state recheck that
+// prevents a stale terminal observation from deleting a workspace after the
+// issue has already returned to active work.
+var terminalCleanupStateFetchTimeout = 45 * time.Second
+var terminalCleanupStateRetryDelay = continuationRetryDelay
+
 // NextDelay implements Scheduler.
 func (s RetryScheduler) NextDelay(req RetryRequest) time.Duration {
 	if req.Kind == RetryKindContinuation {
@@ -970,6 +976,29 @@ func (o *endWorkspaceCleanupOp) apply(st *OrchestratorState) func() {
 	return nil
 }
 
+type continuationAfterSkippedCleanup struct {
+	issue      tracker.Issue
+	identifier string
+	attempt    int
+	workspace  Workspace
+}
+
+type continuationBudgetExhaustedOp struct {
+	o          *Orchestrator
+	id         IssueID
+	issue      tracker.Issue
+	identifier string
+}
+
+func (c *continuationBudgetExhaustedOp) apply(st *OrchestratorState) func() {
+	st.ReleaseClaim(c.id)
+	st.recordFailed(c.id, FailedEntry{State: c.issue.State, UpdatedAt: c.issue.UpdatedAt})
+	msg := "clean continuation budget exhausted after " + strconv.Itoa(c.o.maxTurns) + " turns while tracker issue remained active"
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: c.id, Identifier: c.identifier, Message: msg})
+	log.Printf("event=run_failed issue_id=%s issue_identifier=%s reason=continuation_budget_exhausted budget=%d", c.id, c.identifier, c.o.maxTurns)
+	return nil
+}
+
 // ReconcileInactiveTrackerIssuesAndWait cancels only issues explicitly observed
 // in a terminal or configured inactive tracker state. Missing issues are
 // treated as unknown instead of inactive because tracker adapters may return
@@ -1290,7 +1319,6 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 			continue
 		}
 		st.ReleaseClaim(id)
-		run.ReconcileCancel = true
 		// Refresh the stored issue and (re)evaluate the terminal cleanup gate
 		// against the CURRENT observation every tick. A terminal transition
 		// flags the entry so finalize fires before_remove + remove (SPEC §18.1
@@ -1303,6 +1331,7 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 		// worker exits (Codex P2 follow-up).
 		run.Issue = issue
 		run.ReconcileCleanupWorkspace = isTerminalTrackerState(issue.State, r.terminalStates)
+		run.ReconcileCancel = true
 		cancelEntries = append(cancelEntries, run)
 	}
 	for id, retry := range st.RetryAttempts {
@@ -1351,7 +1380,7 @@ func (o *Orchestrator) reconcileCancelFollowup(cancelEntries []*RunningEntry, bl
 			}
 		}
 		for _, w := range blockedCleanups {
-			o.runReconciledWorkspaceCleanup(w)
+			o.runReconciledWorkspaceCleanup(w, nil)
 		}
 		if result != nil {
 			result <- cancelEntries
@@ -1378,6 +1407,10 @@ func isTerminalTrackerState(state string, terminalStates map[string]struct{}) bo
 	return ok
 }
 
+func runHasCompletedTurn(run *RunningEntry) bool {
+	return run != nil && run.Session.TurnCount > 0
+}
+
 // reconciledWorkspaceCleanup returns a followup that removes the workspace of
 // a terminal-state run whose worker has now exited (SPEC §18.1 active
 // transition). It returns nil — leaving cleanup to the startup sweep — when
@@ -1386,6 +1419,20 @@ func isTerminalTrackerState(state string, terminalStates map[string]struct{}) bo
 // followup goroutine, off the actor loop, so the before_remove hook and
 // remove cannot block state mutation.
 func (o *Orchestrator) reconciledWorkspaceCleanup(id IssueID, entry *RunningEntry) func() {
+	return o.reconciledWorkspaceCleanupFollowup(id, entry, nil)
+}
+
+func (o *Orchestrator) reconciledWorkspaceCleanupOrContinuation(id IssueID, entry *RunningEntry, attempt int) func() {
+	continuation := &continuationAfterSkippedCleanup{
+		issue:      entry.Issue,
+		identifier: entry.Identifier,
+		attempt:    attempt,
+		workspace:  entry.Workspace,
+	}
+	return o.reconciledWorkspaceCleanupFollowup(id, entry, continuation)
+}
+
+func (o *Orchestrator) reconciledWorkspaceCleanupFollowup(id IssueID, entry *RunningEntry, continuation *continuationAfterSkippedCleanup) func() {
 	if entry == nil || !entry.ReconcileCleanupWorkspace {
 		return nil
 	}
@@ -1393,7 +1440,7 @@ func (o *Orchestrator) reconciledWorkspaceCleanup(id IssueID, entry *RunningEntr
 	if !ok || o.workspaceCleaner == nil {
 		return nil
 	}
-	return func() { o.runReconciledWorkspaceCleanup(w) }
+	return func() { o.runReconciledWorkspaceCleanup(w, continuation) }
 }
 
 // refreshRunningIssue updates a still-active run's stored issue and clears any
@@ -1432,7 +1479,7 @@ func terminalWorkspaceForCleanup(id IssueID, identifier, path, root, state strin
 // here guards against a hook that ignores cancellation (AGENTS.md Go-runtime
 // hardening). Callers must invoke it from a followup goroutine, never inside
 // an apply.
-func (o *Orchestrator) runReconciledWorkspaceCleanup(w ReconciledWorkspace) {
+func (o *Orchestrator) runReconciledWorkspaceCleanup(w ReconciledWorkspace, continuation *continuationAfterSkippedCleanup) {
 	if o.workspaceCleaner == nil || strings.TrimSpace(w.Path) == "" {
 		return
 	}
@@ -1445,9 +1492,74 @@ func (o *Orchestrator) runReconciledWorkspaceCleanup(w ReconciledWorkspace) {
 		return
 	}
 	defer o.endReconcileWorkspaceCleanup(w.IssueID)
+	currentState, terminal, known := o.verifyReconciledWorkspaceStillTerminal(w)
+	if !known {
+		o.retryReconciledWorkspaceCleanup(w, continuation)
+		return
+	}
+	if !terminal {
+		o.continueAfterSkippedTerminalCleanup(continuation)
+		return
+	}
+	if strings.TrimSpace(currentState) != "" {
+		w.State = currentState
+	}
 	ctx, cancel := context.WithTimeout(o.runCtx, reconcileWorkspaceCleanupTimeout)
 	defer cancel()
 	o.workspaceCleaner.CleanupReconciledWorkspace(ctx, w)
+}
+
+func (o *Orchestrator) continueAfterSkippedTerminalCleanup(continuation *continuationAfterSkippedCleanup) {
+	if continuation == nil {
+		o.queuePollWake()
+		return
+	}
+	if !o.runnerEnforcesMaxTurns && continuation.attempt >= o.maxTurns {
+		_ = o.submit(o.runCtx, &continuationBudgetExhaustedOp{
+			o:          o,
+			id:         IssueID(continuation.issue.ID),
+			issue:      continuation.issue,
+			identifier: continuation.identifier,
+		})
+		return
+	}
+	_ = o.scheduleContinuationRetry(o.runCtx, continuation.issue, continuation.identifier, continuation.attempt, continuation.workspace)
+}
+
+func (o *Orchestrator) retryReconciledWorkspaceCleanup(w ReconciledWorkspace, continuation *continuationAfterSkippedCleanup) {
+	safeGo("orchestrator.reconcile_cleanup_retry", func() {
+		timer := time.NewTimer(terminalCleanupStateRetryDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			o.runReconciledWorkspaceCleanup(w, continuation)
+		case <-o.runCtx.Done():
+		}
+	})
+}
+
+func (o *Orchestrator) verifyReconciledWorkspaceStillTerminal(w ReconciledWorkspace) (string, bool, bool) {
+	resolver, terminalStates := o.currentRetryTerminalResolver()
+	if resolver == nil || len(terminalStates) == 0 {
+		return w.State, true, true
+	}
+	ctx, cancel := context.WithTimeout(o.runCtx, terminalCleanupStateFetchTimeout)
+	defer cancel()
+	states, err := fetchIssueStates(ctx, resolver, []tracker.IssueRef{{ID: string(w.IssueID), Identifier: w.Identifier}})
+	if err != nil {
+		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_refresh_failed error=%q", w.IssueID, w.Identifier, err.Error())
+		return "", false, false
+	}
+	state, ok := states[string(w.IssueID)]
+	if !ok {
+		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_missing", w.IssueID, w.Identifier)
+		return "", false, false
+	}
+	if !isTerminalTrackerState(state, terminalStates) {
+		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_not_terminal state=%q", w.IssueID, w.Identifier, state)
+		return state, false, true
+	}
+	return state, true, true
 }
 
 // dispatchOp is the actor-side half of RequestDispatch: it checks
@@ -1895,7 +2007,7 @@ func (r *retryFireAfterFetchOp) apply(st *OrchestratorState) func() {
 					Message:    "retry released: issue terminal, removing workspace",
 				})
 				o := r.o
-				return func() { o.runReconciledWorkspaceCleanup(w) }
+				return func() { o.runReconciledWorkspaceCleanup(w, nil) }
 			}
 		}
 		st.ReleaseClaim(r.id)
@@ -1957,6 +2069,16 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 	}
 	if f.result.Err == nil {
 		nextContinuationAttempt := f.entry.ContinuationAttempt + 1
+		if f.entry.ReconcileCleanupWorkspace && runHasCompletedTurn(f.entry) {
+			cleanup := f.o.reconciledWorkspaceCleanupOrContinuation(f.id, f.entry, nextContinuationAttempt)
+			if !st.FinishRunSucceeded(f.id, f.entry, elapsed) {
+				close(f.done)
+				return nil
+			}
+			st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
+			close(f.done)
+			return cleanup
+		}
 		// SPEC §7.1 leaves continuation worker spawns unbounded; only apply
 		// the orchestrator-side cap for runners that cannot enforce
 		// agent.max_turns inside their own session. See issue #216.
@@ -2003,6 +2125,15 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		return func() {
 			_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt, workspace)
 		}
+	}
+	if f.entry.ReconcileCleanupWorkspace && runHasCompletedTurn(f.entry) {
+		cleanup := f.o.reconciledWorkspaceCleanup(f.id, f.entry)
+		if !st.FinishRunReconciledCancelled(f.id, f.entry, elapsed) {
+			close(f.done)
+			return nil
+		}
+		close(f.done)
+		return cleanup
 	}
 	if f.result.NonRetryable {
 		if !st.FinishRunNonRetryableFailed(f.id, f.entry, elapsed) {

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -1940,6 +1940,300 @@ func TestReconcileTerminalRunFiresActiveWorkspaceCleanup(t *testing.T) {
 	}
 }
 
+// TestReconcileTerminalRunAfterTurnCompletedCancelsWorkerButRecordsSuccess is
+// the #448 regression: once app-server has emitted turn_completed, an
+// agent-side move to Done should still cancel the worker so terminal
+// reconciliation cannot leave a hung teardown occupying a running slot, but a
+// clean worker result still records success and terminal cleanup after
+// finalization.
+func TestReconcileTerminalRunAfterTurnCompletedCancelsWorkerButRecordsSuccess(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+	o.SetRetryTerminalStateResolver(staticStateRefresher{"ENG-TC1": "Done"}, []string{"Done"})
+
+	issue := tracker.Issue{ID: "ENG-TC1", Identifier: "ENG-TC1", State: "In Progress"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-TC1"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{
+		Event:   task.EventTurnCompleted,
+		Payload: map[string]any{"turn_id": "turn-1"},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{
+		Event:   task.EventNotification,
+		Payload: map[string]any{"message": "doing final local status check"},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent notification: %v", err)
+	}
+
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+	select {
+	case <-disp.contextAt(0).Done():
+	case <-time.After(time.Second):
+		t.Fatal("worker context was not canceled after terminal reconciliation")
+	}
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+
+	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, time.Second)
+	got := cleaner.snapshot()[0]
+	if got.IssueID != IssueID(issue.ID) || got.Path != wsPath || got.Reason != "terminal" || got.State != "Done" {
+		t.Fatalf("cleanup = %+v, want terminal cleanup for %s at %q reason=terminal state=Done", got, issue.ID, wsPath)
+	}
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 0 || len(view.Retrying) != 0 {
+		t.Fatalf("state after clean terminal finalization = running %+v retrying %+v, want neither", view.Running, view.Retrying)
+	}
+	if len(view.Completed) != 1 || view.Completed[0] != IssueID(issue.ID) {
+		t.Fatalf("completed = %+v, want %s", view.Completed, issue.ID)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("dispatcher spawn count = %d, want no continuation retry", got)
+	}
+}
+
+func TestReconcileTerminalRunAfterTurnCompletedErrorDoesNotRetry(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	oldRetryDelay := terminalCleanupStateRetryDelay
+	terminalCleanupStateRetryDelay = time.Millisecond
+	defer func() { terminalCleanupStateRetryDelay = oldRetryDelay }()
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Millisecond},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+	o.SetRetryTerminalStateResolver(&flakyStateRefresher{states: staticStateRefresher{"ENG-TC2": "Done"}}, []string{"Done"})
+
+	issue := tracker.Issue{ID: "ENG-TC2", Identifier: "ENG-TC2", State: "In Progress"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-TC2"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	disp.finishAt(0, WorkerResult{Err: errors.New("app-server exited after terminal observation"), Elapsed: time.Millisecond})
+
+	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, time.Second)
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 0 || len(view.Retrying) != 0 || len(view.Completed) != 0 {
+		t.Fatalf("state after terminal errored finalization = running %+v retrying %+v completed %+v, want none", view.Running, view.Retrying, view.Completed)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("dispatcher spawn count = %d, want no failure retry", got)
+	}
+}
+
+func TestReconcileTerminalRunAfterTurnCompletedActiveRefreshSkipsStaleCleanup(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+	o.SetRetryTerminalStateResolver(staticStateRefresher{
+		"ENG-TC3": "In Progress",
+		"ENG-T5":  "Done",
+	}, []string{"Done"})
+
+	blip := tracker.Issue{ID: "ENG-TC3", Identifier: "ENG-TC3", State: "In Progress"}
+	barrier := tracker.Issue{ID: "ENG-T5", Identifier: "ENG-T5", State: "In Progress"}
+	const blipPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-TC3"
+	const barrierPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-T5"
+	dispatchRunningIssue(t, o, disp, blip, blipPath, 1)
+	dispatchRunningIssue(t, o, disp, barrier, barrierPath, 2)
+	for _, issue := range []tracker.Issue{blip, barrier} {
+		if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+			t.Fatalf("RecordRuntimeEvent %s: %v", issue.ID, err)
+		}
+	}
+
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		blip.ID:    {ID: blip.ID, Identifier: blip.Identifier, State: "Done"},
+		barrier.ID: {ID: barrier.ID, Identifier: barrier.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	disp.finishAt(1, WorkerResult{Elapsed: time.Millisecond})
+
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(cleaner.snapshot()) == 1 && len(view.Retrying) == 1
+	}, time.Second)
+	calls := cleaner.snapshot()
+	if len(calls) != 1 || calls[0].IssueID != IssueID(barrier.ID) || calls[0].Path != barrierPath {
+		t.Fatalf("only the still-terminal barrier may be cleaned, got %+v", calls)
+	}
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := view.Retrying[0]; got.IssueID != IssueID(blip.ID) || got.Attempt != 1 {
+		t.Fatalf("stale terminal continuation retry = %+v, want issue %s attempt 1", got, blip.ID)
+	}
+}
+
+type redispatchDuringCleanupRefresher struct {
+	orch      *Orchestrator
+	issue     tracker.Issue
+	state     string
+	attempted chan error
+}
+
+type flakyStateRefresher struct {
+	states staticStateRefresher
+	calls  int
+}
+
+func (f *flakyStateRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]string, error) {
+	f.calls++
+	if f.calls == 1 {
+		return nil, errors.New("temporary tracker refresh failure")
+	}
+	return f.states.FetchIssueStatesByIDs(ctx, ids)
+}
+
+func (r *redispatchDuringCleanupRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]string, error) {
+	return r.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(ids))
+}
+
+func (r *redispatchDuringCleanupRefresher) FetchIssueStatesByRefs(ctx context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+	r.attempted <- r.orch.RequestDispatch(ctx, r.issue, nil)
+	out := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		out[ref.ID] = r.state
+	}
+	return out, nil
+}
+
+func TestReconcileWorkspaceCleanupRechecksStateUnderReservation(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-TC4", Identifier: "ENG-TC4", State: "In Progress"}
+	refresher := &redispatchDuringCleanupRefresher{
+		orch:      o,
+		issue:     issue,
+		state:     "In Progress",
+		attempted: make(chan error, 1),
+	}
+	o.SetRetryTerminalStateResolver(refresher, []string{"Done"})
+
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-TC4"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+
+	select {
+	case err := <-refresher.attempted:
+		if !errors.Is(err, ErrNotDispatched) {
+			t.Fatalf("dispatch during cleanup recheck = %v, want ErrNotDispatched", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cleanup recheck did not attempt redispatch")
+	}
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && view.Retrying[0].Attempt == 1
+	}, time.Second)
+	if err := o.RequestDispatch(context.Background(), issue, nil); !errors.Is(err, ErrNotDispatched) {
+		t.Fatalf("plain dispatch after stale cleanup recheck = %v, want ErrNotDispatched while continuation retry is claimed", err)
+	}
+	waitFor(t, func() bool {
+		return o.RequestDispatchAfterTrackerRecheck(context.Background(), issue, nil) == nil
+	}, time.Second)
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Fatalf("cleanup calls = %+v, want none after state rechecked active", calls)
+	}
+}
+
+func TestReconcileWorkspaceCleanupActiveRecheckHonorsContinuationBudget(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	maxTurns := 1
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+		WorkspaceCleaner: cleaner,
+		MaxTurns:         &maxTurns,
+	})
+	defer cancel()
+	o.SetRetryTerminalStateResolver(staticStateRefresher{"ENG-TC5": "In Progress"}, []string{"Done"})
+
+	issue := tracker.Issue{ID: "ENG-TC5", Identifier: "ENG-TC5", State: "In Progress"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-TC5"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Failed) == 1
+	}, time.Second)
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 0 {
+		t.Fatalf("retrying after stale terminal active recheck exhausted budget = %+v, want none", view.Retrying)
+	}
+	if got := disp.count(); got != 1 {
+		t.Fatalf("dispatcher spawn count = %d, want no continuation beyond max_turns=%d", got, maxTurns)
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Fatalf("cleanup calls = %+v, want none after state rechecked active", calls)
+	}
+}
+
 // TestReconcileInactiveNonTerminalRunKeepsWorkspace pins the upstream gating:
 // a run cancelled because its issue went to a merely-inactive (non-terminal)
 // state must NOT have its workspace removed — the issue may return to active
@@ -3190,8 +3484,13 @@ func TestRetryFire_TerminalIssueFiresWorkspaceCleanup(t *testing.T) {
 	}
 
 	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, 2*time.Second)
-	if len(resolver.refs) != 1 || len(resolver.refs[0]) != 1 || resolver.refs[0][0].ID != "global-101" || resolver.refs[0][0].Identifier != "#7" {
-		t.Fatalf("terminal resolver refs = %#v, want global-101 with identifier #7", resolver.refs)
+	if len(resolver.refs) != 2 {
+		t.Fatalf("terminal resolver calls = %d, want retry-fire lookup plus cleanup recheck", len(resolver.refs))
+	}
+	for i, refs := range resolver.refs {
+		if len(refs) != 1 || refs[0].ID != "global-101" || refs[0].Identifier != "#7" {
+			t.Fatalf("terminal resolver refs[%d] = %#v, want global-101 with identifier #7", i, refs)
+		}
 	}
 	got := cleaner.snapshot()[0]
 	if got.IssueID != IssueID(issue.ID) || got.Path != wsPath || got.Reason != "terminal" || got.State != "Done" {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -150,13 +150,13 @@ type RunningEntry struct {
 	// context cancellation, but finalization must release the run without
 	// scheduling a retry because the tracker made the issue ineligible.
 	ReconcileCancel bool
-	// ReconcileCleanupWorkspace is set alongside ReconcileCancel only when the
-	// issue moved to a terminal tracker state (not merely inactive). It tells
-	// the finalize path to remove the workspace via the before_remove hook
-	// after the worker has exited, mirroring the startup sweep (SPEC §18.1
-	// active transition). Upstream gates the same cleanup on terminal state
-	// only (orchestrator.ex terminate_running_issue cleanup_workspace=true);
-	// non-active/route-change cancels keep the workspace for possible reuse.
+	// ReconcileCleanupWorkspace is set when reconciliation observes the issue
+	// in a terminal tracker state (not merely inactive). It tells the finalize
+	// path to remove the workspace via the before_remove hook after the worker
+	// has exited, mirroring the startup sweep (SPEC §18.1 active transition).
+	// Upstream gates the same cleanup on terminal state only (orchestrator.ex
+	// terminate_running_issue cleanup_workspace=true); non-active/route-change
+	// cancels keep the workspace for possible reuse.
 	ReconcileCleanupWorkspace bool
 }
 


### PR DESCRIPTION
Closes #448

Linear issue id: 906e8cb3-097d-463b-83c7-5b7c2153e210

## Summary
- Keep terminal reconciliation cancelling workers after an app-server `turn_completed`, so hung post-turn teardown cannot occupy a running slot.
- Finalize terminal-reconciled completed-turn runs without scheduling failure retries, while still cleaning terminal workspaces.
- Recheck tracker state under the actor-side cleanup reservation before deleting a terminal workspace.
- If deletion-time recheck confirms active state, preserve normal clean-turn continuation retry and max-turn budget instead of falling back to a brand-new dispatch.
- If deletion-time recheck cannot determine state because tracker refresh fails/misses, retry terminal cleanup instead of leaking already-released workspaces until restart.

## Acceptance criteria
- Terminal tracker updates after `turn_completed` cancel the worker and record success on clean exit: `TestReconcileTerminalRunAfterTurnCompletedCancelsWorkerButRecordsSuccess`.
- Terminal tracker updates after `turn_completed` do not schedule a failure retry when the worker exits with an error after cancellation: `TestReconcileTerminalRunAfterTurnCompletedErrorDoesNotRetry` (also covers transient cleanup-state refresh failure retry).
- Stale terminal observations do not delete active workspaces and preserve continuation retry state: `TestReconcileTerminalRunAfterTurnCompletedActiveRefreshSkipsStaleCleanup`.
- Deletion-time recheck runs under cleanup reservation and denies redispatch during that window: `TestReconcileWorkspaceCleanupRechecksStateUnderReservation`.
- Active recheck after stale terminal honors orchestrator-side continuation budget: `TestReconcileWorkspaceCleanupActiveRecheckHonorsContinuationBudget`.

## Tests
- `go test ./internal/orchestrator ./internal/worker`
- `go test ./internal/orchestrator -run 'TestReconcile(WorkspaceCleanupActiveRecheckHonorsContinuationBudget|WorkspaceCleanupRechecksStateUnderReservation|TerminalRunAfterTurnCompletedActiveRefreshSkipsStaleCleanup|TerminalRunAfterTurnCompletedCancelsWorkerButRecordsSuccess|TerminalRunAfterTurnCompletedErrorDoesNotRetry)' -count=1`
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `go build ./cmd/worker ./cmd/tui`
- `go test -race -covermode=atomic ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (exit 0; printed existing baseline findings / stale sibling-worktree warnings; no new finding in this PR diff)
- Mutation check: reintroducing the completed-turn early-continue made the cancellation regression fail with `worker context was not canceled after terminal reconciliation`, then pass after restoring the fix.
- Mutation check: bypassing the deletion-time terminal recheck made the stale-cleanup regression fail, then pass after restoring the fix.
- Mutation check: bypassing actor-side cleanup reservation made `TestReconcileWorkspaceCleanupRechecksStateUnderReservation` fail with `dispatch during cleanup recheck = <nil>, want ErrNotDispatched`, then pass after restoring the reservation.
- Mutation check: replacing the active-recheck continuation path with only `queuePollWake()` made the stale-active tests fail, then pass after restoring continuation preservation.
- Mutation check: treating unknown refresh failure as active made `TestReconcileTerminalRunAfterTurnCompletedErrorDoesNotRetry` fail waiting for cleanup, then pass after restoring cleanup retry.

## Local review
- Codex diff-only review on head `2f2072b43a7cd475644d97821dd34b3c7f912d41`: `LGTM`, `MERGE-READY`.
- Later local Codex review unavailable due Codex usage limit; GitHub Codex review is the active remote gate for current head.
- Claude Code diff-only review: skipped with explicit human signoff because Claude quota is temporarily unavailable. Prior attempts failed to produce a verdict (`max-turns` / timeout); simple health probe returned `OK`.

## CI and remote review
- GitHub CI passed on current head `ac6024c6592a5210176c6069b494ba307dd43636`.
- CI warning audit for run `26489089093` found no `warning:` lines.
- Fresh `@codex review` trigger `4550979481` completed (`eyes=0`). GitHub did not create a new current-head review thread.
- Addressed and resolved Codex threads: `PRRT_kwDOSN-Foc6EzigX`, `PRRT_kwDOSN-Foc6E-ilg`, `PRRT_kwDOSN-Foc6E-pMe`, `PRRT_kwDOSN-Foc6E-9S-`, `PRRT_kwDOSN-Foc6E_EZK`.
- GraphQL review-thread check after resolution shows no unresolved actionable threads.

## Size budget
- 3 files changed, 444 insertions, 14 deletions.
- Exceeds `policy.max_changed_loc` 300. Per human instruction, this PR keeps the needed correctness/race/budget coverage rather than compressing quality away.
- Workflow follow-up for size-budget semantics: #470.

## Deferrals and follow-ups
- No intentional behavior deferrals.
- Workflow follow-up for size-budget semantics: #470.

## Risks
- Draft PR should remain draft until the size gate is accepted or the PR is explicitly split. Code, CI, warning audit, and review-thread gates are clean.

Current head SHA: ac6024c6592a5210176c6069b494ba307dd43636
