### PR TITLE
fix: disambiguate doctor GitHub repos by clone URL (#469)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -66,7 +66,7 @@ func parseDoctorArgs(args []string) (doctor.Options, error) {
 	dashboardURL := fs.String("dashboard-url", "", "optional worker dashboard base URL to verify /api/v1/state auth")
 	goTestDir := fs.String("go-test-dir", "", "repository module root for real-mode targeted go test")
 	githubIssue := fs.Int("github-issue", 0, "optional GitHub issue number for agent-environment gh and git push preflight")
-	githubRepo := fs.String("github-repo", "", "optional owner/name repo for --github-issue when a workflow configures multiple GitHub repos")
+	githubRepo := fs.String("github-repo", "", "optional owner/name or clone_url repo for --github-issue when a workflow configures multiple GitHub repos (use clone_url to disambiguate one owner/name routed to multiple clone URLs)")
 	if err := fs.Parse(reorderDoctorFlags(args)); err != nil {
 		return doctor.Options{}, err
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -354,7 +354,7 @@ func (r *reportBuilder) checkGitHubAgent(ctx context.Context, cfg workflow.Confi
 	}
 	repo, err := selectGitHubRepo(cfg, r.opts.GitHubRepo)
 	if err != nil {
-		r.fail("GitHub agent credentials", err.Error(), "Set repo.owner, repo.name, and repo.clone_url, or pass --github-repo owner/name for the GitHub repository the agent will access.")
+		r.fail("GitHub agent credentials", err.Error(), "Set repo.owner, repo.name, and repo.clone_url, or pass --github-repo owner/name (or the exact clone_url) for the GitHub repository the agent will access.")
 		return
 	}
 	env := runner.AgentEnvForPreflight(cfg.Agent.Default, cfg)
@@ -720,27 +720,80 @@ func selectGitHubRepo(cfg workflow.Config, target string) (githubRepo, error) {
 	repos := githubRepos(cfg)
 	target = strings.TrimSpace(target)
 	if target != "" {
-		for _, repo := range repos {
-			if strings.EqualFold(repo.fullName(), target) {
-				return repo, nil
-			}
+		matches := matchGitHubRepos(repos, target)
+		switch len(matches) {
+		case 0:
+			// target may itself be a clone_url carrying basic-auth userinfo;
+			// mask it before echoing (owner/name targets pass through unchanged).
+			return githubRepo{}, fmt.Errorf("github repo %q not found in workflow", workflow.MaskCloneURL(target))
+		case 1:
+			return matches[0], nil
+		default:
+			// Same owner/name routed to distinct clone URLs (e.g. an HTTPS
+			// fallback and an SSH deploy-key service). owner/name alone cannot
+			// name the credential path the agent will actually push to, so make
+			// the operator pass the exact clone_url instead of silently testing
+			// the first entry.
+			return githubRepo{}, fmt.Errorf("github repo %q matches multiple clone URLs (%s); pass the exact clone_url to --github-repo", workflow.MaskCloneURL(target), cloneURLList(matches))
 		}
-		return githubRepo{}, fmt.Errorf("github repo %q not found in workflow", target)
 	}
 	if len(repos) == 0 {
 		return githubRepo{}, fmt.Errorf("no GitHub repo owner/name and clone_url found in workflow")
 	}
 	if len(repos) > 1 {
-		return githubRepo{}, fmt.Errorf("multiple GitHub repos configured; pass --github-repo owner/name")
+		return githubRepo{}, fmt.Errorf("multiple GitHub repos configured; pass --github-repo owner/name or clone_url")
 	}
 	return repos[0], nil
+}
+
+// matchGitHubRepos returns the configured repos selected by target, which may be
+// an owner/name, a raw clone URL, or the masked clone URL the ambiguity error
+// displays (see workflow.MaskCloneURL) so an operator never has to retype an
+// embedded token on the command line. Exact owner/name and raw clone-URL matches
+// take precedence: a fully specified target is never widened by a masked-form
+// collision with a different repo, and a bare clone URL that exactly matches one
+// repo selects it even if another repo masks to the same value. An owner/name
+// target can still match several repos when the same owner/name is configured
+// with different clone URLs, which selectGitHubRepo reports as ambiguous.
+// Clone-URL comparison is a normalized string match (see normalizeCloneURL), so
+// equivalent SSH spellings such as scp-style git@host:o/r.git versus
+// ssh://git@host/o/r.git are not folded; pass the exact configured form.
+func matchGitHubRepos(repos []githubRepo, target string) []githubRepo {
+	var exact, masked []githubRepo
+	for _, repo := range repos {
+		switch {
+		case strings.EqualFold(repo.fullName(), target) || sameCloneURL(repo.CloneURL, target):
+			exact = append(exact, repo)
+		case sameCloneURL(workflow.MaskCloneURL(repo.CloneURL), target):
+			masked = append(masked, repo)
+		}
+	}
+	if len(exact) > 0 {
+		return exact
+	}
+	return masked
+}
+
+// cloneURLList renders the candidate clone URLs for the ambiguity error. Each
+// URL is masked because clone_url may embed basic-auth userinfo that the repo
+// treats as a secret (see workflow.MaskCloneURL); the detail string is logged.
+func cloneURLList(repos []githubRepo) string {
+	urls := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		urls = append(urls, workflow.MaskCloneURL(repo.CloneURL))
+	}
+	return strings.Join(urls, ", ")
 }
 
 func githubRepos(cfg workflow.Config) []githubRepo {
 	repos := make([]githubRepo, 0, 1+len(cfg.Services))
 	seen := make(map[string]bool, 1+len(cfg.Services))
 	add := func(repo githubRepo) {
-		key := strings.ToLower(repo.fullName())
+		// Keep the clone URL in the identity: a workflow can route the same
+		// owner/name to distinct clone URLs (HTTPS fallback vs SSH service), and
+		// collapsing on owner/name alone would drop the URL the agent actually
+		// pushes to from the preflight.
+		key := strings.ToLower(repo.fullName()) + "\x00" + normalizeCloneURL(repo.CloneURL)
 		if seen[key] {
 			return
 		}
@@ -766,6 +819,17 @@ func githubRepoFromConfig(repo workflow.RepoConfig) (githubRepo, bool) {
 		return githubRepo{}, false
 	}
 	return githubRepo{Owner: owner, Name: name, CloneURL: cloneURL}, true
+}
+
+// normalizeCloneURL canonicalizes a clone URL for identity comparison. GitHub
+// treats the host and owner/name path case-insensitively, so lowercasing folds
+// case-variant duplicates while keeping distinct protocols (https vs ssh) apart.
+func normalizeCloneURL(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func sameCloneURL(a, b string) bool {
+	return normalizeCloneURL(a) == normalizeCloneURL(b)
 }
 
 func isGitHubCloneURL(raw string) bool {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -384,6 +384,140 @@ func TestSelectGitHubRepoDeduplicatesIdenticalRepoEntries(t *testing.T) {
 	}
 }
 
+func TestSelectGitHubRepoDisambiguatesSameOwnerNameByCloneURL(t *testing.T) {
+	const (
+		httpsURL = "https://github.com/owner/repo.git"
+		sshURL   = "git@github.com:owner/repo.git"
+	)
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{
+			Owner:    "owner",
+			Name:     "repo",
+			CloneURL: httpsURL,
+		},
+		Services: []workflow.ServiceConfig{{
+			Repo: workflow.RepoConfig{
+				Owner:    "owner",
+				Name:     "repo",
+				CloneURL: sshURL,
+			},
+		}},
+	}
+
+	// Distinct clone URLs for one owner/name must survive dedup; collapsing
+	// them would hide the URL TaskFromIssue swaps in for service-routed work.
+	if repos := githubRepos(cfg); len(repos) != 2 {
+		t.Fatalf("githubRepos(...) kept %d repos; want 2 (distinct clone URLs)", len(repos))
+	}
+
+	_, err := selectGitHubRepo(cfg, "owner/repo")
+	if err == nil || !strings.Contains(err.Error(), "multiple clone URLs") {
+		t.Fatalf("selectGitHubRepo(cfg, %q) error = %v; want ambiguous clone URL error", "owner/repo", err)
+	}
+	if !strings.Contains(err.Error(), httpsURL) || !strings.Contains(err.Error(), sshURL) {
+		t.Fatalf("selectGitHubRepo(cfg, %q) error = %q; want both clone URLs listed", "owner/repo", err)
+	}
+
+	repo, err := selectGitHubRepo(cfg, sshURL)
+	if err != nil {
+		t.Fatalf("selectGitHubRepo(cfg, %q) = %v; want SSH service repo", sshURL, err)
+	}
+	if repo.CloneURL != sshURL {
+		t.Fatalf("selectGitHubRepo(cfg, %q).CloneURL = %q; want %q", sshURL, repo.CloneURL, sshURL)
+	}
+
+	repo, err = selectGitHubRepo(cfg, httpsURL)
+	if err != nil {
+		t.Fatalf("selectGitHubRepo(cfg, %q) = %v; want HTTPS fallback repo", httpsURL, err)
+	}
+	if repo.CloneURL != httpsURL {
+		t.Fatalf("selectGitHubRepo(cfg, %q).CloneURL = %q; want %q", httpsURL, repo.CloneURL, httpsURL)
+	}
+}
+
+func TestSelectGitHubRepoAmbiguityErrorMasksCloneURLCredentials(t *testing.T) {
+	const secret = "ghp_supersecrettoken"
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{
+			Owner:    "owner",
+			Name:     "repo",
+			CloneURL: "https://x-access-token:" + secret + "@github.com/owner/repo.git",
+		},
+		Services: []workflow.ServiceConfig{{
+			Repo: workflow.RepoConfig{
+				Owner:    "owner",
+				Name:     "repo",
+				CloneURL: "https://oauth2:" + secret + "@github.com/owner/repo.git",
+			},
+		}},
+	}
+
+	_, err := selectGitHubRepo(cfg, "owner/repo")
+	if err == nil {
+		t.Fatalf("selectGitHubRepo(cfg, %q) error = nil; want ambiguity error", "owner/repo")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("selectGitHubRepo(cfg, %q) error = %q; must not leak clone_url credentials", "owner/repo", err)
+	}
+	if !strings.Contains(err.Error(), "github.com/owner/repo.git") {
+		t.Fatalf("selectGitHubRepo(cfg, %q) error = %q; want masked clone URLs listed", "owner/repo", err)
+	}
+}
+
+func TestSelectGitHubRepoAcceptsMaskedCloneURLForSelection(t *testing.T) {
+	const secret = "ghp_supersecrettoken"
+	credURL := "https://x-access-token:" + secret + "@github.com/owner/repo.git"
+	maskedURL := "https://github.com/owner/repo.git"
+	sshURL := "git@github.com:owner/repo.git"
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo", CloneURL: credURL},
+		Services: []workflow.ServiceConfig{{
+			Repo: workflow.RepoConfig{Owner: "owner", Name: "repo", CloneURL: sshURL},
+		}},
+	}
+
+	// The masked URL is what the ambiguity error shows the operator; selecting
+	// the credentialed HTTPS path with it must work without retyping the token.
+	repo, err := selectGitHubRepo(cfg, maskedURL)
+	if err != nil {
+		t.Fatalf("selectGitHubRepo(cfg, %q) = %v; want the credentialed HTTPS repo", maskedURL, err)
+	}
+	if repo.CloneURL != credURL {
+		t.Fatalf("selectGitHubRepo(cfg, %q).CloneURL = %q; want %q", maskedURL, repo.CloneURL, credURL)
+	}
+
+	// The SSH path is still selectable by its own (already credential-free) form.
+	repo, err = selectGitHubRepo(cfg, sshURL)
+	if err != nil {
+		t.Fatalf("selectGitHubRepo(cfg, %q) = %v; want the SSH repo", sshURL, err)
+	}
+	if repo.CloneURL != sshURL {
+		t.Fatalf("selectGitHubRepo(cfg, %q).CloneURL = %q; want %q", sshURL, repo.CloneURL, sshURL)
+	}
+}
+
+func TestSelectGitHubRepoNotFoundErrorMasksCloneURLCredentials(t *testing.T) {
+	const secret = "ghp_supersecrettoken"
+	cfg := workflow.Config{
+		Repo: workflow.RepoConfig{
+			Owner:    "owner",
+			Name:     "repo",
+			CloneURL: "https://github.com/owner/repo.git",
+		},
+	}
+	// An operator may pass a clone_url to --github-repo (the new disambiguation
+	// path); a non-matching one must not echo its embedded token into the report.
+	target := "https://x-access-token:" + secret + "@github.com/other/repo.git"
+
+	_, err := selectGitHubRepo(cfg, target)
+	if err == nil {
+		t.Fatalf("selectGitHubRepo(cfg, <clone_url>) error = nil; want not-found error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("selectGitHubRepo(cfg, <clone_url>) error = %q; must not leak clone_url credentials", err)
+	}
+}
+
 func TestDefaultRunnerResolvesBinaryAgainstSuppliedEnvPATH(t *testing.T) {
 	envDir := t.TempDir()
 	envBin := filepath.Join(envDir, "agentonly")

--- a/internal/worker/print_config.go
+++ b/internal/worker/print_config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -267,7 +266,7 @@ func maskSecrets(cfg workflow.Config) workflow.Config {
 	if cfg.Tracker.APIKey != "" {
 		cfg.Tracker.APIKey = maskedSecret
 	}
-	cfg.Repo.CloneURL = maskCloneURL(cfg.Repo.CloneURL)
+	cfg.Repo.CloneURL = workflow.MaskCloneURL(cfg.Repo.CloneURL)
 	if n := len(cfg.Sandbox.CredentialFiles); n > 0 {
 		masked := make([]string, n)
 		for i := range masked {
@@ -276,24 +275,6 @@ func maskSecrets(cfg workflow.Config) workflow.Config {
 		cfg.Sandbox.CredentialFiles = masked
 	}
 	return cfg
-}
-
-// maskCloneURL strips embedded basic-auth from a clone URL. URLs that
-// do not parse as net/url (notably the SSH-style git@host:path form)
-// return unchanged, since that form does not carry userinfo. A bare
-// username with no password is also stripped: by convention an embedded
-// user in an HTTPS clone URL is a token alias (e.g. "oauth2",
-// "x-access-token", or the token itself), not a real account name.
-func maskCloneURL(raw string) string {
-	if raw == "" {
-		return raw
-	}
-	u, err := url.Parse(raw)
-	if err != nil || u.User == nil {
-		return raw
-	}
-	u.User = nil
-	return u.String()
 }
 
 // printConfig writes the effective workflow for workdir as JSON to

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -2,12 +2,31 @@ package workflow
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// MaskCloneURL strips embedded basic-auth from a clone URL so it is safe to log
+// or display. URLs that do not parse as net/url (notably the SSH-style
+// git@host:path form) return unchanged, since that form does not carry
+// userinfo. A bare username with no password is also stripped: by convention an
+// embedded user in an HTTPS clone URL is a token alias (e.g. "oauth2",
+// "x-access-token", or the token itself), not a real account name.
+func MaskCloneURL(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
+}
 
 // defaultWorkspaceRoot resolves SPEC §6.4's `<system-temp>/symphony_workspaces`
 // default at call time so it tracks the running process's TMPDIR (Elixir uses


### PR DESCRIPTION
Closes #469 — follow-up to the unresolved review thread on PR #461 (`internal/doctor/doctor.go`).

## Problem
The `worker --doctor` GitHub-agent preflight deduplicated configured repos by `owner/name` only. A workflow can route the same `owner/name` to **distinct clone URLs** — e.g. an HTTPS fallback at `repo:` and an SSH deploy-key service at `services[].repo:`. Because `orchestrator.TaskFromIssue` swaps `cfg.Repo = serviceCfg.Repo` for service-routed work, the agent actually pushes to the service clone URL. The old dedup collapsed the two entries, so `--github-repo owner/name` silently selected the first (fallback) entry and the `git push --dry-run` probe could exercise a clone URL the agent never pushes to → **false failures for valid SSH setups, false passes for HTTPS-only setups**.

## Fix
- **Clone URL is part of the dedup identity** (`owner/name\x00normalized-clone-url`): genuine case-variant duplicates still fold, distinct HTTPS/SSH URLs survive.
- **`--github-repo` accepts owner/name OR a clone_url** to name the exact credential path.
- **Ambiguity is explicit**: an `owner/name` target matching multiple clone URLs errors listing the candidates instead of silently testing the first.
- **No credential leak**: every doctor error string (ambiguity list, not-found echo, ambiguity target echo) masks embedded basic-auth via `workflow.MaskCloneURL`. That masking helper was **promoted from the worker package** (duplicate deleted) so `--print-config` and doctor share one source of truth.
- **Masked URL is a usable selector**: `--github-repo` also accepts the *masked* clone URL the error displays, with exact (owner/name or raw-URL) matches taking precedence — so an operator disambiguating a credentialed HTTPS path never has to retype the token on the CLI, and the selected repo's raw `CloneURL` (with creds) is what the dry-run push uses.

## Acceptance criteria
- [x] Same `owner/name` with different clone URLs is no longer collapsed by the doctor preflight.
- [x] The credential path the agent will actually push to (`serviceCfg.Repo.CloneURL`) is selectable.
- [x] Disambiguation provided (`--github-repo <clone_url | masked clone_url>` + ambiguity error), with no token forced onto the CLI.

## Verification
```
gofmt -l $(git ls-files '*.go')        # empty
go mod tidy && git diff --exit-code -- go.mod go.sum
go vet ./...
go test -race -covermode=atomic ./...  # all pass
go build ./cmd/worker ./cmd/tui
```

**Mutation-verified tests** (`internal/doctor/doctor_test.go`):
- Revert dedup-key clone-URL → `TestSelectGitHubRepoDisambiguatesSameOwnerNameByCloneURL` FAIL (`kept 1 repos; want 2`).
- Revert `cloneURLList` masking → `TestSelectGitHubRepoAmbiguityErrorMasksCloneURLCredentials` FAIL (secret leaks).
- Revert case-0 target masking → `TestSelectGitHubRepoNotFoundErrorMasksCloneURLCredentials` FAIL (secret leaks). *(This was the CI-caught regression — an earlier commit lost the fix to a bad local restore; now committed and CI-green.)*
- Revert masked-match branch → `TestSelectGitHubRepoAcceptsMaskedCloneURLForSelection` FAIL (masked target not found).
- Existing `TestSelectGitHubRepoDeduplicatesIdenticalRepoEntries` (case-variant fold) still passes.

## Review
- **Independent dual review** (diff-only, no shared conclusion): both rounds **MERGE-READY**. Findings addressed: credential-leak P2 (masking), masked-selection P2 (masked-URL selector with exact precedence), stale stacked doc-comment removed. Remaining LOW is a documented, can't-leak tie-break (bare vs credentialed HTTPS that mask identically → exact bare match wins).
- **GitHub Codex**: its last successful review (commit `a3cf4d3`) surfaced the masked-selection P2, now fixed; subsequent `@codex review` triggers hit the account's **Codex usage limit** (external), so the final heads were not re-reviewed by the bot. The prior Codex thread is now outdated (code moved) and there are **no unresolved actionable review threads**. The independent dual review compensates for the rate-limited rounds.

## Scope / SPEC alignment
The doctor preflight is an aiops-platform extension (no Symphony SPEC / Elixir-reference equivalent, no `DEVIATIONS.md` entry); self-contained correctness + secret-hygiene fix. No back-compat shims (pre-release).

**Size: `within budget`.**
