### PR TITLE
refactor(orchestrator): decompose finalizeRunOp.apply into per-route handlers (#499)

### DIFF
--- a/internal/orchestrator/actor_finalize.go
+++ b/internal/orchestrator/actor_finalize.go
@@ -30,149 +30,228 @@ type finalizeRunOp struct {
 	done       chan struct{}
 }
 
+// apply routes a worker's terminal RunResult. Each branch is a single-concern
+// handler that, once its guard matches, owns the state transition, the
+// close(f.done), and the returned followup; the guard order is the SPEC routing
+// priority (input-required block → external blocked → clean exit → reconciled
+// cancel cleanup → non-retryable → quota backoff → reconcile cancel → failure
+// retry). Handlers that may schedule async work report (followup, handled); the
+// two pure terminal blocks (input-required, non-retryable) report only handled
+// since they never schedule a followup. applyCleanExit and applyFailureRetry are
+// reached unconditionally on their branch and always handle, so they return the
+// followup directly.
 func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 	elapsed := f.result.Elapsed
 	if elapsed == 0 {
 		elapsed = time.Since(f.started)
 	}
-	if f.entry.InputRequired || f.result.InputRequired || runner.IsInputRequired(f.result.Err) {
-		runErr := "input required"
-		if f.result.Err != nil {
-			runErr = f.result.Err.Error()
-		}
-		if !st.BlockRun(f.id, f.entry, f.entry.InputRequiredAt, runErr, elapsed) {
-			close(f.done)
-			return nil
-		}
-		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventInputBlocked, IssueID: f.id, Identifier: f.identifier, Message: runErr})
-		close(f.done)
+	if f.applyInputRequiredBlock(st, elapsed) {
 		return nil
 	}
