### PR TITLE
fix(orchestrator): preserve continuation when retry cleanup rechecks active (#474)

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -1238,13 +1238,14 @@ type reconcileTrackerIssuesOp struct {
 	issuesByID   map[string]tracker.Issue
 	activeStates map[string]struct{}
 	// terminalStates + refreshedByID let this routing-aware pass terminal-gate
-	// the SPEC §18.1 active-transition workspace cleanup for the runs it cancels.
-	// Upstream is single-project and reaches terminate_running_issue (with
-	// cleanup) in one pass; the aiops routing extension cancels (and waits for) a
-	// routed terminal run here, before the terminal-aware inactive pass would see
-	// it, so the cleanup signal must be computed in this pass. refreshedByID
-	// carries the refreshed post-transition state that issuesByID (the active
-	// listing) no longer contains for a now-inactive/terminal issue (#340).
+	// the SPEC §18.1 active-transition workspace cleanup for the run, blocked, and
+	// retry entries it releases. Upstream is single-project and reaches
+	// terminate_running_issue (with cleanup) in one pass; the aiops routing
+	// extension cancels (and waits for) a routed terminal entry here, before the
+	// terminal-aware inactive pass would see it, so the cleanup signal must be
+	// computed in this pass. refreshedByID carries the refreshed post-transition
+	// state that issuesByID (the active listing) no longer contains for a
+	// now-inactive/terminal issue (#340).
 	terminalStates map[string]struct{}
 	refreshedByID  map[string]tracker.Issue
 	result         chan<- []*RunningEntry
@@ -1276,6 +1277,15 @@ func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
 			retry.Issue = issue
 			st.ClaimedIssues[id] = issue
 			continue
+		}
+		// A routed terminal retry must clean its workspace through the §18.1 seam
+		// here — this pass releases it before the terminal-aware inactive pass
+		// (reconcileInactiveTrackerIssuesOp) would see it, so deferring the
+		// cleanup leaks the directory until the next startup sweep. continuationForRetry
+		// carries the queued continuation so the deletion-time recheck resumes it
+		// if the issue flips back active, matching the inactive pass.
+		if w, okw := r.terminalRetryCleanup(id, retry); okw {
+			blockedCleanups = append(blockedCleanups, reconciledCleanup{workspace: w, continuation: continuationForRetry(retry)})
 		}
 		st.ReleaseClaim(id)
 	}
@@ -1328,6 +1338,25 @@ func (r *reconcileTrackerIssuesOp) terminalBlockedCleanup(id IssueID, blocked *B
 		return ReconciledWorkspace{}, false
 	}
 	return terminalWorkspaceForCleanup(id, blocked.Identifier, blocked.Workspace.Path, blocked.Workspace.Root, refreshed.State)
