### PR TITLE
test: fuzz coverage for hand-written Liquid and GraphQL parsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
       - name: Run tests
         run: go test -race -covermode=atomic ./...
 
+      - name: Run fuzz smoke (short)
+        run: |
+          go test -run='^$' -fuzz='^FuzzRender$' -fuzztime=30s ./internal/workflow
+          go test -run='^$' -fuzz='^FuzzParseLinearGraphQLOperation$' -fuzztime=30s ./internal/runner
+
       - name: Build binaries
         run: |
           mkdir -p dist

--- a/internal/runner/tools_fuzz_test.go
+++ b/internal/runner/tools_fuzz_test.go
@@ -1,0 +1,53 @@
+package runner
+
+import "testing"
+
+// FuzzParseLinearGraphQLOperation guards the hand-written Linear GraphQL
+// operation parser that feeds the SPEC §15.5 mutation gate. A mis-extracted
+// operation kind or field name routes a call down the wrong permission
+// branch (#411), so the target asserts more than "does not panic": Kind is
+// always a known operation kind, and a non-empty FieldName is always a
+// structurally valid GraphQL name. countGraphQLOperations shares the same
+// lexer state machine on the same gate path, so it is exercised on the same
+// corpus and checked for a non-negative count.
+func FuzzParseLinearGraphQLOperation(f *testing.F) {
+	seeds := []string{
+		"",
+		"query Q { issue { id } }",
+		"mutation M($i: String!) { issueUpdate(id: $i) { issue { id } } }",
+		"fragment F on Issue { id }",
+		"query { __typename }",
+		"{ viewer { id } }",
+		"subscription S { issues { id } }",
+		"# comment\nquery Q { issue { id } }",
+		`query Q { issue(filter: "a{b}c") { id } }`,
+		`mutation { commentCreate(input: {body: "}{"}) { success } }`,
+		`query Q { a """block { } string""" b }`,
+		"fragment F on Issue { id } mutation M { issueUpdate(id: 1) { success } }",
+		`query Q($x: String = "\"") { issue { id } }`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, src string) {
+		op := parseLinearGraphQLOperation(src)
+		switch op.Kind {
+		case linearGraphQLOperationQuery, linearGraphQLOperationMutation, linearGraphQLOperationSubscription:
+		default:
+			t.Fatalf("parseLinearGraphQLOperation(%q).Kind = %q; want query, mutation, or subscription", src, op.Kind)
+		}
+		if op.FieldName != "" {
+			if !isGraphQLNameStart(op.FieldName[0]) {
+				t.Fatalf("parseLinearGraphQLOperation(%q).FieldName = %q; first byte is not a valid GraphQL name start", src, op.FieldName)
+			}
+			for i := 0; i < len(op.FieldName); i++ {
+				if !isGraphQLNameContinue(op.FieldName[i]) {
+					t.Fatalf("parseLinearGraphQLOperation(%q).FieldName = %q; byte %d is not a valid GraphQL name char", src, op.FieldName, i)
+				}
+			}
+		}
+		if n := countGraphQLOperations(src); n < 0 {
+			t.Fatalf("countGraphQLOperations(%q) = %d; want >= 0", src, n)
+		}
+	})
+}

