### PR TITLE
refactor(runner): decompose CodexAppServerRunner.Run into setup/pipe/classify helpers (#499)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -48,35 +49,13 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		return Result{}, fmt.Errorf("read %s: %w", PromptPath, err)
 	}
 
-	env := agentEnv(in.Workflow.Config.Codex.EnvPassthrough, in.Workflow.Config)
-	cmd, directCodexExec, err := buildCodexAppServerCmd(ctx, in, env)
+	cmd, directCodexExec, sandboxEnabled, err := setupAppServerCommand(ctx, in)
 	if err != nil {
 		return Result{}, err
 	}
-	cmd.Dir = in.Workdir
-	cmd.Env = env
-	if err := validateAgentCommandWorkdir(in, cmd); err != nil {
-		return Result{}, err
-	}
-	sandboxEnabled := in.Workflow.Config.Sandbox.Enabled && in.Workflow.Config.Sandbox.Backend != "" && in.Workflow.Config.Sandbox.Backend != "none"
-	cmd, err = applySandbox(ctx, in, cmd)
+	stdin, stdout, stderr, err := openAppServerPipes(cmd)
 	if err != nil {
 		return Result{}, err
-	}
-	configurePlatformKill(cmd)
-	cmd.WaitDelay = killGrace
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return Result{}, fmt.Errorf("open codex app-server stdin: %w", err)
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return Result{}, fmt.Errorf("open codex app-server stdout: %w", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return Result{}, fmt.Errorf("open codex app-server stderr: %w", err)
 	}
 
 	buf := &cappedWriter{Cap: CodexOutputCap}
@@ -96,22 +75,11 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 	// so passing maxAppServerLineBytes+1 as the cap allows tokens up to (and
 	// including) maxAppServerLineBytes and rejects anything strictly larger.
 	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
-	// Only emit codex_app_server_pid when we can guarantee cmd.Process.Pid is
-	// the actual codex process: the command must launch the codex binary
-	// directly (no shell wrapper from a custom codex.command), and the
-	// sandbox must not have wrapped cmd in firejail/bwrap. In any wrapper
-	// scenario the PID belongs to the wrapper, which would mislead operators
-	// trying to map `/api/v1/state` rows to a host process. omitempty makes
-	// the JSON field absent in those cases.
-	pid := 0
-	if directCodexExec && !sandboxEnabled && cmd.Process != nil {
-		pid = cmd.Process.Pid
-	}
 	client := &appServerClient{
 		stdin:             stdin,
 		scanner:           sc,
 		out:               buf,
-		codexAppServerPID: pid,
+		codexAppServerPID: appServerProcessPID(cmd, directCodexExec, sandboxEnabled),
 	}
 	runErr := client.run(ctx, in, string(prompt))
 	if runErr != nil && ctx.Err() == nil {
@@ -134,33 +102,111 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		res.OutputHead = string(head)
 	}
 	res.OutputTail = tail
+	return classifyAppServerOutcome(ctx, res, runErr, waitErr, client.readTimeoutMs, start, elapsed)
+}
 
