### PR TITLE
test(orchestrator): gate continuation/external-blocker recheck tests on due-ness

### DIFF
--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -810,7 +810,7 @@ func TestFinalize_FirstFailureAfterCleanContinuationUsesFirstFailureBackoff(t *t
 	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
 	waitFor(t, func() bool {
 		view, err := o.Snapshot(context.Background())
-		return err == nil && len(view.Retrying) == 1
+		return err == nil && len(view.Retrying) == 1 && !view.Retrying[0].DueAt.After(time.Now())
 	}, time.Second)
 
 	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
@@ -1238,7 +1238,8 @@ func TestFinalize_NormalExitStopsAfterMaxTurns(t *testing.T) {
 	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
 	waitFor(t, func() bool {
 		v, err := o.Snapshot(context.Background())
-		return err == nil && len(v.Retrying) == 1 && v.Retrying[0].Attempt == 1
+		return err == nil && len(v.Retrying) == 1 && v.Retrying[0].Attempt == 1 &&
+			!v.Retrying[0].DueAt.After(time.Now())
 	}, time.Second)
 
 	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
@@ -1288,7 +1289,7 @@ func TestFinalize_ContinuationBudgetExhaustedEmitsStderrLine(t *testing.T) {
 	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
 	waitFor(t, func() bool {
 		v, err := o.Snapshot(context.Background())
-		return err == nil && len(v.Retrying) == 1
+		return err == nil && len(v.Retrying) == 1 && !v.Retrying[0].DueAt.After(time.Now())
 	}, time.Second)
 	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
 		t.Fatalf("tracker-rechecked continuation dispatch: %v", err)
@@ -1425,7 +1426,8 @@ func TestFinalize_RunnerEnforcedMaxTurnsSkipsContinuationSpawnCap(t *testing.T) 
 		expectedAttempt := cycle + 1
 		waitFor(t, func() bool {
 			v, err := o.Snapshot(context.Background())
-			return err == nil && len(v.Retrying) == 1 && v.Retrying[0].Attempt == expectedAttempt
+			return err == nil && len(v.Retrying) == 1 && v.Retrying[0].Attempt == expectedAttempt &&
+				!v.Retrying[0].DueAt.After(time.Now())
 		}, time.Second)
 		if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
 			t.Fatalf("tracker-rechecked continuation dispatch cycle %d: %v", cycle, err)


### PR DESCRIPTION
Closes #505.

## Problem

Under `go test -race ./internal/orchestrator/` full-suite contention, several `RequestDispatchAfterTrackerRecheck` tests intermittently fail (~2/49 local) at the recheck call with `orchestrator: issue already claimed` (`ErrNotDispatched`).

Root cause (pre-existing test-harness timing bug, **not** a production bug): the tests schedule a continuation retry with a 1ms cooldown (`DueAt = now+1ms`), then wait only for `len(Retrying)==1` before calling `RequestDispatchAfterTrackerRecheck` — without waiting for the entry to become **due**. When the `waitFor` poll completes within ~1ms of scheduling, the recheck lands before `DueAt` and `resolveDispatchClaim` (`actor_dispatch.go`) correctly rejects it via the `!entry.IsDue(time.Now())` gate.

## Fix (test-only determinism)

Add the due-ness predicate `!Retrying[0].DueAt.After(time.Now())` to each pre-recheck `waitFor`, matching the idiom already used by the sites that wait for due (e.g. `TestContinuationRetryRecheckedDispatchWaitsUntilDue`, `TestDispatchAfterTrackerRecheckConsumesDueExternalBlockerCooldown`).

No production code change — the `IsDue` gate is correct (a recheck must not dispatch a not-yet-due cooldown).

## Scope — audited all 30 recheck call sites

Four sites scheduled a short-delay continuation and expected a successful dispatch without a due barrier:
- `TestFinalize_FirstFailureAfterCleanContinuationUsesFirstFailureBackoff`
- `TestFinalize_NormalExitStopsAfterMaxTurns`
- `TestFinalize_ContinuationBudgetExhaustedEmitsStderrLine` (the issue's named flake)
- `TestFinalize_RunnerEnforcedMaxTurnsSkipsContinuationSpawnCap` (per-cycle recheck in the continuation loop)

All other recheck sites already (a) wait for due-ness / use a 20ms sleep barrier, (b) expect `ErrNotDispatched`/`ErrCapacityFull`, or (c) are a first dispatch with no queued entry (the `IsDue` gate never fires). No change needed.

## Acceptance criteria
- [x] Every continuation/external-blocker recheck test that expects a successful dispatch waits for `!DueAt.After(now)` before the recheck.
- [x] `go test -race -count=50 ./internal/orchestrator/` shows 0 failures (ran twice + the four affected tests `-count=100`, all green).
- [x] No production code change.

## Verification
- `go test -race -count=50 ./internal/orchestrator/` ×2 → 0 failures
- `go test -race -count=100` on the four affected + sibling recheck tests → 0 failures
- Local gates: `gofmt -l`, `go mod tidy` (clean), `go vet ./...`, `go build ./cmd/worker ./cmd/tui` all pass

## Size
`within budget` — 6 insertions / 4 deletions, one file, test-only.

https://claude.ai/code/session_01HA3pSAEK7gawCmnWFiha4d

---
_Generated by [Claude Code](https://claude.ai/code/session_01HA3pSAEK7gawCmnWFiha4d)_