### PR TITLE
refactor(runner): decompose awaitTurnCompletion into per-concern handlers (#499)

### DIFF
--- a/internal/runner/codex_app_server_turn.go
+++ b/internal/runner/codex_app_server_turn.go
@@ -17,118 +17,190 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 )
 
+// awaitTurnCompletion streams a single Codex turn to its terminal outcome. It
+// reads the next protocol message (under the stall budget), classifies read
+// failures, and dispatches decoded messages until one ends the turn. The
+// read → classify → dispatch split mirrors upstream's receive_loop →
+// handle_incoming → handle_turn_method (elixir codex/app_server.ex).
 func (c *appServerClient) awaitTurnCompletion(ctx context.Context) error {
 	c.lastTerminal = time.Now()
 	for {
-		readCtx := ctx
-		var cancel context.CancelFunc
-		var stallBudget time.Duration
-		if c.stallTimeoutMs > 0 {
-			stallBudget = time.Duration(c.stallTimeoutMs) * time.Millisecond
-			remaining := stallBudget - time.Since(c.lastTerminal)
-			if remaining <= 0 {
-				return &StallError{Timeout: stallBudget, Elapsed: time.Since(c.lastTerminal)}
-			}
-			readCtx, cancel = context.WithTimeout(ctx, remaining)
-		}
-		readTimeoutMs := c.readTimeoutMs
-		if stallBudget > 0 {
-			// During turn streaming, inactivity is governed by stall_timeout_ms.
-			// read_timeout_ms remains the per-read transport budget for request/
-			// response setup and for configurations without stall detection, but it
-			// must not preempt the longer event-inactivity watchdog and bypass the
-			// stalled/runner_timeout retry path.
-			c.readTimeoutMs = 0
-		}
-		msg, raw, err := c.readProtocolMessage(readCtx)
-		c.readTimeoutMs = readTimeoutMs
-		if cancel != nil {
-			cancel()
-		}
+		msg, raw, stallBudget, err := c.readTurnMessage(ctx)
 		if err != nil {
-			if raw != nil {
-				if !protocolMessageCandidate(raw) {
-					return fmt.Errorf("decode codex app-server message: %w", err)
-				}
-				c.recordMalformedRuntimeLine(raw, err)
-				c.lastTerminal = time.Now()
+			retErr, retry := c.classifyTurnReadError(ctx, err, raw, stallBudget)
+			if retry {
 				continue
 			}
-			elapsed := time.Since(c.lastTerminal)
-			if stallBudget > 0 && ctx.Err() == nil && elapsed >= stallBudget {
-				if errors.Is(err, context.DeadlineExceeded) || isAppServerReadTimeout(err) {
-					return &StallError{Timeout: stallBudget, Elapsed: elapsed, Cause: err}
-				}
-			}
-			return err
+			return retErr
 		}
-		if method, _ := msg["method"].(string); method != "" {
-			switch method {
-			case "turn/completed":
-				if err := completedTurnError(msg); err != nil {
-					params, _ := msg["params"].(map[string]any)
-					c.recordSafeTurnFailure(task.EventTurnEndedWithError, params)
-					return err
-				}
-				c.handleNotification(msg)
-				c.recordRuntimeMessage(task.EventTurnCompleted, msg)
-				return nil
-			case "turn/failed", "turn/cancelled":
-				params, _ := msg["params"].(map[string]any)
-				reason := safeTurnReason(params)
-				if method == "turn/failed" {
-					c.recordSafeTurnFailure(task.EventTurnFailed, params)
-					return NewError(CategoryTurnFailed, fmt.Sprintf("%s: %s", method, reason), nil)
-				}
-				c.recordSafeTurnFailure(task.EventTurnCancelled, params)
-				return NewError(CategoryTurnCancelled, fmt.Sprintf("%s: %s", method, reason), nil)
-			case "item/tool/call":
-				if err := c.handleDynamicToolCall(ctx, msg); err != nil {
-					return err
-				}
-				c.lastTerminal = time.Now()
-			default:
-				if _, ok := msg["id"]; ok {
-					if err := c.replyServerRequest(msg); err != nil {
-						return err
-					}
-					if inputRequiredServerRequest(method) {
-						c.recordInputRequiredMessage(method, msg)
-						return &InputRequiredError{Method: method}
-					}
-					// SPEC §10.4 turn_input_required also fires for an
-					// approval request that is not auto-approved — the
-					// runner's wire response is a decline / empty
-					// permissions / deny per protocolServerRequestResult,
-					// which is itself a signal that the operator must
-					// act. Without the event the orchestrator cannot
-					// distinguish this from a transient turn failure.
-					if approvalDeclinedServerRequest(method, c.approvalPolicy) {
-						c.recordInputRequiredMessage(method, msg)
-						return &InputRequiredError{Method: method}
-					}
-					c.lastTerminal = time.Now()
-					continue
-				}
-				if inputRequiredNotification(method, msg) {
-					c.recordInputRequiredMessage(method, msg)
-					return &InputRequiredError{Method: method}
-				}
-				if c.stallTimeoutMs > 0 {
-					elapsed := time.Since(c.lastTerminal)
-					if elapsed > time.Duration(c.stallTimeoutMs)*time.Millisecond {
-						return &StallError{Timeout: time.Duration(c.stallTimeoutMs) * time.Millisecond, Elapsed: elapsed}
-					}
-				}
-				c.lastTerminal = time.Now()
-				c.handleNotification(msg)
-				c.recordRuntimeMessage(task.EventNotification, msg)
-			}
-		} else {
-			c.lastTerminal = time.Now()
-			c.recordOtherRuntimeMessage(msg, raw)
+		if done, derr := c.dispatchTurnMessage(ctx, msg, raw); done {
+			return derr
 		}
 	}
+}
+
+// readTurnMessage performs one stall-budget-aware read of the next protocol
+// message. With stall detection enabled it derives a per-read deadline from the
+// remaining stall budget — returning a *StallError without reading once the
+// budget is already spent — and suspends read_timeout_ms for the duration of
+// the read: during turn streaming inactivity is governed by stall_timeout_ms,
+// while read_timeout_ms stays the per-read transport budget for request/
+// response setup and for configurations without stall detection, so it must not
+// preempt the longer event-inactivity watchdog and bypass the stalled/
+// runner_timeout retry path. The returned stallBudget is 0 when stall detection
+// is off.
+func (c *appServerClient) readTurnMessage(ctx context.Context) (map[string]any, []byte, time.Duration, error) {
+	readCtx := ctx
+	var cancel context.CancelFunc
+	var stallBudget time.Duration
+	if c.stallTimeoutMs > 0 {
+		stallBudget = time.Duration(c.stallTimeoutMs) * time.Millisecond
+		remaining := stallBudget - time.Since(c.lastTerminal)
+		if remaining <= 0 {
+			return nil, nil, stallBudget, &StallError{Timeout: stallBudget, Elapsed: time.Since(c.lastTerminal)}
+		}
+		readCtx, cancel = context.WithTimeout(ctx, remaining)
+	}
+	readTimeoutMs := c.readTimeoutMs
+	if stallBudget > 0 {
+		c.readTimeoutMs = 0
+	}
+	msg, raw, err := c.readProtocolMessage(readCtx)
+	c.readTimeoutMs = readTimeoutMs
+	if cancel != nil {
+		cancel()
+	}
+	return msg, raw, stallBudget, err
+}
+
+// classifyTurnReadError decides what a failed read means. A protocol-like line
+// that failed to decode is recorded and skipped (retry=true); a line that is
+// not even a JSON object is a hard decode failure. When stall detection is
+// active and the read deadline elapsed without the outer context being
+// cancelled, the timeout is reclassified as a *StallError so the stalled/
+// runner_timeout retry path fires instead of a bare deadline error.
+//
+// ctx must be the outer loop context, not the per-read deadline context that
+// readTurnMessage builds: a fired per-read stall deadline leaves the outer ctx
+// uncancelled, and that `ctx.Err() == nil` is exactly what distinguishes a
+// stall from a caller-driven cancellation. The pre-read budget-exhausted
+// *StallError readTurnMessage returns (raw==nil, Cause==nil) is neither
+// DeadlineExceeded nor a read timeout, so it falls through the reclassification
+// guard and propagates unchanged.
+func (c *appServerClient) classifyTurnReadError(ctx context.Context, err error, raw []byte, stallBudget time.Duration) (error, bool) {
+	if raw != nil {
+		if !protocolMessageCandidate(raw) {
+			return fmt.Errorf("decode codex app-server message: %w", err), false
+		}
+		c.recordMalformedRuntimeLine(raw, err)
+		c.lastTerminal = time.Now()
+		return nil, true
+	}
+	elapsed := time.Since(c.lastTerminal)
+	if stallBudget > 0 && ctx.Err() == nil && elapsed >= stallBudget {
+		if errors.Is(err, context.DeadlineExceeded) || isAppServerReadTimeout(err) {
+			return &StallError{Timeout: stallBudget, Elapsed: elapsed, Cause: err}, false
+		}
+	}
+	return err, false
+}
+
+// dispatchTurnMessage routes one decoded protocol message. It returns done=true
+// with the turn's terminal error (nil on success) when the turn ends, and
+// done=false to keep streaming. Mirrors upstream handle_incoming.
+func (c *appServerClient) dispatchTurnMessage(ctx context.Context, msg map[string]any, raw []byte) (bool, error) {
+	method, _ := msg["method"].(string)
+	if method == "" {
+		c.lastTerminal = time.Now()
+		c.recordOtherRuntimeMessage(msg, raw)
+		return false, nil
+	}
+	switch method {
+	case "turn/completed":
+		if err := completedTurnError(msg); err != nil {
+			params, _ := msg["params"].(map[string]any)
+			c.recordSafeTurnFailure(task.EventTurnEndedWithError, params)
+			return true, err
+		}
+		c.handleNotification(msg)
+		c.recordRuntimeMessage(task.EventTurnCompleted, msg)
+		return true, nil
+	case "turn/failed", "turn/cancelled":
+		params, _ := msg["params"].(map[string]any)
+		reason := safeTurnReason(params)
+		if method == "turn/failed" {
+			c.recordSafeTurnFailure(task.EventTurnFailed, params)
+			return true, NewError(CategoryTurnFailed, fmt.Sprintf("%s: %s", method, reason), nil)
+		}
+		c.recordSafeTurnFailure(task.EventTurnCancelled, params)
+		return true, NewError(CategoryTurnCancelled, fmt.Sprintf("%s: %s", method, reason), nil)
+	case "item/tool/call":
+		if err := c.handleDynamicToolCall(ctx, msg); err != nil {
+			return true, err
+		}
+		c.lastTerminal = time.Now()
+		return false, nil
+	default:
+		return c.handleTurnMethod(msg, method)
+	}
+}
+
+// handleTurnMethod handles a non-terminal method message: a server->client
+// request (carries an id) is answered through handleServerRequest, anything
+// else is an agent-driven notification. Mirrors upstream handle_turn_method.
+// Returns done=true with the terminal error when the message ends the turn,
+// done=false to keep streaming.
+func (c *appServerClient) handleTurnMethod(msg map[string]any, method string) (bool, error) {
+	if _, ok := msg["id"]; ok {
+		return c.handleServerRequest(msg, method)
+	}
+	return c.handleTurnNotification(msg, method)
+}
+
+// handleServerRequest answers a server->client request and surfaces a declined
+// approval or explicit input request as operator-required input. Mirrors
+// upstream maybe_handle_approval_request.
+func (c *appServerClient) handleServerRequest(msg map[string]any, method string) (bool, error) {
+	if err := c.replyServerRequest(msg); err != nil {
+		return true, err
+	}
+	if inputRequiredServerRequest(method) {
+		c.recordInputRequiredMessage(method, msg)
+		return true, &InputRequiredError{Method: method}
+	}
+	// SPEC §10.4 turn_input_required also fires for an approval request that is
+	// not auto-approved — the runner's wire response is a decline / empty
+	// permissions / deny per protocolServerRequestResult, which is itself a
+	// signal that the operator must act. Without the event the orchestrator
+	// cannot distinguish this from a transient turn failure.
+	if approvalDeclinedServerRequest(method, c.approvalPolicy) {
+		c.recordInputRequiredMessage(method, msg)
+		return true, &InputRequiredError{Method: method}
+	}
+	c.lastTerminal = time.Now()
+	return false, nil
+}
+
+// handleTurnNotification handles an agent-driven notification (no request id):
+// an explicit input request ends the turn, a notification arriving after the
+// stall budget has elapsed surfaces a *StallError, otherwise the message
+// refreshes the stall clock and is recorded. Mirrors upstream
+// handle_turn_method's :unhandled branch.
+func (c *appServerClient) handleTurnNotification(msg map[string]any, method string) (bool, error) {
+	if inputRequiredNotification(method, msg) {
+		c.recordInputRequiredMessage(method, msg)
+		return true, &InputRequiredError{Method: method}
+	}
+	if c.stallTimeoutMs > 0 {
+		elapsed := time.Since(c.lastTerminal)
+		if elapsed > time.Duration(c.stallTimeoutMs)*time.Millisecond {
+			return true, &StallError{Timeout: time.Duration(c.stallTimeoutMs) * time.Millisecond, Elapsed: elapsed}
+		}
+	}
+	c.lastTerminal = time.Now()
+	c.handleNotification(msg)
+	c.recordRuntimeMessage(task.EventNotification, msg)
+	return false, nil
 }
 func (c *appServerClient) handleNotification(msg map[string]any) {
 	params, _ := msg["params"].(map[string]any)

--- a/internal/runner/codex_app_server_turn_test.go
+++ b/internal/runner/codex_app_server_turn_test.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 )
@@ -192,8 +193,11 @@ func TestAwaitTurnCompletion_MalformedProtocolLineRecordedThenContinues(t *testi
 func TestAwaitTurnCompletion_NonProtocolLineReturnsDecodeError(t *testing.T) {
 	c, _ := newTurnLoopClient([]string{`plain text not json`})
 	err := c.awaitTurnCompletion(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "decode codex app-server message") {
-		t.Fatalf("awaitTurnCompletion() = %v; want decode error", err)
+	// A line that is not even a JSON object is a hard decode failure surfaced
+	// as a CategoryResponseError (classify by category, not by message text —
+	// AGENTS.md rule 8), not a recorded-and-skipped malformed line.
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryResponseError {
+		t.Fatalf("awaitTurnCompletion() error category = %q,%v; want %q,true", cat, ok, CategoryResponseError)
 	}
 	if got := runtimeEventNames(c); len(got) != 0 {
 		t.Errorf("runtime events = %v; want none (non-protocol garbage is a hard decode failure)", got)
@@ -282,6 +286,55 @@ func TestAwaitTurnCompletion_UnsupportedToolCallRecordedThenContinues(t *testing
 	}
 	if reply := stdin.String(); !strings.Contains(reply, "unsupported dynamic tool") {
 		t.Errorf("tool-call reply = %q; want it to carry the unsupported-tool failure", reply)
+	}
+}
+
+func TestReadTurnMessage_PreReadBudgetExhaustedReturnsStall(t *testing.T) {
+	// When the stall budget is already spent at the top of an iteration,
+	// readTurnMessage returns a *StallError WITHOUT reading — distinct from the
+	// in-read timeout, which carries a non-nil Cause. The live loop resets
+	// lastTerminal every iteration so this guard is defensive; drive the helper
+	// directly to pin both the Cause==nil discriminator and the no-read
+	// short-circuit (awaitTurnCompletion resets lastTerminal on entry, so the
+	// branch is unreachable through the full loop).
+	c, _ := newTurnLoopClient([]string{`{"method":"turn/completed","params":{}}`},
+		func(c *appServerClient) { c.stallTimeoutMs = 10 })
+	c.lastTerminal = time.Now().Add(-time.Second) // budget already exhausted
+	msg, raw, stallBudget, err := c.readTurnMessage(context.Background())
+	var stall *StallError
+	if !errors.As(err, &stall) {
+		t.Fatalf("readTurnMessage() err = %v; want *StallError on an already-spent budget", err)
+	}
+	if stall.Cause != nil {
+		t.Errorf("StallError.Cause = %v; want nil (pre-read exhaustion has no underlying read error)", stall.Cause)
+	}
+	if msg != nil || raw != nil {
+		t.Errorf("readTurnMessage() msg=%v raw=%v; want nil,nil (no read performed)", msg, raw)
+	}
+	if got, want := stallBudget, 10*time.Millisecond; got != want {
+		t.Errorf("readTurnMessage() stallBudget = %v; want %v", got, want)
+	}
+	// The scanner is untouched: the unread turn/completed line is still there,
+	// proving readTurnMessage short-circuited before reading.
+	if line, lerr := c.readLine(context.Background()); lerr != nil || !strings.Contains(string(line), "turn/completed") {
+		t.Errorf("next line after pre-read stall = %q (err %v); want the unconsumed turn/completed line", line, lerr)
+	}
+}
+
+func TestHandleTurnNotification_LateNotificationSurfacesStall(t *testing.T) {
+	// A notification dispatched after the stall budget has already elapsed ends
+	// the turn with a *StallError. In the live loop the read deadline is tied to
+	// the same budget, so the read-budget stall (classifyTurnReadError) normally
+	// fires first and this notification-path branch is defensive; drive the
+	// extracted handler directly to pin it without relying on read timing.
+	c := &appServerClient{out: io.Discard, stallTimeoutMs: 10}
+	c.lastTerminal = time.Now().Add(-time.Second) // already past the 10ms budget
+	done, err := c.handleTurnNotification(map[string]any{"method": "item/agentMessage"}, "item/agentMessage")
+	if !done {
+		t.Fatalf("handleTurnNotification() done = false; want true when the stall budget is already spent")
+	}
+	if !IsStall(err) {
+		t.Fatalf("handleTurnNotification() err = %v; want *StallError", err)
 	}
 }
 

--- a/internal/runner/codex_app_server_turn_test.go
+++ b/internal/runner/codex_app_server_turn_test.go
@@ -1,0 +1,301 @@
+package runner
+
+// codex_app_server_turn_test.go holds characterization tests that drive
+// (*appServerClient).awaitTurnCompletion directly over an in-memory JSON-RPC
+// stream, without spawning a real `codex app-server` subprocess. They pin the
+// turn loop's input→(returned error, recorded runtime events, continuation
+// signal) behavior at the exact function boundary before #499 decomposes the
+// 78-cognitive-complexity loop into per-concern handlers; the assertions must
+// hold identically before and after that refactor.
+//
+// The end-to-end subprocess tests in codex_app_server_test.go remain the
+// authority for the transport, sandbox, and multi-turn paths; these focus on
+// the single-turn message demux that the decomposition reshapes, especially
+// branches the subprocess suite does not exercise (input-required
+// notifications, non-protocol decode errors, the auto-approve vs. decline
+// server-request fork).
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+)
+
+// newTurnLoopClient builds an appServerClient whose stdout stream is the given
+// newline-delimited JSON-RPC lines. Server-request replies and tool-call
+// outputs land in the returned stdin buffer. opts mutate the client before the
+// loop runs (e.g. to set stallTimeoutMs or override the approval policy).
+func newTurnLoopClient(lines []string, opts ...func(*appServerClient)) (*appServerClient, *bytes.Buffer) {
+	var stdout bytes.Buffer
+	for _, line := range lines {
+		stdout.WriteString(line)
+		stdout.WriteByte('\n')
+	}
+	sc := bufio.NewScanner(&stdout)
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
+	stdin := &bytes.Buffer{}
+	c := &appServerClient{
+		scanner:        sc,
+		stdin:          stdin,
+		out:            io.Discard,
+		approvalPolicy: "never",
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, stdin
+}
+
+func runtimeEventNames(c *appServerClient) []string {
+	names := make([]string, len(c.runtimeEvents))
+	for i, ev := range c.runtimeEvents {
+		names[i] = ev.Event
+	}
+	return names
+}
+
+func TestAwaitTurnCompletion_TurnCompletedSuccess(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"method":"turn/completed","params":{"lastAssistantMessage":"all done","continue":false}}`,
+	})
+	if err := c.awaitTurnCompletion(context.Background()); err != nil {
+		t.Fatalf("awaitTurnCompletion() = %v; want nil on turn/completed success", err)
+	}
+	if got, want := c.summary(), "all done"; got != want {
+		t.Errorf("summary() = %q; want %q", got, want)
+	}
+	if c.continueRun {
+		t.Errorf("continueRun = true; want false (params.continue=false)")
+	}
+	if got, want := runtimeEventNames(c), []string{task.EventTurnCompleted}; !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_TurnCompletedSetsContinueRun(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"method":"turn/completed","params":{"continue":true,"lastAssistantMessage":"keep going"}}`,
+	})
+	if err := c.awaitTurnCompletion(context.Background()); err != nil {
+		t.Fatalf("awaitTurnCompletion() = %v; want nil", err)
+	}
+	if !c.continueRun {
+		t.Errorf("continueRun = false; want true (params.continue=true)")
+	}
+}
+
+func TestAwaitTurnCompletion_TurnCompletedFailedStatusIsTurnFailed(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"method":"turn/completed","params":{"status":"failed","reason":"boom"}}`,
+	})
+	err := c.awaitTurnCompletion(context.Background())
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryTurnFailed {
+		t.Fatalf("ErrorCategory(%v) = %q,%v; want %q,true", err, cat, ok, CategoryTurnFailed)
+	}
+	if got, want := runtimeEventNames(c), []string{task.EventTurnEndedWithError}; !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v (failed turn/completed records turn_ended_with_error)", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_TurnFailed(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"method":"turn/failed","params":{"reason":"explode"}}`,
+	})
+	err := c.awaitTurnCompletion(context.Background())
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryTurnFailed {
+		t.Fatalf("ErrorCategory(%v) = %q,%v; want %q,true", err, cat, ok, CategoryTurnFailed)
+	}
+	if got, want := runtimeEventNames(c), []string{task.EventTurnFailed}; !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_TurnCancelled(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"method":"turn/cancelled","params":{"reason":"user aborted"}}`,
+	})
+	err := c.awaitTurnCompletion(context.Background())
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryTurnCancelled {
+		t.Fatalf("ErrorCategory(%v) = %q,%v; want %q,true", err, cat, ok, CategoryTurnCancelled)
+	}
+	if got, want := runtimeEventNames(c), []string{task.EventTurnCancelled}; !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_UsageLimitIsQuotaBackoff(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"method":"turn/completed","params":{"status":"failed","turn":{"error":{"codexErrorInfo":"usageLimitExceeded","message":"please try again in 30 seconds"}}}}`,
+	})
+	err := c.awaitTurnCompletion(context.Background())
+	var quota *QuotaBackoffError
+	if !errors.As(err, &quota) {
+		t.Fatalf("awaitTurnCompletion() = %v; want *QuotaBackoffError", err)
+	}
+	if quota.RetryAfter <= 0 {
+		t.Errorf("QuotaBackoffError.RetryAfter = %v; want >0 parsed from retry text", quota.RetryAfter)
+	}
+	if got, want := runtimeEventNames(c), []string{task.EventTurnEndedWithError}; !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_NotificationRecordedThenContinues(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"method":"item/agentMessage","params":{"message":"thinking"}}`,
+		`{"method":"turn/completed","params":{}}`,
+	})
+	if err := c.awaitTurnCompletion(context.Background()); err != nil {
+		t.Fatalf("awaitTurnCompletion() = %v; want nil", err)
+	}
+	want := []string{task.EventNotification, task.EventTurnCompleted}
+	if got := runtimeEventNames(c); !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_OtherMessageRecordedThenContinues(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"foo":"bar"}`,
+		`{"method":"turn/completed","params":{}}`,
+	})
+	if err := c.awaitTurnCompletion(context.Background()); err != nil {
+		t.Fatalf("awaitTurnCompletion() = %v; want nil", err)
+	}
+	want := []string{task.EventOtherMessage, task.EventTurnCompleted}
+	if got := runtimeEventNames(c); !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v (method-less message records other_message)", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_MalformedProtocolLineRecordedThenContinues(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{
+		`{"oops": not-valid-json`,
+		`{"method":"turn/completed","params":{}}`,
+	})
+	if err := c.awaitTurnCompletion(context.Background()); err != nil {
+		t.Fatalf("awaitTurnCompletion() = %v; want nil (malformed protocol-like line is reported then skipped)", err)
+	}
+	want := []string{task.EventMalformed, task.EventTurnCompleted}
+	if got := runtimeEventNames(c); !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_NonProtocolLineReturnsDecodeError(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{`plain text not json`})
+	err := c.awaitTurnCompletion(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "decode codex app-server message") {
+		t.Fatalf("awaitTurnCompletion() = %v; want decode error", err)
+	}
+	if got := runtimeEventNames(c); len(got) != 0 {
+		t.Errorf("runtime events = %v; want none (non-protocol garbage is a hard decode failure)", got)
+	}
+}
+
+func TestAwaitTurnCompletion_InputRequiredNotification(t *testing.T) {
+	c, _ := newTurnLoopClient([]string{`{"method":"turn/input_required","params":{}}`})
+	err := c.awaitTurnCompletion(context.Background())
+	if !IsInputRequired(err) {
+		t.Fatalf("awaitTurnCompletion() = %v; want *InputRequiredError", err)
+	}
+	var ire *InputRequiredError
+	errors.As(err, &ire)
+	if ire.Method != "turn/input_required" {
+		t.Errorf("InputRequiredError.Method = %q; want %q", ire.Method, "turn/input_required")
+	}
+	if got, want := runtimeEventNames(c), []string{task.EventTurnInputRequired}; !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+}
+
+func TestAwaitTurnCompletion_ServerRequestAutoApprovedThenContinues(t *testing.T) {
+	c, stdin := newTurnLoopClient([]string{
+		`{"id":7,"method":"item/commandExecution/requestApproval","params":{"command":"ls"}}`,
+		`{"method":"turn/completed","params":{}}`,
+	})
+	if err := c.awaitTurnCompletion(context.Background()); err != nil {
+		t.Fatalf("awaitTurnCompletion() = %v; want nil", err)
+	}
+	want := []string{task.EventApprovalAutoApproved, task.EventTurnCompleted}
+	if got := runtimeEventNames(c); !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+	if reply := stdin.String(); !strings.Contains(reply, "acceptForSession") {
+		t.Errorf("server-request reply = %q; want it to carry acceptForSession", reply)
+	}
+}
+
+func TestAwaitTurnCompletion_ServerRequestDeclinedIsInputRequired(t *testing.T) {
+	c, stdin := newTurnLoopClient([]string{
+		`{"id":9,"method":"item/commandExecution/requestApproval","params":{"command":"rm -rf /"}}`,
+	}, func(c *appServerClient) { c.approvalPolicy = "on-request" })
+	err := c.awaitTurnCompletion(context.Background())
+	if !IsInputRequired(err) {
+		t.Fatalf("awaitTurnCompletion() = %v; want *InputRequiredError under operator-supervised policy", err)
+	}
+	if got, want := runtimeEventNames(c), []string{task.EventTurnInputRequired}; !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+	if reply := stdin.String(); !strings.Contains(reply, "decline") {
+		t.Errorf("server-request reply = %q; want it to carry decline", reply)
+	}
+}
+
+func TestAwaitTurnCompletion_RequestUserInputIsInputRequired(t *testing.T) {
+	c, stdin := newTurnLoopClient([]string{
+		`{"id":3,"method":"item/tool/requestUserInput","params":{"questions":[{"id":"q1"}]}}`,
+	})
+	err := c.awaitTurnCompletion(context.Background())
+	if !IsInputRequired(err) {
+		t.Fatalf("awaitTurnCompletion() = %v; want *InputRequiredError", err)
+	}
+	if got, want := runtimeEventNames(c), []string{task.EventTurnInputRequired}; !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+	if reply := stdin.String(); !strings.Contains(reply, nonInteractiveInputReply) {
+		t.Errorf("user-input reply = %q; want it to carry the non-interactive answer", reply)
+	}
+}
+
+func TestAwaitTurnCompletion_UnsupportedToolCallRecordedThenContinues(t *testing.T) {
+	// With an empty tool set, item/tool/call resolves as an unsupported tool:
+	// the wire still gets a structured failure result and the loop continues,
+	// refreshing the stall clock, to the terminal turn/completed.
+	c, stdin := newTurnLoopClient([]string{
+		`{"id":5,"method":"item/tool/call","params":{"tool":"nope","arguments":{}}}`,
+		`{"method":"turn/completed","params":{}}`,
+	})
+	if err := c.awaitTurnCompletion(context.Background()); err != nil {
+		t.Fatalf("awaitTurnCompletion() = %v; want nil", err)
+	}
+	want := []string{task.EventUnsupportedToolCall, task.EventTurnCompleted}
+	if got := runtimeEventNames(c); !slices.Equal(got, want) {
+		t.Errorf("runtime events = %v; want %v", got, want)
+	}
+	if reply := stdin.String(); !strings.Contains(reply, "unsupported dynamic tool") {
+		t.Errorf("tool-call reply = %q; want it to carry the unsupported-tool failure", reply)
+	}
+}
+
+func TestAwaitTurnCompletion_StallTimeoutWhenStreamSilent(t *testing.T) {
+	// A live stream that stops emitting for longer than stall_timeout_ms must
+	// surface a *StallError rather than block forever. io.Pipe never delivers a
+	// line, so the per-read stall budget elapses on the first iteration.
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+	sc := bufio.NewScanner(pr)
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
+	c := &appServerClient{scanner: sc, out: io.Discard, approvalPolicy: "never", stallTimeoutMs: 50}
+	err := c.awaitTurnCompletion(context.Background())
+	if !IsStall(err) {
+		t.Fatalf("awaitTurnCompletion() = %v; want *StallError when the stream goes silent", err)
+	}
+}


