### PR TITLE
test: add GitHub PR dogfood smoke path

### DIFF
--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -257,6 +257,60 @@ workspace should be cleaned up on the next reconciliation. If you rerun the same
 disposable issue id, clean the previous temporary worktree first; workspace
 branch names are derived from issue ids and can collide.
 
+## 6. Run a GitHub issue-to-PR smoke
+
+Use this only with a disposable GitHub issue and a disposable Linear mirror.
+The goal is to validate the dogfood path that this repo's batch workflow needs:
+the agent reads a GitHub issue with `gh`, implements in an isolated workspace,
+pushes a branch, and opens a draft PR that closes the GitHub issue.
+
+Prepare one throwaway GitHub issue in the target repository:
+
+```bash
+gh_issue_url="$(gh issue create \
+  --repo xrf9268-hue/aiops-platform \
+  --title "Docker dogfood PR smoke $(date -u +%Y%m%dT%H%M%SZ)" \
+  --body "Disposable validation issue. The agent should make a tiny docs-only change, open a draft PR, and leave this issue to be closed by the PR.")"
+gh_issue="${gh_issue_url##*/}"
+```
+
+Mirror that issue into a fresh Linear issue in the configured project. The
+Linear issue title/body must include the GitHub issue number and URL, and the
+workflow prompt must instruct the agent to read the GitHub issue with a
+supported explicit-field command such as:
+
+```bash
+gh issue view "$gh_issue" \
+  --repo xrf9268-hue/aiops-platform \
+  --json number,title,state,labels,body,url,comments
+```
+
+Run the smoke script against the Linear identifier for that mirror:
+
+```bash
+AIOPS_SMOKE_WORKER_BIN=/tmp/aiops-worker \
+  scripts/aiops-todo-smoke.sh \
+  --mode real \
+  --workflow WORKFLOW.md \
+  --issue AIS-125 \
+  --github-repo xrf9268-hue/aiops-platform \
+  --github-issue "$gh_issue" \
+  --expect-draft-pr
+```
+
+The script first runs `worker --doctor --mode=real --github-issue` so `gh issue
+view` and `git push --dry-run` are checked from the sanitized Codex agent
+environment. After the selected Linear issue completes, it verifies that an
+open draft PR in the target GitHub repo has a `closingIssuesReferences` link to
+the disposable GitHub issue. If no draft PR exists, the smoke fails and writes
+the state snapshot plus worker log paths into `docs/validation/smoke/`.
+For slow GitHub PR visibility or long-running handoff paths, tune
+`AIOPS_SMOKE_PR_POLL_ATTEMPTS` and `AIOPS_SMOKE_PR_POLL_INTERVAL_SECONDS`.
+
+After a successful smoke, close or merge the disposable draft PR according to
+the normal PR follow-through gate, then close any intentionally disposable
+GitHub/Linear test issue that is not closed by the PR.
+
 ## Troubleshooting
 
 | Symptom | Next action |
@@ -267,5 +321,6 @@ branch names are derived from issue ids and can collide.
 | `FAIL Codex auth` | Run `codex --login` for the same `CODEX_HOME` and container user context. |
 | `FAIL GitHub agent gh auth` | Set `GITHUB_TOKEN_FILE` to a least-privilege token file or mount a deploy key; do not rely on `GH_TOKEN`/`GITHUB_TOKEN` in the worker environment. |
 | `FAIL GitHub agent git push` | Run the documented doctor command from the container and fix `gh auth setup-git` or deploy-key write access for the target repo. |
+| `FAIL no new open draft PR ... closes GitHub issue` | Confirm the mirrored Linear issue tells the agent to open a draft PR with `Closes #<n>`, and that the GitHub credential has repo write access. |
 | `WARN Codex sandbox` | Either use the documented Docker-isolated profile for real smoke validation or enable the kernel/user namespace support required by Codex `workspace-write`. |
 | smoke timeout | Confirm a disposable issue is in an active state, `/readyz` is healthy, and `tracker.active_states` matches the Linear board. |

--- a/scripts/aiops-todo-smoke.sh
+++ b/scripts/aiops-todo-smoke.sh
@@ -6,12 +6,19 @@ workflow="${AIOPS_SMOKE_WORKFLOW:-${AIOPS_WORKFLOW_PATH:-}}"
 dashboard_url="${AIOPS_SMOKE_DASHBOARD_URL:-http://127.0.0.1:4010}"
 report_dir="${AIOPS_SMOKE_REPORT_DIR:-docs/validation/smoke}"
 issue="${AIOPS_SMOKE_ISSUE:-}"