-	if f.result.ExternalBlocked {
-		reason := strings.TrimSpace(f.result.BlockerReason)
-		if reason == "" && f.result.Err != nil {
-			reason = f.result.Err.Error()
-		}
-		if reason == "" {
-			reason = "external dependency blocked run"
-		}
-		if !st.FinishRunExternalBlocked(f.id, f.entry, elapsed) {
-			close(f.done)
-			return nil
-		}
-		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCandidateBlocked, IssueID: f.id, Identifier: f.identifier, Message: reason})
-		issue := f.entry.Issue
-		workspace := f.entry.Workspace
-		close(f.done)
-		o := f.o
-		identifier := f.identifier
-		delay := f.result.BlockerRetryAfter
-		return func() {
-			_ = o.scheduleExternalBlockerRetry(o.runCtx, issue, identifier, reason, delay, workspace)
-		}
+	if followup, ok := f.applyExternalBlocked(st, elapsed); ok {
+		return followup
 	}
 	if f.result.Err == nil {
-		nextContinuationAttempt := f.entry.ContinuationAttempt + 1
-		if f.entry.ReconcileCleanupWorkspace && runHasCompletedTurn(f.entry) {
-			cleanup := f.o.reconciledWorkspaceCleanupOrContinuation(f.id, f.entry, nextContinuationAttempt)
-			if !st.FinishRunSucceeded(f.id, f.entry, elapsed) {
-				close(f.done)
-				return nil
-			}
-			st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
-			close(f.done)
-			return cleanup
-		}
-		// SPEC §7.1 leaves continuation worker spawns unbounded; only apply
-		// the orchestrator-side cap for runners that cannot enforce
-		// agent.max_turns inside their own session. See issue #216.
-		if !f.o.runnerEnforcesMaxTurns && nextContinuationAttempt >= f.o.maxTurns {
-			if !st.FinishRunNonRetryableFailed(f.id, f.entry, elapsed) {
-				close(f.done)
-				return nil
-			}
-			msg := "clean continuation budget exhausted after " + strconv.Itoa(f.o.maxTurns) + " turns while tracker issue remained active"
-			st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: msg})
-			// SPEC §13.1: the failed outcome must be expressible on stderr,
-			// not only in the in-memory recent_events ring. Operators tailing
-			// stderr otherwise see a run of "Succeeded" lines then silence.
-			log.Printf("event=run_failed issue_id=%s issue_identifier=%s reason=continuation_budget_exhausted budget=%d", f.id, f.identifier, f.o.maxTurns)
-			close(f.done)
-			return nil
-		}
+		return f.applyCleanExit(st, elapsed)
+	}
+	if followup, ok := f.applyReconciledCancelCleanup(st, elapsed); ok {
+		return followup
+	}
+	if f.applyNonRetryable(st, elapsed) {
+		return nil
+	}
+	if followup, ok := f.applyQuotaBackoff(st, elapsed); ok {
+		return followup
+	}
+	if followup, ok := f.applyReconcileCancel(st, elapsed); ok {
+		return followup
+	}
+	return f.applyFailureRetry(st, elapsed)
+}
+
+// applyInputRequiredBlock handles SPEC §7.3 input-required exits: the run is
+// parked in the blocked substate awaiting operator input, never retried. It
+// never schedules a followup, so it reports only whether it handled the exit.
+func (f *finalizeRunOp) applyInputRequiredBlock(st *OrchestratorState, elapsed time.Duration) bool {
+	if !f.entry.InputRequired && !f.result.InputRequired && !runner.IsInputRequired(f.result.Err) {
+		return false
+	}
+	runErr := "input required"
+	if f.result.Err != nil {
+		runErr = f.result.Err.Error()
+	}
+	if !st.BlockRun(f.id, f.entry, f.entry.InputRequiredAt, runErr, elapsed) {
+		close(f.done)
+		return true
+	}
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventInputBlocked, IssueID: f.id, Identifier: f.identifier, Message: runErr})
+	close(f.done)
+	return true
+}
+
+// applyExternalBlocked parks a run blocked on an external dependency and
+// schedules the cooldown retry that re-checks the blocker.
+func (f *finalizeRunOp) applyExternalBlocked(st *OrchestratorState, elapsed time.Duration) (func(), bool) {
+	if !f.result.ExternalBlocked {
+		return nil, false
+	}
+	reason := strings.TrimSpace(f.result.BlockerReason)
+	if reason == "" && f.result.Err != nil {
+		reason = f.result.Err.Error()
+	}
+	if reason == "" {
+		reason = "external dependency blocked run"
+	}
+	if !st.FinishRunExternalBlocked(f.id, f.entry, elapsed) {
+		close(f.done)
+		return nil, true
+	}
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCandidateBlocked, IssueID: f.id, Identifier: f.identifier, Message: reason})
+	issue := f.entry.Issue
+	workspace := f.entry.Workspace
+	close(f.done)
+	o := f.o
+	identifier := f.identifier
+	delay := f.result.BlockerRetryAfter
+	return func() {
+		_ = o.scheduleExternalBlockerRetry(o.runCtx, issue, identifier, reason, delay, workspace)
+	}, true
+}
+
+// applyCleanExit handles a normal (Err==nil) worker exit: reconciled-cleanup
+// continuation, the orchestrator-side continuation cap, or a normal
+// continuation retry. It always handles the exit, so it returns the followup
+// directly.
+func (f *finalizeRunOp) applyCleanExit(st *OrchestratorState, elapsed time.Duration) func() {
+	nextContinuationAttempt := f.entry.ContinuationAttempt + 1
+	if f.entry.ReconcileCleanupWorkspace && runHasCompletedTurn(f.entry) {
+		cleanup := f.o.reconciledWorkspaceCleanupOrContinuation(f.id, f.entry, nextContinuationAttempt)
 		if !st.FinishRunSucceeded(f.id, f.entry, elapsed) {
 			close(f.done)
 			return nil
 		}
 		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
-		// Use f.entry.Issue, not f.issue: reconciliation may have refreshed
-		// the tracker state mid-run, and per-state capacity gates must see
-		// the live state, not the dispatch-time snapshot.
-		issue := f.entry.Issue
-		// Carry the finalized run's workspace onto the continuation retry. A
-		// clean exit can be a SPEC §16.5 self-stop (the per-turn refresher saw
-		// the issue leave the active set); if the issue is later observed
-		// terminal while this continuation is queued, the reconcile pass uses
-		// this path to clean the directory through the §18.1 seam instead of
-		// leaking it until the next startup sweep (#341).
-		workspace := f.entry.Workspace
-		st.Claimed[f.id] = struct{}{}
-		st.ClaimedIssues[f.id] = issue
-		close(f.done)
-		// A clean continuation is a new normal turn. Keep its retry entry
-		// 1-based for the continuation budget, but do not carry it into future
-		// failure backoff; otherwise many successful turns inflate the next
-		// transient failure straight to the max backoff.
-		nextAttempt := nextContinuationAttempt
-		o := f.o
-		identifier := f.identifier
-		return func() {
-			_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt, workspace)
-		}
-	}
-	if f.entry.ReconcileCleanupWorkspace && runHasCompletedTurn(f.entry) {
-		cleanup := f.o.reconciledWorkspaceCleanup(f.id, f.entry)
-		if !st.FinishRunReconciledCancelled(f.id, f.entry, elapsed) {
-			close(f.done)
-			return nil
-		}
 		close(f.done)
 		return cleanup
 	}
