### PR TITLE
refactor(runner): decompose appServerClient.run into session/turn handlers (#499)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -219,7 +219,35 @@ type codexAppServerTurnStartParams struct {
 	SandboxPolicy  workflow.CodexSandboxPolicy `json:"sandboxPolicy"`
 }
 
+// run drives a full app-server session: cache the per-run config, complete the
+// SPEC §10.1 handshake, then loop turns until one stops the run (clean exit /
+// §16.5 self-stop) or the continuation cap is hit. The init → startThread →
+// per-turn split mirrors upstream start_session / run_turn.
 func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) error {
+	c.initSession(in)
+	threadID, err := c.startThread(ctx, in)
+	if err != nil {
+		return err
+	}
+	maxTurns := in.Workflow.Config.Agent.MaxTurns
+	if maxTurns <= 0 {
+		maxTurns = 20
+	}
+	for turn := 1; turn <= maxTurns; turn++ {
+		keepGoing, err := c.runSingleTurn(ctx, in, threadID, prompt, turn)
+		if err != nil {
+			return err
+		}
+		if !keepGoing {
+			return nil
+		}
+	}
+	return fmt.Errorf("codex app-server exceeded agent.max_turns=%d", maxTurns)
+}
+
+// initSession records the run's sinks and caches the per-run codex config off
+// RunInput before any protocol traffic.
+func (c *appServerClient) initSession(in RunInput) {
 	c.runtimeEventSink = in.RuntimeEventSink
 	c.phaseTransitionSink = in.PhaseTransitionSink
 	c.nextID = 1
@@ -237,6 +265,12 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	// emits approval prompts) but autoApproveRequest, which no longer handles
 	// reject:, would decline them unconditionally and flip behavior (#335).
 	c.approvalPolicy = codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
+}
+
+// startThread runs the SPEC §10.1 handshake — initialize, initialized,
+// thread/start — and returns the started thread id. Mirrors upstream
+// start_session.
+func (c *appServerClient) startThread(ctx context.Context, in RunInput) (string, error) {
 	if _, err := c.request(ctx, "initialize", map[string]any{
 		"capabilities": map[string]any{"experimentalApi": true},
 		"clientInfo": map[string]any{
@@ -246,13 +280,12 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 		},
 	}); err != nil {
 		c.recordStartupFailed("initialize", err)
-		return fmt.Errorf("codex app-server initialize: %w", err)
+		return "", fmt.Errorf("codex app-server initialize: %w", err)
 	}
 	if err := c.notify("initialized", map[string]any{}); err != nil {
 		c.recordStartupFailed("initialized", err)
-		return err
+		return "", err
 	}
-
 	threadResult, err := c.request(ctx, "thread/start", map[string]any{
 		"approvalPolicy": c.approvalPolicy,
 		"sandbox":        in.Workflow.Config.Codex.ThreadSandbox,
@@ -261,109 +294,133 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	})
 	if err != nil {
 		c.recordStartupFailed("thread/start", err)
-		return fmt.Errorf("codex app-server thread/start: %w", err)
+		return "", fmt.Errorf("codex app-server thread/start: %w", err)
 	}
 	threadID, err := extractString(threadResult, "thread", "id")
 	if err != nil {
 		c.recordStartupFailed("thread/start", err)
-		return fmt.Errorf("codex app-server thread/start: %w", err)
+		return "", fmt.Errorf("codex app-server thread/start: %w", err)
 	}
 	c.threadID = threadID
 	c.recordPhaseTransition(task.PhaseLaunchingAgentProcess, task.PhaseInitializingSession)
+	return threadID, nil
+}
 