-	if runErr != nil {
-		var stall *StallError
-		if errors.As(runErr, &stall) {
-			return res, runErr
-		}
-		if isAppServerReadTimeout(runErr) {
-			return res, &ReadTimeoutError{Timeout: time.Duration(client.readTimeoutMs) * time.Millisecond, Cause: runErr}
-		}
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: runErr}
-		}
-		if _, ok := ErrorCategory(runErr); ok {
-			return res, runErr
-		}
-		if waitErr != nil {
-			return res, NewError(CategoryPortExit, "codex app-server process exited", errors.Join(runErr, waitErr))
-		}
+// setupAppServerCommand builds the `codex app-server` *exec.Cmd ready to start:
+// it resolves the agent env, constructs the command, pins its workdir/env,
+// validates the command's workdir, applies the sandbox wrapper, and configures
+// the platform kill + WaitDelay. directCodexExec reports whether the command
+// launches codex directly (vs a shell wrapper) and sandboxEnabled whether the
+// sandbox wraps it — both feed appServerProcessPID's PID-emission guard.
+func setupAppServerCommand(ctx context.Context, in RunInput) (cmd *exec.Cmd, directCodexExec, sandboxEnabled bool, err error) {
+	env := agentEnv(in.Workflow.Config.Codex.EnvPassthrough, in.Workflow.Config)
+	cmd, directCodexExec, err = buildCodexAppServerCmd(ctx, in, env)
+	if err != nil {
+		return nil, false, false, err
+	}
+	cmd.Dir = in.Workdir
+	cmd.Env = env
+	if err := validateAgentCommandWorkdir(in, cmd); err != nil {
+		return nil, false, false, err
+	}
+	sandboxEnabled = in.Workflow.Config.Sandbox.Enabled && in.Workflow.Config.Sandbox.Backend != "" && in.Workflow.Config.Sandbox.Backend != "none"
+	cmd, err = applySandbox(ctx, in, cmd)
+	if err != nil {
+		return nil, false, false, err
+	}
+	configurePlatformKill(cmd)
+	cmd.WaitDelay = killGrace
+	return cmd, directCodexExec, sandboxEnabled, nil
+}
+
+// openAppServerPipes wires the subprocess's stdio. Each pipe error carries the
+// stream name so a setup failure is attributable; callers return the wrapped
+// error verbatim.
+func openAppServerPipes(cmd *exec.Cmd) (stdin io.WriteCloser, stdout, stderr io.ReadCloser, err error) {
+	stdin, err = cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("open codex app-server stdin: %w", err)
+	}
+	stdout, err = cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("open codex app-server stdout: %w", err)
+	}
+	stderr, err = cmd.StderrPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("open codex app-server stderr: %w", err)
+	}
+	return stdin, stdout, stderr, nil
+}
+
+// appServerProcessPID returns cmd.Process.Pid only when it is guaranteed to be
+// the actual codex process: the command must launch the codex binary directly
+// (no shell wrapper from a custom codex.command) and the sandbox must not have
+// wrapped cmd in firejail/bwrap. In any wrapper scenario the PID belongs to the
+// wrapper, which would mislead operators trying to map `/api/v1/state` rows to a
+// host process; returning 0 makes the omitempty JSON field absent. Call after
+// cmd.Start() so cmd.Process is populated.
+func appServerProcessPID(cmd *exec.Cmd, directCodexExec, sandboxEnabled bool) int {
+	if directCodexExec && !sandboxEnabled && cmd.Process != nil {
+		return cmd.Process.Pid
+	}
+	return 0
+}
+
+// classifyAppServerOutcome maps a completed app-server run to the (Result, error)
+// the worker finalize path consumes. The precedence is load-bearing: the worker
+// (internal/worker/runtask.go) switches on the error TYPE to pick the terminal
+// phase (stall, read/run timeout, port exit, generic failure), so a run-loop
+// error is classified StallError → read-timeout → outer-deadline TimeoutError →
+// already-categorized error → process-exit PortExit → bare runErr, in that order.
+// res is returned on every path so output telemetry survives the error.
+func classifyAppServerOutcome(ctx context.Context, res Result, runErr, waitErr error, readTimeoutMs int, start time.Time, elapsed time.Duration) (Result, error) {
+	if runErr == nil {
+		return classifyAppServerProcessExit(ctx, res, waitErr, start, elapsed)
+	}
+	var stall *StallError
+	if errors.As(runErr, &stall) {
+		return res, runErr
+	}
+	if isAppServerReadTimeout(runErr) {
+		return res, &ReadTimeoutError{Timeout: time.Duration(readTimeoutMs) * time.Millisecond, Cause: runErr}
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: runErr}
+	}
+	if _, ok := ErrorCategory(runErr); ok {
 		return res, runErr
 	}
 	if waitErr != nil {
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: waitErr}
-		}
-		return res, NewError(CategoryPortExit, "codex app-server process exited", waitErr)
+		return res, NewError(CategoryPortExit, "codex app-server process exited", errors.Join(runErr, waitErr))
 	}