--- a/internal/workflow/template_fuzz_test.go
+++ b/internal/workflow/template_fuzz_test.go
@@ -1,0 +1,61 @@
+package workflow
+
+import "testing"
+
+// FuzzRender guards the hand-written Liquid renderer that builds agent
+// prompts. A silently mis-expanded template is a prompt-injection boundary
+// risk (#411), so the fuzz target asserts two invariants beyond "does not
+// panic / hang": Render never returns partial output alongside an error,
+// and a successful render is deterministic for the same inputs.
+func FuzzRender(f *testing.F) {
+	seeds := []string{
+		"",
+		"   ",
+		"{{ title }}",
+		"{{ task.title }}",
+		"{{ task.title | escape }}",
+		`{{ task.description | default: "no description" }}`,
+		`{{ a | default: "\"" }}`,
+		"{% if x %}yes{% endif %}",
+		"{% if a %}A{% elsif b %}B{% else %}C{% endif %}",
+		"{% if x %}{% if a %}nested{% endif %}{% endif %}",
+		"{% if count > 3 %}many{% endif %}",
+		`{% if name == "v" %}match{% endif %}`,
+		"{% endif %}",
+		"{% if x %}",
+		"{{",
+		"{%",
+		"{{ a.b.c.d }}",
+		"{% if a == b %}{% elsif a != b %}{% endif %}",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	vars := map[string]any{
+		"title": "T",
+		"x":     true,
+		"a":     "v",
+		"b":     false,
+		"count": 5,
+		"name":  "v",
+		"task": map[string]any{
+			"title":       "strict <templates> & prompts",
+			"description": "",
+		},
+	}
+	f.Fuzz(func(t *testing.T, tpl string) {
+		out, err := Render(tpl, vars)
+		if err != nil {
+			// An explicit error is a valid outcome; the contract is that
+			// the renderer must not leak a half-expanded prompt with it.
+			if out != "" {
+				t.Fatalf("Render(%q) = (%q, %v); want empty output on error", tpl, out, err)
+			}
+			return
+		}
+		out2, err2 := Render(tpl, vars)
+		if err2 != nil || out2 != out {
+			t.Fatalf("Render(%q) not deterministic: first=(%q, nil), second=(%q, %v)", tpl, out, out2, err2)
+		}
+	})
+}


### PR DESCRIPTION
Closes #411

## What

Adds fuzz targets for the two hand-written syntax-layer parsers called out in #411, plus a short CI smoke step so a PR cannot land a trivial crash. No parser behavior changes — this is robustness coverage only (the issue's "不在范围内" explicitly excludes replacing the parsers).

| Parser | Why it's security-relevant | New target |
|---|---|---|
| `internal/workflow/template.go` `Render` | builds agent prompts → prompt-injection boundary | `FuzzRender` |
| `internal/runner/tools.go` `parseLinearGraphQLOperation` | feeds the SPEC §15.5 mutation gate; wrong kind/field routes the wrong permission branch | `FuzzParseLinearGraphQLOperation` |

Note the actual exported renderer is `Render` (not `RenderTemplate` from the issue's illustrative snippet); `parseLinearGraphQLOperation` is unexported so its target lives in `package runner`.

## Invariants (beyond "does not panic / hang")

These make the targets non-placebo rather than bare crash detectors:

- **`FuzzRender`** — on error, output must be empty (no half-expanded prompt leaks alongside an error); a successful render is deterministic for fixed vars.
- **`FuzzParseLinearGraphQLOperation`** — `Kind` is always one of `query`/`mutation`/`subscription`; a non-empty `FieldName` is always a structurally valid GraphQL name (the gate relies on this). The sibling `countGraphQLOperations` lexer shares the same state machine on the same gate path, so it's exercised on the same corpus and checked for a non-negative count (cross-cutting checklist item 1: adjacent path on the same SPEC concept).

## CI integration

New `go` job step after the test run:

```yaml
- name: Run fuzz smoke (short)
  run: |
    go test -run='^$' -fuzz='^FuzzRender$' -fuzztime=30s ./internal/workflow
    go test -run='^$' -fuzz='^FuzzParseLinearGraphQLOperation$' -fuzztime=30s ./internal/runner
```

Anchored regexes so each command runs exactly one target; ~60s added total.

## Verification

- Local gate green: `gofmt -l`, `go mod tidy` (clean), `go vet`, `go test -race -covermode=atomic ./...`, `go build ./cmd/worker ./cmd/tui`.
- Fuzzed both targets 10s each locally with no crash (60k–600k execs/sec, 100+ interesting inputs each).
- **Mutation-verified against the committed artifact** (AGENTS.md rule 6): making `Render` return partial output on error fails `FuzzRender/seed#16`; making the parser capture an off-by-one `FieldName` fails `FuzzParseLinearGraphQLOperation` seeds #11/#12. Working tree restored to HEAD afterward.

## SPEC alignment / deviations

No new deviation; no existing deviation closed. Pure test+CI robustness within the SPEC-aligned envelope (harness-engineering principle 3: failures become permanent constraints).

## Size

`within budget` — 2 new test files + one CI step, well under the 12-file / 300-LOC gate.

https://claude.ai/code/session_01NWcS9ihtyMiKGY16HxhPPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWcS9ihtyMiKGY16HxhPPj)_