### PR TITLE
refactor(worker): decompose ReconcileStartup into single-concern helpers (#521)

### DIFF
--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -47,7 +47,47 @@ type ReconcileConfig struct {
 // workspaces intact. It emits reconcile_start, reconcile_workspace, and
 // reconcile_end task events so startup recovery is visible in the same event
 // stream as normal task lifecycle activity.
-func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error { //nolint:gocognit,funlen // baseline (#521)
+func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
+	if err := validateReconcileConfig(cfg); err != nil {
+		return err
+	}
+	taskID := cfg.ReconcileTaskID
+	if taskID == "" {
+		taskID = defaultReconcileTaskID
+	}
+	Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileStart, "startup reconciliation started", map[string]any{
+		"workspace_root":  cfg.WorkspaceRoot,
+		"active_states":   cfg.ActiveStates,
+		"terminal_states": cfg.TerminalStates,
+	})
+
+	fetch, skip := fetchReconcileIssues(ctx, cfg, taskID, nonEmptyStates(cfg.ActiveStates), nonEmptyStates(cfg.TerminalStates))
+	if skip {
+		return nil
+	}
+	idx := newReconcileIndex(cfg, fetch)
+
+	workspaces, err := listIssueWorkspaces(cfg.WorkspaceRoot, cfg.TrackerKind)
+	if err != nil {
+		return err
+	}
+	if fetch.terminalFetchOK && len(workspaces) > 0 && len(fetch.activeIssues)+len(fetch.terminalIssues) == 0 {
+		return fmt.Errorf("tracker returned no active or terminal issues; refusing to remove %d existing workspaces", len(workspaces))
+	}
+
+	removed, kept, err := reconcileWorkspaces(ctx, cfg, taskID, workspaces, idx)
+	if err != nil {
+		return err
+	}
+
+	Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileEnd, "startup reconciliation finished", reconcileEndPayload(fetch, kept, removed))
+	return nil
+}
+
+// validateReconcileConfig enforces the inputs ReconcileStartup cannot proceed
+// without: a workspace root, a tracker, and at least one active and terminal
+// state to classify workspaces against.
+func validateReconcileConfig(cfg ReconcileConfig) error {
 	if strings.TrimSpace(cfg.WorkspaceRoot) == "" {
 		return fmt.Errorf("workspace root is required")
 	}
@@ -60,26 +100,28 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error { //nolint
 	if len(nonEmptyStates(cfg.TerminalStates)) == 0 {
 		return fmt.Errorf("terminal states are required for startup reconciliation")
 	}
-	taskID := cfg.ReconcileTaskID
-	if taskID == "" {
-		taskID = defaultReconcileTaskID
-	}
-	Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileStart, "startup reconciliation started", map[string]any{
-		"workspace_root":  cfg.WorkspaceRoot,
-		"active_states":   cfg.ActiveStates,
-		"terminal_states": cfg.TerminalStates,
-	})
+	return nil
+}
 
-	activeStates := nonEmptyStates(cfg.ActiveStates)
-	terminalStates := nonEmptyStates(cfg.TerminalStates)
-	// SPEC §8.6 / §11.4: transient tracker outages during boot must log a
-	// warning and continue startup, not abort the worker. An active-fetch
-	// failure is the worst case — without the active list we cannot confirm
-	// any workspace is safe to delete — so we emit reconcile_end with
-	// `status: skipped` and return nil, leaving every workspace intact. A
-	// terminal-fetch failure is non-fatal: active workspaces are still kept,
-	// terminal/unknown removal is skipped because `canRemoveUnknown` stays
-	// false when `terminalIssues` is empty.
+// reconcileFetch holds the tracker issue lists gathered at startup and whether
+// the terminal fetch succeeded.
+type reconcileFetch struct {
+	activeIssues     []tracker.Issue
+	terminalIssues   []tracker.Issue
+	terminalFetchOK  bool
+	terminalFetchErr error
+}
+
+// fetchReconcileIssues fetches the active then terminal issue lists.
+//
+// SPEC §8.6 / §11.4: transient tracker outages during boot must log a warning
+// and continue startup, not abort the worker. An active-fetch failure is the
+// worst case — without the active list we cannot confirm any workspace is safe
+// to delete — so it emits reconcile_end with `status: skipped` and returns
+// skip=true, leaving every workspace intact. A terminal-fetch failure is
+// non-fatal: active workspaces are still kept and terminal/unknown removal is
+// skipped because canRemoveUnknown stays false when terminalIssues is empty.
+func fetchReconcileIssues(ctx context.Context, cfg ReconcileConfig, taskID string, activeStates, terminalStates []string) (reconcileFetch, bool) {
 	activeIssues, err := cfg.Tracker.ListIssuesByStates(ctx, activeStates)
 	if err != nil {
 		LogReconcileEventf("startup_reconcile_active_fetch_failed", "error=%q note=%q", err, "SPEC §8.6: log and continue; no cleanup performed")
@@ -88,115 +130,140 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error { //nolint
 			"reason": "active_fetch_failed",
 			"error":  err.Error(),
 		})
-		return nil
+		return reconcileFetch{}, true
 	}