-	return res, nil
+	return res, runErr
+}
+
+// classifyAppServerProcessExit handles the runErr==nil tail of
+// classifyAppServerOutcome: a clean run loop whose subprocess still exited
+// non-zero is an outer-deadline TimeoutError (if the run ctx deadline fired) or
+// a PortExit, and an exitless clean run is success.
+func classifyAppServerProcessExit(ctx context.Context, res Result, waitErr error, start time.Time, elapsed time.Duration) (Result, error) {
+	if waitErr == nil {
+		return res, nil
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: waitErr}
+	}
+	return res, NewError(CategoryPortExit, "codex app-server process exited", waitErr)
 }
 func validateAppServerWorkdir(workdir string) error {
 	if strings.TrimSpace(workdir) == "" {

--- a/internal/runner/codex_app_server_classify_test.go
+++ b/internal/runner/codex_app_server_classify_test.go
@@ -1,0 +1,188 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// deadlineExceededCtx returns a context whose Err() is context.DeadlineExceeded,
+// so the classifier's outer-deadline branch is exercised deterministically.
+func deadlineExceededCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	t.Cleanup(cancel)
+	<-ctx.Done()
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("setup: ctx.Err() = %v; want context.DeadlineExceeded", ctx.Err())
+	}
+	return ctx
+}
+
+// readTimeoutRunErr is shaped to trip isAppServerReadTimeout, which matches on
+// the "codex app-server read timeout" substring.
+func readTimeoutRunErr() error {
+	return errors.New("codex app-server read timeout after 5s")
+}
+
+// The classify tests exercise (CodexAppServerRunner).Run's error-classification
+// tail directly. Four of these branches — outer-deadline-with-runErr,
+// runErr+waitErr PortExit join, waitErr-only deadline, waitErr-only PortExit —
+// were unreachable from the Run-level tests (they need a real subprocess to exit
+// with a specific waitErr alongside a chosen runErr/ctx), so extracting
+// classifyAppServerOutcome is what makes them testable. The ordering tests lock
+// the load-bearing precedence the worker finalize path (internal/worker/
+// runtask.go) depends on to pick the run's terminal phase.
+
+func TestClassifyAppServerOutcome_SuccessPreservesResult(t *testing.T) {
+	res := Result{Summary: "done", OutputBytes: 7, OutputTail: "tail"}
+	got, err := classifyAppServerOutcome(context.Background(), res, nil, nil, 1000, time.Now(), time.Second)
+	if err != nil {
+		t.Fatalf("classifyAppServerOutcome(runErr=nil, waitErr=nil) err = %v; want nil", err)
+	}
+	if got.Summary != "done" || got.OutputBytes != 7 || got.OutputTail != "tail" {
+		t.Fatalf("classifyAppServerOutcome success res = %+v; want telemetry preserved %+v", got, res)
+	}
+}
+
+func TestClassifyAppServerOutcome_WaitErrOnlyIsPortExit(t *testing.T) {
+	waitErr := errors.New("exit status 2")
+	res := Result{OutputBytes: 3}
+	got, err := classifyAppServerOutcome(context.Background(), res, nil, waitErr, 1000, time.Now(), time.Second)
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryPortExit {
+		t.Fatalf("classifyAppServerOutcome(runErr=nil, waitErr) category = %q ok=%v; want %q", cat, ok, CategoryPortExit)
+	}
+	if !errors.Is(err, waitErr) {
+		t.Fatalf("classifyAppServerOutcome(runErr=nil, waitErr) err = %v; want it to wrap waitErr %v", err, waitErr)
+	}
+	if got.OutputBytes != 3 {
+		t.Fatalf("classifyAppServerOutcome PortExit res = %+v; want telemetry preserved", got)
+	}
+}
+
+func TestClassifyAppServerOutcome_WaitErrOnlyDeadlineIsTimeout(t *testing.T) {
+	waitErr := errors.New("signal: killed")
+	_, err := classifyAppServerOutcome(deadlineExceededCtx(t), Result{}, nil, waitErr, 1000, time.Now(), time.Second)
+	var te *TimeoutError
+	if !errors.As(err, &te) {
+		t.Fatalf("classifyAppServerOutcome(runErr=nil, waitErr, deadline) err = %v; want *TimeoutError", err)
+	}
+	if !errors.Is(te.Cause, waitErr) {
+		t.Fatalf("TimeoutError.Cause = %v; want it to wrap waitErr %v", te.Cause, waitErr)
+	}
+}
+
+func TestClassifyAppServerOutcome_StallReturnedAsIs(t *testing.T) {
+	runErr := error(&StallError{Timeout: time.Second, Elapsed: 2 * time.Second})
+	_, err := classifyAppServerOutcome(context.Background(), Result{}, runErr, nil, 1000, time.Now(), time.Second)
+	// Passthrough happy path; the StallBeatsDeadline ordering test is the
+	// non-placebo guard that the stall branch is reached before any wrapping.
+	if !IsStall(err) || IsTimeout(err) || IsReadTimeout(err) {
+		t.Fatalf("classifyAppServerOutcome(StallError) err = %v; want the StallError returned unwrapped", err)
+	}
+}
+
+func TestClassifyAppServerOutcome_ReadTimeoutWrapsWithBudget(t *testing.T) {
+	runErr := readTimeoutRunErr()
+	_, err := classifyAppServerOutcome(context.Background(), Result{}, runErr, nil, 5000, time.Now(), time.Second)
+	var rt *ReadTimeoutError
+	if !errors.As(err, &rt) {
+		t.Fatalf("classifyAppServerOutcome(read-timeout runErr) err = %v; want *ReadTimeoutError", err)
+	}
+	if rt.Timeout != 5000*time.Millisecond {
+		t.Fatalf("ReadTimeoutError.Timeout = %v; want 5s from readTimeoutMs=5000", rt.Timeout)
+	}
+	if !errors.Is(rt.Cause, runErr) {
+		t.Fatalf("ReadTimeoutError.Cause = %v; want it to wrap runErr %v", rt.Cause, runErr)
+	}
+}
+
+func TestClassifyAppServerOutcome_DeadlineWithRunErrIsTimeout(t *testing.T) {
+	runErr := errors.New("connection reset")
+	_, err := classifyAppServerOutcome(deadlineExceededCtx(t), Result{}, runErr, nil, 1000, time.Now(), time.Second)
+	var te *TimeoutError
+	if !errors.As(err, &te) {
+		t.Fatalf("classifyAppServerOutcome(runErr, deadline) err = %v; want *TimeoutError", err)
+	}
+	if !errors.Is(te.Cause, runErr) {
+		t.Fatalf("TimeoutError.Cause = %v; want it to wrap runErr %v", te.Cause, runErr)
+	}
+}
+
+func TestClassifyAppServerOutcome_CategorizedReturnedAsIs(t *testing.T) {
+	runErr := error(NewError(CategoryResponseError, "missing field", nil))
+	_, err := classifyAppServerOutcome(context.Background(), Result{}, runErr, nil, 1000, time.Now(), time.Second)
+	cat, ok := ErrorCategory(err)
+	if !ok || cat != CategoryResponseError || IsTimeout(err) {
+		t.Fatalf("classifyAppServerOutcome(categorized runErr) err = %v (category %q ok=%v); want it returned unwrapped", err, cat, ok)
+	}
+}
+
+func TestClassifyAppServerOutcome_RunErrAndWaitErrJoinAsPortExit(t *testing.T) {
+	runErr := errors.New("client loop failed")
+	waitErr := errors.New("exit status 1")
+	_, err := classifyAppServerOutcome(context.Background(), Result{}, runErr, waitErr, 1000, time.Now(), time.Second)
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryPortExit {
+		t.Fatalf("classifyAppServerOutcome(runErr, waitErr) category = %q ok=%v; want %q", cat, ok, CategoryPortExit)
+	}
+	if !errors.Is(err, runErr) || !errors.Is(err, waitErr) {
+		t.Fatalf("classifyAppServerOutcome(runErr, waitErr) err = %v; want it to join both runErr and waitErr", err)
+	}
+}
+
+func TestClassifyAppServerOutcome_BareRunErrReturnedAsIs(t *testing.T) {
+	runErr := errors.New("opaque failure")
+	_, err := classifyAppServerOutcome(context.Background(), Result{}, runErr, nil, 1000, time.Now(), time.Second)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("classifyAppServerOutcome(bare runErr, no waitErr) err = %v; want runErr returned unwrapped %v", err, runErr)
+	}
+	if _, ok := ErrorCategory(err); ok || IsTimeout(err) || IsReadTimeout(err) {
+		t.Fatalf("classifyAppServerOutcome(bare runErr) err = %v; want no category/timeout wrapping", err)
+	}
+}
+
+// --- precedence/ordering locks ---
+
+func TestClassifyAppServerOutcome_StallBeatsDeadline(t *testing.T) {
+	runErr := error(&StallError{Timeout: time.Second})
+	_, err := classifyAppServerOutcome(deadlineExceededCtx(t), Result{}, runErr, nil, 1000, time.Now(), time.Second)
+	if !IsStall(err) || IsTimeout(err) {
+		t.Fatalf("classifyAppServerOutcome(StallError, deadline) err = %v (IsStall=%v IsTimeout=%v); want StallError to win over the deadline branch", err, IsStall(err), IsTimeout(err))
+	}
+}
+
+func TestClassifyAppServerOutcome_ReadTimeoutBeatsDeadline(t *testing.T) {
+	runErr := readTimeoutRunErr()
+	_, err := classifyAppServerOutcome(deadlineExceededCtx(t), Result{}, runErr, nil, 5000, time.Now(), time.Second)
+	if !IsReadTimeout(err) {
+		t.Fatalf("classifyAppServerOutcome(read-timeout runErr, deadline) err = %v; want *ReadTimeoutError to win over the deadline branch", err)
+	}
+	if IsTimeout(err) {
+		t.Fatalf("classifyAppServerOutcome(read-timeout runErr, deadline) err = %v; must not be classified as *TimeoutError", err)
+	}
+}
+
+func TestClassifyAppServerOutcome_DeadlineBeatsCategorized(t *testing.T) {
+	runErr := error(NewError(CategoryResponseError, "missing field", nil))
+	_, err := classifyAppServerOutcome(deadlineExceededCtx(t), Result{}, runErr, nil, 1000, time.Now(), time.Second)
+	// The deadline branch precedes the ErrorCategory branch: a categorized
+	// runErr that fires under an exceeded deadline is wrapped as *TimeoutError,
+	// not returned bare. If the order flipped, err would be the bare categorized
+	// error (not a TimeoutError).
+	if !IsTimeout(err) {
+		t.Fatalf("classifyAppServerOutcome(categorized runErr, deadline) err = %v; want the deadline branch to wrap it as *TimeoutError", err)
+	}
+}
+
+func TestClassifyAppServerOutcome_CategorizedBeatsPortExit(t *testing.T) {
+	runErr := error(NewError(CategoryResponseError, "missing field", nil))
+	waitErr := errors.New("exit status 1")
+	_, err := classifyAppServerOutcome(context.Background(), Result{}, runErr, waitErr, 1000, time.Now(), time.Second)
+	// The ErrorCategory branch precedes the PortExit-on-waitErr branch: a
+	// categorized runErr is returned as-is even when the process also exited
+	// non-zero. If the order flipped, err would carry CategoryPortExit.
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryResponseError {
+		t.Fatalf("classifyAppServerOutcome(categorized runErr, waitErr) category = %q ok=%v; want %q (categorized wins over PortExit)", cat, ok, CategoryResponseError)
+	}
+}


