### PR TITLE
docs: record earned test/secret rules in AGENTS.md and de-dup size gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,9 +313,15 @@ failure per the "Earned rules" principle above.
 
 6. **Tests must assert the new code path.** A test that would pass even if the
    feature were deleted is a placebo. After writing a test, verify it fails
-   when the production code is broken (mutation or negative assertion). **Earned
-   by:** PR #342 audit (LOW) noted the back-compat test asserted `last_codex_at`
-   presence but not its absence after removal.
+   when the production code is broken (mutation or negative assertion). Run that
+   mutation against the committed artifact, not the working tree — commit the
+   fix first, then break it, restore with `git checkout`, and confirm the tree
+   matches HEAD; a passing local test is not proof of the shipped commit when
+   the working tree and HEAD have diverged. **Earned by:** PR #342 audit (LOW)
+   noted the back-compat test asserted `last_codex_at` presence but not its
+   absence after removal; and a #469/PR #483 session where a backup/restore during
+   mutation testing silently reverted the fix, so local tests stayed green while
+   the commit lacked it and only CI caught the regression.
 
 7. **Function and file size budgets.** New code must keep single functions at
    or below 80 lines and single files at or below 800 lines, excluding test
@@ -365,7 +371,7 @@ failure per the "Earned rules" principle above.
   rather than reviewer memory.
 - **Prefer the `gh` CLI over the GitHub MCP server** for GitHub interactions (PRs, issues, CI status, reviews). The SessionStart hook installs `gh` in remote/cloud/web sessions (`.claude/scripts/session-start.sh`); fall back to the GitHub MCP server only when `gh` is unavailable.
 - **Task events**: when adding a new lifecycle event, add the kind as a constant in `internal/task` rather than inlining the string at the call site.
-- **Secrets**: never commit real credentials. `.env`, `.env.*`, `*.key`, `*.pem` are gitignored; `.env.example` is the only sanctioned env template.
+- **Secrets**: never commit real credentials. `.env`, `.env.*`, `*.key`, `*.pem` are gitignored; `.env.example` is the only sanctioned env template. Secret-bearing values that arrive via config or CLI (e.g. `clone_url` basic-auth userinfo) must be masked before they reach any log, error string, or state output — env-var-only redaction does not cover them. Mask clone URLs with `workflow.MaskCloneURL`. **Earned by:** #469/PR #483, where a doctor ambiguity/not-found error echoed a credentialed `clone_url` because `redact()` only scrubbed env-var values.
 - **`policy.max_changed_files` (12) and `policy.max_changed_loc` (300) are a
   size gate, not an LOC-reduction mandate.** Worker PRs are draft + labeled by
   default; shape them small when you can, but the budget exists to catch scope

--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -13,15 +13,15 @@ generalize beyond the evidence.
 
 ## 1. Test discipline (regression + mutation verification)
 
+The canonical rule lives in [`AGENTS.md`](../../AGENTS.md) clean-code rule 6
+(regression test + mutation against the committed artifact); this section is the
+operational procedure.
+
 1. **Every fix ships a regression test.** A test that would still pass with the
    production fix reverted is a placebo and does not count as done.
 2. **Mutation-verify against the committed artifact, not the working tree.** A
    green local test only proves the working tree passes; it does **not** verify
-   the artifact you push unless the tree equals the pushed HEAD. **Earned by:**
-   a #469/PR #483 session where an uncommitted masking fix was silently lost to
-   a `cp`/`git checkout` backup-restore — local tests stayed green (the working
-   tree transiently held the fix) while the commit did not, and CI caught the
-   regression, not local review.
+   the artifact you push unless the tree equals the pushed HEAD.
 3. **Correct mutation procedure — commit first, then mutate:**
    1. Commit (or amend) the fix so it is in HEAD.
    2. Break the key production line (edit/`sed`/`perl`).
@@ -126,30 +126,27 @@ workflow is a backstop, not a merge substitute.
 
 ## 6. Size gate is a merge gate, not an LOC-reduction mandate
 
-Classify every PR into exactly one state and disclose it in the body.
-Correctness, safety, performance, and necessary regression coverage take
-precedence over LOC compliance. **Never delete meaningful tests, weaken
-state-machine coverage, drop race coverage, or prefer compact code over clear
-reliable code to satisfy the budget.** Only reduce LOC when the code is
-genuinely redundant, over-abstracted, duplicated without purpose, or out of
-scope.
+The size-gate rule — the three states (`within budget` /
+`size-gated: justified overage` / `size-gated: split recommended`) and the
+principle that correctness/coverage/safety take precedence over LOC compliance
+— is canonical in [`AGENTS.md`](../../AGENTS.md) (the `policy.max_changed_files`
+/ `policy.max_changed_loc` bullet). Classify every PR into exactly one state and
+disclose it in the body; never delete meaningful tests or weaken coverage to
+fit the budget.
 
