### PR TITLE
refactor(orchestrator): decompose refreshActive + reconcileStalled ops (#499)

### DIFF
--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -195,35 +195,47 @@ type refreshActiveTrackerIssuesOp struct {
 
 func (r *refreshActiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 	for id, run := range st.Running {
-		issue, ok := r.issuesByID[string(id)]
-		if !ok || !isActiveTrackerState(issue.State, r.activeStates) || !sameServiceRoute(run.Issue, issue) {
-			continue
+		if issue, ok := r.activeMatch(st, id, run.Issue); ok {
+			refreshRunningIssue(run, issue)
 		}
-		refreshRunningIssue(run, issue)
-		st.ClaimedIssues[id] = issue
 	}
 	for id, retry := range st.RetryAttempts {
-		issue, ok := r.issuesByID[string(id)]
-		if !ok || !isActiveTrackerState(issue.State, r.activeStates) || !sameServiceRoute(retry.Issue, issue) {
-			continue
+		if issue, ok := r.activeMatch(st, id, retry.Issue); ok {
+			retry.Issue = issue
 		}
-		retry.Issue = issue
-		st.ClaimedIssues[id] = issue
 	}
 	for id, blocked := range st.Blocked {
-		issue, ok := r.issuesByID[string(id)]
-		if !ok || !isActiveTrackerState(issue.State, r.activeStates) || !sameServiceRoute(blocked.Issue, issue) {
-			continue
+		if issue, ok := r.activeMatch(st, id, blocked.Issue); ok {
+			blocked.Issue = issue
 		}
-		blocked.Issue = issue
-		st.ClaimedIssues[id] = issue
 	}
+	return r.doneFollowup()
+}
+
+// doneFollowup returns the no-op off-actor followup that signals completion by
+// closing the reply channel (the refresh pass cancels nothing).
+func (r *refreshActiveTrackerIssuesOp) doneFollowup() func() {
 	done := r.done
 	return func() {
 		if done != nil {
 			close(done)
 		}
 	}
+}
+
+// activeMatch reports whether id's entry is still observed in the active listing
+// on the same service route as prev. On a match it refreshes the ClaimedIssues
+// snapshot (so per-state capacity gates see the latest state) and returns the
+// fresh issue for the caller to store on the entry; a miss (absent / non-active
+// / route-changed) leaves the entry untouched — absence from a possibly-partial
+// listing is "no information," not "now inactive."
+func (r *refreshActiveTrackerIssuesOp) activeMatch(st *OrchestratorState, id IssueID, prev tracker.Issue) (tracker.Issue, bool) {
+	issue, ok := r.issuesByID[string(id)]
+	if !ok || !isActiveTrackerState(issue.State, r.activeStates) || !sameServiceRoute(prev, issue) {
+		return tracker.Issue{}, false
+	}
+	st.ClaimedIssues[id] = issue
+	return issue, true
 }
 
 // reconcileStalledRunsOp is the actor-side handler for SPEC §8.5 Part A.
@@ -242,22 +254,34 @@ type reconcileStalledRunsOp struct {
 func (r *reconcileStalledRunsOp) apply(st *OrchestratorState) func() {
 	var canceled []*RunningEntry
 	for id, run := range st.Running {
-		ref := run.LastEventAt
-		if ref.IsZero() {
-			ref = run.StartedAt
-		}
-		if ref.IsZero() {
-			// Fresh dispatch without a StartedAt is exceedingly rare (a
-			// test fixture). Skip rather than treat the Unix epoch as a
-			// stall reference, which would cancel every such entry.
-			continue
-		}
-		if r.now.Sub(ref) <= r.timeout {
+		if !r.isStalled(run) {
 			continue
 		}
 		canceled = append(canceled, run)
 		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: id, Identifier: run.Identifier, Message: "stalled"})
 	}
+	return r.cancelStalledFollowup(canceled)
+}
+
+// isStalled reports whether run has gone longer than the stall budget since its
+// last observed runtime event, falling back to StartedAt before any event has
+// been seen. A run with neither timestamp is treated as not-stalled rather than
+// anchoring the stall window at the zero time, which would cancel every such
+// (test-fixture) entry.
+func (r *reconcileStalledRunsOp) isStalled(run *RunningEntry) bool {
+	ref := run.LastEventAt
+	if ref.IsZero() {
+		ref = run.StartedAt
+	}
+	if ref.IsZero() {
+		return false
+	}
+	return r.now.Sub(ref) > r.timeout
+}
+
+// cancelStalledFollowup returns the off-actor followup that cancels each stalled
+// worker and publishes the canceled set to the reply channel.
+func (r *reconcileStalledRunsOp) cancelStalledFollowup(canceled []*RunningEntry) func() {
 	return func() {
 		for _, entry := range canceled {
 			if entry.CancelWorker != nil {

--- a/internal/orchestrator/actor_reconcile_ops_test.go
+++ b/internal/orchestrator/actor_reconcile_ops_test.go
@@ -1,0 +1,109 @@
+package orchestrator
+
+// actor_reconcile_ops_test.go pins the two smallest #499 reconcile ops —
+// refreshActiveTrackerIssuesOp and reconcileStalledRunsOp — at their apply
+// boundary before #499 decomposes them. Both are exercised here directly on an
+// OrchestratorState (no live actor), which pins the per-collection refresh
+// actions and the stall-timing reference the integration suite only samples.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// TestRefreshActiveTrackerIssuesOpApply pins that the refresh pass updates the
+// stored issue + ClaimedIssues snapshot for every in-process entry still
+// observed active on the same route (running/retry/blocked), and leaves a
+// route-changed entry untouched.
+func TestRefreshActiveTrackerIssuesOpApply(t *testing.T) {
+	st := NewOrchestratorState(15000, 10)
+	st.Running[IssueID("R1")] = &RunningEntry{Identifier: "R1", Issue: tracker.Issue{ID: "R1", Identifier: "R1", State: "In Progress", ServiceName: "api"}}
+	st.RetryAttempts[IssueID("T1")] = &RetryEntry{IssueID: IssueID("T1"), Identifier: "T1", Issue: tracker.Issue{ID: "T1", Identifier: "T1", State: "In Progress", ServiceName: "api"}}
+	st.Blocked[IssueID("B1")] = &BlockedEntry{Identifier: "B1", Issue: tracker.Issue{ID: "B1", Identifier: "B1", State: "In Progress", ServiceName: "api"}}
+	// Same active state but a different service route: must be left untouched.
+	st.Running[IssueID("R2")] = &RunningEntry{Identifier: "R2", Issue: tracker.Issue{ID: "R2", Identifier: "R2", State: "In Progress", ServiceName: "api"}}
+	// Absent from the (possibly partial) refresh listing: "no information", not
+	// inactive — must be left untouched, distinct from the route-changed miss.
+	st.Running[IssueID("R3")] = &RunningEntry{Identifier: "R3", Issue: tracker.Issue{ID: "R3", Identifier: "R3", State: "In Progress", ServiceName: "api"}}
+
+	refreshed := map[string]tracker.Issue{
+		"R1": {ID: "R1", Identifier: "R1", State: "Rework", ServiceName: "api"},
+		"T1": {ID: "T1", Identifier: "T1", State: "Rework", ServiceName: "api"},
+		"B1": {ID: "B1", Identifier: "B1", State: "Rework", ServiceName: "api"},
+		"R2": {ID: "R2", Identifier: "R2", State: "Rework", ServiceName: "web"}, // route changed
+		// R3 intentionally omitted (absent from the listing).
+	}
+	done := make(chan struct{}, 1)
+	op := &refreshActiveTrackerIssuesOp{issuesByID: refreshed, activeStates: normalizedStates([]string{"In Progress", "Rework"}), done: done}
+	op.apply(st)()
+
+	for _, id := range []IssueID{"R1", "T1", "B1"} {
+		if got := st.ClaimedIssues[id].State; got != "Rework" {
+			t.Errorf("ClaimedIssues[%s].State = %q; want Rework (refreshed)", id, got)
+		}
+	}
+	if got := st.Running[IssueID("R1")].Issue.State; got != "Rework" {
+		t.Errorf("running R1 Issue.State = %q; want Rework (refreshRunningIssue must update it)", got)
+	}
+	if got := st.RetryAttempts[IssueID("T1")].Issue.State; got != "Rework" {
+		t.Errorf("retry T1 Issue.State = %q; want Rework (refresh must update it)", got)
+	}
+	if got := st.Blocked[IssueID("B1")].Issue.State; got != "Rework" {
+		t.Errorf("blocked B1 Issue.State = %q; want Rework (refresh must update it)", got)
+	}
+	for _, miss := range []struct {
+		id  IssueID
+		why string
+	}{{"R2", "route changed"}, {"R3", "absent from listing"}} {
+		if got := st.Running[miss.id].Issue.State; got != "In Progress" {
+			t.Errorf("running %s Issue.State = %q; want In Progress (%s -> untouched)", miss.id, got, miss.why)
+		}
+		if _, ok := st.ClaimedIssues[miss.id]; ok {
+			t.Errorf("ClaimedIssues[%s] was set; want untouched (%s)", miss.id, miss.why)
+		}
+	}
+	select {
+	case <-done:
+	default:
+		t.Errorf("apply followup did not close done")
+	}
+}
+
+// TestReconcileStalledRunsOpTimingReference pins the stall-timing reference: a
+// run is stalled when now - (LastEventAt, or StartedAt before any event) exceeds
+// the budget, and a run with neither timestamp is skipped rather than anchored
+// at the zero time (which would cancel every fresh fixture).
+func TestReconcileStalledRunsOpTimingReference(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name         string
+		last         time.Time
+		started      time.Time
+		wantCanceled bool
+	}{
+		{"stalled by LastEventAt", now.Add(-time.Hour), now.Add(-2 * time.Hour), true},
+		{"stalled by StartedAt when no event observed", time.Time{}, now.Add(-time.Hour), true},
+		{"within budget", now.Add(-time.Millisecond), now.Add(-time.Hour), false},
+		// Boundary pair pinning strict-greater-than (elapsed == budget is NOT
+		// stalled; one tick over is): catches a `>` -> `>=` regression.
+		{"exactly at budget is not stalled", now.Add(-time.Minute), time.Time{}, false},
+		{"one tick over budget is stalled", now.Add(-time.Minute - time.Nanosecond), time.Time{}, true},
+		{"skipped when no timing reference", time.Time{}, time.Time{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := NewOrchestratorState(15000, 10)
+			st.Running[IssueID("S")] = &RunningEntry{Identifier: "S", LastEventAt: tt.last, StartedAt: tt.started, CancelWorker: func() {}}
+			result := make(chan []*RunningEntry, 1)
+			op := &reconcileStalledRunsOp{timeout: time.Minute, now: now, result: result}
+			op.apply(st)()
+			canceled := <-result
+			if got := len(canceled) == 1; got != tt.wantCanceled {
+				t.Errorf("reconcileStalledRuns(last=%v, started=%v) canceled=%v (n=%d); want canceled=%v",
+					tt.last, tt.started, got, len(canceled), tt.wantCanceled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Close out the **last two** #499-scoped orchestrator hotspots (both gocognit **14**), **zero behavior change**:

- **`refreshActiveTrackerIssuesOp.apply`** — the per-tick refresh-only pass (no cancellation). Extract `activeMatch` (the shared listed-active-on-same-route gate that also refreshes the `ClaimedIssues` snapshot) so each loop just stores the fresh issue on its entry, and `doneFollowup` (the no-op completion signal). A kept entry is refreshed but **not** released; a miss (absent / non-active / route-changed) leaves the entry untouched.
- **`reconcileStalledRunsOp.apply`** — SPEC §8.5 Part A stall detection. Extract `isStalled` (the `LastEventAt`→`StartedAt`→not-stalled timing reference, stalled iff `now.Sub(ref) > timeout`) and `cancelStalledFollowup`.

`apply` mutates `st` synchronously on the actor; the followups run off-actor — the mutation discipline is preserved. No goroutine/timer added.

## Acceptance criteria (#499)

- [x] **Characterization committed first** (`b8414e0`), via direct apply-on-state tests pinning the branches the integration suite missed: the per-collection refresh actions, the route-changed **and** absent-from-listing misses, and the stall-timing reference including the **exact-budget boundary pair** (elapsed == budget is not stalled; one tick over is — pinning strict `>`).
- [x] gocognit **14 + 14 → findings eliminated** (all functions <10); funlen clean.
- [x] No new deviation; no external API change.

## Verification

```
gofmt -l (empty) · go vet · go build ./cmd/worker ./cmd/tui
go test -race ./internal/orchestrator/   # full suite green
# blocking golangci gate → 0 issues
```

**Mutation verification** (committed artifact): dropping the `activeMatch` route gate, the running/retry refresh actions, the StartedAt fallback, the zero-reference skip, and flipping the stall comparison `>` → `>=` (caught by the new exact-budget row) each fail their subtests. ✓

## Size-gate

`within budget` — +159/-26 over two files (production 50/26, tests 109/0).

## Review

Pre-PR 2-lens adversarial panel (equivalence / conventions+test-quality): equivalence **PASS** (no divergence; the `ClaimedIssues`-before-refresh order swap and the `>` ≡ `!(<=)` complement both confirmed). Two findings — a MEDIUM exact-stall-boundary gap and a LOW absent-miss-not-self-contained — both addressed in `b8414e0` (boundary pair + the R3 absent-from-listing case). `@codex review` triggered on the head.

**This is the final #499 hotspot.** With it merged, every named function in the issue's scope (the actor `apply` ops + the codex protocol path) is decomposed below the gocognit threshold; I'll confirm with a full `golangci-lint --enable gocognit` sweep.

Refs #499