+github_issue="${AIOPS_SMOKE_GITHUB_ISSUE:-}"
+github_repo="${AIOPS_SMOKE_GITHUB_REPO:-}"
+github_issue_url=""
+expect_draft_pr="${AIOPS_SMOKE_EXPECT_DRAFT_PR:-false}"
+draft_pr_baseline=""
+draft_pr_poll_attempts="${AIOPS_SMOKE_PR_POLL_ATTEMPTS:-30}"
+draft_pr_poll_interval="${AIOPS_SMOKE_PR_POLL_INTERVAL_SECONDS:-1}"
 timeout_seconds="${AIOPS_SMOKE_TIMEOUT_SECONDS:-180}"
 worker_bin="${AIOPS_SMOKE_WORKER_BIN:-worker}"
 state_api_token="${AIOPS_STATE_API_TOKEN:-}"
 
 usage() {
-  printf 'usage: %s [--mode mock|real] --workflow PATH [--issue IDENTIFIER] [--dashboard-url URL] [--report-dir DIR]\n' "$0" >&2
+  printf 'usage: %s [--mode mock|real] --workflow PATH [--issue IDENTIFIER] [--dashboard-url URL] [--report-dir DIR] [--github-repo OWNER/REPO --github-issue NUMBER --expect-draft-pr]\n' "$0" >&2
 }
 
 while [ "$#" -gt 0 ]; do
@@ -22,6 +29,12 @@ while [ "$#" -gt 0 ]; do
       workflow="${2:-}"; shift 2 ;;
     --issue)
       issue="${2:-}"; shift 2 ;;
+    --github-issue)
+      github_issue="${2:-}"; shift 2 ;;
+    --github-repo)
+      github_repo="${2:-}"; shift 2 ;;
+    --expect-draft-pr)
+      expect_draft_pr="true"; shift ;;
     --dashboard-url)
       dashboard_url="${2:-}"; shift 2 ;;
     --report-dir)
@@ -42,6 +55,34 @@ if [ -z "$workflow" ]; then
   usage
   exit 2
 fi
+case "$github_issue" in
+  ""|*[!0-9]*)
+    if [ -n "$github_issue" ]; then
+      printf 'github-issue must be numeric, got %s\n' "$github_issue" >&2
+      exit 2
+    fi ;;
+esac
+if [ "$expect_draft_pr" = "true" ] && { [ -z "$github_issue" ] || [ -z "$github_repo" ]; }; then
+  printf 'expect-draft-pr requires --github-issue and --github-repo\n' >&2
+  exit 2
+fi
+if [ -n "$github_repo" ] && ! printf '%s\n' "$github_repo" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+  printf 'github-repo must be OWNER/REPO, got %s\n' "$github_repo" >&2
+  exit 2
+fi
+if [ -n "$github_repo" ] && [ -n "$github_issue" ]; then
+  github_issue_url="https://github.com/$github_repo/issues/$github_issue"
+fi
+case "$draft_pr_poll_attempts" in
+  *[!0-9]*|"")
+    printf 'AIOPS_SMOKE_PR_POLL_ATTEMPTS must be numeric, got %s\n' "$draft_pr_poll_attempts" >&2
+    exit 2 ;;
+esac
+case "$draft_pr_poll_interval" in
+  *[!0-9]*|"")
+    printf 'AIOPS_SMOKE_PR_POLL_INTERVAL_SECONDS must be numeric, got %s\n' "$draft_pr_poll_interval" >&2
+    exit 2 ;;
+esac
 dashboard_hostport="${dashboard_url#*://}"
 dashboard_hostport="${dashboard_hostport%%/*}"
 if [ "$dashboard_hostport" = "$dashboard_url" ] || [ "${dashboard_hostport##*:}" = "$dashboard_hostport" ] || [ -z "${dashboard_hostport##*:}" ]; then
@@ -70,8 +111,104 @@ state_array_contains_issue() {
   grep -q "\"$field\":[[:space:]]*\[[^]]*\"$issue_id\"" "$file"
 }
 
