### PR TITLE
feat(doctor): production Codex auth/model config strategy for Docker (#465)

### DIFF
--- a/deploy/codex/config.toml
+++ b/deploy/codex/config.toml
@@ -1,0 +1,23 @@
+# Declarative, version-controlled Codex model configuration for the
+# production-style Docker worker (#465).
+#
+# This file is intentionally NON-SECRET and safe to commit. It carries only
+# model/provider/reasoning selection so the model the worker runs is auditable
+# in review and in `worker --doctor`, instead of hidden in a copied host
+# `config.toml`. Mount it read-only over `$CODEX_HOME/config.toml`; keep the
+# secret `auth.json` (ChatGPT login) or `OPENAI_API_KEY` (API-key mode) out of
+# this file and out of git. See docs/runbooks/codex-app-server-docker.md.
+
+# Model selection. `worker --doctor --mode=real` surfaces these three keys as
+# "Codex model config" so the choice is explicit and reviewable.
+model = "gpt-5-codex"
+model_provider = "openai"
+model_reasoning_effort = "high"
+
+# Optional: a non-default provider endpoint. The provider's credential is named
+# here only by env var (`env_key`); the value still arrives through a Docker
+# secret / env passthrough, never inline in this file.
+# [model_providers.openai]
+# name = "OpenAI"
+# base_url = "https://api.openai.com/v1"
+# env_key = "OPENAI_API_KEY"

--- a/deploy/docker-compose.codex.yml
+++ b/deploy/docker-compose.codex.yml
@@ -31,7 +31,16 @@ services:
       - worker
     volumes:
       - ${AIOPS_WORKFLOW_PATH:?set AIOPS_WORKFLOW_PATH to a workflow file}:/app/WORKFLOW.md:ro
+      # CODEX_HOME is a restricted writable volume: Codex CLI 0.133 writes while
+      # loading config and persists refreshed ChatGPT-login tokens here. Keep it
+      # owned by the worker UID/GID and out of git; auth.json is a secret.
       - ${AIOPS_CODEX_HOME_PATH:?set AIOPS_CODEX_HOME_PATH to a Codex home directory}:/home/aiops/.codex
+      # Optional, recommended (#465): mount a version-controlled, NON-SECRET
+      # config.toml read-only OVER the writable home so model/provider/reasoning
+      # selection is declarative and auditable instead of copied from an opaque
+      # host config. Uncomment and set AIOPS_CODEX_CONFIG_FILE to an absolute path
+      # (e.g. $PWD/deploy/codex/config.toml). Leave auth out of this file.
+      # - ${AIOPS_CODEX_CONFIG_FILE:?set AIOPS_CODEX_CONFIG_FILE to a tracked config.toml}:/home/aiops/.codex/config.toml:ro
     secrets:
       - linear_api_key
       - gitea_token

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -87,25 +87,108 @@ schema snapshot first. Do not add fallback translation for old sandbox fields
 such as `mode`, `access`, or `readOnlyAccess`; this project is pre-release and
 should fail fast on stale workflow shape.
 
-## Authentication mount
+## Production auth and model configuration
 
-`codex app-server` must be authenticated before the worker starts it. For a
-local validation image, mount a temporary Codex home copied from a host session:
+`codex app-server` must be authenticated before the worker starts it. This
+section is the production operator contract for **identity** and **model
+configuration** (#465). The separate skills/MCP/toolchain bundle is #464; see
+"Composition with #464" below for the boundary.
 
-```bash
-mkdir -p /tmp/aiops-codex-home/.codex
-cp ~/.codex/auth.json /tmp/aiops-codex-home/.codex/auth.json
-cp ~/.codex/config.toml /tmp/aiops-codex-home/.codex/config.toml
-```
+### Supported auth modes
 
-For Codex CLI 0.133, mount that directory writable at `/home/aiops/.codex`
-for the default non-root worker image, and set:
+Two modes are supported. Pick one per deployment; do not mix them.
+
+1. **ChatGPT/Codex login (default).** Codex stores the login in
+   `$CODEX_HOME/auth.json`. This file is a secret and is **writable at runtime**
+   because Codex 0.133 refreshes tokens in place. Set it up once with
+   `codex --login` in the same container user / `CODEX_HOME` context, then keep
+   `CODEX_HOME` on a restricted writable volume so refreshed tokens persist
+   across restarts. A read-only `CODEX_HOME` silently breaks long-lived workers
+   the first time a token needs refreshing.
+
+2. **Model API key.** Codex authenticates with `OPENAI_API_KEY` (or the
+   `env_key` named by a custom `[model_providers.*]` block). The worker does
+   **not** pass model-runtime credentials to the agent subprocess unless the
+   workflow opts in: add `OPENAI_API_KEY` to `codex.env_passthrough` in
+   `WORKFLOW.md`. Source the value from a Docker secret / secret file and let the
+   entrypoint export it; never put it on a command line or in a git-tracked file.
+   Tracker/repo tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`, …) stay denied from
+   passthrough by policy — only the model key is opt-in.
+
+`worker --doctor --mode=real` reports the active mode as `Codex auth mode`:
+`API key via OPENAI_API_KEY passthrough` when the passthrough is configured (and
+fails if the key resolves empty), otherwise `ChatGPT/Codex login` plus a
+`Codex auth refresh` warning if `CODEX_HOME` is not writable.
+
+### CODEX_HOME volume layout
+
+Treat `CODEX_HOME` as three concerns with different trust levels:
+
+| Path | Trust | Mount |
+| --- | --- | --- |
+| `auth.json` | secret, mutable | inside the **writable** `CODEX_HOME` volume; never commit |
+| `config.toml` | non-secret, declarative | **read-only** bind from a version-controlled file (see below) |
+| `sessions/`, `log/`, cache | ephemeral | writable; safe to discard between runs |
+
+For Codex CLI 0.133, mount the writable home at `/home/aiops/.codex` for the
+default non-root worker image, owned by the worker UID/GID, and set:
 
 ```text
 CODEX_HOME=/home/aiops/.codex
 ```
 
-Validate inside the container before processing issues:
+Codex resolves its home from `CODEX_HOME` if set, otherwise `$HOME/.codex`. The
+worker passes `HOME` to the agent subprocess but **not** `CODEX_HOME`; if you
+point `CODEX_HOME` somewhere other than `$HOME/.codex`, also add `CODEX_HOME` to
+`codex.env_passthrough` so the agent sees the same home the preflight checked.
+
+### Declarative model configuration
+
+Do not copy an opaque host `config.toml` into the image or the writable home.
+Instead keep a small, non-secret, version-controlled config and mount it
+read-only over `$CODEX_HOME/config.toml`. The repo ships
+[`deploy/codex/config.toml`](../../deploy/codex/config.toml) as the example:
+
+```toml
+model = "gpt-5-codex"
+model_provider = "openai"
+model_reasoning_effort = "high"
+```
+
+Enable it by uncommenting the optional bind in
+`deploy/docker-compose.codex.yml` and pointing `AIOPS_CODEX_CONFIG_FILE` at an
+absolute path:
+
+```text
+AIOPS_CODEX_CONFIG_FILE=$PWD/deploy/codex/config.toml
+```
+
+`worker --doctor --mode=real` reads the three top-level model keys (and nothing
+from `[model_providers.*]` tables, which may name secret env keys) and reports
+them as `Codex model config: model=…, provider=…, reasoning_effort=…`. If no
+`model` is declared it warns rather than silently inheriting Codex's built-in
+default, so model selection is always explicit and auditable in review.
+
+Provider, profile, service tier, reasoning effort, and feature flags all belong
+in this tracked file or in `WORKFLOW.md` front matter (`codex.profile`,
+`codex.thread_sandbox`, `codex.approval_policy`, the `codex.*_timeout_ms`
+fields), never in operator-local state baked into the image.
+
+### Rotation, refresh, and revocation
+
+- **ChatGPT login refresh** happens automatically as long as `CODEX_HOME` is
+  writable; no operator action is needed mid-deployment.
+- **Re-login / rotation:** run `codex --login` again in the container user /
+  `CODEX_HOME` context (or re-provision the `auth.json` on the writable volume),
+  then re-run `worker --doctor --mode=real`. No image rebuild is required.
+- **API-key rotation:** replace the Docker secret file contents and recreate the
+  worker so the entrypoint re-exports the new value; nothing is committed.
+- **Revocation:** revoke the ChatGPT session or API key at the provider, then
+  delete `auth.json` (or clear the secret) on the volume. `codex login status`
+  and `worker --doctor --mode=real` will then fail closed with an actionable
+  `Codex auth` failure instead of running with stale credentials.
+
+### Validate before processing issues
 
 ```bash
 codex login status
@@ -117,6 +200,28 @@ should remain running on stdio until the worker speaks JSON-RPC to it.
 `worker --doctor --mode=real` performs that stdio probe by keeping stdin open,
 sending `initialize`, and waiting for a JSON-RPC response. A probe that only
 starts the process and closes stdin is not a valid app-server check.
+
+### Doctor remediation reference
+
+| Doctor line | Meaning | Remediation |
+| --- | --- | --- |
+| `FAIL Codex auth` | `codex login status` failed or returned not-logged-in | Run `codex --login` (or re-provision `auth.json`) in the same `CODEX_HOME`/container user context. |
+| `FAIL Codex auth mode` | `OPENAI_API_KEY` is in `codex.env_passthrough` but resolves empty | Mount the model API key from a Docker secret into `OPENAI_API_KEY`; never pass it on a command line. |
+| `WARN Codex auth refresh` | ChatGPT-login mode but `CODEX_HOME` is not writable | Mount `CODEX_HOME` as a restricted writable volume so token refresh can persist. |
+| `WARN Codex model config` | no `model` declared in `$CODEX_HOME/config.toml` | Declare `model` (and optional `model_provider`/`model_reasoning_effort`) in the tracked `config.toml`. |
+| `PASS Codex model config` | resolved model selection | none; verify the reported `model`/`provider`/`reasoning_effort` match intent. |
+| `FAIL Codex app-server` | app-server did not answer the JSON-RPC `initialize` probe | Check `CODEX_HOME`, `codex.command`, and app-server support in the installed Codex version. |
+
+### Composition with #464
+
+This issue covers credentials and model configuration only. The agent's
+**toolchain** — repo/Codex skills, plugins, MCP servers, and the `gh`/Go
+command surface — is the separate #464 contract. Both share the same principle:
+secrets stay in Docker secrets / secret files and writable volumes, while
+reproducible, non-secret assets (this `config.toml`, the #464 skills/MCP
+manifest) are version-controlled and verified by `worker --doctor`. The auth
+modes here do not install skills or MCP servers; do not rely on a host `~/.codex`
+to supply them.
 
 ## GitHub agent credentials
 
@@ -167,12 +272,9 @@ using the Codex agent environment. Omit `--github-repo` only when the workflow
 configures one GitHub repo. A failure is a deployment blocker; fix the
 toolchain or credential path before starting the worker.
 
-The supported Compose overlay uses a writable bind for `CODEX_HOME` because
-Codex 0.133 writes while loading configuration and may refresh auth state.
-Use a restricted directory owned by the worker UID/GID. A read-only copy is
-only suitable for archival inspection or a future Codex version that documents
-a no-write startup mode; it is not a valid `worker --doctor --mode=real`
-preflight mount for 0.133.
+The `CODEX_HOME` volume trust layout (writable home, read-only declarative
+`config.toml`, ephemeral cache) is covered under "Production auth and model
+configuration" above.
 
 ## Sandbox note
 

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -10,7 +10,8 @@ aiops-platform with Docker, Linear, and `codex app-server`.
 | macOS host development | Run `go run ./cmd/worker --doctor --mode=mock` and `agent.default: mock` from source. | Use host Codex CLI for local `codex` / `codex-app-server` workflows after `codex --login`. | Host binary mounts into Linux containers are not supported; install Codex in the image. |
 | Linux amd64 Docker worker | Build `Dockerfile` target `codex-worker`; Codex CLI `0.133.0` is installed from a pinned release artifact and checksum. | Use base `worker` target for mock-only validation. | Online installer is not the promoted Docker path until Linux ARM64 checksum behavior is reliable. |
 | Linux arm64 Docker worker | Build `codex-worker`; uses the pinned `aarch64-unknown-linux-musl` release artifact and checksum. | Same as above. | `curl https://chatgpt.com/codex/install.sh \| sh` failed on 2026-05-26 because the installer could not find the ARM64 package checksum. |
-| Codex auth | Mount a restricted writable `CODEX_HOME` directory into `/home/aiops/.codex` for Codex CLI 0.133; verify with `worker --doctor --mode=real`. | Local host development can use the normal host `~/.codex`; read-only copies are only suitable for archival inspection or future no-write smoke modes. | Passing raw bearer tokens on command lines or in logs is not supported. |
+| Codex auth | ChatGPT/Codex login in a restricted writable `CODEX_HOME` (`/home/aiops/.codex`) so token refresh persists, **or** model API key via `OPENAI_API_KEY` added to `codex.env_passthrough` and sourced from a Docker secret; verify with `worker --doctor --mode=real`. See [`codex-app-server-docker.md`](codex-app-server-docker.md) for the full auth/model lifecycle (setup, rotation, revocation). | Local host development can use the normal host `~/.codex`. | Passing raw bearer/API tokens on command lines or in logs is not supported; tracker/repo tokens are never passed through to the agent. |
+| Codex model config | Declarative, version-controlled `config.toml` (model/provider/reasoning) mounted read-only over `$CODEX_HOME/config.toml`; doctor reports the resolved selection. | `WORKFLOW.md` `codex.*` front matter for profile/sandbox/approval/timeouts. | Copying an opaque host `config.toml` into the image or writable home is discouraged — model selection must be auditable. |
 | GitHub agent auth | File-backed `gh` auth from a Docker secret, or a dedicated SSH deploy key, visible to the `aiops` user and verified with `worker --doctor --mode=real --github-issue <n>`. | Read-only issue-only tokens are enough for analysis-only smoke tests; branch push validation needs write-capable repo credentials. | `GH_TOKEN`/`GITHUB_TOKEN` in the worker environment are stripped from agent subprocesses and are not a valid dogfood credential contract. |
 | Linear auth | Personal API key in a Docker Compose secret file. Linear expects `Authorization: <API_KEY>` for personal keys. | Local development may use `LINEAR_API_KEY` in `.env`; do not use this for production-style examples. | OAuth app-actor is documented by Linear and is the intended future service-account path, but aiops-platform still accepts a single `tracker.api_key` string today. |
 | Sandbox | Mock mode works under the base hardened container. Real Codex Docker validation uses a Docker-isolated profile and explicit `codex.thread_sandbox: danger-full-access` only inside that container boundary. | Enable kernel/user namespace support and keep Codex `workspace-write` if your container profile permits it. | Do not copy `danger-full-access` to a shared host run. |
@@ -46,14 +47,20 @@ cp examples/WORKFLOW.md .aiops/WORKFLOW.md
 )
 ```
 
-Run `codex --login` on the host, then copy or provision the Codex home you
-want the container to read:
+Run `codex --login` on the host, then provision the Codex home the container
+will read. Copy only the secret `auth.json`; keep model selection in the
+tracked, non-secret `deploy/codex/config.toml` rather than copying an opaque
+host `config.toml` (see
+[`codex-app-server-docker.md`](codex-app-server-docker.md)):
 
 ```bash
 cp ~/.codex/auth.json .aiops/codex-home/auth.json
-cp ~/.codex/config.toml .aiops/codex-home/config.toml
-chmod 600 .aiops/secrets/* .aiops/codex-home/*
+chmod 600 .aiops/secrets/* .aiops/codex-home/auth.json
 ```
+
+For API-key auth instead of ChatGPT login, skip `auth.json`, write the key to a
+secret file (`.aiops/secrets/openai_api_key`), and add `OPENAI_API_KEY` to
+`codex.env_passthrough` in the workflow.
 
 Edit `.aiops/WORKFLOW.md`:
 
@@ -74,6 +81,9 @@ bind/secret paths avoid project-directory ambiguity.
 cat > .env <<EOF
 AIOPS_WORKFLOW_PATH=$PWD/.aiops/WORKFLOW.md
 AIOPS_CODEX_HOME_PATH=$PWD/.aiops/codex-home
+# Declarative, non-secret Codex model config mounted read-only over the home;
+# uncomment the matching volume in deploy/docker-compose.codex.yml to enable.
+AIOPS_CODEX_CONFIG_FILE=$PWD/deploy/codex/config.toml
 LINEAR_API_KEY_FILE=$PWD/.aiops/secrets/linear_api_key
 GITHUB_TOKEN_FILE=$PWD/.aiops/secrets/github_token
 # Optional: only if this deployment still needs a Gitea API token.
@@ -334,6 +344,9 @@ GitHub/Linear test issue that is not closed by the PR.
 | `FAIL Linear auth` | Personal keys must be sent raw, not as `Bearer`; confirm the token can see `tracker.project_slug`. |
 | `FAIL Codex CLI` | Build the `codex-worker` target or install Codex on the host. |
 | `FAIL Codex auth` | Run `codex --login` for the same `CODEX_HOME` and container user context. |
+| `FAIL Codex auth mode` | `OPENAI_API_KEY` is in `codex.env_passthrough` but empty; mount it from a Docker secret. |
+| `WARN Codex auth refresh` | Mount `CODEX_HOME` as a restricted writable volume so ChatGPT-login token refresh persists. |
+| `WARN Codex model config` | Declare `model` in the tracked `deploy/codex/config.toml`; see `codex-app-server-docker.md`. |
 | `FAIL GitHub agent gh auth` | Set `GITHUB_TOKEN_FILE` to a least-privilege token file or mount a deploy key; do not rely on `GH_TOKEN`/`GITHUB_TOKEN` in the worker environment. |
 | `FAIL GitHub agent git push` | Run the documented doctor command from the container and fix `gh auth setup-git` or deploy-key write access for the target repo. |
 | `FAIL no new open draft PR ... closes GitHub issue` | Confirm the mirrored Linear issue tells the agent to open a draft PR with `Closes #<n>`, and that the GitHub credential has repo write access. |

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -331,6 +331,72 @@ func (r *reportBuilder) checkCodex(ctx context.Context, cfg workflow.Config) {
 	} else {
 		r.pass("Codex app-server", "started and answered a JSON-RPC probe")
 	}
+	r.checkCodexAuthModel(cfg)
+}
+
+// checkCodexAuthModel reports the production auth mode and model configuration
+// the app-server worker will use, so a preflight distinguishes a missing model
+// API key from an expired ChatGPT login and surfaces model selection instead of
+// leaving it hidden in a copied host config.toml (#465). Secrets are never
+// printed: API-key presence is checked without echoing the value, and only the
+// non-secret model/provider/effort keys are read from config.toml.
+func (r *reportBuilder) checkCodexAuthModel(cfg workflow.Config) {
+	home := codexHomeDir()
+	if codexAPIKeyAuthSelected(cfg) {
+		r.checkCodexAPIKeyAuth()
+	} else {
+		r.checkCodexLoginAuth(home)
+	}
+	r.checkCodexModelConfig(home)
+}
+
+func (r *reportBuilder) checkCodexAPIKeyAuth() {
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) != "" {
+		r.pass("Codex auth mode", "API key via OPENAI_API_KEY passthrough")
+		return
+	}
+	status := Warn
+	if r.realMode() {
+		status = Fail
+	}
+	r.add(status, "Codex auth mode", "OPENAI_API_KEY is in codex.env_passthrough but resolved empty",
+		"Mount the model API key from a Docker secret into OPENAI_API_KEY; never pass it on a command line.")
+}
+
+func (r *reportBuilder) checkCodexLoginAuth(home string) {
+	detail := "ChatGPT/Codex login"
+	if home != "" {
+		detail += " (auth.json under " + home + ")"
+	}
+	r.pass("Codex auth mode", detail)
+	if !r.realMode() || home == "" {
+		return
+	}
+	if err := codexHomeWritable(home); err != nil {
+		r.warn("Codex auth refresh", "CODEX_HOME is not writable: "+err.Error(),
+			"Mount CODEX_HOME as a restricted writable volume so ChatGPT-login token refresh can persist for long-lived workers.")
+	}
+}
+
+func (r *reportBuilder) checkCodexModelConfig(home string) {
+	if home == "" {
+		return
+	}
+	configPath := filepath.Join(home, "config.toml")
+	model, provider, effort, ok := readCodexModelConfig(configPath)
+	if !ok {
+		r.warn("Codex model config", "no model declared in "+configPath,
+			"Declare model (and optional model_provider/model_reasoning_effort) in a tracked, non-secret config.toml so model selection is auditable instead of relying on a copied host config.")
+		return
+	}
+	detail := "model=" + model
+	if provider != "" {
+		detail += ", provider=" + provider
+	}
+	if effort != "" {
+		detail += ", reasoning_effort=" + effort
+	}
+	r.pass("Codex model config", detail)
 }
 
 func (r *reportBuilder) checkSandbox(cfg workflow.Config) {
@@ -659,6 +725,98 @@ func lookPathInEnv(name string, env []string) (string, error) {
 
 func requiresCodex(cfg workflow.Config) bool {
 	return cfg.Agent.Default == "codex" || cfg.Agent.Default == runner.NameCodexAppServer
+}
+
+// codexAPIKeyAuthSelected reports whether the workflow opts the agent into
+// model API-key auth by passing OPENAI_API_KEY through to the Codex
+// subprocess. Without the passthrough the key never reaches the agent and the
+// app-server falls back to the ChatGPT/Codex login in CODEX_HOME.
+func codexAPIKeyAuthSelected(cfg workflow.Config) bool {
+	for _, name := range cfg.Codex.EnvPassthrough {
+		if strings.EqualFold(strings.TrimSpace(name), "OPENAI_API_KEY") {
+			return true
+		}
+	}
+	return false
+}
+
+// codexHomeDir resolves the directory Codex reads auth and config from, the
+// same way the CLI does: CODEX_HOME wins, otherwise $HOME/.codex.
+func codexHomeDir() string {
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		return home
+	}
+	if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
+		return filepath.Join(home, ".codex")
+	}
+	return ""
+}
+
+// codexHomeWritable confirms the worker can create files in CODEX_HOME, which
+// a long-lived ChatGPT-login deployment needs so Codex can persist refreshed
+// tokens. The probe file is removed before returning.
+func codexHomeWritable(dir string) error {
+	f, err := os.CreateTemp(dir, ".aiops-doctor-write-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	closeBody(f)
+	_ = os.Remove(name)
+	return nil
+}
+
+// readCodexModelConfig extracts the non-secret top-level model selection keys
+// from a Codex config.toml. It deliberately ignores every `[table]` section so
+// provider blocks (which may name secret env keys) are never surfaced. ok is
+// true only when a model is declared.
+func readCodexModelConfig(path string) (model, provider, effort string, ok bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", "", false
+	}
+	values := topLevelTOMLScalars(string(data))
+	model = values["model"]
+	return model, values["model_provider"], values["model_reasoning_effort"], model != ""
+}
+
+// topLevelTOMLScalars returns the bare top-level `key = value` scalars in a
+// TOML document, skipping every `[table]` section so nested provider blocks
+// (which can name secret env keys) are never surfaced.
+func topLevelTOMLScalars(data string) map[string]string {
+	values := map[string]string{}
+	inTable := false
+	for _, raw := range strings.Split(data, "\n") {
+		line := strings.TrimSpace(raw)
+		switch {
+		case line == "" || strings.HasPrefix(line, "#"):
+		case strings.HasPrefix(line, "["):
+			inTable = true
+		case inTable:
+		default:
+			if key, val, found := strings.Cut(line, "="); found {
+				values[strings.TrimSpace(key)] = tomlScalarString(val)
+			}
+		}
+	}
+	return values
+}
+
+// tomlScalarString reads a quoted or bare TOML scalar, dropping a trailing
+// inline comment on bare values. It is intentionally minimal: doctor only
+// surfaces the value for display, so full TOML parsing is not warranted.
+func tomlScalarString(v string) string {
+	v = strings.TrimSpace(v)
+	if len(v) > 0 && (v[0] == '"' || v[0] == '\'') {
+		if j := strings.IndexByte(v[1:], v[0]); j >= 0 {
+			return v[1 : 1+j]
+		}
+		return strings.Trim(v, string(v[0]))
+	}
+	if i := strings.IndexByte(v, '#'); i >= 0 {
+		v = v[:i]
+	}
+	return strings.TrimSpace(v)
 }
 
 func linearProjectSlugs(cfg workflow.Config) []string {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -712,6 +712,97 @@ func TestRunReturnsFailureWhenReportHasFailures(t *testing.T) {
 	}
 }
 
+func TestCheckCodexAuthModelAPIKeyMissingFailsInRealMode(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "")
+	cfg := workflow.Config{}
+	cfg.Codex.EnvPassthrough = []string{"OPENAI_API_KEY"}
+	r := &reportBuilder{opts: Options{Mode: "real"}}
+	r.checkCodexAuthModel(cfg)
+
+	check := findCheck(t, Report{Checks: r.checks}, "Codex auth mode")
+	if check.Status != Fail {
+		t.Fatalf("checkCodexAuthModel(api-key, OPENAI_API_KEY unset) status = %s; want %s", check.Status, Fail)
+	}
+}
+
+func TestCheckCodexAuthModelAPIKeyPresentPasses(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "sk-doctor-test")
+	cfg := workflow.Config{}
+	cfg.Codex.EnvPassthrough = []string{"OPENAI_API_KEY"}
+	r := &reportBuilder{opts: Options{Mode: "real"}}
+	r.checkCodexAuthModel(cfg)
+
+	check := findCheck(t, Report{Checks: r.checks}, "Codex auth mode")
+	if check.Status != Pass {
+		t.Fatalf("checkCodexAuthModel(api-key, OPENAI_API_KEY set) status = %s; want %s", check.Status, Pass)
+	}
+	if strings.Contains(check.Detail, "sk-doctor-test") {
+		t.Fatalf("Codex auth mode detail = %q; must not echo the API key", check.Detail)
+	}
+}
+
+func TestCheckCodexAuthModelChatGPTLoginReportsModelConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	writeFile(t, filepath.Join(home, "config.toml"), "model = \"gpt-5-codex\"\nmodel_provider = \"openai\"\nmodel_reasoning_effort = \"high\"\n")
+	cfg := workflow.Config{}
+	r := &reportBuilder{opts: Options{Mode: "real"}}
+	r.checkCodexAuthModel(cfg)
+
+	mode := findCheck(t, Report{Checks: r.checks}, "Codex auth mode")
+	if mode.Status != Pass || !strings.Contains(mode.Detail, "ChatGPT/Codex login") {
+		t.Fatalf("Codex auth mode = %+v; want PASS ChatGPT/Codex login", mode)
+	}
+	model := findCheck(t, Report{Checks: r.checks}, "Codex model config")
+	if model.Status != Pass {
+		t.Fatalf("Codex model config status = %s; want %s", model.Status, Pass)
+	}
+	for _, want := range []string{"model=gpt-5-codex", "provider=openai", "reasoning_effort=high"} {
+		if !strings.Contains(model.Detail, want) {
+			t.Fatalf("Codex model config detail = %q; want it to contain %q", model.Detail, want)
+		}
+	}
+}
+
+func TestCheckCodexModelConfigWarnsWhenModelMissing(t *testing.T) {
+	home := t.TempDir()
+	r := &reportBuilder{opts: Options{Mode: "real"}}
+	r.checkCodexModelConfig(home)
+
+	check := findCheck(t, Report{Checks: r.checks}, "Codex model config")
+	if check.Status != Warn {
+		t.Fatalf("checkCodexModelConfig(no config.toml) status = %s; want %s", check.Status, Warn)
+	}
+}
+
+func TestReadCodexModelConfigIgnoresTableSections(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, "config.toml")
+	writeFile(t, path, `# top-level model selection
+model = "gpt-5-codex" # inline comment
+[model_providers.custom]
+model_provider = "leaked-provider"
+model_reasoning_effort = "leaked-effort"
+env_key = "SECRET_PROVIDER_KEY"
+`)
+	model, provider, effort, ok := readCodexModelConfig(path)
+	if !ok || model != "gpt-5-codex" {
+		t.Fatalf("readCodexModelConfig model = %q, ok = %v; want %q, true", model, ok, "gpt-5-codex")
+	}
+	if provider != "" || effort != "" {
+		t.Fatalf("readCodexModelConfig leaked table keys: provider = %q, effort = %q; want both empty", provider, effort)
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
 func writeWorkflow(t *testing.T, trackerKind, apiKey string) string {
 	t.Helper()
 	return writeWorkflowBody(t, trackerKind, apiKey, "mock", "")


### PR DESCRIPTION
Closes #465.

Defines the production Docker contract for Codex **identity** and **model
configuration**, distinct from the #464 skills/MCP toolchain bundle.

## Acceptance criteria

- [x] **Supported auth modes documented (setup/validation/rotation/revocation).**
  `docs/runbooks/codex-app-server-docker.md` → new "Production auth and model
  configuration" section: ChatGPT/Codex login (writable `CODEX_HOME` for token
  refresh) and model API key (`OPENAI_API_KEY` opt-in via `codex.env_passthrough`,
  sourced from a Docker secret), plus a rotation/refresh/revocation subsection.
- [x] **Declarative, auditable model/provider/reasoning config.**
  New tracked, non-secret `deploy/codex/config.toml`; doctor reads and reports
  the resolved `model/provider/reasoning_effort` instead of leaving it in an
  opaque copied host `config.toml`.
- [x] **Compose/runbook use secret files / a clearly separated writable
  `CODEX_HOME`.** `deploy/docker-compose.codex.yml` gains an opt-in read-only
  `config.toml` bind over the writable home; runbook documents the three-layer
  `CODEX_HOME` trust model (secret `auth.json` / read-only config / ephemeral
  cache).
- [x] **Doctor reports auth & model failures with remediation.**
  `worker --doctor --mode=real` now emits `Codex auth mode`
  (FAIL when API-key mode selected but `OPENAI_API_KEY` empty), `Codex auth
  refresh` (WARN when `CODEX_HOME` not writable under ChatGPT login), and
  `Codex model config` (PASS with resolved selection / WARN when no model
  declared). Remediation tables added to both runbooks.
- [x] **No recommended command prints or commits credentials.** API-key
  presence is checked without echoing the value; only top-level TOML scalars are
  read and every `[table]` section is skipped, so a provider block's `env_key`
  is never surfaced.
- [x] **Composition with #464 clarified.** New "Composition with #464" section
  draws the boundary between this credentials/model contract and the
  skills/MCP/toolchain contract.

## Implementation notes

- New doctor checks live in focused helpers
  (`checkCodexAuthModel` → `checkCodexAPIKeyAuth` / `checkCodexLoginAuth` /
  `checkCodexModelConfig`); auth mode is derived from whether `OPENAI_API_KEY`
  is in `codex.env_passthrough`, matching how the runner actually reaches the
  agent subprocess (`internal/runner/env.go` + `agent_env_policy.go`).
- The compose config bind is left commented/opt-in rather than defaulted to
  `/dev/null`, which would silently shadow an existing in-home `config.toml`
  and regress the current first-run path.

## Verification

```
gofmt -l $(git ls-files '*.go')        # empty
go mod tidy && git diff --exit-code -- go.mod go.sum
go vet ./...
go test -race -covermode=atomic ./...   # all pass
go build ./cmd/worker ./cmd/tui
golangci-lint run --config=.golangci.yml --issues-exit-code=0   # no new gocognit violations (8 == baseline)
```

### Mutation check

`TestReadCodexModelConfigIgnoresTableSections` is a negative assertion: it puts
`model_provider`/`model_reasoning_effort` inside a `[model_providers.custom]`
table and asserts they are NOT surfaced. Removing the `case inTable:` skip in
`topLevelTOMLScalars` makes the test fail, confirming it guards the
no-secret-leak behavior.

## Size

`within budget` — diff is doc/deploy-heavy plus one additive doctor check; no
existing behavior changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013BiGm1Ydwi4LLN1iaY9k12)_