+	fetch := reconcileFetch{activeIssues: activeIssues, terminalFetchOK: true}
 	terminalIssues, err := cfg.Tracker.ListIssuesByStates(ctx, terminalStates)
-	terminalFetchOK := true
-	var terminalFetchErr error
 	if err != nil {
 		LogReconcileEventf("startup_reconcile_terminal_fetch_failed", "error=%q note=%q", err, "SPEC §8.6: log and continue; terminal cleanup skipped")
-		terminalFetchOK = false
-		terminalFetchErr = err
-		terminalIssues = nil
+		fetch.terminalFetchOK = false
+		fetch.terminalFetchErr = err
+		return fetch, false
 	}
+	fetch.terminalIssues = terminalIssues
+	return fetch, false
+}
+
+// reconcileIndex is the per-workspace lookup state derived from the fetched
+// issues: active/terminal key maps, whether unknown workspaces may be removed,
+// and the key function used to match active workspaces.
+type reconcileIndex struct {
+	activeKeys         map[string]tracker.Issue
+	terminalKeys       map[string]tracker.Issue
+	canRemoveUnknown   bool
+	activeKeysForIssue func(tracker.Issue) []string
+	activeIssues       []tracker.Issue
+}
+
+func newReconcileIndex(cfg ReconcileConfig, fetch reconcileFetch) reconcileIndex {
 	activeKeysForIssue := cfg.ActiveWorkspaceKeys
 	if activeKeysForIssue == nil {
 		activeKeysForIssue = issueWorkspaceKeys
 	}
-	activeKeys := make(map[string]tracker.Issue, len(activeIssues))
-	for _, issue := range activeIssues {
+	activeKeys := make(map[string]tracker.Issue, len(fetch.activeIssues))
+	for _, issue := range fetch.activeIssues {
 		for _, key := range activeKeysForIssue(issue) {
 			activeKeys[key] = issue
 		}
 	}
-	canRemoveUnknown := len(terminalIssues) > 0
-	terminalKeys := make(map[string]tracker.Issue, len(terminalIssues))
-	for _, issue := range terminalIssues {
+	terminalKeys := make(map[string]tracker.Issue, len(fetch.terminalIssues))
+	for _, issue := range fetch.terminalIssues {
 		for _, key := range issueWorkspaceKeys(issue) {
 			terminalKeys[key] = issue
 		}
 	}
+	return reconcileIndex{
+		activeKeys:         activeKeys,
+		terminalKeys:       terminalKeys,
+		canRemoveUnknown:   len(fetch.terminalIssues) > 0,
+		activeKeysForIssue: activeKeysForIssue,
+		activeIssues:       fetch.activeIssues,
+	}
+}
 
-	workspaces, err := listIssueWorkspaces(cfg.WorkspaceRoot, cfg.TrackerKind)
-	if err != nil {
-		return err
-	}
-	if terminalFetchOK && len(workspaces) > 0 && len(activeIssues)+len(terminalIssues) == 0 {
-		return fmt.Errorf("tracker returned no active or terminal issues; refusing to remove %d existing workspaces", len(workspaces))
-	}
-	var removed, kept int
+// reconcileWorkspaces applies the keep/remove decision to each workspace and
+// returns the removed/kept tallies. A workspace whose removal is declined (e.g.
+// a failing before-remove hook) is counted as neither removed nor kept.
+func reconcileWorkspaces(ctx context.Context, cfg ReconcileConfig, taskID string, workspaces []issueWorkspace, idx reconcileIndex) (removed, kept int, err error) {
 	for _, workspace := range workspaces {
 		if err := ctx.Err(); err != nil {
-			return err
+			return removed, kept, err
 		}
-		if _, ok := activeKeys[workspace.Key]; ok {
-			kept++
-			Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept active workspace", map[string]any{
-				"path":   workspace.Path,
-				"key":    workspace.Key,
-				"action": "keep",
-				"reason": "active",
-			})
-			continue
-		}
-		if activeIssue, ok := activeReworkIssueForWorkspace(workspace.Key, activeIssues, activeKeysForIssue); ok {
-			kept++
-			Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept active workspace", map[string]any{
-				"path":       workspace.Path,
-				"key":        workspace.Key,
-				"issue_id":   activeIssue.ID,
-				"identifier": activeIssue.Identifier,
-				"action":     "keep",
-				"reason":     "active_rework",
-			})
-			continue
-		}
-		if issue, ok := terminalKeys[workspace.Key]; ok {
-			removedOne, err := removeWorkspace(ctx, cfg, taskID, workspace.Path, issue, "terminal")
-			if err != nil {
-				return err
-			}
-			if removedOne {
-				removed++
-			}
-			continue
-		}
-		if !canRemoveUnknown {
-			kept++
-			Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept unknown workspace", map[string]any{
-				"path":   workspace.Path,
-				"key":    workspace.Key,
-				"action": "keep",
-				"reason": "unknown_terminal_state_unconfirmed",
-			})
-			continue
-		}
-		removedOne, err := removeWorkspace(ctx, cfg, taskID, workspace.Path, tracker.Issue{}, "unknown")
+		removedOne, keptOne, err := reconcileWorkspace(ctx, cfg, taskID, workspace, idx)
 		if err != nil {
-			return err
+			return removed, kept, err
 		}
 		if removedOne {
 			removed++
 		}