### PR DESCRIPTION
## What & why

Decompose `(CodexAppServerRunner).Run` (gocognit **29**, ~123 lines) — the `codex app-server` JSON-RPC stdio process lifecycle — into single-responsibility helpers. **Behavior unchanged**; lowers the blast radius on a Codex-protocol path. Part of the #499 batch (continuation of #410; mirrors #501/#502/#503/#506).

### Decomposition
| new symbol | role | gocognit |
|---|---|---|
| `setupAppServerCommand` | env + `buildCodexAppServerCmd` + workdir/env + `validateAgentCommandWorkdir` + `applySandbox` + platform kill/`WaitDelay` | 4 |
| `openAppServerPipes` | the three stdio pipes (per-stream wrapped errors preserved verbatim) | 3 |
| `appServerProcessPID` | the `directCodexExec && !sandboxEnabled` PID-emission gate (operator `/api/v1/state` mapping) + its rationale comment | 2 |
| `classifyAppServerOutcome` | the load-bearing error-classification tail, flattened to nesting-0 guard clauses | 6 |
| `classifyAppServerProcessExit` | the `runErr==nil` tail (deadline `TimeoutError` / `PortExit` / success) | 2 |

`(CodexAppServerRunner).Run` drops **29 → 8**; every new helper ≤ 6. Blocking lint gate (`staticcheck,unparam,unused,errorlint,…`) = 0 issues.

