### PR TITLE
refactor(orchestrator): decompose reconcileTick into single-concern helpers (#521)

### DIFF
--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -201,7 +201,7 @@ func (l activeIssueListerFromStates) ListActiveIssues(ctx context.Context) ([]tr
 	return l.tracker.ListIssuesByStates(ctx, l.states)
 }
 
-func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue) (map[string]tracker.Issue, error) { //nolint:gocognit // baseline (#521)
+func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue) (map[string]tracker.Issue, error) {
 	if p.stateTracker == nil {
 		return nil, errors.New("orchestrator poller reconciliation requires state tracker")
 	}
@@ -224,6 +224,22 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 	if err != nil {
 		fetchErr = errors.Join(fetchErr, err)
 	}
+	mergeRefreshedActiveStates(activeIssuesByID, refreshedIssuesByID, activeStateKeys)
+	if err := p.reconcileActiveRunsPartB(ctx, activeIssuesByID, refreshedIssuesByID, activeStateKeys); err != nil {
+		return nil, err
+	}
+	inactiveByID, deriveErr := p.deriveInactiveIssues(ctx, activeIssuesByID, refreshedIssuesByID, activeStateKeys)
+	fetchErr = errors.Join(fetchErr, deriveErr)
+	reconcileErr := p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, inactiveByID, normalizedStates(p.reconcile.TerminalStates), p.reconcile.WorkerExitTimeout)
+	return inactiveByID, errors.Join(reconcileErr, fetchErr)
+}
+
+// mergeRefreshedActiveStates folds the narrow per-issue state refresh back into
+// the active set: issues still in an active state keep their stored entry with
+// the refreshed state copied in (value-copy update, not pointer mutation),
+// while issues that left the active set are dropped from activeIssuesByID. It
+// mutates activeIssuesByID in place and treats refreshedIssuesByID as read-only.
+func mergeRefreshedActiveStates(activeIssuesByID, refreshedIssuesByID map[string]tracker.Issue, activeStateKeys map[string]struct{}) {
 	for id, issue := range refreshedIssuesByID {
 		if isActiveTrackerState(issue.State, activeStateKeys) {
 			if existing, ok := activeIssuesByID[id]; ok {
@@ -234,6 +250,14 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 			delete(activeIssuesByID, id)
 		}
 	}
+}
+
+// reconcileActiveRunsPartB runs SPEC §16.3 Part B: revalidate active runs
+// against the freshly refreshed active set. The error it returns is fatal to
+// the tick (reconcileTick returns it with a nil map), matching the inline
+// behavior before #521. It mutates activeIssuesByID by reference and treats
+// refreshedIssuesByID as read-only.
+func (p *Poller) reconcileActiveRunsPartB(ctx context.Context, activeIssuesByID, refreshedIssuesByID map[string]tracker.Issue, activeStateKeys map[string]struct{}) error {
 	if p.routing != nil {
 		// Routing-aware listings are complete for their scope, so absence from
 		// the active set is real evidence of inactivity and may cancel runs.
@@ -247,17 +271,22 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 		// entry fires before_remove + reconcile_workspace reason=terminal mid-run,
 		// while a route-change or non-terminal inactive cancel keeps the workspace
 		// for reuse (#340).
-		if err := p.orchestrator.ReconcileTrackerIssuesAndWait(ctx, activeIssuesByID, activeStateKeys, normalizedStates(p.reconcile.TerminalStates), refreshedIssuesByID, p.reconcile.WorkerExitTimeout); err != nil {
-			return nil, err
-		}
-	} else {
-		// Without routing the active listing may be partial; still refresh
-		// stored issue metadata for runs we DO see so per-state capacity gates
-		// observe the latest tracker state without treating absence as inactive.
-		if err := p.orchestrator.RefreshActiveTrackerIssues(ctx, activeIssuesByID, activeStateKeys); err != nil {
-			return nil, err
-		}
+		return p.orchestrator.ReconcileTrackerIssuesAndWait(ctx, activeIssuesByID, activeStateKeys, normalizedStates(p.reconcile.TerminalStates), refreshedIssuesByID, p.reconcile.WorkerExitTimeout)
 	}
+	// Without routing the active listing may be partial; still refresh
+	// stored issue metadata for runs we DO see so per-state capacity gates
+	// observe the latest tracker state without treating absence as inactive.
+	return p.orchestrator.RefreshActiveTrackerIssues(ctx, activeIssuesByID, activeStateKeys)
+}
+
+// deriveInactiveIssues builds the SPEC §16.3 inactive/terminal set for the
+// inactive reconcile pass: refreshed running issues that left the active set
+// for a configured inactive/terminal state, plus explicit terminal/inactive
+// state-group listings (skipping empty IDs and issues still considered active).
+// The returned error joins any per-group listing errors in loop order; it is
+// non-fatal (accumulated into fetchErr by the caller). activeIssuesByID is read
+// only here; refreshedIssuesByID is read-only throughout.
+func (p *Poller) deriveInactiveIssues(ctx context.Context, activeIssuesByID, refreshedIssuesByID map[string]tracker.Issue, activeStateKeys map[string]struct{}) (map[string]tracker.Issue, error) {
 	activeByID := issueMapIDSet(activeIssuesByID)
 	inactiveByID := make(map[string]tracker.Issue)
 	for id, issue := range refreshedIssuesByID {
@@ -270,24 +299,41 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 		delete(activeByID, id)
 		inactiveByID[id] = issue
 	}
+	groupErr := p.appendInactiveFromStateGroups(ctx, inactiveByID, activeByID)
+	return inactiveByID, groupErr
+}
+
+// appendInactiveFromStateGroups fetches the explicit terminal/inactive
+// state-group listings and adds each freshly-listed issue to inactiveByID,
+// skipping empty IDs and issues still considered active. It mutates
+// inactiveByID in place and reads activeByID only; per-group listing errors are
+// joined in loop order and returned non-fatally.
+func (p *Poller) appendInactiveFromStateGroups(ctx context.Context, inactiveByID map[string]tracker.Issue, activeByID map[string]struct{}) error {
+	var groupErr error
 	for _, states := range p.reconcileInactiveStateGroups() {
 		issues, err := p.stateTracker.ListIssuesByStates(ctx, states)
 		if err != nil {
-			fetchErr = errors.Join(fetchErr, err)
+			groupErr = errors.Join(groupErr, err)
 			continue
 		}
-		for _, issue := range issues {
-			if issue.ID == "" {
-				continue
-			}
-			if _, active := activeByID[issue.ID]; active {
-				continue
-			}
-			inactiveByID[issue.ID] = issue
-		}
+		addInactiveListedIssues(inactiveByID, activeByID, issues)
 	}
-	reconcileErr := p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, inactiveByID, normalizedStates(p.reconcile.TerminalStates), p.reconcile.WorkerExitTimeout)
-	return inactiveByID, errors.Join(reconcileErr, fetchErr)
+	return groupErr
+}
+
+// addInactiveListedIssues adds each freshly-listed issue to inactiveByID,
+// skipping empty IDs and issues still considered active. It mutates inactiveByID
+// in place and reads activeByID only.
+func addInactiveListedIssues(inactiveByID map[string]tracker.Issue, activeByID map[string]struct{}, issues []tracker.Issue) {
+	for _, issue := range issues {
+		if issue.ID == "" {
+			continue
+		}
+		if _, active := activeByID[issue.ID]; active {
+			continue
+		}
+		inactiveByID[issue.ID] = issue
+	}
 }
 
 func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID map[string]tracker.Issue) (map[string]tracker.Issue, error) {

--- a/internal/orchestrator/poller_reconciletick_test.go
+++ b/internal/orchestrator/poller_reconciletick_test.go
@@ -1,0 +1,231 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// fixedStateTracker is a minimal IssueStateLister/IssueStateRefresher that
+// drives reconcileTick's inactive-state fan-out (Part B / derive) and narrow
+// refresh (FetchIssueStatesByRefs). It returns scripted, deterministic results
+// so reconcileTick branches can be pinned directly.
+type fixedStateTracker struct {
+	mu sync.Mutex
+	// fixedListIssues, when non-nil, is returned verbatim from every
+	// ListIssuesByStates call (the production fan-out then applies its own
+	// empty-ID/active filters via deriveInactiveIssues). nil means "no inactive
+	// issues".
+	fixedListIssues []tracker.Issue
+
+	fetchStates map[string]string
+}
+
+func (f *fixedStateTracker) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
+	return f.ListIssuesByStates(ctx, nil)
+}
+
+func (f *fixedStateTracker) ListIssuesByStates(_ context.Context, _ []string) ([]tracker.Issue, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fixedListIssues == nil {
+		return nil, nil
+	}
+	out := make([]tracker.Issue, len(f.fixedListIssues))
+	copy(out, f.fixedListIssues)
+	return out, nil
+}
+
+func (f *fixedStateTracker) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	wanted := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		wanted[ref.ID] = struct{}{}
+	}
+	out := make(map[string]string, len(refs))
+	for id, state := range f.fetchStates {
+		if _, ok := wanted[id]; ok {
+			out[id] = state
+		}
+	}
+	return out, nil
+}
+
+func (f *fixedStateTracker) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]string, error) {
+	return f.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(ids))
+}
+
+// TestReconcileTickPartACancelledContextReturnsFatally pins the load-bearing
+// Part A fatal early-return: when the SPEC §16.3 stall reconciliation (Part A)
+// errors AND ctx is already cancelled, reconcileTick must surface that error
+// (return (nil map, err)) rather than swallowing it or proceeding. The actor
+// loop is stopped first so the Part A submit deterministically fails with
+// ctx.Err(); the guard's `if ctx.Err() != nil { return nil, err }` must then
+// fire. A mutation that swallowed the fatal error (return nil, nil) or that did
+// not surface a non-nil error fails this test.
+//
+// Note on scope: the orthogonal "always-accumulate" mutation (dropping the
+// guard so the cancelled-ctx case falls through to Part B) is NOT
+// behaviorally observable here — under a cancelled context every downstream
+// orchestrator call also fails with the same context error, so the
+// (nil map, context error) result is identical with or without the guard.
+// The complementary over-eager-fatal direction (treating a LIVE-ctx Part A
+// timeout as fatal) is pinned by
+// TestPollOnceContinuesReconciliationWhenStalledRunCleanupTimesOut, which
+// asserts Part B still reconciles an unrelated issue after a non-fatal Part A
+// timeout. Together they fence the fatal-vs-non-fatal split.
+func TestReconcileTickPartACancelledContextReturnsFatally(t *testing.T) {
+	trackerClient := &fixedStateTracker{
+		fixedListIssues: []tracker.Issue{{ID: "inactive-1", Identifier: "LIN-9", State: "Cancelled"}},
+	}
+	// The actor loop is intentionally never started, so its unbuffered ops
+	// channel has no reader. Combined with an already-cancelled context, every
+	// submit deterministically resolves via the ctx.Done() branch in submit,
+	// making Part A's ReconcileStalledRuns return ctx.Err() with no scheduling
+	// race.
+	orch := New(NewOrchestratorState(30000, 4), Deps{
+		Dispatcher: &cancellationDispatcher{},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		WorkerExitTimeout: time.Millisecond,
+		StallTimeoutMs:    50,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := poller.reconcileTick(ctx, []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}})
+	if err == nil {
+		t.Fatalf("reconcileTick(cancelled-ctx) err = %v; want non-nil Part A fatal error", err)
+	}
+	if got != nil {
+		t.Fatalf("reconcileTick(cancelled-ctx) map = %#v; want nil (fatal early-return)", got)
+	}
+}
+
+// TestReconcileTickDropsNonActiveNonInactiveRefreshedIssueFromInactiveSet pins
+// the `if !p.isConfiguredInactiveState(issue.State) { continue }` guard in the
+// derive step: a refreshed running issue that has left the active set but sits
+// in a state that is neither terminal nor configured-inactive must NOT be added
+// to inactiveByID (reconcileTick's returned map). A mutation that flipped the
+// guard would add it; this test fails that.
+func TestReconcileTickDropsNonActiveNonInactiveRefreshedIssueFromInactiveSet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fixedStateTracker{
+		fetchStates: map[string]string{"issue-1": "Triage"},
+	}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		InactiveStates:    []string{"Backlog"},
+		WorkerExitTimeout: time.Second,
+	})
+
+	if err := orch.RequestDispatch(ctx, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}, nil); err != nil {
+		t.Fatalf("request dispatch: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher, 1)
+
+	// "Triage" is neither an active state nor a configured terminal/inactive
+	// state. The narrow refresh reports issue-1 there; reconcileTick must drop
+	// it from the active set (no longer active) but must NOT add it to the
+	// inactive map (it is not a configured inactive/terminal state).
+	got, err := poller.reconcileTick(ctx, nil)
+	if err != nil {
+		t.Fatalf("reconcileTick err = %v; want nil", err)
+	}
+	if _, present := got["issue-1"]; present {
+		t.Fatalf("reconcileTick inactive map[issue-1] present = %v; want false (Triage is not a configured inactive state)", got)
+	}
+}
+
+// TestReconcileTickSkipsEmptyIDIssueFromStateGroupFanOut pins the
+// `if issue.ID == "" { continue }` skip inside the inactive state-group
+// fan-out: an inactive-state listing that returns an entry with an empty ID
+// must not be added to inactiveByID under the "" key. A mutation removing the
+// skip would insert a "" key; this test fails that.
+func TestReconcileTickSkipsEmptyIDIssueFromStateGroupFanOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fixedStateTracker{
+		fixedListIssues: []tracker.Issue{
+			{ID: "", Identifier: "LIN-EMPTY", State: "Cancelled"},
+			{ID: "inactive-1", Identifier: "LIN-2", State: "Cancelled"},
+		},
+	}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		WorkerExitTimeout: time.Second,
+	})
+
+	got, err := poller.reconcileTick(ctx, nil)
+	if err != nil {
+		t.Fatalf("reconcileTick err = %v; want nil", err)
+	}
+	if _, present := got[""]; present {
+		t.Fatalf("reconcileTick inactive map[\"\"] present = %v; want false (empty-ID entry must be skipped)", got)
+	}
+	if _, present := got["inactive-1"]; !present {
+		t.Fatalf("reconcileTick inactive map[inactive-1] present = false; want true (valid fan-out entry kept), map=%#v", got)
+	}
+}
+
+// TestReconcileTickRequiresStateTracker pins the nil stateTracker guard: a
+// poller without a state tracker must fail reconciliation with the sentinel
+// error rather than dereferencing a nil tracker. A mutation removing the guard
+// would panic or behave differently.
+func TestReconcileTickRequiresStateTracker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: &cancellationDispatcher{},
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := &Poller{orchestrator: orch, reconcile: ReconciliationConfig{ActiveStates: []string{"In Progress"}}}
+	got, err := poller.reconcileTick(ctx, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires state tracker") {
+		t.Fatalf("reconcileTick(nil stateTracker) err = %v; want \"requires state tracker\" error", err)
+	}
+	if got != nil {
+		t.Fatalf("reconcileTick(nil stateTracker) map = %#v; want nil", got)
+	}
+}


