### PR TITLE
docs: first-class binary (non-Docker) deployment path for Linux & macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ workspaces from tracker state, and re-dispatches eligible active issues on the
 next poll rather than restoring queue rows, retry timers, or running sessions
 from a database.
 
+The worker is a self-contained binary with no container runtime dependency.
+To run it directly under an init system instead of Compose — build/install,
+`worker --doctor` preflight, and a hardened systemd unit — see the
+[binary deployment runbook](docs/runbooks/binary-deployment.md).
+
 The default Compose service starts `worker`:
 
 ```bash
@@ -433,6 +438,7 @@ add a bridge that imports `AGENTS.md` rather than duplicating content.
 - [Research: Symphony-style personal productivity](docs/research/symphony-personal-productivity.md)
 - [ADR 0001: Adopt a Symphony-style personal orchestrator](docs/adr/0001-symphony-style-personal-orchestrator.md)
 - [Local development runbook](docs/runbooks/local-dev.md)
+- [Binary (non-Docker) deployment runbook](docs/runbooks/binary-deployment.md)
 - [CI/CD runbook](docs/runbooks/ci.md)
 - [Runtime debugging API](docs/runbooks/task-api.md)
 - [Workspace cache and cleanup](docs/runbooks/workspace-cache.md)

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ next poll rather than restoring queue rows, retry timers, or running sessions
 from a database.
 
 The worker is a self-contained binary with no container runtime dependency.
-To run it directly under an init system instead of Compose — build/install,
-`worker --doctor` preflight, and a hardened systemd unit — see the
-[binary deployment runbook](docs/runbooks/binary-deployment.md).
+To run it directly under a service manager instead of Compose — build/install,
+`worker --doctor` preflight, and Linux (systemd) / macOS (launchd) samples —
+see the [binary deployment runbook](docs/runbooks/binary-deployment.md).
 
 The default Compose service starts `worker`:
 

--- a/deploy/launchd/com.aiops-platform.worker.plist
+++ b/deploy/launchd/com.aiops-platform.worker.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Sample macOS LaunchAgent for a binary (non-Docker) aiops-platform worker.
+  See docs/runbooks/binary-deployment.md ("macOS: under launchd").
+
+  launchd has no EnvironmentFile= equivalent and does not expand ~ in
+  paths, so all paths below are absolute and the tracker token is kept
+  out of this file: point ProgramArguments at a thin Keychain wrapper
+  (see the runbook) rather than embedding the token in EnvironmentVariables.
+
+  Per-user agent: install into ~/Library/LaunchAgents and bootstrap into
+  the gui/<uid> domain. For a machine-wide daemon, install into
+  /Library/LaunchDaemons, add a <key>UserName</key> entry, and bootstrap
+  into the system domain.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.aiops-platform.worker</string>
+
+  <!-- Swap to /usr/local/bin/aiops-worker-launch (the Keychain wrapper)
+       when the workflow needs a tracker token; see the runbook. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/worker</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AIOPS_WORKFLOW_PATH</key>
+    <string>/usr/local/etc/aiops-platform/WORKFLOW.md</string>
+    <key>AIOPS_WORKSPACE_ROOT</key>
+    <string>/usr/local/var/aiops-platform/workspaces</string>
+    <key>AIOPS_MIRROR_ROOT</key>
+    <string>/usr/local/var/aiops-platform/mirrors</string>
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>/usr/local/var/aiops-platform</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <!-- Restart the worker if it exits; pairs with the loop's restart
+       recovery (SPEC §14.3, fresh state on each start). -->
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/aiops-platform/worker.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/aiops-platform/worker.err.log</string>
+</dict>
+</plist>

--- a/deploy/systemd/aiops-worker.service
+++ b/deploy/systemd/aiops-worker.service
@@ -1,0 +1,57 @@
+# Sample systemd unit for a binary (non-Docker) aiops-platform worker.
+# See docs/runbooks/binary-deployment.md for the full setup. Adjust the
+# ExecStart and EnvironmentFile paths to match where you installed the
+# binary and config. Runs as a dedicated non-root user (mirrors the
+# container hardening in #365); secrets stay out of this file via
+# EnvironmentFile.
+
+[Unit]
+Description=aiops-platform worker (SPEC-aligned tracker polling loop)
+Documentation=https://github.com/xrf9268-hue/aiops-platform/blob/main/docs/runbooks/binary-deployment.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=aiops
+Group=aiops
+
+# Tracker token(s) and any path overrides live here, mode 0600, owned by
+# aiops. The worker reads a tracker token only via WORKFLOW.md
+# `tracker.api_key: $VAR`, so the referenced $VAR must be present here.
+EnvironmentFile=/etc/aiops-platform/worker.env
+
+# Workflow source and mutable state. StateDirectory creates and chowns
+# /var/lib/aiops-platform to the service user on start.
+Environment=AIOPS_WORKFLOW_PATH=/etc/aiops-platform/WORKFLOW.md
+Environment=AIOPS_WORKSPACE_ROOT=/var/lib/aiops-platform/workspaces
+Environment=AIOPS_MIRROR_ROOT=/var/lib/aiops-platform/mirrors
+StateDirectory=aiops-platform
+WorkingDirectory=/var/lib/aiops-platform
+
+ExecStart=/usr/local/bin/worker
+
+Restart=on-failure
+RestartSec=5s
+
+# Hardening. The worker prepares git workspaces and runs agent/hook/
+# verify/git commands, so constrain the blast radius of a compromised
+# runner or hostile repository content. Loosen only with a concrete
+# reason (e.g. an agent CLI that needs a wider filesystem view).
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+LockPersonality=true
+# ProtectSystem=strict makes everything read-only except ReadWritePaths;
+# StateDirectory is writable automatically.
+ReadWritePaths=/var/lib/aiops-platform
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/aiops-worker.service
+++ b/deploy/systemd/aiops-worker.service
@@ -21,6 +21,12 @@ Group=aiops
 # `tracker.api_key: $VAR`, so the referenced $VAR must be present here.
 EnvironmentFile=/etc/aiops-platform/worker.env
 
+# HOME is the state dir, not a path under /home, so ProtectHome=true below
+# does not mask it. The agent's SSH deploy key therefore lives at
+# $HOME/.ssh and stays reachable. See the runbook "SSH deploy key under
+# hardening".
+Environment=HOME=/var/lib/aiops-platform
+
 # Workflow source and mutable state. StateDirectory creates and chowns
 # /var/lib/aiops-platform to the service user on start.
 Environment=AIOPS_WORKFLOW_PATH=/etc/aiops-platform/WORKFLOW.md
@@ -40,6 +46,9 @@ RestartSec=5s
 # reason (e.g. an agent CLI that needs a wider filesystem view).
 NoNewPrivileges=true
 ProtectSystem=strict
+# Masks /home, /root, /run/user only. HOME is set to the StateDirectory
+# path /var/lib/aiops-platform above, so the agent's SSH deploy key under
+# $HOME/.ssh is not hidden.
 ProtectHome=true
 PrivateTmp=true
 PrivateDevices=true

--- a/docs/runbooks/binary-deployment.md
+++ b/docs/runbooks/binary-deployment.md
@@ -145,9 +145,11 @@ worker --doctor --mode=real "$AIOPS_WORKFLOW_PATH"
 
 On a Docker-less binary host, the "Docker Compose" check is a `WARN` in
 `--mode=mock` but is escalated to a `FAIL` (non-zero exit) in
-`--mode=real`. Treat that single Compose `FAIL` as expected on this
-deployment path and read the tracker/agent/workflow checks for the real
-verdict — see §1 on the doctor's container-centric wording.
+`--mode=real`. The Compose `FAIL` is expected on this deployment path —
+but read every *other* check on its own merits, since `--mode=real` also
+FAILs on genuine problems (e.g. a missing `gh`/deploy-key credential at
+the agent `git push` preflight) that are **not** safe to ignore. See §1
+on the doctor's container-centric wording.
 
 Inspect the effective config (secrets are masked with `***`):
 
@@ -244,9 +246,10 @@ It uses the `/usr/local` paths from §3.
 # install the binaries onto PATH
 sudo scripts/install.sh --prefix /usr/local
 
-# config + state/log dir owned by the running user (the plist logs here)
-sudo install -d -o "$USER" /usr/local/etc/aiops-platform
-mkdir -p /usr/local/var/aiops-platform
+# config + state/log dirs owned by the running user (the plist logs here).
+# /usr/local is root-owned on a stock Mac, so create with sudo + -o "$USER".
+sudo install -d -o "$(id -un)" /usr/local/etc/aiops-platform
+sudo install -d -o "$(id -un)" /usr/local/var/aiops-platform
 cp examples/WORKFLOW.md /usr/local/etc/aiops-platform/WORKFLOW.md   # edit tracker.api_key/kind
 
 # install and load the agent (per-user; runs only while you are logged in)
@@ -270,17 +273,25 @@ user and lands in backups. Prefer the login Keychain plus a thin wrapper
 that exports the token before exec, keeping the plist secret-free:
 
 ```bash
