### PR TITLE
fix(policy): match `?` glob wildcard rune-wise, not byte-wise

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // Config mirrors the relevant fields of workflow.PolicyConfig. It is
@@ -134,7 +135,7 @@ func matchAny(patterns []string, path string) (string, bool) {
 
 // Match reports whether path matches the glob pattern. Supported syntax:
 //
-//   - "?"  matches any single character except "/"
+//   - "?"  matches exactly one rune (Unicode code point) except "/"
 //   - "*"  matches any sequence of characters except "/"
 //   - "**" matches any sequence of characters, including "/"
 //   - "/**" as a trailing component matches the empty string or "/<anything>"
@@ -157,8 +158,8 @@ func Match(pattern, path string) bool {
 
 // globMatch is the recursive glob matcher. It is a thin dispatcher: the
 // separator-spanning "**" and single-segment "*" wildcards delegate to
-// helpers, and every other position (a literal byte or "?") consumes exactly
-// one character via matchSingleChar.
+// helpers, "?" consumes exactly one rune via matchSingleRune, and a literal
+// position consumes one byte.
 func globMatch(pattern, path string) bool {
 	for len(pattern) > 0 {
 		switch {
@@ -166,9 +167,20 @@ func globMatch(pattern, path string) bool {
 			return matchDoubleStar(strings.TrimPrefix(pattern, "**"), path)
 		case pattern[0] == '*':
 			return matchSingleStar(pattern[1:], path)
+		case pattern[0] == '?':
+			n, ok := matchSingleRune(path)
+			if !ok {
+				return false
+			}
+			pattern = pattern[1:]
+			path = path[n:]
 		default:
-			// A literal byte or "?" consumes exactly one matching character.
-			if !matchSingleChar(pattern[0], path) {
+			// A literal pattern byte must equal the next byte of path.
+			// Comparing byte-by-byte is rune-correct because both sides are
+			// UTF-8: a full rune matches iff all of its bytes match, and "/"
+			// (0x2F) never appears inside a multi-byte rune, so a "/" is only
+			// ever consumed by a literal "/".
+			if len(path) == 0 || pattern[0] != path[0] {
 				return false
 			}
 			pattern = pattern[1:]
@@ -178,17 +190,16 @@ func globMatch(pattern, path string) bool {
 	return len(path) == 0
 }
 
-// matchSingleChar reports whether the non-wildcard pattern byte pc matches the
-// first byte of path. "?" matches any single byte except "/"; any other byte
-// must equal path[0] exactly, so a "/" is only ever consumed by a literal "/".
-func matchSingleChar(pc byte, path string) bool {
-	if len(path) == 0 {
-		return false
+// matchSingleRune reports the byte length of path's leading rune and whether a
+// "?" wildcard may consume it. "?" matches exactly one rune except "/", so an
+// empty path or a leading "/" is rejected. Invalid UTF-8 decodes to a
+// single-byte RuneError, so "?" still advances by one byte and never stalls.
+func matchSingleRune(path string) (int, bool) {
+	if len(path) == 0 || path[0] == '/' {
+		return 0, false
 	}
-	if pc == '?' {
-		return path[0] != '/'
-	}
-	return pc == path[0]
+	_, n := utf8.DecodeRuneInString(path)
+	return n, true
 }
 
 // matchDoubleStar matches a "**" wildcard against path, where rest is the

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -28,6 +28,16 @@ func TestMatch(t *testing.T) {
 		{"?.md", "ab.md", false},
 		{"?.md", "/x.md", false},
 
+		// question mark matches one rune, not one byte (multi-byte UTF-8)
+		{"secret?.key", "secreté.key", true},
+		{"secret?.key", "secreta.key", true},
+		{"?.md", "é.md", true},
+
+		// "*" / "**" runs span multi-byte runes but never cross "/"
+		{"*.md", "café.md", true},
+		{"*.md", "café/x.md", false},
+		{"**/secrets.yaml", "café/prod/secrets.yaml", true},
+
 		// double star: spans separators
 		{"**", "anything/at/all.go", true},
 		{"infra/**", "infra/", true},
@@ -105,12 +115,18 @@ func TestGlobMatchBranches(t *testing.T) {
 		{"?", "a", true},
 		{"?", "/", false},
 		{"a?", "a", false},
+		// "?" matches exactly one rune, not one byte: a single multi-byte
+		// rune matches one "?", and "?" rejects "/" without splitting runes.
+		{"?", "é", true},
+		{"a?b", "aéb", true},
+		{"??", "é", false},
+		{"?", "ab", false},
 		// Literal comparison: length mismatches and exact equality.
 		{"abc", "ab", false},
 		{"ab", "abc", false},
 		{"", "", true},
 		{"", "x", false},
-		// A literal "/" must match "/" exactly, never another byte (matchSingleChar).
+		// A literal "/" must match "/" exactly, never another byte.
 		{"a/b", "axb", false},
 		{"exact/path.txt", "exact/path.txt", true},
 	}
@@ -145,6 +161,23 @@ func TestEvaluateDenyPaths(t *testing.T) {
 		}
 		if v.Pattern == "" || v.Path == "" {
 			t.Errorf("violation missing path/pattern: %+v", v)
+		}
+	}
+}
+
+// TestEvaluateDenyQuestionMarkMultiByte regresses the byte-wise "?" bug: a
+// "?" deny pattern must catch a multi-byte UTF-8 filename just as it catches
+// its ASCII sibling, so the security-relevant deny gate cannot be bypassed by
+// a non-ASCII character where a "?" sits. Before the fix, the multi-byte path
+// slipped through because "?" consumed a single byte of "é".
+func TestEvaluateDenyQuestionMarkMultiByte(t *testing.T) {
+	cfg := Config{DenyPaths: []string{"config/secret?.key"}}
+	for _, path := range []string{"config/secreta.key", "config/secreté.key"} {
+		d := Diffstat{Files: []string{path}}
+		vs := Evaluate(d, cfg)
+		if len(vs) != 1 || vs[0].Kind != KindDenyPath {
+			t.Errorf("Evaluate(deny %q, %q) = %v; want one deny_path violation",
+				cfg.DenyPaths[0], path, vs)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`policy.Match`'s `?` glob wildcard consumed exactly **one byte**, not one rune. Against a multi-byte UTF-8 path character it matched only the first byte; because the whole-pattern match is anchored at both ends, a lone `?` *failed* to match a multi-byte rune rather than matching it. So `secret?.key` did not match `secreté.key`, and `?`-based **deny** rules behaved inconsistently between ASCII and non-ASCII paths in the pre-push deny/allow gate (`policy.Evaluate`) — a surprising gap in a security-relevant matcher.

Closes #524.

## Change

- `globMatch` now advances `path` by a full rune for `?` via `utf8.DecodeRuneInString` (new `matchSingleRune` helper), rejecting empty paths and `/`. Invalid UTF-8 decodes to a single-byte `RuneError`, so `?` still advances and never stalls.
- Literal and `*`/`**` matching stay byte-wise: UTF-8 is self-synchronizing, a rune matches iff all its bytes match, and `/` (0x2F) never appears inside a multi-byte rune — so those paths are already rune-correct and never split a rune or cross a separator. Confirmed by new multi-byte `*`/`**` test cases.
- Documented the rune semantics in `Match`'s doc comment (`"?" matches exactly one rune (Unicode code point) except "/"`).
- Removed the now-obsolete byte-oriented `matchSingleChar` helper.

This is a deliberate **behavior change** (rune-wise `?`), scoped to its own PR with characterization tests as the issue requested — not folded into the #521/#523 zero-behavior-change decomposition.

## Acceptance criteria

- [x] Decide & document intended `?` semantics (one rune except `/`) in `Match`'s doc comment.
- [x] Make `globMatch` advance by a rune for `?`; confirmed `*`/`**` UTF-8 handling is consistent (byte-wise but rune-correct, with tests).
- [x] Tests for multi-byte paths: `?` vs `é`, `*` not crossing `/` with multi-byte runs, and a deny-rule bypass regression at the `Evaluate` gate.

## Verification

```
gofmt -l internal/policy/*.go        # empty
go mod tidy && git diff --exit-code  # clean
go vet ./internal/policy/
golangci-lint run --config=.golangci.yml internal/policy/...   # 0 issues
go test -race -covermode=atomic ./...  # all pass (policy 94.6% cov)
go build ./cmd/worker ./cmd/tui
```

**Mutation verification** (against the committed artifact): reverting `matchSingleRune` to byte-wise (`return 1`) fails the new tests at all three levels — `TestMatch` (`secret?.key` vs `secreté.key`), `TestGlobMatchBranches` (`?` vs `é`, `??` vs `é`), and `TestEvaluateDenyQuestionMarkMultiByte` (deny gate bypass) — and they pass with the fix.

## Size

`within budget` — small, atomic single-package change.

## Risk / SPEC alignment

The glob matcher is an aiops-platform policy extension with no Symphony/Elixir analog to port, so this is a local correctness fix with no SPEC-alignment or DEVIATIONS.md impact. No new deviation introduced.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6GnTP5Q2dnEPhZFzk2qPL)_