### PR DESCRIPTION
## What

Pure extract-function decomposition of `(*Poller).reconcileTick`
(`internal/orchestrator/poller.go`) for the #521 gocognit-baseline cleanup.
`reconcileTick` implements SPEC §16.3 `reconcile_running_issues`; this is a
**structural extraction only — zero behavior change**.

## Helpers extracted (single concern each)

| Helper | Concern |
|--------|---------|
| `mergeRefreshedActiveStates` | Fold the narrow per-issue state refresh back into the active set: value-copy state update for issues still active, drop issues that left the active set. Mutates `activeIssuesByID` by reference; `refreshedIssuesByID` read-only. |
| `(p *Poller) reconcileActiveRunsPartB` | The SPEC §16.3 Part B routing-vs-non-routing branch (`ReconcileTrackerIssuesAndWait` when routed, else `RefreshActiveTrackerIssues`). Its error stays **fatal** to the tick. Keeps the #340/§18.1 comment on the routing arm. |
| `(p *Poller) deriveInactiveIssues` | Build the inactive/terminal set: refreshed running issues that left the active set into a configured inactive/terminal state. |
| `(p *Poller) appendInactiveFromStateGroups` | The explicit terminal/inactive state-group fan-out (`ListIssuesByStates`), joining per-group errors in loop order, non-fatally. |
| `addInactiveListedIssues` | Per-listing accumulation: skip empty IDs and still-active issues, add the rest. |

