### PR TITLE
refactor(tracker): decompose listIssuesForState into single-concern helpers (#521)

### DIFF
--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -174,12 +174,9 @@ func (c *GitHubClient) ListIssuesByStates(ctx context.Context, states []string) 
 	return out, nil
 }
 
-func (c *GitHubClient) listIssuesForState(ctx context.Context, issueState, label, mappedState string, seen map[string]struct{}, claimedIssueNumbers map[int]struct{}) ([]Issue, bool, error) { //nolint:gocognit // baseline (#521)
+func (c *GitHubClient) listIssuesForState(ctx context.Context, issueState, label, mappedState string, seen map[string]struct{}, claimedIssueNumbers map[int]struct{}) ([]Issue, bool, error) {
 	var out []Issue
-	collectionSeen := make(map[string]struct{}, len(seen))
-	for id := range seen {
-		collectionSeen[id] = struct{}{}
-	}
+	collectionSeen := newGitHubCollectionSeen(seen)
 	maxPages := c.issueMaxPages()
 	scope := githubIssueCollectionScope(issueState, label)
 	for page := 1; page <= maxPages+1; page++ {
@@ -188,38 +185,86 @@ func (c *GitHubClient) listIssuesForState(ctx context.Context, issueState, label
 			return nil, false, err
 		}
 		if page > maxPages {
-			if !hasNext && len(batch) == 0 {
-				return out, false, nil
-			}
-			c.recordPaginationCapHit(scope, maxPages)
-			return nil, true, nil
+			return c.finishGitHubCapProbe(out, batch, hasNext, scope, maxPages)
 		}
-		for _, issue := range batch {
-			if issue.PullRequest != nil {
-				continue
-			}
-			if _, claimed := claimedIssueNumbers[issue.Number]; claimed && strings.EqualFold(strings.TrimSpace(issue.State), "open") {
-				continue
-			}
-			mapped, err := mapGitHubIssue(issue, mappedState)
-			if err != nil {
-				return nil, false, err
-			}
-			if mapped.ID == "" {
-				continue
-			}
-			c.cacheIssueNumber(mapped.ID, issue.Number)
-			if _, ok := collectionSeen[mapped.ID]; ok {
-				continue
-			}
-			collectionSeen[mapped.ID] = struct{}{}
-			out = append(out, mapped)
+		out, err = c.collectIssuesFromPage(batch, mappedState, claimedIssueNumbers, collectionSeen, out)
+		if err != nil {
+			return nil, false, err
 		}
 		if !hasNext && len(batch) < githubIssuePageSize {
 			return out, false, nil
 		}
 	}
 	return nil, true, nil
+}
+
+// newGitHubCollectionSeen seeds a per-collection dedup set from the shared
+// cross-state seen set, copying every key so a global mapped.ID already
+// collected in an earlier state is not re-collected here.
+func newGitHubCollectionSeen(seen map[string]struct{}) map[string]struct{} {
+	collectionSeen := make(map[string]struct{}, len(seen))
+	for id := range seen {
+		collectionSeen[id] = struct{}{}
+	}
+	return collectionSeen
+}
+
+// finishGitHubCapProbe handles the post-cap probe page (page > maxPages): an
+// empty, no-next probe means the collection fit exactly within the cap and the
+// accumulated out is returned; any remaining content records a cap hit and
+// signals capped with a nil issue slice so partial results are not treated as
+// authoritative.
+func (c *GitHubClient) finishGitHubCapProbe(out []Issue, batch []githubIssue, hasNext bool, scope string, maxPages int) ([]Issue, bool, error) {
+	if !hasNext && len(batch) == 0 {
+		return out, false, nil
+	}
+	c.recordPaginationCapHit(scope, maxPages)
+	return nil, true, nil
+}
+
+// collectIssuesFromPage folds one issue batch into out, delegating the
+// per-issue filter/map/dedup decision to collectIssueFromBatch. A mapping
+// error aborts the fold and discards accumulated work. out is passed in and
+// the grown slice returned.
+func (c *GitHubClient) collectIssuesFromPage(batch []githubIssue, mappedState string, claimedIssueNumbers map[int]struct{}, collectionSeen map[string]struct{}, out []Issue) ([]Issue, error) {
+	for _, issue := range batch {
+		mapped, collect, err := c.collectIssueFromBatch(issue, mappedState, claimedIssueNumbers, collectionSeen)
+		if err != nil {
+			return nil, err
+		}
+		if collect {
+			out = append(out, mapped)
+		}
+	}
+	return out, nil
+}
+
+// collectIssueFromBatch applies the single-issue collection rules: it drops PRs
+// disguised as issues, skips issues claimed by an open PR while they are still
+// open, surfaces mapping errors, skips empty-ID issues, caches the issue number
+// for every mapped issue with a non-empty ID before the dedup check, and
+// deduplicates by global mapped.ID against (and into) collectionSeen. It
+// returns the mapped issue and whether the caller should collect it.
+func (c *GitHubClient) collectIssueFromBatch(issue githubIssue, mappedState string, claimedIssueNumbers map[int]struct{}, collectionSeen map[string]struct{}) (Issue, bool, error) {
+	if issue.PullRequest != nil {
+		return Issue{}, false, nil
+	}
+	if _, claimed := claimedIssueNumbers[issue.Number]; claimed && strings.EqualFold(strings.TrimSpace(issue.State), "open") {
+		return Issue{}, false, nil
+	}
+	mapped, err := mapGitHubIssue(issue, mappedState)
+	if err != nil {
+		return Issue{}, false, err
+	}
+	if mapped.ID == "" {
+		return Issue{}, false, nil
+	}
+	c.cacheIssueNumber(mapped.ID, issue.Number)
+	if _, ok := collectionSeen[mapped.ID]; ok {
+		return Issue{}, false, nil
+	}
+	collectionSeen[mapped.ID] = struct{}{}
+	return mapped, true, nil
 }
 
 func (c *GitHubClient) listIssuesPage(ctx context.Context, issueState, label string, page int) ([]githubIssue, bool, error) {

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -643,3 +643,152 @@ func TestGitHubClientFetchIssueStatesByIDsSurfacesNon404Errors(t *testing.T) {
 		t.Fatalf("FetchIssueStatesByIDs error = %v, want HTTP 500 surfaced", err)
 	}
 }
+
+// TestGitHubClientListIssuesForStateKeepsClaimedNonOpenIssue characterizes the
+// compound claimed-skip guard in listIssuesForState before the #521
+// decomposition: an issue claimed by an open PR is only skipped while it is
+// itself open. A claimed issue in a non-open state must still be collected
+// (e.g. a "closed" issue surfaced by an "all" state query). Every other fixture
+// in this suite uses state:"open", so dropping the `&& EqualFold(...,"open")`
+// half of the guard would go undetected without this case.
+func TestGitHubClientListIssuesForStateKeepsClaimedNonOpenIssue(t *testing.T) {
+	// An open PR claims BOTH #77 and #78, so both enter claimedIssueNumbers.
+	// The "all" state query returns #77 (closed) and #78 (open). The compound
+	// guard must skip #78 (claimed AND open) but keep #77 (claimed but closed).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]githubPullRequestSummary{{
+				Number:  300,
+				State:   "open",
+				Title:   "Fix it",
+				Body:    "Closes #77\nCloses #78",
+				HTMLURL: "https://github.com/acme/api/pull/300",
+			}})
+		case "/repos/acme/api/issues":
+			if got := r.URL.Query().Get("state"); got != "all" {
+				t.Fatalf("issue state query = %q, want all", got)
+			}
+			_ = json.NewEncoder(w).Encode([]githubIssue{
+				{
+					ID:        77,
+					Number:    77,
+					Title:     "claimed but closed",
+					HTMLURL:   "https://github.com/acme/api/issues/77",
+					State:     "closed",
+					CreatedAt: "2026-05-20T01:02:03Z",
+					UpdatedAt: "2026-05-20T02:03:04Z",
+				},
+				{
+					ID:        78,
+					Number:    78,
+					Title:     "claimed and open",
+					HTMLURL:   "https://github.com/acme/api/issues/78",
+					State:     "open",
+					CreatedAt: "2026-05-20T01:02:03Z",
+					UpdatedAt: "2026-05-20T02:03:04Z",
+				},
+			})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token"}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"all"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates(all) = %v; want nil error", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("ListIssuesByStates(all) returned %d issues (%+v); want 1 (claimed-but-closed #77 kept, claimed-and-open #78 skipped)", len(issues), issues)
+	}
+	if got := issues[0].Identifier; got != "#77" {
+		t.Fatalf("ListIssuesByStates(all)[0].Identifier = %q; want %q (claimed non-open issue must be kept)", got, "#77")
+	}
+}
+
+// TestGitHubClientListIssuesForStateSurfacesMapError characterizes that a
+// mapGitHubIssue failure on the list path (here a malformed created_at) is
+// surfaced as an error rather than silently dropped, and that the accumulated
+// partial result is discarded.
+func TestGitHubClientListIssuesForStateSurfacesMapError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]githubPullRequestSummary{})
+		case "/repos/acme/api/issues":
+			_ = json.NewEncoder(w).Encode([]githubIssue{
+				{
+					ID:        90,
+					Number:    90,
+					Title:     "malformed timestamp",
+					HTMLURL:   "https://github.com/acme/api/issues/90",
+					State:     "open",
+					CreatedAt: "not-a-timestamp",
+					UpdatedAt: "2026-05-20T02:03:04Z",
+				},
+			})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token"}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"open"})
+	if err == nil || !strings.Contains(err.Error(), "created_at") {
+		t.Fatalf("ListIssuesByStates(open) err = %v; want mapGitHubIssue created_at parse error surfaced", err)
+	}
+	if issues != nil {
+		t.Fatalf("ListIssuesByStates(open) issues = %#v; want nil when a mapping error aborts the listing", issues)
+	}
+}
+
+// TestGitHubClientListIssuesForStateDeduplicatesAcrossStates characterizes that
+// a single global mapped.ID appearing in two different state collections is
+// collected exactly once. The dedup carries across states because each
+// per-state collection seeds collectionSeen from the shared seen set.
+func TestGitHubClientListIssuesForStateDeduplicatesAcrossStates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]githubPullRequestSummary{})
+		case "/repos/acme/api/issues":
+			// ID 42 is returned for BOTH the open and closed state queries.
+			_ = json.NewEncoder(w).Encode([]githubIssue{{
+				ID:        42,
+				Number:    42,
+				Title:     "appears in two states",
+				HTMLURL:   "https://github.com/acme/api/issues/42",
+				State:     r.URL.Query().Get("state"),
+				CreatedAt: "2026-05-20T01:02:03Z",
+				UpdatedAt: "2026-05-20T02:03:04Z",
+			}})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token"}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"open", "closed"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates(open,closed) = %v; want nil error", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("ListIssuesByStates(open,closed) returned %d issues (%+v); want 1 deduplicated by global ID", len(issues), issues)
+	}
+	if got := issues[0].ID; got != "42" {
+		t.Fatalf("ListIssuesByStates(open,closed)[0].ID = %q; want %q", got, "42")
+	}
+}


