### PR TITLE
chore: make low-risk lint gate blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,13 @@ jobs:
             exit 1
           fi
 
-      - name: Run golangci-lint (report only)
+      - name: Run golangci-lint blocking correctness gate
+        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+        with:
+          version: v2.12.2
+          args: --config=.golangci.yml --enable-only=errorlint,ineffassign,unused
+
+      - name: Run golangci-lint report-only baseline
         uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
         with:
           version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 version: "2"
 
+# Full lint surface. CI runs the clean low-risk subset as blocking, then runs
+# this full set report-only while follow-up cleanup continues.
 run:
   timeout: 5m
 

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -37,17 +37,6 @@ func newLoopbackRequest(method, target string, body io.Reader) *http.Request {
 	return req
 }
 
-func samePath(a, b string) bool {
-	eval := func(path string) string {
-		resolved, err := filepath.EvalSymlinks(path)
-		if err != nil {
-			return path
-		}
-		return resolved
-	}
-	return eval(a) == eval(b)
-}
-
 func (f fakeReconcileTracker) ListIssuesByStates(_ context.Context, states []string) ([]tracker.Issue, error) {
 	want := map[string]struct{}{}
 	for _, state := range states {

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -25,7 +25,10 @@ Checks:
 - setup Go from `go.mod`
 - Go module download
 - `gofmt` check
-- report-only `golangci-lint` baseline for earned Go engineering rules
+- blocking `golangci-lint` correctness gate for `errorlint`, `ineffassign`,
+  and `unused`
+- report-only `golangci-lint` baseline for the remaining earned Go engineering
+  rules
 - `go mod tidy` check
 - `go test -race -covermode=atomic ./...`
 - build `worker` and `tui`
@@ -45,12 +48,13 @@ only if the rebuilt image still contains a fixed finding. Do not add a
 `.trivyignore` entry for a vulnerability that the package manager can already
 fix.
 
-The `golangci-lint` step is intentionally report-only for lint findings during
-the initial baseline. It runs with `--issues-exit-code=0` so CI surfaces
-`errorlint`, `contextcheck`, `funlen`, `gocognit`, and related findings without
-blocking existing debt. Configuration, action, or runtime failures still fail
-the workflow. New PRs should avoid adding reported violations; follow-up cleanup
-PRs can later tighten the gate once the baseline is below the agreed threshold.
+The `golangci-lint` gate runs in two phases. The first phase blocks on the
+clean low-risk linters (`errorlint`, `ineffassign`, and `unused`) so
+regressions in those classes fail CI. The second phase keeps the full
+earned-rule baseline visible with `--issues-exit-code=0` while the remaining
+classes (`contextcheck`, `errcheck`, `funlen`, `gocognit`, `gocritic`,
+`staticcheck`, and `unparam`) are burned down in follow-up cleanup.
+Configuration, action, or runtime failures still fail the workflow.
 
 ### Release
 
@@ -88,6 +92,7 @@ Run:
 ```bash
 go mod tidy
 gofmt -w cmd internal
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --enable-only=errorlint,ineffassign,unused
 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0
 go test ./...
 go build ./cmd/worker ./cmd/tui

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -347,16 +347,6 @@ func nonEmptyStateList(states []string) []string {
 	return out
 }
 
-func issueIDSet(issues []tracker.Issue) map[string]struct{} {
-	out := make(map[string]struct{}, len(issues))
-	for _, issue := range issues {
-		if issue.ID != "" {
-			out[issue.ID] = struct{}{}
-		}
-	}
-	return out
-}
-
 func issueMapIDSet(issues map[string]tracker.Issue) map[string]struct{} {
 	out := make(map[string]struct{}, len(issues))
 	for id := range issues {

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -110,7 +110,7 @@ func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
 		t.Fatalf("tool result leaked Gitea token: %q", result)
 	}
 
-	auth, _, _, body, requests := server.recorded()
+	auth, _, _, _, requests := server.recorded()
 	if requests != 3 {
 		t.Fatalf("requests = %d, want GET, DELETE, POST", requests)
 	}
@@ -124,7 +124,7 @@ func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
 	if paths[1] != "/api/v1/repos/owner/repo/issues/7/labels" || paths[2] != "/api/v1/repos/owner/repo/issues/7/labels/101" {
 		t.Fatalf("paths = %#v", paths)
 	}
-	body = bodies[1]
+	body := bodies[1]
 	if strings.Contains(body, token) || !strings.Contains(body, "aiops/in-progress") {
 		t.Fatalf("unexpected request body: %s", body)
 	}

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -317,7 +317,7 @@ func RunTask(ctx context.Context, ev EventEmitter, t task.Task, cfg Config) (ret
 		recordPolicyViolation(ctx, ev, t.ID, t.SourceEventID, err, feedback, feedbackPath, willRetry, feedbackErr, policyBudget)
 		WriteFailureArtifacts(ctx, workdir, nil, "policy check failed: "+ErrSummary(err))
 		if feedbackErr != nil {
-			return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("write policy violation feedback: %w; original policy error: %v", feedbackErr, err), NonRetryable: true}
+			return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("write policy violation feedback: %w; original policy error: %w", feedbackErr, err), NonRetryable: true}
 		}
 		if !willRetry {
 			return &RunTaskError{Cfg: wcfg, Err: fmt.Errorf("repeated policy violation after %d attempts: %w", feedback.Count, err), NonRetryable: true}

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -33,3 +33,36 @@ func TestCITrivyImageScanBlocksHighAndCriticalVulnerabilities(t *testing.T) {
 		}
 	}
 }
+
+func TestCIGolangCILintHasBlockingCorrectnessGate(t *testing.T) {
+	body, err := os.ReadFile("../.github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("ReadFile(ci.yml): %v", err)
+	}
+
+	text := string(body)
+	blockingStep := regexp.MustCompile(`(?s)- name: Run golangci-lint blocking correctness gate.*?(?:\n\n|$)`).FindString(text)
+	if blockingStep == "" {
+		t.Fatal("CI workflow missing blocking golangci-lint correctness gate")
+	}
+	for _, want := range []string{
+		"golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c",
+		"version: v2.12.2",
+		"args: --config=.golangci.yml --enable-only=errorlint,ineffassign,unused",
+	} {
+		if !strings.Contains(blockingStep, want) {
+			t.Fatalf("blocking golangci-lint step missing %q:\n%s", want, blockingStep)
+		}
+	}
+	if strings.Contains(blockingStep, "--issues-exit-code=0") {
+		t.Fatalf("blocking golangci-lint step must not be report-only:\n%s", blockingStep)
+	}
+
+	reportStep := regexp.MustCompile(`(?s)- name: Run golangci-lint report-only baseline.*?(?:\n\n|$)`).FindString(text)
+	if reportStep == "" {
+		t.Fatal("CI workflow missing report-only golangci-lint baseline step")
+	}
+	if !strings.Contains(reportStep, "args: --config=.golangci.yml --issues-exit-code=0") {
+		t.Fatalf("report-only golangci-lint step missing issues-exit-code=0:\n%s", reportStep)
+	}
+}

--- a/test/e2e/fixtures/ci_security_test.go
+++ b/test/e2e/fixtures/ci_security_test.go
@@ -35,34 +35,54 @@ func TestCIRunsSecurityScanning(t *testing.T) {
 	}
 }
 
-// TestCIRunsReportOnlyGoLint guards #413's rollout model: newly earned Go
-// engineering rules need a machine-visible golangci-lint gate, but the initial
-// baseline must be report-only so existing violations can be burned down in
-// follow-up PRs.
-func TestCIRunsReportOnlyGoLint(t *testing.T) {
+// TestCIRunsTwoPhaseGoLint guards #413/#433's rollout model: clean low-risk
+// linters block CI, while the remaining baseline stays visible as report-only.
+func TestCIRunsTwoPhaseGoLint(t *testing.T) {
 	ci := readCIWorkflow(t)
-	const stepName = "      - name: Run golangci-lint (report only)"
-	stepStart := strings.Index(ci, stepName)
-	if stepStart < 0 {
-		t.Fatalf("ci.yml is missing %q", stepName)
+
+	blocking := workflowStep(t, ci, "Run golangci-lint blocking correctness gate")
+	for _, want := range []string{
+		"golangci/golangci-lint-action@",
+		"version: v2.",
+		"--config=.golangci.yml",
+		"--enable-only=errorlint,ineffassign,unused",
+	} {
+		if !strings.Contains(blocking, want) {
+			t.Errorf("blocking golangci-lint step = %q, want marker %q", blocking, want)
+		}
 	}
-	step := ci[stepStart:]
-	if next := strings.Index(step[len(stepName):], "\n      - name:"); next >= 0 {
-		step = step[:len(stepName)+next]
+	if strings.Contains(blocking, "--issues-exit-code=0") {
+		t.Errorf("blocking golangci-lint step = %q, want no report-only marker", blocking)
 	}
+
+	reportOnly := workflowStep(t, ci, "Run golangci-lint report-only baseline")
 	for _, want := range []string{
 		"golangci/golangci-lint-action@",
 		"version: v2.",
 		"--config=.golangci.yml",
 		"--issues-exit-code=0",
 	} {
-		if !strings.Contains(step, want) {
-			t.Errorf("golangci-lint step is missing report-only marker %q", want)
+		if !strings.Contains(reportOnly, want) {
+			t.Errorf("report-only golangci-lint step = %q, want marker %q", reportOnly, want)
 		}
 	}
-	if strings.Contains(step, "continue-on-error") {
-		t.Errorf("golangci-lint step must not mask configuration or action failures with continue-on-error")
+	if strings.Contains(reportOnly, "continue-on-error") {
+		t.Errorf("report-only golangci-lint step = %q, want no continue-on-error", reportOnly)
 	}
+}
+
+func workflowStep(t *testing.T, workflow, name string) string {
+	t.Helper()
+	stepName := "      - name: " + name
+	stepStart := strings.Index(workflow, stepName)
+	if stepStart < 0 {
+		t.Fatalf("ci.yml is missing step %q", name)
+	}
+	step := workflow[stepStart:]
+	if next := strings.Index(step[len(stepName):], "\n      - name:"); next >= 0 {
+		step = step[:len(stepName)+next]
+	}
+	return step
 }
 
 // TestCIActionsArePinnedToSHA guards supply-chain hardening (#372): every


### PR DESCRIPTION
Closes #433

Linear issue: fcb69d97-9a82-4a07-8f62-42c7dfc39d5b (AIS-34)

## Summary

- Splits CI golangci-lint into a blocking low-risk gate and a report-only full baseline.
- Blocks `errorlint`, `ineffassign`, and `unused` by removing `--issues-exit-code=0` from that selected lint run.
- Fixes the current findings in those classes and adds script plus e2e fixture coverage.
- Updates the CI runbook with the two-phase lint gate.

## Acceptance Criteria

- [x] Re-ran and refreshed the current baseline: 112 findings before this PR, 108 report-only findings after.
- [x] Fixed selected low-risk findings: `errorlint`, `ineffassign`, and `unused`.
- [x] CI now blocks on `errorlint`, `ineffassign`, and `unused`.
- [x] Full baseline remains report-only for remaining classes without `continue-on-error`.
- [x] Fixture coverage prevents silently reverting the blocking step to report-only.
- [x] Deferrals are tracked in #459; larger complexity work remains related to #410.

## Tests

- Mutation check: `go test ./scripts -run TestCIGolangCILintHasBlockingCorrectnessGate -count=1` failed after adding `--issues-exit-code=0` to the blocking step, then passed after restore.
- `gofmt -l $(git ls-files '*.go')`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --enable-only=errorlint,ineffassign,unused`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go test ./scripts ./test/e2e/fixtures -run 'TestCI|TestCIRunsTwoPhaseGoLint' -count=1`
- `go test ./scripts ./internal/worker ./internal/orchestrator ./internal/runner ./cmd/worker -run 'TestCI|TestDynamicTools|TestBuildCodexAppServer|TestNewCodexAppServerRunner|TestParseShellFields|TestRunSecretScan|TestReleaseFailed' -count=1`
- `go test ./scripts ./internal/worker ./internal/orchestrator ./internal/tracker ./internal/workspace ./cmd/worker`
- `go vet ./...`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `git diff --check HEAD`

Full `go test ./internal/runner` could not be used locally because `python3` is not installed for codex app-server stub scripts; focused runner tests passed.

## Local Reviews

- Codex diff-only review on `e233f48d565140a0894e451acab81a18ef9f26bb` with function/import context: `MERGE-READY`.
- Claude Code unavailable: `claude: command not found`.

## Size Budget

- Changed files: 9 / 12.
- Diff stat: 93 insertions, 48 deletions / 300 LOC.

## Deferrals / Follow-ups

- #459 tracks remaining report-only lint classes: `contextcheck`, `errcheck`, `funlen`, `gocognit`, `gocritic`, `staticcheck`, and `unparam`.
- #410 remains the larger function/complexity decomposition tracker.

## CI / Review Status

- Previous CI run `26452755669` proved both new lint steps passed, then failed on a stale e2e fixture expectation; current head fixes that.
- Fresh CI run `26453074750` is green for `e233f48d565140a0894e451acab81a18ef9f26bb`.
- Current `@codex review` trigger: https://github.com/xrf9268-hue/aiops-platform/pull/460#issuecomment-4544814877

## Risks

- CI now runs golangci-lint twice, adding modest lint time.
- The full lint baseline still reports 108 findings by design; only the clean subset blocks here.

Current head SHA: `e233f48d565140a0894e451acab81a18ef9f26bb`