### PR TITLE
Fix release workflow tag pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,20 +27,52 @@ jobs:
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       ref: ${{ steps.release.outputs.ref }}
+      commit_sha: ${{ steps.release.outputs.commit_sha }}
     steps:
+      - name: Validate release tag
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$RELEASE_INPUT_TAG"
+          else
+            tag="$GITHUB_REF_NAME"
+          fi
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must match vMAJOR.MINOR.PATCH: $tag"
+            exit 1
+          fi
+          git check-ref-format "refs/tags/$tag"
+
+      - name: Checkout release ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
       - name: Resolve release tag
         id: release
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$RELEASE_INPUT_TAG"
             ref="refs/tags/${tag}"
           else
             tag="${GITHUB_REF_NAME}"
             ref="${GITHUB_REF}"
           fi
+          commit_sha="$(git rev-parse --verify "${ref}^{commit}")"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${commit_sha}" >> "$GITHUB_OUTPUT"
 
   ci:
     name: Reuse CI quality gates
@@ -50,7 +82,7 @@ jobs:
     permissions:
       contents: read
     with:
-      ref: ${{ needs.resolve.outputs.ref }}
+      ref: ${{ needs.resolve.outputs.commit_sha }}
 
   release:
     name: Build and publish release artifacts
@@ -70,7 +102,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ needs.resolve.outputs.ref }}
+          ref: ${{ needs.resolve.outputs.commit_sha }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -82,10 +114,24 @@ jobs:
             go.sum
 
       - name: Verify tag exists
-        run: git rev-parse --verify "refs/tags/${{ needs.resolve.outputs.tag }}"
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+          RELEASE_COMMIT_SHA: ${{ needs.resolve.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          git check-ref-format "refs/tags/$RELEASE_TAG"
+          git fetch --force --tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          resolved_sha="$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}")"
+          if [ "$resolved_sha" != "$RELEASE_COMMIT_SHA" ]; then
+            echo "Release tag $RELEASE_TAG moved from $RELEASE_COMMIT_SHA to $resolved_sha"
+            exit 1
+          fi
 
       - name: Build release binaries
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
         run: |
           set -euo pipefail
           mkdir -p dist
@@ -98,7 +144,7 @@ jobs:
           )
           for target in "${targets[@]}"; do
             read -r goos goarch <<< "$target"
-            out="dist/aiops-platform_${{ needs.resolve.outputs.tag }}_${goos}_${goarch}"
+            out="dist/aiops-platform_${RELEASE_TAG}_${goos}_${goarch}"
             for binary in "${binaries[@]}"; do
               GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 \
                 go build -trimpath -ldflags="-s -w" -o "${out}/${binary}" "./cmd/${binary}"
@@ -115,9 +161,11 @@ jobs:
 
       - name: Package release archives
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
         run: |
           set -euo pipefail
-          for out in dist/aiops-platform_${{ needs.resolve.outputs.tag }}_*; do
+          for out in dist/aiops-platform_${RELEASE_TAG}_*; do
             [ -d "$out" ] || continue
             tar -C dist -czf "${out}.tar.gz" "$(basename "$out")"
             rm -rf "$out"
@@ -131,9 +179,18 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+          RELEASE_COMMIT_SHA: ${{ needs.resolve.outputs.commit_sha }}
         run: |
-          gh release create "${{ needs.resolve.outputs.tag }}" dist/*.tar.gz dist/*_sbom.cdx.json \
+          set -euo pipefail
+          git fetch --force --tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          resolved_sha="$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}")"
+          if [ "$resolved_sha" != "$RELEASE_COMMIT_SHA" ]; then
+            echo "Release tag $RELEASE_TAG moved from $RELEASE_COMMIT_SHA to $resolved_sha"
+            exit 1
+          fi
+          gh release create "$RELEASE_TAG" dist/*.tar.gz dist/*_sbom.cdx.json \
             --repo "$GITHUB_REPOSITORY" \
-            --title "${{ needs.resolve.outputs.tag }}" \
-            --notes "Automated aiops-platform release for ${{ needs.resolve.outputs.tag }}" \
+            --title "$RELEASE_TAG" \
+            --notes "Automated aiops-platform release for $RELEASE_TAG" \
             --verify-tag


### PR DESCRIPTION
Closes #441

Linear issue: AIS-32 / a6d1c822-919a-4120-a216-b991ddfd0151

## Summary
- Resolve the release tag to an immutable `commit_sha` in the release workflow.
- Pass that SHA to the reusable CI workflow and release checkout.
- Validate release tags as strict `vMAJOR.MINOR.PATCH` before checkout/resolve.
- Avoid shell/CLI injection by passing tag/SHA values through environment variables in shell steps.
- Re-fetch and compare the tag target before build and immediately before `gh release create`.

## Acceptance Criteria Status
- Unresolved PR #426 review thread addressed: release checkout and CI now use the resolved immutable commit SHA instead of the mutable tag ref.
- Tag movement before publishing is checked explicitly immediately before release creation.
- Local review follow-up findings on tag shell/CLI injection and the final publish race were fixed in this head.

## Tests
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml` passed.
- `git diff --check HEAD` passed.
- `gh pr checks 457 --repo xrf9268-hue/aiops-platform --watch` passed: Go build and test, Security and supply-chain, E2E Gitea mock loop, Docker image build.
- Go tests not run locally: only GitHub Actions YAML changed.

## Local Review Results
- Reviewer A, Codex diff-only against `origin/main...HEAD` at `efb5a88ec585e898d90d7bc90f62194691f744bc`: no findings, `MERGE-READY`.
- Reviewer B, Codex diff-only against `origin/main...HEAD` at `efb5a88ec585e898d90d7bc90f62194691f744bc`: no findings, `MERGE-READY`.
- Earlier local review rounds found and fixed: shell injection from tag interpolation, dash-prefixed tag CLI option parsing, slash/glob tag path ambiguity, and final publish-time tag race.
- Claude Code unavailable in this Docker image, per dogfood instructions; two independent Codex reviewers were used instead.

## Post-push Review / Threads
- Fresh current-head `@codex review` trigger: https://github.com/xrf9268-hue/aiops-platform/pull/457#issuecomment-4545721028
- Trigger comment id: `4545721028`.
- Eyes appeared and cleared.
- Current-head GitHub Codex completion: https://github.com/xrf9268-hue/aiops-platform/pull/457#issuecomment-4545768213 reported no major issues.
- GraphQL `reviewThreads` for current head returned zero threads.

## Size Budget
- Changed files: 1, within policy limit 12.
- Changed LOC: 77 changed lines in `.github/workflows/release.yml`, within policy limit 300.

## Deferrals / Follow-ups
- None.

## Merge
- Squash-merged on 2026-05-26.
- Merge commit: `651d13bbb6b3b57436c827bba1f54dffc29b7bc2`.
- GitHub issue #441 is closed.

## Current Head
- `efb5a88ec585e898d90d7bc90f62194691f744bc`