### PR TITLE
refactor(orchestrator): decompose retryFireOp.apply into guard/wake/fetch helpers (#499)

### DIFF
--- a/internal/orchestrator/actor_retry.go
+++ b/internal/orchestrator/actor_retry.go
@@ -260,114 +260,158 @@ type retryFireOp struct {
 	kind    RetryKind
 }
 
-func (r *retryFireOp) apply(st *OrchestratorState) func() {
-	entry, ok := st.RetryAttempts[r.id]
+// matchingRetryEntry returns the queued RetryEntry for id only while it still
+// matches this fire's (attempt, kind) identity, and false otherwise. The two
+// false cases both mean "drop this fire as a no-op": (1) the entry is absent —
+// already consumed by reconciliation's ReleaseClaim or by an earlier fire of
+// the same retry; and (2) a newer ScheduleRetry replaced the entry with a
+// different attempt/kind, so an older timer fired late (the Stop()-missed race,
+// SPEC §16.6). It mirrors upstream pop_retry_attempt_state's :missing result
+// (orchestrator.ex:1045-1060) minus the pop — the Go port keeps the entry in
+// RetryAttempts across the async candidate fetch and re-checks this guard at
+// every actor re-entry (retryFireOp, retryPollFailedOp, retryFireAfterFetchOp).
+// The returned *RetryEntry is the live pointer from the map, so callers'
+// in-place mutations (entry.Timer, entry.Issue, entry.Identifier) still reach
+// the stored struct.
+func matchingRetryEntry(st *OrchestratorState, id IssueID, attempt int, kind RetryKind) (*RetryEntry, bool) {
+	entry, ok := st.RetryAttempts[id]
 	if !ok {
-		// Already consumed by reconciliation (ReleaseClaim) or by an
-		// earlier fire of the same retry. Either is correct.
-		return nil
+		return nil, false
 	}
-	if entry.Attempt != r.attempt || entry.Kind != r.kind {
-		// A newer ScheduleRetry replaced this entry; the older timer
-		// fired late. Drop the stale fire — the newer entry will
-		// re-dispatch on its own timer.
+	if entry.Attempt != attempt || entry.Kind != kind {
+		return nil, false
+	}
+	return entry, true
+}
+
+func (r *retryFireOp) apply(st *OrchestratorState) func() {
+	entry, ok := matchingRetryEntry(st, r.id, r.attempt, r.kind)
+	if !ok {
 		return nil
 	}
 	if entry.Kind == RetryKindContinuation || entry.Kind == RetryKindExternalBlocker {
-		// Continuation and external-blocker cooldown retries are wake-up
-		// signals. They must not spawn from the cached issue snapshot or carry
-		// failure retry accounting: a poll has to observe the issue still
-		// active and call RequestDispatchAfterTrackerRecheck, which consumes
-		// the entry before spawning the next normal turn.
-		entry.Timer = nil
-		o := r.o
-		return func() { o.wakeRetryPollLoop() }
+		return r.fireWakeSignal(entry)
 	}
-	// SPEC §16.6 on_retry_timer: the fired failure-retry timer must (1)
-	// fetch active candidates, (2) re-schedule with "retry poll failed"
-	// on fetch error, (3) release the claim if the issue is absent, and
-	// only then (4/5) dispatch from the refreshed tracker state. When a
-	// CandidateLister is wired (production via RuntimePoller) we defer
-	// the I/O to a followup; without one we fall back to direct dispatch
-	// from the cached entry.Issue so existing unit tests keep working.
 	o := r.o
 	if lister := o.currentCandidateLister(); lister != nil {
-		entry.Timer = nil
-		id := r.id
-		attempt := r.attempt
-		kind := r.kind
-		return func() {
-			// Per-fetch timeout. The followup runs on a fresh goroutine
-			// outside the actor, and o.runCtx has no deadline of its own.
-			// A tracker client that ignores ctx cancellation would otherwise
-			// pin this goroutine indefinitely — entry.Timer is already
-			// cleared and no retryFireOp would be resubmitted, leaving the
-			// issue stuck in Claimed/RetryAttempts forever. Surfacing the
-			// timeout as a "retry poll failed" reschedule keeps the SPEC
-			// §16.6 backoff window the only source of forward progress.
-			fetchCtx, cancel := context.WithTimeout(o.runCtx, retryFetchTimeout)
-			defer cancel()
-			issues, fetchErr := lister.ListActiveIssues(fetchCtx)
-			found := findIssueByID(issues, id)
-			if fetchErr != nil && found == nil {
-				// Either the whole fetch failed (including timeout), or a
-				// multi-tracker partial failure happened on the tracker that
-				// owns this issue. We can't tell "absent" from "tracker down"
-				// — treat as fetch failure per SPEC §16.6 and reschedule
-				// with the typed error.
-				_ = o.submit(o.runCtx, &retryPollFailedOp{
-					o:        o,
-					id:       id,
-					attempt:  attempt,
-					kind:     kind,
-					fetchErr: fetchErr,
-				})
-				return
-			}
-			// found==nil means the issue is not in the active candidate set:
-			// terminal, merely-inactive, or deleted. The active-only fetch
-			// cannot tell them apart, so resolve the actual state (the way the
-			// reconcile pass does) to recover upstream handle_retry_issue_lookup's
-			// terminal branch — terminal → clean the workspace + release, every
-			// other absence → release only (#341). Resolver errors / unknown
-			// states leave terminal=false, preserving the release-only default.
-			terminal := false
-			terminalState := ""
-			if found == nil {
-				if resolver, terminalStates := o.currentRetryTerminalResolver(); resolver != nil && len(terminalStates) > 0 {
-					// Give the terminal-state lookup its own timeout budget rather
-					// than the already-consumed fetchCtx: a slow-but-successful
-					// ListActiveIssues near the deadline would otherwise leave this
-					// call to fail immediately with context-deadline-exceeded,
-					// dropping a terminal issue onto the release-only path and
-					// leaking its workspace — the exact leak this resolves (Codex
-					// P2). Derived from runCtx so actor shutdown still cancels it.
-					resolveCtx, resolveCancel := context.WithTimeout(o.runCtx, retryFetchTimeout)
-					statesByID, rerr := fetchIssueStates(resolveCtx, resolver, []tracker.IssueRef{{
-						ID:         string(id),
-						Identifier: entry.Identifier,
-					}})
-					resolveCancel()
-					if rerr == nil {
-						if s := strings.TrimSpace(statesByID[string(id)]); s != "" && isTerminalTrackerState(s, terminalStates) {
-							terminal = true
-							terminalState = s
-						}
-					}
-				}
-			}
-			_ = o.submit(o.runCtx, &retryFireAfterFetchOp{
-				o:             o,
-				id:            id,
-				attempt:       attempt,
-				kind:          kind,
-				found:         found,
-				terminal:      terminal,
-				terminalState: terminalState,
-			})
-		}
+		return r.fireWithCandidateFetch(entry, lister)
 	}
+	// No CandidateLister wired (unit-test fallback): dispatch directly from the
+	// cached entry.Issue. Production always wires one via RuntimePoller.
 	return retryFireDispatchTail(st, entry, r.id, r.attempt, o)
+}
+
+// fireWakeSignal handles a fired continuation or external-blocker cooldown
+// retry. Both kinds are wake-up signals, not dispatches: they must not spawn
+// from the cached issue snapshot or carry failure-retry accounting. The entry
+// stays in RetryAttempts (timer cleared) and the followup wakes the poll loop;
+// a poll then observes the issue still active and calls
+// RequestDispatchAfterTrackerRecheck, which consumes the entry before spawning
+// the next normal turn.
+func (r *retryFireOp) fireWakeSignal(entry *RetryEntry) func() {
+	entry.Timer = nil
+	o := r.o
+	return func() { o.wakeRetryPollLoop() }
+}
+
+// fireWithCandidateFetch builds the SPEC §16.6 on_retry_timer followup for a
+// fired failure/quota retry when a CandidateLister is wired: (1) fetch active
+// candidates, (2) reschedule with "retry poll failed" on fetch error, (3)
+// release the claim if the issue is absent, and only then (4/5) dispatch from
+// the refreshed tracker state. The actor-side timer clear happens here (before
+// the followup is returned) so a subsequent ScheduleRetry's Stop() is a no-op
+// on the already-fired timer; the entry is NOT popped — it stays in
+// RetryAttempts so the post-fetch ops re-validate it under actor serialization.
+// id/attempt/kind/identifier are captured by value (not the op or the entry
+// pointer) because the returned closure runs off-actor.
+func (r *retryFireOp) fireWithCandidateFetch(entry *RetryEntry, lister ActiveIssueLister) func() {
+	entry.Timer = nil
+	o := r.o
+	id := r.id
+	attempt := r.attempt
+	kind := r.kind
+	identifier := entry.Identifier
+	return func() {
+		// Per-fetch timeout. The followup runs on a fresh goroutine outside the
+		// actor, and o.runCtx has no deadline of its own. A tracker client that
+		// ignores ctx cancellation would otherwise pin this goroutine
+		// indefinitely — entry.Timer is already cleared and no retryFireOp would
+		// be resubmitted, leaving the issue stuck in Claimed/RetryAttempts
+		// forever. Surfacing the timeout as a "retry poll failed" reschedule
+		// keeps the SPEC §16.6 backoff window the only source of forward progress.
+		fetchCtx, cancel := context.WithTimeout(o.runCtx, retryFetchTimeout)
+		defer cancel()
+		issues, fetchErr := lister.ListActiveIssues(fetchCtx)
+		found := findIssueByID(issues, id)
+		if fetchErr != nil && found == nil {
+			// Either the whole fetch failed (including timeout), or a
+			// multi-tracker partial failure happened on the tracker that owns
+			// this issue. We can't tell "absent" from "tracker down" — treat as
+			// fetch failure per SPEC §16.6 and reschedule with the typed error.
+			_ = o.submit(o.runCtx, &retryPollFailedOp{
+				o:        o,
+				id:       id,
+				attempt:  attempt,
+				kind:     kind,
+				fetchErr: fetchErr,
+			})
+			return
+		}
+		// found==nil means the issue is not in the active candidate set:
+		// terminal, merely-inactive, or deleted. The active-only fetch cannot
+		// tell them apart, so resolve the actual state (the way the reconcile
+		// pass does) to recover upstream handle_retry_issue_lookup's terminal
+		// branch — terminal → clean the workspace + release, every other absence
+		// → release only (#341).
+		terminal := false
+		terminalState := ""
+		if found == nil {
+			terminal, terminalState = resolveRetryTerminalState(o, id, identifier)
+		}
+		_ = o.submit(o.runCtx, &retryFireAfterFetchOp{
+			o:             o,
+			id:            id,
+			attempt:       attempt,
+			kind:          kind,
+			found:         found,
+			terminal:      terminal,
+			terminalState: terminalState,
+		})
+	}
+}
+
+// resolveRetryTerminalState reproduces the reconcile pass's terminal-vs-absent
+// classification for a fired failure-retry whose issue is absent from the active
+// candidate set, recovering upstream handle_retry_issue_lookup's terminal branch
+// that the active-only fetch collapses into plain absence (#341). It returns
+// (true, state) only when a resolver is wired and reports a terminal state;
+// every other outcome (no resolver, fetch error, empty/non-terminal state)
+// returns (false, "") so the caller keeps the release-only default. Runs
+// off-actor; the lookup gets its OWN timeout budget rather than reusing the
+// already-consumed candidate-fetch ctx, because a slow-but-successful fetch near
+// the deadline would otherwise fail this call immediately with
+// context-deadline-exceeded, dropping a terminal issue onto the release-only
+// path and leaking its workspace (Codex P2). Derived from runCtx so actor
+// shutdown still cancels it.
+func resolveRetryTerminalState(o *Orchestrator, id IssueID, identifier string) (terminal bool, terminalState string) {
+	resolver, terminalStates := o.currentRetryTerminalResolver()
+	if resolver == nil || len(terminalStates) == 0 {
+		return false, ""
+	}
+	resolveCtx, resolveCancel := context.WithTimeout(o.runCtx, retryFetchTimeout)
+	statesByID, rerr := fetchIssueStates(resolveCtx, resolver, []tracker.IssueRef{{
+		ID:         string(id),
+		Identifier: identifier,
+	}})
+	resolveCancel()
+	if rerr != nil {
+		return false, ""
+	}
+	s := strings.TrimSpace(statesByID[string(id)])
+	if s == "" || !isTerminalTrackerState(s, terminalStates) {
+		return false, ""
+	}
+	return true, s
 }
 
 // retryFireDispatchTail runs the post-fetch tail of a failure-retry fire:
@@ -470,14 +514,10 @@ type retryPollFailedOp struct {
 }
 
 func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
-	entry, ok := st.RetryAttempts[r.id]
+	entry, ok := matchingRetryEntry(st, r.id, r.attempt, r.kind)
 	if !ok {
-		// Reconciliation released the claim between fetch and apply.
-		return nil
-	}
-	if entry.Attempt != r.attempt || entry.Kind != r.kind {
-		// Replaced by a newer ScheduleRetry; the newer entry owns the
-		// re-dispatch.
+		// Entry absent (reconciliation released the claim between fetch and
+		// apply) or replaced by a newer ScheduleRetry that owns the re-dispatch.
 		return nil
 	}
 	o := r.o
@@ -539,11 +579,8 @@ type retryFireAfterFetchOp struct {
 }
 
 func (r *retryFireAfterFetchOp) apply(st *OrchestratorState) func() {
-	entry, ok := st.RetryAttempts[r.id]
+	entry, ok := matchingRetryEntry(st, r.id, r.attempt, r.kind)
 	if !ok {
-		return nil
-	}
-	if entry.Attempt != r.attempt || entry.Kind != r.kind {
 		return nil
 	}
 	if r.found == nil {

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -3313,6 +3313,146 @@ func TestRetryFire_DropsStaleFailureFireAfterContinuationReplacement(t *testing.
 	}
 }
 
+// TestRetryFire_DropsFireWhenEntryAlreadyConsumed pins the entry-absent guard of
+// (*retryFireOp).apply (the upstream pop_retry_attempt_state :missing case,
+// orchestrator.ex:1057-1058). A retry timer can fire after reconciliation's
+// ReleaseClaim, or an earlier fire of the same retry, already removed the entry;
+// the late fire must be a no-op rather than dispatching from the stale snapshot.
+func TestRetryFire_DropsFireWhenEntryAlreadyConsumed(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	o := New(st, Deps{Dispatcher: disp})
+
+	issueID := IssueID("ENG-GONE")
+	followup := (&retryFireOp{
+		o:       o,
+		id:      issueID,
+		issue:   tracker.Issue{ID: string(issueID), Identifier: "ENG-GONE", State: "Needs Fix"},
+		attempt: 1,
+		kind:    RetryKindFailure,
+	}).apply(st)
+	if followup != nil {
+		t.Fatal("fire for already-consumed entry returned a followup, want nil no-op")
+	}
+	if got := disp.count(); got != 0 {
+		t.Fatalf("Dispatcher.Spawn calls = %d, want 0 for absent retry entry", got)
+	}
+	if len(st.Running) != 0 {
+		t.Fatalf("running after absent-entry fire = %+v, want none", st.Running)
+	}
+	if _, ok := st.RetryAttempts[issueID]; ok {
+		t.Fatal("absent-entry fire created a retry entry, want none")
+	}
+}
+
+// TestRetryFire_DropsStaleFireAfterAttemptBumpReplacement pins the attempt arm of
+// the stale-fire guard (entry.Attempt != r.attempt). The existing stale-fire
+// tests only vary Kind; this one keeps Kind constant and varies the attempt, so
+// the (Attempt,Kind) identity check that catches a Stop()-missed late timer is
+// pinned on both arms of the OR (mirrors upstream's make_ref token mismatch,
+// orchestrator.ex:1047).
+func TestRetryFire_DropsStaleFireAfterAttemptBumpReplacement(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	o := New(st, Deps{Dispatcher: disp})
+
+	issueID := IssueID("ENG-ATT")
+	issue := tracker.Issue{ID: string(issueID), Identifier: "ENG-ATT", State: "Needs Fix", Title: "bumped"}
+	// Live entry is attempt 3 (a newer ScheduleRetry bumped it); the late timer
+	// fires for attempt 2 of the same kind.
+	st.ScheduleRetry(&RetryEntry{
+		Issue:      issue,
+		IssueID:    issueID,
+		Identifier: issue.Identifier,
+		Attempt:    3,
+		Kind:       RetryKindFailure,
+	})
+
+	followup := (&retryFireOp{
+		o:       o,
+		id:      issueID,
+		issue:   issue,
+		attempt: 2,
+		kind:    RetryKindFailure,
+	}).apply(st)
+	if followup != nil {
+		t.Fatal("stale attempt fire returned a followup, want it dropped before side effects")
+	}
+	if got := disp.count(); got != 0 {
+		t.Fatalf("stale attempt fire spawned %d workers, want 0", got)
+	}
+	entry, ok := st.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("stale attempt fire consumed the replacement retry")
+	}
+	if entry.Attempt != 3 {
+		t.Fatalf("replacement retry attempt = %d, want 3 preserved", entry.Attempt)
+	}
+	if !st.IsClaimed(issueID) {
+		t.Fatal("stale attempt fire released claim for replacement retry")
+	}
+}
+
+// TestRetryFire_ExternalBlockerFireWakesPollLoopWithoutDispatch pins the
+// external-blocker arm of the wake-only branch of (*retryFireOp).apply. Until
+// now only the continuation arm of that shared OR condition was exercised
+// (TestContinuationRetryTimerRequiresTrackerRecheckedDispatch), and that test
+// drives the eventual dispatch via an explicit RequestDispatchAfterTrackerRecheck
+// — so deleting the wake-emission call would not fail it. This test fires an
+// external-blocker timer straight into apply and asserts (a) the entry is
+// retained for the tracker recheck, (b) its timer is cleared, (c) nothing
+// dispatches from the cached snapshot, and (d) the followup actually queues a
+// poll wake (closing the placebo gap for both wake arms).
+func TestRetryFire_ExternalBlockerFireWakesPollLoopWithoutDispatch(t *testing.T) {
+	disp := &fakeDispatcher{}
+	st := NewOrchestratorState(15000, 10)
+	o := New(st, Deps{Dispatcher: disp})
+
+	issueID := IssueID("ENG-BLOCK")
+	issue := tracker.Issue{ID: string(issueID), Identifier: "ENG-BLOCK", State: "Blocked", Title: "external blocker"}
+	timer := time.AfterFunc(time.Hour, func() {})
+	defer timer.Stop()
+	st.ScheduleRetry(&RetryEntry{
+		Issue:      issue,
+		IssueID:    issueID,
+		Identifier: issue.Identifier,
+		Attempt:    0,
+		Timer:      timer,
+		Kind:       RetryKindExternalBlocker,
+	})
+
+	followup := (&retryFireOp{
+		o:       o,
+		id:      issueID,
+		issue:   issue,
+		attempt: 0,
+		kind:    RetryKindExternalBlocker,
+	}).apply(st)
+	if followup == nil {
+		t.Fatal("external-blocker fire returned nil, want a poll-wake followup")
+	}
+
+	entry, ok := st.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("external-blocker fire consumed the retry entry, want it retained for tracker recheck")
+	}
+	if entry.Timer != nil {
+		t.Fatal("external-blocker fire left entry.Timer set, want it cleared after firing")
+	}
+	if got := disp.count(); got != 0 {
+		t.Fatalf("external-blocker fire spawned %d workers, want 0 (must re-observe via poll)", got)
+	}
+
+	// The followup must actually wake the poll loop; otherwise the cooldown
+	// retry would never be re-observed and the issue would stall in the queue.
+	followup()
+	select {
+	case <-o.retryWakeCh():
+	default:
+		t.Fatal("external-blocker fire followup did not queue a poll wake")
+	}
+}
+
 func TestRetryFire_RespectsPerStateCapacityBeforeSpawning(t *testing.T) {
 	disp := &fakeDispatcher{}
 	st := NewOrchestratorState(15000, 10)


### PR DESCRIPTION
## What & why

Decompose `(*retryFireOp).apply` (gocognit **30**, ~108 lines) — the SPEC §16.6 retry-timer-fire handler on the orchestrator actor state machine — into single-responsibility helpers. **Behavior is unchanged**; this only lowers the blast radius of future edits on a high-risk concurrency path. Part of the #499 batch (continuation of #410's complexity-hotspot decomposition; mirrors #501/#502/#503).

### Decomposition
| new symbol | role |
|---|---|
| `matchingRetryEntry` | the entry-present + `(attempt,kind)` identity guard, now **one source of truth** shared byte-for-byte by `retryFireOp` / `retryPollFailedOp` / `retryFireAfterFetchOp` (was duplicated 3×). Mirrors upstream `pop_retry_attempt_state` `:missing` (orchestrator.ex:1045-1060). |
| `(*retryFireOp).fireWakeSignal` | the continuation / external-blocker wake-only arm. |
| `(*retryFireOp).fireWithCandidateFetch` | the off-actor SPEC §16.6 candidate-fetch followup. |
| `resolveRetryTerminalState` | the `found==nil` terminal-vs-absent classification (#341), flattened from a 4-deep `if` pyramid to guard-clause early-returns. |

### gocognit (`uudashr/gocognit`)
`(*retryFireOp).apply` **30 → 4**; `retryFireAfterFetchOp.apply` → 8, `retryPollFailedOp.apply` → 6, every new helper ≤ 5. No `funlen` regression. Blocking lint gate (`staticcheck,unparam,unused,…`) = 0 issues.

## Behavior preservation (audited)
- Timer clear stays **on-actor** (in `fireWakeSignal`/`fireWithCandidateFetch`, before the followup is returned) — a later `ScheduleRetry`'s `Stop()` is still a no-op on the fired timer.
- Followup captures `id/attempt/kind/identifier` **by value** (not the op or the live entry pointer); it runs off-actor and is launched via the existing `safeGo` panic guard. The eager `identifier` capture is equivalent to the original lazy read: `resolveRetryTerminalState` runs only when `found==nil`, and `entry.Identifier` is mutated only on the `found!=nil` path — mutually exclusive per fetch.
- **Both** `context.WithTimeout(o.runCtx, retryFetchTimeout)` budgets preserved (candidate fetch + separate terminal resolve); `resolveCancel()` kept explicit to mirror the pre-refactor prompt-cancel.
- Shared `matchingRetryEntry` returns the live `*RetryEntry` map pointer, so `retryFireAfterFetchOp`'s `entry.Issue`/`entry.Identifier` mutations still reach the stored struct.

## Acceptance criteria (#499)
- [x] **Characterization tests added before the refactor**, mutation-verified non-placebo. Three new tests pin apply branches the prior suite left uncovered: entry-absent no-op (branch 1), stale **attempt**-bump drop (the attempt arm of the identity guard — previously only the kind arm was pinned), and external-blocker wake (asserts the poll wake actually fires via `retryWakeCh()`, closing the shared wake-arm placebo).
- [x] Decompose into single-responsibility helpers, BEAM guarantees preserved (followup `context.WithTimeout`, `safeGo`, on-actor timer clear), **behavior zero-change**.
- [x] `gocognit`/`funlen` finding for `retryFireOp.apply` eliminated (30→4); mutation-verified.
- [x] No new deviation, no external API change.

## Verification
```
gofmt -l $(git ls-files '*.go')        # empty
go vet ./...                            # clean
go mod tidy && git diff --exit-code     # clean
golangci-lint --enable-only=…,staticcheck,unparam,unused  # 0 issues
go test -race -covermode=atomic ./internal/orchestrator/  # ok, 84.9% cov
go build ./cmd/worker ./cmd/tui         # ok
```
- New tests: `-race -count=200` → 0 flake (deterministic; direct `.apply()`, no actor/timers).
- **Mutation (against committed artifact `4363adab01dc0aec2eabfc04c4104b4bec30c4ed`)**: break `matchingRetryEntry` not-found guard / attempt arm / `fireWakeSignal` wake emission / apply's external-blocker OR arm → each matching test **FAILS**; `git checkout` restores; tree == HEAD.

## Current state (head 4363ada)
- **CI: green** — run 26630460807, 4/4 checks pass (Go build and test, E2E Gitea mock loop, Security and supply-chain, Docker image build).
- **Review threads: 0** unresolved, non-outdated, actionable (GraphQL).
- Merge-ready **pending human size-gate sign-off** (justified overage) + explicit merge permission.

## Pre-push dual review (diff-only)
- **Reviewer A (Claude `feature-dev:code-reviewer`):** initial HIGH on eager `identifier` capture, **self-resolved to behaviorally-equivalent** under adversarial re-analysis; remaining = LOW (test `t.Fatal` on a `func()` value, rule-9). 
- **Reviewer B (Claude `feature-dev:code-reviewer`, behavior-equivalence lens):** **MERGE-READY**, all 7 checklist items equivalent, 3 tests confirmed non-placebo; one LOW (`defer` vs explicit `resolveCancel()`).
- **Codex family unavailable on BOTH paths**: local CLI reviewer (access-token expired) **and** the GitHub `@codex review` bot (account **usage limit** reached for code reviews — bot replied with the limit message, no review produced). Per protocol §4.4, compensated by the two independent Claude-family diff-only reviews above; disclosed here.

### Recorded LOW decisions (not changed)
1. `followup != nil` checks use bare `t.Fatal` — consistent with every existing `TestRetryFire_*` in the file; the message states actual-vs-expected for a binary condition and `%v` of a `func()` is a non-diagnostic address.
2. `resolveRetryTerminalState` keeps **explicit** `resolveCancel()` to exactly mirror the pre-refactor code (zero behavior change); no early-return exists between `WithTimeout` and the cancel, so no leak.

## Deferral
- **#505** — pre-existing 1ms-`due_at` race in continuation/external-blocker recheck tests (e.g. `TestFinalize_ContinuationBudgetExhaustedEmitsStderrLine`). Mechanism is in untouched code (`dispatchOp.apply` IsDue gate); **not introduced here**. Filed for a deterministic-barrier sweep across all recheck sites.

### Size gate
- [ ] `within budget`
- [x] `size-gated: justified overage` — rationale: 2 files / 395 churn LOC (added+deleted) > 300. Pure behavior-zero-change decomposition + the acceptance-criterion-mandated, mutation-verified characterization tests, which cannot be split from the refactor without losing the safety atomicity the issue requires (same bundling as #501/#502/#503). No scope creep; needs human size-gate sign-off before merge.
- [ ] `size-gated: split recommended`

Refs #499.
