### PR TITLE
refactor(orchestrator): decompose reconcileTrackerIssuesOp.apply (#499)

### DIFF
--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -288,57 +288,89 @@ type reconcileTrackerIssuesOp struct {
 	result         chan<- []*RunningEntry
 }
 
+// apply revalidates every in-process entry against the active listing: an entry
+// still listed in an active state on the same service route is kept (its stored
+// issue refreshed so per-state capacity gates see the latest state), otherwise
+// it is cancelled (running) or released (retry/blocked), with a routed terminal
+// transition cleaning its workspace through the §18.1 seam in this pass — before
+// the terminal-aware inactive pass would see it. Each per-collection helper
+// returns what to collect.
 func (r *reconcileTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	var cancelEntries []*RunningEntry
 	var blockedCleanups []reconciledCleanup
 	for id, run := range st.Running {
-		issue, ok := r.issuesByID[string(id)]
-		if ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(run.Issue, issue) {
-			// Refresh stored issue metadata so per-state capacity gates
-			// (RunningCountByState, StateCapacityFull) see the latest tracker
-			// state. Without this, an issue that moved between active states
-			// keeps counting toward its dispatch-time bucket and a later poll
-			// can exceed max_concurrent_agents_by_state for the new state.
-			refreshRunningIssue(run, issue)
-			st.ClaimedIssues[id] = issue
-			continue
+		if entry := r.reconcileActiveRun(st, id, run); entry != nil {
+			cancelEntries = append(cancelEntries, entry)
 		}
-		st.ReleaseClaim(id)
-		run.ReconcileCancel = true
-		r.flagTerminalRunCleanup(run, id)
-		cancelEntries = append(cancelEntries, run)
 	}
 	for id, retry := range st.RetryAttempts {
-		issue, ok := r.issuesByID[string(id)]
-		if ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(retry.Issue, issue) {
-			retry.Issue = issue
-			st.ClaimedIssues[id] = issue
-			continue
+		if cleanup, ok := r.reconcileActiveRetry(st, id, retry); ok {
+			blockedCleanups = append(blockedCleanups, cleanup)
 		}
-		// A routed terminal retry must clean its workspace through the §18.1 seam
-		// here — this pass releases it before the terminal-aware inactive pass
-		// (reconcileInactiveTrackerIssuesOp) would see it, so deferring the
-		// cleanup leaks the directory until the next startup sweep. continuationForRetry
-		// carries the queued continuation so the deletion-time recheck resumes it
-		// if the issue flips back active, matching the inactive pass.
-		if w, okw := r.terminalRetryCleanup(id, retry); okw {
-			blockedCleanups = append(blockedCleanups, reconciledCleanup{workspace: w, continuation: continuationForRetry(retry)})
-		}
-		st.ReleaseClaim(id)
 	}
 	for id, blocked := range st.Blocked {
-		issue, ok := r.issuesByID[string(id)]
-		if ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(blocked.Issue, issue) {
-			blocked.Issue = issue
-			st.ClaimedIssues[id] = issue
-			continue
+		if cleanup, ok := r.reconcileActiveBlocked(st, id, blocked); ok {
+			blockedCleanups = append(blockedCleanups, cleanup)
 		}
-		if w, okw := r.terminalBlockedCleanup(id, blocked); okw {
-			blockedCleanups = append(blockedCleanups, reconciledCleanup{workspace: w})
-		}
-		st.ReleaseClaim(id)
 	}
 	return r.o.reconcileCancelFollowup(cancelEntries, blockedCleanups, r.result)
+}
+
+// reconcileActiveRun keeps a running entry still listed in an active state on
+// the same route — refreshing its stored issue so per-state capacity gates
+// (RunningCountByState, StateCapacityFull) see the latest state, otherwise an
+// issue that moved between active states keeps counting toward its dispatch-time
+// bucket and a later poll can exceed max_concurrent_agents_by_state. Any other
+// observation (unlisted, non-active, route-changed) releases the claim, flags
+// the SPEC §18.1 terminal cleanup, and returns the entry to cancel.
+func (r *reconcileTrackerIssuesOp) reconcileActiveRun(st *OrchestratorState, id IssueID, run *RunningEntry) *RunningEntry {
+	if issue, ok := r.issuesByID[string(id)]; ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(run.Issue, issue) {
+		refreshRunningIssue(run, issue)
+		st.ClaimedIssues[id] = issue
+		return nil
+	}
+	st.ReleaseClaim(id)
+	run.ReconcileCancel = true
+	r.flagTerminalRunCleanup(run, id)
+	return run
+}
+
+// reconcileActiveRetry keeps a retry-queued entry still listed in an active
+// state on the same route (refreshing its issue); otherwise it releases the
+// claim and, for a routed terminal transition, returns the workspace cleanup. A
+// routed terminal retry must clean here — this pass releases it before the
+// terminal-aware inactive pass would see it, so deferring would leak the
+// directory until the next startup sweep. continuationForRetry carries the
+// queued continuation so the deletion-time recheck resumes it if the issue flips
+// back active, matching the inactive pass.
+func (r *reconcileTrackerIssuesOp) reconcileActiveRetry(st *OrchestratorState, id IssueID, retry *RetryEntry) (reconciledCleanup, bool) {
+	if issue, ok := r.issuesByID[string(id)]; ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(retry.Issue, issue) {
+		retry.Issue = issue
+		st.ClaimedIssues[id] = issue
+		return reconciledCleanup{}, false
+	}
+	defer st.ReleaseClaim(id)
+	if w, okw := r.terminalRetryCleanup(id, retry); okw {
+		return reconciledCleanup{workspace: w, continuation: continuationForRetry(retry)}, true
+	}
+	return reconciledCleanup{}, false
+}
+
+// reconcileActiveBlocked keeps a blocked entry still listed in an active state
+// on the same route (refreshing its issue); otherwise it releases the claim and,
+// for a routed terminal transition, returns the workspace cleanup (mirroring the
+// retry path and upstream reconcile_blocked_issue_state).
+func (r *reconcileTrackerIssuesOp) reconcileActiveBlocked(st *OrchestratorState, id IssueID, blocked *BlockedEntry) (reconciledCleanup, bool) {
+	if issue, ok := r.issuesByID[string(id)]; ok && isActiveTrackerState(issue.State, r.activeStates) && sameServiceRoute(blocked.Issue, issue) {
+		blocked.Issue = issue
+		st.ClaimedIssues[id] = issue
+		return reconciledCleanup{}, false
+	}
+	defer st.ReleaseClaim(id)
+	if w, okw := r.terminalBlockedCleanup(id, blocked); okw {
+		return reconciledCleanup{workspace: w}, true
+	}
+	return reconciledCleanup{}, false
 }
 
 // flagTerminalRunCleanup sets ReconcileCleanupWorkspace on a routed run this

--- a/internal/orchestrator/actor_reconcile_active_test.go
+++ b/internal/orchestrator/actor_reconcile_active_test.go
@@ -1,0 +1,89 @@
+package orchestrator
+
+// actor_reconcile_active_test.go pins reconcileTrackerIssuesOp (the per-tick
+// active-revalidation pass) keep-vs-release branches the existing suite left
+// unpinned, before #499 decomposes its three per-collection loops into helpers.
+// A mutation audit showed the running route-change/refresh and retry
+// route-change branches are covered, but two were not: a running entry observed
+// in a NON-ACTIVE state must be cancelled (the isActiveTrackerState gate — the
+// documented "cancels workers whose issues moved out of active states"), and a
+// BLOCKED entry whose route changes must be released (parity with the covered
+// running/retry route-change tests).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// TestReconcileTrackerIssuesCancelsRunMovedToNonActiveState pins the
+// isActiveTrackerState gate: a running entry still listed on the same route but
+// whose state is no longer active must have its worker cancelled.
+func TestReconcileTrackerIssuesCancelsRunMovedToNonActiveState(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-NA1", Identifier: "ENG-NA1", State: "In Progress"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	// Same id and route, but moved to a non-active state — must cancel.
+	active := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "Backlog"}}
+	if err := o.ReconcileTrackerIssues(context.Background(), active, normalizedStates([]string{"In Progress"})); err != nil {
+		t.Fatalf("ReconcileTrackerIssues: %v", err)
+	}
+	select {
+	case <-disp.contexts[0].Done():
+	case <-time.After(time.Second):
+		t.Fatal("run moved to a non-active state was not canceled")
+	}
+	disp.finishAt(0, WorkerResult{Err: context.Canceled, Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0
+	}, time.Second)
+}
+
+// TestReconcileTrackerIssuesReleasesBlockedWhenServiceRouteChanges pins the
+// blocked route-change release: a blocked entry still in an active state but now
+// routed to a different service is released (kept-claimed only on same route).
+func TestReconcileTrackerIssuesReleasesBlockedWhenServiceRouteChanges(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Minute},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-BR1", Identifier: "ENG-BR1", State: "AI Ready", ServiceName: "api"}
+	blockIssue(t, o, disp, iss, 0, 1)
+
+	// Same active state, different service route -> release (route changed);
+	// no refreshedByID, so this is a non-terminal release that keeps the
+	// workspace.
+	active := map[string]tracker.Issue{
+		iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "AI Ready", ServiceName: "web"},
+	}
+	if err := o.ReconcileTrackerIssuesAndWait(context.Background(), active,
+		map[string]struct{}{"ai ready": {}}, nil, nil, time.Second); err != nil {
+		t.Fatalf("ReconcileTrackerIssuesAndWait: %v", err)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Blocked) != 0 {
+		t.Errorf("Blocked after route-change reconcile = %d; want 0 (route-changed block released)", len(view.Blocked))
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Errorf("workspace cleanups = %+v; want none (route change keeps the workspace)", calls)
+	}
+}


