### PR TITLE
refactor(runner): decompose toSnakeCase into per-decision helpers (#499)

### DIFF
--- a/internal/runner/codex_app_server_events.go
+++ b/internal/runner/codex_app_server_events.go
@@ -135,15 +135,8 @@ func toSnakeCase(s string) string {
 	var b strings.Builder
 	var prev rune
 	for i, r := range s {
-		nextIsLower := false
-		if i+1 < len(s) {
-			next := rune(s[i+1])
-			nextIsLower = next >= 'a' && next <= 'z'
-		}
 		if r >= 'A' && r <= 'Z' {
-			prevIsLowerOrDigit := (prev >= 'a' && prev <= 'z') || (prev >= '0' && prev <= '9')
-			prevIsUpper := prev >= 'A' && prev <= 'Z'
-			if i > 0 && (prevIsLowerOrDigit || (prevIsUpper && nextIsLower)) {
+			if i > 0 && snakeCaseWordBoundary(prev, asciiByteIsLower(s, i+1)) {
 				b.WriteByte('_')
 			}
 			r += 'a' - 'A'
@@ -152,4 +145,27 @@ func toSnakeCase(s string) string {
 		prev = rune(s[i])
 	}
 	return b.String()
+}
+
+// asciiByteIsLower reports whether the byte at index i in s is an ASCII
+// lowercase letter. Codex payload keys are ASCII camelCase, so toSnakeCase scans
+// bytes rather than runes; this is the one-byte lookahead its acronym-boundary
+// rule needs.
+func asciiByteIsLower(s string, i int) bool {
+	if i >= len(s) {
+		return false
+	}
+	return s[i] >= 'a' && s[i] <= 'z'
+}
+
+// snakeCaseWordBoundary reports whether an uppercase rune starts a new
+// snake_case word given the previous rune and whether the next byte is
+// lowercase. Two boundaries insert an underscore: after a lowercase/digit (the
+// camelCase boundary, fooB -> foo_b) and at the tail of an acronym run that is
+// followed by a word (an uppercase prev with a lowercase next, HTTPServer ->
+// http_server).
+func snakeCaseWordBoundary(prev rune, nextIsLower bool) bool {
+	prevIsLowerOrDigit := (prev >= 'a' && prev <= 'z') || (prev >= '0' && prev <= '9')
+	prevIsUpper := prev >= 'A' && prev <= 'Z'
+	return prevIsLowerOrDigit || (prevIsUpper && nextIsLower)
 }

--- a/internal/runner/codex_app_server_events_test.go
+++ b/internal/runner/codex_app_server_events_test.go
@@ -1,0 +1,59 @@
+package runner
+
+// codex_app_server_events_test.go pins toSnakeCase at its own function boundary
+// before #499 decomposes its 17-cognitive-complexity loop into per-decision
+// helpers. toSnakeCase normalizes Codex JSON-RPC payload keys (camelCase /
+// acronym) to the snake_case the runtime-event surface emits, so its
+// word-boundary rules must hold identically across the refactor.
+//
+// The subprocess suite only samples specific normalized keys; this exercises
+// the boundary rules directly, including the ASCII byte-oriented lookahead the
+// implementation relies on (Codex keys are ASCII camelCase).
+
+import "testing"
+
+func TestToSnakeCase(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"thread", "thread"},
+		{"user_id", "user_id"}, // already snake: underscore passes through unchanged
+
+		// camelCase boundary: underscore before an uppercase preceded by lower.
+		{"threadId", "thread_id"},
+		{"callId", "call_id"},
+		{"lastAssistantMessage", "last_assistant_message"},
+		{"retryAfterSeconds", "retry_after_seconds"},
+
+		// camelCase boundary where the boundary uppercase is the final byte: the
+		// underscore comes from the lower-prev branch, independent of the
+		// (out-of-range, don't-care) lookahead.
+		{"fooB", "foo_b"},
+
+		// digit -> uppercase boundary.
+		{"a1B", "a1_b"},
+		{"fooBar2Baz", "foo_bar2_baz"},
+
+		// acronym -> word boundary: underscore before the last uppercase of a
+		// run when the next rune is lowercase.
+		{"HTTPServer", "http_server"},
+		{"ABc", "a_bc"},
+
+		// pure acronym / trailing uppercase run: no internal underscore.
+		{"HTTP", "http"},
+		{"ID", "id"},
+		{"AB", "ab"},
+
+		// leading uppercase never gets a prefix underscore.
+		{"A", "a"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := toSnakeCase(tt.in); got != tt.want {
+				t.Errorf("toSnakeCase(%q) = %q; want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Decompose `toSnakeCase` (gocognit **17**) — the Codex JSON-RPC payload-key normalizer (camelCase/acronym → snake_case for the runtime-event surface) — into two single-concern helpers, **zero behavior change**:

- `asciiByteIsLower` — the one-byte lowercase lookahead. Codex keys are ASCII camelCase, so the scan is **byte-oriented** (reads `s[i+1]` as a byte; `prev = rune(s[i])` is the byte at the rune's start), correct only for ASCII — this is preserved exactly.
- `snakeCaseWordBoundary` — whether an uppercase rune starts a new word: the camelCase boundary (lower/digit prev) or the acronym-tail boundary (upper prev + lower next).

The loop now just lowercases an uppercase rune and inserts the boundary underscore.

## Acceptance criteria (#499)

- [x] **Characterization committed first** (`9da8714`): a 16-case table covering every boundary branch — camelCase (incl. the boundary uppercase as the final byte), digit→upper, acronym→word, pure-acronym/trailing run, leading uppercase, underscore passthrough, empty.
- [x] gocognit **17 → finding eliminated** (all three functions <10); funlen clean.
- [x] No new deviation; no external API change.

## Behavior preservation — empirically proven

A **throwaway differential fuzz** (not committed) compared the decomposed `toSnakeCase` against a frozen copy of the original: **3.7M executions, zero divergence**, including multi-byte UTF-8 (`café`, `中Ab`) and invalid UTF-8 (`\xc3\x28`, `A\xffB`) seeds — confirming the byte-oriented logic is faithfully preserved. The review panel independently brute-forced 41k combinations over ASCII boundary chars + high/invalid bytes: also zero divergence.

## Verification

```
gofmt -l (empty) · go vet · go build ./cmd/worker ./cmd/tui
go test -race ./internal/runner/   # green except the known
                                   # TestCodexAppServerInitializeTimeoutDiagnostics sandbox-flaky
# blocking golangci gate → 0 issues
```

**Mutation verification** (committed decomposed artifact): inverting the acronym-boundary `nextIsLower` clause (5 fails), turning the camelCase `||` into `&&` (8 fails), dropping the digit from the prev check (2 fails), and inverting the lookahead (3 fails) each fail their subtests. ✓

## Size-gate

`within budget` — +83/-8 over two files (production 24/8, tests 59/0).

## Review

Pre-PR 2-lens adversarial panel (equivalence+conventions+byte-orientation / test quality): both **APPROVE/PASS with no HIGH/MEDIUM** — byte-orientation confirmed preserved, all branches covered; one LOW informational nit (a camelCase-boundary-at-final-byte case) was added in `9da8714`. `@codex review` triggered on the head.

Refs #499
