### PR TITLE
docs: consolidate workflow skills into one shared review+merge protocol (#484)

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -10,7 +10,10 @@ metadata:
 
 # Handle Issue #$ARGUMENTS
 
-本仓库是 OpenAI Symphony SPEC 的 Go 端口，SPEC 对齐是硬要求。本 skill 覆盖 **issue → 开 PR** 阶段；PR 之后交给 `handle-pr`（SPEC 对齐审查轮）+ `gh-pr-follow-through`（盯到 merge-ready）。处理 issue #$ARGUMENTS（xrf9268-hue/aiops-platform）按下面流程。
+本仓库是 OpenAI Symphony SPEC 的 Go 端口，SPEC 对齐是硬要求。本 skill 覆盖 **issue → 开 PR** 阶段；PR 之后交给 `handle-pr`（SPEC 对齐审查轮）+ `gh-pr-follow-through`（盯到 merge-ready）。
+
+> **审查 / 合并协议是共享的。** pre-push 双 reviewer、`@codex review` 收敛、GraphQL review threads、size-gate 三态、合并门槛、回归+变异测试纪律统一在
+> [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md)。本 skill 只写 **issue→PR 阶段差异**，到 push/审查/合并步骤直接照那份协议执行，不在此复述。
 
 ## 何时用 / 不该用
 - **用**：要开始处理本仓库一个已建的 GitHub issue（"处理下一个 issue"、"修 #N"、"实现这个 issue"）。
@@ -38,13 +41,9 @@ metadata:
 - 从 `main` 开 `fix/<n>-<slug>`（如 `fix/331-active-transition-workspace-cleanup`）。
 - **显式补上 Elixir 隐式的 BEAM 保证**（checklist item 2）：followup goroutine 包 `context.WithTimeout`；每个 `go func`/`time.AfterFunc` 上 `defer recoverPanic` 或走 `safeGo`；重置 timer 前先 `Timer.Stop()`。
 - 算法对齐 upstream 分支（如终态清理仅在 terminal 转换、引用 `orchestrator.ex` 行号）。
+- 测试纪律（回归 + 变异 + fire-and-forget 的确定性 barrier + `-race`）见协议 §1；**别把"本地变绿"当成验证了发布物**。
 
-### 4. 测试纪律
-- **每个修复配回归测试 + 变异测试**：删掉新代码关键行 → 新测试必须 FAIL；恢复 → PASS。安慰剂测试是最隐蔽的陷阱。
-- fire-and-forget followup 的负向断言要有**确定性 barrier**（如再放一个仍处终态的 sibling 让「未发生」可观测）；别把概率性 barrier 写成「race-free」。
-- 并发改动跑 `go test -race`。
-
-### 5. 本地门禁（必须，CI 主门禁 + go vet）
+### 4. 本地门禁（必须，CI 主门禁 + go vet）
 ```bash
 gofmt -l $(git ls-files '*.go')          # 必须为空
 go mod tidy && git diff --exit-code -- go.mod go.sum
@@ -54,23 +53,16 @@ go build ./cmd/worker ./cmd/tui
 ```
 **暂存只 add 明确路径，绝不 `git add -A` / `git add .`**（会把 `.codex/` 等本地未跟踪文件卷入 PR）。commit 前 `git status --short` 核对只暂存了预期文件。
 
-### 6. 提交 + pre-push 双审 + 开 PR（关键）
-1. 先 `git fetch origin main`，再 commit/amend 候选改动；每次 push 前审的对象必须是稳定 head SHA，不审半成品工作区，也不审陈旧 base。
-2. **每次 push 前派两个独立 reviewer**：Codex reviewer + Claude Code reviewer，均只看 `git diff origin/main...HEAD`，prompt 带 issue/PR 意图、head SHA、相关 SPEC/upstream 路径、AGENTS.md 政策，不透露你的结论。要求 severity + verdict（`MERGE-READY` / `NEEDS-CHANGES` / `BLOCKED`）。
-   - **Codex reviewer**：主 agent 是 Claude Code 时，**首选** [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 提供的 `codex:codex-rescue` subagent（`Agent` 工具 `subagent_type: "codex:codex-rescue"`，prompt 里完整给出 PR head SHA / 改动文件 / SPEC/upstream 引用 / AGENTS.md 政策 / 验收项），它封装了 `codex exec review` 的 CLI flag 互斥（`--base`/`--commit`/`PROMPT` 三者两两互斥，详见 `codex exec review --help`）并通过 `codex:codex-result-handling` 结构化输出。**仅当**主 agent 是 codex 自身或插件不可用时，回退到 bash `codex exec review --base origin/main --title "..."` — review 子命令不接受自定义 PROMPT，跑的是 codex 默认 review heuristic（generic 审查），repo-specific 上下文（issue 意图、SPEC 引用、验收项）丢失。若 fallback 仍需传 repo-specific prompt，改用普通 `codex exec` 子命令（自由 PROMPT，diff 作 `<stdin>` 块），代价是失去 review 子命令的内置 review 结构。
-   - **Claude Code reviewer**：首选 `Agent` 工具 `subagent_type: "feature-dev:code-reviewer"`；受限环境用 hardened `claude -p`，必须接收 stdin diff，加 `--permission-mode bypassPermissions --no-session-persistence --tools "" --max-turns 2` 等约束，避免读取可变工作区或继承会话。
-3. HIGH/MEDIUM/Critical finding 先修复、amend、重跑本地门禁和两路 reviewer；只有用户在 push 前明确签核接受风险时才可保留未修复项。LOW/P3 若是小而真实的回归类问题就顺手修，否则先记在 review notes，PR 创建后写入 PR body。reviewer 执行失败不算通过，先改用更小的 diff-only prompt 重试；若某一路 reviewer 持续不可用，必须拿到同族等价 diff-only 审查通过或 push 前人工签核，并先记在 review notes，PR 创建后写入 PR body，不能只靠单 reviewer push。
-4. push 后开 **一个** PR 对应该 issue，body 引用 issue（`Closes #N`），列验收项、验证命令、变异验证、风险/deferral。治理/文档类改动**单开 PR**，不要塞进 fix PR。PR body 是活账本，每次重大 push 后更新 head/验证/review/size-gate 状态。
-5. **每次 push 都 `@codex review` 并等它收敛**——不是每个 PR 一次，是每个 commit。`gh pr comment <pr> --body "@codex review"`，记下该 trigger comment 的 id → **轮询**它自带的 reactions 计数摘要：`gh api repos/<owner>/<repo>/issues/comments/<id> --jq '.reactions.eyes'`（issue-comment 对象本身就含 `.reactions` 计数摘要，要的是 👀 的计数，不必用单独的 `/reactions` 列举端点）。Codex review 不是 check run，reactions 也没有 watch/订阅 API（REST 仅 GET/POST/DELETE），所以只能轮询；**CI 绿**则用原生 `gh pr checks <pr> --watch --fail-fast`（阻塞到 checks 完成），别 sleep 轮询。**只 `eyes==0` 不算完成**（也可能是还没开始 👀）：必须等到先出现 👀、再消失，**且**有正向完成信号——Codex 在该 head 贴了 review/comment，或 trigger comment 拿到 👍。然后用 GraphQL 查 `reviewThreads` 有无新的未解决 actionable thread，不能只看 flat comments 或 `latestReviews`。本地审查**不能替代**它（GitHub Codex bot 与 stop-time Codex gate 抓到本地 Claude reviewer 漏掉的缺陷类）。
-6. 每条 finding 归入 ≥1 类（算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试），然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。**Size budget 是 gate 不是 LOC 削减强制**：把 PR 明确归入三态 `within budget` / `size-gated: justified overage` / `size-gated: split recommended`，并写进 PR body。review finding 若暴露真实 correctness/safety/performance/coverage 问题且无法原子拆分，可超出预算 → `size-gated: justified overage`，禁自动合并，body 写超限原因+签核证据，等人工签核。若超限是 scope creep/无关清理 → `size-gated: split recommended`，hard stop 拆 PR。**严禁为压 LOC 删测试、弱化覆盖或绕过缺陷**。
-7. **审查深度匹配 blast radius**：双 reviewer 是每个 pushed head 的最低门槛；破坏性/并发路径要穷尽多轮对抗式审查，纯增量或文档改动一轮双审即可。
-8. 收敛后交给 `gh-pr-follow-through`（来自私有 `xrf9268-hue/yy-skills`；本地开发机已装，**云端容器通常没装**）盯 CI + 线程到 merge-ready。**该 skill 不可用时（如当前云端环境）就地内联这步**：`gh pr checks <pr> --watch --fail-fast` 等 CI 收敛 → 查 `reviewThreads` 解决所有未决 actionable thread → 直到 merge-ready，别因为缺 skill 而跳过这步。follow-through 期间若推了修复，按 step 2/5 对新 head 重跑 pre-push 双审和 `@codex review` 环（新 push 会重开审查轮）。
+### 5. 提交 → 双审 → 开 PR
+1. 按协议 §2–§3 commit-first + pre-push 双 reviewer，§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
+2. push 后开 **一个** PR 对应该 issue，body 引用 issue（`Closes #N`），列验收项、验证命令、变异验证、风险/deferral；PR body 是活账本（协议 §7）。
+3. **每条 finding 归入 ≥1 类**：算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试；然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。
+4. **Deferred 偏差必须开 issue**（AGENTS.md rule 2）：决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
+5. **Scope 分离**：治理/文档类改动从 main 开新分支**单独 PR**，不要塞进 fix PR。
+6. 收敛后交给 `gh-pr-follow-through`（私有 `xrf9268-hue/yy-skills`；云端容器通常没装）盯 CI + 线程到 merge-ready。**该 skill 不可用时就地内联**：`gh pr checks <pr> --watch --fail-fast` 等 CI → GraphQL `reviewThreads` 解决所有未决 actionable thread → merge-ready。期间推了修复就对新 head 重跑协议 §3–§5。
 
-### 7. 合并
-- **必须等用户明确许可**再合并。
-- 例外：用户给了**按批次、按 scope 的显式授权**时，可走 `docs/runbooks/batch-issue-processing.md` 的 opt-in 自动合并流程（全部放行门槛 + hard stops；优先 GitHub 原生 auto-merge）。授权不是长期的，批次外/scope 外仍要重新确认。
-- squash + 删分支；commit message 写**最终状态**，不要按轮次罗列。
-- 强推统一 `--force-with-lease=<branch>:<known-sha>`。
+### 6. 合并
+按协议 §8：**必须等用户明确许可**；squash + 删分支，commit message 写最终状态；`--force-with-lease=<branch>:<known-sha>`。批次/scope 显式授权下的 opt-in 自动合并见 [`docs/runbooks/batch-issue-processing.md`](../../../docs/runbooks/batch-issue-processing.md)。
 
 ## 反模式备忘（踩过的坑）
 - **pre-release 别加 back-compat**：别名 / 双发同一数据 / 保留旧 wire 名都是技术债，要单独清理 PR（#338 双发 `last_codex_at`+`last_event_at` → 清理 #342）。SPEC 重命名就全量原子改名，内部 Go 标识符也对齐 SPEC 词汇，注释只解释 why（AGENTS.md「These rules apply to every PR」§1–§5）。仓库内消费者用旧名就在同一 PR 改掉。
@@ -82,21 +74,19 @@ go build ./cmd/worker ./cmd/tui
 - 一个契约在姊妹路径上只兑现一半（running vs blocked；reconcile-poll vs §16.5 self-stop）。
 
 ## 示例（两条真实路径）
-**看似简单实则有坑 — #328（PR #338）**：`/api/v1/state` 缺 SPEC §13.7.2 的 `rate_limits` + `last_event_at`。一个 commit、一轮 review 就合了——但它**双发** `last_codex_at`（旧名）+ `last_event_at`（spec 名）当 back-compat，违反本仓库 pre-release 的「无 back-compat shim / 一个概念一个真相源 / 名字对齐 domain」规则（AGENTS.md「These rules apply to every PR」§1–§4），结果要靠清理 PR #342 删掉别名。→ 教训：pre-release 没有外部消费者，SPEC 重命名就**全量原子改名**（struct 字段 + JSON tag + dashboard + runbook + test 一次改完），别加别名/双发；小改动也逃不过这些规则。`rate_limits` 去 `omitempty` 让键恒在那部分是干净的 spec 对齐。
+**看似简单实则有坑 — #328（PR #338）**：`/api/v1/state` 缺 SPEC §13.7.2 的 `rate_limits` + `last_event_at`。一个 commit、一轮 review 就合了——但它**双发** `last_codex_at`（旧名）+ `last_event_at`（spec 名）当 back-compat，违反 pre-release「无 back-compat shim / 一个概念一个真相源 / 名字对齐 domain」规则，结果要靠清理 PR #342 删掉别名。→ 教训：SPEC 重命名就**全量原子改名**（struct 字段 + JSON tag + dashboard + runbook + test 一次改完），小改动也逃不过这些规则。
 
 **硬路径 — #331（PR #339，多轮级联）**：running issue mid-run 转终态时未清理 workspace（§18.1）。破坏性 + 并发路径，经历 P1 数据丢失竞态 → P2 超时耦合（前一个修复引入的）→ P2 陈旧标志 → TOCTOU → P2 root 不匹配 的级联，每轮 `@codex review` 抓到新缺陷（含修复引入的）。每个修复配回归 + 变异测试；路由模式与 §16.5 self-stop 两处缺口延后到 #340/#341。→ 破坏性/并发路径要穷尽对抗式审查，且**每个 push 都重新 @codex review**。
 
 ## 验证（完成判定）
-- 本地门禁全绿：`gofmt -l $(git ls-files '*.go')` 为空、`go mod tidy` 后 `go.mod`/`go.sum` 无改动、`go vet ./...`、`go test -race -covermode=atomic ./...`、`go build ./cmd/worker ./cmd/tui`。
-- 新测试经变异验证（删关键行 FAIL / 恢复 PASS）。
-- 每个已 push 的 head 都先经过提交后、push 前的 Codex + Claude Code 双 reviewer，或有明确人工签核的等价 fallback；HIGH/MEDIUM/Critical 已修复，未修复项必须有 push 前人工签核并在 PR body 记录风险。
+- 本地门禁全绿（§4）；新测试经变异验证（协议 §1）。
+- 每个已 push 的 head 过了 pre-push 双 reviewer + fresh `@codex review` 收敛 + GraphQL threads 无未决 actionable thread（协议 §3–§5）。
 - CI 全绿：`gh pr checks <pr> --watch --fail-fast` 阻塞到完成。
-- PR 最新 head 上 `@codex review` 收敛：👀 出现后消失、**且**有正向完成信号（Codex 在该 head 贴了 review/comment 或 👍），GraphQL reviewThreads 无新的未解决 actionable thread。仅 `eyes==0` 或陈旧 `latestReviews` 不足以判定完成。
 - issue 的每条 Acceptance criteria 满足或显式延后到 tracked issue。
-- 用户明确许可后才合并。
+- 用户明确许可后才合并（协议 §8）。
 
 ## 默认行为
 - 中文回复，简洁；每次只汇报变化，不复述。
 - worker 永不 push/合并 PR 或写 tracker 状态（D8/#76）。
 - Go 版本由 go.mod 锁定，别顺手改 `go` 指令。
-- **批处理多个 issue 时**（`/goal` over a set）：独立 issue **默认并行**开分支推进，只在有真实依赖（共享文件 / migration 顺序 / 后者消费前者的 API）时串行；决定某条 acceptance criterion 延后时**当场**告知用户并立即开 follow-up issue，别留到收尾汇报。完整批处理纪律见 `docs/runbooks/batch-issue-processing.md`。
+- **批处理多个 issue 时**（`/goal` over a set）：独立 issue **默认并行**开分支推进，只在有真实依赖（共享文件 / migration 顺序 / 后者消费前者的 API）时串行；决定某条 acceptance criterion 延后时**当场**告知用户并立即开 follow-up issue。完整批处理纪律见 [`docs/runbooks/batch-issue-processing.md`](../../../docs/runbooks/batch-issue-processing.md)。

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -7,7 +7,10 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
 
 # Handle PR #$ARGUMENTS
 
-本仓库是 OpenAI Symphony SPEC 的 Go 端口，SPEC 对齐是硬要求。处理 PR #$ARGUMENTS（xrf9268-hue/aiops-platform）按以下流程。
+本仓库是 OpenAI Symphony SPEC 的 Go 端口，SPEC 对齐是硬要求。本 skill 覆盖 **已有 PR 的 SPEC 对齐审查轮**。
+
+> **审查 / 合并协议是共享的。** commit-first、pre-push 双 reviewer（含 Codex `codex exec review` 的 flag 互斥与 fallback）、`@codex review` 每 push 收敛、GraphQL review threads 判定、size-gate 三态 + PR-body checklist、合并/auto-merge 门槛与 hard stops、回归+变异测试纪律统一在
+> [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md)。本 skill 只写 **PR 审查阶段差异**，到 push/审查/合并步骤照那份协议执行。
 
 ## Upstream 已就位
 
@@ -19,78 +22,24 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
 
 !`git fetch origin main 2>&1 | tail -1 && git log --oneline origin/main -1`
 
-## 必做的几件不常规的事
+## PR 审查阶段差异
 
-1. **读 AGENTS.md** 的 "SPEC alignment" 和 "Cross-cutting checklist when porting from the Elixir reference" 两节作为审查清单。每个 finding 至少归到一类：
+1. **读 AGENTS.md** 的 "SPEC alignment" 和 "Cross-cutting checklist when porting from the Elixir reference" 两节作为审查清单。**每个 finding 至少归到一类**：
    - 算法级 SPEC 偏差（vs upstream `handle_*` 逐分支比对）
    - 跨模块一致性漏镜像（grep 同概念其他 consumer，列出 aiops-platform 扩展 routing / fan-out / capacity caps / eligibility filter 是否都镜像了）
    - Go 运行时硬化（followup goroutine 是否 `context.WithTimeout` / `defer recoverPanic` / `Timer.Stop()`——Elixir BEAM 隐式给的保证 Go 必须显式补）
    - 测试是否安慰剂（assertion 真的读到新代码改的字段吗？）
 
-2. **修一轮、提交一轮、push 前双审一轮**：
-   - 先 `git fetch origin main`，再 commit/amend；审稳定 head SHA，不审未提交工作区或陈旧 base
-   - 同时派 Codex reviewer + Claude Code reviewer，均只看 `git diff origin/main...HEAD`
-   - **Codex reviewer 选哪条路径**：主 agent 是 Claude Code 时，**首选** [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 提供的 `codex:codex-rescue` subagent（通过 `Agent` 工具 `subagent_type: "codex:codex-rescue"` 调用，prompt 里完整给出 PR head SHA / 改动文件 / SPEC/upstream 引用 / AGENTS.md 政策 / 验收项），它封装了 `codex exec review` 的 CLI flag 互斥（`--base`/`--commit`/`PROMPT` 三者两两互斥，详见 `codex exec review --help`）并通过 `codex:codex-result-handling` 结构化输出。**仅当**主 agent 是 codex 自身或插件不可用时，回退到 bash `codex exec review --base origin/main --title "..."` — 注意 review 子命令不接受自定义 PROMPT，跑的是 codex 默认 review heuristic（generic correctness/style 审查），repo-specific 上下文（issue 意图、SPEC 引用、验收项）丢失。若 fallback 路径仍需传 repo-specific prompt，改用普通 `codex exec` 子命令（自由 PROMPT，把 diff 作为 `<stdin>` 块），代价是失去 review 子命令的内置 review 结构
-   - Claude Code reviewer 用 `Agent` 工具 `subagent_type: "feature-dev:code-reviewer"`（首选），或在受限环境用 hardened `claude -p`：必须接收 stdin diff，并加 `--permission-mode bypassPermissions --no-session-persistence --tools "" --max-turns 2` 等约束，避免读取可变工作区或继承会话
-   - prompt brief 完整（PR head SHA、文件路径、upstream 参考路径、AGENTS.md 政策、验收项）
-   - **不透露你的结论**
-   - 要求 ≤700 字 + severity 标注 + 末尾 `MERGE-READY / NEEDS-CHANGES / BLOCKED` 判决
-   - HIGH/MEDIUM/Critical 先修复、amend、重跑本地门禁和双审；只有用户在 push 前明确签核接受风险时才可保留未修复项。LOW/P3 若小而真实就修，否则在 PR body 记录不阻塞理由
-   - reviewer 失败不算通过；先改用更小的 diff-only prompt 重试。若某一路 reviewer 持续不可用，必须拿到同族等价 diff-only 审查通过或 push 前人工签核，并先记在 review notes，PR 存在后写入 PR body，不能只靠单 reviewer push
-   - 一般 2-3 轮收敛
+2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，HIGH/MEDIUM/Critical 先修再 amend 重审；一般 2–3 轮收敛。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
 
-3. **Mutation test 验证新测试有效**：删掉新代码的关键行，跑新测试，确认 fail；恢复，确认 pass。安慰剂测试是最隐蔽的陷阱。
+3. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria（AGENTS.md rule 2）。决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
 
-4. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria。AGENTS.md rule 2 要求。决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
+4. **Scope 分离**：治理 / 文档改动从 main 开新分支单独 PR，不要塞进 fix PR。
 
-5. **Scope 分离**：治理 / 文档改动从 main 开新分支单独 PR，不要塞进 fix PR。
-
-6. **Fresh `@codex review` 是 post-push gate**：每次 push 后在 PR 评论
-   `@codex review`，记录 trigger comment id，等 👀 先出现再消失，并要求
-   Codex 在该 head 贴 review/comment 或给 trigger 👍。`latestReviews` 可能
-   滞后，不能单独作为新 head clean 的证据。
-
-7. **Review threads 用 GraphQL 判定**：flat comments 不够。只在以下条件之一
-   成立时 resolve thread：
-   - 代码确实修复了该 thread 的问题
-   - thread 已 outdated，且 fresh Codex trigger clean
-   - 用户明确要求处理该 PR，fresh trigger 已完成，且 thread-aware recheck 确认该 thread 不再 actionable
-   合并前必须零 unresolved、non-outdated actionable thread。
-
-8. **Size gate 是 merge gate，不是质量上限，更不是 LOC 削减强制**：
-   correctness / safety / performance / coverage 修复带来的 LOC 增量优先于
-   预算合规。**严禁为了压 LOC 删测试、弱化 state-machine 覆盖、跳过 race 覆盖
-   或留下已知缺陷**。把每个 PR 准确归入三态之一，并在 body 写明：
-   - `within budget`：diff 在预算内。
-   - `size-gated: justified overage`：因 correctness / safety / performance / coverage
-     修复超出预算且无法拆分成原子单元。**禁止自动合并**，body 写清超限原因、head SHA、
-     验证、CI、bot review、thread 状态和剩余风险，等人工 size-gate 签核后再合。
-   - `size-gated: split recommended`：因 scope creep / 无关清理 / 实际可拆分的
-     关注点超出预算。**Hard stop**——拆成多个小 PR，不要拿签核当替代。
-
-9. **PR body 是活账本**：每次重大 push 后更新 head SHA、验收项、验证命令、
-   mutation check、CI、双 reviewer、`@codex review`、thread、size-gate
-   classification（必须三态之一；超限时附说明）、deferral/follow-up 状态，
-   避免 stale body 误导后续合并判断。PR body 必带一行 size-gate checklist：
-
-   ```markdown
-   ### Size gate
-   - [ ] `within budget` — diff fits effective `policy.max_changed_files` /
-         `max_changed_loc`
-   - [ ] `size-gated: justified overage` — overage rationale: <why correctness/
-         coverage/safety/perf justifies the extra LOC; not auto-mergeable; needs
-         human size-gate sign-off>
-   - [ ] `size-gated: split recommended` — split rationale: <which concerns
-         to split into separate PRs; hard stop, do not seek sign-off in lieu
-         of splitting>
-   ```
+5. **PR body 是活账本**（协议 §7）：每次重大 push 后更新 head SHA、验收项、验证命令、mutation check、CI、双 reviewer、`@codex review`、thread、size-gate 三态 checklist、deferral 状态，避免 stale body 误导合并判断。
 
 ## 默认行为
 
-- 工作分支：系统会告诉你具体名字
-- 合并方式：squash（本仓库惯例），commit_message 写最终状态不要按轮次罗列
-- 强推统一 `--force-with-lease=<branch>:<known-sha>`
-- merge 前必须等用户明确许可；例外：用户给了**按批次、按 scope 的显式授权**时，走 `docs/runbooks/batch-issue-processing.md` 的 opt-in 自动合并流程（全门槛 + hard stops）。授权不跨批次/scope 沿用
-- 即便有 auto-merge 授权，也只有在本地门禁、CI、fresh `@codex review`、GraphQL threads、size gate、branch protection 全部满足时才可合并；启用 GitHub 原生 auto-merge 前必须先确认这些非 check gates 已经 clean。size gate 必须分态处理：只有 `within budget` 可走 auto-merge；`size-gated: justified overage` 必须等人工 size-gate 签核（不可 auto-merge）；`size-gated: split recommended` 是 hard stop，必须拆 PR，不要拿签核当替代
-- 批处理多个 PR 时的并行与状态清单纪律见 `docs/runbooks/batch-issue-processing.md`
-- 中文回复，简洁；每次只汇报变化不复述
+- 工作分支：系统会告诉你具体名字。
+- 合并、force-push、auto-merge 门槛、hard stops：全部按协议 §8。merge 前必须等用户明确许可；批次/scope 显式授权下的 opt-in 自动合并见 [`docs/runbooks/batch-issue-processing.md`](../../../docs/runbooks/batch-issue-processing.md)，授权不跨批次/scope 沿用。
+- 中文回复，简洁；每次只汇报变化不复述。

--- a/docs/runbooks/batch-issue-processing.md
+++ b/docs/runbooks/batch-issue-processing.md
@@ -4,6 +4,15 @@ How an agent should run a batch of issues (a `/goal` over a set of tracker
 issues) so the work stays reviewable, parallel where it can be, and safe to
 merge.
 
+> **The per-PR review & merge gates are shared.** Dual diff-only reviewers,
+> `@codex review` convergence, GraphQL review-thread closure, the size-gate
+> three states, the merge / authorized-auto-merge gate list, and regression +
+> mutation test discipline live once in
+> [`pr-review-merge-protocol.md`](pr-review-merge-protocol.md). This runbook
+> covers only the **batch-orchestration delta** — parallelism, the live ledger,
+> deferral timing, pause/resume, and the *opt-in* authorization wrapper around
+> the shared merge gate.
+
 Every rule below is earned by a specific failure or friction observed in batch
 runs:
 
@@ -11,12 +20,11 @@ runs:
   #374, #376–#381; the one acceptance-criterion deferral was filed as a
   separate follow-up, issue #375 — which is why the PR numbers skip it).
 - **2026-05 ten-issue automated batch** (issues #384–#393). This run added the
-  quality-over-throughput lessons: post-commit dual local review before push,
-  fresh `@codex review` trigger tracking, thread-aware review closure, the
-  three-state size-gate classification (`within budget` /
-  `size-gated: justified overage` / `size-gated: split recommended`) with
-  explicit sign-off paths, pause/resume state recovery, and follow-up capture
-  for late unresolved review threads.
+  quality-over-throughput lessons now in the shared protocol (post-commit dual
+  local review before push, fresh `@codex review` trigger tracking,
+  thread-aware review closure, the three-state size-gate classification with
+  explicit sign-off paths) plus the batch-level pause/resume state recovery and
+  follow-up capture for late unresolved review threads.
 
 Per the "Earned rules" principle in [`AGENTS.md`](../../AGENTS.md), do not
 generalize beyond what those runs actually taught.
@@ -29,14 +37,14 @@ generalize beyond what those runs actually taught.
    and a revert touches exactly one concern. **Earned by:** the eight-issue
    batch shipped as eight independent PRs and every one was reviewable in
    isolation; the value was in the isolation, not the volume.
-2. **Each PR is self-contained and self-verifying.** It includes the fix plus
-   regression tests, and the test must fail when the production code is broken
-   (mutation or negative assertion — see "Clean code" rule 6 in `AGENTS.md`). A
-   PR whose tests would pass with the fix reverted does not count as done.
-3. **Run the local CI gate and dual local review before pushing**, then confirm
-   CI green and run the adversarial pass (`@codex review`) on the pushed head
-   commit. Resolve or explicitly defer every finding before marking ready. This
-   is the cross-cutting checklist in `AGENTS.md`, applied per PR.
+2. **Each PR is self-contained and self-verifying** — fix plus regression tests,
+   mutation-verified per the protocol's test discipline
+   ([protocol §1](pr-review-merge-protocol.md#1-test-discipline-regression--mutation-verification)).
+   A PR whose tests would pass with the fix reverted does not count as done.
+3. **Run the full per-PR gate for each PR** — local CI gate, dual local review
+   before push, CI green, and `@codex review` on the pushed head — exactly as
+   the shared protocol specifies. This runbook does not change those gates; it
+   only governs how many run in parallel.
 
 ## Parallelize independent issues by default
 
@@ -60,78 +68,10 @@ ordering dependency.
    worker's per-state capacity caps are the hard ceiling; your review bandwidth
    is the practical one. Do not open more parallel work than you can drive to
    mergeable without letting reviews rot.
-4. **Respect the size budget per PR regardless of parallelism**
-   (`policy.max_changed_files: 12`, `policy.max_changed_loc: 300`).
-   Parallelism is about more small PRs, never bigger ones — but the budget
-   is a *gate* to be classified and disclosed, not a ceiling that forces
-   LOC cuts at the expense of quality. See "Size gate semantics" below.
-
-### Size gate semantics
-
-Size budget is an auto-merge eligibility gate, not a quality throttle nor an
-LOC-reduction mandate. **Quality, correctness, performance, and necessary
-regression coverage take precedence over LOC compliance**: if HIGH/MEDIUM
-review feedback exposes a real correctness, safety, performance, or coverage
-gap, fix it even when that pushes the PR over the default budget. Never
-delete meaningful tests, weaken state-machine coverage, drop race coverage,
-or prefer compact code over clear reliable code solely to satisfy the
-budget.
-
-Classify every PR into exactly one of three states and call it out in the PR
-body:
-
-- `within budget` — diff fits the effective budget; standard auto-merge path.
-- `size-gated: justified overage` — over the budget because the extra LOC
-  pays for correctness, regression coverage, race/state-machine safety, or
-  other best-practice hardening that cannot be split without losing
-  atomicity. Keep it out of auto-merge and provide a human sign-off bundle:
-  why the extra scope is necessary, the final head SHA, local verification,
-  CI state, bot review state, unresolved-thread state, and residual risk.
-- `size-gated: split recommended` — over the budget because of scope creep,
-  unrelated cleanup, or genuinely separable concerns. Stop and split into
-  smaller PRs; do not ask for size-gate sign-off in lieu of splitting.
-
-Only reduce LOC when the code is genuinely redundant, over-abstracted,
-duplicated without purpose, or outside scope.
-
-## Review the committed diff before every push
-
-The 2026-05 ten-issue batch showed that review before commit is too easy to
-invalidate with an amend. Make the commit object the review artifact:
-
-1. **Refresh `origin/main`, then commit or amend first**, with only explicit
-   paths staged.
-2. **Before every push**, dispatch two independent diff-only reviewers against
-   the exact committed range (`origin/main...HEAD`):
-   - a Codex reviewer (subagent or `codex exec`)
-   - a Claude Code reviewer (subagent or hardened `claude -p`)
-
-   Bare `claude -p` is shorthand for a diff-only invocation that receives the
-   diff on stdin, disables tool use, and avoids session carryover, for example
-   `claude -p '<review prompt>' --permission-mode bypassPermissions
-   --no-session-persistence --tools "" --max-turns 2`.
-3. **Do not feed either reviewer your conclusions.** Provide the issue/PR
-   intent, head SHA, changed files, relevant SPEC/upstream pointers, and the
-   diff. Ask for severity-tagged findings and a final verdict.
-4. **HIGH/MEDIUM/Critical findings block the push.** Fix them, amend, and rerun
-   both reviewers unless the human explicitly signs off on accepting that risk
-   before push. LOW/P3 findings should be fixed when they are small, localized,
-   and regression-like; otherwise record the decision in review notes and the
-   PR body.
-5. **A failed reviewer run is not approval.** Retry with a bounded diff-only
-   prompt. If one reviewer family remains unavailable, use an equivalent
-   successful diff-only review from the same family or get explicit human
-   sign-off before pushing. Record the fallback/sign-off in local review notes
-   before a first push, then copy it into the PR body when the PR exists. Do not
-   push with only one local reviewer verdict. The pushed PR still needs the
-   GitHub `@codex review` gate.
-
-This local review gate is in addition to the GitHub bot review. It catches
-pre-push defects; it does not replace the post-push, thread-aware gate. Two
-reviewers are the minimum for a pushed head; the blast radius controls how many
-rounds you run after that. A pure documentation change may need only one clean
-dual-review round, while destructive or concurrent code paths need repeated
-rounds until the findings stop.
+4. **Parallelism means more small PRs, never bigger ones.** The size budget
+   still applies per PR and is classified/disclosed per
+   [protocol §6](pr-review-merge-protocol.md#6-size-gate-is-a-merge-gate-not-an-loc-reduction-mandate)
+   — it is a gate, not a ceiling that forces LOC cuts at the expense of quality.
 
 ## Surface deferrals at the moment you defer, not at the end
 
@@ -182,35 +122,12 @@ issue → branch/worktree → PR → head → state
 This mirrors the per-event status-checklist discipline the harness expects when
 watching PR activity; apply it to the batch as a whole.
 
-For each PR, also track:
-
-- current head SHA
-- validation commands run locally
-- CI conclusion and run id
-- `@codex review` trigger comment id and reaction state
-- unresolved review thread ids, including whether each is outdated
-- size-budget classification (`within budget` / `size-gated: justified overage`
-  / `size-gated: split recommended`) and, if over budget, the rationale
-- deferral/follow-up issue links
-
-Treat the PR body as the public ledger for the same facts. Update it after each
-material push instead of leaving stale validation or review status in place.
-
-## Treat bot review and review threads as live gates
-
-`@codex review` is not a normal check run and `latestReviews` can lag the fresh
-trigger. For every pushed head:
-
-1. Comment `@codex review` and record that issue-comment id.
-2. Wait for the trigger's 👀 reaction to appear, then disappear, and require a
-   positive completion signal: Codex posted a review/comment for that head or
-   reacted 👍 to the trigger.
-3. Query review threads with GraphQL. Flat review comments are not enough.
-4. Resolve addressed or outdated threads only after the fresh trigger completes
-   and a thread-aware recheck shows no non-outdated actionable threads.
-5. If a PR is merged with non-trivial bot review activity, sanity-check the next
-   `Capture unresolved reviews` workflow run or linked follow-up issues. That
-   workflow is a backstop, not a merge substitute.
+For each PR, also track the per-PR ledger facts the protocol already requires
+([protocol §7](pr-review-merge-protocol.md#7-pr-body-is-a-living-ledger)) —
+current head SHA, local validation commands, CI conclusion/run id,
+`@codex review` trigger id + reaction state, unresolved review-thread ids (and
+whether each is outdated), size-gate classification, and deferral/follow-up
+links — and keep the PR body in sync as the public copy of the same facts.
 
 ## Pause, resume, and external merges
 
@@ -223,8 +140,8 @@ On resume, do not trust the paused snapshot. Re-fetch `origin/main`, refresh
 each live issue/PR with `gh`, and reclassify externally changed work:
 
 - If the human merged a PR, mark it `merged-by-user` and move on.
-- If the head changed, restart local verification and review gates for that
-  head.
+- If the head changed, restart local verification and the review gates for that
+  head (protocol §3–§5).
 - If a trigger comment is still active, wait for that exact trigger or start a
   fresh review on the current head.
 - If unresolved review follow-up issues were created after merge, link them in
@@ -244,58 +161,20 @@ its own `/goal` at the end (the Stop hook released only after the human ran
    and clearing the goal. Plan for PRs to queue waiting for a human; that is
    expected, not a stall.
 
-## Authorized auto-merge flow (opt-in, scope-bounded)
+## Authorized auto-merge (opt-in, scope-bounded)
 
 The default above (human merges) stands unless the human grants explicit,
-scope-bounded authorization for the agent to merge. Authorization is per-batch
-and per-scope — "you may merge the PRs for issues #365–#372 once they pass the
-gate" — never a standing grant. Approving one merge does not authorize the
-next.
+scope-bounded authorization for the agent to merge — "you may merge the PRs for
+issues #365–#372 once they pass the gate" — never a standing grant. Approving
+one merge does not authorize the next.
 
-When auto-merge **is** authorized, a PR may be merged only when **all** of
-these hold:
-
-1. **CI is green** on the head commit (not a stale run).
-2. **`@codex review` is clean** — no unresolved HIGH/MEDIUM findings — and
-   there are **zero unresolved, non-outdated review threads**. The review must
-   be fresh for the current head: trigger-comment reactions have converged and
-   thread-aware GraphQL state is clean.
-3. **Every acceptance criterion is met, or each gap is deferred to a tracked,
-   linked issue** (per the deferral protocol above).
-4. **The PR is classified `within budget` and changes no
-   `policy.deny_paths`.** Read both from the repo's `WORKFLOW.md`; do not trust
-   a hardcoded list — workflows differ (defaults are 12 files / 300 LOC and
-   deny `infra/**`, `deploy/**`, `db/migrations/**`, `secrets/**`, but e.g. the
-   `github-local` example uses 20 / 600). `size-gated: justified overage`
-   requires explicit human size-gate sign-off before merge and is never
-   auto-mergeable; `size-gated: split recommended` is a hard stop — split the
-   PR instead of asking for sign-off.
-5. **Branch protection's required reviews are satisfied.**
-6. **The merge uses the agreed method** (default: squash) into the agreed base.
-
-**Native auto-merge enforces only required status checks (CI) and branch
-protection's required reviews — not gates 2–4.** `gh pr merge --auto` merges the
-instant required CI passes, regardless of an open `@codex` finding, an
-unresolved review thread, an unmet acceptance criterion, or a size-budget
-breach. So:
-
-- Confirm gates 2–4 **yourself, immediately before** enabling auto-merge.
-- A new commit re-opens them — any push restarts the `@codex` round, so
-  re-confirm before re-enabling.
-- Prefer native auto-merge over an immediate merge only after the non-check
-  gates are already confirmed, and only to win the CI race — not as a
-  substitute for checking the policy gates.
-
-Hard stops — **always require human sign-off even under an auto-merge grant:**
-
-- Force-pushing or merging into `main` out of band, or any history rewrite.
-- Editing `go.mod`'s `go` directive opportunistically, or touching `policy.deny_paths`.
-- A PR classified `size-gated: justified overage` — flag, don't merge without
-  explicit human size-gate sign-off (acceptable to merge once given). A PR
-  classified `size-gated: split recommended` — flag and split; do not seek
-  sign-off as a substitute for splitting.
-- Anything the human's instructions for this batch put off-limits. When a PR
-  sits at the edge of the grant, use `AskUserQuestion` rather than assuming the
-  grant covers it.
+When auto-merge **is** authorized, apply the full merge gate and hard-stop list
+in [protocol §8](pr-review-merge-protocol.md#8-merge): CI green on the head,
+fresh `@codex review` clean with zero unresolved non-outdated threads, every
+acceptance criterion met or deferred to a tracked issue, classified
+`within budget` and changing no `policy.deny_paths`, required reviews
+satisfied, agreed squash method. Native auto-merge enforces only CI + required
+reviews, so confirm the non-check gates yourself immediately before enabling it,
+and re-confirm after any push (a new commit re-opens the `@codex` round).
 
 Stop the moment the human revokes the grant or asks you to stop.

--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -1,0 +1,206 @@
+# PR review & merge protocol
+
+The single source of truth for how any pushed head in this repo is tested,
+reviewed, and merged. `handle-issue`, `handle-pr`, and
+[`batch-issue-processing.md`](batch-issue-processing.md) all reference this
+file instead of restating it — update the protocol here, in one place
+(clean-code rule 3, one source of truth per concept; see
+[`AGENTS.md`](../../AGENTS.md)).
+
+Every rule below is earned by a specific observed failure; the consuming
+docs name the runs (e.g. the 2026-05 eight- and ten-issue batches). Do not
+generalize beyond the evidence.
+
+## 1. Test discipline (regression + mutation verification)
+
+1. **Every fix ships a regression test.** A test that would still pass with the
+   production fix reverted is a placebo and does not count as done.
+2. **Mutation-verify against the committed artifact, not the working tree.** A
+   green local test only proves the working tree passes; it does **not** verify
+   the artifact you push unless the tree equals the pushed HEAD. **Earned by:**
+   a #469/PR #483 session where an uncommitted masking fix was silently lost to
+   a `cp`/`git checkout` backup-restore — local tests stayed green (the working
+   tree transiently held the fix) while the commit did not, and CI caught the
+   regression, not local review.
+3. **Correct mutation procedure — commit first, then mutate:**
+   1. Commit (or amend) the fix so it is in HEAD.
+   2. Break the key production line (edit/`sed`/`perl`).
+   3. Run the matching test — it **must FAIL**.
+   4. `git checkout -- <file>` to restore (idempotent now that the fix is
+      committed — checkout restores the fix instead of losing it).
+   5. Confirm `git status` is clean and `git diff HEAD` is empty before moving
+      on, so "tested" equals "shipped".
+4. **Fire-and-forget negative assertions need a deterministic barrier** (e.g. a
+   sibling still in the terminal state that makes "did not happen" observable);
+   never sell a probabilistic barrier as race-free.
+5. **Run `go test -race` for concurrency changes.**
+
+## 2. Review the committed range before every push
+
+1. **Refresh `origin/main`, then commit/amend first**, staging only explicit
+   paths (never `git add -A` / `git add .`). The review artifact is a stable
+   head SHA, never a half-finished working tree or a stale base.
+2. The diff under review is always `git diff origin/main...HEAD`.
+
+## 3. Pre-push dual diff-only reviewers
+
+Dispatch **two independent reviewers** before every push; both see only the
+committed diff and are **not told your conclusion**. Require severity-tagged
+findings (keep each review ≤700 words) and a final verdict —
+`MERGE-READY` / `NEEDS-CHANGES` / `BLOCKED`. Give each a complete brief: head
+SHA, changed files, intent (issue/PR), relevant SPEC/upstream pointers, and
+AGENTS.md policy.
+
+- **Codex reviewer.** When the main agent is Claude Code, **prefer** the
+  `codex:codex-rescue` subagent from
+  [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) (`Agent` tool,
+  `subagent_type: "codex:codex-rescue"`); pass the full brief in the prompt. It
+  wraps `codex exec review`'s CLI flag mutex (`--base` / `--commit` / `PROMPT`
+  are pairwise exclusive — see `codex exec review --help`) and returns
+  structured output via `codex:codex-result-handling`. **Only when** the main
+  agent is Codex itself or the plugin is unavailable, fall back to
+  `codex exec review --base origin/main --title "…"` — the `review` subcommand
+  takes no custom PROMPT and runs Codex's generic review heuristic, so
+  repo-specific context (issue intent, SPEC refs, acceptance criteria) is lost.
+  If the fallback still needs a repo-specific prompt, use plain `codex exec`
+  (free PROMPT, diff as a `<stdin>` block) at the cost of the `review`
+  subcommand's built-in review structure.
+- **Claude Code reviewer.** Prefer the `Agent` tool with
+  `subagent_type: "feature-dev:code-reviewer"`. In a restricted environment use
+  a hardened `claude -p` that receives the diff on stdin and cannot read the
+  mutable working tree or inherit the session:
+  `--permission-mode bypassPermissions --no-session-persistence --tools "" --max-turns 2`.
+
+Triage:
+
+- **HIGH / MEDIUM / Critical block the push.** Fix, amend, rerun the local
+  gate and both reviewers. Keep an unfixed item only if the human explicitly
+  signs off on the risk before push.
+- **LOW / P3:** fix when small, localized, and regression-like; otherwise record
+  the decision in review notes and copy it into the PR body once the PR exists.
+- **A failed reviewer run is not approval.** Retry with a smaller diff-only
+  prompt. If one reviewer family stays unavailable, get an equivalent successful
+  diff-only review from the same family or explicit human sign-off before push,
+  and record it (review notes → PR body). Never push on a single reviewer.
+- **Review depth matches blast radius.** Two reviewers are the minimum for a
+  pushed head; destructive/concurrent paths need repeated adversarial rounds
+  until findings stop, while pure incremental or documentation changes need one
+  clean dual-review round.
+
+## 4. `@codex review` is a per-push, post-push gate
+
+Run it **on every pushed head**, not once per PR.
+
+1. `gh pr comment <pr> --body "@codex review"`; record that trigger
+   comment's id.
+2. **Poll** its reactions summary —
+   `gh api repos/<owner>/<repo>/issues/comments/<id> --jq '.reactions.eyes'`
+   (the issue-comment object carries the `.reactions` counts; no separate
+   `/reactions` endpoint needed). Codex review is not a check run and reactions
+   have no watch/subscribe API (REST is GET/POST/DELETE only), so polling is the
+   only option. **`eyes==0` alone is not done** (it may not have started): wait
+   for 👀 to **appear then disappear**, **and** for a positive completion
+   signal — Codex posted a review/comment for that head, or 👍'd the trigger.
+3. **CI green** uses native `gh pr checks <pr> --watch --fail-fast` (blocks to
+   completion) — never `sleep`-poll.
+4. Local review **does not replace** this gate: the GitHub Codex bot and the
+   stop-time Codex gate catch defect classes local reviewers miss. If Codex is
+   externally unavailable (e.g. account usage limit), compensate with an
+   equivalent independent dual review and disclose it in the PR body.
+
+## 5. Review threads — judge with GraphQL
+
+Flat review comments and `latestReviews` are not enough (they lag the fresh
+trigger). Query `reviewThreads` via GraphQL. Resolve a thread only when one
+holds:
+
+- the code actually fixed the thread's issue, or
+- the thread is already outdated **and** a fresh Codex trigger is clean, or
+- the human asked you to handle the PR, the fresh trigger completed, and a
+  thread-aware recheck confirms it is no longer actionable.
+
+**Merge requires zero unresolved, non-outdated actionable threads.** After
+merging a PR with non-trivial bot activity, sanity-check the next
+`Capture unresolved reviews` workflow run / linked follow-up issues — that
+workflow is a backstop, not a merge substitute.
+
+## 6. Size gate is a merge gate, not an LOC-reduction mandate
+
+Classify every PR into exactly one state and disclose it in the body.
+Correctness, safety, performance, and necessary regression coverage take
+precedence over LOC compliance. **Never delete meaningful tests, weaken
+state-machine coverage, drop race coverage, or prefer compact code over clear
+reliable code to satisfy the budget.** Only reduce LOC when the code is
+genuinely redundant, over-abstracted, duplicated without purpose, or out of
+scope.
+
+- `within budget` — diff fits the effective `policy.max_changed_files` /
+  `policy.max_changed_loc`. Standard auto-merge path.
+- `size-gated: justified overage` — over budget because the extra LOC pays for
+  correctness, regression coverage, race/state-machine safety, or other
+  hardening that cannot be split without losing atomicity. **Not
+  auto-mergeable**; provide a human sign-off bundle (why the scope is
+  necessary, head SHA, local verification, CI state, bot-review state,
+  unresolved-thread state, residual risk).
+- `size-gated: split recommended` — over budget because of scope creep,
+  unrelated cleanup, or separable concerns. **Hard stop — split into smaller
+  PRs**; do not seek sign-off in lieu of splitting.
+
+Read the effective budget and `policy.deny_paths` from the repo's
+`WORKFLOW.md`; do not trust a hardcoded list (defaults are 12 files / 300 LOC
+and deny `infra/**`, `deploy/**`, `db/migrations/**`, `secrets/**`, but
+workflows differ — e.g. the `github-local` example uses 20 / 600).
+
+## 7. PR body is a living ledger
+
+After every material push, refresh the body: head SHA, acceptance criteria,
+verification commands, mutation check, CI conclusion/run id, dual-reviewer
+verdicts, `@codex review` trigger id + reaction/thread state, size-gate
+classification (one of the three states; rationale if over budget), and
+deferral/follow-up links. A stale body misleads the merge decision.
+
+Include a size-gate checklist (exactly one box checked):
+
+```markdown
+### Size gate
+- [ ] `within budget` — diff fits effective `policy.max_changed_files` /
+      `max_changed_loc`
+- [ ] `size-gated: justified overage` — rationale: <why correctness/coverage/
+      safety/perf justifies the extra LOC; not auto-mergeable; needs human
+      size-gate sign-off>
+- [ ] `size-gated: split recommended` — rationale: <which concerns to split
+      into separate PRs; hard stop, do not seek sign-off in lieu of splitting>
+```
+
+## 8. Merge
+
+- **Merge only after explicit human permission.** Squash into the agreed base
+  (repo convention) with a commit message describing the **final state**, not a
+  round-by-round log; delete the branch.
+- Force-push uniformly with `--force-with-lease=<branch>:<known-sha>`.
+- **Authorized auto-merge is opt-in and scope-bounded** — "you may merge the
+  PRs for issues #N–#M once they pass the gate", never a standing grant.
+  Approving one merge does not authorize the next. When authorized, merge only
+  when **all** hold:
+  1. CI green on the head commit (not a stale run).
+  2. `@codex review` clean for the current head (converged trigger, GraphQL
+     thread state clean) — no unresolved HIGH/MEDIUM and zero unresolved,
+     non-outdated threads.
+  3. Every acceptance criterion met, or each gap deferred to a tracked, linked
+     issue.
+  4. Classified `within budget` and changes no `policy.deny_paths`.
+  5. Branch protection's required reviews satisfied.
+  6. The agreed merge method (default squash) into the agreed base.
+
+  **Native auto-merge enforces only required status checks (CI) and branch
+  protection — not gates 2–4.** Confirm gates 2–4 yourself immediately before
+  enabling auto-merge; any new push re-opens them (re-confirm before
+  re-enabling).
+
+  **Hard stops — always require human sign-off even under an auto-merge grant:**
+  force-pushing/merging into `main` out of band or any history rewrite; editing
+  `go.mod`'s `go` directive or touching `policy.deny_paths`; a
+  `size-gated: justified overage` PR (flag, don't merge without size-gate
+  sign-off); a `size-gated: split recommended` PR (split, don't seek sign-off);
+  anything the human's instructions put off-limits. When at the edge of the
+  grant, use `AskUserQuestion`. Stop the moment the human revokes the grant.


### PR DESCRIPTION
Closes #484.

## What

The three agent-workflow assets triplicated the same "pushed-head review & merge protocol", violating the repo's own one-source-of-truth rule and already drifting between copies (the size-gate three-state wording differed across files).

- **New single source**: `docs/runbooks/pr-review-merge-protocol.md` — test discipline (regression + mutation), commit-first review of the committed range, dual diff-only reviewers (Codex + Claude paths, flag-mutex, fallback), `@codex review` per-push convergence, GraphQL review-thread closure, size-gate three states + PR-body checklist, merge / authorized-auto-merge gates + hard stops.
- **Slimmed to phase-specific delta + a pointer**:
  - `.claude/skills/handle-issue/SKILL.md` 102 → 92 (issue→PR investigation, SPEC/upstream, BEAM-guarantee porting, anti-patterns, examples).
  - `.claude/skills/handle-pr/SKILL.md` 96 → 45 (PR-audit rounds, finding classification).
  - `docs/runbooks/batch-issue-processing.md` 301 → 180 (parallelism, live ledger, deferral timing, BLOCKED.json, pause/resume, opt-in auto-merge wrapper).

## Earned addition

Folds in one newly-earned test-discipline gotcha (protocol §1.3): mutation-verify against the **committed artifact** — commit first, mutate, test must FAIL, `git checkout` restore, confirm tree == HEAD. A green local test alone is **not** verification of the shipped artifact. Earned by the #469/PR #483 session where an uncommitted masking fix was lost to a `cp`/`git checkout` restore and only CI caught it.

## Verification

- All heading anchors (`#1-…`, `#6-…`, `#7-…`, `#8-merge`) and relative paths (`../../../docs/runbooks/…`) resolve; skill frontmatter and `!`-bootstrap lines intact.
- No code change → Go CI gate unaffected.
- Content-preservation audited: every previously-documented rule relocated to the protocol (Codex flag-mutex + fallback, hardened `claude -p` flags, `.reactions.eyes` polling, GraphQL thread rules, size-gate states, auto-merge gate list + caveat, BLOCKED.json, examples). Restored the `github-local` 20/600 example and the ≤700-word reviewer cap after review.

## Notes

- Independent dual diff-only review: both **MERGE-READY** (only LOW content-preservation nits, addressed).
- Net-new (beyond pure relocation): the §1.3 mutation gotcha and a §4 note that an externally-unavailable Codex (usage-limit) is compensated by independent dual review + PR-body disclosure. Both additive and consistent with existing philosophy.
- No workflow behavior change; consolidation + one earned rule.

**Size: `within budget`** (4 files, +~291/−~266; net ≈ +25, single-source dedup).

### Size gate
- [x] `within budget` — diff fits effective `policy.max_changed_files` / `max_changed_loc`
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