+matching_draft_prs() {
+  local draft_lines
+  local line
+  local number
+  local pr_line
+  local viewed_pr
+  local view_status
+  draft_lines="$(open_draft_prs)" || return 1
+  while IFS='|' read -r number pr_line; do
+    if [ -z "$number" ] || baseline_has_pr "$number"; then
+      continue
+    fi
+    view_status=0
+    viewed_pr="$(gh pr view "$number" \
+      --repo "$github_repo" \
+      --json number,isDraft,url,closingIssuesReferences \
+      --jq ". | select(.isDraft == true and (.closingIssuesReferences | any(.number == $github_issue and .url == \"$github_issue_url\"))) | \"\\(.number)|#\\(.number) \\(.url)\"")" || view_status=$?
+    if [ "$view_status" -ne 0 ]; then
+      return 1
+    fi
+    if [ -n "$viewed_pr" ]; then
+      printf '%s\n' "$viewed_pr"
+    fi
+  done <<EOF
+$draft_lines
+EOF
+}
+
+open_draft_prs() {
+  gh api --paginate "repos/$github_repo/pulls?state=open&per_page=100" \
+    --jq '.[] | select(.draft == true) | "\(.number)|#\(.number) \(.html_url)"'
+}
+
+capture_draft_pr_baseline() {
+  if [ "$expect_draft_pr" != "true" ]; then
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    printf '\n## result\n\nFAIL `gh` is required to verify the draft PR for GitHub issue `%s`.\n\n' "$github_issue" >>"$report"
+    return 1
+  fi
+  err_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-gh-pr-list.err.XXXXXX")"
+  if ! draft_pr_baseline="$(open_draft_prs 2>"$err_file")"; then
+    printf '\n## result\n\nFAIL `gh api` could not inspect draft PRs for `%s#%s`.\n\n' "$github_repo" "$github_issue" >>"$report"
+    printf 'Error output: `%s`\n' "$err_file" >>"$report"
+    return 1
+  fi
+  rm -f "$err_file"
+}
+
+baseline_has_pr() {
+  local number="$1"
+  local line
+  while IFS= read -r line; do
+    if [ "${line%%|*}" = "$number" ]; then
+      return 0
+    fi
+  done <<EOF
+$draft_pr_baseline
+EOF
+  return 1
+}
+
+verify_expected_draft_pr() {
+  if [ "$expect_draft_pr" != "true" ]; then
+    return 0
+  fi
+  attempt=1
+  while [ "$attempt" -le "$draft_pr_poll_attempts" ]; do
+    err_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-gh-pr-list.err.XXXXXX")"
+    if ! pr_lines="$(matching_draft_prs 2>"$err_file")"; then
+      printf '\n## result\n\nFAIL `gh` could not inspect draft PRs for `%s#%s`.\n\n' "$github_repo" "$github_issue" >>"$report"
+      printf 'Error output: `%s`\n' "$err_file" >>"$report"
+      return 1
+    fi
+    rm -f "$err_file"
+    while IFS= read -r line; do
+      number="${line%%|*}"
+      pr_line="${line#*|}"
+      if [ -n "$number" ]; then
+        printf '\n## GitHub draft PR\n\nVerified new `%s` closes `%s#%s`.\n\n' "$pr_line" "$github_repo" "$github_issue" >>"$report"
+        return 0
+      fi
+    done <<EOF
+$pr_lines
+EOF
+    if [ "$attempt" -lt "$draft_pr_poll_attempts" ]; then
+      sleep "$draft_pr_poll_interval"
+    fi
+    attempt=$((attempt + 1))
+  done
+  printf '\n## result\n\nFAIL no new open draft PR in `%s` closes GitHub issue `%s`.\n\n' "$github_repo" "$github_issue" >>"$report"
+  return 1
+}
+
 mkdir -p "$report_dir"
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+smoke_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 report="$report_dir/${stamp}-todo-${mode}.md"
 workspace_root="${AIOPS_SMOKE_WORKSPACE_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/aiops-smoke-workspaces.XXXXXX")}"
 log_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-worker.log.XXXXXX")"
@@ -88,14 +225,29 @@ trap cleanup EXIT
 {
   printf '# aiops todo smoke report\n\n'
   printf -- '- timestamp: `%s`\n' "$stamp"
+  printf -- '- smoke_started_at: `%s`\n' "$smoke_started_at"
   printf -- '- mode: `%s`\n' "$mode"
   printf -- '- workflow: `%s`\n' "$workflow"
   printf -- '- dashboard_url: `%s`\n' "$dashboard_url"
   printf -- '- issue: `%s`\n' "${issue:-not specified}"
+  printf -- '- github_repo: `%s`\n' "${github_repo:-not specified}"
+  printf -- '- github_issue: `%s`\n' "${github_issue:-not specified}"
+  printf -- '- expect_draft_pr: `%s`\n' "$expect_draft_pr"
   printf -- '- workspace_root: `%s`\n\n' "$workspace_root"
 } >"$report"
 