-# store once
-security add-generic-password -a "$USER" -s aiops-linear-api-key -w 'your-token'
-```
+# 1. store the token once, keyed to the login account
+security add-generic-password -a "$(id -un)" -s aiops-linear-api-key -w 'your-token'
 
-```bash
+# 2. install the wrapper into a PATH dir and make it executable. The 'EOF'
+#    is quoted, so id -un / the security lookup run at launch, not now.
+sudo tee /usr/local/bin/aiops-worker-launch >/dev/null <<'EOF'
 #!/usr/bin/env bash
-# /usr/local/bin/aiops-worker-launch — point ProgramArguments at this.
 set -euo pipefail
-LINEAR_API_KEY="$(security find-generic-password -a "$USER" -s aiops-linear-api-key -w)"
+LINEAR_API_KEY="$(security find-generic-password -a "$(id -un)" -s aiops-linear-api-key -w)"
 export LINEAR_API_KEY
 exec /usr/local/bin/worker
+EOF
+sudo chmod 755 /usr/local/bin/aiops-worker-launch
+
+# 3. point the agent at the wrapper instead of the bare binary, then reload
+plutil -replace ProgramArguments.0 -string /usr/local/bin/aiops-worker-launch \
+  ~/Library/LaunchAgents/com.aiops-platform.worker.plist
+launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.aiops-platform.worker.plist
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.aiops-platform.worker.plist
 ```
 
 SSH keys on macOS need no special placement — `ProtectHome` does not

--- a/docs/runbooks/binary-deployment.md
+++ b/docs/runbooks/binary-deployment.md
@@ -1,0 +1,191 @@
+# Binary (non-Docker) deployment runbook
+
+This runbook deploys `cmd/worker` as a plain binary on a host, with no
+container runtime. Docker is **optional** in this project (see
+[`local-dev.md`](local-dev.md) "Prerequisites"); the worker is a
+self-contained Go binary that launches the configured agent as a local
+subprocess. Use this path when you want to run the worker directly under
+an init system (systemd) or a process supervisor instead of Compose.
+
+> This runbook is the operator companion to README's "Quick start:
+> worker-owned tracker polling path" and to [`local-dev.md`](local-dev.md).
+> If they ever diverge, **the README is canonical**; this runbook
+> elaborates the same flow for a binary host deployment.
+
+## What the binary does and does not depend on
+
+- **No Postgres / queue.** `cmd/worker` never reads `DATABASE_URL`.
+  Restart recovery follows SPEC §14.3: fresh runtime state, re-dispatch
+  eligible active issues on the next poll.
+- **No container runtime.** The agent runners (`mock`, `codex`,
+  `codex-app-server`, `claude`) launch local subprocesses via `os/exec`;
+  none shell out to `docker`. `testcontainers-go` is test-only.
+- **No PR creation / tracker writes.** The worker prepares a git
+  workspace, runs the agent, enforces policy, and stops. Push and
+  draft-PR creation happen agent-side.
+
+## 1. Host prerequisites
+
+These are host-level tools (not an image). Install whatever your
+configured `agent.default` and clone URLs actually exercise:
+
+| Tool | Required? | Why |
+| --- | --- | --- |
+| `git` | Always | Prepares the deterministic per-issue workspace. |
+| `ca-certificates` | Always | TLS to the tracker / git remote. |
+| `ssh` (`openssh-client`) | When pushing over an SSH clone URL | The agent pushes branches; `worker --doctor` flags a missing `ssh` only when SSH clone URLs are configured. |
+| `rg` (ripgrep) | Recommended | Faster agent code search; doctor warns if absent. |
+| `codex` / `claude` CLI on `PATH` | Only when `agent.default` selects it | `mock` needs no external CLI. Keep first real runs on `mock`. |
+
+> **Note on `worker --doctor` wording.** Several doctor remediation
+> strings say "… in the worker image" (e.g. a missing `ssh` suggests
+> "Install ssh in the worker image"), and the run includes Docker
+> Compose checks. Those messages assume the container path; on a binary
+> host read them as "install the tool on this host and ensure it is on
+> `PATH`," and ignore the Compose checks. Making doctor
+> deployment-mode-aware is tracked separately.
+
+## 2. Obtain the binaries
+
+### Option A — build from source (pin Go 1.25 per `go.mod`)
+
+```bash
+scripts/install.sh                 # builds dist/worker and dist/tui
+sudo scripts/install.sh --prefix /usr/local   # build + install to /usr/local/bin
+```
+
+The script uses the same canonical flags as CI
+(`-trimpath -ldflags="-s -w"`). Equivalent manual build:
+
+```bash
+mkdir -p dist
+go build -trimpath -ldflags="-s -w" -o dist/worker ./cmd/worker
+go build -trimpath -ldflags="-s -w" -o dist/tui    ./cmd/tui
+```
+
+### Option B — download a release archive
+
+`.github/workflows/release.yml` publishes static archives
+(`CGO_ENABLED=0`) for `linux/{amd64,arm64}` and `darwin/{amd64,arm64}`,
+each with an SBOM and build-provenance attestation. Download the archive
+matching your `GOOS/GOARCH`, verify the attestation with
+`gh attestation verify`, then unpack `worker` (and optionally `tui`)
+onto the host `PATH`.
+
+## 3. Configure the workflow and environment
+
+The worker reads its workflow from `AIOPS_WORKFLOW_PATH` and its fallback
+workspace root from `AIOPS_WORKSPACE_ROOT`. Tracker tokens are **not**
+read directly by the worker — they flow through `tracker.api_key: $VAR`
+expansion in `WORKFLOW.md` (see [`local-dev.md`](local-dev.md)
+"Missing tracker credentials"). Set `tracker.api_key` for your
+`tracker.kind`:
+
+| `tracker.kind` | `WORKFLOW.md` token reference |
+| --- | --- |
+| `linear` | `tracker.api_key: $LINEAR_API_KEY` |
+| `gitea`  | `tracker.api_key: $GITEA_TOKEN` |
+| `github` | `tracker.api_key: $GITHUB_TOKEN` |
+
+Lay down a config directory and an env file (never commit a real env
+file):
+
+```bash
+sudo install -d -o aiops -g aiops /etc/aiops-platform
+sudo cp examples/WORKFLOW.md /etc/aiops-platform/WORKFLOW.md   # edit tracker.api_key/kind
+sudo cp .env.example /etc/aiops-platform/worker.env           # fill in the token + paths
+sudo chmod 600 /etc/aiops-platform/worker.env
+```
+
+Keep `agent.default: mock` in `WORKFLOW.md` until the loop is trusted on
+the target repo.
+
+## 4. Validate before running
+
+Run the operator preflight; it should pass with no Docker present (the
+Compose checks are advisory on this path — see §1):
+
+```bash
+export AIOPS_WORKFLOW_PATH=/etc/aiops-platform/WORKFLOW.md
+worker --doctor --mode=mock "$AIOPS_WORKFLOW_PATH"
+# then, when the workflow should validate live tracker auth + a real agent:
+worker --doctor --mode=real "$AIOPS_WORKFLOW_PATH"
+```
+
+Inspect the effective config (secrets are masked with `***`):
+
+```bash
+worker --print-config "$(dirname "$AIOPS_WORKFLOW_PATH")"
+```
+
+## 5. Run
+
+### Foreground (development)
+
+```bash
+export AIOPS_WORKFLOW_PATH=/etc/aiops-platform/WORKFLOW.md
+export AIOPS_WORKSPACE_ROOT=/var/lib/aiops-platform/workspaces
+export LINEAR_API_KEY=...        # only the var your WORKFLOW.md tracker.api_key references
+worker
+```
+
+The worker exposes a loopback-only HTTP server on
+`127.0.0.1:${server.port}` (default `4000`): `/livez`, `/readyz`
+(`503` until startup reconciliation finishes), and `/api/v1/state`.
+Override the bind port with `-port` (`-1` disables the server) and the
+host with `AIOPS_SERVER_HOST`. The dashboard/state API is unauthenticated
+on pure loopback; if you bind anything other than loopback, require a
+token via `AIOPS_STATE_API_TOKEN` — see README "Operator surfaces".
+
+### Under systemd (production)
+
+A hardened sample unit ships at
+[`deploy/systemd/aiops-worker.service`](../../deploy/systemd/aiops-worker.service).
+It runs as a dedicated non-root `aiops` user (mirroring the Docker
+hardening in #365), loads secrets from an `EnvironmentFile`, and keeps
+mutable state under `/var/lib/aiops-platform` via `StateDirectory`.
+
+```bash
+# one-time: create the service user and state dir
+sudo useradd --system --create-home --home-dir /var/lib/aiops-platform \
+  --shell /usr/sbin/nologin aiops
+
+# install the binary and unit
+sudo scripts/install.sh --prefix /usr/local
+sudo cp deploy/systemd/aiops-worker.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now aiops-worker.service
+
+# observe
+systemctl status aiops-worker.service
+journalctl -u aiops-worker.service -f
+curl http://127.0.0.1:4000/api/v1/state
+```
+
+Edit the unit's `EnvironmentFile=` / `ExecStart=` paths if you installed
+the binary or config elsewhere. If you set `server.port: -1` to disable
+the HTTP server, drop any external health probe that targets it.
+
+## Common failure modes
+
+- **`missing_tracker_api_key` at startup** — `tracker.api_key` references
+  a `$VAR` that is unset. Confirm the env var is exported in the same
+  environment as the worker (for systemd, that it is present in
+  `EnvironmentFile`).
+- **Agent cannot push** — the worker does not hold git credentials;
+  provide a file-backed credential (e.g. a dedicated SSH deploy key) the
+  agent subprocess can read. See [`local-dev.md`](local-dev.md)
+  "Agent fails to push or open PRs".
+- **`/api/v1/state` refuses to bind** — the server is loopback-only and
+  disabled when `server.port: -1`. Confirm with `worker --print-config`.
+- **Workspace permission errors under systemd** — ensure
+  `AIOPS_WORKSPACE_ROOT` and `AIOPS_MIRROR_ROOT` point at directories the
+  `aiops` user owns (the sample unit uses `StateDirectory`).
+
+## See also
+
+- [`local-dev.md`](local-dev.md) — the canonical local loop and the
+  full failure-mode catalog.
+- [`codex-app-server-docker.md`](codex-app-server-docker.md) — the
+  container path for `agent.default: codex-app-server`.
+- README "Quick start" and "Operator surfaces".

--- a/docs/runbooks/binary-deployment.md
+++ b/docs/runbooks/binary-deployment.md
@@ -109,6 +109,8 @@ file):
 
 ```bash
 sudo install -d -o aiops -g aiops /etc/aiops-platform
