### PR TITLE
refactor(tracker): decompose ListIssuesByStates into single-concern helpers (#521)

### DIFF
--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -129,33 +129,17 @@ func (c *LinearClient) ListActiveIssues(ctx context.Context) ([]Issue, error) {
 	return c.ListIssuesByStates(ctx, c.Config.ActiveStates)
 }
 
-func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) ([]Issue, error) { //nolint:gocognit,funlen // baseline (#521)
-	if c.APIKey == "" {
-		return nil, NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
-	}
-	projectSlug := strings.TrimSpace(c.Config.ProjectSlug)
-	if projectSlug == "" {
-		return nil, NewError(CategoryMissingTrackerProjectSlug, "Linear project slug is required", nil)
-	}
-	// SPEC §17.3: empty fetch_issues_by_states([]) returns empty without API call.
-	nonEmpty := make([]string, 0, len(states))
-	for _, s := range states {
-		if t := strings.TrimSpace(s); t != "" {
-			nonEmpty = append(nonEmpty, t)
-		}
-	}
-	if len(nonEmpty) == 0 {
-		return nil, nil
-	}
-	// customFieldValues is intentionally NOT requested. Linear's GraphQL
-	// schema does not expose a customFieldValues field on Issue (only
-	// customerTicketCount matches `custom*`); requesting it produced
-	// HTTP 400 GRAPHQL_VALIDATION_FAILED on every poll (#326). The
-	// upstream Elixir reference (elixir/lib/symphony_elixir/linear/client.ex)
-	// also omits any custom-field fragment for the same reason.
-	// `services[].tracker.custom_fields` route predicates are rejected at
-	// workflow load time until Linear surfaces a working query field.
-	query := `query ListIssues($projectSlug: String!, $states: [String!], $first: Int!, $after: String) {
+// listLinearIssuesQuery is the fixed ListIssues GraphQL query.
+//
+// customFieldValues is intentionally NOT requested. Linear's GraphQL
+// schema does not expose a customFieldValues field on Issue (only
+// customerTicketCount matches `custom*`); requesting it produced
+// HTTP 400 GRAPHQL_VALIDATION_FAILED on every poll (#326). The
+// upstream Elixir reference (elixir/lib/symphony_elixir/linear/client.ex)
+// also omits any custom-field fragment for the same reason.
+// `services[].tracker.custom_fields` route predicates are rejected at
+// workflow load time until Linear surfaces a working query field.
+const listLinearIssuesQuery = `query ListIssues($projectSlug: String!, $states: [String!], $first: Int!, $after: String) {
   issues(filter: { project: { slugId: { eq: $projectSlug } }, state: { name: { in: $states } } }, first: $first, after: $after) {
     nodes {
       id
@@ -175,88 +159,169 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
     pageInfo { hasNextPage endCursor }
   }
 }`
+
+// linearIssueNode is one node of the ListIssues response. The json tags are
+// the wire contract; keep them byte-for-byte in step with listLinearIssuesQuery.
+type linearIssueNode struct {
+	ID          string `json:"id"`
+	Identifier  string `json:"identifier"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	Priority    int    `json:"priority"`
+	BranchName  string `json:"branchName"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+	Project     struct {
+		SlugID string `json:"slugId"`
+	} `json:"project"`
+	Team struct {
+		Key string `json:"key"`
+	} `json:"team"`
+	Labels struct {
+		Nodes []struct {
+			Name string `json:"name"`
+		} `json:"nodes"`
+	} `json:"labels"`
+	State struct {
+		Name string `json:"name"`
+	} `json:"state"`
+}
+
+// linearIssuesResponse wraps a single ListIssues page.
+type linearIssuesResponse struct {
+	Data struct {
+		Issues struct {
+			Nodes    []linearIssueNode `json:"nodes"`
+			PageInfo struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
+		} `json:"issues"`
+	} `json:"data"`
+	Errors []map[string]any `json:"errors"`
+}
+
+func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) ([]Issue, error) {
+	projectSlug, err := c.requireListIssuesConfig()
+	if err != nil {
+		return nil, err
+	}
+	nonEmpty := normalizeRequestedStates(states)
+	// SPEC §17.3: empty fetch_issues_by_states([]) returns empty without API call.
+	if len(nonEmpty) == 0 {
+		return nil, nil
+	}
 	var issues []Issue
 	var after any
 	for page := 0; page < maxLinearIssuePages; page++ {
-		var out struct {
-			Data struct {
-				Issues struct {
-					Nodes []struct {
-						ID          string `json:"id"`
-						Identifier  string `json:"identifier"`
-						Title       string `json:"title"`
-						Description string `json:"description"`
-						URL         string `json:"url"`
-						Priority    int    `json:"priority"`
-						BranchName  string `json:"branchName"`
-						CreatedAt   string `json:"createdAt"`
-						UpdatedAt   string `json:"updatedAt"`
-						Project     struct {
-							SlugID string `json:"slugId"`
-						} `json:"project"`
-						Team struct {
-							Key string `json:"key"`
-						} `json:"team"`
-						Labels struct {
-							Nodes []struct {
-								Name string `json:"name"`
-							} `json:"nodes"`
-						} `json:"labels"`
-						State struct {
-							Name string `json:"name"`
-						} `json:"state"`
-					} `json:"nodes"`
-					PageInfo struct {
-						HasNextPage bool   `json:"hasNextPage"`
-						EndCursor   string `json:"endCursor"`
-					} `json:"pageInfo"`
-				} `json:"issues"`
-			} `json:"data"`
-			Errors []map[string]any `json:"errors"`
-		}
-		if err := c.graphql(ctx, query, map[string]any{"projectSlug": projectSlug, "states": nonEmpty, "first": linearIssuePageSize, "after": after}, &out); err != nil {
+		mapped, pageInfo, err := c.fetchLinearIssuesPage(ctx, map[string]any{"projectSlug": projectSlug, "states": nonEmpty, "first": linearIssuePageSize, "after": after})
+		if err != nil {
 			return nil, err
 		}
-		if len(out.Errors) > 0 {
-			return nil, linearGraphQLErrors(out.Errors)
-		}
-		for _, n := range out.Data.Issues.Nodes {
-			createdAt, err := parseLinearIssueTime("createdAt", n.CreatedAt)
-			if err != nil {
-				return nil, err
-			}
-			updatedAt, err := parseLinearIssueTime("updatedAt", n.UpdatedAt)
-			if err != nil {
-				return nil, err
-			}
-			var blockers []BlockerRef
-			if isTodoState(n.State.Name) {
-				var err error
-				blockers, err = c.linearBlockersForIssue(ctx, n.ID)
-				if err != nil {
-					return nil, err
-				}
-			}
-			labels := make([]string, 0, len(n.Labels.Nodes))
-			for _, label := range n.Labels.Nodes {
-				if strings.TrimSpace(label.Name) != "" {
-					labels = append(labels, strings.ToLower(strings.TrimSpace(label.Name)))
-				}
-			}
-			// Issue.CustomFields stays nil — Linear's GraphQL schema does not
-			// expose any custom-field data on Issue (introspection confirms
-			// only `customerTicketCount` matches `custom*`). See #326.
-			issues = append(issues, Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, BranchName: n.BranchName, CreatedAt: createdAt, UpdatedAt: updatedAt, ProjectSlug: n.Project.SlugID, TeamKey: n.Team.Key, Labels: labels, State: n.State.Name, BlockedBy: blockers})
-		}
-		if !out.Data.Issues.PageInfo.HasNextPage {
+		issues = append(issues, mapped...)
+		if !pageInfo.HasNextPage {
 			return issues, nil
 		}
-		if out.Data.Issues.PageInfo.EndCursor == "" {
+		if pageInfo.EndCursor == "" {
 			return nil, NewError(CategoryLinearMissingEndCursor, "linear pagination missing endCursor", nil)
 		}
-		after = out.Data.Issues.PageInfo.EndCursor
+		after = pageInfo.EndCursor
 	}
 	return nil, fmt.Errorf("linear pagination exceeded %d pages", maxLinearIssuePages)
+}
+
+// requireListIssuesConfig enforces the two ListIssuesByStates preconditions
+// and returns the trimmed project slug. It mirrors the original guard order:
+// the API key is checked before the project slug.
+func (c *LinearClient) requireListIssuesConfig() (string, error) {
+	if c.APIKey == "" {
+		return "", NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
+	}
+	projectSlug := strings.TrimSpace(c.Config.ProjectSlug)
+	if projectSlug == "" {
+		return "", NewError(CategoryMissingTrackerProjectSlug, "Linear project slug is required", nil)
+	}
+	return projectSlug, nil
+}
+
+// normalizeRequestedStates trims each requested state and drops empties.
+// The caller keeps the empty short-circuit (SPEC §17.3).
+func normalizeRequestedStates(states []string) []string {
+	nonEmpty := make([]string, 0, len(states))
+	for _, s := range states {
+		if t := strings.TrimSpace(s); t != "" {
+			nonEmpty = append(nonEmpty, t)
+		}
+	}
+	return nonEmpty
+}
+
+// linearPageInfo carries the page-control fields the ListIssuesByStates loop
+// inspects after each page so the HasNextPage / EndCursor branches stay
+// visible in the caller.
+type linearPageInfo struct {
+	HasNextPage bool
+	EndCursor   string
+}
+
+// fetchLinearIssuesPage issues one ListIssues page request, surfaces any
+// GraphQL errors, and maps the page's nodes to domain Issues in order. Page
+// control (HasNextPage / EndCursor / cursor advance) stays in the caller so
+// the early-return semantics remain visible. A page with no nodes yields a nil
+// issue slice so the caller's accumulator preserves nil-vs-empty.
+func (c *LinearClient) fetchLinearIssuesPage(ctx context.Context, vars map[string]any) ([]Issue, linearPageInfo, error) {
+	var out linearIssuesResponse
+	if err := c.graphql(ctx, listLinearIssuesQuery, vars, &out); err != nil {
+		return nil, linearPageInfo{}, err
+	}
+	if len(out.Errors) > 0 {
+		return nil, linearPageInfo{}, linearGraphQLErrors(out.Errors)
+	}
+	var issues []Issue
+	for _, n := range out.Data.Issues.Nodes {
+		iss, err := c.mapLinearIssueNode(ctx, n)
+		if err != nil {
+			return nil, linearPageInfo{}, err
+		}
+		issues = append(issues, iss)
+	}
+	pageInfo := linearPageInfo{
+		HasNextPage: out.Data.Issues.PageInfo.HasNextPage,
+		EndCursor:   out.Data.Issues.PageInfo.EndCursor,
+	}
+	return issues, pageInfo, nil
+}
+
+// mapLinearIssueNode maps one ListIssues node to a domain Issue. Blockers are
+// fetched only for Todo-state issues; createdAt is parsed before updatedAt so
+// the first malformed timestamp wins.
+func (c *LinearClient) mapLinearIssueNode(ctx context.Context, n linearIssueNode) (Issue, error) {
+	createdAt, err := parseLinearIssueTime("createdAt", n.CreatedAt)
+	if err != nil {
+		return Issue{}, err
+	}
+	updatedAt, err := parseLinearIssueTime("updatedAt", n.UpdatedAt)
+	if err != nil {
+		return Issue{}, err
+	}
+	var blockers []BlockerRef
+	if isTodoState(n.State.Name) {
+		blockers, err = c.linearBlockersForIssue(ctx, n.ID)
+		if err != nil {
+			return Issue{}, err
+		}
+	}
+	labels := make([]string, 0, len(n.Labels.Nodes))
+	for _, label := range n.Labels.Nodes {
+		if strings.TrimSpace(label.Name) != "" {
+			labels = append(labels, strings.ToLower(strings.TrimSpace(label.Name)))
+		}
+	}
+	// Issue.CustomFields stays nil — Linear's GraphQL schema does not
+	// expose any custom-field data on Issue (introspection confirms
+	// only `customerTicketCount` matches `custom*`). See #326.
+	return Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, BranchName: n.BranchName, CreatedAt: createdAt, UpdatedAt: updatedAt, ProjectSlug: n.Project.SlugID, TeamKey: n.Team.Key, Labels: labels, State: n.State.Name, BlockedBy: blockers}, nil
 }
 
 func parseLinearIssueTime(field, value string) (time.Time, error) {

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -874,3 +874,112 @@ func TestListIssuesByStatesEmptyShortCircuitsWithoutAPICall(t *testing.T) {
 		t.Fatalf("server received %d requests, want 0 (SPEC §17.3: empty fetch_issues_by_states returns empty without API call)", got)
 	}
 }
+
+// TestListIssuesByStatesSkipsBlockerFetchForNonTodoIssue pins the isTodoState
+// gate (#521 decomposition characterization): blockers are fetched ONLY for
+// Todo-state issues, so a non-Todo issue must end with empty BlockedBy AND must
+// not trigger a ListIssueInverseRelations request. The existing pagination test
+// only asserts the positive (Todo) branch; flipping the gate would survive it.
+func TestListIssuesByStatesSkipsBlockerFetchForNonTodoIssue(t *testing.T) {
+	var mu sync.Mutex
+	var ops []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		mu.Lock()
+		ops = append(ops, opNameFromQuery(payload.Query))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		// Single In Progress (non-Todo) issue; if the gate is flipped and a
+		// blocker fetch fires, the inverse-relations op falls through to this
+		// same handler and is recorded below.
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer srv.Close()
+	client := newTestClient(t, srv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"In Progress"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(issues))
+	}
+	if got := len(issues[0].BlockedBy); got != 0 {
+		t.Fatalf("issues[0].BlockedBy = %d, want 0 (non-Todo issue must not fetch blockers)", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, op := range ops {
+		if op == "ListIssueInverseRelations" {
+			t.Fatalf("server ops = %v, want no ListIssueInverseRelations (blockers fetched only for Todo state)", ops)
+		}
+	}
+	if got, want := len(ops), 1; got != want {
+		t.Fatalf("server ops = %v (len %d), want %d (single ListIssues call only)", ops, got, want)
+	}
+}
+
+// TestListIssuesByStatesSkipsBlankLabelNames pins the empty-label skip branch
+// (#521 decomposition characterization): a node label whose name is blank or
+// whitespace-only is dropped from the mapped Labels slice; surviving names are
+// trimmed and lower-cased. No existing test feeds a blank label name.
+func TestListIssuesByStatesSkipsBlankLabelNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","labels":{"nodes":[{"name":"  "},{"name":""},{"name":" Backend "}]},"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer srv.Close()
+	client := newTestClient(t, srv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"In Progress"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(issues))
+	}
+	if got := strings.Join(issues[0].Labels, ","); got != "backend" {
+		t.Fatalf("issues[0].Labels = %q, want %q (blank/whitespace label names skipped, survivor trimmed+lowered)", got, "backend")
+	}
+}
+
+// TestListIssuesByStatesReturnsParseErrorForMalformedTimestamp pins the
+// parse-error propagation branch end-to-end (#521 decomposition
+// characterization): a malformed createdAt/updatedAt routed THROUGH
+// ListIssuesByStates must surface the parse error. parseLinearIssueTime is unit
+// tested standalone, but no test exercises it via the list path; createdAt is
+// parsed before updatedAt, so the first malformed field wins.
+func TestListIssuesByStatesReturnsParseErrorForMalformedTimestamp(t *testing.T) {
+	cases := []struct {
+		name      string
+		createdAt string
+		updatedAt string
+		wantField string
+		wantValue string
+	}{
+		{"malformed-createdAt", "not-a-time", "2026-05-16T00:00:00Z", "createdAt", "not-a-time"},
+		{"malformed-updatedAt", "2026-05-15T00:00:00Z", "also-bad", "updatedAt", "also-bad"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, fmt.Sprintf(`{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":%q,"updatedAt":%q,"state":{"name":"In Progress"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`, c.createdAt, c.updatedAt))
+			}))
+			defer srv.Close()
+			client := newTestClient(t, srv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+			issues, err := client.ListIssuesByStates(context.Background(), []string{"In Progress"})
+			if err == nil {
+				t.Fatalf("ListIssuesByStates(%s) = %v, nil; want parse error", c.name, issues)
+			}
+			if !strings.Contains(err.Error(), c.wantField) || !strings.Contains(err.Error(), c.wantValue) {
+				t.Fatalf("ListIssuesByStates(%s) err = %q; want field %q and value %q", c.name, err.Error(), c.wantField, c.wantValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Pure extract-function decomposition of `(*LinearClient).ListIssuesByStates` (`internal/tracker/linear.go`) for the #521 complexity-baseline cleanup. The function becomes a thin orchestrator delegating to single-concern helpers, matching the merged #523/#525/#526 style. **Zero behavior change** — identical output, error wrapping/ordering/classification, side effects and ordering, and request shape for identical input.

## Helpers extracted (single concern each)

- **`listLinearIssuesQuery`** (package const) — hoisted the fixed ListIssues GraphQL query out of the function body. Byte-identical to the original literal (verified by diff); the #326 "no customFieldValues" explanatory comment block stays attached.
- **`linearIssueNode`** / **`linearIssuesResponse`** (named types) — name the previously-inline anonymous response structs. Every `json` tag copied byte-for-byte.
- **`requireListIssuesConfig`** — the two precondition guards (API key checked before project slug, same sentinels `CategoryMissingTrackerAPIKey` / `CategoryMissingTrackerProjectSlug`, same order).
- **`normalizeRequestedStates`** — trim each requested state, drop empties (cap `len(states)`). The SPEC §17.3 `if len(nonEmpty)==0 { return nil, nil }` short-circuit stays in the caller.
- **`fetchLinearIssuesPage`** — one page request (`c.graphql`) + the `out.Errors -> linearGraphQLErrors` guard + node mapping, returning mapped issues plus a typed `linearPageInfo`. The page-control branches (HasNextPage / EndCursor / cursor advance) and the terminal plain `fmt.Errorf` stay visible in the parent loop.
- **`mapLinearIssueNode`** — maps one node: `parseLinearIssueTime("createdAt")` then `parseLinearIssueTime("updatedAt")` (first malformed field wins), `isTodoState`-gated `c.linearBlockersForIssue` (blockers fetched only for Todo state, error returned verbatim), label normalization into a fresh `make([]string,0,len(n.Labels.Nodes))` with trim+ToLower and skip-empty, and the `Issue` literal (`CustomFields` stays nil). Same `ctx` threaded into `graphql` / `linearBlockersForIssue`.

> Deviation from the literal plan: instead of separate `mapLinearIssueNodes` + `nextLinearIssuePage` helpers, the final `fetchLinearIssuesPage` returns mapped issues + a typed `linearPageInfo` and the parent keeps the three page-control branches inline. The blocking CI gate is golangci-lint `gocognit` with `min-complexity: 10` (stricter than the `-over 29` verification helper); the merged #525/#526 orchestrators all land under 10. This factoring reaches 9 while keeping page-control fully visible in the parent, as the plan required.

## Complexity (before/after)

| function | gocognit before | gocognit after |
|---|---|---|
| `(*LinearClient).ListIssuesByStates` | **37** | **9** |

funlen: the target was also funlen-flagged (`//nolint:gocognit,funlen`); the decomposed orchestrator is now well under the 80-line / 50-statement budget. All new helpers are under both gates and add **no** new `//nolint`.

The `//nolint:gocognit,funlen // baseline (#521)` directive was **removed** from the target. golangci-lint scoped to `./internal/tracker/...` reports **0 issues**, and the target no longer appears in the `gocognit -over 29` list.

## Zero-behavior-change invariants preserved

- **Max-pages terminal error stays a plain `fmt.Errorf("linear pagination exceeded %d pages", ...)`** — NOT `ErrIssueListingCapped`. Linear is intentionally not "aligned" with github/gitea cap semantics; this keeps `TestListIssuesByStatesErrorsWhenMaxPagesExceeded` green.
- **`isTodoState` gate stays gated** — blockers fetched only for Todo state. Re-verified by `TestListIssuesByStatesPaginates` (requests==3) plus the new test below.
- **nil-vs-empty preserved** — the accumulator `var issues []Issue` stays nil-initialized; a `!HasNextPage` page that mapped no nodes returns a nil slice (`fetchLinearIssuesPage` returns a nil issue slice for an empty page; `append(nil)` of zero elements stays nil).
- **Missing-endCursor error path returns `nil, err`**, not the accumulated slice (matched the original `return nil, NewError(...)`).
- **Fresh labels slice per node; double-applied trim+lower intentional; same `ctx` threaded** (not a fresh context) so `TestLinearClient_EnforcesRequestTimeout` still pins the deadline. No named returns on the orchestrator.
- **GraphQL query byte-identical**, including the absence of `customFieldValues` (#326).

## Characterization tests (committed first, mutation-verified non-placebo)

Added to `internal/tracker/linear_test.go` (package `tracker`, httptest pattern), pinning coverage gaps the existing suite left unasserted:

- `TestListIssuesByStatesSkipsBlockerFetchForNonTodoIssue` — a non-Todo issue ends with empty `BlockedBy` AND triggers no `ListIssueInverseRelations` request. Mutation: flipping `isTodoState` to `!isTodoState` makes it fail.
- `TestListIssuesByStatesSkipsBlankLabelNames` — blank / whitespace-only label names are dropped; survivors trimmed+lowered. Mutation: dropping the `if strings.TrimSpace(label.Name) != ""` skip yields `,,backend`, failing the test.
- `TestListIssuesByStatesReturnsParseErrorForMalformedTimestamp` — a malformed `createdAt` or `updatedAt` routed THROUGH `ListIssuesByStates` surfaces the parse error (createdAt parsed first). Mutation: swallowing the parse errors (`_ =`) returns nil error, failing both subcases.

Each mutation was run against the branch, confirmed to fail the targeted test, then restored with `git checkout`; the working tree was reconfirmed clean against HEAD after each restore (#469/#483 footgun guard). Tests committed in a separate first commit before the decomposition.

## Local gates (all pass)

- `gofmt -l` on touched files: empty
- `go vet ./...`: clean
- `go test -race -covermode=atomic ./internal/tracker/...`: ok (86.3% coverage)
- golangci-lint (`./internal/tracker/...`): 0 issues; target gone from funlen/gocognit
- `go build ./cmd/worker ./cmd/tui`: ok
- `gocognit -over 29 ./internal ./cmd`: target absent
- consumer packages `internal/worker`, `internal/orchestrator` race tests: ok

## Size-gate classification

**within budget** — small, atomic refactor + the characterization coverage it depends on.

Refs #521