+}
+
+// terminalRetryCleanup builds the WorkspaceCleaner removal for a routed retry
+// this pass is releasing, but only when its refreshed state is terminal — so a
+// terminal continuation/failure retry fires before_remove + reconcile_workspace
+// reason=terminal (mirroring reconcileInactiveTrackerIssuesOp's retry loop and
+// upstream handle_retry_issue_lookup) while a route-change or non-terminal
+// inactive transition keeps the directory for reuse (#341). Without it the
+// routing pass released terminal retries with no §18.1 cleanup, leaking the
+// workspace until the next startup sweep.
+func (r *reconcileTrackerIssuesOp) terminalRetryCleanup(id IssueID, retry *RetryEntry) (ReconciledWorkspace, bool) {
+	if retry == nil {
+		return ReconciledWorkspace{}, false
+	}
+	refreshed, ok := r.refreshedByID[string(id)]
+	if !ok || !isTerminalTrackerState(refreshed.State, r.terminalStates) {
+		return ReconciledWorkspace{}, false
+	}
+	return terminalWorkspaceForCleanup(id, retry.Identifier, retry.Workspace.Path, retry.Workspace.Root, refreshed.State)
 }
 
 func sameServiceRoute(previous, current tracker.Issue) bool {

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -991,6 +991,27 @@ type continuationAfterSkippedCleanup struct {
 	workspace  Workspace
 }
 
+// continuationForRetry returns the continuation to resume when a queued
+// continuation retry's terminal-cleanup recheck (verifyReconciledWorkspaceStillTerminal)
+// finds the issue active again. Only RetryKindContinuation entries carry a
+// continuation attempt and max-turn budget worth preserving; for every other
+// retry kind it returns nil so the recheck falls back to a plain poll wake
+// (their re-dispatch does not depend on a preserved ContinuationAttempt). The
+// reconcile pass builds this before ReleaseClaim drops the entry so the
+// off-actor cleanup can reschedule the same attempt + workspace instead of
+// resetting ContinuationAttempt to 0 on the next poll (Codex review, PR #455).
+func continuationForRetry(retry *RetryEntry) *continuationAfterSkippedCleanup {
+	if retry == nil || retry.Kind != RetryKindContinuation {
+		return nil
+	}
+	return &continuationAfterSkippedCleanup{
+		issue:      retry.Issue,
+		identifier: retry.Identifier,
+		attempt:    retry.Attempt,
+		workspace:  retry.Workspace,
+	}
+}
+
 type continuationBudgetExhaustedOp struct {
 	o          *Orchestrator
 	id         IssueID
@@ -1231,7 +1252,7 @@ type reconcileTrackerIssuesOp struct {
 
 func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	var cancelEntries []*RunningEntry
-	var blockedCleanups []ReconciledWorkspace
+	var blockedCleanups []reconciledCleanup
 	for id, run := range st.Running {
 		issue, ok := r.issuesByID[string(id)]
 		if ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(run.Issue, issue) {
@@ -1266,7 +1287,7 @@ func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
 			continue
 		}
 		if w, okw := r.terminalBlockedCleanup(id, blocked); okw {
-			blockedCleanups = append(blockedCleanups, w)
+			blockedCleanups = append(blockedCleanups, reconciledCleanup{workspace: w})
 		}
 		st.ReleaseClaim(id)
 	}
@@ -1330,8 +1351,10 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	// same WorkspaceCleaner so before_remove fires and a reconcile_workspace
 	// event is emitted — mirroring upstream reconcile_blocked_issue_state and
 	// handle_retry_issue_lookup, which clean the workspace only on a terminal
-	// transition.
-	var terminalCleanups []ReconciledWorkspace
+	// transition. A continuation retry also carries its continuation so the
+	// deletion-time recheck can resume it (preserving the queued attempt and
+	// max-turn budget) if the issue flips back active before removal.
+	var terminalCleanups []reconciledCleanup
 	for id, run := range st.Running {
 		issue, ok := r.issuesByID[string(id)]
 		if !ok {
@@ -1363,10 +1386,14 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 		// a merely-inactive (non-terminal) one releases only, keeping the
 		// directory for possible reuse. The continuation retry carries the
 		// finalized run's workspace (#341); a failure retry without one yields
-		// no path and is released only.
+		// no path and is released only. continuationForRetry threads the queued
+		// continuation attempt + workspace through the cleanup so a terminal
+		// observation the deletion-time recheck finds active again resumes the
+		// continuation instead of resetting ContinuationAttempt to 0 on the next
+		// poll (Codex review, PR #455).
 		if isTerminalTrackerState(issue.State, r.terminalStates) {
 			if w, okw := terminalWorkspaceForCleanup(id, retry.Identifier, retry.Workspace.Path, retry.Workspace.Root, issue.State); okw {
-				terminalCleanups = append(terminalCleanups, w)
+				terminalCleanups = append(terminalCleanups, reconciledCleanup{workspace: w, continuation: continuationForRetry(retry)})
 			}
 		}
 		st.ReleaseClaim(id)
@@ -1378,7 +1405,7 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 		}
 		if isTerminalTrackerState(issue.State, r.terminalStates) {
 			if w, okw := terminalWorkspaceForCleanup(id, blocked.Identifier, blocked.Workspace.Path, blocked.Workspace.Root, issue.State); okw {
-				terminalCleanups = append(terminalCleanups, w)
+				terminalCleanups = append(terminalCleanups, reconciledCleanup{workspace: w})
 			}
 		}
 		st.ReleaseClaim(id)
@@ -1386,20 +1413,34 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	return r.o.reconcileCancelFollowup(cancelEntries, terminalCleanups, r.result)
 }
 
+// reconciledCleanup pairs a terminal-transition workspace removal with the
+// optional continuation to resume when the deletion-time recheck finds the
+// issue active again. Blocked and failure/quota/external-blocker retry cleanups
+// carry a nil continuation — they have no queued continuation attempt to
+// preserve; a continuation retry carries its attempt + workspace so a terminal
+// blip that flips back active reschedules the continuation rather than losing
+// the attempt and max-turn budget (Codex review, PR #455).
+type reconciledCleanup struct {
+	workspace    ReconciledWorkspace
+	continuation *continuationAfterSkippedCleanup
+}
+
 // reconcileCancelFollowup builds the off-actor followup both reconcile passes
-// return: cancel each worker, then run any terminal blocked-workspace cleanups
-// through the WorkspaceCleaner (before_remove + reconcile_workspace event),
-// then deliver the cancelled entries to the waiting caller. Cleanup runs here,
-// off the actor loop, so a slow before_remove hook cannot block state mutation.
-func (o *Orchestrator) reconcileCancelFollowup(cancelEntries []*RunningEntry, blockedCleanups []ReconciledWorkspace, result chan<- []*RunningEntry) func() {
+// return: cancel each worker, then run any terminal workspace cleanups through
+// the WorkspaceCleaner (before_remove + reconcile_workspace event), then deliver
+// the cancelled entries to the waiting caller. Cleanup runs here, off the actor
+// loop, so a slow before_remove hook cannot block state mutation. A cleanup
+// carrying a continuation resumes it when the deletion-time recheck finds the
+// issue active again instead of removing the workspace.
+func (o *Orchestrator) reconcileCancelFollowup(cancelEntries []*RunningEntry, cleanups []reconciledCleanup, result chan<- []*RunningEntry) func() {
 	return func() {
 		for _, entry := range cancelEntries {
 			if entry.CancelWorker != nil {
 				entry.CancelWorker()
 			}
 		}
-		for _, w := range blockedCleanups {
-			o.runReconciledWorkspaceCleanup(w, nil)
+		for _, c := range cleanups {
+			o.runReconciledWorkspaceCleanup(c.workspace, c.continuation)
 		}
 		if result != nil {
 			result <- cancelEntries

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -2616,6 +2616,72 @@ func TestReconcileInactiveContinuationRetryKeepsWorkspace(t *testing.T) {
 	}
 }
 
+// TestReconcileTerminalContinuationRetryActiveRecheckPreservesContinuation is
+// the regression for PR #455's unresolved review thread (actor.go:1383): when a
+// queued continuation retry is observed terminal by the inactive reconcile pass
+// but the deletion-time recheck (verifyReconciledWorkspaceStillTerminal) finds
+// the issue active again, the retry-cleanup path must resume the continuation —
+// preserving the queued attempt and max-turn budget — instead of only waking
+// polling. Before the fix the retry cleanup recheck carried a nil continuation,
+// so ReleaseClaim dropped the entry and the next poll dispatched a fresh run
+// with ContinuationAttempt reset to 0. Mirrors the running-entry recheck path
+// (TestReconcileWorkspaceCleanupRechecksStateUnderReservation) for the retry
+// branch.
+func TestReconcileTerminalContinuationRetryActiveRecheckPreservesContinuation(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		// Two short delays: one for the original continuation scheduled at
+		// finalize, one for the continuation the recheck reschedules.
+		Scheduler:        &sequenceScheduler{delays: []time.Duration{time.Millisecond, time.Millisecond}},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-CRR1", Identifier: "ENG-CRR1", State: "In Progress", Title: "self-stop"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-CRR1"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+
+	// Clean §16.5 self-stop → finalize schedules a continuation retry (attempt 1)
+	// carrying the finalized run's workspace.
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Running) == 0 && len(view.Retrying) == 1 && view.Retrying[0].Attempt == 1
+	}, time.Second)
+
+	// The recheck resolver reports the issue active again (not in the terminal
+	// set), so the deletion-time recheck must skip removal and resume the
+	// continuation rather than delete the workspace or reset the attempt.
+	o.SetRetryTerminalStateResolver(staticStateRefresher{issue.ID: "In Progress"}, []string{"Done"})
+
+	// The continuation is still queued when the inactive pass observes terminal.
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	// Continuation resumed with the queued attempt preserved (not reset to 0).
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && view.Retrying[0].Attempt == 1
+	}, time.Second)
+	// Re-claimed by the resumed continuation, so a plain poll dispatch is denied;
+	// only a tracker-rechecked dispatch consumes it and carries the budget.
+	if err := o.RequestDispatch(context.Background(), issue, nil); !errors.Is(err, ErrNotDispatched) {
+		t.Fatalf("RequestDispatch after recheck-active continuation = %v, want ErrNotDispatched while continuation retry is claimed", err)
+	}
+	waitFor(t, func() bool {
+		return o.RequestDispatchAfterTrackerRecheck(context.Background(), issue, nil) == nil
+	}, time.Second)
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Fatalf("cleanup calls = %+v, want none after state rechecked active", calls)
+	}
+}
+
 // TestReconcileWorkspaceCleanupLockDeniesDispatch backs the Codex stop-time
 // finding: the re-claim guard must be race-free. While a terminal workspace
 // cleanup is in flight (reserved on the actor), dispatch onto the same issue —

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -2043,6 +2043,163 @@ func TestReconcileRoutingNonTerminalBlockedKeepsWorkspace(t *testing.T) {
 	}
 }
 