### PR DESCRIPTION
## What

Pure extract-function refactor of `(*GitHubClient).listIssuesForState`
(`internal/tracker/github.go`) for the #521 gocognit-decomposition umbrella.
The function becomes a thin orchestrator delegating to single-concern helpers,
matching the established style of the already-merged #523/#525/#526.

**Zero behavior change** — identical output, identical error wrapping/ordering/
classification, identical side effects and ordering of side effects. This is
structural extraction only.

## Helpers extracted (each a single concern)

| Helper | Concern |
|--------|---------|
| `newGitHubCollectionSeen` | Seed the per-collection dedup set from the shared cross-state `seen` set (copy every key). |
| `finishGitHubCapProbe` | Handle the `page > maxPages` cap-probe page: allowed empty probe returns accumulated `out`; otherwise record a cap hit and signal capped with a nil issue slice. |
| `collectIssuesFromPage` | Fold one issue batch into `out`, aborting on a mapping error (discarding accumulated work). |
| `collectIssueFromBatch` | The per-issue filter/map/cache/dedup decision for one `githubIssue`. |

> Note vs. the original plan: the plan split into `newGitHubCollectionSeen` +
> `collectIssuesFromPage` (+ optional `finishCapProbe`). The repo's golangci
> `gocognit` gate is `min-complexity: 10`, and a single `collectIssuesFromPage`
> owning the whole inner loop lands at gocognit 12 — which would fail the gate
> and is forbidden to silence with a new `//nolint`. I therefore split the
> per-issue body out into `collectIssueFromBatch` so every new helper lands at
> **≤ 10** with no new `//nolint`. Same pure extraction, one extra seam.