-	maxTurns := in.Workflow.Config.Agent.MaxTurns
-	if maxTurns <= 0 {
-		maxTurns = 20
+// runSingleTurn starts one turn, awaits its completion, and reports whether the
+// loop should continue. Mirrors upstream run_turn: keepGoing=false stops the run
+// (a clean turn with continue=false, or a SPEC §16.5 self-stop), a non-nil error
+// aborts it.
+func (c *appServerClient) runSingleTurn(ctx context.Context, in RunInput, threadID, prompt string, turn int) (bool, error) {
+	turnID, err := c.startTurn(ctx, in, threadID, prompt, turn)
+	if err != nil {
+		return false, err
 	}
-	for turn := 1; turn <= maxTurns; turn++ {
-		input := []codexAppServerTextInput{{
-			Type:         "text",
-			Text:         appServerContinuationPrompt(in, turn),
-			TextElements: []any{},
-		}}
-		if turn == 1 {
-			input = []codexAppServerTextInput{{
-				Type:         "text",
-				Text:         prompt,
-				TextElements: []any{},
-			}}
-		}
-		turnResult, err := c.request(ctx, "turn/start", codexAppServerTurnStartParams{
-			ThreadID:       threadID,
-			Input:          input,
-			CWD:            in.Workdir,
-			Title:          appServerTurnTitle(in),
-			ApprovalPolicy: c.approvalPolicy,
-			SandboxPolicy:  in.Workflow.Config.Codex.TurnSandboxPolicy,
-		})
+	c.turnID = turnID
+	if turn == 1 {
+		c.recordFirstTurnStarted(threadID, turnID)
+	}
+	c.continueRun = false
+	turnCtx := ctx
+	var cancel context.CancelFunc
+	if c.turnTimeoutMs > 0 {
+		turnCtx, cancel = context.WithTimeout(ctx, time.Duration(c.turnTimeoutMs)*time.Millisecond)
+	}
+	turnStarted := time.Now()
+	err = c.awaitTurnCompletion(turnCtx)
+	if cancel != nil {
+		cancel()
+	}
+	if err != nil {
+		return false, c.classifyTurnError(ctx, err, turnStarted)
+	}
+	// SPEC §16.5: refresh tracker state between turns so an operator who
+	// cancelled the issue mid-run sees the worker exit after the current turn
+	// rather than at the next orchestrator poll tick. Errors here are surfaced
+	// verbatim per SPEC ("if refreshed_issue failed: fail"); a nil refresher
+	// keeps the legacy continueRun-only path for callers (mock runner, tests)
+	// with no tracker hook.
+	if c.refreshIssueState != nil {
+		active, err := c.refreshIssueState(ctx)
 		if err != nil {
-			if turn == 1 {
-				c.recordStartupFailed("turn/start", err)
-			}
-			return fmt.Errorf("codex app-server turn/start: %w", err)
+			return false, fmt.Errorf("codex app-server refresh issue state: %w", err)
 		}
-		turnID, err := extractString(turnResult, "turn", "id")
-		if err != nil {
-			if turn == 1 {
-				c.recordStartupFailed("turn/start", err)
-			}
-			return fmt.Errorf("codex app-server turn/start: %w", err)
-		}
-		c.turnID = turnID
-		if turn == 1 {
-			payload := map[string]any{
-				"session_id": threadID + "-" + turnID,
-				"thread_id":  threadID,
-				"turn_id":    turnID,
-			}
-			if c.codexAppServerPID > 0 {
-				payload["codex_app_server_pid"] = c.codexAppServerPID
-			}
-			c.recordRuntimeEvent(task.EventSessionStarted, payload)
-			c.recordPhaseTransition(task.PhaseInitializingSession, task.PhaseStreamingTurn)
-		}
-		c.continueRun = false
-		turnCtx := ctx
-		var cancel context.CancelFunc
-		if c.turnTimeoutMs > 0 {
-			turnCtx, cancel = context.WithTimeout(ctx, time.Duration(c.turnTimeoutMs)*time.Millisecond)
-		}
-		turnStarted := time.Now()
-		err = c.awaitTurnCompletion(turnCtx)
-		if cancel != nil {
-			cancel()
-		}
-		if err != nil {
-			var stall *StallError
-			if errors.As(err, &stall) {
-				return err
-			}
-			if c.turnTimeoutMs > 0 && errors.Is(err, context.DeadlineExceeded) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				return &TurnTimeoutError{Timeout: time.Duration(c.turnTimeoutMs) * time.Millisecond, Elapsed: time.Since(turnStarted), Cause: err}
-			}
-			return err
-		}
-		// SPEC §16.5: refresh tracker state between turns so an
-		// operator who cancelled the issue mid-run sees the worker
-		// exit after the current turn rather than at the next
-		// orchestrator poll tick. Errors here are surfaced verbatim per
-		// SPEC ("if refreshed_issue failed: fail"); a nil refresher
-		// keeps the legacy continueRun-only path for callers (mock
-		// runner, tests) with no tracker hook.
-		if c.refreshIssueState != nil {
-			active, err := c.refreshIssueState(ctx)
-			if err != nil {
-				return fmt.Errorf("codex app-server refresh issue state: %w", err)
-			}
-			if !active {
-				return nil
-			}
-		}
-		if !c.continueRun {
-			return nil
+		if !active {
+			return false, nil
 		}
 	}
-	return fmt.Errorf("codex app-server exceeded agent.max_turns=%d", maxTurns)
+	return c.continueRun, nil
+}
+
+// startTurn issues turn/start and resolves the turn id. A failure on the first
+// turn is also recorded as a startup failure (the session never produced a
+// turn). Mirrors upstream start_turn.
+func (c *appServerClient) startTurn(ctx context.Context, in RunInput, threadID, prompt string, turn int) (string, error) {
+	turnResult, err := c.request(ctx, "turn/start", codexAppServerTurnStartParams{
+		ThreadID:       threadID,
+		Input:          turnInput(in, prompt, turn),
+		CWD:            in.Workdir,
+		Title:          appServerTurnTitle(in),
+		ApprovalPolicy: c.approvalPolicy,
+		SandboxPolicy:  in.Workflow.Config.Codex.TurnSandboxPolicy,
+	})
+	if err != nil {
+		if turn == 1 {
+			c.recordStartupFailed("turn/start", err)
+		}
+		return "", fmt.Errorf("codex app-server turn/start: %w", err)
+	}
+	turnID, err := extractString(turnResult, "turn", "id")
+	if err != nil {
+		if turn == 1 {
+			c.recordStartupFailed("turn/start", err)
+		}
+		return "", fmt.Errorf("codex app-server turn/start: %w", err)
+	}
+	return turnID, nil
+}
+
+// turnInput builds the turn/start input: the full prompt on the first turn, a
+// continuation nudge thereafter.
+func turnInput(in RunInput, prompt string, turn int) []codexAppServerTextInput {
+	text := prompt
+	if turn > 1 {
+		text = appServerContinuationPrompt(in, turn)
+	}
+	return []codexAppServerTextInput{{
+		Type:         "text",
+		Text:         text,
+		TextElements: []any{},
+	}}
+}
+
+// recordFirstTurnStarted emits the SPEC §10.4 session_started event and the
+// initializing→streaming phase transition, once, on the first turn.
+func (c *appServerClient) recordFirstTurnStarted(threadID, turnID string) {
+	payload := map[string]any{
+		"session_id": threadID + "-" + turnID,
+		"thread_id":  threadID,
+		"turn_id":    turnID,
+	}
+	if c.codexAppServerPID > 0 {
+		payload["codex_app_server_pid"] = c.codexAppServerPID
+	}
+	c.recordRuntimeEvent(task.EventSessionStarted, payload)
+	c.recordPhaseTransition(task.PhaseInitializingSession, task.PhaseStreamingTurn)
+}
+
+// classifyTurnError maps an awaitTurnCompletion failure to the run's returned
+// error: a *StallError and a generic error pass through unchanged; a per-turn
+// deadline that fired while the outer run context is still alive becomes a
+// *TurnTimeoutError.
+func (c *appServerClient) classifyTurnError(ctx context.Context, err error, turnStarted time.Time) error {
+	var stall *StallError
+	if errors.As(err, &stall) {
+		return err
+	}
+	if c.turnTimeoutMs > 0 && errors.Is(err, context.DeadlineExceeded) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return &TurnTimeoutError{Timeout: time.Duration(c.turnTimeoutMs) * time.Millisecond, Elapsed: time.Since(turnStarted), Cause: err}
+	}
+	return err
 }
 func (c *appServerClient) request(ctx context.Context, method string, params any) (map[string]any, error) {
 	id := c.nextID


### PR DESCRIPTION
## What & why

Third #499 target (next-highest after #501/#502): decompose
`(*appServerClient).run` — the Codex app-server JSON-RPC session driver —
a single **gocognit 46 / ~145-line** function that fused per-run config
caching, the SPEC §10.1 handshake, and the whole turn loop. Split along
upstream Symphony's `start_session` / `start_turn` / `run_turn` seam
(`elixir/lib/symphony_elixir/codex/app_server.ex`):

| helper | responsibility |
|---|---|
| `initSession` | cache sinks + per-run codex config off `RunInput` |
| `startThread` | initialize → initialized → thread/start handshake |
| `runSingleTurn` | one turn: start, await, classify error, §16.5 refresh gate |
| `startTurn` | turn/start + turn-id resolution (startup-failed on turn 1) |
| `turnInput` | first-turn prompt vs continuation nudge |
| `recordFirstTurnStarted` | once-per-run `session_started` event + phase transition |
| `classifyTurnError` | stall / turn-timeout / passthrough mapping |

`run` now reads as `init → startThread → loop(runSingleTurn) → max-turns error`.

**Zero behavior change.** The handshake order and `recordStartupFailed`
phases, the `maxTurns<=0 → 20` default, the `turn==1` gates (session_started,
turn/start startup-failed), the `continueRun` reset/return, the §16.5
refresh-active gate, the per-turn timeout context, and `classifyTurnError`'s
use of the **outer** ctx for the deadline discriminator are all identical.
The `keepGoing` contract maps the original inline `return nil`/`return err`/
continue faithfully: `(false,nil)` = clean stop / §16.5 self-stop, `(false,err)`
= abort, `(true,nil)` = next turn.

## Acceptance criteria (#499, for `run`)

- [x] **Characterization first.** The existing app-server integration suite is
  the safety net; I validated it as non-placebo by mutating the **un-decomposed**
  `run` (refresh-active gate, continueRun gate, session-started-once gate,
  turn-timeout classification) and confirming each mutation fails the suite — no
  gap found, so no redundant test was added.
- [x] **Decomposed** into single-concern helpers; the read goroutine + per-turn
  `context.WithTimeout` are unchanged from origin/main.
- [x] **gocognit eliminated:** `run` **46 → eliminated**; every helper ≤10 and
  ≤80 lines (file 645 < 800). No new gocognit/funlen findings.
- [x] **Mutation-verified non-placebo** against the **decomposed committed**
  artifact: the same 4 routing mutations each fail the matching test; tree
  restored to HEAD after each.
- [x] **No new deviation, no external API change.** Blocking golangci gate
  (`staticcheck`/`unparam`/…) run locally before push: 0 issues.

Out of scope (separate #499 PRs): `(CodexAppServerRunner).Run` (29),
`parseRetryAfterText` (24), `handleDynamicToolCall` (20), and the orchestrator
`retryFireOp.apply` (30) / `dispatchOp.apply` (22) / reconcile hotspots.

## Verification

```
gofmt -l $(git ls-files '*.go')                                   # clean
golangci-lint ... --enable-only=...,staticcheck,unparam,unused ./...  # 0 issues (blocking gate)
go vet ./internal/runner/... ; go mod tidy                        # clean
go test -race ./...                                               # green (see note)
go build ./cmd/worker ./cmd/tui                                   # ok
```

Note: `TestCodexAppServerInitializeTimeoutDiagnostics` (untouched, initialize
path) fails **locally only** — the Python `codex` stub does not write its
started-log in this sandbox; it passes in CI. Not a regression.

## Review

Pre-push dual diff-only review (protocol §3): an independent
behavior-preservation pass and a `feature-dev:code-reviewer` pass both returned
**MERGE-READY** with no findings, each verifying handshake order, startup-failed
phases, the `turn==1` gates, `classifyTurnError`'s outer-ctx discriminator, the
§16.5 gate, and the `keepGoing` contract line-by-line. The second reviewer also
ran the blocking golangci gate independently (0 issues).

**Codex review remains unavailable** on both paths (expired local CLI token +
GitHub bot usage limit — see #501/#502). `@codex review` is triggered on this
head; if still limited, the independent dual review is the protocol §4
compensation.

Pre-existing observations the reviewers surfaced (NOT introduced here, out of
scope): the `readLine` goroutine lacks `safeGo`/`recoverPanic`, and
`isAppServerReadTimeout` string-matches error text (AGENTS.md rule 8) — both in
untouched code; candidates for a follow-up, not this PR.

## Size gate

`size-gated: justified overage` — +147/-90, dominated by re-indented verbatim
handshake/turn bodies + carried comments; no test added (existing validated
suite is the net). Needs human size-gate sign-off (merge requires explicit
permission per protocol §8).

Refs #499
