### PR TITLE
refactor(orchestrator): extract resolveDispatchClaim from dispatchOp.apply (#499)

### DIFF
--- a/internal/orchestrator/actor_dispatch.go
+++ b/internal/orchestrator/actor_dispatch.go
@@ -83,32 +83,8 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 		return nil
 	}
 	st.ReleaseFailedIfIssueChanged(d.issue)
-	attempt := d.attempt
-	continuationAttempt := 0
-	var consumedContinuation *RetryEntry
-	if d.trackerRechecked {
-		if entry, ok := st.RetryAttempts[id]; ok {
-			if entry.Kind != RetryKindContinuation && entry.Kind != RetryKindExternalBlocker {
-				d.result <- ErrNotDispatched
-				return nil
-			}
-			if !entry.IsDue(time.Now()) {
-				d.result <- ErrNotDispatched
-				return nil
-			}
-			// Tracker-rechecked dispatch consumes clean continuation and
-			// external-blocker cooldown entries. Failure retries stay claimed
-			// until retryFireOp carries their scheduled attempt into a retry
-			// dispatch.
-			if entry.Kind == RetryKindContinuation {
-				continuationAttempt = entry.Attempt
-			}
-			consumedContinuation = entry
-		} else if st.IsClaimed(id) {
-			d.result <- ErrNotDispatched
-			return nil
-		}
-	} else if st.IsClaimed(id) {
+	consumedContinuation, continuationAttempt, deny := resolveDispatchClaim(st, id, d.trackerRechecked)
+	if deny {
 		d.result <- ErrNotDispatched
 		return nil
 	}
@@ -144,11 +120,44 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	st.ClaimedIssues[id] = d.issue
 	o := d.o
 	issue := d.issue
+	attempt := d.attempt
 	result := d.result
 	return func() {
 		o.spawn(id, issue, attempt, continuationAttempt)
 		result <- nil
 	}
+}
+
+// resolveDispatchClaim decides whether a dispatchOp may proceed past the claim
+// gate, and (for a tracker-rechecked dispatch) which queued retry entry it
+// consumes. A fresh dispatch is denied only when the issue is already claimed.
+// A tracker-rechecked dispatch consumes a DUE continuation or external-blocker
+// cooldown entry (returned so the caller can clear it, with continuationAttempt
+// carried forward only for continuations); it is denied when the queued entry is
+// any other kind (e.g. a failure retry, which stays claimed until retryFireOp
+// re-dispatches it) or not yet due, and — when no such entry exists — when the
+// issue is already claimed. deny is true on every rejection path.
+func resolveDispatchClaim(st *OrchestratorState, id IssueID, trackerRechecked bool) (consumed *RetryEntry, continuationAttempt int, deny bool) {
+	if !trackerRechecked {
+		return nil, 0, st.IsClaimed(id)
+	}
+	entry, ok := st.RetryAttempts[id]
+	if !ok {
+		return nil, 0, st.IsClaimed(id)
+	}
+	if entry.Kind != RetryKindContinuation && entry.Kind != RetryKindExternalBlocker {
+		return nil, 0, true
+	}
+	if !entry.IsDue(time.Now()) {
+		return nil, 0, true
+	}
+	// Only a continuation carries a turn count forward; an external-blocker
+	// cooldown is a wake signal, so continuationAttempt stays 0 and the resumed
+	// turn does not inherit a stale count.
+	if entry.Kind == RetryKindContinuation {
+		continuationAttempt = entry.Attempt
+	}
+	return entry, continuationAttempt, false
 }
 
 // spawn asks the dispatcher for a worker, records the Running entry

