### PR TITLE
refactor(orchestrator): decompose reconcileInactiveTrackerIssuesOp.apply (#499)

### DIFF
--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -406,76 +406,104 @@ type reconcileInactiveTrackerIssuesOp struct {
 	result         chan<- []*RunningEntry
 }
 
+// apply releases every in-process entry whose issue is observed in the inactive
+// listing, gating SPEC §18.1 workspace cleanup on a terminal transition. Each
+// per-collection helper returns what to collect: running entries are cancelled
+// (their workspace cleanup deferred to finalize), while blocked (input-required)
+// and retry-queued (a clean §16.5 self-stop finalized the run) entries hold no
+// live worker, so a terminal one's workspace is removed now via the shared
+// WorkspaceCleaner. An entry whose issue is absent from the (possibly partial)
+// listing is left untouched.
 func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	var cancelEntries []*RunningEntry
-	// terminalCleanups collects terminal-state entries that hold no live worker
-	// — blocked (input-required, stopped executing) and retry-queued (a clean
-	// SPEC §16.5 self-stop finalized the run before scheduling the continuation
-	// retry) — whose workspace must be removed now rather than deferred to the
-	// finalize path the way running entries are. Every path goes through the
-	// same WorkspaceCleaner so before_remove fires and a reconcile_workspace
-	// event is emitted — mirroring upstream reconcile_blocked_issue_state and
-	// handle_retry_issue_lookup, which clean the workspace only on a terminal
-	// transition. A continuation retry also carries its continuation so the
-	// deletion-time recheck can resume it (preserving the queued attempt and
-	// max-turn budget) if the issue flips back active before removal.
 	var terminalCleanups []reconciledCleanup
 	for id, run := range st.Running {
-		issue, ok := r.issuesByID[string(id)]
-		if !ok {
-			continue
+		if entry := r.reconcileInactiveRun(st, id, run); entry != nil {
+			cancelEntries = append(cancelEntries, entry)
 		}
-		st.ReleaseClaim(id)
-		// Refresh the stored issue and (re)evaluate the terminal cleanup gate
-		// against the CURRENT observation every tick. A terminal transition
-		// flags the entry so finalize fires before_remove + remove (SPEC §18.1
-		// active transition) with the terminal state labeling the
-		// reconcile_workspace event; a merely-inactive cancel leaves it false,
-		// keeping the workspace for reuse (upstream terminate_running_issue
-		// cleanup gating). Assigning unconditionally — rather than only setting
-		// true — clears a flag left by an earlier terminal blip when the issue
-		// has since flipped back to a non-terminal inactive state before the
-		// worker exits (Codex P2 follow-up).
-		run.Issue = issue
-		run.ReconcileCleanupWorkspace = isTerminalTrackerState(issue.State, r.terminalStates)
-		run.ReconcileCancel = true
-		cancelEntries = append(cancelEntries, run)
 	}
 	for id, retry := range st.RetryAttempts {
-		issue, ok := r.issuesByID[string(id)]
-		if !ok {
-			continue
+		if cleanup, ok := r.reconcileInactiveRetry(st, id, retry); ok {
+			terminalCleanups = append(terminalCleanups, cleanup)
 		}
-		// Mirror upstream handle_retry_issue_lookup (orchestrator.ex:1082-1100):
-		// a retry whose issue is now terminal cleans its workspace + releases;
-		// a merely-inactive (non-terminal) one releases only, keeping the
-		// directory for possible reuse. The continuation retry carries the
-		// finalized run's workspace (#341); a failure retry without one yields
-		// no path and is released only. continuationForRetry threads the queued
-		// continuation attempt + workspace through the cleanup so a terminal
-		// observation the deletion-time recheck finds active again resumes the
-		// continuation instead of resetting ContinuationAttempt to 0 on the next
-		// poll (Codex review, PR #455).
-		if isTerminalTrackerState(issue.State, r.terminalStates) {
-			if w, okw := terminalWorkspaceForCleanup(id, retry.Identifier, retry.Workspace.Path, retry.Workspace.Root, issue.State); okw {
-				terminalCleanups = append(terminalCleanups, reconciledCleanup{workspace: w, continuation: continuationForRetry(retry)})
-			}
-		}
-		st.ReleaseClaim(id)
 	}
 	for id, blocked := range st.Blocked {
-		issue, ok := r.issuesByID[string(id)]
-		if !ok {
-			continue
+		if cleanup, ok := r.reconcileInactiveBlocked(st, id, blocked); ok {
+			terminalCleanups = append(terminalCleanups, cleanup)
 		}
-		if isTerminalTrackerState(issue.State, r.terminalStates) {
-			if w, okw := terminalWorkspaceForCleanup(id, blocked.Identifier, blocked.Workspace.Path, blocked.Workspace.Root, issue.State); okw {
-				terminalCleanups = append(terminalCleanups, reconciledCleanup{workspace: w})
-			}
-		}
-		st.ReleaseClaim(id)
 	}
 	return r.o.reconcileCancelFollowup(cancelEntries, terminalCleanups, r.result)
+}
+
+// reconcileInactiveRun releases a running entry observed inactive, refreshes its
+// stored issue, and (re)evaluates the SPEC §18.1 terminal cleanup gate against
+// the CURRENT observation: a terminal transition flags the entry so finalize
+// fires before_remove + remove with the terminal state labeling the
+// reconcile_workspace event, while a merely-inactive cancel leaves it false to
+// keep the workspace for reuse (upstream terminate_running_issue gating).
+// Assigning the flag unconditionally clears one left by an earlier terminal blip
+// when the issue has since flipped back to a non-terminal inactive state before
+// the worker exits (Codex P2 follow-up). Returns nil when the issue is absent
+// from the (possibly partial) listing — unknown, not inactive — so it is left
+// untouched.
+func (r *reconcileInactiveTrackerIssuesOp) reconcileInactiveRun(st *OrchestratorState, id IssueID, run *RunningEntry) *RunningEntry {
+	issue, ok := r.issuesByID[string(id)]
+	if !ok {
+		return nil
+	}
+	st.ReleaseClaim(id)
+	run.Issue = issue
+	run.ReconcileCleanupWorkspace = isTerminalTrackerState(issue.State, r.terminalStates)
+	run.ReconcileCancel = true
+	return run
+}
+
+// reconcileInactiveRetry releases a retry-queued entry observed inactive and,
+// when its issue is terminal, returns the workspace cleanup. Mirrors upstream
+// handle_retry_issue_lookup (orchestrator.ex:1082-1100): a terminal retry cleans
+// its workspace + releases, carrying the queued continuation so the
+// deletion-time recheck can resume it (preserving the attempt + max-turn budget)
+// if the issue flips back active before removal (#455); a merely-inactive one
+// releases only, keeping the directory for reuse. A failure retry without a
+// workspace (#341) yields no path and is released only. An issue absent from the
+// (possibly partial) listing is unknown, not inactive, so the claim is left
+// intact.
+func (r *reconcileInactiveTrackerIssuesOp) reconcileInactiveRetry(st *OrchestratorState, id IssueID, retry *RetryEntry) (reconciledCleanup, bool) {
+	issue, ok := r.issuesByID[string(id)]
+	if !ok {
+		return reconciledCleanup{}, false
+	}
+	defer st.ReleaseClaim(id)
+	if !isTerminalTrackerState(issue.State, r.terminalStates) {
+		return reconciledCleanup{}, false
+	}
+	w, okw := terminalWorkspaceForCleanup(id, retry.Identifier, retry.Workspace.Path, retry.Workspace.Root, issue.State)
+	if !okw {
+		return reconciledCleanup{}, false
+	}
+	return reconciledCleanup{workspace: w, continuation: continuationForRetry(retry)}, true
+}
+
+// reconcileInactiveBlocked releases a blocked entry observed inactive and, when
+// its issue is terminal, returns the workspace cleanup. Mirrors upstream
+// reconcile_blocked_issue_state's terminal branch (cleanup + release) vs. its
+// non-terminal inactive branch (release only). An issue absent from the
+// (possibly partial) listing is unknown, not inactive, so the claim is left
+// intact.
+func (r *reconcileInactiveTrackerIssuesOp) reconcileInactiveBlocked(st *OrchestratorState, id IssueID, blocked *BlockedEntry) (reconciledCleanup, bool) {
+	issue, ok := r.issuesByID[string(id)]
+	if !ok {
+		return reconciledCleanup{}, false
+	}
+	defer st.ReleaseClaim(id)
+	if !isTerminalTrackerState(issue.State, r.terminalStates) {
+		return reconciledCleanup{}, false
+	}
+	w, okw := terminalWorkspaceForCleanup(id, blocked.Identifier, blocked.Workspace.Path, blocked.Workspace.Root, issue.State)
+	if !okw {
+		return reconciledCleanup{}, false
+	}
+	return reconciledCleanup{workspace: w}, true
 }
 func isActiveTrackerState(state string, activeStates map[string]struct{}) bool {
 	if len(activeStates) == 0 {

--- a/internal/orchestrator/actor_reconcile_inactive_test.go
+++ b/internal/orchestrator/actor_reconcile_inactive_test.go
@@ -1,0 +1,165 @@
+package orchestrator
+
+// actor_reconcile_inactive_test.go pins reconcileInactiveTrackerIssuesOp release
+// behaviors the existing reconcile suite left unpinned, before #499 decomposes
+// the op's three per-collection loops into helpers. Two classes are covered:
+//
+//   - Partial-listing safety: an in-process entry whose issue is ABSENT from a
+//     (possibly pagination-truncated) inactive listing is "unknown", not
+//     "inactive" — its claim stays intact and no cleanup fires. The running
+//     loop's guard is covered by existing terminal/non-terminal reconcile tests;
+//     these add the retry-queued and blocked loops (dropping their `if !ok`
+//     guard otherwise releases the claim).
+//
+//   - Non-terminal listed release: a blocked entry whose issue IS listed but in a
+//     merely-inactive (non-terminal) state must be released WITHOUT workspace
+//     cleanup. The retry non-terminal release is covered by
+//     TestReconcileInactiveContinuationRetryKeepsWorkspace; the blocked one was
+//     not, so gating the release behind the terminal check would slip past the
+//     suite (the helper releases via `defer st.ReleaseClaim`, which must run on
+//     the non-terminal path too).
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// blockIssue dispatches issue and drives it to the Blocked state via an
+// input-required runtime event, returning once the actor reports it blocked.
+func blockIssue(t *testing.T, o *Orchestrator, disp *fakeDispatcher, issue tracker.Issue, spawnIndex, wantBlocked int) {
+	t.Helper()
+	if err := o.RequestDispatch(context.Background(), issue, nil); err != nil {
+		t.Fatalf("RequestDispatch %s: %v", issue.ID, err)
+	}
+	waitFor(t, func() bool { return disp.count() == spawnIndex+1 }, time.Second)
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{
+		Event:   task.EventTurnInputRequired,
+		Payload: map[string]any{"method": "item/tool/requestUserInput"},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent %s: %v", issue.ID, err)
+	}
+	disp.finishAt(spawnIndex, WorkerResult{Err: errors.New("input required"), Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Blocked) == wantBlocked
+	}, time.Second)
+}
+
+// TestReconcileInactiveLeavesUnlistedRetryClaimed pins that a retry-queued entry
+// survives an inactive reconcile that does not list its issue.
+func TestReconcileInactiveLeavesUnlistedRetryClaimed(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-PR1", Identifier: "ENG-PR1", State: "In Progress"}
+	if err := o.RequestDispatch(context.Background(), issue, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+	disp.finishAt(0, WorkerResult{Err: errors.New("transient"), Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.Retrying) == 1
+	}, time.Second)
+
+	// Inactive listing that omits ENG-PR1 (a pagination-truncated fetch). The
+	// retry must be treated as unknown, not released.
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(),
+		map[string]tracker.Issue{}, map[string]struct{}{"done": {}}, time.Second); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Retrying) != 1 {
+		t.Errorf("Retrying after reconcile omitting the issue = %d; want 1 (unlisted retry must stay claimed)", len(view.Retrying))
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Errorf("workspace cleanups = %+v; want none for an unlisted retry", calls)
+	}
+}
+
+// TestReconcileInactiveLeavesUnlistedBlockedClaimed pins that a blocked entry
+// survives an inactive reconcile that does not list its issue.
+func TestReconcileInactiveLeavesUnlistedBlockedClaimed(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-PB1", Identifier: "ENG-PB1", State: "AI Ready"}
+	blockIssue(t, o, disp, issue, 0, 1)
+
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(),
+		map[string]tracker.Issue{}, map[string]struct{}{"done": {}}, time.Second); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Blocked) != 1 {
+		t.Errorf("Blocked after reconcile omitting the issue = %d; want 1 (unlisted block must stay claimed)", len(view.Blocked))
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Errorf("workspace cleanups = %+v; want none for an unlisted block", calls)
+	}
+}
+
+// TestReconcileInactiveNonTerminalBlockedReleasesWithoutCleanup pins that a
+// blocked entry whose issue IS listed but in a merely-inactive (non-terminal)
+// state is released — its claim removed — WITHOUT a workspace cleanup. This is
+// the release-but-keep-workspace branch upstream reconcile_blocked_issue_state
+// takes for a non-terminal inactive transition; gating the release behind the
+// terminal check (rather than releasing on every listed entry) would leave the
+// block claimed and pass the rest of the suite.
+func TestReconcileInactiveNonTerminalBlockedReleasesWithoutCleanup(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-NB1", Identifier: "ENG-NB1", State: "AI Ready"}
+	blockIssue(t, o, disp, issue, 0, 1)
+
+	// Listed, but in a configured-inactive non-terminal state (Backlog, with
+	// only "done" terminal): release the block, keep the workspace.
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Backlog"},
+	}, map[string]struct{}{"done": {}}, time.Second); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Blocked) != 0 {
+		t.Errorf("Blocked after non-terminal inactive reconcile = %d; want 0 (listed non-terminal block must be released)", len(view.Blocked))
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Errorf("workspace cleanups = %+v; want none for a non-terminal release", calls)
+	}
+}