-	if f.result.NonRetryable {
-		if !st.FinishRunNonRetryableFailed(f.id, f.entry, elapsed) {
-			close(f.done)
-			return nil
-		}
-		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: f.result.Err.Error()})
-		// SPEC §13.1 failed outcome on stderr (see continuation-budget site).
-		log.Printf("event=run_failed issue_id=%s issue_identifier=%s reason=non_retryable_runner_error error=%q", f.id, f.identifier, f.result.Err.Error())
+	// SPEC §7.1 leaves continuation worker spawns unbounded; only apply
+	// the orchestrator-side cap for runners that cannot enforce
+	// agent.max_turns inside their own session. See issue #216.
+	if !f.o.runnerEnforcesMaxTurns && nextContinuationAttempt >= f.o.maxTurns {
+		return f.applyContinuationBudgetExhausted(st, elapsed)
+	}
+	if !st.FinishRunSucceeded(f.id, f.entry, elapsed) {
 		close(f.done)
 		return nil
 	}
-	if cleanup, ok := f.applyQuotaBackoff(st, elapsed); ok {
-		return cleanup
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
+	// Use f.entry.Issue, not f.issue: reconciliation may have refreshed
+	// the tracker state mid-run, and per-state capacity gates must see
+	// the live state, not the dispatch-time snapshot.
+	issue := f.entry.Issue
+	// Carry the finalized run's workspace onto the continuation retry. A
+	// clean exit can be a SPEC §16.5 self-stop (the per-turn refresher saw
+	// the issue leave the active set); if the issue is later observed
+	// terminal while this continuation is queued, the reconcile pass uses
+	// this path to clean the directory through the §18.1 seam instead of
+	// leaking it until the next startup sweep (#341).
+	workspace := f.entry.Workspace
+	st.Claimed[f.id] = struct{}{}
+	st.ClaimedIssues[f.id] = issue
+	close(f.done)
+	// A clean continuation is a new normal turn. Keep its retry entry
+	// 1-based for the continuation budget, but do not carry it into future
+	// failure backoff; otherwise many successful turns inflate the next
+	// transient failure straight to the max backoff.
+	nextAttempt := nextContinuationAttempt
+	o := f.o
+	identifier := f.identifier
+	return func() {
+		_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt, workspace)
 	}