`deriveInactiveIssues` was split one level further than the original plan
(`appendInactiveFromStateGroups` + `addInactiveListedIssues`) so every new
helper clears the repo's local `gocognit.min-complexity: 10`
threshold without any new `//nolint`.

The parent `reconcileTick` keeps Part A inline (its fatal-vs-non-fatal split is
load-bearing) and keeps the `fetchErr` accumulation + the SPEC §16.3
Part-A-before-Part-B ordering visible.

## gocognit

| Function | Before | After |
|----------|--------|-------|
| `(*Poller).reconcileTick` | **33** | **6** |

New helpers: `deriveInactiveIssues` 5, `mergeRefreshedActiveStates` 7,
`appendInactiveFromStateGroups` 3, `addInactiveListedIssues` 5,
`reconcileActiveRunsPartB` 1 — all well under the gate. `reconcileTick` is gone
from `gocognit -over 29 ./internal ./cmd`. funlen was **not** flagged on this
target (the baseline directive was `//nolint:gocognit`, gocognit-only).

## nolint baseline removed

The `//nolint:gocognit // baseline (#521)` directive on `reconcileTick` is
removed. No new `//nolint` added anywhere.

## Zero-behavior-change invariants preserved (the high-risk ones from the spec)

- **errors.Join order is unchanged.** `fetchErr` accumulates in the same order
  (Part-A-nonfatal, then `refreshRunningIssueStates` err, then the per-group
  fan-out errors via `deriveErr`), and the final return is
  `errors.Join(reconcileErr, fetchErr)` with **reconcileErr first**. The
  per-group errors are now returned from `deriveInactiveIssues` as a single
  joined `deriveErr` and joined into `fetchErr` by the caller; `errors.Join`
  flattening makes the `Error()` string and `errors.Is`/`errors.As` traversal
  identical (verified against `TestPollOnceCancelsTerminalIssueBeforeReturningLaterInactiveFetchError`
  (substring) and the `errors.Is`-based reconciliation tests).
