### PR TITLE
refactor(runner): decompose handleDynamicToolCall into per-concern helpers (#499)

### DIFF
--- a/internal/runner/codex_app_server_approval.go
+++ b/internal/runner/codex_app_server_approval.go
@@ -248,52 +248,61 @@ func (c *appServerClient) handleDynamicToolCall(ctx context.Context, msg map[str
 	params, _ := msg["params"].(map[string]any)
 	name := appServerToolCallName(params)
 	arguments := appServerToolCallArguments(params)
-	result, err := dynamicToolResult(false, "unsupported dynamic tool: "+name)
+	result, err := c.resolveDynamicToolResult(ctx, name, arguments)
 	if err != nil {
 		return err
 	}
-	if tool, ok := c.tools.Lookup(name); ok {
-		call := ToolCall{}
-		if err := json.Unmarshal(arguments, &call); err != nil {
-			failure, failureErr := dynamicToolFailure(err.Error())
-			if failureErr != nil {
-				return failureErr
-			}
-			result = failure
-		} else {
-			// Install the audit sink for any tool that may route
-			// through the Linear GraphQL proxy. linear_ai_workpad
-			// composes deterministic commentCreate/commentUpdate
-			// mutations through the same token-isolated transport
-			// (via callRaw); operators need the runtime event for
-			// those harness-attributable writes too. Only the
-			// proxy itself fires the sink, so installing it on
-			// unrelated tools is a no-op.
-			toolCtx := WithLinearGraphQLMutationSink(ctx, func(operationField string) {
-				payload := map[string]any{"tool": name}
-				if operationField != "" {
-					payload["operation_field"] = operationField
-				}
-				c.recordRuntimeEvent(task.EventToolCallMutation, c.withRuntimeContext(payload))
-			})
-			result, err = tool.Call(toolCtx, call)
-			if err != nil {
-				failure, failureErr := dynamicToolFailure(err.Error())
-				if failureErr != nil {
-					return failureErr
-				}
-				result = failure
-			}
-		}
-	} else {
-		// SPEC §10.4 unsupported_tool_call: the wire still carries the
-		// structured failure result, but the orchestrator/state surface
-		// needs a typed event to distinguish "agent invoked an
-		// unadvertised tool" from "advertised tool failed". The structured
-		// failure path above already emits its own error; this branch is
-		// reached only when the tool name is not in c.tools.
+	return c.replyDynamicToolOutput(msg, params, result)
+}
+
+// resolveDynamicToolResult runs the named dynamic tool and returns its wire
+// result string. A name not in the advertised set records the SPEC §10.4
+// unsupported_tool_call event — so the orchestrator/state surface can tell
+// "agent invoked an unadvertised tool" apart from "advertised tool failed" —
+// and returns the structured "unsupported dynamic tool" failure; a present
+// tool's argument-decode and execution failures are wrapped as structured
+// dynamicToolFailure results. The returned error is non-nil only when a failure
+// result itself cannot be marshaled, mirroring the original handler's fatal
+// early-return.
+func (c *appServerClient) resolveDynamicToolResult(ctx context.Context, name string, arguments json.RawMessage) (string, error) {
+	tool, ok := c.tools.Lookup(name)
+	if !ok {
 		c.recordUnsupportedToolCall(name, arguments)
+		return dynamicToolResult(false, "unsupported dynamic tool: "+name)
 	}
+	call := ToolCall{}
+	if err := json.Unmarshal(arguments, &call); err != nil {
+		return dynamicToolFailure(err.Error())
+	}
+	result, err := tool.Call(c.withMutationAuditSink(ctx, name), call)
+	if err != nil {
+		return dynamicToolFailure(err.Error())
+	}
+	return result, nil
+}
+
+// withMutationAuditSink derives the tool-execution context carrying the audit
+// sink that fires for any tool routing through the Linear GraphQL proxy.
+// linear_ai_workpad composes deterministic commentCreate/commentUpdate
+// mutations through the same token-isolated callRaw transport, so operators
+// need the tool_call_mutation runtime event for those harness-attributable
+// writes too. Only the proxy itself fires the sink, so installing it on
+// unrelated tools is a no-op.
+func (c *appServerClient) withMutationAuditSink(ctx context.Context, name string) context.Context {
+	return WithLinearGraphQLMutationSink(ctx, func(operationField string) {
+		payload := map[string]any{"tool": name}
+		if operationField != "" {
+			payload["operation_field"] = operationField
+		}
+		c.recordRuntimeEvent(task.EventToolCallMutation, c.withRuntimeContext(payload))
+	})
+}
+
+// replyDynamicToolOutput returns result to codex: parsed as JSON (falling back
+// to a {success:false, output} envelope when result is not valid JSON), sent as
+// the JSON-RPC result when the inbound message carries an id, or emitted as an
+// item/tool/call/output notification keyed by call_id otherwise.
+func (c *appServerClient) replyDynamicToolOutput(msg, params map[string]any, result string) error {
 	var payload any
 	if err := json.Unmarshal([]byte(result), &payload); err != nil {
 		payload = map[string]any{"success": false, "output": result}

--- a/internal/runner/codex_app_server_approval_test.go
+++ b/internal/runner/codex_app_server_approval_test.go
@@ -1,0 +1,253 @@
+package runner
+
+// codex_app_server_approval_test.go holds characterization tests that drive
+// (*appServerClient).handleDynamicToolCall directly, without spawning a real
+// `codex app-server` subprocess. They pin the dynamic tool-call bridge's
+// input→(wire reply, recorded runtime events) behavior at the exact function
+// boundary before #499 decomposes the 20-cognitive-complexity handler into
+// per-concern helpers; the assertions must hold identically before and after
+// that refactor.
+//
+// The end-to-end subprocess tests in codex_app_server_test.go remain the
+// authority for the transport and multi-turn paths; these focus on the
+// tool-call demux the decomposition reshapes, especially branches the
+// subprocess suite does not exercise (undecodable arguments, tool execution
+// errors, the request-id vs. notification reply fork, and the linear_graphql
+// mutation audit sink).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+)
+
+// newDynamicToolCallClient builds an appServerClient whose server->client
+// replies (request results and notifications) land in the returned stdin
+// buffer. tools is the dynamic tool surface the handler looks names up against;
+// a nil entry leaves the set empty so every lookup misses.
+func newDynamicToolCallClient(tools map[string]DynamicTool) (*appServerClient, *bytes.Buffer) {
+	stdin := &bytes.Buffer{}
+	c := &appServerClient{
+		stdin: stdin,
+		tools: DynamicToolSet{tools: tools},
+	}
+	return c, stdin
+}
+
+// decodeSentMessage parses the single newline-delimited JSON-RPC message the
+// handler wrote to stdin.
+func decodeSentMessage(t *testing.T, stdin *bytes.Buffer) map[string]any {
+	t.Helper()
+	line := strings.TrimSpace(stdin.String())
+	if line == "" {
+		t.Fatal("handler wrote no message to stdin")
+	}
+	var msg map[string]any
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		t.Fatalf("decode sent message %q: %v", line, err)
+	}
+	return msg
+}
+
+func TestHandleDynamicToolCall_ContextCancelledReturnsErrWithoutReply(t *testing.T) {
+	c, stdin := newDynamicToolCallClient(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := c.handleDynamicToolCall(ctx, map[string]any{
+		"id":     "call-1",
+		"params": map[string]any{"tool": "linear_graphql"},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("handleDynamicToolCall(cancelled ctx) = %v; want context.Canceled", err)
+	}
+	if stdin.Len() != 0 {
+		t.Errorf("handleDynamicToolCall(cancelled ctx) wrote %q to stdin; want no reply", stdin.String())
+	}
+}
+
+func TestHandleDynamicToolCall_UnsupportedToolRecordsEventAndReplies(t *testing.T) {
+	c, stdin := newDynamicToolCallClient(nil) // empty set: every lookup misses
+
+	err := c.handleDynamicToolCall(context.Background(), map[string]any{
+		"id":     "call-7",
+		"params": map[string]any{"tool": "missing_tool", "arguments": map[string]any{"query": "q"}},
+	})
+	if err != nil {
+		t.Fatalf("handleDynamicToolCall() = %v; want nil", err)
+	}
+	if names := runtimeEventNames(c); !slices.Contains(names, task.EventUnsupportedToolCall) {
+		t.Errorf("runtime events = %v; want to include %q", names, task.EventUnsupportedToolCall)
+	}
+	sent := decodeSentMessage(t, stdin)
+	if sent["id"] != "call-7" {
+		t.Errorf("reply id = %v; want call-7", sent["id"])
+	}
+	result, _ := sent["result"].(map[string]any)
+	if result["success"] != false {
+		t.Errorf("result.success = %v; want false for an unsupported tool", result["success"])
+	}
+	if out, _ := result["output"].(string); !strings.Contains(out, "unsupported dynamic tool: missing_tool") {
+		t.Errorf("result.output = %q; want the unsupported-tool message", out)
+	}
+}
+
+func TestHandleDynamicToolCall_SuccessfulToolResultDecodesArgsAndReplies(t *testing.T) {
+	c, stdin := newDynamicToolCallClient(map[string]DynamicTool{
+		"linear_graphql": {Name: "linear_graphql", Call: func(_ context.Context, call ToolCall) (string, error) {
+			return `{"success":true,"output":"ok","query":"` + call.Query + `"}`, nil
+		}},
+	})
+
+	err := c.handleDynamicToolCall(context.Background(), map[string]any{
+		"id":     "call-2",
+		"params": map[string]any{"tool": "linear_graphql", "arguments": map[string]any{"query": "viewer"}},
+	})
+	if err != nil {
+		t.Fatalf("handleDynamicToolCall() = %v; want nil", err)
+	}
+	sent := decodeSentMessage(t, stdin)
+	result, _ := sent["result"].(map[string]any)
+	if result["success"] != true {
+		t.Errorf("result.success = %v; want true", result["success"])
+	}
+	if result["query"] != "viewer" {
+		t.Errorf("result.query = %v; want viewer (tool must receive decoded arguments)", result["query"])
+	}
+	if names := runtimeEventNames(c); slices.Contains(names, task.EventUnsupportedToolCall) {
+		t.Errorf("runtime events = %v; want no unsupported_tool_call for a present tool", names)
+	}
+}
+
+func TestHandleDynamicToolCall_UndecodableArgumentsSkipCallAndReplyFailure(t *testing.T) {
+	var called bool
+	c, stdin := newDynamicToolCallClient(map[string]DynamicTool{
+		"linear_graphql": {Name: "linear_graphql", Call: func(_ context.Context, _ ToolCall) (string, error) {
+			called = true
+			return "{}", nil
+		}},
+	})
+
+	// A string arguments value marshals to a JSON string, which cannot decode
+	// into ToolCall — exercising the json.Unmarshal failure branch.
+	err := c.handleDynamicToolCall(context.Background(), map[string]any{
+		"id":     "call-3",
+		"params": map[string]any{"tool": "linear_graphql", "arguments": "not-an-object"},
+	})
+	if err != nil {
+		t.Fatalf("handleDynamicToolCall() = %v; want nil", err)
+	}
+	if called {
+		t.Error("tool.Call was invoked despite undecodable arguments; want skipped")
+	}
+	sent := decodeSentMessage(t, stdin)
+	result, _ := sent["result"].(map[string]any)
+	if result["success"] != false {
+		t.Errorf("result.success = %v; want false on argument decode failure", result["success"])
+	}
+	out, _ := result["output"].(string)
+	if !strings.Contains(out, "unmarshal") {
+		t.Errorf("result.output = %q; want it to surface the decode error", out)
+	}
+	if strings.Contains(out, "unsupported dynamic tool") {
+		t.Errorf("result.output = %q; want a decode failure, not the unsupported-tool message (tool was present)", out)
+	}
+}
+
+func TestHandleDynamicToolCall_ToolErrorRepliesStructuredFailure(t *testing.T) {
+	c, stdin := newDynamicToolCallClient(map[string]DynamicTool{
+		"linear_graphql": {Name: "linear_graphql", Call: func(_ context.Context, _ ToolCall) (string, error) {
+			return "", errors.New("boom from tool")
+		}},
+	})
+
+	err := c.handleDynamicToolCall(context.Background(), map[string]any{
+		"id":     "call-4",
+		"params": map[string]any{"tool": "linear_graphql", "arguments": map[string]any{"query": "x"}},
+	})
+	if err != nil {
+		t.Fatalf("handleDynamicToolCall() = %v; want nil", err)
+	}
+	sent := decodeSentMessage(t, stdin)
+	result, _ := sent["result"].(map[string]any)
+	if result["success"] != false {
+		t.Errorf("result.success = %v; want false on tool execution error", result["success"])
+	}
+	if out, _ := result["output"].(string); !strings.Contains(out, "boom from tool") {
+		t.Errorf("result.output = %q; want it to carry the tool error reason", out)
+	}
+}
+
+func TestHandleDynamicToolCall_NotificationUsesToolOutputNotify(t *testing.T) {
+	c, stdin := newDynamicToolCallClient(map[string]DynamicTool{
+		"linear_graphql": {Name: "linear_graphql", Call: func(_ context.Context, _ ToolCall) (string, error) {
+			return `{"success":true}`, nil
+		}},
+	})
+
+	// No "id" key → the message is a notification, so the reply must go out as
+	// an item/tool/call/output notification keyed by call_id rather than a
+	// JSON-RPC result.
+	err := c.handleDynamicToolCall(context.Background(), map[string]any{
+		"params": map[string]any{"tool": "linear_graphql", "call_id": "cid-9", "arguments": map[string]any{"query": "x"}},
+	})
+	if err != nil {
+		t.Fatalf("handleDynamicToolCall() = %v; want nil", err)
+	}
+	sent := decodeSentMessage(t, stdin)
+	if sent["method"] != "item/tool/call/output" {
+		t.Errorf("notify method = %v; want item/tool/call/output", sent["method"])
+	}
+	if _, ok := sent["id"]; ok {
+		t.Errorf("notification reply carried an id %v; want none", sent["id"])
+	}
+	params, _ := sent["params"].(map[string]any)
+	if params["call_id"] != "cid-9" {
+		t.Errorf("notify call_id = %v; want cid-9", params["call_id"])
+	}
+	if _, ok := params["output"]; !ok {
+		t.Errorf("notify params missing output; got %v", params)
+	}
+}
+
+func TestHandleDynamicToolCall_MutationSinkRecordsToolCallMutationEvent(t *testing.T) {
+	c, _ := newDynamicToolCallClient(map[string]DynamicTool{
+		"linear_graphql": {Name: "linear_graphql", Call: func(ctx context.Context, _ ToolCall) (string, error) {
+			// A real proxy fires the sink installed on the tool context when it
+			// dispatches a mutation; emulate that here.
+			if sink := linearGraphQLMutationSinkFrom(ctx); sink != nil {
+				sink("issueUpdate")
+			}
+			return `{"success":true}`, nil
+		}},
+	})
+
+	err := c.handleDynamicToolCall(context.Background(), map[string]any{
+		"id":     "call-5",
+		"params": map[string]any{"tool": "linear_graphql", "arguments": map[string]any{"query": "mutation"}},
+	})
+	if err != nil {
+		t.Fatalf("handleDynamicToolCall() = %v; want nil", err)
+	}
+	var payload map[string]any
+	for _, ev := range c.runtimeEvents {
+		if ev.Event == task.EventToolCallMutation {
+			payload, _ = ev.Payload.(map[string]any)
+		}
+	}
+	if payload == nil {
+		t.Fatalf("runtime events = %v; want a %q event fired by the mutation sink", runtimeEventNames(c), task.EventToolCallMutation)
+	}
+	if payload["tool"] != "linear_graphql" {
+		t.Errorf("mutation event tool = %v; want linear_graphql", payload["tool"])
+	}
+	if payload["operation_field"] != "issueUpdate" {
+		t.Errorf("mutation event operation_field = %v; want issueUpdate", payload["operation_field"])
+	}
+}


### PR DESCRIPTION
## What

Decompose `(*appServerClient).handleDynamicToolCall` (gocognit **20**, the highest remaining #499-scoped hotspot) into three single-concern helpers, **zero behavior change**:

- `resolveDynamicToolResult` — tool lookup + invoke, returning the wire result string. Name not advertised → records the SPEC §10.4 `unsupported_tool_call` event + returns the structured "unsupported dynamic tool" failure; argument-decode and execution failures → structured `dynamicToolFailure`.
- `withMutationAuditSink` — derives the tool-execution context carrying the Linear GraphQL mutation audit sink (aiops-platform extension; no upstream equivalent).
- `replyDynamicToolOutput` — parse the result and reply as a JSON-RPC result (`id` present) or `item/tool/call/output` notification (`call_id`).

Boundaries mirror upstream `elixir/.../codex/app_server.ex` `maybe_handle_approval_request("item/tool/call", …)`: `tool_call_name`/`tool_call_arguments` (already extracted) → tool execution + `normalize_dynamic_tool_result` → send/emit.

## Acceptance criteria (#499)

- [x] **Characterization tests committed first** (`8053f21`), before any decomposition. The end-to-end subprocess suite only asserts the unsupported-tool stdin reply; these pin the runtime-event, undecodable-args, tool-error, id-vs-notification, and mutation-sink branches at the function boundary. `go test -count=1 -race` clean twice (no flake).
- [x] Function purified into single-concern helpers; BEAM guarantees N/A (no new goroutine/timer/followup; `ctx` flows to `tool.Call` unchanged).
- [x] gocognit **20 → finding eliminated** (`handleDynamicToolCall` + all 3 helpers <10); funlen clean. Mutation-verified non-placebo.
- [x] No new deviation; no external API change.

## Behavior preservation note

The only removed work: the original computed `dynamicToolResult(false, "unsupported…")` **unconditionally** (and checked its error) even on the tool-found path, then discarded it. That marshal is a fixed struct of string/bool/slice scalars and cannot fail, so the checked error was dead code on every reachable path. Removing it on the found path is unobservable. (Confirmed by both pre-push reviewers.)

## Verification

```
gofmt -l … (empty) · go vet ./... · go mod tidy (clean) · go build ./cmd/worker ./cmd/tui
go test -race -covermode=atomic ./...   # all green except the known
                                        # TestCodexAppServerInitializeTimeoutDiagnostics
                                        # local-sandbox-only failure (passes in CI)
# blocking golangci gate (contextcheck,errcheck,errorlint,gocritic,govet,
#   ineffassign,revive,staticcheck,unparam,unused) → 0 issues
```

**Mutation verification** (against the committed artifact, then `git checkout` restore): dropping `recordUnsupportedToolCall`, corrupting the `item/tool/call/output` notify method, dropping the mutation-sink context, ignoring the argument decode error, and flipping the id-present guard each fail exactly one characterization test. ✓

## Size-gate

`size-gated: justified overage` — +303/-41 over two files, marginally past the 300-LOC default. The production diff is only **91 lines (50 net)**; the 253-line characterization suite is the issue-mandated "tests-before-decompose" coverage and is **atomic with the refactor it guards** (it proves before/after equivalence, so it cannot be split into a separate PR). Requesting size-gate sign-off as part of merge approval.

## Review

Pre-push dual review (protocol §3): `general-purpose` (line-by-line behavior equivalence) → **BEHAVIOR PRESERVED**; `feature-dev:code-reviewer` (bugs/conventions) → no HIGH/MEDIUM. Triggering `@codex review` on the head; if the bot is still usage-limited (as last #499 session), the independent dual review above is the compensating control per checklist item 4 / protocol §4.

Refs #499