-	if f.entry.ReconcileCancel {
-		// Capture the cleanup followup before FinishRunReconciledCancelled
-		// drops the entry from state: the worker has now exited, so the
-		// workspace dir is free to remove (SPEC §18.1 active transition).
-		// Done stays tied to worker exit (closed here), so the reconcile wait
-		// keeps its worker_exit_timeout meaning and a slow before_remove hook
-		// cannot surface as a spurious "deadline exceeded" poll error (Codex
-		// P2). Cleanup runs asynchronously, bounded by its own hook timeout;
-		// the re-dispatch data-loss race — a re-opened issue dispatched to the
-		// same deterministic path while cleanup is still running — is prevented
-		// inside the cleaner, which skips removal when the issue has been
-		// re-claimed (Codex P1), rather than by gating the wait on cleanup.
-		cleanup := f.o.reconciledWorkspaceCleanup(f.id, f.entry)
-		if !st.FinishRunReconciledCancelled(f.id, f.entry, elapsed) {
-			close(f.done)
-			return nil
-		}
+}
+
+// applyContinuationBudgetExhausted is the terminal failure for a clean exit that
+// would exceed the orchestrator-side continuation cap (#216).
+func (f *finalizeRunOp) applyContinuationBudgetExhausted(st *OrchestratorState, elapsed time.Duration) func() {
+	if !st.FinishRunNonRetryableFailed(f.id, f.entry, elapsed) {
 		close(f.done)
-		return cleanup
+		return nil
 	}
+	msg := "clean continuation budget exhausted after " + strconv.Itoa(f.o.maxTurns) + " turns while tracker issue remained active"
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: msg})
+	// SPEC §13.1: the failed outcome must be expressible on stderr, not only in
+	// the in-memory recent_events ring. Operators tailing stderr otherwise see a
+	// run of "Succeeded" lines then silence.
+	log.Printf("event=run_failed issue_id=%s issue_identifier=%s reason=continuation_budget_exhausted budget=%d", f.id, f.identifier, f.o.maxTurns)
+	close(f.done)
+	return nil
+}
+
+// applyReconciledCancelCleanup cleans the workspace of a run that reconciliation
+// marked for cleanup and that has a completed turn, on an abnormal exit (#341).
+func (f *finalizeRunOp) applyReconciledCancelCleanup(st *OrchestratorState, elapsed time.Duration) (func(), bool) {
+	if !f.entry.ReconcileCleanupWorkspace || !runHasCompletedTurn(f.entry) {
+		return nil, false
+	}
+	cleanup := f.o.reconciledWorkspaceCleanup(f.id, f.entry)
+	if !st.FinishRunReconciledCancelled(f.id, f.entry, elapsed) {
+		close(f.done)
+		return nil, true
+	}
+	close(f.done)
+	return cleanup, true
+}
+
+// applyNonRetryable is the terminal failure for a runner error flagged
+// non-retryable (e.g. a malformed WORKFLOW.md), never retried. It never
+// schedules a followup, so it reports only whether it handled the exit.
+func (f *finalizeRunOp) applyNonRetryable(st *OrchestratorState, elapsed time.Duration) bool {
+	if !f.result.NonRetryable {
+		return false
+	}
+	if !st.FinishRunNonRetryableFailed(f.id, f.entry, elapsed) {
+		close(f.done)
+		return true
+	}
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: f.id, Identifier: f.identifier, Message: f.result.Err.Error()})
+	// SPEC §13.1 failed outcome on stderr (see continuation-budget site).
+	log.Printf("event=run_failed issue_id=%s issue_identifier=%s reason=non_retryable_runner_error error=%q", f.id, f.identifier, f.result.Err.Error())
+	close(f.done)
+	return true
+}
+
+// applyReconcileCancel cleans the workspace of a run reconciliation cancelled
+// mid-run (the issue left the active set), now that the worker has exited.
+func (f *finalizeRunOp) applyReconcileCancel(st *OrchestratorState, elapsed time.Duration) (func(), bool) {
+	if !f.entry.ReconcileCancel {
+		return nil, false
+	}
+	// Capture the cleanup followup before FinishRunReconciledCancelled
+	// drops the entry from state: the worker has now exited, so the
+	// workspace dir is free to remove (SPEC §18.1 active transition).
+	// Done stays tied to worker exit (closed here), so the reconcile wait
+	// keeps its worker_exit_timeout meaning and a slow before_remove hook
+	// cannot surface as a spurious "deadline exceeded" poll error (Codex
+	// P2). Cleanup runs asynchronously, bounded by its own hook timeout;
+	// the re-dispatch data-loss race — a re-opened issue dispatched to the
+	// same deterministic path while cleanup is still running — is prevented
+	// inside the cleaner, which skips removal when the issue has been
+	// re-claimed (Codex P1), rather than by gating the wait on cleanup.
+	cleanup := f.o.reconciledWorkspaceCleanup(f.id, f.entry)
+	if !st.FinishRunReconciledCancelled(f.id, f.entry, elapsed) {
+		close(f.done)
+		return nil, true
+	}
+	close(f.done)
+	return cleanup, true
+}
+
+// applyFailureRetry is the default terminal route for a retryable runner error:
+// schedule a backoff retry with attempt+1, or fail permanently once an explicit
+// failure-retry cap is exceeded. It always handles the exit, so it returns the
+// followup directly.
+func (f *finalizeRunOp) applyFailureRetry(st *OrchestratorState, elapsed time.Duration) func() {
 	// Schedule a retry with attempt+1. Per SPEC §4.1.5 the first run's
 	// RetryAttempt is nil; the first retry is attempt 1, the second 2,
 	// and so on. SPEC §8.4 / §16.6 expect the orchestrator to keep
@@ -226,6 +305,7 @@ func (f *finalizeRunOp) apply(st *OrchestratorState) func() {
 		_ = o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace)
 	}
 }