- **Fatal returns stay fatal with a nil map.** The Part A `ctx.Err() != nil`
  early-return and **both** Part B arms return `(nil, err)` from
  `reconcileTick` — never converted into accumulated errors.
- **Map mutation by reference.** `activeIssuesByID`/`activeByID` are mutated by
  reference; **`refreshedIssuesByID` is read-only** in merge, derive, and the
  `ReconcileTrackerIssuesAndWait` hand-off. No helper writes to it.
- **Value-copy state update** preserved in `mergeRefreshedActiveStates`
  (`existing := m[id]; existing.State = …; m[id] = existing`), not pointer
  mutation.
- `normalizedStates(...)` recomputed identically where used;
  `WorkerExitTimeout` passed unchanged to every orchestrator call. No named
  returns.

## Characterization tests (committed first, mutation-verified non-placebo)

New file `internal/orchestrator/poller_reconciletick_test.go`:

- `TestReconcileTickPartACancelledContextReturnsFatally` — Part A
  ctx-cancelled fatal early-return surfaces the error and returns a nil map.
  Killed by mutating `return nil, err` → `return nil, nil`.
- `TestReconcileTickDropsNonActiveNonInactiveRefreshedIssueFromInactiveSet` —
  a refreshed running issue in a non-active, non-configured-inactive state is
  dropped from the active set but **not** added to `inactiveByID`. Killed by
  flipping the `!p.isConfiguredInactiveState` guard.