+// TestReconcileRoutingTerminalContinuationRetryFiresWorkspaceCleanup is the
+// routing-mode half of the #341 retry-cleanup contract: the routing-aware pass
+// runs before the terminal-aware inactive pass and releases the retry, so a
+// queued continuation retry whose issue went terminal must clean its workspace
+// HERE through the WorkspaceCleaner (before_remove + reconcile_workspace
+// reason=terminal). Pre-fix the routing pass released terminal retries with no
+// §18.1 cleanup, leaking the directory until the next startup sweep.
+func TestReconcileRoutingTerminalContinuationRetryFiresWorkspaceCleanup(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-RCR1", Identifier: "ENG-RCR1", State: "In Progress", Title: "self-stop"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-RCR1"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+
+	// Clean §16.5 self-stop → continuation retry carrying the run's workspace.
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && view.Retrying[0].Attempt == 1
+	}, time.Second)
+
+	// Routing pass: the issue is absent from the active set (it went terminal);
+	// refreshedByID carries its terminal state so the retry cleanup fires here.
+	if err := o.ReconcileTrackerIssuesAndWait(context.Background(),
+		map[string]tracker.Issue{},
+		map[string]struct{}{"in progress": {}},
+		map[string]struct{}{"done": {}},
+		map[string]tracker.Issue{issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"}},
+		0); err != nil {
+		t.Fatalf("ReconcileTrackerIssuesAndWait: %v", err)
+	}
+
+	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, time.Second)
+	got := cleaner.snapshot()[0]
+	if got.IssueID != IssueID(issue.ID) || got.Path != wsPath || got.Reason != "terminal" || got.State != "Done" {
+		t.Fatalf("cleanup = %+v, want terminal cleanup for %s at %q reason=terminal state=Done", got, issue.ID, wsPath)
+	}
+	if got.Root != testWorkspaceRoot {
+		t.Fatalf("cleanup root = %q, want recorded dispatch-time root %q", got.Root, testWorkspaceRoot)
+	}
+	view, _ := o.Snapshot(context.Background())
+	if len(view.Retrying) != 0 {
+		t.Fatalf("retry not released after routing terminal reconcile: %+v", view.Retrying)
+	}
+}
+
+// TestReconcileRoutingNonTerminalContinuationRetryKeepsWorkspace is the routing
+// retry negative (mirrors TestReconcileRoutingNonTerminalBlockedKeepsWorkspace):
+// a continuation retry released because its issue moved to a non-terminal
+// inactive state must keep its workspace. A terminal sibling cleaned in the same
+// pass is the progress barrier that makes the single-call assertion a real
+// negative; a reverted terminal gate would clean both and push the count to 2.
+func TestReconcileRoutingNonTerminalContinuationRetryKeepsWorkspace(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	kept := tracker.Issue{ID: "ENG-NCR1", Identifier: "ENG-NCR1", State: "In Progress", Title: "kept self-stop"}
+	barrier := tracker.Issue{ID: "ENG-NCR2", Identifier: "ENG-NCR2", State: "In Progress", Title: "terminal self-stop"}
+	const keptPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-NCR1"
+	const barrierPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-NCR2"
+	dispatchRunningIssue(t, o, disp, kept, keptPath, 1)
+	dispatchRunningIssue(t, o, disp, barrier, barrierPath, 2)
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	disp.finishAt(1, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 2
+	}, time.Second)
+
+	// kept → Backlog (non-terminal inactive) keeps its workspace; barrier → Done
+	// is cleaned, proving the pass released both retries.
+	if err := o.ReconcileTrackerIssuesAndWait(context.Background(),
+		map[string]tracker.Issue{},
+		map[string]struct{}{"in progress": {}},
+		map[string]struct{}{"done": {}},
+		map[string]tracker.Issue{
+			kept.ID:    {ID: kept.ID, Identifier: kept.Identifier, State: "Backlog"},
+			barrier.ID: {ID: barrier.ID, Identifier: barrier.Identifier, State: "Done"},
+		},
+		0); err != nil {
+		t.Fatalf("ReconcileTrackerIssuesAndWait: %v", err)
+	}
+
+	waitFor(t, func() bool { return len(cleaner.snapshot()) == 1 }, time.Second)
+	calls := cleaner.snapshot()
+	if len(calls) != 1 || calls[0].IssueID != IssueID(barrier.ID) || calls[0].Path != barrierPath {
+		t.Fatalf("only the terminal barrier may be cleaned, got %+v", calls)
+	}
+}
+
+// TestReconcileRoutingTerminalContinuationRetryActiveRecheckPreservesContinuation
+// is the routing-mode counterpart of
+// TestReconcileTerminalContinuationRetryActiveRecheckPreservesContinuation: when
+// the routing pass collects a terminal continuation retry but the deletion-time
+// recheck finds the issue active again, the continuation must be resumed
+// (attempt + budget preserved), not dropped to a bare poll wake. Pins that the
+// routing pass carries continuationForRetry through its retry cleanup too.
+func TestReconcileRoutingTerminalContinuationRetryActiveRecheckPreservesContinuation(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-RCR3", Identifier: "ENG-RCR3", State: "In Progress", Title: "self-stop"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-RCR3"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && view.Retrying[0].Attempt == 1
+	}, time.Second)
+
+	// The recheck resolver reports the issue active again, so the deletion-time
+	// recheck must skip removal and resume the continuation.
+	o.SetRetryTerminalStateResolver(staticStateRefresher{issue.ID: "In Progress"}, []string{"Done"})
+
+	if err := o.ReconcileTrackerIssuesAndWait(context.Background(),
+		map[string]tracker.Issue{},
+		map[string]struct{}{"in progress": {}},
+		map[string]struct{}{"done": {}},
+		map[string]tracker.Issue{issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"}},
+		0); err != nil {
+		t.Fatalf("ReconcileTrackerIssuesAndWait: %v", err)
+	}
+
+	// Continuation resumed with the queued attempt preserved (not reset to 0).
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil && len(view.Retrying) == 1 && view.Retrying[0].Attempt == 1
+	}, time.Second)
+	if err := o.RequestDispatch(context.Background(), issue, nil); !errors.Is(err, ErrNotDispatched) {
+		t.Fatalf("RequestDispatch after recheck-active continuation = %v, want ErrNotDispatched while continuation retry is claimed", err)
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Fatalf("cleanup calls = %+v, want none after state rechecked active", calls)
+	}
+}
+
 // TestFinalize_AbnormalExitHoldsClaimAcrossScheduleRetryGap is a
 // regression for the gap that Codex flagged on PR #102: finalizeRunOp's
 // apply ran FinishRunFailed (which dropped Claimed[id]) and then