-- `within budget` — diff fits the effective `policy.max_changed_files` /
-  `policy.max_changed_loc`. Standard auto-merge path.
-- `size-gated: justified overage` — over budget because the extra LOC pays for
-  correctness, regression coverage, race/state-machine safety, or other
-  hardening that cannot be split without losing atomicity. **Not
-  auto-mergeable**; provide a human sign-off bundle (why the scope is
-  necessary, head SHA, local verification, CI state, bot-review state,
-  unresolved-thread state, residual risk).
-- `size-gated: split recommended` — over budget because of scope creep,
-  unrelated cleanup, or separable concerns. **Hard stop — split into smaller
-  PRs**; do not seek sign-off in lieu of splitting.
+Merge-flow application of those states:
 
-Read the effective budget and `policy.deny_paths` from the repo's
-`WORKFLOW.md`; do not trust a hardcoded list (defaults are 12 files / 300 LOC
-and deny `infra/**`, `deploy/**`, `db/migrations/**`, `secrets/**`, but
-workflows differ — e.g. the `github-local` example uses 20 / 600).
+- `within budget` — standard auto-merge path.
+- `size-gated: justified overage` — **not auto-mergeable**; provide a human
+  sign-off bundle (why the scope is necessary, head SHA, local verification, CI
+  state, bot-review state, unresolved-thread state, residual risk).
+- `size-gated: split recommended` — **hard stop, split into smaller PRs**; do
+  not seek sign-off in lieu of splitting.
+
+Read the effective budget and `policy.deny_paths` from the repo's `WORKFLOW.md`;
+do not trust a hardcoded list (defaults are 12 files / 300 LOC and deny
+`infra/**`, `deploy/**`, `db/migrations/**`, `secrets/**`, but workflows differ
+— e.g. the `github-local` example uses 20 / 600).
 
 ## 7. PR body is a living ledger
 


### PR DESCRIPTION
Follow-up to #485 (workflow-skill consolidation) and #483/#469 (doctor clone-URL fix). Records two rules earned in those sessions into AGENTS.md (the single source of truth for engineering rules) and removes the redundancy that surfaces against the freshly-merged `pr-review-merge-protocol.md`.

## Add (earned, cross-cutting)

- **Clean-code rule 6** — mutation must be verified against the **committed artifact**, not the working tree: commit the fix first, break it, `git checkout` restore, confirm tree == HEAD; a green local test is not proof of the shipped commit when tree and HEAD diverge. *Earned by* the #469/PR #483 session where a backup/restore silently reverted the fix and only CI caught it.
- **Secrets convention** — secret-bearing values from config/CLI (e.g. `clone_url` basic-auth) must be masked before reaching any log/error/state output; env-var-only redaction does not cover them (mask clone URLs with `workflow.MaskCloneURL`). *Earned by* #469/PR #483.

## Remove (de-dup → one source of truth)

The size-gate three-state rule is canonical in AGENTS.md (earned by #455). After #485 it also existed in `pr-review-merge-protocol.md`, so:

- Protocol §6 now **references** AGENTS.md for the state definitions and keeps only the merge-flow application (which states are auto-mergeable / need sign-off / are a hard stop) + the WORKFLOW.md budget-reading note.
- Protocol §1 points its principle/earned-by at AGENTS.md rule 6 and keeps only the operational procedure.

Net: the three-state definition and the mutation principle now live in exactly one place (AGENTS.md), with the protocol referencing rather than restating.

## Verification

- No code change → Go CI gate unaffected.
- Independent dual diff-only review: both **MERGE-READY**. Content-preservation audited — every trimmed protocol line is provably relocated to AGENTS.md or retained verbatim (commit-first procedure, sign-off bundle, WORKFLOW.md defaults + `github-local` 20/600, race rule, deterministic-barrier rule). No new duplication.
- Protocol headings `## 1./6./7./8.` unchanged, so `batch-issue-processing.md` anchor links still resolve; new `../../AGENTS.md` links resolve.

## Notes

No behavioral change; this is rule capture + de-duplication, applying the same earned-rules / one-source-of-truth discipline the changed files enforce.

**Size: `within budget`** (2 files, +36/−33).

### Size gate
- [x] `within budget`
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
