### PR TITLE
refactor(gitea): decompose listIssuesByStateLabel into single-concern helpers (#521)

### DIFF
--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -262,7 +262,7 @@ func giteaIssueNumberFromIdentifier(identifier string) (int, bool) {
 	return number, true
 }
 
-func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, issueState string, wantedStates map[string]struct{}, seenIssues map[string]struct{}) ([]tracker.Issue, bool, error) { //nolint:gocognit // baseline (#521)
+func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, issueState string, wantedStates map[string]struct{}, seenIssues map[string]struct{}) ([]tracker.Issue, bool, error) {
 	var out []tracker.Issue
 	collectionSeen := make(map[string]struct{}, len(seenIssues))
 	for id := range seenIssues {
@@ -274,65 +274,125 @@ func (c *TrackerClient) listIssuesByStateLabel(ctx context.Context, labelName, i
 		scope = issueState
 	}
 	for page := 1; page <= maxPages+1; page++ {
-		batch, hasNext, err := c.listIssuesPage(ctx, labelName, issueState, page)
+		grown, capped, done, err := c.scopePageStep(ctx, labelName, issueState, page, maxPages, scope, wantedStates, collectionSeen, out)
 		if err != nil {
 			return nil, false, err
 		}
-		if page > maxPages {
-			if !hasNext && len(batch) == 0 {
-				return out, false, nil
-			}
-			c.recordPaginationCapHit(scope, maxPages)
-			return nil, true, nil
+		if done {
+			return grown, capped, nil
 		}
-		for _, issue := range batch {
-			issueKey := giteaIssueID(issue)
-			if _, ok := collectionSeen[issueKey]; ok {
-				continue
-			}
-			c.cacheIssueNumber(issue)
-			state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
-			c.logDiagnostics(issue, diagnostics)
-			if state == "" {
-				continue
-			}
-			if len(wantedStates) > 0 {
-				if _, ok := wantedStates[strings.ToLower(state)]; !ok {
-					continue
-				}
-			}
-			createdAt, err := parseGiteaIssueTime("created_at", issue.CreatedAt)
-			if err != nil {
-				return nil, false, err
-			}
-			updatedAt, err := parseGiteaIssueTime("updated_at", issue.UpdatedAt)
-			if err != nil {
-				return nil, false, err
-			}
-			collectionSeen[issueKey] = struct{}{}
-			out = append(out, tracker.Issue{
-				ID:          issueKey,
-				Identifier:  fmt.Sprintf("#%d", issue.Number),
-				Title:       issue.Title,
-				Description: issue.Body,
-				URL:         issue.HTMLURL,
-				State:       state,
-				CreatedAt:   createdAt,
-				UpdatedAt:   updatedAt,
-				Labels:      extractGiteaLabels(issue.Labels),
-				BlockedBy:   c.buildBlockedBy(ctx, issue.Body),
-				// Priority: Gitea has no native priority field — see
-				// dependsOnRegexp comment / SPEC §4.1.1 note. Left at the zero
-				// value; dispatch sort treats every Gitea issue as equal priority
-				// and falls back to created_at. Operators can opt in to
-				// label-driven priority in a follow-up.
-			})
-		}
-		if !hasNext && len(batch) < listIssuesPageSize {
-			return out, false, nil
-		}
+		out = grown
 	}
 	return nil, true, nil
+}
+
+// scopePageStep fetches one page and either ends the collection or grows out.
+// It returns done=true with the verbatim return values the parent must pass
+// through: the post-cap probe page yields (out|nil, capped) via finishCapProbe;
+// a natural end (no next page and a short final batch) yields (out, false); and
+// a mid-collection page yields done=false so the parent keeps paging with the
+// grown slice. capped is meaningful only when done is true.
+func (c *TrackerClient) scopePageStep(ctx context.Context, labelName, issueState string, page, maxPages int, scope string, wantedStates, collectionSeen map[string]struct{}, out []tracker.Issue) (grown []tracker.Issue, capped, done bool, err error) {
+	batch, hasNext, err := c.listIssuesPage(ctx, labelName, issueState, page)
+	if err != nil {
+		return nil, false, false, err
+	}
+	if page > maxPages {
+		out, capped = c.finishCapProbe(out, batch, hasNext, scope, maxPages)
+		return out, capped, true, nil
+	}
+	out, err = c.collectScopePage(ctx, batch, wantedStates, collectionSeen, out)
+	if err != nil {
+		return nil, false, false, err
+	}
+	if !hasNext && len(batch) < listIssuesPageSize {
+		return out, false, true, nil
+	}
+	return out, false, false, nil
+}
+
+// finishCapProbe owns the post-cap probe page (page > maxPages): an empty,
+// terminal probe response confirms the previous pages were the full result, so
+// the collected issues are authoritative (capped=false); anything else means
+// there were more pages than the cap allows, which records a cap hit and
+// returns capped=true with nil issues so reconcile does not treat the partial
+// result as authoritative.
+func (c *TrackerClient) finishCapProbe(out []tracker.Issue, batch []Issue, hasNext bool, scope string, maxPages int) ([]tracker.Issue, bool) {
+	if !hasNext && len(batch) == 0 {
+		return out, false
+	}
+	c.recordPaginationCapHit(scope, maxPages)
+	return nil, true
+}
+
+// collectScopePage folds one page of Gitea issues into out, applying the
+// dedup-then-filter-then-include ordering: a duplicate (already in
+// collectionSeen) is skipped before any caching/logging so it is neither
+// re-cached nor re-logged; an issue with no derivable state or one outside
+// wantedStates is dropped before the include-only work; and the issue is marked
+// seen only on the include path, after both timestamps parse and right before
+// the blocker lookup + append.
+func (c *TrackerClient) collectScopePage(ctx context.Context, batch []Issue, wantedStates, collectionSeen map[string]struct{}, out []tracker.Issue) ([]tracker.Issue, error) {
+	for _, issue := range batch {
+		issueKey := giteaIssueID(issue)
+		if _, ok := collectionSeen[issueKey]; ok {
+			continue
+		}
+		c.cacheIssueNumber(issue)
+		converted, include, err := c.scopeIssue(ctx, issue, wantedStates)
+		if err != nil {
+			return nil, err
+		}
+		if !include {
+			continue
+		}
+		collectionSeen[issueKey] = struct{}{}
+		out = append(out, converted)
+	}
+	return out, nil
+}
+
+// scopeIssue derives an issue's workflow state (logging label diagnostics),
+// drops it when the state is empty or outside wantedStates, and on the include
+// path parses created_at then updated_at (first malformed wins) and builds the
+// normalized tracker.Issue including the blocker lookup. include is false for a
+// filtered issue; callers must not mark it seen unless include is true.
+func (c *TrackerClient) scopeIssue(ctx context.Context, issue Issue, wantedStates map[string]struct{}) (tracker.Issue, bool, error) {
+	state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
+	c.logDiagnostics(issue, diagnostics)
+	if state == "" {
+		return tracker.Issue{}, false, nil
+	}
+	if len(wantedStates) > 0 {
+		if _, ok := wantedStates[strings.ToLower(state)]; !ok {
+			return tracker.Issue{}, false, nil
+		}
+	}
+	createdAt, err := parseGiteaIssueTime("created_at", issue.CreatedAt)
+	if err != nil {
+		return tracker.Issue{}, false, err
+	}
+	updatedAt, err := parseGiteaIssueTime("updated_at", issue.UpdatedAt)
+	if err != nil {
+		return tracker.Issue{}, false, err
+	}
+	return tracker.Issue{
+		ID:          giteaIssueID(issue),
+		Identifier:  fmt.Sprintf("#%d", issue.Number),
+		Title:       issue.Title,
+		Description: issue.Body,
+		URL:         issue.HTMLURL,
+		State:       state,
+		CreatedAt:   createdAt,
+		UpdatedAt:   updatedAt,
+		Labels:      extractGiteaLabels(issue.Labels),
+		BlockedBy:   c.buildBlockedBy(ctx, issue.Body),
+		// Priority: Gitea has no native priority field — see
+		// dependsOnRegexp comment / SPEC §4.1.1 note. Left at the zero
+		// value; dispatch sort treats every Gitea issue as equal priority
+		// and falls back to created_at. Operators can opt in to
+		// label-driven priority in a follow-up.
+	}, true, nil
 }
 
 func (c *TrackerClient) recordPaginationCapHit(labelName string, maxPages int) {

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -661,6 +661,104 @@ func TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure(t *testin
 	}
 }
 
+// TestTrackerClientListIssuesByStatesSurfacesMalformedTimestamp pins coverage
+// gap (a) for #521: a malformed created_at/updated_at routed THROUGH the
+// listing (not just parseGiteaIssueTime in isolation) must surface the parse
+// error from listIssuesByStateLabel. created_at is parsed before updated_at,
+// so a malformed created_at wins; the error names the field and bad value.
+func TestTrackerClientListIssuesByStatesSurfacesMalformedTimestamp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 401, Number: 1, Title: "todo", HTMLURL: "https://gitea.local/o/r/issues/1", CreatedAt: "not-a-timestamp", UpdatedAt: "2026-05-17T00:00:00Z", Labels: []Label{{Name: "aiops/todo"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err == nil {
+		t.Fatalf("ListIssuesByStates(malformed created_at) = %#v, nil; want parse error", issues)
+	}
+	if !strings.Contains(err.Error(), "created_at") || !strings.Contains(err.Error(), "not-a-timestamp") {
+		t.Fatalf("ListIssuesByStates err = %q; want created_at field name and bad value", err.Error())
+	}
+	if issues != nil {
+		t.Fatalf("ListIssuesByStates(malformed created_at) issues = %#v; want nil on parse error", issues)
+	}
+}
+
+// TestTrackerClientListIssuesByStatesDeduplicatesWithinSingleLabelScope pins
+// coverage gap (b) for #521: when the SAME issueKey appears twice across the
+// pages of ONE label scope, the collectionSeen dedup (marked on the include
+// path) must keep it once. Existing coverage only exercises cross-label dedup
+// seeded from seenIssues; this exercises intra-scope dedup across pages.
+func TestTrackerClientListIssuesByStatesDeduplicatesWithinSingleLabelScope(t *testing.T) {
+	var requestedPages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPages = append(requestedPages, r.URL.Query().Get("page"))
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil {
+			t.Fatalf("page query = %q: %v", r.URL.Query().Get("page"), err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if page < 2 {
+			w.Header().Add("Link", fmt.Sprintf(`<%s%s?page=%d>; rel="next"`, serverURL(r), r.URL.Path, page+1))
+		}
+		// Same issue (ID 501) returned on both page 1 and page 2.
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 501, Number: 1, Title: "todo", HTMLURL: "https://gitea.local/o/r/issues/1", CreatedAt: "2026-05-16T23:59:00Z", UpdatedAt: "2026-05-17T00:00:00Z", Labels: []Label{{Name: "aiops/todo"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if !slices.Equal(requestedPages, []string{"1", "2"}) {
+		t.Fatalf("requested pages = %#v; want pages 1 and 2 (same issue repeated)", requestedPages)
+	}
+	if len(issues) != 1 || issues[0].ID != "501" {
+		t.Fatalf("ListIssuesByStates(duplicate across pages) = %#v; want issue 501 once", issues)
+	}
+}
+
+// TestTrackerClientListIssuesByStateLabelSkipsEmptyStateWithoutWantedStatesFilter
+// pins coverage gap (c) for #521: an issue whose labels yield an empty state
+// must be dropped by the state=="" guard INDEPENDENTLY of the wantedStates
+// filter. It drives listIssuesByStateLabel directly with an empty wantedStates
+// set, so the wantedStates filter is a no-op (len==0) and cannot drop anything;
+// the unlabelled issue can only be removed by the state=="" guard, while the
+// labelled issue (which would survive the wantedStates filter regardless) is
+// kept.
+func TestTrackerClientListIssuesByStateLabelSkipsEmptyStateWithoutWantedStatesFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 601, Number: 1, Title: "no aiops label", HTMLURL: "https://gitea.local/o/r/issues/1", CreatedAt: "2026-05-16T23:59:00Z", UpdatedAt: "2026-05-17T00:00:00Z", Labels: []Label{{Name: "bug"}}},
+			{ID: 602, Number: 2, Title: "todo", HTMLURL: "https://gitea.local/o/r/issues/2", CreatedAt: "2026-05-16T23:59:00Z", UpdatedAt: "2026-05-17T00:00:00Z", Labels: []Label{{Name: "aiops/todo"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	issues, capped, err := client.listIssuesByStateLabel(context.Background(), "aiops/todo", "open", map[string]struct{}{}, map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("listIssuesByStateLabel: %v", err)
+	}
+	if capped {
+		t.Fatalf("listIssuesByStateLabel capped = true; want false")
+	}
+	if len(issues) != 1 || issues[0].ID != "602" || issues[0].State != "AI Ready" {
+		t.Fatalf("listIssuesByStateLabel(empty wantedStates) = %#v; want only issue 602 (unlabelled issue 601 dropped by state==\"\" guard, not wantedStates)", issues)
+	}
+}
+
 func serverURL(r *http.Request) string {
 	return "http://" + r.Host
 }


### PR DESCRIPTION
## What

Pure extract-function refactor for the #521 gocognit umbrella. `(*TrackerClient).listIssuesByStateLabel` (`internal/gitea/tracker_client.go`) was at gocognit **35** with a `//nolint:gocognit // baseline (#521)` directive; it is now a thin orchestrator delegating to single-concern helpers, the directive is removed, and every function — orchestrator and helpers — is at or below the local golangci `gocognit.min-complexity: 10` so none needs a nolint.

**Zero behavior change.** Identical output for identical input, identical error wrapping/ordering/classification, identical side effects and ordering. This is structural extraction only.

## Helpers extracted (single concern each)

| Helper | Concern |
|---|---|
| `scopePageStep` | Fetch one page and decide end-vs-grow, returning the verbatim `(issues, capped)` the parent passes through. |
| `finishCapProbe` | The post-cap probe block: an empty terminal probe means the prior pages were authoritative; otherwise record a cap hit and fail the listing. |
| `collectScopePage` | The per-page fold with dedup-then-include ordering (dedup skip before cache/log; mark-seen only on the include path). |
| `scopeIssue` | Per-issue state derivation + diagnostics logging, the `state==""` / `wantedStates` filters, `created_at`-then-`updated_at` parse, and `tracker.Issue` construction (including `buildBlockedBy`). |

## gocognit before/after (target)

- `listIssuesByStateLabel`: **35 → 7**
- new helpers: `collectScopePage` 7, `scopeIssue` 6, `scopePageStep` 5, `finishCapProbe` 2 — all ≤ 10 (the blocking golangci gate), so no new `//nolint`.
- `//nolint:gocognit // baseline (#521)` directive on the target **removed**. (The two other baseline directives in this file — `ListIssuesByStates`, `FetchIssueStatesByRefs` — are separate #521 targets and are left untouched.)

This function is not `funlen`-flagged, so no funlen baseline applies.

## Zero-behavior-change invariants preserved

Quoting the specific risks from the target spec:

- **Dedup ordering**: a duplicate (already in `collectionSeen`) is skipped at the TOP of the loop body, BEFORE `cacheIssueNumber` / `IssueStateFromLabels` / `logDiagnostics` — duplicates are neither re-cached nor re-logged. (Kept in `collectScopePage`, before the `scopeIssue` call.)
- **Mark-seen only on include**: `collectionSeen[issueKey] = struct{}{}` happens ONLY on the include path, after both timestamps parse and right before append. A state/`wantedStates`-filtered issue is NOT marked. (`scopeIssue` returns `include=false` without the caller marking it.)
- **`buildBlockedBy` (network IO) runs only on the include path**, after the filters — not moved earlier.
- **`parseGiteaIssueTime` order**: `created_at` THEN `updated_at` (first malformed wins).
- **Return triples verbatim**: `(nil,false,err)` on fetch/parse error; `(out,false,nil)` on natural end / empty-probe end; `(nil,true,nil)` on cap and the trailing post-loop fallthrough. `scope` precedence: `labelName`, else `issueState`. `out` is grown by append (passed in/out, never re-allocated in a closure).

## Characterization tests (added first, separate commit, mutation-verified)

Three branches the existing suite left unpinned. Each was verified to PASS on the un-decomposed code, then mutation-verified non-placebo by breaking the exact branch, confirming the test FAILS, and restoring with `git checkout` (working tree confirmed clean vs HEAD after each restore, per the #469/#483 footgun):

- `TestTrackerClientListIssuesByStatesSurfacesMalformedTimestamp` — gap (a): a malformed `created_at` routed THROUGH the listing surfaces the parse error (previously only `parseGiteaIssueTime` was pinned in isolation). Mutation: swallow the `created_at` error → test failed.
- `TestTrackerClientListIssuesByStatesDeduplicatesWithinSingleLabelScope` — gap (b): the SAME `issueKey` repeated across the pages of ONE label scope appears once (existing coverage only exercised cross-label `seenIssues` seeding). Mutation: disable the `collectionSeen` skip → issue appeared twice, test failed.
- `TestTrackerClientListIssuesByStateLabelSkipsEmptyStateWithoutWantedStatesFilter` — gap (c): the `state==""` skip pinned INDEPENDENTLY of the `wantedStates` filter by driving `listIssuesByStateLabel` directly with an empty `wantedStates` set (so that filter is a no-op). Mutation: disable the `state==""` guard → the unlabelled empty-state issue leaked through, test failed.

## Local gates (all pass)

- `gofmt -l` on touched files: empty
- `go vet ./...`: clean
- `go test -race ./internal/gitea/...`: ok (89.0% coverage)
- `golangci-lint --config=.golangci.yml ./internal/gitea/...`: **0 issues**
- `go build ./cmd/worker ./cmd/tui`: ok
- `gocognit -over 29 ./internal ./cmd`: target absent from the list

## Deviation from the plan

The plan specified two helpers (`finishCapProbe`, `collectScopePage`) under "gocognit 30". The actual blocking gate is golangci `gocognit.min-complexity: 10`, and with only those two helpers the orchestrator and `collectScopePage` came in at 12/14 — over the gate. I added two more pure-extraction helpers (`scopeIssue`, `scopePageStep`) to bring every function ≤ 10 without any new `//nolint`. `finishCapProbe` drops its always-nil `error` return (flagged by `unparam`); the original cap-probe block never errored, so this is behavior-preserving.

## Size gate

`within budget` — refactor (+113/-53 in one production file) plus 98 lines of mutation-verified characterization tests. Test LOC is exempt from the size budget per AGENTS.md rule 7.

Refs #521
