### PR TITLE
docs: create state API token and secret files with 0600 perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ opt-in overlay to reach the dashboard from the host:
 
 ```bash
 mkdir -p .aiops/secrets
-openssl rand -hex 24 > .aiops/secrets/state_api_token
+# Create the token with 0600 so co-tenant users/processes cannot read it; the
+# subshell scopes umask 077 to this write and never exposes a 0644 window.
+( umask 077; openssl rand -hex 24 > .aiops/secrets/state_api_token )
 AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token \
 docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.dashboard.yml up worker
 ```

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -37,9 +37,13 @@ Official references checked for this path:
 ```bash
 mkdir -p .aiops/secrets .aiops/codex-home
 cp examples/WORKFLOW.md .aiops/WORKFLOW.md
-printf '%s' 'replace-with-linear-personal-key' > .aiops/secrets/linear_api_key
-printf '%s' 'replace-with-least-privilege-github-token' > .aiops/secrets/github_token
-openssl rand -hex 24 > .aiops/secrets/state_api_token
+# Scope umask 077 so every secret lands as 0600; co-tenant users/processes
+# must never get a readable window on these credential files.
+( umask 077
+  printf '%s' 'replace-with-linear-personal-key' > .aiops/secrets/linear_api_key
+  printf '%s' 'replace-with-least-privilege-github-token' > .aiops/secrets/github_token
+  openssl rand -hex 24 > .aiops/secrets/state_api_token
+)
 ```
 
 Run `codex --login` on the host, then copy or provision the Codex home you

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -161,7 +161,8 @@ container loopback, so the overlay requires a state API token:
 
 ```bash
 mkdir -p .aiops/secrets
-openssl rand -hex 24 > .aiops/secrets/state_api_token
+# Scope umask 077 to the write so the token lands as 0600 with no 0644 window.
+( umask 077; openssl rand -hex 24 > .aiops/secrets/state_api_token )
 AIOPS_STATE_API_TOKEN_FILE=$PWD/.aiops/secrets/state_api_token \
 docker compose -f deploy/docker-compose.yml \
   -f deploy/docker-compose.dashboard.yml up worker


### PR DESCRIPTION
Closes #473 — follow-up of the unresolved review thread on merged PR #454 (`README.md:181`, @chatgpt-codex-connector).

## Problem
The dashboard / state-API setup snippets generated the auth token with:

```bash
openssl rand -hex 24 > .aiops/secrets/state_api_token
```

Under the common `umask 022` the file is created `0644`, so the token — which grants access to the state API/dashboard — is readable by other local users/processes. On multi-tenant hosts (the same trust-boundary caveat the README already calls out for the status surface) that is a real leak.

## Fix
Scope `umask 077` around the write via a subshell so the file lands as `0600` with **no** `0644` window (an atomic-ish alternative to `chmod 600` after the fact, avoiding the brief readable interval):

```bash
( umask 077; openssl rand -hex 24 > .aiops/secrets/state_api_token )
```

Applied consistently to all three docs carrying the same pattern (cross-cutting: audit adjacent paths):
- `README.md` — Docker Compose dashboard overlay snippet (the exact location flagged).
- `docs/runbooks/local-dev.md` — same overlay snippet.
- `docs/runbooks/first-run-docker-linear-codex.md` — also wraps the Linear and GitHub credential writes in the same `umask 077` subshell, since they share `.aiops/secrets`.

## Acceptance criteria
- [x] Token file is documented to be created with restrictive (`0600`) permissions.
- [x] Same insecure pattern fixed everywhere it appears, not just the flagged line.

## Verification
Docs-only change — no Go files touched, so the Go CI gates don't apply. Verified the new snippet produces `0600`:

```
$ ( umask 077; openssl rand -hex 24 > /tmp/t ); stat -c '%a' /tmp/t
600
```

## Size
`within budget` — 3 docs files, +12/-5.

## Risk
None to runtime; documentation guidance only.

https://claude.ai/code/session_015bj9LaiBipdnkNFEadwYm3

---
_Generated by [Claude Code](https://claude.ai/code/session_015bj9LaiBipdnkNFEadwYm3)_