## gocognit before/after (gate `min-complexity: 10`)

- `listIssuesForState`: **31 → 10** (now absent from the `gocognit -over 29` gate list).
- New helpers: `collectIssueFromBatch` 6, `collectIssuesFromPage` 5, `finishGitHubCapProbe` 2, `newGitHubCollectionSeen` 1.
- `funlen`: target was not funlen-flagged; all functions remain well under 80 lines.

`go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml ./internal/tracker/...` → **0 issues**.

## `//nolint` baseline directive removed

The `//nolint:gocognit // baseline (#521)` directive on `listIssuesForState`
is removed. The sibling baselines `ListIssuesByStates` and
`openPullRequestClaimedIssueNumbers` keep their directives (out of scope). No
new `//nolint` was added anywhere.

## Zero-behavior-change invariants preserved

- **`cacheIssueNumber` ordering**: still called for every mapped issue with a
  non-empty ID **before** the `collectionSeen` dedup check (consumed by
  `FetchIssueStatesByRefs`). Preserved inside `collectIssueFromBatch`.
- **Map-error discards accumulated `out`**: a `mapGitHubIssue` error returns
  `(nil, err)` from the helper and the parent translates to `(nil, false, err)`,
  returning `nil` (not the partial `out`).
- **Compound claimed guard verbatim**:
  `claimed && strings.EqualFold(strings.TrimSpace(issue.State), "open")` copied
  unchanged — short-circuit equivalence holds.