## Behavior preservation (audited; verified byte-identical ordering vs origin/main)
The error-classification **precedence is load-bearing** — `internal/worker/runtask.go` switches on the returned error TYPE via `errors.As`. Preserved exactly:
- `runErr!=nil`: `StallError` → read-timeout → outer-deadline `TimeoutError` → categorized (`ErrorCategory`) → `PortExit` (join) → bare `runErr`.
- `runErr==nil`: deadline `TimeoutError` → `PortExit(waitErr)` → success.
- `res` (Summary/RuntimeEvents/OutputBytes/OutputDropped/OutputHead/OutputTail) returned on **every** path.
- Hazards intact: on-actor `<-stderrDone` before `headTail(buf)`; `stdin.Close` before `cmd.Wait`; `terminateProcess` only when `runErr != nil && ctx.Err() == nil`; scanner buffer cap `maxAppServerLineBytes+1`; `appServerProcessPID` called after `cmd.Start` with the unchanged 3-part guard.

The `if runErr != nil { …nested… }` block was flattened via an early `if runErr == nil { return classifyAppServerProcessExit(…) }`; both reviewers enumerated all 8 `(runErr, waitErr, deadline)` combinations and confirmed identical `(Result, error)`.

## Acceptance criteria (#499)
- [x] **Characterization tests added**, mutation-verified non-placebo. Direct unit tests for `classifyAppServerOutcome` cover all 9 branches + 4 precedence locks (stall>deadline, read-timeout>deadline, deadline>categorized, categorized>port-exit). **Four branches** (outer-deadline+runErr, runErr+waitErr join, waitErr-only deadline, waitErr-only PortExit) were **previously unreachable** without a real subprocess exit — the extraction is what makes them testable. Reachable branches stay guarded by the existing `TestCodexAppServerRunner*` Run-level tests (confirmed green post-refactor).
- [x] Decompose into single-responsibility helpers, behavior zero-change.
- [x] `gocognit`/`funlen` finding for `Run` eliminated (29→8).
- [x] No new deviation, no external API change.