--- a/internal/orchestrator/actor_dispatch_test.go
+++ b/internal/orchestrator/actor_dispatch_test.go
@@ -1,0 +1,75 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+)
+
+// TestResolveDispatchClaim_Table characterizes every branch of the dispatch
+// claim gate extracted from (*dispatchOp).apply: fresh vs tracker-rechecked,
+// present vs absent retry entry, consumable (due continuation / external
+// blocker) vs non-consumable (wrong kind / not due) entry, and the
+// already-claimed deny paths. The tracker-rechecked + absent + claimed deny had
+// no dedicated coverage before this extraction.
+func TestResolveDispatchClaim_Table(t *testing.T) {
+	const id = IssueID("ENG-DISP")
+	due := time.Now().Add(-time.Hour)
+	notDue := time.Now().Add(time.Hour)
+	entry := func(kind RetryKind, attempt int, dueAt time.Time) *RetryEntry {
+		return &RetryEntry{IssueID: id, Identifier: string(id), Kind: kind, Attempt: attempt, DueAt: dueAt}
+	}
+	cases := []struct {
+		name             string
+		rechecked        bool
+		setup            func(st *OrchestratorState)
+		wantConsumed     bool
+		wantConsumedKind RetryKind // checked only when wantConsumed
+		wantContAttempt  int
+		wantDeny         bool
+	}{
+		{name: "fresh unclaimed proceeds", rechecked: false, setup: func(*OrchestratorState) {}, wantDeny: false},
+		{name: "fresh claimed denied", rechecked: false, setup: func(st *OrchestratorState) { st.Claimed[id] = struct{}{} }, wantDeny: true},
+		{name: "rechecked absent unclaimed proceeds", rechecked: true, setup: func(*OrchestratorState) {}, wantDeny: false},
+		{name: "rechecked absent claimed denied", rechecked: true, setup: func(st *OrchestratorState) { st.Claimed[id] = struct{}{} }, wantDeny: true},
+		{name: "rechecked failure retry denied", rechecked: true, setup: func(st *OrchestratorState) {
+			st.RetryAttempts[id] = entry(RetryKindFailure, 2, due)
+		}, wantDeny: true},
+		{name: "rechecked quota retry denied", rechecked: true, setup: func(st *OrchestratorState) {
+			st.RetryAttempts[id] = entry(RetryKindQuotaBackoff, 1, due)
+		}, wantDeny: true},
+		{name: "rechecked due continuation consumed", rechecked: true, setup: func(st *OrchestratorState) {
+			st.RetryAttempts[id] = entry(RetryKindContinuation, 3, due)
+		}, wantConsumed: true, wantConsumedKind: RetryKindContinuation, wantContAttempt: 3, wantDeny: false},
+		{name: "rechecked due continuation attempt zero", rechecked: true, setup: func(st *OrchestratorState) {
+			st.RetryAttempts[id] = entry(RetryKindContinuation, 0, due)
+		}, wantConsumed: true, wantConsumedKind: RetryKindContinuation, wantContAttempt: 0, wantDeny: false},
+		{name: "rechecked not-due continuation denied", rechecked: true, setup: func(st *OrchestratorState) {
+			st.RetryAttempts[id] = entry(RetryKindContinuation, 3, notDue)
+		}, wantDeny: true},
+		{name: "rechecked due external blocker consumed without continuation attempt", rechecked: true, setup: func(st *OrchestratorState) {
+			st.RetryAttempts[id] = entry(RetryKindExternalBlocker, 7, due)
+		}, wantConsumed: true, wantConsumedKind: RetryKindExternalBlocker, wantContAttempt: 0, wantDeny: false},
+		{name: "rechecked not-due external blocker denied", rechecked: true, setup: func(st *OrchestratorState) {
+			st.RetryAttempts[id] = entry(RetryKindExternalBlocker, 0, notDue)
+		}, wantDeny: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := NewOrchestratorState(15000, 10)
+			tc.setup(st)
+			consumed, contAttempt, deny := resolveDispatchClaim(st, id, tc.rechecked)
+			if deny != tc.wantDeny {
+				t.Fatalf("resolveDispatchClaim deny = %v; want %v", deny, tc.wantDeny)
+			}
+			switch {
+			case tc.wantConsumed && (consumed == nil || consumed.Kind != tc.wantConsumedKind):
+				t.Fatalf("resolveDispatchClaim consumed = %+v; want a %q entry", consumed, tc.wantConsumedKind)
+			case !tc.wantConsumed && consumed != nil:
+				t.Fatalf("resolveDispatchClaim consumed = %+v; want nil (no entry consumed)", consumed)
+			}
+			if contAttempt != tc.wantContAttempt {
+				t.Fatalf("resolveDispatchClaim continuationAttempt = %d; want %d", contAttempt, tc.wantContAttempt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What & why

Extract the claim/continuation-consume decision out of `(*dispatchOp).apply` (gocognit **22**) — the orchestrator actor's dispatch gate — into a pure helper. **Behavior unchanged.** Part of the #499 batch (continuation of #410; mirrors #501/#502/#503/#506/#508/#509).

### Decomposition
| symbol | role | gocognit |
|---|---|---|
| `resolveDispatchClaim(st, id, trackerRechecked) (consumed *RetryEntry, continuationAttempt int, deny bool)` | the claim gate: fresh dispatch denies only on already-claimed; a tracker-rechecked dispatch consumes a **due** continuation/external-blocker entry (continuationAttempt carried only for continuations) and denies on wrong-kind / not-due / claimed-without-consumable-entry | 6 |

`(*dispatchOp).apply` drops **22 → 8**. Blocking lint gate (`staticcheck,unparam,unused,errorlint,…`) = 0 issues.

## Behavior preservation
- `resolveDispatchClaim` reproduces the original nested decision across all 12 combinations `{fresh, rechecked} × {absent, continuation due/not-due, external-blocker due/not-due, failure, quota} × {claimed, unclaimed}`.
- `apply` post-deny ordering unchanged: `IsCleaningWorkspace` deny → `ReleaseFailedIfIssueChanged` → `resolveDispatchClaim` deny → global cap → `capacityExcluded=id` iff `consumedContinuation!=nil` → `StateCapacityFullExcluding` → (if consumed) `Timer.Stop()` + delete `RetryAttempts`/`Claimed` → `RecordEvent` → reserve `Claimed`/`ClaimedIssues` → followup `spawn`.
- `resolveDispatchClaim` returns the **live** `*RetryEntry` pointer; the caller's `Timer.Stop()` + deletes still hit the stored entry (used within the same actor-goroutine apply call, before the map is re-read). `attempt := d.attempt` moved to just before the closure (its only use) — behavior-neutral.
- Aligns with upstream `dispatch_issue` / `dispatch_slots_available?` / `state_slots_available?` (orchestrator.ex).

## Acceptance criteria (#499)
- [x] **Direct table test added** (`TestResolveDispatchClaim_Table`), mutation-verified non-placebo, covering all 10 branches — including the **tracker-rechecked + absent-entry + already-claimed deny** (no prior coverage) and a continuation `Attempt==0` boundary. The external-blocker row uses `Attempt=7` to prove `continuationAttempt` stays 0 for non-continuation kinds.
- [x] Extract single-responsibility helper, behavior zero-change.
- [x] `gocognit` finding for `dispatchOp.apply` eliminated (22→8).
- [x] No new deviation, no external API change.

## Verification
```
gofmt -l $(git ls-files '*.go')   # empty
go vet ./...                       # clean
go mod tidy && git diff --exit-code # clean
golangci-lint --enable-only=…,errorlint  # 0 issues
go test -race -count=1 ./internal/orchestrator/  # ok (x4 runs, no flake on changed path)
go build ./cmd/worker ./cmd/tui    # ok
```
- **Mutation (against committed artifact 3248ce6)**: drop external-blocker from consumable kinds / disable not-due deny / drop continuationAttempt carry (ext-blocker Attempt=7 catches unconditional carry) / drop rechecked-absent IsClaimed deny / drop fresh IsClaimed deny → each matching table case **FAILS**; `git checkout` restores; tree == HEAD.

## Pre-push dual review (diff-only, head 3248ce6)
- **Reviewer A (equivalence + test lens)** and **Reviewer B (cross-cutting/SPEC + pointer-safety lens)**, both Claude `feature-dev:code-reviewer`: both **MERGE-READY, equivalence holds, zero findings** on the final head. (An earlier review of head `0b11ec0` raised advisory LOW/MEDIUM items — a missing AGENTS.md "why" comment on the external-blocker reset, an empty-string `RetryKind` test sentinel, and a continuation `Attempt==0` boundary gap — all addressed in `3248ce6` and re-reviewed clean.)
- **Codex family unavailable on BOTH paths** (local CLI access-token expired; GitHub `@codex review` account usage limit). Per protocol §4.4, compensated by the two independent Claude-family diff-only reviews above; disclosed here.

### Size gate
- [x] `within budget` — 2 files / 132 churn LOC, well under 12 files / 300 LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Refs #499.
