### PR TITLE
fix(runner): type app-server read-timeout signal & close pipes on setup failure (#507)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -134,21 +134,36 @@ func setupAppServerCommand(ctx context.Context, in RunInput) (cmd *exec.Cmd, dir
 
 // openAppServerPipes wires the subprocess's stdio. Each pipe error carries the
 // stream name so a setup failure is attributable; callers return the wrapped
-// error verbatim.
+// error verbatim. If a later pipe fails after an earlier one succeeded, the
+// already-opened pipes are closed so their fds do not leak (the process is never
+// started on this path, so cmd.Wait never runs to close them for us).
 func openAppServerPipes(cmd *exec.Cmd) (stdin io.WriteCloser, stdout, stderr io.ReadCloser, err error) {
 	stdin, err = cmd.StdinPipe()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("open codex app-server stdin: %w", err)
 	}
+	defer closeOnError(&err, stdin)
 	stdout, err = cmd.StdoutPipe()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("open codex app-server stdout: %w", err)
 	}
+	defer closeOnError(&err, stdout)
 	stderr, err = cmd.StderrPipe()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("open codex app-server stderr: %w", err)
 	}
 	return stdin, stdout, stderr, nil
+}
+
+// closeOnError closes c when *errp is non-nil at defer time. A setup function
+// that opens several resources defers one of these per resource so a later
+// failure releases the ones already opened, without each early return unwinding
+// by hand. The closer value is captured when the defer is registered, so it
+// survives the failing return that resets the named result to nil.
+func closeOnError(errp *error, c io.Closer) {
+	if *errp != nil {
+		_ = c.Close()
+	}
 }
 
 // appServerProcessPID returns cmd.Process.Pid only when it is guaranteed to be
@@ -183,6 +198,17 @@ func classifyAppServerOutcome(ctx context.Context, res Result, runErr, waitErr e
 	if isAppServerReadTimeout(runErr) {
 		return res, &ReadTimeoutError{Timeout: time.Duration(readTimeoutMs) * time.Millisecond, Cause: runErr}
 	}
+	// This outer-deadline check intentionally precedes the ErrorCategory check
+	// below: when the run ctx deadline has genuinely fired, a coinciding
+	// *TurnTimeoutError (categorized CategoryTurnTimeout) is reported as a
+	// *TimeoutError carrying the run budget. The worker (internal/worker/
+	// runtask.go) routes both to task.PhaseTimedOut, so this only changes the
+	// reported budget/elapsed, not the terminal phase; reporting the run budget
+	// is defensible once the run deadline has elapsed. Kept deliberately (#507
+	// item 3) — flipping the order would be a behavior change with no phase-level
+	// payoff. TestClassifyAppServerOutcome_TurnTimeoutUnderDeadlineIsTimeout pins
+	// this; the worker-routing equivalence is covered by
+	// TestRunRunnerWithTimeoutEmitsTerminalErrorPhases.
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return res, &TimeoutError{Timeout: deadlineBudget(ctx, start), Elapsed: elapsed, Cause: runErr}
 	}
