### PR TITLE
refactor(policy): decompose globMatch into wildcard helpers (#521)

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -155,60 +155,20 @@ func Match(pattern, path string) bool {
 	return globMatch(pattern, path)
 }
 
-// globMatch is the recursive glob matcher. It walks both pattern and path
-// with explicit handling for "**" so that double-star spans path separators
-// while single "*" and "?" do not.
-func globMatch(pattern, path string) bool { //nolint:gocognit // baseline (#521)
+// globMatch is the recursive glob matcher. It is a thin dispatcher: the
+// separator-spanning "**" and single-segment "*" wildcards delegate to
+// helpers, and every other position (a literal byte or "?") consumes exactly
+// one character via matchSingleChar.
+func globMatch(pattern, path string) bool {
 	for len(pattern) > 0 {
 		switch {
 		case strings.HasPrefix(pattern, "**"):
-			rest := strings.TrimPrefix(pattern, "**")
-			// Allow leading "/" after "**" to consume an arbitrary number of
-			// path segments, including zero.
-			if strings.HasPrefix(rest, "/") {
-				inner := rest[1:]
-				// "**/" matches zero segments.
-				if globMatch(inner, path) {
-					return true
-				}
-				for i := 0; i < len(path); i++ {
-					if path[i] == '/' && globMatch(inner, path[i+1:]) {
-						return true
-					}
-				}
-				return false
-			}
-			// Trailing "**" matches the rest of path.
-			if rest == "" {
-				return true
-			}
-			// "**" followed by non-slash: try every suffix.
-			for i := 0; i <= len(path); i++ {
-				if globMatch(rest, path[i:]) {
-					return true
-				}
-			}
-			return false
+			return matchDoubleStar(strings.TrimPrefix(pattern, "**"), path)
 		case pattern[0] == '*':
-			rest := pattern[1:]
-			// Match any run of non-"/" characters, including empty.
-			for i := 0; i <= len(path); i++ {
-				if i > 0 && path[i-1] == '/' {
-					return false
-				}
-				if globMatch(rest, path[i:]) {
-					return true
-				}
-			}
-			return false
-		case pattern[0] == '?':
-			if len(path) == 0 || path[0] == '/' {
-				return false
-			}
-			pattern = pattern[1:]
-			path = path[1:]
+			return matchSingleStar(pattern[1:], path)
 		default:
-			if len(path) == 0 || pattern[0] != path[0] {
+			// A literal byte or "?" consumes exactly one matching character.
+			if !matchSingleChar(pattern[0], path) {
 				return false
 			}
 			pattern = pattern[1:]
@@ -216,4 +176,71 @@ func globMatch(pattern, path string) bool { //nolint:gocognit // baseline (#521)
 		}
 	}
 	return len(path) == 0
+}
+
+// matchSingleChar reports whether the non-wildcard pattern byte pc matches the
+// first byte of path. "?" matches any single byte except "/"; any other byte
+// must equal path[0] exactly, so a "/" is only ever consumed by a literal "/".
+func matchSingleChar(pc byte, path string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	if pc == '?' {
+		return path[0] != '/'
+	}
+	return pc == path[0]
+}
+
+// matchDoubleStar matches a "**" wildcard against path, where rest is the
+// pattern that follows the "**". A "**" spans path separators: "**/<inner>"
+// skips whole leading segments, a trailing "**" matches the remainder, and
+// "**" before a non-"/" literal tries every suffix of path.
+func matchDoubleStar(rest, path string) bool {
+	// A leading "/" after "**" consumes an arbitrary number of path segments,
+	// including zero, before matching the inner pattern.
+	if strings.HasPrefix(rest, "/") {
+		return matchDoubleStarSegment(rest[1:], path)
+	}
+	// Trailing "**" matches the rest of path.
+	if rest == "" {
+		return true
+	}
+	// "**" followed by a non-"/" literal: try every suffix.
+	for i := 0; i <= len(path); i++ {
+		if globMatch(rest, path[i:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchDoubleStarSegment matches inner (the pattern after a "**/") against
+// path, allowing inner to start at the beginning of path (zero skipped
+// segments) or immediately after any "/" separator.
+func matchDoubleStarSegment(inner, path string) bool {
+	// "**/" matches zero segments.
+	if globMatch(inner, path) {
+		return true
+	}
+	for i := 0; i < len(path); i++ {
+		if path[i] == '/' && globMatch(inner, path[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchSingleStar matches a "*" wildcard against path, where rest is the
+// pattern that follows the "*". A "*" matches a run of non-"/" characters,
+// including the empty run, but never crosses a separator.
+func matchSingleStar(rest, path string) bool {
+	for i := 0; i <= len(path); i++ {
+		if i > 0 && path[i-1] == '/' {
+			return false
+		}
+		if globMatch(rest, path[i:]) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -59,6 +59,71 @@ func TestMatch(t *testing.T) {
 	}
 }
 
+// TestGlobMatchBranches pins globMatch's behavior at the boundary of each
+// matching branch (** spanning separators, **/ segment skipping, * runs that
+// stop at "/", ? single-char, and literal comparison). It calls globMatch
+// directly (not via Match) so the cases also cover inputs that Match's
+// pre-processing — empty-pattern guard, trailing-"/" → "/**" rewrite — would
+// otherwise mask. This is the characterization net for the #521 decomposition:
+// every case must keep the same verdict before and after extracting helpers.
+func TestGlobMatchBranches(t *testing.T) {
+	cases := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		// "**" trailing (rest == "") matches the remainder, including empty.
+		{"**", "", true},
+		{"**", "a/b/c", true},
+		{"a**", "a", true},
+		// "**" followed by a non-"/" literal spans separators ("try every suffix").
+		{"**x", "x", true},
+		{"**x", "abx", true},
+		{"**x", "a/b/cx", true},
+		{"**x", "ab", false},
+		// "**" between literals: the suffix scan must succeed at a non-zero,
+		// non-segment-boundary offset (here "**" consumes "ab" / "" / fails).
+		{"x**y", "xaby", true},
+		{"x**y", "xy", true},
+		{"x**y", "xab", false},
+		// "**/" segment skipping: zero or more whole leading path segments.
+		{"**/x", "x", true},
+		{"**/x", "a/x", true},
+		{"**/x", "a/b/x", true},
+		{"**/x", "ax", false},
+		{"**/x", "a/", false},
+		{"a/**/b", "a/b", true},
+		{"a/**/b", "a/x/y/b", true},
+		// "*" matches a run of non-"/" characters, including empty, never "/".
+		{"a*", "a", true},
+		{"a*b", "ab", true},
+		{"a*b", "axyzb", true},
+		{"a*b", "ax/b", false},
+		{"*x", "/x", false},
+		// "?" matches exactly one non-"/" character.
+		{"?", "", false},
+		{"?", "a", true},
+		{"?", "/", false},
+		{"a?", "a", false},
+		// Literal comparison: length mismatches and exact equality.
+		{"abc", "ab", false},
+		{"ab", "abc", false},
+		{"", "", true},
+		{"", "x", false},
+		// A literal "/" must match "/" exactly, never another byte (matchSingleChar).
+		{"a/b", "axb", false},
+		{"exact/path.txt", "exact/path.txt", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.pattern+"\x00"+tc.path, func(t *testing.T) {
+			if got := globMatch(tc.pattern, tc.path); got != tc.want {
+				t.Errorf("globMatch(%q, %q) = %v; want %v", tc.pattern, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateDenyPaths(t *testing.T) {
 	cfg := Config{
 		DenyPaths: []string{"infra/**", "deploy/**", "**/secrets.yaml", "db/migrations/**"},


### PR DESCRIPTION
## What & why

First PR of #521 (decompose the 10 heaviest `gocognit` hotspots, one function per PR, descending). Target: **`policy.globMatch`** — gocognit **54**, the heaviest baseline function. The repo's blocking gate (`.golangci.yml` `gocognit.min-complexity: 10`) fails any non-test function over 10.

`globMatch` is now a thin dispatcher; each matching concern is a single-purpose helper:

| function | role | gocognit |
|---|---|---|
| `globMatch` | dispatch loop | **6** |
| `matchDoubleStar` | `**` trailing / non-`/` suffix scan | 5 |
| `matchDoubleStarSegment` | `**/<inner>` segment skipping | 5 |
| `matchSingleStar` | `*` run that stops at `/` | 6 |
| `matchSingleChar` | one literal byte or `?` vs `path[0]` | 2 |

`globMatch` drops **54 → 6**; every helper ≤ 6. The `//nolint:gocognit // baseline (#521)` directive is removed (AGENTS.md rule 7).

## Zero behavior change — how it's verified

- The `**`/`*` switch cases already returned unconditionally → turning them into `return helper(...)` is exact.
- The original separate `?` case and literal `default` fold into one `default` calling `matchSingleChar` (same verdict: `?` never matches `/`; a literal must equal `path[0]`, so a literal `/` only matches `/`).
- **Characterization test committed first** (`TestGlobMatchBranches`, calls `globMatch` directly), pinning every branch boundary; **mutation-verified non-placebo** against the committed artifact (broke `matchSingleChar`'s `?`/`/` guard, `matchDoubleStarSegment`'s boundary, and `matchSingleStar`'s slash-stop — each caught).
- **Throwaway differential fuzz** vs a frozen copy of the pre-refactor matcher: **0 divergence** (~12.5M execs locally; the independent adversarial reviewer re-ran its own frozen-copy differential, ~50M execs cumulative, also 0). Bounded input size + `*`-count to avoid the matcher's pre-existing exponential `**`-stack blowup (identical in both copies; not introduced here).

## Verification

```
gofmt -l            # clean
go vet ./internal/policy/...
go test -race -covermode=atomic ./internal/policy/...   # ok, 94.2% cov
go build ./cmd/worker ./cmd/tui
go run .../golangci-lint@v2.12.2 run --config=.golangci.yml \
  --new-from-rev=origin/main --enable-only=gocognit,funlen ./internal/policy/...  # 0 issues
```

### Size gate
- [x] `within budget` — 2 files, well under 12 files / 300 LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Out of scope
`Evaluate` (gocognit 14) keeps its `//nolint baseline (#521)` — not in this issue's curated 10. The other 9 targets follow as separate serial PRs.

A pre-existing latent issue surfaced while characterizing `matchSingleChar` — `?` matches **byte-wise**, not rune-wise — is deferred to **#524** (behavior change, out of scope for this decomposition).

Refs #521

---
### Review & gate status (head 6222a1c)
- **CI:** 7/7 green (lint, test, build, **golangci blocking gate**, e2e, security, docker).
- **Pre-push review:** two independent Claude adversarial reviews, both **MERGE-READY** (one ran its own differential fuzz + the gate). Reviewer-1's only LOW — a literal-`/` mismatch case — is addressed (`{"a/b","axb",false}`).
- **`@codex` review:** the GitHub `@codex` bot hit **Codex usage limits** and did not run. Per the documented usage-limit fallback (independent dual review + green CI + disclosure), coverage rests on the two Claude adversarial reviews above plus green CI. 0 unresolved review threads.
