### PR TITLE
test(runner): deterministic initialize read-timeout diagnostics (#476)

### DIFF
--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -52,8 +52,6 @@ func appServerInput(workdir string) RunInput {
 
 func codexAppServerStubScript(t *testing.T, body string) string {
 	t.Helper()
-	dir := t.TempDir()
-	scriptPath := filepath.Join(dir, "codex")
 	header := `#!/usr/bin/env python3
 import os, sys
 with open(os.environ['CODEX_ARGV_LOG'], 'w') as f:
@@ -62,7 +60,19 @@ with open(os.environ['CODEX_ARGV_LOG'], 'w') as f:
 with open(os.environ['CODEX_STARTED_LOG'], 'w') as f:
     f.write('started\n')
 `
-	if err := os.WriteFile(scriptPath, []byte(header+body), 0o755); err != nil {
+	return installCodexStub(t, header+body)
+}
+
+// installCodexStub installs `script` as an executable `codex` on PATH and
+// exports the CODEX_*_LOG paths the app-server stubs read. `script` must carry
+// its own interpreter shebang so callers can install non-Python stubs (e.g. the
+// shell stub the initialize-timeout diagnostics test uses to write its
+// started-log evidence without paying the Python startup cost).
+func installCodexStub(t *testing.T, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	path := dir + string(os.PathListSeparator) + os.Getenv("PATH")
@@ -1397,18 +1407,27 @@ for line in sys.stdin:
 }
 
 func TestCodexAppServerInitializeTimeoutDiagnostics(t *testing.T) {
-	codexAppServerStubScript(t, `
-import json, time
-time.sleep(2)
-for line in sys.stdin:
-    msg=json.loads(line)
-    if msg.get('method') == 'initialize':
-        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+	// Route the started-log evidence and a JSON-RPC handshake through a fast
+	// shell preamble instead of the Python interpreter's startup. The runner
+	// reads the handshake line — which the stub prints only after it has
+	// written the started-log to disk — so by the time the next read hits the
+	// initialize read timeout, the started-log is guaranteed present. And even
+	// if the handshake read itself were to time out, the shell has already
+	// written the started-log within a few milliseconds of exec, so the
+	// process-start evidence holds either way. This removes the race where a
+	// tight read timeout fired before Python startup wrote the file (#476); the
+	// runtime read-timeout behavior is unchanged — the stub simply never answers
+	// initialize, so the initialize request still times out.
+	installCodexStub(t, `#!/bin/sh
+printf 'started\n' > "$CODEX_STARTED_LOG"
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/started"}'
+# Stay initialized-but-silent so the runner's next read hits the read timeout.
+cat > /dev/null
 `)
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
-	in.Workflow.Config.Codex.ReadTimeoutMs = 25
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	in.Workflow.Config.Codex.ReadTimeoutMs = 200
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	var logs []string
@@ -1417,14 +1436,14 @@ for line in sys.stdin:
 	})
 
 	if err == nil || !strings.Contains(err.Error(), "codex app-server initialize") || !strings.Contains(err.Error(), "read timeout") {
-		t.Fatalf("Run error = %v, want initialize read timeout", err)
+		t.Fatalf("Run() error = %v; want initialize read timeout", err)
 	}
 	diagnostics := strings.Join(logs, "\n")
 	if !strings.Contains(diagnostics, "started log") || !strings.Contains(diagnostics, "started\n") {
-		t.Fatalf("diagnostics missing started log; diagnostics=\n%s", diagnostics)
+		t.Fatalf("Run() diagnostics = %q; want started-log process-start evidence", diagnostics)
 	}
 	if !strings.Contains(diagnostics, "stdin log") {
-		t.Fatalf("diagnostics missing stdin log status; diagnostics=\n%s", diagnostics)
+		t.Fatalf("Run() diagnostics = %q; want stdin-log status line", diagnostics)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the flaky local race gate in `TestCodexAppServerInitializeTimeoutDiagnostics` (#476). The test set `Codex.ReadTimeoutMs = 25` and relied on a Python stub whose shared header wrote `CODEX_STARTED_LOG` ("started\n") at process start. Under `-race` load the runner could hit the 25ms read timeout and kill the stub **before** Python startup wrote the started-log, so the diagnostic's process-start evidence was missing and the assertion failed before the intended initialized-but-silent scenario was ever reached.

## Fix (test-harness only — runtime read-timeout behavior unchanged)

- This test now installs a pure `#!/bin/sh` stub that:
  1. writes the started-log (`printf 'started\n' > "$CODEX_STARTED_LOG"`) as its **first** statement, within ~ms of `exec` — off the slow Python-startup path;
  2. prints a JSON-RPC `session/started` handshake (no `id`, so the runner dispatches it to the no-op `handleNotification` and reads again with a fresh per-read timeout);
  3. stays initialized-but-silent (`cat > /dev/null`) so it **never** answers `initialize`, leaving the next read to hit the read timeout exactly as the production path intends.
- Because the stub prints the handshake only *after* the started-log is on disk, the runner observes process-start before the timing-out read; and even if the handshake read itself timed out, the started-log was already written. This is an **ordering** guarantee, not just a wider window.
- `ReadTimeoutMs` 25→200ms and ctx 1s→2s keep the timing-out read well inside the context budget.
- Extracted `installCodexStub` so non-Python stubs share the PATH/`CODEX_*_LOG` setup; `codexAppServerStubScript` still prepends the existing Python header (no behavior change for its ~40 callers).

## Acceptance criteria

- [x] Deterministic under `go test -race` on macOS and CI Linux — `-count=10` all PASS at ~0.20s each; ordering guarantee (not a widened window).
- [x] Coverage preserved — diagnostics still assert initialize read-timeout error (`codex app-server initialize` + `read timeout`) and process-start evidence (`started log` + `started\n`).
- [x] Runtime app-server read-timeout behavior not weakened — only `_test.go` changed; `readLine`/`readLineOnce` untouched.

## Verification

```
go test -race -covermode=atomic ./internal/runner -run TestCodexAppServerInitializeTimeoutDiagnostics -count=10 -v   # 10/10 PASS
go test -race -covermode=atomic ./...                                                                                # all packages PASS
gofmt -l … (clean) · go mod tidy (clean) · go vet ./... (clean) · go build ./cmd/worker ./cmd/tui (ok)
```

**Mutation (against committed artifact, HEAD then `git checkout`):**
- Break the production read-timeout string → test FAILS (`want initialize read timeout`).
- Drop the started-log line from diagnostics → test FAILS (`want started-log process-start evidence`).

## Review notes

- Pre-push **dual diff-only reviewers** (both Claude-family in this restricted environment; the cross-family GitHub `@codex review` bot runs post-push as the second family): both returned **MERGE-READY**, no HIGH/CRITICAL.
- LOW (pre-existing, not introduced here): the `"stdin log"` assertion passes whether or not stdin is captured, since `appendFileDiagnostic` emits the label even on a read error.

### Size gate
- [x] `within budget` — 1 file, +34/−15 LOC
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Closes #476

https://claude.ai/code/session_01EWAhk3JmeC8wrjMsQhHRyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWAhk3JmeC8wrjMsQhHRyb)_