### PR TITLE
refactor(runner): decompose parseRetryAfterText into per-format helpers (#499)

### DIFF
--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1354,6 +1354,51 @@ func TestParseRetryAfterTextAcceptsAbsoluteClockTime(t *testing.T) {
 	}
 }
 
+// TestParseRetryAfterText_Table characterizes both parse branches (relative
+// "in N units" and absolute "at H:MM am/pm") and their edge cases, locking the
+// behavior of parseRetryAfterText across its decomposition into the per-branch
+// helpers parseRelativeRetryDelay / parseAbsoluteRetryDelay / to24Hour. now is
+// fixed at 18:00 local so the absolute-time deltas are deterministic
+// (parseRetryAfterText computes against now.Location()).
+func TestParseRetryAfterText_Table(t *testing.T) {
+	now := time.Date(2026, 5, 27, 18, 0, 0, 0, time.Local)
+	cases := []struct {
+		name string
+		msg  string
+		want time.Duration
+	}{
+		// relative branch
+		{"relative seconds", "try again in 30 seconds", 30 * time.Second},
+		{"relative sec abbrev", "please retry in 45 secs", 45 * time.Second},
+		{"relative minutes", "retry in 5 minutes", 5 * time.Minute},
+		{"relative min abbrev", "try again in 10 min", 10 * time.Minute},
+		{"relative hours", "try again in 2 hours", 2 * time.Hour},
+		{"relative decimal hours", "try again in 1.5 hours", 90 * time.Minute},
+		{"relative zero is ignored", "try again in 0 seconds", 0},
+		// absolute branch (now = 18:00)
+		{"absolute pm with minutes", "try again at 6:20 PM", 20 * time.Minute},
+		{"absolute pm no minutes", "try again at 7 PM", time.Hour},
+		{"absolute am non-noon identity", "try again at 9 AM", 15 * time.Hour},
+		{"absolute earlier today rolls to tomorrow", "try again at 5 PM", 23 * time.Hour},
+		{"absolute 12am is midnight", "try again at 12 AM", 6 * time.Hour},
+		{"absolute 12pm is noon", "try again at 12 PM", 18 * time.Hour},
+		{"absolute hour zero rejected", "try again at 0 PM", 0},
+		{"absolute dotted meridiem", "try again at 6:30 p.m.", 30 * time.Minute},
+		{"absolute invalid hour", "try again at 13 PM", 0},
+		{"absolute invalid minute", "try again at 6:75 PM", 0},
+		// no match
+		{"no retry phrasing", "the agent finished the task", 0},
+		{"empty", "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseRetryAfterText(tc.msg, now); got != tc.want {
+				t.Errorf("parseRetryAfterText(%q) = %s; want %s", tc.msg, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCodexAppServerRunnerTreatsInterruptedTurnCompletedAsSuccess(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json

--- a/internal/runner/codex_app_server_turn.go
+++ b/internal/runner/codex_app_server_turn.go
@@ -392,45 +392,70 @@ var (
 
 func parseRetryAfterText(message string, now time.Time) time.Duration {
 	if match := retryInPattern.FindStringSubmatch(message); len(match) == 3 {
-		n, err := strconv.ParseFloat(match[1], 64)
-		if err != nil || n <= 0 {
-			return 0
-		}
-		switch strings.ToLower(match[2]) {
-		case "second", "seconds", "sec", "secs":
-			return time.Duration(n * float64(time.Second))
-		case "minute", "minutes", "min", "mins":
-			return time.Duration(n * float64(time.Minute))
-		case "hour", "hours", "hr", "hrs":
-			return time.Duration(n * float64(time.Hour))
-		}
+		return parseRelativeRetryDelay(match)
 	}
 	if match := retryAtPattern.FindStringSubmatch(message); len(match) == 4 {
-		hour, err := strconv.Atoi(match[1])
-		if err != nil || hour < 1 || hour > 12 {
-			return 0
-		}
-		minute := 0
-		if match[2] != "" {
-			minute, err = strconv.Atoi(match[2])
-			if err != nil || minute > 59 {
-				return 0
-			}
-		}
-		meridiem := strings.ToLower(strings.ReplaceAll(match[3], ".", ""))
-		if meridiem == "pm" && hour != 12 {
-			hour += 12
-		}
-		if meridiem == "am" && hour == 12 {
-			hour = 0
-		}
-		retryAt := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
-		if !retryAt.After(now) {
-			retryAt = retryAt.Add(24 * time.Hour)
-		}
-		return retryAt.Sub(now)
+		return parseAbsoluteRetryDelay(match, now)
 	}
 	return 0
+}
+
+// parseRelativeRetryDelay converts a retryInPattern submatch ("in N <unit>")
+// into a delay. N is regex-constrained to a non-negative decimal, and the unit
+// group is exhaustive over the switch cases, so the only non-positive result is
+// an explicit N<=0 (treated as "no usable hint").
+func parseRelativeRetryDelay(match []string) time.Duration {
+	n, err := strconv.ParseFloat(match[1], 64)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	switch strings.ToLower(match[2]) {
+	case "second", "seconds", "sec", "secs":
+		return time.Duration(n * float64(time.Second))
+	case "minute", "minutes", "min", "mins":
+		return time.Duration(n * float64(time.Minute))
+	case "hour", "hours", "hr", "hrs":
+		return time.Duration(n * float64(time.Hour))
+	}
+	return 0
+}
+
+// parseAbsoluteRetryDelay converts a retryAtPattern submatch ("at H[:MM] am/pm")
+// into the delay until that clock time relative to now, rolling to the next day
+// when the time has already passed today. An out-of-range hour (>12) or minute
+// (>59) yields 0.
+func parseAbsoluteRetryDelay(match []string, now time.Time) time.Duration {
+	hour, err := strconv.Atoi(match[1])
+	if err != nil || hour < 1 || hour > 12 {
+		return 0
+	}
+	minute := 0
+	if match[2] != "" {
+		minute, err = strconv.Atoi(match[2])
+		if err != nil || minute > 59 {
+			return 0
+		}
+	}
+	meridiem := strings.ToLower(strings.ReplaceAll(match[3], ".", ""))
+	hour = to24Hour(hour, meridiem)
+	retryAt := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
+	if !retryAt.After(now) {
+		retryAt = retryAt.Add(24 * time.Hour)
+	}
+	return retryAt.Sub(now)
+}
+
+// to24Hour converts a 1-12 clock hour plus a normalized meridiem ("am"/"pm")
+// to a 0-23 hour: 12 PM stays noon, 12 AM becomes midnight (0), every other PM
+// hour is shifted by 12.
+func to24Hour(hour int, meridiem string) int {
+	if meridiem == "pm" && hour != 12 {
+		return hour + 12
+	}
+	if meridiem == "am" && hour == 12 {
+		return 0
+	}
+	return hour
 }
 func (c *appServerClient) recordSafeTurnFailure(event string, params map[string]any) {
 	c.recordRuntimeEvent(event, c.withRuntimeContext(safeTurnFailurePayload(params)))


### PR DESCRIPTION
## What & why

Decompose `parseRetryAfterText` (gocognit **24**) — the pure parser that turns a Codex quota/rate-limit "try again …" hint into a backoff `time.Duration` — into per-format helpers. **Behavior unchanged.** Part of the #499 batch (continuation of #410; mirrors #501/#502/#503/#506/#508).

### Decomposition
| new symbol | role | gocognit |
|---|---|---|
| `parseRelativeRetryDelay` | "try again **in** N seconds/minutes/hours" | 3 |
| `parseAbsoluteRetryDelay` | "try again **at** H[:MM] am/pm" → delay until that clock time (rolls to tomorrow if past) | 7 |
| `to24Hour` | 12-hour → 24-hour meridiem conversion (12 PM=noon, 12 AM=midnight) | 4 |

`parseRetryAfterText` drops **24 → 2**; every helper ≤ 7. Blocking lint gate (`staticcheck,unparam,unused,errorlint,…`) = 0 issues.

## Behavior preservation
- The relative-branch unit `switch` is **exhaustive over `retryInPattern`'s unit capture group**, so returning `parseRelativeRetryDelay(match)` directly preserves all reachable behavior — the original's implicit fall-through from a switch-miss to the absolute branch was dead code (no regex match can produce a unit outside the switch). Documented in the helper comment.
- `to24Hour` reproduces the original inline `pm && hour!=12 → +12` / `am && hour==12 → 0` / else-unchanged exactly.
- `parseAbsoluteRetryDelay` preserves the hour (1–12) and minute (≤59) guards, the optional-minute path, and the `!retryAt.After(now)` next-day roll using `now.Location()`.
- Only caller (`quotaRetryAfterFromParams`, same file) gets identical results; `0` still means "no usable hint".

## Acceptance criteria (#499)
- [x] **Characterization table test added before the split**, mutation-verified non-placebo. Covers both branches' edges: relative sec/min/hour + abbreviations + decimal + N=0; absolute am/pm, 12 AM (midnight), 12 PM (noon), AM-non-noon identity, dotted meridiem, earlier-today→tomorrow roll, out-of-range hour (`13 PM`, `0 PM`) and minute (`6:75 PM`); no-match + empty.
- [x] Decompose into single-responsibility helpers, behavior zero-change.
- [x] `gocognit` finding for `parseRetryAfterText` eliminated (24→2).
- [x] No new deviation, no external API change.

## Verification
```
gofmt -l $(git ls-files '*.go')   # empty
go vet ./...                       # clean
go mod tidy && git diff --exit-code # clean
golangci-lint --enable-only=…,errorlint  # 0 issues
go test -race -skip TestCodexAppServerInitializeTimeoutDiagnostics ./internal/runner/  # ok
go build ./cmd/worker ./cmd/tui    # ok
```
- **Mutation (against committed artifact 1493bc2)**: break to24Hour pm / to24Hour am-12 / to24Hour am-identity (`return hour`) / hour>12 guard / hour<1 guard / minute>59 guard / relative unit multiplier → each matching table case **FAILS**; `git checkout` restores; tree == HEAD.
- `TestCodexAppServerInitializeTimeoutDiagnostics` fails only locally under sandbox (known environmental flake), untouched here.

## Pre-push dual review (diff-only)
- **Reviewer A & B (Claude `feature-dev:code-reviewer`, equivalence + caller/edge lenses):** both **MERGE-READY**. Both independently proved the switch-fallthrough divergence is unreachable (regex unit group ⊆ switch cases). Findings addressed in this head: a MEDIUM (stale "before decomposition" test comment → reworded to "across its decomposition") and two LOW coverage gaps (AM-non-noon identity + `0 PM` hour-zero) → both added to the table and mutation-verified.
- **Codex family unavailable on BOTH paths** (local CLI access-token expired; GitHub `@codex review` account usage limit). Per protocol §4.4, compensated by the two independent Claude-family diff-only reviews above; disclosed here.

### Size gate
- [x] `within budget` — 2 files / 138 churn LOC, well under 12 files / 300 LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Refs #499.