### PR DESCRIPTION
## Summary

Follows up the unresolved review thread on PR #455 (`internal/orchestrator/actor.go:1383`, @chatgpt-codex-connector).

When a queued **continuation** retry is observed terminal by reconciliation and the off-actor deletion-time recheck (`verifyReconciledWorkspaceStillTerminal`) then finds the issue **active again**, the orchestrator must resume the continuation — preserving the queued attempt + max-turn budget — exactly as the running-entry path already does via `reconciledWorkspaceCleanupOrContinuation`. Previously the retry-cleanup path passed a `nil` continuation, so `continueAfterSkippedTerminalCleanup(nil)` only woke polling and the next dispatch reset `ContinuationAttempt` to 0, losing the attempt and budget.

This threads the continuation through the retry-cleanup path in **both** reconcile passes.

Closes #474.

## Changes

**1. Inactive reconcile pass (`reconcileInactiveTrackerIssuesOp`)** — the exact review-thread concern:
- New `reconciledCleanup` pairs a terminal workspace removal with an optional continuation; `reconcileCancelFollowup` forwards it to `runReconciledWorkspaceCleanup`.
- New `continuationForRetry` builds the continuation for `RetryKindContinuation` entries (nil for blocked / failure / quota / external-blocker).
- The deletion-time recheck now reschedules the continuation when it finds the issue active again.

