### PR TITLE
docs: harden GitHub issue intake smoke

### DIFF
--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -276,14 +276,25 @@ gh_issue="${gh_issue_url##*/}"
 
 Mirror that issue into a fresh Linear issue in the configured project. The
 Linear issue title/body must include the GitHub issue number and URL, and the
-workflow prompt must instruct the agent to read the GitHub issue with a
-supported explicit-field command such as:
+workflow prompt must instruct the agent to read the GitHub issue with
+explicit fields, then read comments through the REST comments endpoint:
 
 ```bash
 gh issue view "$gh_issue" \
   --repo xrf9268-hue/aiops-platform \
-  --json number,title,state,labels,body,url,comments
+  --json number,title,state,labels,body,url
+
+gh api --paginate \
+  "repos/xrf9268-hue/aiops-platform/issues/${gh_issue}/comments?per_page=100"
 ```
+
+Do not use `gh issue view --comments` in the dogfood workflow. Older GitHub CLI
+versions query the deprecated Projects Classic `projectCards` field for that
+shape, and GitHub returns a GraphQL deprecation error before the agent reads the
+issue. Treat that exact `repository.issue.projectCards` failure as a GitHub CLI
+query-shape issue, not an authentication failure. Also avoid unsupported
+`gh issue view --json` fields such as `closedBy`; use `closed` and `closedAt`
+only if the installed `gh issue view --json` help lists them.
 
 Run the smoke script against the Linear identifier for that mirror:
 

--- a/scripts/github_issue_intake_docs_test.go
+++ b/scripts/github_issue_intake_docs_test.go
@@ -1,0 +1,52 @@
+package scripts
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDockerDogfoodGitHubIssueIntakeAvoidsProjectCardsQuery(t *testing.T) {
+	body, err := os.ReadFile("../docs/runbooks/first-run-docker-linear-codex.md")
+	if err != nil {
+		t.Fatalf("ReadFile(first-run docker runbook) = %v; want nil", err)
+	}
+	text := string(body)
+	section := dogfoodGitHubIssueSmokeSection(t, text)
+
+	for _, forbidden := range []string{
+		"gh issue view \"$gh_issue\" \\\n  --repo xrf9268-hue/aiops-platform \\\n  --comments",
+		"--json number,title,state,labels,body,url,comments",
+		"--json closed,closedAt,closedBy",
+		"closedBy,number,state,url",
+	} {
+		if strings.Contains(section, forbidden) {
+			t.Fatalf("GitHub issue intake section contains forbidden %q:\n%s", forbidden, section)
+		}
+	}
+
+	for _, want := range []string{
+		"--json number,title,state,labels,body,url",
+		"gh api --paginate",
+		"issues/${gh_issue}/comments?per_page=100",
+		"repository.issue.projectCards",
+		"not an authentication failure",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("GitHub issue intake section missing %q:\n%s", want, section)
+		}
+	}
+}
+
+func dogfoodGitHubIssueSmokeSection(t *testing.T, text string) string {
+	t.Helper()
+	start := strings.Index(text, "## 6. Run a GitHub issue-to-PR smoke")
+	if start < 0 {
+		t.Fatal("runbook missing GitHub issue-to-PR smoke section")
+	}
+	end := strings.Index(text[start+1:], "\n## ")
+	if end < 0 {
+		return text[start:]
+	}
+	return text[start : start+1+end]
+}


### PR DESCRIPTION
Closes #463

## Summary
- replace the dogfood GitHub issue intake example with explicit supported `gh issue view --json` fields
- read issue comments through the REST comments endpoint via `gh api --paginate`
- document the `repository.issue.projectCards` failure as a GitHub CLI query-shape issue, not an auth failure
- add a runbook regression test that rejects `--comments`, `--json ... comments`, and invalid `closedBy` command shapes

## Acceptance criteria
- [x] Replace `gh issue view ... --comments` workflow guidance with explicit JSON fields plus REST comments query.
- [x] Document `projectCards` as a known GitHub CLI query-shape failure, not authentication failure.
- [x] Remove/correct invalid `closedBy` guidance.
- [x] Add regression coverage showing mirrored issue intake succeeds without `--comments`.

## Validation
- [x] `go test ./scripts -run TestDockerDogfoodGitHubIssueIntakeAvoidsProjectCardsQuery -count=1`
- [x] `go test ./scripts -count=1`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go vet ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `GOLANGCI_LINT_CACHE=/tmp/aiops-463-lint-cache go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (no findings in changed files)
- [x] `gh issue view 463 --repo xrf9268-hue/aiops-platform --json number,title,state,labels,body,url`
- [x] `gh api --paginate 'repos/xrf9268-hue/aiops-platform/issues/463/comments?per_page=100'`
- [x] GitHub CI on `cf6ac3171d8092075cff042f0bbc3bc43847f368`: all checks green (run `26558156215`)
- [x] CI warning grep: no `warning:` lines found in run `26558156215`
- [ ] `go test -race -covermode=atomic ./...` blocked by pre-existing `internal/runner TestCodexAppServerInitializeTimeoutDiagnostics`, tracked in #476

## Mutation checks
- [x] Re-adding `,comments` to the documented `gh issue view --json` field list made `TestDockerDogfoodGitHubIssueIntakeAvoidsProjectCardsQuery` fail.

## Review gates
- [x] Codex/subagent diff review on `cf6ac31` clean
- [x] Human sign-off: Claude pre-push reviewer is temporarily waived because local Claude quota is unavailable
- [x] Fresh `@codex review`: trigger comment `4561300163`; Codex replied clean for current head
- [ ] GraphQL reviewThreads: final check in progress

## Size gate
- [x] `within budget` — 2 files, 66 insertions / 3 deletions
- [ ] `size-gated: justified overage` — overage rationale: n/a
- [ ] `size-gated: split recommended` — split rationale: n/a

## PR follow-through ledger
- Head: `cf6ac3171d8092075cff042f0bbc3bc43847f368`
- CI: green (`26558156215`)
- Fresh `@codex review`: clean (`4561300163` -> clean Codex comment)
- GraphQL reviewThreads: final check in progress
- Merge state: CLEAN
- Deferrals: #476 covers the pre-existing full race-suite blocker