+# Pick the example matching your tracker.kind: examples/WORKFLOW.md (linear),
+# examples/gitea-WORKFLOW.md, or examples/github-local-WORKFLOW.md.
 sudo cp examples/WORKFLOW.md /etc/aiops-platform/WORKFLOW.md   # edit tracker.api_key/kind
 sudo cp .env.example /etc/aiops-platform/worker.env           # fill in the token + paths
 sudo chmod 600 /etc/aiops-platform/worker.env
@@ -171,7 +173,7 @@ for the supervised setups below.
 The worker exposes a loopback-only HTTP server on
 `127.0.0.1:${server.port}` (default `4000`): `/livez`, `/readyz`
 (`503` until startup reconciliation finishes), and `/api/v1/state`.
-Override the bind port with `-port` (`-1` disables the server) and the
+Override the bind port with `--port` (`-1` disables the server) and the
 host with `AIOPS_SERVER_HOST`. The dashboard/state API is unauthenticated
 on pure loopback; if you bind anything other than loopback, require a
 token via `AIOPS_STATE_API_TOKEN` — see README "Operator surfaces".

--- a/docs/runbooks/binary-deployment.md
+++ b/docs/runbooks/binary-deployment.md
@@ -5,7 +5,7 @@ container runtime. Docker is **optional** in this project (see
 [`local-dev.md`](local-dev.md) "Prerequisites"); the worker is a
 self-contained Go binary that launches the configured agent as a local
 subprocess. Use this path when you want to run the worker directly under