### PR DESCRIPTION
## What

Decompose `reconcileInactiveTrackerIssuesOp.apply` (gocognit **19**, the highest remaining #499-scoped orchestrator actor hotspot) into three per-collection helpers, **zero behavior change**:

- `reconcileInactiveRun` — release + refresh + terminal cleanup-flag + cancel a running entry; returns nil for an unlisted issue.
- `reconcileInactiveRetry` — terminal retry → workspace cleanup (carrying the queued continuation) + release; else release only.
- `reconcileInactiveBlocked` — terminal block → workspace cleanup + release; else release only.

`apply` now just loops and collects. Boundaries mirror upstream `orchestrator.ex` per-entry functions (`reconcile_issue_state` / `handle_retry_issue_lookup` / `reconcile_blocked_issue_state`) and the sibling active op's existing helper structure.

**Translation care (actor state machine):** the `if !ok { continue }` partial-listing guard becomes each helper's early return *before* the deferred release is registered; the retry/blocked unconditional `st.ReleaseClaim(id)` moves to `defer st.ReleaseClaim(id)`, which runs after the cleanup is built (same order, same release on every listed path). The followup (`reconcileCancelFollowup`) is unchanged, so the BEAM panic-recovery/goroutine discipline is inherited.

## Acceptance criteria (#499)

- [x] **Characterization committed first** (`578068d`), pinning the apply's state changes + followup per the actor acceptance. A mutation audit + adversarial review found **two release branches the existing suite did not pin** — the retry/blocked **partial-listing** guards (an issue absent from a pagination-truncated listing must be left untouched) and the **blocked non-terminal listed release** (release without cleanup). Both are now pinned and mutation-verified.
- [x] BEAM guarantees preserved (followup unchanged; no new goroutine/timer).
- [x] gocognit **19 → finding eliminated** (all four functions <10); funlen clean.
- [x] No new deviation; no external API change.

## Verification

```
gofmt -l (empty) · go vet · go mod tidy (clean) · go build ./cmd/worker ./cmd/tui
go test -race ./internal/orchestrator/   # full suite green
# blocking golangci gate → 0 issues
```

**Mutation verification** (against the committed decomposed artifact): never-flag-terminal-cleanup on running (8 fails), invert retry/blocked terminal gate (3 / 1), drop the run/retry/blocked `!ok` guard (caught by existing `TestPollOnce*` + the new tests), and gating the blocked release behind the terminal check (caught by the new non-terminal-release test) each fail their subtests. ✓

## Size-gate

`within budget` — +250/-57 over two files (production 85/57, tests 165/0), under the 300-LOC default.

## Review

Pre-push 3-lens adversarial panel (state-machine equivalence / conventions+BEAM+correctness / followup+state-change coverage): equivalence **PASS** (all four translation risks traced + 20× -race stress, no counterexample — the `defer`-vs-explicit release reorder is observationally invisible because `ReleaseClaim` mutates only state maps, never a field the cleanup builder reads), conventions **APPROVE**, coverage **APPROVE** after the one MEDIUM gap (blocked non-terminal release) was closed in `578068d`. `@codex review` triggered on the head; if usage-limited (as in the prior #499 sessions), the panel + green CI is the compensating control per checklist item 4 / protocol §4.

Refs #499