**2. Routing-aware pass (`reconcileTrackerIssuesOp`)** — adjacent-path gap surfaced while auditing #1, fixed here per maintainer request:
- This pass runs *before* the inactive pass and previously released terminal retries with **no §18.1 cleanup at all** (workspace leaked until the next startup sweep), and dropped the continuation on a blip.
- New `terminalRetryCleanup` (mirrors `terminalBlockedCleanup`) cleans routed terminal retry workspaces through the `WorkspaceCleaner` and carries the same continuation.

Blocked / failure / quota / external-blocker cleanups carry a `nil` continuation as before (no queued continuation attempt to preserve).

## Verification

```
gofmt -l $(git ls-files '*.go')              # empty
go vet ./...
go mod tidy && git diff --exit-code -- go.mod go.sum
go test -race -covermode=atomic ./...
go build ./cmd/worker ./cmd/tui
```
All green.

### Regression tests (mutation-verified)
- `TestReconcileTerminalContinuationRetryActiveRecheckPreservesContinuation` — inactive pass, recheck-active resumes continuation (attempt preserved, re-claimed, consumable; no cleanup).
- `TestReconcileRoutingTerminalContinuationRetryFiresWorkspaceCleanup` — routing pass cleans terminal retry workspace (leak fix).
- `TestReconcileRoutingNonTerminalContinuationRetryKeepsWorkspace` — routing terminal-gating negative (non-terminal retry keeps workspace; terminal sibling is the progress barrier).
- `TestReconcileRoutingTerminalContinuationRetryActiveRecheckPreservesContinuation` — routing pass also carries the continuation through the recheck.