-an init system (systemd) or a process supervisor instead of Compose.
+a service manager (systemd on Linux, launchd on macOS) instead of Compose.
 
 > This runbook is the operator companion to README's "Quick start:
 > worker-owned tracker polling path" and to [`local-dev.md`](local-dev.md).
@@ -26,6 +26,11 @@ an init system (systemd) or a process supervisor instead of Compose.
 
 ## 1. Host prerequisites
 
+This runbook covers both **Linux** (systemd) and **macOS** (launchd)
+hosts. The binary, build, config, and `--doctor` steps are identical on
+both; only the service-manager integration (§5) and a few default paths
+differ, called out inline.
+
 These are host-level tools (not an image). Install whatever your
 configured `agent.default` and clone URLs actually exercise:
 
@@ -36,6 +41,12 @@ configured `agent.default` and clone URLs actually exercise:
 | `ssh` (`openssh-client`) | When pushing over an SSH clone URL | The agent pushes branches; `worker --doctor` flags a missing `ssh` only when SSH clone URLs are configured. |
 | `rg` (ripgrep) | Recommended | Faster agent code search; doctor warns if absent. |
 | `codex` / `claude` CLI on `PATH` | Only when `agent.default` selects it | `mock` needs no external CLI. Keep first real runs on `mock`. |