-"$worker_bin" --doctor --mode="$mode" "$workflow" >>"$report"
+doctor_args=(--doctor --mode="$mode")
+if [ -n "$github_issue" ]; then
+  doctor_args+=(--github-issue "$github_issue")
+fi
+if [ -n "$github_repo" ]; then
+  doctor_args+=(--github-repo "$github_repo")
+fi
+doctor_args+=("$workflow")
+"$worker_bin" "${doctor_args[@]}" >>"$report"
+if ! capture_draft_pr_baseline; then
+  exit 1
+fi
 
 AIOPS_WORKFLOW_PATH="$workflow" \
 AIOPS_WORKSPACE_ROOT="$workspace_root" \
@@ -107,6 +259,7 @@ deadline=$(( $(date +%s) + timeout_seconds ))
 ready="false"
 while [ "$(date +%s)" -lt "$deadline" ]; do
   if ! kill -0 "$worker_pid" >/dev/null 2>&1; then
+    verify_expected_draft_pr || true
     printf '\n## result\n\nFAIL worker exited before smoke completed\n\n' >>"$report"
     printf 'Worker log: `%s`\n' "$log_file" >>"$report"
     exit 1
@@ -119,12 +272,18 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
 done
 
 if [ "$ready" != "true" ]; then
+  verify_expected_draft_pr || true
   printf '\n## result\n\nFAIL timed out waiting for worker readiness.\n\n' >>"$report"
   printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
   exit 1
 fi
 
-api_curl -X POST -H 'X-AIOPS-Refresh: true' "$dashboard_url/api/v1/refresh" >/dev/null
+if ! api_curl -X POST -H 'X-AIOPS-Refresh: true' "$dashboard_url/api/v1/refresh" >/dev/null; then
+  verify_expected_draft_pr || true
+  printf '\n## result\n\nFAIL refresh request failed.\n\n' >>"$report"
+  printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+  exit 1
+fi
 
 completed_before="0"
 failed_before="0"
@@ -138,7 +297,12 @@ completed_before="${completed_before:-0}"
 failed_before="${failed_before:-0}"
 
 while [ "$(date +%s)" -lt "$deadline" ]; do
-  api_curl "$dashboard_url/api/v1/state" >"$state_file"
+  if ! api_curl "$dashboard_url/api/v1/state" >"$state_file"; then
+    verify_expected_draft_pr || true
+    printf '\n## result\n\nFAIL state request failed.\n\n' >>"$report"
+    printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+    exit 1
+  fi
   if [ -n "$issue" ] && [ "$selected_observed" = "false" ]; then
     issue_file="$(mktemp "${TMPDIR:-/tmp}/aiops-smoke-issue.json.XXXXXX")"
     if api_curl "$dashboard_url/api/v1/$issue" >"$issue_file"; then
@@ -152,29 +316,40 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   completed_now="${completed_now:-0}"
   failed_now="${failed_now:-0}"
   if [ -n "$selected_issue_id" ] && state_array_contains_issue completed "$selected_issue_id" "$state_file"; then
+    if ! verify_expected_draft_pr; then
+      printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+      exit 1
+    fi
     printf '\n## result\n\nPASS selected issue `%s` completed.\n\n' "$issue" >>"$report"
     printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
     printf '%s\n' "$report"
     exit 0
   fi
   if [ -n "$selected_issue_id" ] && state_array_contains_issue failed "$selected_issue_id" "$state_file"; then
+    verify_expected_draft_pr || true
     printf '\n## result\n\nFAIL selected issue `%s` failed.\n\n' "$issue" >>"$report"
     printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
     exit 1
   fi
   if [ -z "$issue" ] && [ "$completed_now" -gt "$completed_before" ]; then
+    if ! verify_expected_draft_pr; then
+      printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
+      exit 1
+    fi
     printf '\n## result\n\nPASS completed_total advanced from `%s` to `%s`.\n\n' "$completed_before" "$completed_now" >>"$report"
     printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
     printf '%s\n' "$report"
     exit 0
   fi
   if [ -z "$issue" ] && [ "$failed_now" -gt "$failed_before" ]; then
+    verify_expected_draft_pr || true
     printf '\n## result\n\nFAIL failed_total advanced from `%s` to `%s`.\n\n' "$failed_before" "$failed_now" >>"$report"
     printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
     exit 1
   fi
   if [ -n "$issue" ]; then
     if [ "$completed_now" -gt "$completed_before" ] && [ "$selected_observed" != "true" ]; then
+      verify_expected_draft_pr || true
       printf '\n## result\n\nFAIL completed_total advanced, but selected issue `%s` was never observed in runtime state.\n\n' "$issue" >>"$report"
       printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
       exit 1
@@ -183,6 +358,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 3
 done
 