- **`out` grow-by-append**: passed in / returned, parent reassigns;
  `collectionSeen` is the same map reference threaded through. The cap-probe
  returns `out` on the allowed-empty probe but `nil` on a real cap. No named
  returns.

## Characterization tests (committed first, mutation-verified non-placebo)

Added to `internal/tracker/github_test.go`, all using the
`f(%q) = %v; want %v` failure shape:

- `TestGitHubClientListIssuesForStateKeepsClaimedNonOpenIssue` — a claimed
  issue in a **non-open** state must be kept (every existing fixture is
  `state:"open"`, so dropping the `&& EqualFold(...,"open")` half would
  otherwise survive). Mutation: drop the open-state half → test fails (0 issues, want 1). ✓
- `TestGitHubClientListIssuesForStateSurfacesMapError` — a `mapGitHubIssue`
  error (malformed `created_at`) routed via the list path is surfaced and the
  partial result discarded. Mutation: `continue` instead of `return err` →
  test fails (nil error). ✓
- `TestGitHubClientListIssuesForStateDeduplicatesAcrossStates` — the same
  global `mapped.ID` appearing in two states is collected once. Mutation: drop
  the `seen`→`collectionSeen` seeding → test fails (2 issues, want 1). ✓

Each mutation was run against the code, confirmed failing, then restored with
`git checkout`; `git status`/`git diff` confirmed the tree matched HEAD after
each restore.

Coverage gap (d) — the empty `mapped.ID` skip — is **not constructible via the
`githubIssue` fixtures**: `mapGitHubIssue` formats `ID=0` as `"0"` (and falls
back to the number), so it never returns `""`. The skip branch is dead for
fixture-built input; I deliberately did not add a placebo test for it. The
branch is preserved verbatim in `collectIssueFromBatch`.

## Local gates (all pass)

- `gofmt -l` on touched files: empty.
- `go vet ./internal/tracker/`: clean.
- `go test -race ./internal/tracker/`: pass.
- golangci-lint scoped to `./internal/tracker/...`: 0 issues; target gone from funlen/gocognit findings.
- `go build ./cmd/worker ./cmd/tui`: ok.
- `go mod tidy`: leaves `go.mod`/`go.sum` clean.

## Size gate

**within budget** — 2 files touched; the diff is a refactor (net structure
move) plus three small characterization tests.

Refs #521