### PR TITLE
refactor(worker): decompose listIssueWorkspaces into single-concern helpers (#521)

### DIFF
--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -271,13 +271,17 @@ type issueWorkspace struct {
 	Key  string
 }
 
-func listIssueWorkspaces(root, trackerKind string) ([]issueWorkspace, error) { //nolint:gocognit // baseline (#521)
-	ownerEntries, err := os.ReadDir(root)
+// listIssueWorkspaces walks the workspace root and returns one issueWorkspace
+// per per-issue directory, in owner->repo->sourceDir->entry traversal order.
+// It returns (nil, nil) when the root does not exist and short-circuits on the
+// first owner/source read error in traversal order.
+func listIssueWorkspaces(root, trackerKind string) ([]issueWorkspace, error) {
+	ownerEntries, err := readWorkspaceRootEntries(root)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read workspace root %s: %w", root, err)
+		return nil, err
+	}
+	if ownerEntries == nil {
+		return nil, nil
 	}
 	sourceDirs := issueWorkspaceSourceDirs(trackerKind)
 	var workspaces []issueWorkspace
@@ -285,34 +289,83 @@ func listIssueWorkspaces(root, trackerKind string) ([]issueWorkspace, error) { /
 		if !ownerEntry.IsDir() {
 			continue
 		}
-		ownerPath := filepath.Join(root, ownerEntry.Name())
-		repoEntries, err := os.ReadDir(ownerPath)
+		ownerWorkspaces, err := collectOwnerIssueWorkspaces(filepath.Join(root, ownerEntry.Name()), sourceDirs)
 		if err != nil {
-			return nil, fmt.Errorf("read workspace owner %s: %w", ownerPath, err)
+			return nil, err
 		}
-		for _, repoEntry := range repoEntries {
-			if !repoEntry.IsDir() {
-				continue
-			}
-			repoPath := filepath.Join(ownerPath, repoEntry.Name())
-			for _, sourceDir := range sourceDirs {
-				sourcePath := filepath.Join(repoPath, sourceDir)
-				workspaceEntries, err := os.ReadDir(sourcePath)
-				if err != nil {
-					if os.IsNotExist(err) {
-						continue
-					}
-					return nil, fmt.Errorf("read issue workspace source %s: %w", sourcePath, err)
-				}
-				for _, workspaceEntry := range workspaceEntries {
-					if !workspaceEntry.IsDir() {
-						continue
-					}
-					path := filepath.Join(sourcePath, workspaceEntry.Name())
-					workspaces = append(workspaces, issueWorkspace{Path: path, Key: workspaceEntry.Name()})
-				}
-			}
+		workspaces = append(workspaces, ownerWorkspaces...)
+	}
+	return workspaces, nil
+}
+
+// readWorkspaceRootEntries reads the workspace root. A non-existent root yields
+// (nil, nil) so reconciliation no-ops before any workspaces are created; any
+// other read error is wrapped.
+func readWorkspaceRootEntries(root string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
 		}
+		return nil, fmt.Errorf("read workspace root %s: %w", root, err)
+	}
+	return entries, nil
+}
+
+// collectOwnerIssueWorkspaces reads one owner directory and gathers the issue
+// workspaces under each of its repo directories. Unlike the source-dir level,
+// an owner read error is always fatal (no os.IsNotExist special-case).
+func collectOwnerIssueWorkspaces(ownerPath string, sourceDirs []string) ([]issueWorkspace, error) {
+	repoEntries, err := os.ReadDir(ownerPath)
+	if err != nil {
+		return nil, fmt.Errorf("read workspace owner %s: %w", ownerPath, err)
+	}
+	var workspaces []issueWorkspace
+	for _, repoEntry := range repoEntries {
+		if !repoEntry.IsDir() {
+			continue
+		}
+		repoWorkspaces, err := collectRepoIssueWorkspaces(filepath.Join(ownerPath, repoEntry.Name()), sourceDirs)
+		if err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, repoWorkspaces...)
+	}
+	return workspaces, nil
+}
+
+// collectRepoIssueWorkspaces gathers the issue workspaces under one repo
+// directory across all candidate source dirs, in source-dir declaration order.
+func collectRepoIssueWorkspaces(repoPath string, sourceDirs []string) ([]issueWorkspace, error) {
+	var workspaces []issueWorkspace
+	for _, sourceDir := range sourceDirs {
+		sourceWorkspaces, err := collectSourceDirIssueWorkspaces(filepath.Join(repoPath, sourceDir))
+		if err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, sourceWorkspaces...)
+	}
+	return workspaces, nil
+}
+
+// collectSourceDirIssueWorkspaces reads one candidate source dir and returns
+// its per-issue workspace directories. A missing source dir yields (nil, nil)
+// so the caller skips it (os.IsNotExist); any other read error is wrapped.
+func collectSourceDirIssueWorkspaces(sourcePath string) ([]issueWorkspace, error) {
+	workspaceEntries, err := os.ReadDir(sourcePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read issue workspace source %s: %w", sourcePath, err)
+	}
+	var workspaces []issueWorkspace
+	for _, workspaceEntry := range workspaceEntries {
+		if !workspaceEntry.IsDir() {
+			continue
+		}
+		path := filepath.Join(sourcePath, workspaceEntry.Name())
+		workspaces = append(workspaces, issueWorkspace{Path: path, Key: workspaceEntry.Name()})
 	}
 	return workspaces, nil
 }

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -936,4 +937,196 @@ func TestReconcileStartupEndPayloadCountsReworkKeep(t *testing.T) {
 	payload := reconcileEndPayloadFor(t, emitter)
 	wantPayloadCount(t, payload, "kept", 1) // matched via active_rework prefix branch
 	wantPayloadCount(t, payload, "removed", 0)
+}
+
+// listIssueWorkspaceKeys returns just the sanitized keys discovered by
+// listIssueWorkspaces, sorted, so order-independent membership assertions read
+// cleanly. Traversal-order assertions use the raw slice instead.
+func listIssueWorkspaceKeys(t *testing.T, root, trackerKind string) []string {
+	t.Helper()
+	workspaces, err := listIssueWorkspaces(root, trackerKind)
+	if err != nil {
+		t.Fatalf("listIssueWorkspaces(%q) = _, %v; want nil error", root, err)
+	}
+	keys := make([]string, 0, len(workspaces))
+	for _, ws := range workspaces {
+		keys = append(keys, ws.Key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestListIssueWorkspacesMissingRootReturnsNil pins the root os.IsNotExist
+// branch: a non-existent workspace root yields (nil, nil), never an error.
+func TestListIssueWorkspacesMissingRootReturnsNil(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	workspaces, err := listIssueWorkspaces(missing, "linear")
+	if err != nil {
+		t.Fatalf("listIssueWorkspaces(%q) = _, %v; want nil error", missing, err)
+	}
+	if workspaces != nil {
+		t.Errorf("listIssueWorkspaces(%q) = %v; want nil", missing, workspaces)
+	}
+}
+
+// TestListIssueWorkspacesUnknownTrackerYieldsNoWorkspaces pins the nil
+// sourceDirs branch: an unknown tracker kind ranges over nil source dirs, so a
+// real workspace directory laid out on disk is never discovered.
+func TestListIssueWorkspacesUnknownTrackerYieldsNoWorkspaces(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	workspaces, err := listIssueWorkspaces(root, "bitbucket")
+	if err != nil {
+		t.Fatalf("listIssueWorkspaces(%q) = _, %v; want nil error", root, err)
+	}
+	if len(workspaces) != 0 {
+		t.Errorf("listIssueWorkspaces(%q, unknown tracker) = %v; want no workspaces", root, workspaces)
+	}
+}
+
+// TestListIssueWorkspacesExcludesNonDirectoryEntries pins the three !IsDir
+// guards (owner, repo, workspace level). Regular files placed beside real
+// workspace dirs at every level must be excluded from the result; only the
+// genuine workspace directory is reported.
+func TestListIssueWorkspacesExcludesNonDirectoryEntries(t *testing.T) {
+	root := t.TempDir()
+	workspaceDir := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1")
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A file at the owner level (beside the "acme" owner dir).
+	mustWriteFile(t, filepath.Join(root, "owner-file.txt"))
+	// A file at the repo level (beside the "repo" repo dir).
+	mustWriteFile(t, filepath.Join(root, "acme", "repo-file.txt"))
+	// A file at the workspace level (beside the "LIN-1" workspace dir).
+	mustWriteFile(t, filepath.Join(root, "acme", "repo", "linear_issue", "workspace-file.txt"))
+
+	got := listIssueWorkspaceKeys(t, root, "linear")
+	want := []string{"LIN-1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("listIssueWorkspaces(%q) keys = %v; want %v (non-directory entries must be excluded)", root, got, want)
+	}
+}
+
+// TestListIssueWorkspacesUnreadableOwnerDirReturnsWrappedError pins the owner
+// read-error branch: an unreadable owner directory is fatal (no IsNotExist
+// special-case at this level) and surfaces the "read workspace owner %s: %w"
+// wrap with the owner path. Skipped under root, which bypasses 0o000.
+func TestListIssueWorkspacesUnreadableOwnerDirReturnsWrappedError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses 0o000 permissions")
+	}
+	root := t.TempDir()
+	ownerPath := filepath.Join(root, "acme")
+	if err := os.MkdirAll(ownerPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(ownerPath, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(ownerPath, 0o755) })
+
+	_, err := listIssueWorkspaces(root, "linear")
+	if err == nil {
+		t.Fatalf("listIssueWorkspaces(%q) = _, nil; want owner read error", root)
+	}
+	wantPrefix := "read workspace owner " + ownerPath + ":"
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Errorf("listIssueWorkspaces(%q) error = %q; want prefix %q", root, err.Error(), wantPrefix)
+	}
+}
+
+// TestListIssueWorkspacesUnreadableSourceDirReturnsWrappedError pins the
+// source-dir read-error branch: an unreadable issue-workspace source directory
+// is fatal (distinct from the IsNotExist skip) and surfaces the "read issue
+// workspace source %s: %w" wrap with the source path. Skipped under root.
+func TestListIssueWorkspacesUnreadableSourceDirReturnsWrappedError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses 0o000 permissions")
+	}
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "acme", "repo", "linear_issue")
+	if err := os.MkdirAll(sourcePath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(sourcePath, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sourcePath, 0o755) })
+
+	_, err := listIssueWorkspaces(root, "linear")
+	if err == nil {
+		t.Fatalf("listIssueWorkspaces(%q) = _, nil; want source read error", root)
+	}
+	wantPrefix := "read issue workspace source " + sourcePath + ":"
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Errorf("listIssueWorkspaces(%q) error = %q; want prefix %q", root, err.Error(), wantPrefix)
+	}
+}
+
+// TestListIssueWorkspacesMissingSourceDirIsSkipped pins the source-dir
+// os.IsNotExist branch: when one of the candidate source dirs does not exist
+// the traversal continues to the next candidate rather than erroring, so the
+// sibling source dir's workspaces are still discovered.
+func TestListIssueWorkspacesMissingSourceDirIsSkipped(t *testing.T) {
+	root := t.TempDir()
+	// Only the hyphen variant "linear-issue" exists; the underscore variant
+	// "linear_issue" is absent and must be skipped, not error.
+	if err := os.MkdirAll(filepath.Join(root, "acme", "repo", "linear-issue", "LIN-1"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	got := listIssueWorkspaceKeys(t, root, "linear")
+	want := []string{"LIN-1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("listIssueWorkspaces(%q) keys = %v; want %v (missing source dir must be skipped)", root, got, want)
+	}
+}
+
+// TestListIssueWorkspacesPreservesTraversalOrder pins the owner->repo->
+// sourceDir->workspaceEntry concatenation order that feeds reconcile_workspace
+// event emission ordering. Entries within a directory come back from os.ReadDir
+// sorted by name, so the expected order is deterministic.
+func TestListIssueWorkspacesPreservesTraversalOrder(t *testing.T) {
+	root := t.TempDir()
+	// Two owners (alpha, beta), each with one repo. Within alpha/repo both
+	// source dirs exist; the inner loop ranges issueWorkspaceSourceDirs in its
+	// declared order ("linear_issue" then "linear-issue"), NOT ReadDir's
+	// name-sorted order, so A2 (under linear_issue) must precede A1 (under
+	// linear-issue) even though "linear-issue" sorts first on disk. This pins
+	// the sourceDir-ordering branch alongside the owner-major sequence.
+	dirs := []string{
+		filepath.Join(root, "alpha", "repo", "linear-issue", "A1"),
+		filepath.Join(root, "alpha", "repo", "linear_issue", "A2"),
+		filepath.Join(root, "beta", "repo", "linear-issue", "B1"),
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	workspaces, err := listIssueWorkspaces(root, "linear")
+	if err != nil {
+		t.Fatalf("listIssueWorkspaces(%q) = _, %v; want nil error", root, err)
+	}
+	gotPaths := make([]string, 0, len(workspaces))
+	for _, ws := range workspaces {
+		gotPaths = append(gotPaths, ws.Path)
+	}
+	wantPaths := []string{
+		filepath.Join(root, "alpha", "repo", "linear_issue", "A2"),
+		filepath.Join(root, "alpha", "repo", "linear-issue", "A1"),
+		filepath.Join(root, "beta", "repo", "linear-issue", "B1"),
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Errorf("listIssueWorkspaces(%q) paths = %v; want %v (traversal order must be owner->repo->sourceDir->entry)", root, gotPaths, wantPaths)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file %s: %v", path, err)
+	}
 }


### PR DESCRIPTION
## What

Pure extract-function refactor of `listIssueWorkspaces` (`internal/worker/reconcile.go`) for the #521 gocognit decomposition. The function nested four loops (owner → repo → sourceDir → workspaceEntry) and scored **gocognit 34** — the only non-test function in `internal/worker` over the #521 gate. It is now a thin owner-traversal orchestrator delegating to single-concern helpers, matching the established style of the already-merged #523/#525/#526 decompositions.

**Zero behavior change.** Structural extraction only — no algorithm change, no renamed domain concepts, no changed error sentinels.

## Helpers extracted (single concern each)

- **`readWorkspaceRootEntries(root)`** — owns *only* the root read: returns `(nil, nil)` on `os.IsNotExist`, else wraps other errors as `read workspace root %s: %w`, else returns the entries.
- **`collectOwnerIssueWorkspaces(ownerPath, sourceDirs)`** — reads one owner dir (any error fatal: `read workspace owner %s: %w`, **no** `IsNotExist` special-case at this level) and concatenates the workspaces under each repo dir.
- **`collectRepoIssueWorkspaces(repoPath, sourceDirs)`** — ranges the candidate source dirs in declared order and concatenates their workspaces.
- **`collectSourceDirIssueWorkspaces(sourcePath)`** — reads one source dir: returns `(nil, nil)` on `os.IsNotExist` (caller skips it), else wraps `read issue workspace source %s: %w`; appends only directory entries.

> The plan called for three helpers. I added a fourth (`collectSourceDirIssueWorkspaces`, split out of `collectRepoIssueWorkspaces`) because the repo's golangci-lint `gocognit.min-complexity` is **10** (stricter than the #521 gate's 29), and the combined repo-level helper scored 11. Splitting it keeps every helper under the linter threshold without adding any `//nolint`. Returning `(nil, nil)` and appending a nil slice is behavior-identical to the original `continue`.

## Scores

| Function | gocognit before | gocognit after |
|---|---|---|
| `listIssueWorkspaces` | **34** | **7** |
| `readWorkspaceRootEntries` | — | 3 |
| `collectOwnerIssueWorkspaces` | — | 6 |
| `collectRepoIssueWorkspaces` | — | 3 |
| `collectSourceDirIssueWorkspaces` | — | 6 |

`listIssueWorkspaces` no longer appears in `gocognit -over 29 ./internal ./cmd`. `golangci-lint run --config=.golangci.yml ./internal/worker/...` reports **0 issues**. The function was not funlen-flagged (only `//nolint:gocognit`), so no funlen budget applies.

## `//nolint` baseline directive

The `//nolint:gocognit // baseline (#521)` directive on `listIssueWorkspaces` is **removed**. No new `//nolint` was added anywhere. The four sibling baseline directives in the same file (`reworkWorkspaceKeyPrefixes`, `workspaceKeysForRawIssueKeys`, `serviceMatchesIssueForReconcile`, `sanitizeLegacyWorkspaceKey`) are left untouched, as instructed.

## Zero-behavior-change invariants preserved

- **Output ordering** owner → repo → sourceDir → workspaceEntry is byte-identical (feeds `reconcile_workspace` event emission order). Child results are concatenated in order; nothing is reordered.
- **First-error short-circuit**: the first owner/source read error in traversal order is returned immediately.
- **Wrap strings + path args byte-identical**: `read workspace root %s: %w` (root), `read workspace owner %s: %w` (ownerPath), `read issue workspace source %s: %w` (sourcePath).
- **`IsNotExist` semantics differ by level and are not homogenized**: root → `(nil, nil)`; source-dir → skip/continue; owner-level → no special-case (any error fatal).
- **`sourceDirs` is nil for unknown `trackerKind`** → ranging nil is a no-op (preserved); no slice aliasing of a parent accumulator.

## Characterization tests (committed first, mutation-verified non-placebo)

Added to `internal/worker/reconcile_test.go`, calling `listIssueWorkspaces` directly:

- `TestListIssueWorkspacesMissingRootReturnsNil` — root `os.IsNotExist` → `(nil, nil)`.
- `TestListIssueWorkspacesUnknownTrackerYieldsNoWorkspaces` — nil `sourceDirs` for an unknown tracker discovers nothing.
- `TestListIssueWorkspacesExcludesNonDirectoryEntries` — files placed beside real workspace dirs at **owner, repo, and workspace** levels are excluded (the three `!IsDir` guards).
- `TestListIssueWorkspacesUnreadableOwnerDirReturnsWrappedError` — unreadable owner dir → `read workspace owner %s: %w` (fatal). Skips under root (`os.Geteuid() == 0`), which bypasses `0o000`.
- `TestListIssueWorkspacesUnreadableSourceDirReturnsWrappedError` — unreadable source dir → `read issue workspace source %s: %w`. Skips under root.
- `TestListIssueWorkspacesMissingSourceDirIsSkipped` — missing source dir → `os.IsNotExist` skip, sibling source dir still discovered.
- `TestListIssueWorkspacesPreservesTraversalOrder` — owner → repo → sourceDir → entry ordering (sourceDir order is the declared list order, not ReadDir's name sort).

Each test was **mutation-verified**: I broke the exact branch it targets against the committed test code, confirmed the test FAILED, then restored with `git checkout -- internal/worker/reconcile.go` and confirmed the working tree matched HEAD each time (the three `!IsDir` guards were mutated individually; both wrap strings, both `IsNotExist` branches, the unknown-tracker default, and the sourceDir order were each mutated and caught). Tests were committed **before** the decomposition (commit 1: tests, commit 2: refactor).

## Local gates (all pass)

- `gofmt -l` on touched files: clean
- `go vet ./internal/worker/...`: clean
- `go test -race ./internal/worker/...`: pass
- `golangci-lint run --config=.golangci.yml ./internal/worker/...`: **0 issues**
- `go build ./cmd/worker ./cmd/tui`: OK
- `gocognit -over 29 ./internal ./cmd`: target gone
- `go mod tidy`: `go.mod`/`go.sum` clean

## Size gate

**within budget** — the refactor + characterization tests are a single atomic change (the tests pin the branches the refactor must preserve).

Refs #521