- `TestReconcileTickSkipsEmptyIDIssueFromStateGroupFanOut` — the empty-ID skip
  in the fan-out loop. Killed by neutralizing `if issue.ID == "" { continue }`
  in the fan-out helper.
- `TestReconcileTickRequiresStateTracker` — the nil-`stateTracker` sentinel
  guard. Killed by neutralizing the guard.

Each test was mutation-verified non-placebo **after the decomposition** by
breaking the exact targeted branch in its new helper location, confirming the
test FAILS, then restoring; the working tree was re-confirmed against HEAD with
`git status`/`git diff` after each restore (the #469/#483 footgun).

### Note on the "always-accumulate" Part A mutation

The orthogonal mutation that drops the Part A guard entirely (so the
cancelled-ctx case falls through to Part B instead of bailing) is **not
behaviorally observable** through the public Poller/Orchestrator surface: under
a cancelled context every downstream orchestrator submit also fails with the
same context error, so the `(nil map, context error)` result is identical with
or without the guard, and the only divergent signal (a non-nil inactive map) is
gated behind a non-deterministic actor `select` that cannot be forced. The
complementary over-eager-fatal direction (treating a **live-ctx** Part A timeout
as fatal) is already pinned by the existing
`TestPollOnceContinuesReconciliationWhenStalledRunCleanupTimesOut`. Together
they fence the fatal-vs-non-fatal split. This is documented in the test file's
header comment.

## Local gates (all pass, scoped to package)

- `gofmt -l` on touched files: clean
- `go vet ./internal/orchestrator/...`: clean
- `go test -race -covermode=atomic ./internal/orchestrator/...`: ok (85.7%)
- `golangci-lint run --config=.golangci.yml ./internal/orchestrator/...`: **0 issues**
- `go build ./cmd/worker ./cmd/tui`: ok
- `gocognit -over 29 ./internal ./cmd`: `reconcileTick` gone
- `go mod tidy`: go.mod/go.sum clean

## Size gate

**within budget** — refactor + characterization tests; no scope creep.

Refs #521