Mutations confirmed each test fails against broken code (run against the committed artifact, then restored):
- `continuationForRetry` → always `nil`: both recheck-active tests fail at the continuation-preserved assertion; pure-cleanup tests still pass.
- `terminalRetryCleanup` → always `(_, false)`: routing leak-fix + routing recheck tests fail.

## Codex-review classification
- **Algorithm fidelity**: mirrors upstream `handle_retry_issue_lookup` (terminal branch cleans workspace + releases) and the running-entry continuation path; the deletion-time recheck is the existing aiops TOCTOU guard, now consistent for the retry path in both passes.
- **Cross-module consistency**: both reconcile passes now apply the same retry terminal-cleanup + continuation contract — no "half a contract" between routing and inactive passes.
- **Go runtime hardening**: no new goroutines/timers; reuses the existing timeout-bounded recheck + `safeGo` retry path.
- **No placebo tests**: every new test is mutation-verified.

## Size gate
`size-gated: justified overage` — ~335 changed LOC, of which ~223 are tests; the production diff is ~112 LOC in `actor.go`. The overage is regression coverage for a concurrent/destructive cleanup path across both reconcile passes and cannot be split without losing atomicity (both passes share the new `reconciledCleanup` / `continuationForRetry` infra introduced here). Requests human size-gate sign-off before merge.

## Notes / deferrals
- `reconcileTrackerIssuesOp.apply` gocognit ticks 14 → 16 (pre-existing baseline over-threshold function; the new logic mirrors the sibling blocked loop). Not refactored to keep the diff scoped; the `funlen`/`gocognit` gate is non-blocking during burndown.
- No SPEC deviation opened or closed; this is a correctness fix within the SPEC-aligned envelope.

https://claude.ai/code/session_01UQvnpVLkwVmvoexAhkLm3M

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQvnpVLkwVmvoexAhkLm3M)_