### PR DESCRIPTION
## What

Decompose `reconcileTrackerIssuesOp.apply` (gocognit **16**, the per-tick active-revalidation pass) into three per-collection helpers, mirroring the just-merged sibling `reconcileInactiveTrackerIssuesOp` decomposition (#516) and upstream's per-entry reconcile functions, **zero behavior change**:

- `reconcileActiveRun` — keep (refresh issue for capacity gates) when listed active + same route; else release + flag §18.1 terminal cleanup + cancel.
- `reconcileActiveRetry` — keep when listed active + same route; else release, cleaning a routed-terminal retry's workspace (with queued continuation).
- `reconcileActiveBlocked` — keep when listed active + same route; else release, cleaning a routed-terminal block's workspace.

**The distinguishing aspect vs the inactive op:** this op has a KEEP path — an entry still listed active on the same route is refreshed and **stays claimed** (not released). The helpers return `nil`/`false` on the keep branch *before* registering `defer st.ReleaseClaim(id)`, so kept entries are never released; the deferred release fires only on the cancel/release path, after the terminal cleanup is built (same order, same conditions as the original). The pre-extracted `flagTerminalRunCleanup` / `terminalRetryCleanup` / `terminalBlockedCleanup` helpers are unchanged.

## Acceptance criteria (#499)

- [x] **Characterization committed first** (`a1ea0b1`). A mutation audit found two keep-vs-release gates unpinned — the running `isActiveTrackerState` gate (the documented "cancels workers whose issues moved out of active states") and the **blocked** `sameServiceRoute` gate (parity with the covered running/retry route-change tests) — both now pinned + mutation-verified.
- [x] BEAM guarantees preserved (followup unchanged; no new goroutine/timer).
- [x] gocognit **16 → finding eliminated** (all four functions <10); funlen clean.
- [x] No new deviation; no external API change.

## Verification

```
gofmt -l (empty) · go vet · go mod tidy (clean) · go build ./cmd/worker ./cmd/tui
go test -race ./internal/orchestrator/   # full suite green (85.0% coverage)
# blocking golangci gate → 0 issues
```

**Mutation verification** (against the committed decomposed artifact): dropping the run `isActive` gate, dropping the run/retry/blocked `sameServiceRoute` gate, and dropping the running `refreshRunningIssue` each fail their subtests. ✓

## Size-gate

`within budget` — +159/-38 over two files (production 70/38, tests 89/0), under the 300-LOC default.

## Review

Pre-push 3-lens adversarial panel (keep-vs-release equivalence / conventions+BEAM+correctness / test coverage): **all three PASS/APPROVE with zero findings** — kept entries confirmed never released (defer not registered on the keep path), the `defer`-vs-explicit release reorder observationally invisible (ReleaseClaim mutates only state maps, never a field the cleanup builder reads), and all keep/release branches covered (reviewer independently mutation-confirmed the three keep-refresh assertions). `@codex review` triggered on the head.

Refs #499
