### PR TITLE
fix(tui): keep dashboard within terminal width on narrow terminals

### DIFF
--- a/cmd/tui/layout.go
+++ b/cmd/tui/layout.go
@@ -1,0 +1,129 @@
+// cmd/tui layout policy: keep every rendered frame line within the live
+// terminal width so the dashboard stays readable on narrow terminals (#466).
+//
+// SPEC scope: §2.2 lists "prescribing a specific dashboard or terminal UI
+// implementation" as a non-goal and §13.4 makes the terminal status surface
+// OPTIONAL and implementation-defined, so the narrow-width policy here is an
+// implementation choice, not a deviation. The /api/v1/state data contract
+// (§13.7.2) is untouched. cellRight restores upstream parity: the Elixir
+// reference renders the TOKENS column with format_cell(.., :right), which
+// truncates, but the Go port previously right-padded without truncating.
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// truncateCell trims a column value to width, replacing the overflow with "..."
+// — the shared body of cell (left aligned) and cellRight (right aligned),
+// mirroring truncate_plain/2 in status_dashboard.ex.
+func truncateCell(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	if width <= 3 {
+		return string(runes[:width])
+	}
+	return string(runes[:width-3]) + "..."
+}
+
+// cellRight right-aligns a value to width, truncating with "..." when it
+// overflows. Mirrors format_cell(value, width, :right): a long token count must
+// not push the EVENT column out of alignment.
+func cellRight(s string, width int) string {
+	return fmt.Sprintf("%*s", width, truncateCell(sanitize(s), width))
+}
+
+// clipFrame joins the frame lines, first clipping each to the live terminal
+// width so a header line or table row can never wrap or word-split on a narrow
+// terminal (#466). Clipping is applied only when a real terminal width is
+// measured (TIOCGWINSZ); piped or redirected output stays full-fidelity because
+// the consumer (a file, a pager, `less -S`) is not a fixed-width wrapping
+// surface and may scroll horizontally. It clips lines in place, so callers pass
+// a freshly built slice (every call site does).
+func clipFrame(lines []string) string {
+	if width, ok := liveTerminalWidth(); ok {
+		for i := range lines {
+			lines[i] = truncateToWidth(lines[i], width)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// truncateToWidth clips a single rendered line to at most width visible columns.
+// ANSI escape sequences (colour codes) are passed through verbatim and never
+// counted toward the width or split mid-sequence; when the line is cut a reset
+// is appended so a truncation inside a colourised span can't bleed colour into
+// the rest of the screen. A single-column ellipsis marks the cut.
+func truncateToWidth(line string, width int) string {
+	if width <= 0 {
+		return line
+	}
+	runes := []rune(line)
+	if visibleColumns(runes) <= width {
+		return line
+	}
+	var b strings.Builder
+	visible := 0
+	for i := 0; i < len(runes); {
+		if runes[i] == 0x1b {
+			j := ansiSeqLen(runes, i)
+			b.WriteString(string(runes[i:j]))
+			i = j
+			continue
+		}
+		if visible >= width-1 {
+			break
+		}
+		b.WriteRune(runes[i])
+		visible++
+		i++
+	}
+	b.WriteRune('…')
+	b.WriteString(ansiReset)
+	return b.String()
+}
+
+// visibleColumns counts the display columns of runes, skipping ANSI escape
+// sequences. Like the rest of this file it assumes one column per visible rune,
+// matching the column-width bookkeeping in format_cell/3.
+func visibleColumns(runes []rune) int {
+	visible := 0
+	for i := 0; i < len(runes); {
+		if runes[i] == 0x1b {
+			i = ansiSeqLen(runes, i)
+			continue
+		}
+		visible++
+		i++
+	}
+	return visible
+}
+
+// ansiSeqLen returns the index just past the escape sequence starting at
+// runes[i] (which must be ESC, 0x1b). It recognises CSI sequences (ESC '[' …
+// final byte 0x40-0x7e) and bare two-rune escapes, matching the reCSISeq /
+// reEscapeSeq patterns used by sanitize.
+func ansiSeqLen(runes []rune, i int) int {
+	n := len(runes)
+	if i+1 < n && runes[i+1] == '[' {
+		j := i + 2
+		for j < n {
+			r := runes[j]
+			j++
+			if r >= 0x40 && r <= 0x7e {
+				break
+			}
+		}
+		return j
+	}
+	if i+1 < n {
+		return i + 2
+	}
+	return i + 1
+}

--- a/cmd/tui/layout_test.go
+++ b/cmd/tui/layout_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// visibleString strips ANSI escape sequences so tests can reason about the
+// columns a terminal actually renders. It reuses the package's sanitize
+// patterns but, unlike sanitize, leaves spacing and box-drawing runes intact.
+func visibleString(s string) string {
+	s = reCSISeq.ReplaceAllString(s, "")
+	s = reEscapeSeq.ReplaceAllString(s, "")
+	return s
+}
+
+func visibleWidth(s string) int { return utf8.RuneCountInString(visibleString(s)) }
+
+// ── truncateToWidth ────────────────────────────────────────────────────────
+
+// A line that already fits (counting only visible columns, so ANSI codes are
+// free) is returned byte-for-byte; non-positive widths are a no-op.
+func TestTruncateToWidth_Unchanged(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		width int
+	}{
+		{"plain shorter", "hello", 10},
+		{"plain exact", "hello", 5},
+		{"non-positive width", "hello", 0},
+		{"ansi fits (codes are zero-width)", ansiRed + "hi" + ansiReset, 5},
+	}
+	for _, c := range cases {
+		if got := truncateToWidth(c.in, c.width); got != c.in {
+			t.Errorf("%s: truncateToWidth(%q, %d) = %q; want unchanged", c.name, c.in, c.width, got)
+		}
+	}
+}
+
+// An over-long line is cut to the width with an ellipsis; colour codes before
+// the cut survive and a reset is appended so colour can't bleed past the cut.
+func TestTruncateToWidth_Clips(t *testing.T) {
+	cases := []struct {
+		name, in, wantVisible, wantCode string
+		width                           int
+	}{
+		{name: "plain overflow", in: "hello world", width: 5, wantVisible: "hell…"},
+		{name: "ansi overflow", in: ansiRed + "hello world" + ansiReset, width: 5, wantVisible: "hell…", wantCode: ansiRed},
+	}
+	for _, c := range cases {
+		got := truncateToWidth(c.in, c.width)
+		if vis := visibleString(got); vis != c.wantVisible {
+			t.Errorf("%s: truncateToWidth(%q, %d) visible = %q; want %q", c.name, c.in, c.width, vis, c.wantVisible)
+		}
+		if !strings.HasSuffix(got, "…"+ansiReset) {
+			t.Errorf("%s: truncateToWidth(%q, %d) = %q; want an ellipsis+reset suffix", c.name, c.in, c.width, got)
+		}
+		if c.wantCode != "" && !strings.Contains(got, c.wantCode) {
+			t.Errorf("%s: truncateToWidth(%q, %d) = %q; dropped colour code %q", c.name, c.in, c.width, got, c.wantCode)
+		}
+	}
+}
+
+// ── cellRight (TOKENS column parity with format_cell(.., :right)) ───────────
+
+func TestCellRight_RightAlignsAndTruncates(t *testing.T) {
+	t.Run("short value is right-aligned", func(t *testing.T) {
+		if got := cellRight("42", 10); got != "        42" {
+			t.Errorf("cellRight(%q, 10) = %q; want %q", "42", got, "        42")
+		}
+	})
+	t.Run("long value is truncated to width", func(t *testing.T) {
+		got := cellRight("1,000,000,000", 10) // 13 runes → must not exceed 10
+		if utf8.RuneCountInString(got) != 10 {
+			t.Errorf("cellRight(%q, 10) width = %d; want 10 (got %q)", "1,000,000,000", utf8.RuneCountInString(got), got)
+		}
+		if got != "1,000,0..." {
+			t.Errorf("cellRight(%q, 10) = %q; want %q", "1,000,000,000", got, "1,000,0...")
+		}
+	})
+}
+
+// ── alignment: a long token count must not push EVENT out of column ─────────
+
+// TestFormatRunningRow_TokensDoNotCorruptAlignment guards the port-parity fix:
+// upstream renders TOKENS with format_cell(.., :right) (truncating), so a huge
+// token value cannot widen the row. A regression to a non-truncating right pad
+// makes the row wider than the fixed layout, which this asserts against.
+func TestFormatRunningRow_TokensDoNotCorruptAlignment(t *testing.T) {
+	now := time.Now()
+	started := now.Add(-90 * time.Second)
+	const eventWidth = 44
+	wantWidth := fixedRunningWidth() + chromeWidth + eventWidth // 66 + 10 + 44 = 120
+
+	r := runningEntry{
+		Identifier:        "ENG-1234",
+		State:             "running",
+		SessionID:         "sess-1", // short → no "..." from the session cell
+		TurnCount:         7,
+		LastEvent:         "codex/event/token_count",
+		StartedAt:         &started,
+		Tokens:            tokenInfo{TotalTokens: 1_000_000_000}, // "1,000,000,000" = 13 runes
+		CodexAppServerPID: 12345,
+	}
+
+	row := formatRunningRow(r, now, eventWidth)
+	if got := visibleWidth(row); got != wantWidth {
+		t.Errorf("formatRunningRow visible width = %d; want %d (a long token count corrupted alignment): %q", got, wantWidth, visibleString(row))
+	}
+	if !strings.Contains(row, "1,000,0...") {
+		t.Errorf("formatRunningRow TOKENS not truncated; row = %q", visibleString(row))
+	}
+}
+
+// ── acceptance criteria: readable at 80 / 100 / 120 columns ─────────────────
+
+func representativeState(now time.Time) *stateResponse {
+	started := now.Add(-3600 * time.Second)
+	due := now.Add(30 * time.Second)
+	return &stateResponse{
+		MaxConcurrentAgents: 10,
+		CodexTotals:         codexTotals{InputTokens: 123456, OutputTokens: 654321, TotalTokens: 1_000_000_000, SecondsRunning: 3600},
+		Running: []runningEntry{{
+			Identifier:        "ENG-1234",
+			State:             "running",
+			SessionID:         "01HXAYZ-very-long-session-identifier-0001",
+			TurnCount:         7,
+			LastEvent:         "codex/event/token_count",
+			LastMessage:       "notification", // the word that wrapped (noti / fication) in #466
+			StartedAt:         &started,
+			LastEventAt:       &now,
+			Tokens:            tokenInfo{TotalTokens: 1_000_000_000},
+			CodexAppServerPID: 12345,
+		}},
+		Retrying: []retryEntry{{
+			Identifier: "ENG-9999",
+			Attempt:    2,
+			DueAt:      &due,
+			Kind:       "quota_backoff",
+			Error:      "a deliberately long error message that would overflow a narrow terminal by a wide margin indeed",
+		}},
+		RateLimits: map[string]interface{}{
+			"limit_id":  "anthropic-opus-primary-secondary-credits-very-long-bucket-name",
+			"primary":   map[string]interface{}{"remaining": float64(1234567), "limit": float64(2000000), "reset_in_seconds": float64(3600)},
+			"secondary": map[string]interface{}{"remaining": float64(987654), "limit": float64(1000000), "reset_in_seconds": float64(60)},
+			"credits":   map[string]interface{}{"has_credits": true, "balance": float64(123.45)},
+		},
+	}
+}
+
+func TestRenderFrame_StaysWithinTerminalWidth(t *testing.T) {
+	orig := liveTerminalWidth
+	t.Cleanup(func() { liveTerminalWidth = orig })
+
+	now := time.Now()
+	state := representativeState(now)
+
+	// 80/100/120 are the issue's representative widths; 40 is an extreme where
+	// the running-row event column floors at colEventMin and the whole row is
+	// far wider than the terminal.
+	for _, width := range []int{40, 80, 100, 120} {
+		t.Run(strconv.Itoa(width)+"cols", func(t *testing.T) {
+			liveTerminalWidth = func() (int, bool) { return width, true }
+			assertFrameWithinWidth(t, state, now, width)
+		})
+	}
+}
+
+// assertFrameWithinWidth renders the frame and checks that no line exceeds the
+// terminal width and that the (over-long) rate-limits line was clipped to fill
+// it — proving the policy engaged at this width and the line did not wrap.
+func assertFrameWithinWidth(t *testing.T, state *stateResponse, now time.Time, width int) {
+	t.Helper()
+	lines := strings.Split(renderFrame(state, nil, now, 100, "http://127.0.0.1:4001", 5*time.Second), "\n")
+	for _, line := range lines {
+		if w := visibleWidth(line); w > width {
+			t.Errorf("at %d cols a line is too wide (visible %d): %q", width, w, visibleString(line))
+		}
+	}
+	rate := findLine(t, lines, "│ Rate Limits:")
+	if w := visibleWidth(rate); w != width {
+		t.Errorf("at %d cols rate-limits line visible width = %d; want %d (clipped to fill): %q", width, w, width, visibleString(rate))
+	}
+	if !strings.HasSuffix(rate, "…"+ansiReset) {
+		t.Errorf("at %d cols rate-limits line was not clipped with an ellipsis: %q", width, visibleString(rate))
+	}
+}
+
+// On a non-tty (no live width measured) the frame is emitted in full so piped
+// or redirected output keeps every column for pagers / files.
+func TestRenderFrame_NoClipWithoutLiveWidth(t *testing.T) {
+	orig := liveTerminalWidth
+	t.Cleanup(func() { liveTerminalWidth = orig })
+	liveTerminalWidth = func() (int, bool) { return 0, false }
+	t.Setenv("COLUMNS", "80")
+
+	now := time.Now()
+	frame := renderFrame(representativeState(now), nil, now, 0, "http://127.0.0.1:4001", 5*time.Second)
+
+	rate := findLine(t, strings.Split(frame, "\n"), "│ Rate Limits:")
+	if visibleWidth(rate) <= 80 {
+		t.Errorf("rate-limits line was clipped without a live terminal width (width %d): %q", visibleWidth(rate), visibleString(rate))
+	}
+	if strings.HasSuffix(rate, "…"+ansiReset) {
+		t.Errorf("rate-limits line should not be clipped when no live width is measured: %q", visibleString(rate))
+	}
+}
+
+// ── rate-limit values must not corrupt the row (#466) ───────────────────────
+
+// A crafted limit_id / reset value with embedded control bytes, newlines or
+// ANSI must be neutralised: clipping is per-line, so an unsanitized newline
+// would split the row regardless of width.
+func TestFormatRateLimits_SanitizesUntrustedValues(t *testing.T) {
+	rl := map[string]interface{}{
+		"limit_id": "lim\x1b[31mit\nid\x07x",
+		"primary":  map[string]interface{}{"remaining": float64(5), "limit": float64(10), "reset_at": "2026\n05\x07"},
+	}
+	got := formatRateLimits(rl)
+
+	for _, r := range visibleString(got) {
+		if r < 0x20 || r == 0x7f {
+			t.Errorf("formatRateLimits kept control byte %#x: %q", r, visibleString(got))
+		}
+	}
+	// ansiRed is not used by formatRateLimits, so its presence means the
+	// injected colour code survived.
+	if strings.Contains(got, ansiRed) {
+		t.Errorf("formatRateLimits did not strip an injected colour code: %q", got)
+	}
+	if !strings.Contains(visibleString(got), "limit id x") {
+		t.Errorf("formatRateLimits dropped the sanitized limit_id: %q", visibleString(got))
+	}
+}
+
+// ── ansiSeqLen bounds (no OOB on truncated/lone escapes) ────────────────────
+
+func TestAnsiSeqLen_Bounds(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"csi colour", "\x1b[31m", 5},
+		{"csi reset", "\x1b[0m", 4},
+		{"bare escape", "\x1bX", 2},
+		{"lone trailing ESC", "\x1b", 1},
+		{"unterminated CSI at end", "\x1b[12", 4},
+	}
+	for _, c := range cases {
+		if got := ansiSeqLen([]rune(c.in), 0); got != c.want {
+			t.Errorf("%s: ansiSeqLen(%q, 0) = %d; want %d", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+func findLine(t *testing.T, lines []string, visiblePrefix string) string {
+	t.Helper()
+	for _, line := range lines {
+		if strings.HasPrefix(visibleString(line), visiblePrefix) {
+			return line
+		}
+	}
+	t.Fatalf("no line with visible prefix %q in frame:\n%s", visiblePrefix, strings.Join(lines, "\n"))
+	return ""
+}

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -374,11 +374,11 @@ func (s *screen) draw(content string) {
 func safeRenderFrame(state *stateResponse, fetchErr error, now time.Time, tps float64, baseURL string, interval time.Duration) (out string) {
 	defer func() {
 		if r := recover(); r != nil {
-			out = strings.Join([]string{
+			out = clipFrame([]string{
 				colorize("╭─ AIOPS STATUS", ansiBold),
 				colorize(fmt.Sprintf("│ Render error: %v", r), ansiRed),
 				colorize("╰─", ansiBold),
-			}, "\n")
+			})
 		}
 	}()
 	return renderFrame(state, fetchErr, now, tps, baseURL, interval)
@@ -421,14 +421,14 @@ func stateAPIAuthTokenFromEnv() string {
 
 func renderFrame(state *stateResponse, fetchErr error, now time.Time, tps float64, baseURL string, interval time.Duration) string {
 	if fetchErr != nil {
-		return strings.Join([]string{
+		return clipFrame([]string{
 			colorize("╭─ AIOPS STATUS", ansiBold),
 			colorize("│ Orchestrator snapshot unavailable: ", ansiRed) + colorize(fetchErr.Error(), ansiRed),
 			colorize("│ Throughput: ", ansiBold) + colorize(formatTPS(tps)+" tps", ansiCyan),
 			colorize("│ Dashboard:  ", ansiBold) + colorize(baseURL+"/", ansiCyan),
 			colorize("│ Next refresh: ", ansiBold) + colorize(strconv.Itoa(int(interval.Seconds()))+"s", ansiCyan),
 			colorize("╰─", ansiBold),
-		}, "\n")
+		})
 	}
 
 	cols := terminalColumns()
@@ -502,7 +502,7 @@ func renderFrame(state *stateResponse, fetchErr error, now time.Time, tps float6
 		}
 	}
 	lines = append(lines, colorize("╰─", ansiBold))
-	return strings.Join(lines, "\n")
+	return clipFrame(lines)
 }
 
 // runningTableHeader mirrors running_table_header_row/1.
@@ -545,7 +545,9 @@ func formatRunningRow(r runningEntry, now time.Time, eventWidth int) string {
 		runtimeSecs = now.Sub(*r.StartedAt).Seconds()
 	}
 	age := cell(formatRuntimeAndTurns(runtimeSecs, r.TurnCount), colAge)
-	tokens := padLeft(formatCount(r.Tokens.TotalTokens), colTokens)
+	// Right-aligned *and* truncated (mirrors format_cell(.., :right)); a long
+	// token count must not widen the row and push EVENT out of alignment (#466).
+	tokens := cellRight(formatCount(r.Tokens.TotalTokens), colTokens)
 	session := cell(compactSession(r.SessionID), colSession)
 
 	eventText := r.LastMessage
@@ -615,7 +617,10 @@ func formatRateLimits(rl map[string]interface{}) string {
 	if rl == nil {
 		return colorize("unavailable", ansiGray)
 	}
-	limitID := strMapGet(rl, "limit_id", "limit_name", "")
+	// limit_id is the one free-form API string on this line; sanitize it so an
+	// embedded newline/control byte can't split or corrupt the row (#466). The
+	// numeric bucket/credit fields are formatted from typed values below.
+	limitID := sanitize(strMapGet(rl, "limit_id", "limit_name", ""))
 	if limitID == "" {
 		limitID = "unknown"
 	}
@@ -638,7 +643,7 @@ func formatRateLimitBucket(v interface{}) string {
 	}
 	m, ok := v.(map[string]interface{})
 	if !ok {
-		return fmt.Sprintf("%v", v)
+		return sanitize(fmt.Sprintf("%v", v))
 	}
 	remaining := intVal(m, "remaining")
 	limit := intVal(m, "limit")
@@ -711,18 +716,11 @@ func compactSession(id string) string {
 	return id
 }
 
-// cell left-pads to width, truncating with "…" when needed.
-// Mirrors format_cell/3 in status_dashboard.ex.
+// cell left-aligns to width, truncating with "..." when needed.
+// Mirrors format_cell/3 in status_dashboard.ex; cellRight (layout.go) is the
+// right-aligned counterpart and they share truncateCell.
 func cell(s string, width int) string {
-	s = sanitize(s)
-	runes := []rune(s)
-	if len(runes) > width {
-		if width <= 3 {
-			return string(runes[:width])
-		}
-		s = string(runes[:width-3]) + "..."
-	}
-	return fmt.Sprintf("%-*s", width, s)
+	return fmt.Sprintf("%-*s", width, truncateCell(sanitize(s), width))
 }
 
 func padLeft(s string, width int) string  { return fmt.Sprintf("%*s", width, s) }
@@ -840,9 +838,9 @@ func formatResetValue(v interface{}) string {
 	case int:
 		return strconv.Itoa(x) + "s"
 	case string:
-		return x
+		return sanitize(x)
 	default:
-		return fmt.Sprintf("%v", v)
+		return sanitize(fmt.Sprintf("%v", v))
 	}
 }
 


### PR DESCRIPTION
Closes #466

## Problem

At narrow terminal widths (~80 cols) the `cmd/tui` running-session table and header lines overflowed and the terminal wrapped them — splitting the EVENT value `notification` into `noti`/`fication` and destroying row alignment. A running row is `fixed_running(66) + chrome(10) + event` wide with `event` floored at 12, so the minimum row is **88 columns**; any terminal narrower than that wraps the trailing EVENT cell. The `Rate Limits` header line was never width-bounded at all.

## SPEC alignment

`cmd/tui` mirrors upstream `status_dashboard.ex`, which has the *identical* 88-column overflow. But SPEC **§2.2** lists "prescribing a specific dashboard or terminal UI implementation" as a non-goal and **§13.4** makes the terminal status surface "OPTIONAL and implementation-defined", so a narrow-width layout policy is within the implementation-defined envelope — **not a deviation** (no `DEVIATIONS.md` entry owed). The `/api/v1/state` data contract (**§13.7.2**) is unchanged (no struct / JSON-tag edits).

## Changes

1. **Narrow-width layout policy** (`cmd/tui/layout.go`): an ANSI-aware per-line truncator clips every rendered frame line to the live terminal width (`TIOCGWINSZ`). Colour codes are zero-width and never split; a reset is appended on a cut so colour can't bleed. Lines truncate with a single-column ellipsis instead of wrapping. When no live width is measured (piped/redirected), output stays full-fidelity for pagers/files.
2. **TOKENS column parity fix**: the Elixir reference renders TOKENS with `format_cell(.., :right)` (truncating); the Go port used a non-truncating `padLeft`, so a long token count widened the row and pushed EVENT out of alignment. Now uses a right-aligned truncating `cellRight` (shares `truncateCell` with `cell`).
3. **Rate-limit value sanitization**: clipping is per-line, so an embedded newline / control byte in the free-form `limit_id` or a string reset value would still split the row. These now flow through the same `sanitize` already applied to `last_message` / `error` / `event`, closing the issue's "rate-limit values must not corrupt row alignment" criterion.

## Acceptance criteria (#466)

- [x] Add a layout policy for `cmd/tui` at narrow widths → uniform per-line clip + truncating columns.
- [x] Verify at 80, 100, 120 columns → `TestRenderFrame_StaysWithinTerminalWidth` covers **40 / 80 / 100 / 120**.
- [x] Long session IDs / rate-limit reset values / token counts / event names don't corrupt row alignment → `cell` / `cellRight` truncation + rate-limit `sanitize` + per-line clip.
- [x] Focused / snapshot-style test → `cmd/tui/layout_test.go`.

## Verification

- Local gate green: `gofmt -l` empty, `go vet ./...`, `go mod tidy` clean, `go build ./cmd/worker ./cmd/tui`, `go test -race -covermode=atomic ./...`.
- golangci-lint: no new findings on the new code (the only `gocognit` reports are pre-existing on `run` / `renderFrame`; this diff adds no branches there).
- **Mutation-verified against the committed artifact** (commit → break → test FAILs → `git checkout` → tree == HEAD):
  - disable clipping → `TestRenderFrame_StaysWithinTerminalWidth` fails (lines 176 / 155 > width).
  - revert TOKENS to a non-truncating pad → `TestFormatRunningRow_TokensDoNotCorruptAlignment` fails (row 123 ≠ 120).
  - drop `limit_id` `sanitize` → `TestFormatRateLimits_SanitizesUntrustedValues` fails (control bytes + injected colour survive).

## Size gate

`within budget` — production diff ~170 LOC across `layout.go` (new) + `main.go` (net −5); test file excluded per policy. No concurrency or destructive paths.

## Review notes

Two independent diff-only review rounds (4 reviews), all **MERGE-READY**, no HIGH/MEDIUM/LOW correctness findings. One optional non-blocking note: `truncateToWidth`'s `width<=0` branch returns the line unclipped — intentionally distinct from `truncateCell`'s `""` (a no-width-budget guard for a line clipper) and unreachable from production, since `terminalWidth` guards `ws.Col == 0`.

https://claude.ai/code/session_01C6FR75bn3Gn9arhtggBpt5