+		if keptOne {
+			kept++
+		}
 	}
+	return removed, kept, nil
+}
 
+// reconcileWorkspace classifies a single workspace and keeps or removes it,
+// returning whether it was removed and/or kept (both false when removal was
+// declined). Mirrors SPEC §8.6: keep active (exact key or rework), remove
+// terminal, and keep-or-remove unknown depending on canRemoveUnknown.
+func reconcileWorkspace(ctx context.Context, cfg ReconcileConfig, taskID string, workspace issueWorkspace, idx reconcileIndex) (removedOne, keptOne bool, err error) {
+	if _, ok := idx.activeKeys[workspace.Key]; ok {
+		Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept active workspace", map[string]any{
+			"path":   workspace.Path,
+			"key":    workspace.Key,
+			"action": "keep",
+			"reason": "active",
+		})
+		return false, true, nil
+	}
+	if activeIssue, ok := activeReworkIssueForWorkspace(workspace.Key, idx.activeIssues, idx.activeKeysForIssue); ok {
+		Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept active workspace", map[string]any{
+			"path":       workspace.Path,
+			"key":        workspace.Key,
+			"issue_id":   activeIssue.ID,
+			"identifier": activeIssue.Identifier,
+			"action":     "keep",
+			"reason":     "active_rework",
+		})
+		return false, true, nil
+	}
+	if issue, ok := idx.terminalKeys[workspace.Key]; ok {
+		removedOne, err = removeWorkspace(ctx, cfg, taskID, workspace.Path, issue, "terminal")
+		return removedOne, false, err
+	}
+	if !idx.canRemoveUnknown {
+		Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept unknown workspace", map[string]any{
+			"path":   workspace.Path,
+			"key":    workspace.Key,
+			"action": "keep",
+			"reason": "unknown_terminal_state_unconfirmed",
+		})
+		return false, true, nil
+	}
+	removedOne, err = removeWorkspace(ctx, cfg, taskID, workspace.Path, tracker.Issue{}, "unknown")
+	return removedOne, false, err
+}
+
+// reconcileEndPayload assembles the reconcile_end event payload, recording a
+// partial status (with the fetch error) when the terminal fetch failed.
+func reconcileEndPayload(fetch reconcileFetch, kept, removed int) map[string]any {
 	endPayload := map[string]any{
-		"active_issues":   len(activeIssues),
-		"terminal_issues": len(terminalIssues),
+		"active_issues":   len(fetch.activeIssues),
+		"terminal_issues": len(fetch.terminalIssues),
 		"kept":            kept,
 		"removed":         removed,
 	}
-	if !terminalFetchOK {
+	if !fetch.terminalFetchOK {
 		endPayload["status"] = "partial"
 		endPayload["reason"] = "terminal_fetch_failed"
-		if terminalFetchErr != nil {
-			endPayload["error"] = terminalFetchErr.Error()
+		if fetch.terminalFetchErr != nil {
+			endPayload["error"] = fetch.terminalFetchErr.Error()
 		}
 	} else {
 		endPayload["status"] = "ok"
 	}
-	Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileEnd, "startup reconciliation finished", endPayload)
-	return nil
+	return endPayload
 }
 
 type issueWorkspace struct {

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -815,3 +815,125 @@ func mustTime(value string) time.Time {
 	}
 	return parsed
 }
+
+// reconcileEndPayloadFor returns the single reconcile_end payload, failing if
+// there is not exactly one. Existing tests assert the skipped/partial status
+// strings but not the kept/removed counts; the tests below pin those counts so
+// the #521 decomposition (which moves the per-workspace counting into
+// reconcileWorkspaces and payload assembly into reconcileEndPayload) is
+// provably behavior-preserving.
+func reconcileEndPayloadFor(t *testing.T, em *fakeEmitter) map[string]any {
+	t.Helper()
+	ends := em.byKind(task.EventReconcileEnd)
+	if len(ends) != 1 {
+		t.Fatalf("reconcile_end events = %d, want 1", len(ends))
+	}
+	payload, ok := ends[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("reconcile_end payload = %T, want map", ends[0].Payload)
+	}
+	return payload
+}
+
+func wantPayloadCount(t *testing.T, payload map[string]any, key string, want int) {
+	t.Helper()
+	if got, _ := payload[key].(int); got != want {
+		t.Errorf("reconcile_end payload[%q] = %v, want %d", key, payload[key], want)
+	}
+}
+
+func TestReconcileStartupEndPayloadReportsKeptRemovedCounts(t *testing.T) {
+	root := t.TempDir()
+	for _, key := range []string{"LIN-1", "LIN-2", "LIN-3"} {
+		if err := os.MkdirAll(filepath.Join(root, "acme", "repo", "linear_issue", key), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", key, err)
+		}
+	}
+	emitter := &fakeEmitter{}
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:  root,
+		ActiveStates:   []string{"In Progress"},
+		TerminalStates: []string{"Done"},
+		Tracker: fakeReconcileTracker{issues: []tracker.Issue{
+			{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"},
+			{ID: "issue-2", Identifier: "LIN-2", State: "Done"},
+		}},
+		Emitter:         emitter,
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup: %v", err)
+	}
+	payload := reconcileEndPayloadFor(t, emitter)
+	if status, _ := payload["status"].(string); status != "ok" {
+		t.Errorf("reconcile_end status = %q, want \"ok\"", status)
+	}
+	wantPayloadCount(t, payload, "kept", 1)    // LIN-1 active
+	wantPayloadCount(t, payload, "removed", 2) // LIN-2 terminal + LIN-3 unknown
+	wantPayloadCount(t, payload, "active_issues", 1)
+	wantPayloadCount(t, payload, "terminal_issues", 1)
+}
+
+func TestReconcileStartupEndPayloadCountsOnTerminalFetchFailure(t *testing.T) {
+	root := t.TempDir()
+	for _, key := range []string{"LIN-1", "LIN-9"} {
+		if err := os.MkdirAll(filepath.Join(root, "acme", "repo", "linear_issue", key), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", key, err)
+		}
+	}
+	emitter := &fakeEmitter{}
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:  root,
+		ActiveStates:   []string{"In Progress"},
+		TerminalStates: []string{"Done"},
+		Tracker: &fakeReconcileTrackerByCall{
+			issuesByCall: [][]tracker.Issue{{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}, nil},
+			errByCall:    []error{nil, errors.New("terminal outage")},
+		},
+		Emitter:         emitter,
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup: %v", err)
+	}
+	payload := reconcileEndPayloadFor(t, emitter)
+	if status, _ := payload["status"].(string); status != "partial" {
+		t.Errorf("reconcile_end status = %q, want \"partial\"", status)
+	}
+	wantPayloadCount(t, payload, "removed", 0)
+	wantPayloadCount(t, payload, "kept", 2) // LIN-1 active + LIN-9 unknown kept (terminal unconfirmed)
+}
+
+// TestReconcileStartupEndPayloadCountsReworkKeep pins the active_rework branch's
+// kept count. The on-disk workspace timestamp differs from the issue's current
+// updatedAt, so it matches via reworkWorkspaceKeyPrefixes (not an exact active
+// key); a terminal issue arms canRemoveUnknown, so a rework branch that failed
+// to count/keep would remove the workspace instead.
+func TestReconcileStartupEndPayloadCountsReworkKeep(t *testing.T) {
+	root := t.TempDir()
+	reworkPath := filepath.Join(root, "acme", "repo", "linear-issue", "issue-3-rework-2026-05-16t10-00-00z")
+	if err := os.MkdirAll(reworkPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	emitter := &fakeEmitter{}
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:  root,
+		ActiveStates:   []string{"Rework"},
+		TerminalStates: []string{"Done"},
+		Tracker: fakeReconcileTracker{issues: []tracker.Issue{
+			{ID: "issue-3", Identifier: "LIN-3", State: "Rework", UpdatedAt: mustTime("2026-05-16T11:30:00Z")},
+			{ID: "issue-2", Identifier: "LIN-2", State: "Done"},
+		}},
+		Emitter:         emitter,
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup: %v", err)
+	}
+	if _, err := os.Stat(reworkPath); err != nil {
+		t.Fatalf("active_rework workspace should remain: %v", err)
+	}
+	payload := reconcileEndPayloadFor(t, emitter)
+	wantPayloadCount(t, payload, "kept", 1) // matched via active_rework prefix branch
+	wantPayloadCount(t, payload, "removed", 0)
+}