+verify_expected_draft_pr || true
 printf '\n## result\n\nFAIL timed out waiting for one worker lifecycle.\n\n' >>"$report"
 printf 'State snapshot: `%s`\nWorker log: `%s`\n' "$state_file" "$log_file" >>"$report"
 exit 1

--- a/scripts/aiops_todo_smoke_test.go
+++ b/scripts/aiops_todo_smoke_test.go
@@ -1,10 +1,15 @@
 package scripts_test
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTodoSmokeScriptRunsDoctorAndWritesReport(t *testing.T) {
@@ -16,7 +21,9 @@ func TestTodoSmokeScriptRunsDoctorAndWritesReport(t *testing.T) {
 	}
 	text := string(body)
 	for _, want := range []string{
-		"\"$worker_bin\" --doctor --mode=\"$mode\" \"$workflow\"",
+		`doctor_args=(--doctor --mode="$mode")`,
+		`doctor_args+=("$workflow")`,
+		`"$worker_bin" "${doctor_args[@]}"`,
 		"Authorization: Bearer $state_api_token",
 		"api_curl -X POST -H 'X-AIOPS-Refresh: true'",
 		"dashboard-url must include an explicit host:port",
@@ -36,6 +43,139 @@ func TestTodoSmokeScriptRunsDoctorAndWritesReport(t *testing.T) {
 	}
 }
 
+func TestTodoSmokeScriptSupportsGitHubDraftPRValidation(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "aiops-todo-smoke.sh")
+	body, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("read %s: %v", script, err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		`--github-repo OWNER/REPO --github-issue NUMBER --expect-draft-pr`,
+		`expect-draft-pr requires --github-issue and --github-repo`,
+		`draft_pr_poll_attempts="${AIOPS_SMOKE_PR_POLL_ATTEMPTS:-30}"`,
+		`doctor_args+=(--github-issue "$github_issue")`,
+		`doctor_args+=(--github-repo "$github_repo")`,
+		`verify_expected_draft_pr`,
+		`gh api --paginate`,
+		`gh pr view "$number"`,
+		`open_draft_prs`,
+		`pulls?state=open&per_page=100`,
+		`smoke_started_at`,
+		`--json number,isDraft,url,closingIssuesReferences`,
+		`.url == \"$github_issue_url\"`,
+		`while [ "$attempt" -le "$draft_pr_poll_attempts" ]`,
+		`no new open draft PR in`,
+		"Verified new `%s` closes `%s#%s`.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("smoke script missing GitHub PR validation fragment %q", want)
+		}
+	}
+	if strings.Contains(text, `--search "$github_issue"`) {
+		t.Fatalf("smoke script should not use gh search API for draft PR verification")
+	}
+}
+
+func TestTodoSmokeScriptAcceptsDraftPRCreatedAfterBaseline(t *testing.T) {
+	report, err := runTodoSmokePRFixture(t, "new")
+	if err != nil {
+		t.Fatalf("smoke script with new draft PR failed: %v\n%s", err, report)
+	}
+	if !strings.Contains(report, "Verified new `#11 https://example.test/pr/11` closes `xrf9268-hue/aiops-platform#450`") {
+		t.Fatalf("report missing new draft PR verification:\n%s", report)
+	}
+}
+
+func TestTodoSmokeScriptRejectsStaleDraftPR(t *testing.T) {
+	report, err := runTodoSmokePRFixture(t, "stale")
+	if err == nil {
+		t.Fatalf("smoke script with only stale draft PR succeeded; report:\n%s", report)
+	}
+	if !strings.Contains(report, "FAIL no new open draft PR") {
+		t.Fatalf("report missing stale draft PR failure:\n%s", report)
+	}
+	if !strings.Contains(report, "State snapshot:") || !strings.Contains(report, "Worker log:") {
+		t.Fatalf("report missing diagnostics for stale draft PR failure:\n%s", report)
+	}
+}
+
+func TestTodoSmokeScriptRejectsEditedExistingDraftPR(t *testing.T) {
+	report, err := runTodoSmokePRFixture(t, "edited")
+	if err == nil {
+		t.Fatalf("smoke script accepted existing draft PR edited after baseline; report:\n%s", report)
+	}
+	if !strings.Contains(report, "FAIL no new open draft PR") {
+		t.Fatalf("report missing edited existing draft PR failure:\n%s", report)
+	}
+}
+
+func TestTodoSmokeScriptRecordsDraftPRWhenWorkerFails(t *testing.T) {
+	report, err := runTodoSmokePRFixture(t, "new", "failed")
+	if err == nil {
+		t.Fatalf("smoke script with failed worker succeeded; report:\n%s", report)
+	}
+	if !strings.Contains(report, "Verified new `#11 https://example.test/pr/11` closes `xrf9268-hue/aiops-platform#450`") {
+		t.Fatalf("report missing draft PR verification on worker failure:\n%s", report)
+	}
+	if !strings.Contains(report, "FAIL selected issue `AIS-1` failed.") {
+		t.Fatalf("report missing selected issue failure:\n%s", report)
+	}
+}
+
+func TestTodoSmokeScriptRecordsDraftPRWhenWorkerExitsBeforeReady(t *testing.T) {
+	report, err := runTodoSmokePRFixture(t, "new", "exit")
+	if err == nil {
+		t.Fatalf("smoke script with early worker exit succeeded; report:\n%s", report)
+	}
+	if !strings.Contains(report, "Verified new `#11 https://example.test/pr/11` closes `xrf9268-hue/aiops-platform#450`") {
+		t.Fatalf("report missing draft PR verification on early worker exit:\n%s", report)
+	}
+	if !strings.Contains(report, "FAIL worker exited before smoke completed") {
+		t.Fatalf("report missing worker exit failure:\n%s", report)
+	}
+}
+
+func TestTodoSmokeScriptRecordsDraftPRWhenRefreshFails(t *testing.T) {
+	report, err := runTodoSmokePRFixture(t, "new", "refresh-fail")
+	if err == nil {
+		t.Fatalf("smoke script with refresh failure succeeded; report:\n%s", report)
+	}
+	if !strings.Contains(report, "Verified new `#11 https://example.test/pr/11` closes `xrf9268-hue/aiops-platform#450`") {
+		t.Fatalf("report missing draft PR verification on refresh failure:\n%s", report)
+	}
+	if !strings.Contains(report, "FAIL refresh request failed.") {
+		t.Fatalf("report missing refresh failure:\n%s", report)
+	}
+}
+
+func TestTodoSmokeScriptRecordsDraftPRWhenStateRequestFails(t *testing.T) {
+	report, err := runTodoSmokePRFixture(t, "new", "state-fail")
+	if err == nil {
+		t.Fatalf("smoke script with state failure succeeded; report:\n%s", report)
+	}
+	if !strings.Contains(report, "Verified new `#11 https://example.test/pr/11` closes `xrf9268-hue/aiops-platform#450`") {
+		t.Fatalf("report missing draft PR verification on state failure:\n%s", report)
+	}
+	if !strings.Contains(report, "FAIL state request failed.") {
+		t.Fatalf("report missing state failure:\n%s", report)
+	}
+}
+
+func TestTodoSmokeScriptClassifiesPRViewFailure(t *testing.T) {
+	report, err := runTodoSmokePRFixture(t, "view-fail")
+	if err == nil {
+		t.Fatalf("smoke script with pr view failure succeeded; report:\n%s", report)
+	}
+	if !strings.Contains(report, "FAIL `gh` could not inspect draft PRs") {
+		t.Fatalf("report missing gh inspection failure:\n%s", report)
+	}
+	if strings.Contains(report, "FAIL no new open draft PR") {
+		t.Fatalf("report misclassified gh inspection failure as missing PR:\n%s", report)
+	}
+}
+
 func TestTodoSmokeScriptUsesPrintfOptionSeparatorForMarkdownLists(t *testing.T) {
 	root := repoRoot(t)
 	script := filepath.Join(root, "scripts", "aiops-todo-smoke.sh")
@@ -50,6 +190,9 @@ func TestTodoSmokeScriptUsesPrintfOptionSeparatorForMarkdownLists(t *testing.T) 
 		`printf -- '- workflow:`,
 		`printf -- '- dashboard_url:`,
 		`printf -- '- issue:`,
+		`printf -- '- github_repo:`,
+		`printf -- '- github_issue:`,
+		`printf -- '- expect_draft_pr:`,
 		`printf -- '- workspace_root:`,
 	} {
 		if !strings.Contains(text, want) {
@@ -110,6 +253,220 @@ func TestTodoSmokeScriptRequiresIssueIDInsideTerminalArrays(t *testing.T) {
 			t.Fatalf("smoke script contains false-positive selected-issue grep %q", forbidden)
 		}
 	}
+}
+
+func runTodoSmokePRFixture(t *testing.T, ghMode string, workerMode ...string) (string, error) {
+	t.Helper()
+	root := repoRoot(t)
+	fakeBin := t.TempDir()
+	reportDir := t.TempDir()
+	workflow := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	if err := os.WriteFile(workflow, []byte("prompt\n"), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	port := freePort(t)
+	writeFakeWorker(t, filepath.Join(fakeBin, "worker"))
+	writeFakeGH(t, filepath.Join(fakeBin, "gh"))
+	countFile := filepath.Join(t.TempDir(), "gh-count")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	fakeWorkerState := "completed"
+	if len(workerMode) > 0 {
+		fakeWorkerState = workerMode[0]
+	}
+	cmd := exec.CommandContext(ctx,
+		filepath.Join(root, "scripts", "aiops-todo-smoke.sh"),
+		"--mode", "real",
+		"--workflow", workflow,
+		"--issue", "AIS-1",
+		"--dashboard-url", fmt.Sprintf("http://127.0.0.1:%d", port),
+		"--report-dir", reportDir,
+		"--github-repo", "xrf9268-hue/aiops-platform",
+		"--github-issue", "450",
+		"--expect-draft-pr",
+	)
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AIOPS_FAKE_GH_COUNT="+countFile,
+		"AIOPS_FAKE_GH_MODE="+ghMode,
+		"AIOPS_FAKE_WORKER_STATE="+fakeWorkerState,
+		"AIOPS_SMOKE_TIMEOUT_SECONDS=10",
+		"AIOPS_SMOKE_PR_POLL_ATTEMPTS=2",
+		"AIOPS_SMOKE_PR_POLL_INTERVAL_SECONDS=0",
+	)
+	out, err := cmd.CombinedOutput()
+	report := latestSmokeReport(t, reportDir)
+	if len(out) > 0 {
+		report += "\nstdout/stderr:\n" + string(out)
+	}
+	return report, err
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for free port: %v", err)
+	}
+	defer func() {
+		if err := ln.Close(); err != nil {
+			t.Fatalf("close free-port listener: %v", err)
+		}
+	}()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func writeFakeWorker(t *testing.T, path string) {
+	t.Helper()
+	body := `#!/usr/bin/env python3
+import http.server, json, os, sys
+
+if "--doctor" in sys.argv:
+    sys.exit(0)
+if os.environ.get("AIOPS_FAKE_WORKER_STATE") == "exit":
+    sys.exit(0)
+
+port = None
+for arg in sys.argv:
+    if arg.startswith("--port="):
+        port = int(arg.split("=", 1)[1])
+if port is None:
+    sys.exit(2)
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+    def do_POST(self):
+        if self.path == "/api/v1/refresh":
+            if os.environ.get("AIOPS_FAKE_WORKER_STATE") == "refresh-fail":
+                self.send_response(500)
+                self.end_headers()
+                return
+            self.send_response(204)
+            self.end_headers()
+            return
+        self.send_response(404)
+        self.end_headers()
+    def do_GET(self):
+        if self.path == "/readyz":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+            return
+        if self.path == "/api/v1/AIS-1":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"issue_id":"issue-1"}).encode())
+            return
+        if self.path == "/api/v1/state":
+            if os.environ.get("AIOPS_FAKE_WORKER_STATE") == "state-fail":
+                self.send_response(500)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            if os.environ.get("AIOPS_FAKE_WORKER_STATE") == "failed":
+                state = {"completed_total":0,"failed_total":1,"completed":[],"failed":["issue-1"]}
+            else:
+                state = {"completed_total":1,"failed_total":0,"completed":["issue-1"],"failed":[]}
+            self.wfile.write(json.dumps(state).encode())
+            return
+        self.send_response(404)
+        self.end_headers()
+
+http.server.HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+`
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write fake worker: %v", err)
+	}
+}
+
+func writeFakeGH(t *testing.T, path string) {
+	t.Helper()
+	body := `#!/bin/sh
+set -eu
+args=" $* "
+case "$args" in
+  *" --search "* ) printf 'unexpected search API use: %s\n' "$args" >&2; exit 43 ;;
+esac
+count_file="${AIOPS_FAKE_GH_COUNT:?}"
+if [ "$1" = "api" ]; then
+  case "$args" in
+    *" --paginate repos/xrf9268-hue/aiops-platform/pulls?state=open&per_page=100 "* ) ;;
+    * ) printf 'missing paginated pulls API: %s\n' "$args" >&2; exit 41 ;;
+  esac
+  count=0
+  if [ -f "$count_file" ]; then
+    count="$(cat "$count_file")"
+  fi
+  count=$((count + 1))
+  printf '%s' "$count" >"$count_file"
+  if [ "${AIOPS_FAKE_GH_MODE:-}" = "edited" ]; then
+    printf '10|#10 https://example.test/pr/10\n'
+  else
+    printf '10|#10 https://example.test/pr/10\n'
+  fi
+  if { [ "${AIOPS_FAKE_GH_MODE:-}" = "new" ] || [ "${AIOPS_FAKE_GH_MODE:-}" = "view-fail" ]; } && [ "$count" -ge 2 ]; then
+    printf '11|#11 https://example.test/pr/11\n'
+  fi
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  case "$args" in
+    *" --repo xrf9268-hue/aiops-platform "* ) ;;
+    * ) printf 'missing pr view repo: %s\n' "$args" >&2; exit 44 ;;
+  esac
+  case "$args" in
+    *" --json number,isDraft,url,closingIssuesReferences "* ) ;;
+    * ) printf 'missing pr view json: %s\n' "$args" >&2; exit 44 ;;
+  esac
+  case "$args" in
+    *"https://github.com/xrf9268-hue/aiops-platform/issues/450"* ) ;;
+    * ) printf 'missing issue-url jq filter: %s\n' "$args" >&2; exit 45 ;;
+  esac
+  count=0
+  if [ -f "$count_file" ]; then
+    count="$(cat "$count_file")"
+  fi
+  if [ "$3" = "10" ]; then
+    if [ "${AIOPS_FAKE_GH_MODE:-}" != "edited" ] || [ "$count" -ge 2 ]; then
+      printf '10|#10 https://example.test/pr/10\n'
+    fi
+  fi
+  if [ "$3" = "11" ]; then
+    if [ "${AIOPS_FAKE_GH_MODE:-}" = "view-fail" ]; then
+      printf 'simulated pr view failure\n' >&2
+      exit 47
+    fi
+    printf '11|#11 https://example.test/pr/11\n'
+  fi
+  exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$args" >&2
+exit 46
+`
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+}
+
+func latestSmokeReport(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read report dir: %v", err)
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+	path := filepath.Join(dir, entries[len(entries)-1].Name())
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read report %s: %v", path, err)
+	}
+	return string(body)
 }
 
 func repoRoot(t *testing.T) string {


### PR DESCRIPTION
Closes #450

## Summary
- add a GitHub issue-to-draft-PR path to `scripts/aiops-todo-smoke.sh`
- verify the worker doctor GitHub preflight and detect a newly-created draft PR that closes the target issue
- document the GitHub dogfood smoke flow in the production Docker first-run runbook

## Acceptance criteria
- [x] GitHub CLI / agent-environment smoke path can target `--github-repo` and `--github-issue`
- [x] Smoke can require a newly-created draft PR with `--expect-draft-pr`
- [x] Existing non-GitHub / mock smoke behavior remains covered
- [x] Runbook documents the GitHub issue-to-PR dogfood path and secret-backed preflight expectations

## Validation
- [x] `bash -n scripts/aiops-todo-smoke.sh`
- [x] `go test ./scripts -run TestTodoSmoke -count=1`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go vet ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (report-only baseline; no findings in the changed smoke files)
- [x] GitHub CI on `33859359fd667c461d0fe197882c97e8d9eb9874`: all checks green (run `26554700602`)
- [x] CI warning grep: no `warning:` lines found in run `26554700602`
- [ ] `go test -race -covermode=atomic ./...` blocked by pre-existing `internal/runner` timeout tracked in #476

## Mutation checks
- [x] Removing baseline-new draft detection failed the stale/edited draft regression tests
- [x] Removing early worker-exit handoff evidence failed the early-exit regression test
- [x] Removing refresh/state failure evidence failed the corresponding regression tests

## Review gates
- [x] Codex/subagent diff review on `3385935` clean: no actionable blockers
- [x] Human sign-off: Claude pre-push reviewer is temporarily waived because local Claude quota returns `You've hit your session limit · resets 3pm (Asia/Shanghai)`
- [x] Fresh `@codex review`: trigger comment `4560835564`; Codex replied clean for current head
- [x] GraphQL reviewThreads: zero unresolved/non-outdated threads

## Size gate
- [ ] `within budget` — diff fits effective `policy.max_changed_files` / `max_changed_loc`
- [x] `size-gated: justified overage` — overage rationale: the extra LOC is regression coverage and shell harness safety for a new end-to-end GitHub draft-PR smoke path; user explicitly signed off on continuing despite the size overage. Not auto-mergeable without human size-gate sign-off.
- [ ] `size-gated: split recommended` — split rationale: n/a

## PR follow-through ledger
- Head: `33859359fd667c461d0fe197882c97e8d9eb9874`
- CI: green (`26554700602`)
- Fresh `@codex review`: clean (`4560835564` -> clean Codex comment)
- GraphQL reviewThreads: clean
- Merge state: CLEAN
- Deferrals: #476 tracks the pre-existing full race-suite blocker