## Verification
```
gofmt -l $(git ls-files '*.go')                 # empty
go vet ./...                                     # clean
go mod tidy && git diff --exit-code              # clean
golangci-lint --enable-only=…,staticcheck,unparam,unused,errorlint  # 0 issues
go test -race -count=1 -skip TestCodexAppServerInitializeTimeoutDiagnostics ./internal/runner/  # ok
go build ./cmd/worker ./cmd/tui                  # ok
```
- `TestCodexAppServerInitializeTimeoutDiagnostics` fails **only locally under sandbox** (process-start evidence); passes in CI — known environmental flake, not a regression, untouched by this diff.
- **Mutation (against committed artifact 7f20de7)**: disable stall / run-deadline / join / waitexit-deadline / read-timeout branches → each matching classifier test **FAILS**; `git checkout` restores; tree == HEAD.

## Current state (head 7f20de7)
- **CI green** — run 26631959744, 4/4 checks pass.
- **Review threads: 0** unresolved, non-outdated, actionable (GraphQL).
- Merge-ready **pending human size-gate sign-off** (justified overage) + explicit merge permission.

## Pre-push dual review (diff-only)
- **Reviewer A (Claude `feature-dev:code-reviewer`, equivalence lens):** **MERGE-READY** — all 8 `(runErr,waitErr,deadline)` cases equivalent, hazards preserved, 4 ordering tests confirmed non-placebo.
- **Reviewer B (Claude `feature-dev:code-reviewer`, consumer-contract/SPEC lens):** **NEEDS-CHANGES** on one HIGH — but it is a **pre-existing** precedence (`TurnTimeoutError` wrapped as `TimeoutError` when the outer deadline fires in the `classifyTurnError`→`Run` window), **verified byte-identical to origin/main** (deadline check has always preceded the `ErrorCategory` check). The zero-change mandate prohibits altering it here; both error types route to `PhaseTimedOut` in the worker, so the difference is cosmetic telemetry in a coinciding-deadline window. Its MEDIUM/LOW (pipe-leak-on-later-failure, `strings.Contains` read-timeout match) are also pre-existing. All three tracked in **#507**.
- **Codex family unavailable on BOTH paths**: local CLI reviewer (access-token expired) and GitHub `@codex review` (account usage limit). Per protocol §4.4, compensated by the two independent Claude-family diff-only reviews above; disclosed here.

## Deferral / follow-ups
- **#507** — pre-existing codex_app_server.go gaps surfaced in review (read-timeout `strings.Contains` rule-8 violation; `openAppServerPipes` stdin leak on later-pipe failure; TurnTimeout-vs-deadline attribution). Not introduced here; out of scope for a zero-change refactor.

### Size gate
- [ ] `within budget`
- [x] `size-gated: justified overage` — rationale: 2 files / 340 churn LOC (added+deleted) > 300. Pure behavior-zero-change decomposition + the acceptance-criterion-mandated, mutation-verified classifier tests (which the extraction newly enables for 4 previously-unreachable branches) and cannot be split from the refactor without losing safety atomicity. Same bundling as #506/#501/#502/#503. No scope creep; needs human size-gate sign-off before merge.
- [ ] `size-gated: split recommended`

Refs #499.