### PR DESCRIPTION
## What & why

Second PR of #521 (decompose the 10 heaviest `gocognit` hotspots, one per PR, descending). Target: **`worker.ReconcileStartup`** — gocognit **42** + funlen-flagged (the 2nd heaviest baseline function). The blocking gate (`.golangci.yml` `gocognit.min-complexity: 10`) fails any non-test function over 10.

`ReconcileStartup` becomes a thin orchestrator; each concern is a single-purpose helper:

| helper | role |
|---|---|
| `validateReconcileConfig` | required-input guards |
| `fetchReconcileIssues` | active/terminal fetch + SPEC §8.6 skip/partial outcomes |
| `newReconcileIndex` | active/terminal key maps + `canRemoveUnknown` |
| `reconcileWorkspaces` | per-workspace loop + removed/kept tally + `ctx.Err()` check |
| `reconcileWorkspace` | keep/remove decision for one workspace |
| `reconcileEndPayload` | `reconcile_end` payload assembly |

`ReconcileStartup` drops **42 → 8**; every helper ≤ 9. The `//nolint:gocognit,funlen` baseline directive is removed.

## Zero behavior change — how it's verified

Preserved exactly: active-then-terminal fetch **order**; the skip-on-active-fail path (`reconcile_end{status:skipped}` + return nil); the terminal-fail partial path (`terminalIssues=nil`, `terminalFetchOK=false`, `status:partial`); `canRemoveUnknown` derivation; the `activeKeysForIssue` nil-default; the per-iteration `ctx.Err()` check; the mass-delete guard; the per-workspace classification; and — the subtlest invariant — **a declined removal (`removeWorkspace` returns false) counts as NEITHER kept nor removed** (`reconcileWorkspace` returns `(false,false)`).