### PR DESCRIPTION
## What & why

First and highest-complexity target of #499: safely decompose
`(*appServerClient).awaitTurnCompletion` — the Codex JSON-RPC turn loop —
which was a single **gocognit 78 / ~114-line** function fusing four concerns
(stall-budget-aware reading, read-failure classification, message demux, and
server-request/notification handling). #410/#497/#500 only moved this function
into its own file; this PR does the internal decomposition #410 deferred as
behavior-sensitive.

Split along upstream Symphony's `receive_loop → handle_incoming →
handle_turn_method → maybe_handle_approval_request` seam
(`elixir/lib/symphony_elixir/codex/app_server.ex`):

| helper | responsibility |
|---|---|
| `readTurnMessage` | stall-budget deadline + `read_timeout_ms` suspension around one read |
| `classifyTurnReadError` | malformed-skip vs hard-decode vs stall-reclassify |
| `dispatchTurnMessage` | terminal `turn/*` vs tool-call vs other-message demux |
| `handleTurnMethod` | server-request vs notification fork |
| `handleServerRequest` | reply + declined/input-required surfacing |
| `handleTurnNotification` | input-required / stall / record fallback |

**Zero behavior change.** Read→classify→dispatch ordering, every
`lastTerminal` stall-clock reset, the `read_timeout_ms` suspend/restore, the
`turn/failed` vs `turn/cancelled` split, declined-approval → `InputRequiredError`,
and every recorded runtime event are identical. The pre-read budget-exhausted
`*StallError` (originally a direct `return`) now flows out of `readTurnMessage`
and through `classifyTurnReadError` unchanged — it is neither `DeadlineExceeded`
nor a read-timeout, so it falls through the reclassification guard with
`Cause==nil` intact.

## Acceptance criteria (#499, for `awaitTurnCompletion`)

- [x] **Characterization tests added before decomposing.** 18 tests pin the
  loop's input→(returned error, recorded runtime events, continuation signal)
  at the function boundary, driving it over an in-memory JSON-RPC stream (no
  subprocess), incl. branches the e2e suite did not exercise (input-required
  notifications, non-protocol decode error, auto-approve vs. decline fork).
  Green on the **original** function before the refactor; `-count=1 -race`
  twice, no flake.
- [x] **Decomposed into single-responsibility helpers**, preserving the BEAM
  guarantees already in place (the read goroutine + per-read `context.WithTimeout`
  are unchanged from origin/main).
- [x] **gocognit eliminated/reduced:** `awaitTurnCompletion` **78 → eliminated**;
  every extracted helper is ≤10 gocognit and ≤80 lines. No new gocognit/funlen
  findings.
- [x] **Mutation-verified non-placebo:** 5 mutations (wrong event, dropped
  malformed-skip, dropped declined-approval, dropped notification stall, removed
  pre-read budget guard) each fail the matching test against the **committed**
  artifact; tree restored to HEAD after each.
- [x] **No new deviation, no external API change.**

Out of scope (separate #499 PRs, highest-first): `(*appServerClient).run` (46),
`(CodexAppServerRunner).Run` (29), and the orchestrator `apply` hotspots
(`finalizeRunOp` 47, `retryFireOp` 30, …).

## Verification

```
gofmt -l $(git ls-files '*.go')   # clean
go vet ./internal/runner/...      # clean
go mod tidy                       # go.mod/go.sum clean
go test -race ./...               # green (see note)
go build ./cmd/worker ./cmd/tui   # ok
golangci-lint (gocognit,funlen)   # no new findings on the turn loop
```

Note: `TestCodexAppServerInitializeTimeoutDiagnostics` (untouched
`codex_app_server_test.go`, initialize path) fails **locally** because the
Python `codex` stub does not write its started-log in this sandbox; it fails
identically on `origin/main`'s un-refactored turn loop (confirmed by stashing
the diff) and passes in CI. Not a regression from this PR.

## Review

Pre-push dual diff-only review (protocol §3): an independent
behavior-preservation/SPEC pass and a `feature-dev:code-reviewer` pass both
landed **MERGE-READY** on the final head; their one shared finding (the pre-read
budget-exhausted `*StallError` branch was untested) is closed by
`TestReadTurnMessage_PreReadBudgetExhaustedReturnsStall` (mutation-verified).
Findings fixed pre-push: a `classifyTurnReadError` doc note that `ctx` must be
the outer-loop context, and an error-text `strings.Contains` assertion swapped
for `ErrorCategory` (AGENTS.md rule 8).

**Local `codex exec review` was unavailable** (CLI refresh token expired); the
per-push GitHub `@codex review` gate (protocol §4) is the codex-family review
and runs on this head.

Pre-existing observation (not introduced here, out of scope): `isAppServerReadTimeout`
(`codex_app_server.go`) still string-matches error text — a rule-8 nit in a
stable helper `classifyTurnReadError` calls; flag for a follow-up, not this PR.

## Size gate

`size-gated: justified overage` — +496/-102. 322 lines are the #499-mandated
characterization suite; the production decomposition is net-modest and cannot be
split from the tests that guard its zero-behavior-change property without losing
atomicity. Needs human size-gate sign-off (and merge requires explicit
permission per protocol §8).

Refs #499