+
+Install hints by platform:
+
+- **Debian/Ubuntu:** `sudo apt-get install -y git ca-certificates openssh-client ripgrep`
+- **macOS:** `git` and `ssh` ship with the Xcode Command Line Tools
+  (`xcode-select --install`); add ripgrep with `brew install ripgrep`.
 
 > **Note on `worker --doctor` wording.** Several doctor remediation
 > strings say "… in the worker image" (e.g. a missing `ssh` suggests
@@ -54,8 +65,10 @@ scripts/install.sh                 # builds dist/worker and dist/tui
 sudo scripts/install.sh --prefix /usr/local   # build + install to /usr/local/bin
 ```
 
-The script uses the same canonical flags as CI
-(`-trimpath -ldflags="-s -w"`). Equivalent manual build:
+The script uses the same canonical flags as the CI build
+(`-trimpath -ldflags="-s -w"`). It does not set `CGO_ENABLED=0`, so a
+source build may be dynamically linked against the host libc, unlike the
+fully static release archives below. Equivalent manual build:
 
 ```bash
 mkdir -p dist
@@ -65,12 +78,16 @@ go build -trimpath -ldflags="-s -w" -o dist/tui    ./cmd/tui
 
 ### Option B — download a release archive
 
-`.github/workflows/release.yml` publishes static archives
-(`CGO_ENABLED=0`) for `linux/{amd64,arm64}` and `darwin/{amd64,arm64}`,
-each with an SBOM and build-provenance attestation. Download the archive
-matching your `GOOS/GOARCH`, verify the attestation with
-`gh attestation verify`, then unpack `worker` (and optionally `tui`)
-onto the host `PATH`.
+`.github/workflows/release.yml` publishes one fully static
+(`CGO_ENABLED=0`) archive per platform —
+`aiops-platform_<tag>_<goos>_<goarch>.tar.gz` for `linux/{amd64,arm64}`
+and `darwin/{amd64,arm64}`, each containing both `worker` and `tui` —
+plus a single aggregate CycloneDX SBOM
+(`aiops-platform_<tag>_sbom.cdx.json`) and a build-provenance attestation
+covering all release assets. Download the archive matching your
+`GOOS/GOARCH`, verify its provenance with
+`gh attestation verify <archive> --repo xrf9268-hue/aiops-platform`,
+then unpack `worker` (and optionally `tui`) onto the host `PATH`.
 
 ## 3. Configure the workflow and environment
 
@@ -97,6 +114,18 @@ sudo cp .env.example /etc/aiops-platform/worker.env           # fill in the toke
 sudo chmod 600 /etc/aiops-platform/worker.env
 ```
 
+`examples/WORKFLOW.md` and `.env.example` ship in the source checkout
+(Option A). If you installed from a release archive (Option B), the
+archive contains only the binaries — copy these two files from the repo,
+or author a `WORKFLOW.md` from the README configuration table and a
+minimal env file by hand.
+
+The paths above use the Linux FHS layout (`/etc`, `/var/lib`). On macOS
+the conventional equivalents are `/usr/local/etc/aiops-platform` and
+`/usr/local/var/aiops-platform` (Homebrew prefix), or a per-user
+`~/Library/Application Support/aiops-platform`. The §5 launchd example
+uses the `/usr/local` paths; substitute consistently.
+
 Keep `agent.default: mock` in `WORKFLOW.md` until the loop is trusted on
 the target repo.
 
@@ -112,6 +141,12 @@ worker --doctor --mode=mock "$AIOPS_WORKFLOW_PATH"
 worker --doctor --mode=real "$AIOPS_WORKFLOW_PATH"
 ```
 
+On a Docker-less binary host, the "Docker Compose" check is a `WARN` in
+`--mode=mock` but is escalated to a `FAIL` (non-zero exit) in
+`--mode=real`. Treat that single Compose `FAIL` as expected on this
+deployment path and read the tracker/agent/workflow checks for the real
+verdict — see §1 on the doctor's container-centric wording.
+
 Inspect the effective config (secrets are masked with `***`):
 
 ```bash
@@ -123,11 +158,15 @@ worker --print-config "$(dirname "$AIOPS_WORKFLOW_PATH")"
 ### Foreground (development)
 
 ```bash
-export AIOPS_WORKFLOW_PATH=/etc/aiops-platform/WORKFLOW.md
-export AIOPS_WORKSPACE_ROOT=/var/lib/aiops-platform/workspaces
+export AIOPS_WORKFLOW_PATH=$PWD/WORKFLOW.md
+export AIOPS_WORKSPACE_ROOT=$PWD/.aiops/workspaces   # any path the user can write
 export LINEAR_API_KEY=...        # only the var your WORKFLOW.md tracker.api_key references
 worker
 ```
+
+This works the same on Linux and macOS. Use a user-writable workspace
+root here; the system paths in §3 are owned by the service user and are
+for the supervised setups below.
 
 The worker exposes a loopback-only HTTP server on
 `127.0.0.1:${server.port}` (default `4000`): `/livez`, `/readyz`
@@ -137,7 +176,7 @@ host with `AIOPS_SERVER_HOST`. The dashboard/state API is unauthenticated
 on pure loopback; if you bind anything other than loopback, require a
 token via `AIOPS_STATE_API_TOKEN` — see README "Operator surfaces".
 
-### Under systemd (production)
+### Linux: under systemd (production)
 
 A hardened sample unit ships at
 [`deploy/systemd/aiops-worker.service`](../../deploy/systemd/aiops-worker.service).
@@ -146,8 +185,9 @@ hardening in #365), loads secrets from an `EnvironmentFile`, and keeps
 mutable state under `/var/lib/aiops-platform` via `StateDirectory`.
 
 ```bash
-# one-time: create the service user and state dir
-sudo useradd --system --create-home --home-dir /var/lib/aiops-platform \
+# one-time: create the service user. StateDirectory= creates and chowns
+# /var/lib/aiops-platform on first start, so --create-home is not needed.
+sudo useradd --system --home-dir /var/lib/aiops-platform \
   --shell /usr/sbin/nologin aiops
 
 # install the binary and unit
@@ -166,21 +206,108 @@ Edit the unit's `EnvironmentFile=` / `ExecStart=` paths if you installed
 the binary or config elsewhere. If you set `server.port: -1` to disable
 the HTTP server, drop any external health probe that targets it.
 
+**SSH deploy key under hardening.** The unit sets `ProtectHome=true`,
+which makes `/home`, `/root`, and `/run/user` inaccessible — but **not**
+`/var/lib`. Because the unit sets the `aiops` user's `$HOME` to its state
+dir (`/var/lib/aiops-platform`), place the agent's git deploy key at
+`/var/lib/aiops-platform/.ssh/id_ed25519` (owned by `aiops`, mode `0600`)
+so `ssh` resolves it via `$HOME/.ssh` and `ReadWritePaths=` already
+covers it:
+
+```bash
+sudo -u aiops install -d -m 700 /var/lib/aiops-platform/.ssh
+sudo -u aiops ssh-keygen -t ed25519 -N '' \
+  -f /var/lib/aiops-platform/.ssh/id_ed25519 -C aiops-worker-deploy-key
+# register /var/lib/aiops-platform/.ssh/id_ed25519.pub as a deploy key, then:
+sudo -u aiops bash -c 'ssh-keyscan -H <git-host> >> /var/lib/aiops-platform/.ssh/known_hosts'
+```
+
+A key left under a conventional home such as `/home/aiops/.ssh` is hidden
+by `ProtectHome=true` and the agent's `git push` over SSH then fails with
+a confusing missing-key/auth error. For the same reason the unit pins
+`AIOPS_MIRROR_ROOT` inside the state dir: the worker's default mirror root
+is `os.UserCacheDir()/aiops-platform/mirrors`, which would otherwise
+resolve under `$HOME` and must stay within `ReadWritePaths=`.
+
+### macOS: under launchd
+
+A sample per-user LaunchAgent ships at
+[`deploy/launchd/com.aiops-platform.worker.plist`](../../deploy/launchd/com.aiops-platform.worker.plist).
+launchd has no sandboxing directives equivalent to systemd's, so the
+hardening here is "run as an ordinary (non-admin) user with least
+filesystem footprint" plus keeping the secret out of the plist (below).
+It uses the `/usr/local` paths from §3.
+
+```bash
+# install the binaries onto PATH
+sudo scripts/install.sh --prefix /usr/local
+
+# config + state/log dir owned by the running user (the plist logs here)
+sudo install -d -o "$USER" /usr/local/etc/aiops-platform
+mkdir -p /usr/local/var/aiops-platform
+cp examples/WORKFLOW.md /usr/local/etc/aiops-platform/WORKFLOW.md   # edit tracker.api_key/kind
+
+# install and load the agent (per-user; runs only while you are logged in)
+cp deploy/launchd/com.aiops-platform.worker.plist ~/Library/LaunchAgents/
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.aiops-platform.worker.plist
+launchctl enable "gui/$(id -u)/com.aiops-platform.worker"
+
+# observe
+launchctl print "gui/$(id -u)/com.aiops-platform.worker" | head -n 40
+tail -f /usr/local/var/aiops-platform/worker.err.log
+curl http://127.0.0.1:4000/api/v1/state
+```
+
+For a machine-wide daemon that runs without a login session, install the
+plist into `/Library/LaunchDaemons/` instead, add a `UserName` key, and
+bootstrap into the `system` domain (`sudo launchctl bootstrap system …`).
+
+**Secrets on macOS.** launchd has no `EnvironmentFile=` equivalent, and a
+token pasted into the plist's `EnvironmentVariables` is readable by the
+user and lands in backups. Prefer the login Keychain plus a thin wrapper
+that exports the token before exec, keeping the plist secret-free:
+
+```bash
+# store once
+security add-generic-password -a "$USER" -s aiops-linear-api-key -w 'your-token'
+```
+
+```bash
+#!/usr/bin/env bash
+# /usr/local/bin/aiops-worker-launch — point ProgramArguments at this.
+set -euo pipefail
+LINEAR_API_KEY="$(security find-generic-password -a "$USER" -s aiops-linear-api-key -w)"
+export LINEAR_API_KEY
+exec /usr/local/bin/worker
+```
+
+SSH keys on macOS need no special placement — `ProtectHome` does not
+exist, so a standard `~/.ssh/id_ed25519` for the running user works.
+
+> The existing [`scripts/install-local-launchagents.sh`](../../scripts/install-local-launchagents.sh)
+> is a different, higher-level macOS flow that bundles a GitHub worker
+> wrapper and a PR follow-through agent
+> (see [`github-local-automation.md`](github-local-automation.md)); use
+> the plist above when you just want the bare worker binary as a service.
+
 ## Common failure modes
 
 - **`missing_tracker_api_key` at startup** — `tracker.api_key` references
   a `$VAR` that is unset. Confirm the env var is exported in the same
   environment as the worker (for systemd, that it is present in
-  `EnvironmentFile`).
+  `EnvironmentFile`; for launchd, that the Keychain wrapper exported it).
 - **Agent cannot push** — the worker does not hold git credentials;
   provide a file-backed credential (e.g. a dedicated SSH deploy key) the
