### PR TITLE
refactor(runner): decompose MockRunner.Run into single-concern helpers (#521)

### DIFF
--- a/internal/runner/mock.go
+++ b/internal/runner/mock.go
@@ -25,24 +25,9 @@ type MockRunner struct {
 	SetBaseToHead       bool
 }
 
-func (m MockRunner) Run(ctx context.Context, in RunInput) (Result, error) { //nolint:gocognit,funlen // baseline (#521)
-	if m.Sleep > 0 {
-		start := time.Now()
-		t := time.NewTimer(m.Sleep)
-		defer t.Stop()
-		select {
-		case <-ctx.Done():
-			elapsed := time.Since(start)
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				return Result{}, &TimeoutError{
-					Timeout: deadlineBudget(ctx, start),
-					Elapsed: elapsed,
-					Cause:   ctx.Err(),
-				}
-			}
-			return Result{}, ctx.Err()
-		case <-t.C:
-		}
+func (m MockRunner) Run(ctx context.Context, in RunInput) (Result, error) {
+	if err := m.awaitMockSleep(ctx); err != nil {
+		return Result{}, err
 	}
 
 	dir := filepath.Join(in.Workdir, ".aiops")
@@ -50,8 +35,66 @@ func (m MockRunner) Run(ctx context.Context, in RunInput) (Result, error) { //no
 		return Result{}, err
 	}
 	completedAt := time.Now().Format(time.RFC3339)
-	if in.Workflow.Config.Policy.Mode == "analysis_only" && !m.SkipAnalysisPlan {
-		plan := fmt.Sprintf(`# Analysis plan (mock)
+
+	if err := m.writeAnalysisPlan(dir, in, completedAt); err != nil {
+		return Result{}, err
+	}
+	if err := m.writeMockSourceFile(in.Workdir); err != nil {
+		return Result{}, err
+	}
+	if err := m.commitMockChange(ctx, in.Workdir); err != nil {
+		return Result{}, err
+	}
+	if err := m.setMockWorkspaceBase(ctx, in.Workdir); err != nil {
+		return Result{}, err
+	}
+	if err := m.writeMockWorkflowEdit(dir); err != nil {
+		return Result{}, err
+	}
+	if err := m.writeMockTaskArtifact(dir, in, completedAt); err != nil {
+		return Result{}, err
+	}
+	if err := m.writeMockRunSummary(dir, in, completedAt); err != nil {
+		return Result{}, err
+	}
+	return Result{Summary: "mock completed"}, nil
+}
+
+// awaitMockSleep blocks for m.Sleep (when > 0) so tests can drive the timeout
+// path. It returns a *TimeoutError when the context deadline elapsed and the
+// bare ctx.Err() for any other cancellation (e.g. context.Canceled), matching
+// the worker's timeout-vs-cancel retry routing. The timer is always stopped on
+// every return path.
+func (m MockRunner) awaitMockSleep(ctx context.Context) error {
+	if m.Sleep <= 0 {
+		return nil
+	}
+	start := time.Now()
+	t := time.NewTimer(m.Sleep)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		elapsed := time.Since(start)
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return &TimeoutError{
+				Timeout: deadlineBudget(ctx, start),
+				Elapsed: elapsed,
+				Cause:   ctx.Err(),
+			}
+		}
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// writeAnalysisPlan writes .aiops/PLAN.md in analysis-only mode unless the
+// mock is configured to skip it.
+func (m MockRunner) writeAnalysisPlan(dir string, in RunInput, completedAt string) error {
+	if in.Workflow.Config.Policy.Mode != "analysis_only" || m.SkipAnalysisPlan {
+		return nil
+	}
+	plan := fmt.Sprintf(`# Analysis plan (mock)
 
 - Task: %s
 - Title: %s
@@ -64,46 +107,83 @@ runner does not edit source files; it writes only analysis artifacts under
 .aiops/ so the worker can exercise analysis-only gating without committing,
 pushing, opening PRs, or writing tracker comments on the runner's behalf.
 `, in.Task.ID, in.Task.Title, in.Task.Actor, in.Task.Model, completedAt)
-		if err := os.WriteFile(filepath.Join(dir, "PLAN.md"), []byte(plan), 0o644); err != nil {
-			return Result{}, fmt.Errorf("write PLAN.md: %w", err)
-		}
+	if err := os.WriteFile(filepath.Join(dir, "PLAN.md"), []byte(plan), 0o644); err != nil {
+		return fmt.Errorf("write PLAN.md: %w", err)
 	}
+	return nil
+}
+
+// writeMockSourceFile writes the mock source-change file when the runner is
+// configured to edit source (directly, or to commit a source change rather
+// than an analysis-only artifact).
+func (m MockRunner) writeMockSourceFile(workdir string) error {
 	if m.WriteSourceFiles || (m.CommitSourceFiles && !m.CommitOnlyArtifacts) {
-		if err := os.WriteFile(filepath.Join(in.Workdir, "mock-source-change.txt"), []byte("mock source change\n"), 0o644); err != nil {
-			return Result{}, fmt.Errorf("write mock source change: %w", err)
+		if err := os.WriteFile(filepath.Join(workdir, "mock-source-change.txt"), []byte("mock source change\n"), 0o644); err != nil {
+			return fmt.Errorf("write mock source change: %w", err)
 		}
 	}
-	if m.CommitSourceFiles {
-		commitPath := "mock-source-change.txt"
-		if m.CommitOnlyArtifacts {
-			commitPath = filepath.Join(".aiops", "PLAN.md")
-		}
-		gitCommands := [][]string{
-			{"git", "add", commitPath},
-			{"git", "-c", "user.email=mock@example.com", "-c", "user.name=mock", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "commit", "-q", "-m", "mock source commit"},
-		}
-		for _, args := range gitCommands {
-			cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-			cmd.Dir = in.Workdir
-			if out, err := cmd.CombinedOutput(); err != nil {
-				return Result{}, fmt.Errorf("%s: %w\n%s", strings.Join(args, " "), err, out)
-			}
-		}
+	return nil
+}
+
+// commitMockChange adds and commits the mock change when configured. The
+// committed path is the source file by default, or .aiops/PLAN.md when the
+// runner commits only the analysis artifact.
+func (m MockRunner) commitMockChange(ctx context.Context, workdir string) error {
+	if !m.CommitSourceFiles {
+		return nil
 	}
-	if m.SetBaseToHead {
-		cmd := exec.CommandContext(ctx, "git", "config", "--local", "aiops.workspaceBase", "HEAD")
-		cmd.Dir = in.Workdir
+	commitPath := "mock-source-change.txt"
+	if m.CommitOnlyArtifacts {
+		commitPath = filepath.Join(".aiops", "PLAN.md")
+	}
+	gitCommands := [][]string{
+		{"git", "add", commitPath},
+		{"git", "-c", "user.email=mock@example.com", "-c", "user.name=mock", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "commit", "-q", "-m", "mock source commit"},
+	}
+	for _, args := range gitCommands {
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		cmd.Dir = workdir
 		if out, err := cmd.CombinedOutput(); err != nil {
-			return Result{}, fmt.Errorf("git config aiops.workspaceBase: %w\n%s", err, out)
+			return fmt.Errorf("%s: %w\n%s", strings.Join(args, " "), err, out)
 		}
 	}
-	if m.WriteAiopsWorkflow {
-		if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte("tracked workflow edit\n"), 0o644); err != nil {
-			return Result{}, fmt.Errorf("write WORKFLOW.md: %w", err)
-		}
+	return nil
+}
+
+// setMockWorkspaceBase records aiops.workspaceBase=HEAD in the repo's local
+// git config when configured, simulating a runner that pins the workspace
+// base after committing.
+func (m MockRunner) setMockWorkspaceBase(ctx context.Context, workdir string) error {
+	if !m.SetBaseToHead {
+		return nil
 	}
-	if in.Workflow.Config.Policy.Mode != "analysis_only" {
-		content := fmt.Sprintf(`# AI Ops Mock Run
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", "aiops.workspaceBase", "HEAD")
+	cmd.Dir = workdir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git config aiops.workspaceBase: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// writeMockWorkflowEdit writes a tracked .aiops/WORKFLOW.md edit when
+// configured, exercising the worker's handling of a workflow-file change.
+func (m MockRunner) writeMockWorkflowEdit(dir string) error {
+	if !m.WriteAiopsWorkflow {
+		return nil
+	}
+	if err := os.WriteFile(filepath.Join(dir, "WORKFLOW.md"), []byte("tracked workflow edit\n"), 0o644); err != nil {
+		return fmt.Errorf("write WORKFLOW.md: %w", err)
+	}
+	return nil
+}
+
+// writeMockTaskArtifact writes the per-task .aiops/<task>.md file outside
+// analysis-only mode.
+func (m MockRunner) writeMockTaskArtifact(dir string, in RunInput, completedAt string) error {
+	if in.Workflow.Config.Policy.Mode == "analysis_only" {
+		return nil
+	}
+	content := fmt.Sprintf(`# AI Ops Mock Run
 
 Task: %s
 Title: %s
@@ -115,13 +195,16 @@ This file is generated by the Symphony-style Day 1 mock runner.
 
 Prompt was written to .aiops/PROMPT.md.
 `, in.Task.ID, in.Task.Title, in.Task.Actor, in.Task.Model, completedAt)
-		if err := os.WriteFile(filepath.Join(dir, in.Task.ID+".md"), []byte(content), 0o644); err != nil {
-			return Result{}, err
-		}
+	if err := os.WriteFile(filepath.Join(dir, in.Task.ID+".md"), []byte(content), 0o644); err != nil {
+		return err
 	}
-	// Write the RUN_SUMMARY.md artifact the worker requires before opening
-	// a PR. The mock runner produces a minimal but recognisably non-stub
-	// summary so the worker's CheckSummary gate accepts it.
+	return nil
+}
+
+// writeMockRunSummary writes the RUN_SUMMARY.md artifact the worker requires
+// before opening a PR. The mock runner produces a minimal but recognisably
+// non-stub summary so the worker's CheckSummary gate accepts it.
+func (m MockRunner) writeMockRunSummary(dir string, in RunInput, completedAt string) error {
 	summary := fmt.Sprintf(`# Run summary (mock)
 
 - Task: %s
@@ -136,7 +219,7 @@ so end-to-end gating logic (worker requires RUN_SUMMARY.md before opening a
 PR) can be exercised in tests and local dev.
 `, in.Task.ID, in.Task.Title, in.Task.Actor, in.Task.Model, completedAt)
 	if err := os.WriteFile(filepath.Join(dir, "RUN_SUMMARY.md"), []byte(summary), 0o644); err != nil {
-		return Result{}, fmt.Errorf("write RUN_SUMMARY.md: %w", err)
+		return fmt.Errorf("write RUN_SUMMARY.md: %w", err)
 	}
-	return Result{Summary: "mock completed"}, nil
+	return nil
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -327,4 +328,304 @@ func TestIsTimeoutNilAndOther(t *testing.T) {
 	if !IsTimeout(wrapped) {
 		t.Fatal("IsTimeout should unwrap joined errors")
 	}
+}
+
+// analysisOnlyWorkflow builds a workflow whose policy mode is "analysis_only"
+// so the mock runner takes the analysis-artifact branch (writes PLAN.md and
+// skips the per-task <ID>.md file).
+func analysisOnlyWorkflow() workflow.Workflow {
+	wf := workflow.Workflow{}
+	wf.Config.Policy.Mode = "analysis_only"
+	return wf
+}
+
+// mockRunTask is a fixed task used by the artifact characterization tests so
+// the asserted file names and template substitutions stay stable.
+func mockRunTask() task.Task {
+	return task.Task{ID: "tsk_chr", Title: "Characterize", Actor: "actor-x", Model: "model-y"}
+}
+
+// TestMockRunnerArtifactMatrix pins exactly which files (MockRunner).Run writes
+// for each flag/policy combination and their content, covering the per-helper
+// guards that the pre-#521 suite left unexercised. These assertions are the
+// contract the #521 extraction must preserve byte-for-byte.
+func TestMockRunnerArtifactMatrix(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceFile    = "mock-source-change.txt"
+		sourceContent = "mock source change\n"
+	)
+
+	tests := []struct {
+		name     string
+		runner   MockRunner
+		workflow workflow.Workflow
+		// present maps a relative path to its exact expected content.
+		present map[string]string
+		// absent lists relative paths that must NOT exist.
+		absent []string
+	}{
+		{
+			name:     "default non-analysis writes task md and run summary only",
+			runner:   MockRunner{},
+			workflow: workflow.Workflow{},
+			present: map[string]string{
+				filepath.Join(".aiops", "tsk_chr.md"):     "",
+				filepath.Join(".aiops", "RUN_SUMMARY.md"): "",
+			},
+			absent: []string{
+				sourceFile,
+				filepath.Join(".aiops", "PLAN.md"),
+				filepath.Join(".aiops", "WORKFLOW.md"),
+			},
+		},
+		{
+			name:     "WriteSourceFiles emits source change file",
+			runner:   MockRunner{WriteSourceFiles: true},
+			workflow: workflow.Workflow{},
+			present: map[string]string{
+				sourceFile:                            sourceContent,
+				filepath.Join(".aiops", "tsk_chr.md"): "",
+			},
+			absent: []string{filepath.Join(".aiops", "PLAN.md")},
+		},
+		{
+			name:     "analysis_only writes PLAN.md and skips task md",
+			runner:   MockRunner{},
+			workflow: analysisOnlyWorkflow(),
+			present: map[string]string{
+				filepath.Join(".aiops", "PLAN.md"):        "",
+				filepath.Join(".aiops", "RUN_SUMMARY.md"): "",
+			},
+			absent: []string{
+				filepath.Join(".aiops", "tsk_chr.md"),
+				sourceFile,
+			},
+		},
+		{
+			name:     "analysis_only with SkipAnalysisPlan writes neither PLAN nor task md",
+			runner:   MockRunner{SkipAnalysisPlan: true},
+			workflow: analysisOnlyWorkflow(),
+			present: map[string]string{
+				filepath.Join(".aiops", "RUN_SUMMARY.md"): "",
+			},
+			absent: []string{
+				filepath.Join(".aiops", "PLAN.md"),
+				filepath.Join(".aiops", "tsk_chr.md"),
+				sourceFile,
+			},
+		},
+		{
+			name:     "WriteAiopsWorkflow writes tracked workflow edit",
+			runner:   MockRunner{WriteAiopsWorkflow: true},
+			workflow: workflow.Workflow{},
+			present: map[string]string{
+				filepath.Join(".aiops", "WORKFLOW.md"): "tracked workflow edit\n",
+				filepath.Join(".aiops", "tsk_chr.md"):  "",
+			},
+			absent: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			workdir := t.TempDir()
+			res, err := tc.runner.Run(context.Background(), RunInput{
+				Task:     mockRunTask(),
+				Workflow: tc.workflow,
+				Workdir:  workdir,
+			})
+			if err != nil {
+				t.Fatalf("Run(%q) error = %v; want nil", tc.name, err)
+			}
+			if res.Summary != "mock completed" {
+				t.Fatalf("Run(%q).Summary = %q; want %q", tc.name, res.Summary, "mock completed")
+			}
+			for rel, wantContent := range tc.present {
+				path := filepath.Join(workdir, rel)
+				body, readErr := os.ReadFile(path)
+				if readErr != nil {
+					t.Errorf("ReadFile(%q) = %v; want file present", rel, readErr)
+					continue
+				}
+				if wantContent != "" && string(body) != wantContent {
+					t.Errorf("content(%q) = %q; want %q", rel, string(body), wantContent)
+				}
+			}
+			for _, rel := range tc.absent {
+				path := filepath.Join(workdir, rel)
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					t.Errorf("Stat(%q) = %v; want os.IsNotExist", rel, statErr)
+				}
+			}
+		})
+	}
+}
+
+// TestMockRunnerCommitOnlyArtifactsCommitsPlan pins the CommitSourceFiles +
+// CommitOnlyArtifacts branch: the runner must `git add` and commit
+// .aiops/PLAN.md (not mock-source-change.txt), and must not write the source
+// file at all. This exercises the commitMockChange guard and commitPath
+// selection that the pre-#521 suite never reached.
+func TestMockRunnerCommitOnlyArtifactsCommitsPlan(t *testing.T) {
+	t.Parallel()
+	workdir := initGitRepo(t)
+
+	r := MockRunner{CommitSourceFiles: true, CommitOnlyArtifacts: true}
+	if _, err := r.Run(context.Background(), RunInput{
+		Task:     mockRunTask(),
+		Workflow: analysisOnlyWorkflow(),
+		Workdir:  workdir,
+	}); err != nil {
+		t.Fatalf("Run(CommitOnlyArtifacts) error = %v; want nil", err)
+	}
+
+	// The source file must be absent because the verbatim guard
+	// (WriteSourceFiles || (CommitSourceFiles && !CommitOnlyArtifacts)) is
+	// false when CommitOnlyArtifacts is set.
+	if _, err := os.Stat(filepath.Join(workdir, "mock-source-change.txt")); !os.IsNotExist(err) {
+		t.Fatalf("Stat(mock-source-change.txt) = %v; want os.IsNotExist", err)
+	}
+
+	committed := gitLastCommitFiles(t, workdir)
+	wantPath := filepath.Join(".aiops", "PLAN.md")
+	if len(committed) != 1 || committed[0] != wantPath {
+		t.Fatalf("committed files = %v; want [%q]", committed, wantPath)
+	}
+}
+
+// TestMockRunnerCommitSourceChangeCommitsSourceFile pins the default commit
+// branch (CommitSourceFiles without CommitOnlyArtifacts): the committed path
+// is mock-source-change.txt.
+func TestMockRunnerCommitSourceChangeCommitsSourceFile(t *testing.T) {
+	t.Parallel()
+	workdir := initGitRepo(t)
+
+	r := MockRunner{CommitSourceFiles: true}
+	if _, err := r.Run(context.Background(), RunInput{
+		Task:     mockRunTask(),
+		Workflow: workflow.Workflow{},
+		Workdir:  workdir,
+	}); err != nil {
+		t.Fatalf("Run(CommitSourceFiles) error = %v; want nil", err)
+	}
+
+	committed := gitLastCommitFiles(t, workdir)
+	if len(committed) != 1 || committed[0] != "mock-source-change.txt" {
+		t.Fatalf("committed files = %v; want [%q]", committed, "mock-source-change.txt")
+	}
+}
+
+// TestMockRunnerSetBaseToHeadWritesWorkspaceBaseConfig pins the SetBaseToHead
+// branch: the runner records aiops.workspaceBase=HEAD in the repo's local git
+// config.
+func TestMockRunnerSetBaseToHeadWritesWorkspaceBaseConfig(t *testing.T) {
+	t.Parallel()
+	workdir := initGitRepo(t)
+
+	r := MockRunner{SetBaseToHead: true}
+	if _, err := r.Run(context.Background(), RunInput{
+		Task:     mockRunTask(),
+		Workflow: workflow.Workflow{},
+		Workdir:  workdir,
+	}); err != nil {
+		t.Fatalf("Run(SetBaseToHead) error = %v; want nil", err)
+	}
+
+	got := gitConfigLocal(t, workdir, "aiops.workspaceBase")
+	if got != "HEAD" {
+		t.Fatalf("git config aiops.workspaceBase = %q; want %q", got, "HEAD")
+	}
+}
+
+// TestMockRunnerManualCancelReturnsBareContextError pins the non-deadline
+// cancellation path: when the context is cancelled (not deadline-exceeded)
+// while the runner is sleeping, Run returns the bare ctx.Err()
+// (context.Canceled) rather than a *TimeoutError. The pre-#521 suite only
+// pinned the DeadlineExceeded branch.
+func TestMockRunnerManualCancelReturnsBareContextError(t *testing.T) {
+	t.Parallel()
+	r := MockRunner{Sleep: 5 * time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel shortly after Run begins sleeping so the select observes
+	// ctx.Done() with context.Canceled (no deadline on this context).
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	_, err := r.Run(ctx, RunInput{
+		Task:     mockRunTask(),
+		Workflow: workflow.Workflow{},
+		Workdir:  t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("Run(manual-cancel) error = nil; want context.Canceled")
+	}
+	if IsTimeout(err) {
+		t.Fatalf("Run(manual-cancel) IsTimeout = true (%T); want bare context error", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run(manual-cancel) error = %v; want errors.Is(context.Canceled)", err)
+	}
+}
+
+// initGitRepo creates a temp dir with an initialized git repo holding one
+// commit so the mock runner's commit / config branches operate against a real
+// repo.
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "test")
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "seed.txt")
+	runGit(t, dir, "commit", "-q", "-m", "seed")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s = %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// gitLastCommitFiles returns the files changed by HEAD relative to its parent.
+func gitLastCommitFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	cmd := exec.Command("git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git diff-tree HEAD = %v\n%s", err, out)
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files
+}
+
+func gitConfigLocal(t *testing.T, dir, key string) string {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--local", "--get", key)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git config --get %s = %v\n%s", key, err, out)
+	}
+	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
## What

Pure extract-function refactor of `(MockRunner).Run` (`internal/runner/mock.go`) for the #521 gocognit/funlen baseline. The function becomes a thin orchestrator delegating to one single-concern helper per artifact/side-effect, matching the already-merged #523/#525/#526 style. **Zero behavior change** — structural extraction only.

## Helpers extracted (each value receiver `m MockRunner`)

| Helper | Single concern |
|--------|----------------|
| `awaitMockSleep(ctx)` | Block for `m.Sleep`; return `*TimeoutError` on deadline, bare `ctx.Err()` otherwise; timer `Stop()` owned inside |
| `writeAnalysisPlan(dir, in, completedAt)` | Write `.aiops/PLAN.md` in `analysis_only` mode unless `SkipAnalysisPlan` |
| `writeMockSourceFile(workdir)` | Write `mock-source-change.txt` under the verbatim compound guard |
| `commitMockChange(ctx, workdir)` | `git add` + commit the source file (or `.aiops/PLAN.md` when `CommitOnlyArtifacts`) |
| `setMockWorkspaceBase(ctx, workdir)` | `git config --local aiops.workspaceBase HEAD` when `SetBaseToHead` |
| `writeMockWorkflowEdit(dir)` | Write `.aiops/WORKFLOW.md` = `"tracked workflow edit\n"` when `WriteAiopsWorkflow` |
| `writeMockTaskArtifact(dir, in, completedAt)` | Write `.aiops/<task>.md` outside `analysis_only` (keeps bare-error return) |
| `writeMockRunSummary(dir, in, completedAt)` | Always write `.aiops/RUN_SUMMARY.md` |

## Complexity

- **gocognit:** `Run` **34 → 9**. Every new helper ≤ 5.
- **funlen:** `Run` was also funlen-flagged; the decomposed `Run` and all helpers are well under 80 lines.
- The `//nolint:gocognit,funlen // baseline (#521)` directive was **removed** (confirmed: no `nolint` remains in `mock.go`). No new `//nolint` added.
- `gocognit -over 29 ./internal ./cmd` no longer lists `MockRunner.Run`.

## Zero-behavior-change invariants preserved

- **`completedAt` computed ONCE in `Run`** (`time.Now().Format(time.RFC3339)`) and threaded to every artifact helper — helpers do **not** call `time.Now()` independently, so artifact timestamps cannot diverge.
- **`.aiops/<task>.md` keeps its BARE `err` return** while every other write keeps its `fmt.Errorf(...)` wrap — the asymmetry is preserved exactly.
- **Strict order preserved:** sleep → PLAN → source file → commit → base config → workflow edit → task md → run summary, with short-circuit on first error (every call is `if err := ...; err != nil { return Result{}, err }`).
- **Compound guards copied verbatim**, including parenthesization: `m.WriteSourceFiles || (m.CommitSourceFiles && !m.CommitOnlyArtifacts)` (kept in positive form to avoid a spurious staticcheck QF1001 De Morgan suggestion while staying byte-identical to the original guard).
- **Timer ownership preserved:** `start`/`timer`/`defer t.Stop()` re-snapshotted inside `awaitMockSleep`, so `Stop()` still runs on every return path.
- **`dir` (=`Workdir/.aiops`) vs `workdir` (=`Workdir`) distinction kept** per helper signature.
- All `git -c ...` commit flags preserved byte-for-byte.

## Characterization tests (committed FIRST, separate commit)

Added to `internal/runner/runner_test.go` (package `runner`, constructing `MockRunner` directly):

- `TestMockRunnerArtifactMatrix` — table test over flag/policy combinations asserting exactly which files exist and their content (source file, `PLAN.md` vs `SkipAnalysisPlan`, `<task>.md` vs `analysis_only`, `WORKFLOW.md` content, always `RUN_SUMMARY.md`).
- `TestMockRunnerCommitOnlyArtifactsCommitsPlan` — `CommitSourceFiles + CommitOnlyArtifacts` commits `.aiops/PLAN.md` (via `git diff-tree`) and `mock-source-change.txt` is absent.
- `TestMockRunnerCommitSourceChangeCommitsSourceFile` — default commit branch commits `mock-source-change.txt`.
- `TestMockRunnerSetBaseToHeadWritesWorkspaceBaseConfig` — `aiops.workspaceBase=HEAD` recorded in local git config.
- `TestMockRunnerManualCancelReturnsBareContextError` — `context.WithCancel` + `cancel()` with `Sleep>0` returns bare `context.Canceled`, **not** a `*TimeoutError` (only the `DeadlineExceeded` path was pinned previously).

Failure messages use the Go review-comment shape `f(%q) = %v; want %v` (AGENTS.md rule 9).

**Mutation-verified non-placebo** (broke each targeted branch, confirmed the test FAILED, restored with `git checkout`, confirmed `git diff` clean):
1. `commitPath` → wrong file ⇒ `TestMockRunnerCommitOnlyArtifactsCommitsPlan` fails.
2. manual-cancel branch always returns `*TimeoutError` ⇒ `TestMockRunnerManualCancelReturnsBareContextError` fails.
3. flipped `!m.SkipAnalysisPlan` ⇒ `TestMockRunnerArtifactMatrix` PLAN.md cases fail.
4. `aiops.workspaceBase` value → `WRONG` ⇒ `TestMockRunnerSetBaseToHeadWritesWorkspaceBaseConfig` fails.
5. `WORKFLOW.md` content → `WRONG` ⇒ `TestMockRunnerArtifactMatrix` workflow case fails.

A final mutation run against the **committed decomposed** artifact (post-refactor `awaitMockSleep`) re-confirmed the manual-cancel + deadline tests still catch the break.

## Gates (all green, scoped to `internal/runner`)

- `gofmt -l` empty
- `go vet ./...`
- `go test -race ./internal/runner/...`
- `golangci-lint run --config=.golangci.yml ./internal/runner/...` → 0 issues (target gone from funlen/gocognit)
- `go build ./cmd/worker ./cmd/tui`

## Size gate

`within budget` — pure structural extraction plus the characterization coverage that pins the branches being decomposed.

Refs #521
