### PR TITLE
Fix Docker GitHub agent credential preflight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,24 @@ RUN set -eux; \
     ln -sf /opt/codex/bin/codex /usr/local/bin/codex; \
     rm -f /tmp/codex.tar.gz; \
     codex --version
+# gh CLI is required by the codex-worker image so the documented
+# `aiops-secret-entrypoint` path can wire `/run/secrets/github_token` into
+# `gh auth setup-git` and `worker --doctor --github-issue` can run inside the
+# container. The plain `worker` target does not need it.
+ARG GH_CLI_VERSION=2.92.0
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) gh_arch="linux_amd64"; gh_sha="b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4" ;; \
+      arm64) gh_arch="linux_arm64"; gh_sha="c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee" ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}; supported: amd64, arm64" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_${gh_arch}.tar.gz"; \
+    wget -qO /tmp/gh.tar.gz "${url}"; \
+    echo "${gh_sha}  /tmp/gh.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tar.gz -C /tmp; \
+    install -m 0755 "/tmp/gh_${GH_CLI_VERSION}_${gh_arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_CLI_VERSION}_${gh_arch}"; \
+    gh --version
 USER ${AIOPS_UID}:${AIOPS_GID}
 
 # Keep `docker build .` on the baseline worker image; codex-worker is opt-in.

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -62,6 +62,8 @@ func parseDoctorArgs(args []string) (doctor.Options, error) {
 	fs := flag.NewFlagSet("worker --doctor", flag.ContinueOnError)
 	mode := fs.String("mode", "mock", "preflight depth: mock or real")
 	dashboardURL := fs.String("dashboard-url", "", "optional worker dashboard base URL to verify /api/v1/state auth")
+	githubIssue := fs.Int("github-issue", 0, "optional GitHub issue number for agent-environment gh and git push preflight")
+	githubRepo := fs.String("github-repo", "", "optional owner/name repo for --github-issue when a workflow configures multiple GitHub repos")
 	if err := fs.Parse(reorderDoctorFlags(args)); err != nil {
 		return doctor.Options{}, err
 	}
@@ -75,7 +77,7 @@ func parseDoctorArgs(args []string) (doctor.Options, error) {
 	if fs.NArg() == 1 {
 		path = fs.Arg(0)
 	}
-	return doctor.Options{WorkflowPath: path, Mode: *mode, DashboardURL: *dashboardURL, Stdout: os.Stdout, Stderr: os.Stderr}, nil
+	return doctor.Options{WorkflowPath: path, Mode: *mode, DashboardURL: *dashboardURL, GitHubIssue: *githubIssue, GitHubRepo: *githubRepo, Stdout: os.Stdout, Stderr: os.Stderr}, nil
 }
 
 func reorderDoctorFlags(args []string) []string {
@@ -86,7 +88,7 @@ func reorderDoctorFlags(args []string) []string {
 		case a == "--":
 			positional = append(positional, append([]string{"--"}, args[i+1:]...)...)
 			i = len(args)
-		case a == "--mode" || a == "-mode" || a == "--dashboard-url" || a == "-dashboard-url":
+		case a == "--mode" || a == "-mode" || a == "--dashboard-url" || a == "-dashboard-url" || a == "--github-issue" || a == "-github-issue" || a == "--github-repo" || a == "-github-repo":
 			flags = append(flags, a)
 			if i+1 < len(args) {
 				flags = append(flags, args[i+1])

--- a/deploy/aiops-secret-entrypoint.sh
+++ b/deploy/aiops-secret-entrypoint.sh
@@ -13,6 +13,21 @@ if [ -s /run/secrets/aiops_state_api_token ]; then
   export AIOPS_STATE_API_TOKEN="$(cat /run/secrets/aiops_state_api_token)"
 fi
 
+if [ -s /run/secrets/github_token ]; then
+  home="${HOME:-/home/aiops}"
+  mkdir -p "$home/.config/gh"
+  chmod 0700 "$home/.config" "$home/.config/gh"
+  {
+    printf 'github.com:\n'
+    printf '    git_protocol: https\n'
+    printf '    oauth_token: %s\n' "$(cat /run/secrets/github_token)"
+  } > "$home/.config/gh/hosts.yml"
+  chmod 0600 "$home/.config/gh/hosts.yml"
+  if command -v gh >/dev/null 2>&1; then
+    gh auth setup-git -h github.com >/dev/null 2>&1 || true
+  fi
+fi
+
 if [ "$#" -eq 0 ]; then
   set -- worker
 elif [ "${1#-}" != "$1" ]; then

--- a/deploy/docker-compose.codex.yml
+++ b/deploy/docker-compose.codex.yml
@@ -21,7 +21,9 @@ services:
       # Clear plain-env tokens inherited from the base local-dev compose file;
       # this production-style overlay feeds them through service secrets below.
       AIOPS_STATE_API_TOKEN: ""
+      GH_TOKEN: ""
       GITEA_TOKEN: ""
+      GITHUB_TOKEN: ""
       LINEAR_API_KEY: ""
     entrypoint:
       - /usr/local/bin/aiops-secret-entrypoint
@@ -33,6 +35,7 @@ services:
     secrets:
       - linear_api_key
       - gitea_token
+      - github_token
       - aiops_state_api_token
 
 secrets:
@@ -40,5 +43,7 @@ secrets:
     file: ${LINEAR_API_KEY_FILE:?set LINEAR_API_KEY_FILE to a file containing the Linear API key}
   gitea_token:
     file: ${GITEA_TOKEN_FILE:-/dev/null}
+  github_token:
+    file: ${GITHUB_TOKEN_FILE:-/dev/null}
   aiops_state_api_token:
     file: ${AIOPS_STATE_API_TOKEN_FILE:?set AIOPS_STATE_API_TOKEN_FILE to a file containing the state API token}

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -118,6 +118,48 @@ should remain running on stdio until the worker speaks JSON-RPC to it.
 sending `initialize`, and waiting for a JSON-RPC response. A probe that only
 starts the process and closes stdin is not a valid app-server check.
 
+## GitHub agent credentials
+
+Dogfood workflows that expect the agent shell to run `gh` or push GitHub
+branches need credentials visible from the agent environment. Worker process
+variables such as `GH_TOKEN` and `GITHUB_TOKEN` are stripped before Codex
+subprocesses start, so they are not a supported credential contract.
+
+The Docker overlay supports file-backed `gh` auth for the unprivileged `aiops`
+user:
+
+```bash
+printf '%s' 'replace-with-least-privilege-github-token' > .aiops/secrets/github_token
+chmod 600 .aiops/secrets/github_token
+```
+
+```text
+GITHUB_TOKEN_FILE=$PWD/.aiops/secrets/github_token
+```
+
+The entrypoint writes `/home/aiops/.config/gh/hosts.yml` with `0600`
+permissions, clears plain GitHub token env, and runs `gh auth setup-git` when
+`gh` is installed. Keep the token least-privilege and never commit
+`.aiops/secrets`, `hosts.yml`, or copied credential files. For deploy-key
+installs, mount the dedicated key and `known_hosts` from `deploy/ssh/README.md`
+and use an SSH `repo.clone_url`.
+
+Validate the exact agent environment before moving real issues into an active
+state:
+
+```bash
+docker compose --env-file .env \
+  -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.codex.yml \
+  run --rm worker --doctor --mode=real --github-issue 451 \
+    --github-repo xrf9268-hue/aiops-platform
+```
+
+With `--github-issue`, doctor runs `gh issue view` and `git push --dry-run`
+using the Codex agent environment. Omit `--github-repo` only when the workflow
+configures one GitHub repo. A failure is a deployment blocker; fix the
+credential path before starting the worker.
+
 The supported Compose overlay uses a writable bind for `CODEX_HOME` because
 Codex 0.133 writes while loading configuration and may refresh auth state.
 Use a restricted directory owned by the worker UID/GID. A read-only copy is

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -138,11 +138,15 @@ GITHUB_TOKEN_FILE=$PWD/.aiops/secrets/github_token
 ```
 
 The entrypoint writes `/home/aiops/.config/gh/hosts.yml` with `0600`
-permissions, clears plain GitHub token env, and runs `gh auth setup-git` when
-`gh` is installed. Keep the token least-privilege and never commit
-`.aiops/secrets`, `hosts.yml`, or copied credential files. For deploy-key
-installs, mount the dedicated key and `known_hosts` from `deploy/ssh/README.md`
-and use an SSH `repo.clone_url`.
+permissions, clears plain GitHub token env, and runs `gh auth setup-git`. The
+`codex-worker` Dockerfile target installs the GitHub CLI alongside Codex so
+`worker --doctor --github-issue` and runtime `git push` can both use the
+file-backed credential; under that image the `command -v gh` guard in the
+entrypoint always passes. The plain `worker` target does not ship `gh` and
+that guard stays a no-op there, by design. Keep the token least-privilege
+and never commit `.aiops/secrets`, `hosts.yml`, or copied credential files.
+For deploy-key installs, mount the dedicated key and `known_hosts` from
+`deploy/ssh/README.md` and use an SSH `repo.clone_url`.
 
 Validate the exact agent environment before moving real issues into an active
 state:

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -11,6 +11,7 @@ aiops-platform with Docker, Linear, and `codex app-server`.
 | Linux amd64 Docker worker | Build `Dockerfile` target `codex-worker`; Codex CLI `0.133.0` is installed from a pinned release artifact and checksum. | Use base `worker` target for mock-only validation. | Online installer is not the promoted Docker path until Linux ARM64 checksum behavior is reliable. |
 | Linux arm64 Docker worker | Build `codex-worker`; uses the pinned `aarch64-unknown-linux-musl` release artifact and checksum. | Same as above. | `curl https://chatgpt.com/codex/install.sh \| sh` failed on 2026-05-26 because the installer could not find the ARM64 package checksum. |
 | Codex auth | Mount a restricted writable `CODEX_HOME` directory into `/home/aiops/.codex` for Codex CLI 0.133; verify with `worker --doctor --mode=real`. | Local host development can use the normal host `~/.codex`; read-only copies are only suitable for archival inspection or future no-write smoke modes. | Passing raw bearer tokens on command lines or in logs is not supported. |
+| GitHub agent auth | File-backed `gh` auth from a Docker secret, or a dedicated SSH deploy key, visible to the `aiops` user and verified with `worker --doctor --mode=real --github-issue <n>`. | Read-only issue-only tokens are enough for analysis-only smoke tests; branch push validation needs write-capable repo credentials. | `GH_TOKEN`/`GITHUB_TOKEN` in the worker environment are stripped from agent subprocesses and are not a valid dogfood credential contract. |
 | Linear auth | Personal API key in a Docker Compose secret file. Linear expects `Authorization: <API_KEY>` for personal keys. | Local development may use `LINEAR_API_KEY` in `.env`; do not use this for production-style examples. | OAuth app-actor is documented by Linear and is the intended future service-account path, but aiops-platform still accepts a single `tracker.api_key` string today. |
 | Sandbox | Mock mode works under the base hardened container. Real Codex Docker validation uses a Docker-isolated profile and explicit `codex.thread_sandbox: danger-full-access` only inside that container boundary. | Enable kernel/user namespace support and keep Codex `workspace-write` if your container profile permits it. | Do not copy `danger-full-access` to a shared host run. |
 
@@ -37,6 +38,7 @@ Official references checked for this path:
 mkdir -p .aiops/secrets .aiops/codex-home
 cp examples/WORKFLOW.md .aiops/WORKFLOW.md
 printf '%s' 'replace-with-linear-personal-key' > .aiops/secrets/linear_api_key
+printf '%s' 'replace-with-least-privilege-github-token' > .aiops/secrets/github_token
 openssl rand -hex 24 > .aiops/secrets/state_api_token
 ```
 
@@ -69,6 +71,7 @@ cat > .env <<EOF
 AIOPS_WORKFLOW_PATH=$PWD/.aiops/WORKFLOW.md
 AIOPS_CODEX_HOME_PATH=$PWD/.aiops/codex-home
 LINEAR_API_KEY_FILE=$PWD/.aiops/secrets/linear_api_key
+GITHUB_TOKEN_FILE=$PWD/.aiops/secrets/github_token
 # Optional: only if this deployment still needs a Gitea API token.
 # GITEA_TOKEN_FILE=$PWD/.aiops/secrets/gitea_token
 AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token
@@ -77,11 +80,14 @@ AIOPS_GID=$(id -g)
 EOF
 ```
 
-The Codex overlay reads Linear, optional Gitea, and dashboard tokens from Docker
-secret files. The Codex home is a writable bind because Codex CLI 0.133 writes
-while loading configuration and may persist refreshed auth state. Keep this
-directory restricted to the worker UID/GID and do not point it at a shared host
-home unless that is your intended trust boundary.
+The Codex overlay reads Linear, GitHub, optional Gitea, and dashboard tokens
+from Docker secret files. The entrypoint converts the GitHub secret into
+`/home/aiops/.config/gh/hosts.yml` with restrictive permissions and clears
+plain `GH_TOKEN`/`GITHUB_TOKEN` environment variables so the preflight matches
+the agent shell. The Codex home is a writable bind because Codex CLI 0.133
+writes while loading configuration and may persist refreshed auth state. Keep
+these directories restricted to the worker UID/GID and do not point them at a
+shared host home unless that is your intended trust boundary.
 
 ## 3. Run preflight
 
@@ -97,7 +103,8 @@ Docker real preflight:
 docker compose --env-file .env \
   -f deploy/docker-compose.yml \
   -f deploy/docker-compose.codex.yml \
-  run --rm worker --doctor --mode=real
+  run --rm worker --doctor --mode=real --github-issue 451 \
+    --github-repo xrf9268-hue/aiops-platform
 ```
 
 Expected output is action-oriented:
@@ -116,7 +123,10 @@ Docker/Codex paths that are not needed by the mock runner. On the host,
 `--mode=real` also checks Docker Compose. Inside the Docker worker it skips the
 host Docker CLI check and validates live Linear auth/project visibility, Codex
 CLI version, Codex login status, and a minimal `codex app-server` JSON-RPC
-probe.
+probe. When `--github-issue` is set, it also validates `gh issue view` and
+`git push --dry-run` from the exact Codex agent environment. Omit
+`--github-repo` only for single-repo workflows; multi-service workflows must
+name the target repo so the preflight cannot validate the wrong route.
 
 ## 4. Run a todo smoke
 
@@ -185,5 +195,7 @@ branch names are derived from issue ids and can collide.
 | `FAIL Linear auth` | Personal keys must be sent raw, not as `Bearer`; confirm the token can see `tracker.project_slug`. |
 | `FAIL Codex CLI` | Build the `codex-worker` target or install Codex on the host. |
 | `FAIL Codex auth` | Run `codex --login` for the same `CODEX_HOME` and container user context. |
+| `FAIL GitHub agent gh auth` | Set `GITHUB_TOKEN_FILE` to a least-privilege token file or mount a deploy key; do not rely on `GH_TOKEN`/`GITHUB_TOKEN` in the worker environment. |
+| `FAIL GitHub agent git push` | Run the documented doctor command from the container and fix `gh auth setup-git` or deploy-key write access for the target repo. |
 | `WARN Codex sandbox` | Either use the documented Docker-isolated profile for real smoke validation or enable the kernel/user namespace support required by Codex `workspace-write`. |
 | smoke timeout | Confirm a disposable issue is in an active state, `/readyz` is healthy, and `tracker.active_states` matches the Linear board. |

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -501,6 +501,18 @@ func defaultRunner(ctx context.Context, name string, args []string, env []string
 		cmd.Env = os.Environ()
 	} else {
 		cmd.Env = env
+		// exec.CommandContext resolves a bare name against the worker's PATH.
+		// For the GitHub agent preflight to be authoritative, re-resolve the
+		// lookup against the PATH that the agent will actually see in cmd.Env,
+		// and overwrite both cmd.Path and cmd.Err (set by the worker-PATH probe).
+		if !strings.ContainsRune(name, os.PathSeparator) {
+			resolved, lookErr := lookPathInEnv(name, env)
+			if lookErr != nil {
+				return nil, lookErr
+			}
+			cmd.Path = resolved
+			cmd.Err = nil
+		}
 	}
 	cmd.Stdin = stdin
 	out, err := cmd.CombinedOutput()
@@ -508,6 +520,34 @@ func defaultRunner(ctx context.Context, name string, args []string, env []string
 		return out, ctx.Err()
 	}
 	return out, err
+}
+
+// lookPathInEnv resolves name against the PATH entry in env, mirroring
+// exec.LookPath's executable-bit check on Unix without touching process state.
+func lookPathInEnv(name string, env []string) (string, error) {
+	var pathVal string
+	for _, kv := range env {
+		if rest, ok := strings.CutPrefix(kv, "PATH="); ok {
+			pathVal = rest
+		}
+	}
+	if pathVal == "" {
+		return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+	}
+	for _, dir := range filepath.SplitList(pathVal) {
+		if dir == "" {
+			dir = "."
+		}
+		candidate := filepath.Join(dir, name)
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
 }
 
 func requiresCodex(cfg workflow.Config) bool {
@@ -591,12 +631,21 @@ func selectGitHubRepo(cfg workflow.Config, target string) (githubRepo, error) {
 
 func githubRepos(cfg workflow.Config) []githubRepo {
 	repos := make([]githubRepo, 0, 1+len(cfg.Services))
-	if repo, ok := githubRepoFromConfig(cfg.Repo); ok {
+	seen := make(map[string]bool, 1+len(cfg.Services))
+	add := func(repo githubRepo) {
+		key := strings.ToLower(repo.fullName())
+		if seen[key] {
+			return
+		}
+		seen[key] = true
 		repos = append(repos, repo)
+	}
+	if repo, ok := githubRepoFromConfig(cfg.Repo); ok {
+		add(repo)
 	}
 	for _, service := range cfg.Services {
 		if repo, ok := githubRepoFromConfig(service.Repo); ok {
-			repos = append(repos, repo)
+			add(repo)
 		}
 	}
 	return repos

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,6 +41,8 @@ type Options struct {
 	WorkflowPath string
 	Mode         string
 	DashboardURL string
+	GitHubIssue  int
+	GitHubRepo   string
 	Stdout       io.Writer
 	Stderr       io.Writer
 	Runner       CommandRunner
@@ -73,6 +76,7 @@ func BuildReport(ctx context.Context, opts Options) Report {
 	if wf != nil {
 		r.checkLinear(ctx, wf.Config)
 		r.checkCodex(ctx, wf.Config)
+		r.checkGitHubAgent(ctx, wf.Config)
 		r.checkSandbox(wf.Config)
 	}
 	r.checkDashboard(ctx)
@@ -235,6 +239,59 @@ func (r *reportBuilder) checkSandbox(cfg workflow.Config) {
 		return
 	}
 	r.pass("Codex sandbox", "selected profile is compatible with this preflight")
+}
+
+func (r *reportBuilder) checkGitHubAgent(ctx context.Context, cfg workflow.Config) {
+	if r.opts.GitHubIssue == 0 {
+		return
+	}
+	if !requiresCodex(cfg) {
+		r.warn("GitHub agent credentials", "not checked because the selected agent is not Codex", "Use --github-issue only with a Codex workflow that expects agent-side GitHub access.")
+		return
+	}
+	repo, err := selectGitHubRepo(cfg, r.opts.GitHubRepo)
+	if err != nil {
+		r.fail("GitHub agent credentials", err.Error(), "Set repo.owner, repo.name, and repo.clone_url, or pass --github-repo owner/name for the GitHub repository the agent will access.")
+		return
+	}
+	env := runner.AgentEnvForPreflight(cfg.Agent.Default, cfg)
+	if out, err := r.runEnv(ctx, "gh", []string{"issue", "view", strconv.Itoa(r.opts.GitHubIssue), "--repo", repo.fullName(), "--json", "number,title,url"}, env); err != nil {
+		r.fail("GitHub agent gh auth", safeCommandFailure("gh issue view", out, err), "Create file-backed gh auth for the aiops user; do not rely on GH_TOKEN/GITHUB_TOKEN in the worker environment.")
+		return
+	}
+	r.pass("GitHub agent gh auth", fmt.Sprintf("agent env can read %s#%d", repo.fullName(), r.opts.GitHubIssue))
+	probeDir, cleanup, err := r.prepareGitPushProbe(ctx, env)
+	if err != nil {
+		r.fail("GitHub agent git push", err.Error(), "Create a writable temporary directory for the doctor git probe.")
+		return
+	}
+	defer cleanup()
+	if out, err := r.runEnv(ctx, "git", []string{"-C", probeDir, "push", "--dry-run", repo.CloneURL, "HEAD:refs/heads/aiops-doctor-preflight"}, env); err != nil {
+		r.fail("GitHub agent git push", safeCommandFailure("git push --dry-run", out, err), "Configure deploy-key or gh git credential-helper access for the aiops user, then rerun worker --doctor --mode=real --github-issue.")
+		return
+	}
+	r.pass("GitHub agent git push", "agent env passed git push --dry-run")
+}
+
+func (r *reportBuilder) prepareGitPushProbe(ctx context.Context, env []string) (string, func(), error) {
+	dir, err := os.MkdirTemp("", "aiops-doctor-git-*")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	steps := [][]string{
+		{"-C", dir, "init", "-q"},
+		{"-C", dir, "config", "user.email", "aiops-doctor@example.invalid"},
+		{"-C", dir, "config", "user.name", "aiops doctor"},
+		{"-C", dir, "commit", "--allow-empty", "-m", "aiops doctor preflight", "-q"},
+	}
+	for _, args := range steps {
+		if out, err := r.runEnv(ctx, "git", args, env); err != nil {
+			cleanup()
+			return "", func() {}, fmt.Errorf("%s", safeCommandFailure("git "+strings.Join(args, " "), out, err))
+		}
+	}
+	return dir, cleanup, nil
 }
 
 func (r *reportBuilder) checkDashboard(ctx context.Context) {
@@ -416,6 +473,12 @@ func (r *reportBuilder) run(ctx context.Context, name string, args []string) ([]
 	return r.opts.Runner(runCtx, name, args, nil, nil)
 }
 
+func (r *reportBuilder) runEnv(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+	runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return r.opts.Runner(runCtx, name, args, env, nil)
+}
+
 func (r *reportBuilder) pass(name, detail string) {
 	r.add(Pass, name, detail, "")
 }
@@ -434,7 +497,11 @@ func (r *reportBuilder) add(status Status, name, detail, fix string) {
 
 func defaultRunner(ctx context.Context, name string, args []string, env []string, stdin io.Reader) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = append(os.Environ(), env...)
+	if env == nil {
+		cmd.Env = os.Environ()
+	} else {
+		cmd.Env = env
+	}
 	cmd.Stdin = stdin
 	out, err := cmd.CombinedOutput()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -492,6 +559,72 @@ func workflowCloneURLs(cfg workflow.Config) []string {
 	return urls
 }
 
+type githubRepo struct {
+	Owner    string
+	Name     string
+	CloneURL string
+}
+
+func (r githubRepo) fullName() string {
+	return r.Owner + "/" + r.Name
+}
+
+func selectGitHubRepo(cfg workflow.Config, target string) (githubRepo, error) {
+	repos := githubRepos(cfg)
+	target = strings.TrimSpace(target)
+	if target != "" {
+		for _, repo := range repos {
+			if strings.EqualFold(repo.fullName(), target) {
+				return repo, nil
+			}
+		}
+		return githubRepo{}, fmt.Errorf("github repo %q not found in workflow", target)
+	}
+	if len(repos) == 0 {
+		return githubRepo{}, fmt.Errorf("no GitHub repo owner/name and clone_url found in workflow")
+	}
+	if len(repos) > 1 {
+		return githubRepo{}, fmt.Errorf("multiple GitHub repos configured; pass --github-repo owner/name")
+	}
+	return repos[0], nil
+}
+
+func githubRepos(cfg workflow.Config) []githubRepo {
+	repos := make([]githubRepo, 0, 1+len(cfg.Services))
+	if repo, ok := githubRepoFromConfig(cfg.Repo); ok {
+		repos = append(repos, repo)
+	}
+	for _, service := range cfg.Services {
+		if repo, ok := githubRepoFromConfig(service.Repo); ok {
+			repos = append(repos, repo)
+		}
+	}
+	return repos
+}
+
+func githubRepoFromConfig(repo workflow.RepoConfig) (githubRepo, bool) {
+	owner := strings.TrimSpace(repo.Owner)
+	name := strings.TrimSpace(repo.Name)
+	cloneURL := strings.TrimSpace(repo.CloneURL)
+	if owner == "" || name == "" || cloneURL == "" || !isGitHubCloneURL(cloneURL) {
+		return githubRepo{}, false
+	}
+	return githubRepo{Owner: owner, Name: name, CloneURL: cloneURL}, true
+}
+
+func isGitHubCloneURL(raw string) bool {
+	cloneURL := strings.TrimSpace(raw)
+	if strings.Contains(cloneURL, "://") {
+		u, err := url.Parse(cloneURL)
+		if err != nil || !strings.EqualFold(u.Hostname(), "github.com") {
+			return false
+		}
+		scheme := strings.ToLower(u.Scheme)
+		return scheme == "https" || scheme == "ssh" || scheme == "git+ssh"
+	}
+	return strings.HasPrefix(strings.ToLower(cloneURL), "git@github.com:")
+}
+
 func cloneURLNeedsSSH(raw string) bool {
 	cloneURL := strings.TrimSpace(raw)
 	if cloneURL == "" {
@@ -533,6 +666,18 @@ func trimOutput(out []byte, err error) string {
 		msg = err.Error()
 	}
 	return msg
+}
+
+func safeCommandFailure(command string, out []byte, err error) string {
+	_ = out
+	var detail string
+	if err != nil {
+		detail = err.Error()
+	}
+	if detail == "" {
+		return command + " failed"
+	}
+	return command + " failed: " + detail
 }
 
 func firstLine(out []byte) string {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 func TestBuildReportMockModeCatchesMissingLinearKeyDuringWorkflowLoad(t *testing.T) {
@@ -159,6 +161,98 @@ func TestBuildReportRealModeSkipsCodexForMockAgent(t *testing.T) {
 	}
 }
 
+func TestBuildReportGitHubAgentPreflightUsesAgentEnvironment(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "worker-token-must-not-leak")
+	path := writeGitHubWorkflow(t, "codex")
+	var checked []string
+	runner := func(_ context.Context, name string, args []string, env []string, _ io.Reader) ([]byte, error) {
+		switch name {
+		case "docker":
+			return []byte("ok\n"), nil
+		case "codex":
+			if len(args) > 0 && args[0] == "--version" {
+				return []byte("codex-cli 0.133.0\n"), nil
+			}
+			if len(args) > 1 && args[0] == "login" && args[1] == "status" {
+				return []byte("Logged in\n"), nil
+			}
+			return nil, errors.New("unexpected codex command")
+		case "gh", "git":
+			joinedEnv := strings.Join(env, "\n")
+			if strings.Contains(joinedEnv, "GITHUB_TOKEN=") || strings.Contains(joinedEnv, "GH_TOKEN=") {
+				t.Fatalf("%s env leaked worker GitHub token:\n%s", name, joinedEnv)
+			}
+			if !strings.Contains(joinedEnv, "HOME=") || !strings.Contains(joinedEnv, "PATH=") {
+				t.Fatalf("%s env = %q; want agent baseline HOME and PATH", name, joinedEnv)
+			}
+			checked = append(checked, name+" "+strings.Join(args, " "))
+			return []byte("ok\n"), nil
+		default:
+			return nil, errors.New("unexpected command")
+		}
+	}
+
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		GitHubIssue:  451,
+		Runner:       runner,
+	})
+
+	for _, name := range []string{"GitHub agent gh auth", "GitHub agent git push"} {
+		if got := findCheck(t, report, name).Status; got != Pass {
+			t.Fatalf("%s status = %s; want PASS", name, got)
+		}
+	}
+	if len(checked) != 6 {
+		t.Fatalf("checked commands = %#v; want gh plus five git probe commands", checked)
+	}
+	if checked[0] != "gh issue view 451 --repo xrf9268-hue/aiops-platform --json number,title,url" {
+		t.Fatalf("first checked command = %q; want gh issue view", checked[0])
+	}
+	if !strings.Contains(checked[5], " push --dry-run https://github.com/xrf9268-hue/aiops-platform.git HEAD:refs/heads/aiops-doctor-preflight") {
+		t.Fatalf("final checked command = %q; want git push dry-run", checked[5])
+	}
+}
+
+func TestSafeCommandFailureOmitsCommandOutput(t *testing.T) {
+	detail := safeCommandFailure("git push --dry-run", []byte("fatal: https://secret@github.com/o/r.git\n"), errors.New("exit status 128"))
+	if strings.Contains(detail, "secret") || strings.Contains(detail, "github.com/o/r") {
+		t.Fatalf("safeCommandFailure leaked command output: %q", detail)
+	}
+	if !strings.Contains(detail, "git push --dry-run failed") {
+		t.Fatalf("safeCommandFailure = %q; want command failure detail", detail)
+	}
+}
+
+func TestSelectGitHubRepoRequiresExplicitTargetForMultiRepoWorkflow(t *testing.T) {
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{
+			Owner:    "owner",
+			Name:     "primary",
+			CloneURL: "https://github.com/owner/primary.git",
+		},
+		Services: []workflow.ServiceConfig{{
+			Repo: workflow.RepoConfig{
+				Owner:    "owner",
+				Name:     "service",
+				CloneURL: "https://github.com/owner/service.git",
+			},
+		}},
+	}
+
+	if _, err := selectGitHubRepo(cfg, ""); err == nil || !strings.Contains(err.Error(), "multiple GitHub repos") {
+		t.Fatalf("selectGitHubRepo without target error = %v; want multiple repo error", err)
+	}
+	repo, err := selectGitHubRepo(cfg, "owner/service")
+	if err != nil {
+		t.Fatalf("selectGitHubRepo explicit target: %v", err)
+	}
+	if repo.fullName() != "owner/service" {
+		t.Fatalf("selected repo = %q; want owner/service", repo.fullName())
+	}
+}
+
 func TestBuildReportFailsCodexAppServerErrorResponse(t *testing.T) {
 	wrapper := installFakeCodexWrapperBody(t, `#!/bin/sh
 if [ "$1" = "app-server" ]; then
@@ -185,19 +279,20 @@ exit 1
 }
 
 func TestBuildReportRealModeKeepsCodexAppServerProbeStdinOpen(t *testing.T) {
-	wrapper := installFakeCodexWrapperBody(t, `#!/usr/bin/env python3
-import json, select, sys
-
-if len(sys.argv) > 1 and sys.argv[1] == "app-server":
-    _ = sys.stdin.readline()
-    ready, _, _ = select.select([sys.stdin], [], [], 0.2)
-    if ready and sys.stdin.readline() == "":
-        print(json.dumps({"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"stdin closed during probe"}}), flush=True)
-        sys.exit(0)
-    print(json.dumps({"jsonrpc":"2.0","id":1,"result":{"ok":True}}), flush=True)
-    sys.exit(0)
-
-sys.exit(1)
+	wrapper := installFakeCodexWrapperBody(t, `#!/bin/sh
+if [ "$1" = "app-server" ]; then
+  read line
+  tmp="$(mktemp)"
+  if timeout 0.2 cat >"$tmp"; then
+    rm -f "$tmp"
+    echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"stdin closed during probe"}}'
+    exit 0
+  fi
+  rm -f "$tmp"
+  echo '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}'
+  exit 0
+fi
+exit 1
 `)
 	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server")
 	report := BuildReport(context.Background(), Options{
@@ -404,6 +499,30 @@ agent:
   default: codex-app-server
 codex:
   command: ` + command + `
+---
+prompt
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	return path
+}
+
+func writeGitHubWorkflow(t *testing.T, agent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: xrf9268-hue
+  name: aiops-platform
+  clone_url: https://github.com/xrf9268-hue/aiops-platform.git
+tracker:
+  kind: gitea
+  api_key: token
+  project_slug: platform
+agent:
+  default: ` + agent + `
 ---
 prompt
 `

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -250,6 +251,71 @@ func TestSelectGitHubRepoRequiresExplicitTargetForMultiRepoWorkflow(t *testing.T
 	}
 	if repo.fullName() != "owner/service" {
 		t.Fatalf("selected repo = %q; want owner/service", repo.fullName())
+	}
+}
+
+func TestSelectGitHubRepoDeduplicatesIdenticalRepoEntries(t *testing.T) {
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{
+			Owner:    "owner",
+			Name:     "primary",
+			CloneURL: "https://github.com/owner/primary.git",
+		},
+		Services: []workflow.ServiceConfig{
+			{
+				Repo: workflow.RepoConfig{
+					Owner:    "Owner",
+					Name:     "Primary",
+					CloneURL: "https://github.com/Owner/Primary.git",
+				},
+			},
+			{
+				Repo: workflow.RepoConfig{
+					Owner:    "owner",
+					Name:     "primary",
+					CloneURL: "https://github.com/owner/primary.git",
+				},
+			},
+		},
+	}
+
+	repo, err := selectGitHubRepo(cfg, "")
+	if err != nil {
+		t.Fatalf("selectGitHubRepo(cfg, \"\") = %v; want single repo after dedup", err)
+	}
+	if repo.fullName() != "owner/primary" {
+		t.Fatalf("selectGitHubRepo full name = %q; want owner/primary", repo.fullName())
+	}
+}
+
+func TestDefaultRunnerResolvesBinaryAgainstSuppliedEnvPATH(t *testing.T) {
+	envDir := t.TempDir()
+	envBin := filepath.Join(envDir, "agentonly")
+	if err := os.WriteFile(envBin, []byte("#!/bin/sh\necho from-env\n"), 0o700); err != nil {
+		t.Fatalf("write env-only binary: %v", err)
+	}
+
+	workerDir := t.TempDir()
+	workerBin := filepath.Join(workerDir, "workeronly")
+	if err := os.WriteFile(workerBin, []byte("#!/bin/sh\necho from-worker\n"), 0o700); err != nil {
+		t.Fatalf("write worker-only binary: %v", err)
+	}
+	t.Setenv("PATH", workerDir)
+
+	out, err := defaultRunner(context.Background(), "agentonly", nil, []string{"PATH=" + envDir}, nil)
+	if err != nil {
+		t.Fatalf("defaultRunner(agentonly) = %v; want success using env PATH", err)
+	}
+	if strings.TrimSpace(string(out)) != "from-env" {
+		t.Fatalf("defaultRunner(agentonly) stdout = %q; want from-env", string(out))
+	}
+
+	_, err = defaultRunner(context.Background(), "workeronly", nil, []string{"PATH=" + envDir}, nil)
+	if err == nil {
+		t.Fatalf("defaultRunner(workeronly) err = nil; want not-found because env PATH excludes worker binary")
+	}
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("defaultRunner(workeronly) err = %v; want exec.ErrNotFound (worker PATH must not leak)", err)
 	}
 }
 