-  agent subprocess can read. See [`local-dev.md`](local-dev.md)
-  "Agent fails to push or open PRs".
+  agent subprocess can read. Under the systemd unit the key must live
+  inside the state dir (see §5 "SSH deploy key under hardening"), because
+  `ProtectHome=true` hides keys under `/home`. See also
+  [`local-dev.md`](local-dev.md) "Agent fails to push or open PRs".
 - **`/api/v1/state` refuses to bind** — the server is loopback-only and
   disabled when `server.port: -1`. Confirm with `worker --print-config`.
-- **Workspace permission errors under systemd** — ensure
+- **Workspace permission errors under a service manager** — ensure
   `AIOPS_WORKSPACE_ROOT` and `AIOPS_MIRROR_ROOT` point at directories the
-  `aiops` user owns (the sample unit uses `StateDirectory`).
+  running user owns (the systemd unit uses `StateDirectory`; the launchd
+  agent runs as your user and writes under `/usr/local/var`).
 
 ## See also
 

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -42,7 +42,9 @@ needs Postgres, it is stale — file an issue.
   source of truth; `AIOPS_WORKSPACE_ROOT` (legacy alias `WORKSPACE_ROOT`)
   is the fallback when omitted.
 - Optional: Docker and Docker Compose v2, only if you want the