- The existing reconcile suite (24 tests: terminal/unknown removal, skipped/partial status, rework keep, mass-delete guard, layouts, hooks, validation) passes unchanged.
- **New characterization** pins the `reconcile_end` kept/removed counts (ok path, terminal-fetch partial, and the `active_rework` prefix branch) that existing tests didn't assert — **mutation-verified non-placebo** (status flip, kept/removed swap, and active_rework `keptOne` flip each caught).

## Verification

```
go vet ./internal/worker/...
go test -race -covermode=atomic ./internal/worker/...   # ok (~25s)
go build ./cmd/worker ./cmd/tui
go run .../golangci-lint@v2.12.2 run --config=.golangci.yml \
  --new-from-rev=origin/main --enable-only=gocognit,funlen ./internal/worker/...  # 0 issues
```
gocognit: every function in reconcile.go ≤ 10 (ReconcileStartup = 8).

## Pre-push review
Two independent Claude adversarial reviews (one ran the gate + race suite + its own mutation testing), both **MERGE-READY**, no HIGH/MED, no behavior divergence found. Their shared LOW — the `active_rework` keep-count was untested — is now addressed (`TestReconcileStartupEndPayloadCountsReworkKeep`, mutation-verified). The local Codex pre-push reviewer remains unavailable (expired CLI auth); per the documented usage-limit fallback, coverage rests on the two adversarial reviews + green CI, and the `@codex` bot is triggered post-push.

### Size gate
- [x] `within budget` — 2 files, ~264 LOC (refactor relocation + characterization), under 12 files / 300 LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Out of scope
`listIssueWorkspaces` (gocognit 34, same file) is target #6 and follows as its own serial PR per the one-function-per-PR plan. Pre-existing `ctx.Err()` per-iteration cancellation has no direct test (untouched here).

Refs #521

---
### Review & gate status (head 3f2d9c8)
- **CI:** 4/4 green (Go build+test incl. golangci blocking gate, e2e, security, docker).
- **Pre-push:** two independent Claude adversarial reviews → MERGE-READY; consensus LOW (active_rework count) closed + mutation-verified.
- **`@codex` review:** GitHub `@codex` bot hit **Codex usage limits** and did not run. Per the documented usage-limit fallback, coverage = the two adversarial reviews + green CI. 0 unresolved review threads.