+
 func (f *finalizeRunOp) applyQuotaBackoff(st *OrchestratorState, elapsed time.Duration) (func(), bool) {
 	var quota *runner.QuotaBackoffError
 	if !errors.As(f.result.Err, &quota) {

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -1184,6 +1184,41 @@ func TestFinalize_NormalExitMarksCompletedAndSchedulesContinuationRetry(t *testi
 	}, time.Second)
 }
 
+// TestFinalize_NormalExitRecordsCompletedEvent pins the runtime-event KIND a
+// clean worker exit records — `completed`, not `failed`. The sibling
+// continuation test above asserts only the snapshot bucket (Completed), which
+// FinishRunSucceeded drives independently of the recorded event; mutating the
+// RecordEvent kind alone leaves that test green. This characterizes the
+// clean-exit success signal before #499 splits the finalize routing.
+func TestFinalize_NormalExitRecordsCompletedEvent(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-DONE", Identifier: "ENG-DONE", Title: "ok"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Err: nil, Elapsed: 100 * time.Millisecond})
+
+	var kind RuntimeEventKind
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		for _, ev := range v.RecentEvents {
+			if ev.IssueID == IssueID(iss.ID) && (ev.Kind == RuntimeEventCompleted || ev.Kind == RuntimeEventFailed) {
+				kind = ev.Kind
+				return true
+			}
+		}
+		return false
+	}, time.Second)
+	if kind != RuntimeEventCompleted {
+		t.Fatalf("clean worker exit recorded event kind = %q; want %q", kind, RuntimeEventCompleted)
+	}
+}
+
 func TestFinalize_NormalExitStopsAfterMaxTurns(t *testing.T) {
 	disp := &fakeDispatcher{}
 	maxTurns := 2


### PR DESCRIPTION
## What & why

Second #499 target (highest in the orchestrator package): decompose
`(*finalizeRunOp).apply` — the actor handler that routes a worker's terminal
`RunResult` — which was a single **gocognit 47 / ~196-line** function fusing
eight terminal-routing branches. This is the orchestrator state machine, the
highest-risk path (the #331/#339/#341 cascades lived here), so the split is
purely mechanical and behavior-preserving, mirroring the already-extracted
`applyQuotaBackoff`.

`apply` now reads as the SPEC routing priority and delegates to one
single-concern helper per branch:

```
input-required block → external blocked → clean exit → reconciled-cancel
cleanup → non-retryable → quota backoff → reconcile cancel → failure retry
```

| helper | branch |
|---|---|
| `applyInputRequiredBlock` | SPEC §7.3 input-required → blocked substate |
| `applyExternalBlocked` | external-dependency block + cooldown retry |
| `applyCleanExit` (+ `applyContinuationBudgetExhausted`) | Err==nil: reconciled cleanup / §216 cap / normal continuation |
| `applyReconciledCancelCleanup` | abnormal exit + reconcile cleanup (#341) |
| `applyNonRetryable` | non-retryable runner error |
| `applyQuotaBackoff` | quota/rate-limit backoff (pre-existing) |
| `applyReconcileCancel` | reconcile-cancelled mid-run cleanup |
| `applyFailureRetry` | default backoff retry + §15.5 cap |

The `applyXxx` helpers report `(followup, handled)`; `applyCleanExit` and
`applyFailureRetry` are reached unconditionally on their branch and always
handle, so they return the followup directly.

**Zero behavior change.** Guard order, every guard condition, the `handled`
wiring on all defensive `if !st.FinishRunXxx{ close; return nil }` sub-branches
(each returns `handled=true` so `apply` never falls through to double-process),
`close(f.done)` exactly once per path, the `st.Claimed`/`ClaimedIssues` hold
across the retry gap, the `#341` workspace carry, and every recorded
`RuntimeEvent` kind/message + stderr `log.Printf` line are identical.

## Acceptance criteria (#499, for `finalizeRunOp.apply`)

- [x] **Characterization first.** The existing actor suite already pins the
  routing; I validated it as a safety net by mutation-testing the **un-decomposed**
  function (5 routing mutations) and found **one placebo gap** — the clean-exit
  `completed` event kind was unasserted (only the snapshot bucket was). Closed
  it with `TestFinalize_NormalExitRecordsCompletedEvent` **before** refactoring
  (commit 71aa33e).
- [x] **Decomposed** into single-concern handlers (BEAM guarantees unchanged:
  the followup closures, timers, and `close(f.done)` discipline are preserved).
- [x] **gocognit eliminated:** `apply` **47 → eliminated**; every helper ≤10 and
  ≤80 lines. No new gocognit/funlen findings.
- [x] **Mutation-verified non-placebo:** 5 routing mutations against the
  **decomposed committed** artifact (input-required/external/non-retryable
  routing wiring, clean-exit event kind, failure-retry budget cap) each fail the
  matching test; tree restored to HEAD after each.
- [x] **No new deviation, no external API change.**

Out of scope (separate #499 PRs): `retryFireOp.apply` (30), `dispatchOp.apply`
(22), the `reconcile*Op.apply` hotspots, and the remaining `internal/runner`
functions (`run` 46, `Run` 29, …).

## Verification

```
gofmt -l $(git ls-files '*.go')   # clean
go vet ./internal/orchestrator/... # clean
go mod tidy                        # go.mod/go.sum clean
go test -race ./...                # green (5x -race on the orchestrator pkg, stable)
go build ./cmd/worker ./cmd/tui    # ok
golangci-lint (gocognit,funlen)    # apply finding gone; no new findings
```

## Review

Pre-push dual diff-only review (protocol §3): an independent
behavior-preservation pass (guard order, `handled` wiring, close-once, state
mutations, closure captures — all verified line-by-line) returned MERGE-READY
with no findings; a `feature-dev:code-reviewer` pass returned NEEDS-CHANGES on a
single claimed `gofmt` blank-line violation. **That CI-blocker claim was a
false positive** — `gofmt -l` and `gofmt -d` are both clean (gofmt does not
require blank lines between top-level decls; origin/main had the same adjacency
and passed CI) — but the underlying readability suggestion was applied (blank
line between `applyFailureRetry` and `applyQuotaBackoff`).

**Codex review was unavailable** on both paths during the prior PR (#501):
expired local CLI token + GitHub bot usage limit. `@codex review` is triggered
on this head; if it is still limited, the independent dual review above is the
protocol §4 compensation. A `-race` flake in an unrelated routing test
(`ops-9`) surfaced once in ~7 runs and did not reproduce in 5 consecutive
`-race` runs; it is pre-existing and not introduced by this pure extraction.

## Size gate

`size-gated: justified overage` — the production decomposition is net-modest;
the diff is dominated by re-indented verbatim branch bodies + carried comments,
and the one added characterization test is required by #499 and atomic with the
refactor it guards. Needs human size-gate sign-off (merge requires explicit
permission per protocol §8).

Refs #499