--- a/internal/runner/env.go
+++ b/internal/runner/env.go
@@ -25,6 +25,20 @@ func agentEnv(passthrough []string, cfg workflow.Config) []string {
 	return agentEnvWithLookup(passthrough, cfg, os.LookupEnv, agentLoginPATH)
 }
 
+// AgentEnvForPreflight returns the same sanitized environment used by the
+// selected agent runner so operator preflights cannot pass on worker-only
+// credentials that the agent subprocess will never inherit.
+func AgentEnvForPreflight(agent string, cfg workflow.Config) []string {
+	switch agent {
+	case "codex", NameCodexAppServer:
+		return agentEnv(cfg.Codex.EnvPassthrough, cfg)
+	case "claude":
+		return agentEnv(cfg.Claude.EnvPassthrough, cfg)
+	default:
+		return agentEnv(nil, cfg)
+	}
+}
+
 func agentEnvWithLookup(passthrough []string, cfg workflow.Config, lookup func(string) (string, bool), loginPath func() string) []string {
 	seen := make(map[string]struct{}, len(baselineAgentEnvAllowlist)+len(passthrough))
 	env := make([]string, 0, len(baselineAgentEnvAllowlist)+len(passthrough))

--- a/test/e2e/fixtures/compose_config_test.go
+++ b/test/e2e/fixtures/compose_config_test.go
@@ -74,7 +74,7 @@ func TestCodexComposeOverlayUsesSecrets(t *testing.T) {
 	if got := environment["AIOPS_WORKFLOW_PATH"]; got != "/app/WORKFLOW.md" {
 		t.Fatalf("codex overlay AIOPS_WORKFLOW_PATH = %#v, want /app/WORKFLOW.md", got)
 	}
-	for _, name := range []string{"AIOPS_STATE_API_TOKEN", "GITEA_TOKEN", "LINEAR_API_KEY"} {
+	for _, name := range []string{"AIOPS_STATE_API_TOKEN", "GH_TOKEN", "GITEA_TOKEN", "GITHUB_TOKEN", "LINEAR_API_KEY"} {
 		if got := environment[name]; got != "" {
 			t.Fatalf("codex overlay %s = %#v, want blank because secret files feed production tokens", name, got)
 		}
@@ -93,7 +93,7 @@ func TestCodexComposeOverlayUsesSecrets(t *testing.T) {
 	if !ok {
 		t.Fatal("codex overlay missing top-level secrets")
 	}
-	for _, name := range []string{"linear_api_key", "gitea_token", "aiops_state_api_token"} {
+	for _, name := range []string{"linear_api_key", "gitea_token", "github_token", "aiops_state_api_token"} {
 		if _, ok := declared[name]; !ok {
 			t.Fatalf("codex overlay missing secret %s", name)
 		}
@@ -116,6 +116,12 @@ func TestCodexComposeOverlayUsesSecrets(t *testing.T) {
 	if !strings.Contains(string(entrypointFile), "/run/secrets/gitea_token") {
 		t.Fatalf("secret entrypoint does not read optional Gitea token from /run/secrets")
 	}
+	if !strings.Contains(string(entrypointFile), "/run/secrets/github_token") {
+		t.Fatalf("secret entrypoint does not read GitHub token from /run/secrets")
+	}
+	if !strings.Contains(string(entrypointFile), ".config/gh/hosts.yml") {
+		t.Fatalf("secret entrypoint does not create file-backed gh auth")
+	}
 	if !strings.Contains(string(entrypointFile), "set -- worker \"$@\"") {
 		t.Fatalf("secret entrypoint does not prepend worker for flag-only docker compose run commands")
 	}
@@ -131,6 +137,7 @@ func TestFirstRunRunbookWritesAbsoluteComposePaths(t *testing.T) {
 		"AIOPS_WORKFLOW_PATH=$PWD/.aiops/WORKFLOW.md",
 		"AIOPS_CODEX_HOME_PATH=$PWD/.aiops/codex-home",
 		"LINEAR_API_KEY_FILE=$PWD/.aiops/secrets/linear_api_key",
+		"GITHUB_TOKEN_FILE=$PWD/.aiops/secrets/github_token",
 		"AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token",
 	} {
 		if !strings.Contains(text, want) {

--- a/test/e2e/fixtures/dockerfile_buildlayer_test.go
+++ b/test/e2e/fixtures/dockerfile_buildlayer_test.go
@@ -77,6 +77,38 @@ func TestDockerfileDefinesCodexWorkerTarget(t *testing.T) {
 	}
 }
 
+// TestDockerfileCodexWorkerInstallsGhCLI pins the codex-worker image's gh CLI
+// install. Without gh on PATH the documented aiops-secret-entrypoint silently
+// skips `gh auth setup-git`, leaving git push without GitHub credentials and
+// breaking `worker --doctor --github-issue` inside the container.
+func TestDockerfileCodexWorkerInstallsGhCLI(t *testing.T) {
+	df := dockerfileContents(t)
+
+	codexStart := strings.Index(df, "FROM worker AS codex-worker")
+	if codexStart < 0 {
+		t.Fatal("Dockerfile missing codex-worker target")
+	}
+	nextStage := strings.Index(df[codexStart+1:], "\nFROM ")
+	end := len(df)
+	if nextStage >= 0 {
+		end = codexStart + 1 + nextStage
+	}
+	stage := df[codexStart:end]
+
+	for _, want := range []string{
+		"ARG GH_CLI_VERSION=",
+		"github.com/cli/cli/releases/download/",
+		"gh_${GH_CLI_VERSION}_${gh_arch}.tar.gz",
+		"sha256sum -c -",
+		"install -m 0755",
+		"gh --version",
+	} {
+		if !strings.Contains(stage, want) {
+			t.Fatalf("Dockerfile codex-worker gh install missing %q", want)
+		}
+	}
+}
+
 func TestDockerfileKeepsWorkerAsDefaultTarget(t *testing.T) {
 	df := dockerfileContents(t)
 


### PR DESCRIPTION
Closes #451

Linear issue: 645abfbc-835d-407c-a23b-95f91ae0c15d

## Summary
- Adds `worker --doctor --github-issue` and `--github-repo` so Docker dogfood operators can verify `gh issue view` and `git push --dry-run` from the same sanitized environment used by Codex agent subprocesses.
- Adds Docker Codex overlay support for a GitHub token Docker secret materialized as `/home/aiops/.config/gh/hosts.yml`, while clearing plain GitHub token env vars.
- Documents the supported file-backed gh / deploy-key credential contract for Docker Codex dogfood workflows.

## Acceptance criteria
- Supported Docker GitHub credential mechanism: implemented via `github_token` Docker secret -> gh `hosts.yml`, with deploy-key path documented.
- Same effective agent environment preflight: implemented with `--github-issue` and optional `--github-repo`; uses `runner.AgentEnvForPreflight`.
- Least privilege / not committed: documented; no credential material committed.
- Avoid retrying unauthenticated active tasks: production runbook now requires the real doctor preflight before moving issues active; I intentionally did not add a worker dispatch credential gate after local review because that would make the scheduler a GitHub-auth policy owner outside the SPEC boundary.
- #450 linkage: not changed; #451 is handled independently.

## Verification
- `go test ./cmd/worker ./internal/doctor ./test/e2e/fixtures -count=1`
- `go test ./internal/orchestrator -run 'ValidateDispatchPreflight|PollOncePreflight' -count=1`
- `go test ./internal/runner -run 'AgentEnv|Env|Passthrough' -count=1`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go build ./cmd/worker ./cmd/tui`
- `gofmt -l $(git ls-files '*.go')`
- `git diff --check HEAD`

## Local reviews
- Codex diff review: MERGE-READY on head `6194aec62f6de59f2a2672dba808aed3c2a809b7`; LOW note only for negative `--github-issue` polish.
- Claude diff review: unavailable in this container; `claude: command not found`.

## CI and bot review
- CI: green on head `6194aec62f6de59f2a2672dba808aed3c2a809b7`.
- GitHub `@codex review`: triggered at https://github.com/xrf9268-hue/aiops-platform/pull/461#issuecomment-4544937884; still pending with an eyes reaction at last check.
- Review threads: GraphQL returned zero review threads at last check.

## Size budget
- Size-gated: 9 files, 386 insertions, 25 deletions. This is above the default 300 changed-LOC budget because the issue needs CLI, doctor, Docker, docs, and regression-test coverage in one coherent change. Not auto-merge eligible.

## Risks / follow-up
- No known acceptance-criterion deferrals.
- Doctor intentionally omits command output from GitHub auth failures to avoid echoing credential-bearing URLs.

Current head SHA: `6194aec62f6de59f2a2672dba808aed3c2a809b7`