### PR TITLE
Docs: update handle-issue build gate

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -50,7 +50,7 @@ gofmt -l $(git ls-files '*.go')          # 必须为空
 go mod tidy && git diff --exit-code -- go.mod go.sum
 go vet ./...
 go test -race -covermode=atomic ./...
-go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller
+go build ./cmd/worker ./cmd/tui
 ```
 **暂存只 add 明确路径，绝不 `git add -A` / `git add .`**（会把 `.codex/` 等本地未跟踪文件卷入 PR）。commit 前 `git status --short` 核对只暂存了预期文件。
 
@@ -85,7 +85,7 @@ go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller
 **硬路径 — #331（PR #339，多轮级联）**：running issue mid-run 转终态时未清理 workspace（§18.1）。破坏性 + 并发路径，经历 P1 数据丢失竞态 → P2 超时耦合（前一个修复引入的）→ P2 陈旧标志 → TOCTOU → P2 root 不匹配 的级联，每轮 `@codex review` 抓到新缺陷（含修复引入的）。每个修复配回归 + 变异测试；路由模式与 §16.5 self-stop 两处缺口延后到 #340/#341。→ 破坏性/并发路径要穷尽对抗式审查，且**每个 push 都重新 @codex review**。
 
 ## 验证（完成判定）
-- 本地门禁全绿：`gofmt -l $(git ls-files '*.go')` 为空、`go mod tidy` 后 `go.mod`/`go.sum` 无改动、`go vet ./...`、`go test -race -covermode=atomic ./...`、`go build ./cmd/worker ./cmd/linear-poller ./cmd/gitea-poller`。
+- 本地门禁全绿：`gofmt -l $(git ls-files '*.go')` 为空、`go mod tidy` 后 `go.mod`/`go.sum` 无改动、`go vet ./...`、`go test -race -covermode=atomic ./...`、`go build ./cmd/worker ./cmd/tui`。
 - 新测试经变异验证（删关键行 FAIL / 恢复 PASS）。
 - 每个已 push 的 head 都先经过提交后、push 前的 Codex + Claude Code 双 reviewer，或有明确人工签核的等价 fallback；HIGH/MEDIUM/Critical 已修复，未修复项必须有 push 前人工签核并在 PR body 记录风险。
 - CI 全绿：`gh pr checks <pr> --watch --fail-fast` 阻塞到完成。


### PR DESCRIPTION
Closes #438

Linear issue: 3017ccd6-b0c6-46ad-8f3a-bee457dc27bb / AIS-33

## Summary
- Updated `.claude/skills/handle-issue/SKILL.md` so the local gate builds the current binaries: `go build ./cmd/worker ./cmd/tui`.
- Updated the completion checklist to use the same current build command.
- Confirmed the handle-issue skill body no longer references removed `linear-poller` or `gitea-poller` commands.

## Acceptance Criteria
- [x] Local gate uses `go build ./cmd/worker ./cmd/tui`.
- [x] Completion checklist uses `go build ./cmd/worker ./cmd/tui`.
- [x] Stale `linear-poller` / `gitea-poller` references were searched in the skill body and removed.
- [x] Stable-commit-before-review guidance is unchanged.

## Verification
- `rg -n "linear-poller|gitea-poller" .claude/skills/handle-issue/SKILL.md` returned no matches.
- `rg -n "go build ./cmd/worker" .claude/skills/handle-issue/SKILL.md` shows both updated references.
- `go build ./cmd/worker ./cmd/tui`
- `git diff --check HEAD`

No regression test was added because this is a documentation-only skill command correction with no executable behavior changed.

## Local Reviews
- Codex diff-only review against `origin/main...HEAD` at `c4a77fa98c8adc94ec1616833e2887755c5971bf`: no blocking findings, `MERGE-READY`.
- Claude Code diff-only review attempted with `claude -p --no-session-persistence --tools ""`; unavailable in this container: `/bin/bash: line 1: claude: command not found`.

## CI / Remote Review
- CI: all reported checks passed on head `c4a77fa98c8adc94ec1616833e2887755c5971bf` (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`).
- `@codex review` trigger: https://github.com/xrf9268-hue/aiops-platform/pull/458#issuecomment-4544622710
- Codex completion: https://github.com/xrf9268-hue/aiops-platform/pull/458#issuecomment-4544642970 (`Didn't find any major issues.`)
- Review threads: GraphQL returned no review threads.

## Size Budget
- Changed files: 1 tracked file.
- Changed LOC: 2 insertions / 2 deletions.
- Within default policy budget.

## Deferrals / Follow-ups
- None.

## Risks
- Low. Documentation-only update to match current command entrypoints.

Current head SHA: `c4a77fa98c8adc94ec1616833e2887755c5971bf`