@@ -585,7 +611,7 @@ func (c *appServerClient) readLineOnce(ctx context.Context, ch <-chan readResult
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-timeout:
-		return nil, fmt.Errorf("codex app-server read timeout after %dms", c.readTimeoutMs)
+		return nil, &appServerReadTimeoutError{afterMs: c.readTimeoutMs}
 	case res := <-ch:
 		if res.err != nil {
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -607,8 +633,26 @@ func deadlineDuration(ctx context.Context) (time.Duration, bool) {
 	}
 	return remaining, true
 }
+
+// appServerReadTimeoutError signals that a single stdio read exceeded the
+// configured codex read_timeout_ms budget. It is a typed error so the
+// classification paths detect it via errors.As rather than substring-matching
+// the message (AGENTS.md clean-code rule 8). The message is unchanged from the
+// original fmt.Errorf so existing logs and string-asserting tests still hold.
+type appServerReadTimeoutError struct {
+	afterMs int
+}
+
+func (e *appServerReadTimeoutError) Error() string {
+	return fmt.Sprintf("codex app-server read timeout after %dms", e.afterMs)
+}
+
+// isAppServerReadTimeout reports whether err is (or wraps) the read-timeout
+// signal. Both classifyAppServerOutcome and classifyTurnReadError consume it, so
+// the typed check lives here once rather than being inlined at each call site.
 func isAppServerReadTimeout(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "codex app-server read timeout")
+	var rt *appServerReadTimeoutError
+	return errors.As(err, &rt)
 }
 func protocolMessageCandidate(raw []byte) bool {
 	return strings.HasPrefix(strings.TrimLeft(string(raw), " \t\r\n"), "{")

--- a/internal/runner/codex_app_server_classify_test.go
+++ b/internal/runner/codex_app_server_classify_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -20,10 +21,11 @@ func deadlineExceededCtx(t *testing.T) context.Context {
 	return ctx
 }
 
-// readTimeoutRunErr is shaped to trip isAppServerReadTimeout, which matches on
-// the "codex app-server read timeout" substring.
+// readTimeoutRunErr returns the typed read-timeout signal isAppServerReadTimeout
+// detects via errors.As — the same value (CodexAppServerRunner).Run propagates
+// from readLineOnce.
 func readTimeoutRunErr() error {
-	return errors.New("codex app-server read timeout after 5s")
+	return &appServerReadTimeoutError{afterMs: 5000}
 }
 
 // The classify tests exercise (CodexAppServerRunner).Run's error-classification
@@ -184,5 +186,43 @@ func TestClassifyAppServerOutcome_CategorizedBeatsPortExit(t *testing.T) {
 	// non-zero. If the order flipped, err would carry CategoryPortExit.
 	if cat, ok := ErrorCategory(err); !ok || cat != CategoryResponseError {
 		t.Fatalf("classifyAppServerOutcome(categorized runErr, waitErr) category = %q ok=%v; want %q (categorized wins over PortExit)", cat, ok, CategoryResponseError)
+	}
+}
+
+// TestClassifyAppServerOutcome_TurnTimeoutUnderDeadlineIsTimeout pins the #507
+// item-3 wontfix: when the outer run deadline has fired, a coinciding
+// *TurnTimeoutError is reported as a *TimeoutError (the outer-deadline branch
+// precedes the ErrorCategory branch that would otherwise return the categorized
+// turn timeout as-is). This is a deliberate cosmetic precedence — the worker
+// routes both to PhaseTimedOut (TestRunRunnerWithTimeoutEmitsTerminalErrorPhases)
+// — so the lock guards against an accidental future flip, not a bug.
+func TestClassifyAppServerOutcome_TurnTimeoutUnderDeadlineIsTimeout(t *testing.T) {
+	turnTimeout := &TurnTimeoutError{Timeout: 30 * time.Millisecond, Elapsed: 60 * time.Millisecond, Cause: context.DeadlineExceeded}
+	_, err := classifyAppServerOutcome(deadlineExceededCtx(t), Result{}, error(turnTimeout), nil, 1000, time.Now(), time.Second)
+	var te *TimeoutError
+	if !errors.As(err, &te) {
+		t.Fatalf("classifyAppServerOutcome(*TurnTimeoutError, deadline) err = %T %[1]v; want outer *TimeoutError", err)
+	}
+	if !errors.Is(te.Cause, error(turnTimeout)) {
+		t.Fatalf("TimeoutError.Cause = %v; want it to wrap the *TurnTimeoutError %v", te.Cause, turnTimeout)
+	}
+}
+
+// TestIsAppServerReadTimeout_TypedNotSubstring proves the read-timeout signal is
+// detected by type (errors.As), not by the old strings.Contains match: the typed
+// error is detected through a %w wrap, while a lookalike string error carrying
+// the same words is not.
+func TestIsAppServerReadTimeout_TypedNotSubstring(t *testing.T) {
+	typed := error(&appServerReadTimeoutError{afterMs: 5000})
+	if !isAppServerReadTimeout(typed) {
+		t.Fatalf("isAppServerReadTimeout(%v) = false; want true for the typed read-timeout error", typed)
+	}
+	wrapped := fmt.Errorf("codex app-server initialize: %w", typed)
+	if !isAppServerReadTimeout(wrapped) {
+		t.Fatalf("isAppServerReadTimeout(%v) = false; want true through a %%w wrap", wrapped)
+	}
+	lookalike := errors.New("codex app-server read timeout after 5s")
+	if isAppServerReadTimeout(lookalike) {
+		t.Fatalf("isAppServerReadTimeout(%v) = true; want false — detection must be typed, not substring", lookalike)
 	}
 }

--- a/internal/runner/codex_app_server_pipes_test.go
+++ b/internal/runner/codex_app_server_pipes_test.go
@@ -1,0 +1,77 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// recordingCloser counts Close calls so closeOnError's two branches can be
+// asserted directly.
+type recordingCloser struct{ closed int }
+
+func (r *recordingCloser) Close() error {
+	r.closed++
+	return nil
+}
+
+func TestCloseOnError(t *testing.T) {
+	t.Run("closes when err is set", func(t *testing.T) {
+		rc := &recordingCloser{}
+		err := error(errors.New("boom"))
+		closeOnError(&err, rc)
+		if rc.closed != 1 {
+			t.Fatalf("closeOnError(*errp=%v) closed = %d; want 1", err, rc.closed)
+		}
+	})
+	t.Run("no-op when err is nil", func(t *testing.T) {
+		rc := &recordingCloser{}
+		var err error
+		closeOnError(&err, rc)
+		if rc.closed != 0 {
+			t.Fatalf("closeOnError(*errp=nil) closed = %d; want 0", rc.closed)
+		}
+	})
+}
+
+// TestOpenAppServerPipesClosesStdinOnLaterPipeFailure proves openAppServerPipes
+// closes the already-opened stdin pipe when a later pipe fails (#507 item 2).
+// Presetting cmd.Stdout forces StdoutPipe to fail after StdinPipe succeeded.
+// StdinPipe stored the pipe's read end on cmd.Stdin; if the returned write end
+// was closed on the failure, reading that read end returns io.EOF instead of
+// blocking forever on the leaked fd.
+func TestOpenAppServerPipesClosesStdinOnLaterPipeFailure(t *testing.T) {
+	cmd := exec.Command("codex-app-server-never-started")
+	cmd.Stdout = &bytes.Buffer{} // makes StdoutPipe fail: "exec: Stdout already set"
+
+	stdin, stdout, stderr, err := openAppServerPipes(cmd)
+	if err == nil || !strings.Contains(err.Error(), "stdout") {
+		t.Fatalf("openAppServerPipes(stdout-preset) err = %v; want a wrapped stdout error", err)
+	}
+	if stdin != nil || stdout != nil || stderr != nil {
+		t.Fatalf("openAppServerPipes(err) returned non-nil pipe: stdin=%v stdout=%v stderr=%v; want all nil", stdin, stdout, stderr)
+	}
+
+	pr, ok := cmd.Stdin.(*os.File)
+	if !ok {
+		t.Fatalf("cmd.Stdin = %T; want *os.File stored by StdinPipe", cmd.Stdin)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, readErr := pr.Read(make([]byte, 1))
+		done <- readErr
+	}()
+	select {
+	case readErr := <-done:
+		if !errors.Is(readErr, io.EOF) {
+			t.Fatalf("read cmd.Stdin = %v; want io.EOF (write end closed on later-pipe failure)", readErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("read cmd.Stdin blocked; stdin write end was not closed on later-pipe failure (fd leak)")
+	}
+}

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1449,6 +1449,13 @@ for line in sys.stdin:
 	if err == nil || !strings.Contains(err.Error(), "read timeout") {
 		t.Fatalf("Run error = %v, want app-server read timeout", err)
 	}
+	// End-to-end the read timeout must classify as a *ReadTimeoutError, not just
+	// carry the substring: this pins that readLineOnce emits the typed signal and
+	// classifyAppServerOutcome detects it via errors.As (#507 item 1). A revert to
+	// the bare string error would fall through to a PortExit and fail here.
+	if !IsReadTimeout(err) {
+		t.Fatalf("Run error = %T %[1]v, want *ReadTimeoutError classification", err)
+	}
 }
 
 func TestCodexAppServerInitializeTimeoutDiagnostics(t *testing.T) {

--- a/internal/worker/run_test.go
+++ b/internal/worker/run_test.go
@@ -628,6 +628,15 @@ func TestRunRunnerWithTimeoutEmitsTerminalErrorPhases(t *testing.T) {
 			to:   task.PhaseTimedOut,
 		},
 		{
+			// Locks the #507 item-3 rationale: an outer-deadline *TimeoutError
+			// routes to the same terminal phase as the *TurnTimeoutError above,
+			// so the classifier reporting one as the other in the coinciding
+			// deadline window is a cosmetic budget difference, not a mis-route.
+			name: "outer_timeout",
+			err:  &runner.TimeoutError{Timeout: 30 * time.Millisecond, Elapsed: 60 * time.Millisecond},
+			to:   task.PhaseTimedOut,
+		},
+		{
 			name: "read_timeout",
 			err:  &runner.ReadTimeoutError{Timeout: 30 * time.Millisecond},
 			to:   task.PhaseTimedOut,


### PR DESCRIPTION
Closes #507.

Three pre-existing gaps in `internal/runner/codex_app_server.go`, surfaced by the
#499 adversarial review and faithfully preserved by that behavior-zero
decomposition. Each acceptance item below is addressed; everything is
mutation-verified against the committed code path.

## Item 1 — typed read-timeout signal, not a substring match ✅
`AGENTS.md` clean-code rule 8: "Never compare error text with `strings.Contains`."

- `readLineOnce` now returns a typed `*appServerReadTimeoutError` instead of a
  bare `fmt.Errorf`.
- `isAppServerReadTimeout` is **reduced to an `errors.As` check** (criterion
  allows "removed or reduced to an `errors.As` check").
- Kept the helper rather than dropping it: **two** callers consume it —
  `classifyAppServerOutcome` and `classifyTurnReadError` (codex_app_server_turn.go:101)
  — so the typed check lives in one place instead of being inlined twice.
- `Error()` text is byte-for-byte unchanged (`codex app-server read timeout after
  %dms`), so existing logs and string-asserting tests still hold.

## Item 2 — `openAppServerPipes` no longer leaks stdin on a later-pipe failure ✅
A new `closeOnError(&err, c)` deferred once per opened pipe closes the
already-opened fds if a subsequent `StdoutPipe`/`StderrPipe` fails. The process
is never started on this path, so `cmd.Wait` never closes them for us. The closer
value is captured at defer-registration time, so it survives the failing return
that resets the named result to `nil`.

## Item 3 — keep (wontfix) the TurnTimeout-vs-outer-deadline precedence ✅ (decided + documented)
**Decision: keep**, with the rationale now in an in-code comment at the
precedence point.

Rationale: the worker (`RunRunnerWithTimeout`, internal/worker/runtask.go) routes
**both** `*TurnTimeoutError` and `*TimeoutError` to `task.PhaseTimedOut`. So when
the outer run deadline fires in the sub-microsecond window between
`classifyTurnError` producing a `*TurnTimeoutError` and `classifyAppServerOutcome`
re-checking `ctx.Err()`, reporting it as `*TimeoutError` only changes the
reported budget/elapsed — **not the terminal phase**. Reporting the run budget
once the run deadline has genuinely elapsed is defensible. Flipping the order
would be a behavior change with no phase-level payoff.

Worker consumer verified: `TestRunRunnerWithTimeoutEmitsTerminalErrorPhases`
(now with an explicit `outer_timeout` row alongside `turn_timeout`) confirms both
route to `PhaseTimedOut`.

## Tests (mutation-verified)
| Test | Mutation it catches |
|------|---------------------|
| `TestIsAppServerReadTimeout_TypedNotSubstring` | revert helper to `strings.Contains` → lookalike string error wrongly matches |
| `TestCodexAppServerRunnerUsesReadTimeout` (strengthened with `IsReadTimeout`) | revert `readLineOnce` to bare string → read timeout falls through to PortExit |
| `TestCloseOnError` (both branches) | helper closes on nil err / fails to close on set err |
| `TestOpenAppServerPipesClosesStdinOnLaterPipeFailure` | drop the `defer closeOnError` → read of the stored read end blocks on a leaked fd instead of EOF |
| `TestClassifyAppServerOutcome_TurnTimeoutUnderDeadlineIsTimeout` | flip outer-deadline/ErrorCategory precedence |

All four mutations were applied to the committed code, observed to fail the
corresponding test, then reverted (`git checkout`).

## Size gate
**within budget** — ~180 LOC across 5 files (1 production file, 4 test
files/additions); the bulk is regression + characterization coverage and the
Item-3 rationale comment, all in scope for the three acceptance items.

## Local gates (all green)
- `gofmt -l` — clean
- `go mod tidy` — no diff
- `go vet ./...`
- `golangci-lint run` — 0 issues (funlen/gocognit pass; no new `//nolint`)
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/tui`

## SPEC alignment
No SPEC behavior change: error-type plumbing + a defer-close + a documented
keep-decision. No new deviation; closes a tech-debt issue under the #67 umbrella.