-  containerized worker or e2e tests.
+  containerized worker or e2e tests. To deploy the worker as a plain
+  binary under an init system instead, see the
+  [binary deployment runbook](binary-deployment.md).
 - Optional: the Codex CLI installed and on `PATH`, only if you set
   `agent.default: codex` and want a real model loop.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build the aiops-platform binaries (worker, tui) from source with the
+# same flags CI uses, and optionally install them onto a PATH prefix.
+# This is the binary (non-Docker) deployment helper documented in
+# docs/runbooks/binary-deployment.md.
+#
+# Usage:
+#   scripts/install.sh                      # build into ./dist
+#   scripts/install.sh --prefix /usr/local  # build, then install to <prefix>/bin
+#   scripts/install.sh --prefix ~/.local    # user-local install
+#
+# Run the --prefix form with sufficient privileges for the target
+# (e.g. sudo for /usr/local).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dist_dir="${repo_root}/dist"
+prefix=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prefix)
+      [ "$#" -ge 2 ] || { echo "error: --prefix requires a path" >&2; exit 2; }
+      prefix="$2"
+      shift 2
+      ;;
+    --prefix=*)
+      prefix="${1#--prefix=}"
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+command -v go >/dev/null 2>&1 || { echo "error: go toolchain not found on PATH (need Go 1.25 per go.mod)" >&2; exit 1; }
+
+binaries=(worker tui)
+mkdir -p "$dist_dir"
+for binary in "${binaries[@]}"; do
+  echo "building ${binary} -> dist/${binary}"
+  ( cd "$repo_root" && go build -trimpath -ldflags="-s -w" -o "dist/${binary}" "./cmd/${binary}" )
+done
+
+if [ -n "$prefix" ]; then
+  bin_dir="${prefix%/}/bin"
+  install -d "$bin_dir"
+  for binary in "${binaries[@]}"; do
+    install -m 0755 "${dist_dir}/${binary}" "${bin_dir}/${binary}"
+    echo "installed ${bin_dir}/${binary}"
+  done
+else
+  echo "built into ${dist_dir} (pass --prefix <dir> to install onto PATH)"
+fi


