### PR TITLE
fix: include Go toolchain in dogfood worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ FROM worker AS codex-worker
 ARG AIOPS_UID=1000
 ARG AIOPS_GID=1000
 USER root
+COPY --from=build /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
 ARG CODEX_CLI_VERSION=0.133.0
 ARG TARGETARCH
 RUN set -eux; \
@@ -75,6 +77,8 @@ RUN set -eux; \
     tar -xzf /tmp/codex.tar.gz -C /opt/codex; \
     ln -sf /opt/codex/bin/codex /usr/local/bin/codex; \
     rm -f /tmp/codex.tar.gz; \
+    go version; \
+    command -v gofmt; \
     codex --version
 # gh CLI is required by the codex-worker image so the documented
 # `aiops-secret-entrypoint` path can wire `/run/secrets/github_token` into

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -62,6 +62,7 @@ func parseDoctorArgs(args []string) (doctor.Options, error) {
 	fs := flag.NewFlagSet("worker --doctor", flag.ContinueOnError)
 	mode := fs.String("mode", "mock", "preflight depth: mock or real")
 	dashboardURL := fs.String("dashboard-url", "", "optional worker dashboard base URL to verify /api/v1/state auth")
+	goTestDir := fs.String("go-test-dir", "", "repository module root for real-mode targeted go test")
 	githubIssue := fs.Int("github-issue", 0, "optional GitHub issue number for agent-environment gh and git push preflight")
 	githubRepo := fs.String("github-repo", "", "optional owner/name repo for --github-issue when a workflow configures multiple GitHub repos")
 	if err := fs.Parse(reorderDoctorFlags(args)); err != nil {
@@ -71,13 +72,13 @@ func parseDoctorArgs(args []string) (doctor.Options, error) {
 		return doctor.Options{}, fmt.Errorf("--mode must be mock or real")
 	}
 	if fs.NArg() > 1 {
-		return doctor.Options{}, fmt.Errorf("usage: worker --doctor [--mode=mock|real] [--dashboard-url=http://127.0.0.1:4000] [path-to-WORKFLOW.md]")
+		return doctor.Options{}, fmt.Errorf("usage: worker --doctor [--mode=mock|real] [--dashboard-url=http://127.0.0.1:4000] [--go-test-dir=/repo-module] [--github-issue=N] [--github-repo=owner/name] [path-to-WORKFLOW.md]")
 	}
 	var path string
 	if fs.NArg() == 1 {
 		path = fs.Arg(0)
 	}
-	return doctor.Options{WorkflowPath: path, Mode: *mode, DashboardURL: *dashboardURL, GitHubIssue: *githubIssue, GitHubRepo: *githubRepo, Stdout: os.Stdout, Stderr: os.Stderr}, nil
+	return doctor.Options{WorkflowPath: path, Mode: *mode, DashboardURL: *dashboardURL, GoTestDir: *goTestDir, GitHubIssue: *githubIssue, GitHubRepo: *githubRepo, Stdout: os.Stdout, Stderr: os.Stderr}, nil
 }
 
 func reorderDoctorFlags(args []string) []string {
@@ -88,7 +89,7 @@ func reorderDoctorFlags(args []string) []string {
 		case a == "--":
 			positional = append(positional, append([]string{"--"}, args[i+1:]...)...)
 			i = len(args)
-		case a == "--mode" || a == "-mode" || a == "--dashboard-url" || a == "-dashboard-url" || a == "--github-issue" || a == "-github-issue" || a == "--github-repo" || a == "-github-repo":
+		case a == "--mode" || a == "-mode" || a == "--dashboard-url" || a == "-dashboard-url" || a == "--go-test-dir" || a == "-go-test-dir" || a == "--github-issue" || a == "-github-issue" || a == "--github-repo" || a == "-github-repo":
 			flags = append(flags, a)
 			if i+1 < len(args) {
 				flags = append(flags, args[i+1])

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -2360,11 +2360,11 @@ func TestParseRunArgs_HelpReturnsFlagErrHelp(t *testing.T) {
 }
 
 func TestParseDoctorArgs_AllowsTrailingFlags(t *testing.T) {
-	opts, err := parseDoctorArgs([]string{"/wf.md", "--mode", "real", "--dashboard-url", "http://127.0.0.1:4000"})
+	opts, err := parseDoctorArgs([]string{"/wf.md", "--mode", "real", "--dashboard-url", "http://127.0.0.1:4000", "--go-test-dir", "/repo"})
 	if err != nil {
 		t.Fatalf("parseDoctorArgs returned error: %v", err)
 	}
-	if opts.WorkflowPath != "/wf.md" || opts.Mode != "real" || opts.DashboardURL != "http://127.0.0.1:4000" {
+	if opts.WorkflowPath != "/wf.md" || opts.Mode != "real" || opts.DashboardURL != "http://127.0.0.1:4000" || opts.GoTestDir != "/repo" {
 		t.Fatalf("parseDoctorArgs = %+v", opts)
 	}
 }

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -155,14 +155,17 @@ state:
 docker compose --env-file .env \
   -f deploy/docker-compose.yml \
   -f deploy/docker-compose.codex.yml \
-  run --rm worker --doctor --mode=real --github-issue 451 \
+  run --rm -v "$PWD:/repo:ro" worker \
+    --doctor --mode=real --go-test-dir=/repo --github-issue 451 \
     --github-repo xrf9268-hue/aiops-platform
 ```
 
+With `--go-test-dir`, doctor verifies this repo's Go toolchain by running
+`go version`, `gofmt`, and a targeted `go test` from the mounted module root.
 With `--github-issue`, doctor runs `gh issue view` and `git push --dry-run`
 using the Codex agent environment. Omit `--github-repo` only when the workflow
 configures one GitHub repo. A failure is a deployment blocker; fix the
-credential path before starting the worker.
+toolchain or credential path before starting the worker.
 
 The supported Compose overlay uses a writable bind for `CODEX_HOME` because
 Codex 0.133 writes while loading configuration and may refresh auth state.

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -30,6 +30,12 @@ const (
 	Fail Status = "FAIL"
 )
 
+const (
+	aiopsModulePath       = "github.com/xrf9268-hue/aiops-platform"
+	defaultCommandTimeout = 10 * time.Second
+	goTestProbeTimeout    = 2 * time.Minute
+)
+
 type Check struct {
 	Status Status
 	Name   string
@@ -41,6 +47,7 @@ type Options struct {
 	WorkflowPath string
 	Mode         string
 	DashboardURL string
+	GoTestDir    string
 	GitHubIssue  int
 	GitHubRepo   string
 	Stdout       io.Writer
@@ -72,6 +79,7 @@ func BuildReport(ctx context.Context, opts Options) Report {
 	r.normalize()
 	wf, path := r.checkWorkflow()
 	r.checkHostBinaries(wf)
+	r.checkProjectToolchain(ctx)
 	r.checkDockerCompose(ctx)
 	if wf != nil {
 		r.checkLinear(ctx, wf.Config)
@@ -151,6 +159,101 @@ func (r *reportBuilder) checkHostBinaries(wf *workflow.Workflow) {
 	} else {
 		r.pass("rg", "found on PATH")
 	}
+}
+
+func (r *reportBuilder) checkProjectToolchain(ctx context.Context) {
+	if !r.realMode() {
+		return
+	}
+	modulePath, goModVersion := r.goModule()
+	moduleRoot := strings.TrimSpace(r.opts.GoTestDir)
+	out, err := r.run(ctx, "go", []string{"version"})
+	if err != nil {
+		r.fail("Go version", trimOutput(out, err), "Install the Go toolchain required by go.mod in the worker image.")
+	} else if version := strings.TrimSpace(string(out)); goModVersion != "" && !goVersionCompatible(version, goModVersion) {
+		r.fail("Go version", version, "Install a Go toolchain compatible with go.mod version "+goModVersion+".")
+	} else {
+		if goModVersion != "" {
+			version += "; go.mod requires " + goModVersion
+		}
+		r.pass("Go version", version)
+	}
+	gofmtProbe, err := writeGofmtProbe()
+	if err != nil {
+		r.fail("gofmt", err.Error(), "Create a writable temp directory for doctor preflight probes.")
+	} else if gofmtPath, out, err := r.gofmtPath(ctx); err != nil {
+		r.fail("gofmt", trimOutput(out, err), "Install the Go toolchain with gofmt in the worker image.")
+	} else if out, err := r.run(ctx, gofmtPath, []string{"-l", gofmtProbe}); err != nil {
+		r.fail("gofmt", trimOutput(out, err), "Install gofmt in the worker image.")
+	} else {
+		r.pass("gofmt", "found at "+gofmtPath)
+	}
+	if gofmtProbe != "" {
+		_ = os.Remove(gofmtProbe)
+	}
+	if moduleRoot == "" {
+		r.warn("Go test", "not checked; no --go-test-dir supplied", "Pass --go-test-dir pointing at the repository module root for dogfood image preflight.")
+		return
+	}
+	if modulePath != aiopsModulePath || goModVersion == "" {
+		r.fail("Go test", goModuleFailureDetail(modulePath, goModVersion), "Pass --go-test-dir pointing at the aiops-platform checkout root.")
+		return
+	}
+	if !fileExists(filepath.Join(moduleRoot, "internal", "doctor")) {
+		r.fail("Go test", "targeted package internal/doctor not found under --go-test-dir", "Pass --go-test-dir pointing at the aiops-platform checkout root.")
+		return
+	}
+	if out, err := r.runWithTimeout(ctx, goTestProbeTimeout, "go", []string{"test", "-C", moduleRoot, "./internal/doctor", "-run", "TestDoctorGoToolchainProbe", "-count=1"}); err != nil {
+		r.fail("Go test", trimOutput(out, err), "Fix the project Go test prerequisites in the worker image or checkout.")
+		return
+	}
+	r.pass("Go test", "go test ./internal/doctor -run TestDoctorGoToolchainProbe -count=1")
+}
+
+func (r *reportBuilder) goModule() (string, string) {
+	start := strings.TrimSpace(r.opts.GoTestDir)
+	if start == "" {
+		return "", ""
+	}
+	return readGoMod(filepath.Join(start, "go.mod"))
+}
+
+func (r *reportBuilder) gofmtPath(ctx context.Context) (string, []byte, error) {
+	out, err := r.run(ctx, "go", []string{"env", "GOROOT"})
+	if err != nil {
+		return "", out, err
+	}
+	goRoot := strings.TrimSpace(string(out))
+	if goRoot == "" {
+		return "", out, errors.New("go env GOROOT returned empty output")
+	}
+	return filepath.Join(goRoot, "bin", "gofmt"), out, nil
+}
+
+func goModuleFailureDetail(modulePath, version string) string {
+	switch {
+	case modulePath == "":
+		return "no go.mod found for targeted project verification"
+	case modulePath != aiopsModulePath:
+		return fmt.Sprintf("go.mod module %q is not %s", modulePath, aiopsModulePath)
+	case version == "":
+		return "go.mod is missing a go version"
+	default:
+		return "go.mod is not usable for targeted project verification"
+	}
+}
+
+func writeGofmtProbe() (string, error) {
+	f, err := os.CreateTemp("", "aiops-doctor-gofmt-*.go")
+	if err != nil {
+		return "", err
+	}
+	defer closeBody(f)
+	if _, err := io.WriteString(f, "package main\n"); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 func (r *reportBuilder) checkDockerCompose(ctx context.Context) {
@@ -468,7 +571,11 @@ func (r *reportBuilder) realMode() bool {
 }
 
 func (r *reportBuilder) run(ctx context.Context, name string, args []string) ([]byte, error) {
-	runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	return r.runWithTimeout(ctx, defaultCommandTimeout, name, args)
+}
+
+func (r *reportBuilder) runWithTimeout(ctx context.Context, timeout time.Duration, name string, args []string) ([]byte, error) {
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return r.opts.Runner(runCtx, name, args, nil, nil)
 }
@@ -727,6 +834,49 @@ func safeCommandFailure(command string, out []byte, err error) string {
 		return command + " failed"
 	}
 	return command + " failed: " + detail
+}
+
+func readGoMod(path string) (string, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", ""
+	}
+	var modulePath, version string
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 {
+			switch fields[0] {
+			case "module":
+				modulePath = fields[1]
+			case "go":
+				version = fields[1]
+			}
+		}
+	}
+	return modulePath, version
+}
+
+func goVersionCompatible(output, goModVersion string) bool {
+	gotMajor, gotMinor, gotOK := goMajorMinor(output)
+	wantMajor, wantMinor, wantOK := majorMinor(goModVersion)
+	return gotOK && wantOK && (gotMajor > wantMajor || gotMajor == wantMajor && gotMinor >= wantMinor)
+}
+
+func goMajorMinor(output string) (int, int, bool) {
+	for _, field := range strings.Fields(output) {
+		if strings.HasPrefix(field, "go1.") {
+			return majorMinor(strings.TrimPrefix(field, "go"))
+		}
+	}
+	return 0, 0, false
+}
+
+func majorMinor(version string) (int, int, bool) {
+	var major, minor int
+	if _, err := fmt.Sscanf(version, "%d.%d", &major, &minor); err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
 }
 
 func firstLine(out []byte) string {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -162,6 +164,90 @@ func TestBuildReportRealModeSkipsCodexForMockAgent(t *testing.T) {
 	}
 }
 
+func TestBuildReportRealModeChecksGoToolchain(t *testing.T) {
+	installFakeGitOnly(t)
+	moduleRoot := writeGoModule(t, "1.24.0")
+	var goTestArgs []string
+	var goTestDeadline time.Duration
+	var gofmtCommand string
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeWorkflow(t, "gitea", "token"),
+		Mode:         "real",
+		GoTestDir:    moduleRoot,
+		Runner: func(ctx context.Context, name string, args []string, env []string, stdin io.Reader) ([]byte, error) {
+			if filepath.Base(name) == "gofmt" {
+				gofmtCommand = name
+			}
+			if name == "go" && len(args) > 0 && args[0] == "test" {
+				goTestArgs = append([]string(nil), args...)
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatalf("go test context has no deadline")
+				}
+				goTestDeadline = time.Until(deadline)
+			}
+			return fakeRealRunner(ctx, name, args, env, stdin)
+		},
+	})
+
+	if got := findCheck(t, report, "Go version"); got.Status != Pass || !strings.Contains(got.Detail, "go.mod requires 1.24.0") {
+		t.Fatalf("Go version check = %+v; want PASS with go.mod compatibility detail", got)
+	}
+	if got := findCheck(t, report, "gofmt").Status; got != Pass {
+		t.Fatalf("gofmt status = %s; want PASS", got)
+	}
+	if got, want := gofmtCommand, filepath.Join("/usr/local/go", "bin", "gofmt"); got != want {
+		t.Fatalf("gofmt command = %q; want %q", got, want)
+	}
+	if got := findCheck(t, report, "Go test").Status; got != Pass {
+		t.Fatalf("Go test status = %s; want PASS", got)
+	}
+	if got, want := strings.Join(goTestArgs, " "), "test -C "+moduleRoot+" ./internal/doctor -run TestDoctorGoToolchainProbe -count=1"; got != want {
+		t.Fatalf("go test args = %q; want %q", got, want)
+	}
+	if goTestDeadline < time.Minute {
+		t.Fatalf("go test deadline = %s; want at least 1m to avoid cold-cache false negatives", goTestDeadline)
+	}
+}
+
+func TestBuildReportRealModeFailsWithoutGoModuleForTargetedTest(t *testing.T) {
+	installFakeGitOnly(t)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeWorkflow(t, "gitea", "token"),
+		Mode:         "real",
+		GoTestDir:    t.TempDir(),
+		Runner:       fakeRealRunner,
+	})
+
+	check := findCheck(t, report, "Go test")
+	if check.Status != Fail {
+		t.Fatalf("Go test status = %s; want FAIL", check.Status)
+	}
+	if !strings.Contains(check.Fix, "--go-test-dir") {
+		t.Fatalf("Go test fix = %q; want --go-test-dir guidance", check.Fix)
+	}
+}
+
+func TestBuildReportRealModeWarnsWithoutExplicitGoTestDir(t *testing.T) {
+	installFakeGitOnly(t)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeWorkflow(t, "gitea", "token"),
+		Mode:         "real",
+		Runner:       fakeRealRunner,
+	})
+
+	check := findCheck(t, report, "Go test")
+	if check.Status != Warn {
+		t.Fatalf("Go test status = %s; want WARN", check.Status)
+	}
+	if !strings.Contains(check.Fix, "--go-test-dir") {
+		t.Fatalf("Go test fix = %q; want --go-test-dir guidance", check.Fix)
+	}
+	if report.HasFailures() {
+		t.Fatalf("report.HasFailures() = true; want false when only targeted Go test dir is omitted")
+	}
+}
+
 func TestBuildReportGitHubAgentPreflightUsesAgentEnvironment(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "worker-token-must-not-leak")
 	path := writeGitHubWorkflow(t, "codex")
@@ -170,6 +256,16 @@ func TestBuildReportGitHubAgentPreflightUsesAgentEnvironment(t *testing.T) {
 		switch name {
 		case "docker":
 			return []byte("ok\n"), nil
+		case "go":
+			if len(args) > 0 && args[0] == "version" {
+				return []byte("go version go1.25.0 linux/amd64\n"), nil
+			}
+			if len(args) > 1 && args[0] == "env" && args[1] == "GOROOT" {
+				return []byte("/usr/local/go\n"), nil
+			}
+			return nil, errors.New("unexpected go command")
+		case "gofmt", filepath.Join("/usr/local/go", "bin", "gofmt"):
+			return []byte(""), nil
 		case "codex":
 			if len(args) > 0 && args[0] == "--version" {
 				return []byte("codex-cli 0.133.0\n"), nil
@@ -622,13 +718,48 @@ prompt
 	return path
 }
 
+func writeGoModule(t *testing.T, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module "+aiopsModulePath+"\n\ngo "+version+"\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "doctor"), 0o700); err != nil {
+		t.Fatalf("create internal/doctor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "internal", "doctor", "doctor_test.go"), []byte("package doctor\n"), 0o600); err != nil {
+		t.Fatalf("write doctor test package: %v", err)
+	}
+	return dir
+}
+
+func TestDoctorGoToolchainProbe(t *testing.T) {}
+
 func passingRunner(context.Context, string, []string, []string, io.Reader) ([]byte, error) {
 	return []byte("ok\n"), nil
 }
 
 func fakeRealRunner(_ context.Context, name string, args []string, _ []string, _ io.Reader) ([]byte, error) {
-	if name != "docker" && name != "codex" {
+	if name != "docker" && name != "codex" && name != "go" && filepath.Base(name) != "gofmt" {
 		return nil, errors.New("unexpected command")
+	}
+	if filepath.Base(name) == "gofmt" {
+		return []byte(""), nil
+	}
+	if name == "go" && len(args) > 0 && args[0] == "version" {
+		return []byte("go version go1.25.0 linux/amd64\n"), nil
+	}
+	if name == "go" && len(args) > 1 && args[0] == "env" && args[1] == "GOROOT" {
+		return []byte("/usr/local/go\n"), nil
+	}
+	if name == "go" && len(args) > 0 && args[0] == "test" {
+		if len(args) < 4 || args[1] != "-C" || args[3] != "./internal/doctor" {
+			return nil, fmt.Errorf("unexpected go test args: %v", args)
+		}
+		if !fileExists(filepath.Join(args[2], "internal", "doctor", "doctor_test.go")) {
+			return nil, errors.New("missing targeted doctor test package")
+		}
+		return []byte("ok\n"), nil
 	}
 	if name == "codex" && len(args) > 0 && args[0] == "login" {
 		return []byte("Logged in\n"), nil
@@ -639,9 +770,18 @@ func fakeRealRunner(_ context.Context, name string, args []string, _ []string, _
 	return []byte("ok\n"), nil
 }
 
-func dockerOnlyRunner(_ context.Context, name string, _ []string, _ []string, _ io.Reader) ([]byte, error) {
-	if name != "docker" {
+func dockerOnlyRunner(_ context.Context, name string, args []string, _ []string, _ io.Reader) ([]byte, error) {
+	if name != "docker" && name != "go" && filepath.Base(name) != "gofmt" {
 		return nil, errors.New("unexpected command")
+	}
+	if filepath.Base(name) == "gofmt" {
+		return []byte(""), nil
+	}
+	if name == "go" && len(args) > 0 && args[0] == "version" {
+		return []byte("go version go1.25.0 linux/amd64\n"), nil
+	}
+	if name == "go" && len(args) > 1 && args[0] == "env" && args[1] == "GOROOT" {
+		return []byte("/usr/local/go\n"), nil
 	}
 	return []byte("ok\n"), nil
 }


### PR DESCRIPTION
Closes #452

Linear issue: d813a2c4-7774-45a9-ad89-930f59ace019 (AIS-39)

## Summary

- Copies the Go toolchain from the build stage into the `codex-worker` image and verifies `go version` plus `gofmt` during image build.
- Adds `worker --doctor --mode=real --go-test-dir=<repo>` checks for `go version`, same-GOROOT `gofmt`, and a targeted project `go test`.
- Documents generic worker runtime requirements separately from this repo's Go toolchain requirements in the Codex app-server Docker runbook.

## Acceptance Criteria

- Go toolchain compatible with `go.mod`: addressed by reusing the build stage Go 1.25 toolchain in the dogfood image.
- Real-mode preflight verifies `go version`, `gofmt`, and targeted `go test`: addressed via `--go-test-dir`; omitting the flag is WARN, not FAIL.
- Runbook lists project toolchain requirements separately from generic runtime requirements: addressed.
- Secret safety: no tokens or credential material are added; checks redact configured token environment values.

## Verification

Local:

- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `git diff --check origin/main...HEAD`
- `go test ./internal/doctor ./cmd/worker -count=1`
- `go vet ./...`
- `go build ./cmd/worker ./cmd/tui`

Mutation checks:

- Removing the production `checkProjectToolchain` call made `TestBuildReportRealModeChecksGoToolchain` fail as expected, then the call was restored.
- Reverting same-GOROOT `gofmt` execution back to PATH `gofmt` made `TestBuildReportRealModeChecksGoToolchain` fail as expected, then the code was restored.

CI on `f7fb919f5ef11b8bde3204b78a5222daa7726e29`:

- Go build and test: success.
- Security and supply-chain: success.
- E2E Gitea mock loop: success.
- Docker image build: success.
- CI log warning scan: no `warning:` lines found.

Not run locally:

- Full `go test -race -covermode=atomic ./...`: blocked by an existing `origin/main` failure in `internal/runner` (`TestCodexAppServerInitializeTimeoutDiagnostics`), reproduced on main in the pre-push session.

## Reviews

- Claude diff-only review: `MERGE-READY`; only LOW observations.
- Local Codex diff-only review on stable head `f7fb919`: `MERGE-READY`; one LOW note about hand-parsing `go.mod`, accepted as non-blocking because this repo's standard `go.mod` shape is sufficient and adding a parser dependency would widen scope.
- GitHub `@codex review` was triggered on `f7fb919`, but `chatgpt-codex-connector` replied that Codex review usage limits were reached. Existing Codex P1/P2 threads are fixed and resolved.

## Size Gate

- Changed files: 6.
- Diff size: 309 insertions, 11 deletions, 320 total changed lines.
- This exceeds the default 300 LOC policy budget, so the PR is labeled `size-gated` and must not be auto-merged without explicit human signoff.
- Over-budget reason: the PR needs production preflight behavior, CLI parsing, Docker image wiring, runbook instructions, and non-placebo tests/mutation-covered assertions in one atomic fix for #452.

## Deferrals / Follow-Ups

- None for the code change.
- External blocker before merge: fresh GitHub-hosted Codex review is unavailable due to Codex review usage limits, and the PR is `size-gated`.

## Risks

- The `go.mod` parser is intentionally narrow and supports this repo's standard `module` / `go` directive shape.

Current head SHA: f7fb919f5ef11b8bde3204b78a5222daa7726e29