### PR DESCRIPTION
Closes #537.

## Summary

The worker is already a self-contained binary with no container runtime dependency, but there was no documented, supported way to deploy it without Docker. This adds a first-class binary deployment path covering **both Linux (systemd) and macOS (launchd)**. Docs + ops scaffold only — **no Go source changes**, no SPEC behavior change.

## What's included

- **`docs/runbooks/binary-deployment.md`** (new) — host prerequisites (per-platform install hints), obtain-the-binary (source build or verified release archive), the `tracker.api_key: $VAR` credential model, `worker --doctor` preflight, foreground run, and supervised run under systemd / launchd, plus a failure-mode catalog.
- **`deploy/systemd/aiops-worker.service`** (new) — hardened non-root unit: `EnvironmentFile=` secrets, `StateDirectory=`, `ProtectSystem=strict` + `ProtectHome=true` etc. `HOME` is pinned to the state dir so `ProtectHome=true` (which per `systemd.exec(5)` masks only `/home`, `/root`, `/run/user`) does not hide the agent's SSH deploy key. Mirrors the Docker hardening posture in #365.
- **`deploy/launchd/com.aiops-platform.worker.plist`** (new) — per-user LaunchAgent (with system-daemon notes), keeping the tracker token out of the plist via a login-Keychain wrapper.
- **`scripts/install.sh`** (new) — builds `worker`+`tui` with the CI build flags; optional `--prefix` install onto PATH.
- **`README.md`, `docs/runbooks/local-dev.md`** — cross-link the new runbook.

## Acceptance criteria (from #537)

- [x] `docs/runbooks/binary-deployment.md` exists, covers Linux + macOS, linked from `README.md` and `local-dev.md`.
- [x] Lists exact host prerequisites + the `--doctor` validation step; verified end-to-end with `agent.default: mock`.
- [x] `scripts/install.sh` builds/installs both binaries; documented in the runbook.
- [x] systemd unit runs non-root, loads secrets via `EnvironmentFile`, and its `ProtectHome`/SSH-key interaction is documented and correct.
- [x] launchd plist with a documented per-user load flow and a secret-handling story.
- [ ] `worker --doctor` deployment-mode-aware remediation — **deferred to #538** (it is a Go code change; kept out of this docs PR per scope separation). The runbook documents the current container-centric wording as an interim caveat.

## Verification

Run locally on the head commit (no Docker present):

```
scripts/install.sh                       # builds dist/worker + dist/tui
LINEAR_API_KEY=dummy ./dist/worker --doctor --mode=mock examples/WORKFLOW.md
                                         # runs standalone; only the Docker Compose check is container-specific
systemd-analyze verify deploy/systemd/aiops-worker.service   # parses (only the expected missing-binary notice)
xmllint --noout deploy/launchd/com.aiops-platform.worker.plist   # plist well-formed
bash -n scripts/install.sh               # syntax OK
```

External facts verified against authoritative sources: `ProtectHome=`/`ProtectSystem=strict` semantics against `systemd.exec(5)`; `gh attestation verify` syntax against the GitHub CLI manual; release-archive layout (per-platform static tar.gz + one aggregate CycloneDX SBOM + provenance attestation) against `.github/workflows/release.yml`.

## Review

One clean dual diff-only review round on the committed head (docs change → one round is the bar):
- **Reviewer A** (correctness/house-style): **MERGE-READY**; applied its two follow-ups (example selection per `tracker.kind`; `--port` wording).
- **Reviewer B** (operational walkthrough + security): **NEEDS-CHANGES** → all four addressed: macOS `/usr/local/var` state dir created with `sudo install`; Keychain wrapper given real install/`chmod`/`plutil`/reload steps and `id -un`; `--mode=real` caveat reworded so a genuine auth/push FAIL is not mistaken for the expected Compose FAIL.

### Size gate
- [ ] `within budget`
- [x] `size-gated: justified overage` — +520/−1 LOC across 6 files vs. the default 300 LOC budget. It is one cohesive deliverable (a single runbook plus the systemd unit, launchd plist, and install script it references) that does not split cleanly without breaking cross-references; no code paths or tests are affected. **Not auto-mergeable — needs human size-gate sign-off.**
- [ ] `size-gated: split recommended`

> ⚠️ **`policy.deny_paths` touch.** This PR adds files under `deploy/**`, a default `policy.deny_path`. These are operator-facing sample service files (alongside the existing `deploy/docker-compose*.yml`), not infra the worker mutates — flagging for human sign-off per the merge protocol's hard-stop on deny-path changes.

## Deferrals
- #538 — make `worker --doctor` remediation text + Compose checks deployment-mode-aware (Go change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NRybcythFnxy7jUvjByhWZ)_