### PR TITLE
feat(doctor): add --deploy=binary|docker so preflight fits binary hosts

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -53,6 +53,7 @@ func main() { //nolint:gocognit // baseline (#521)
 func parseDoctorArgs(args []string) (doctor.Options, error) {
 	fs := flag.NewFlagSet("worker --doctor", flag.ContinueOnError)
 	mode := fs.String("mode", "mock", "preflight depth: mock or real")
+	deploy := fs.String("deploy", "docker", "deployment target for remediation hints and Docker checks: binary or docker")
 	dashboardURL := fs.String("dashboard-url", "", "optional worker dashboard base URL to verify /api/v1/state auth")
 	goTestDir := fs.String("go-test-dir", "", "repository module root for real-mode targeted go test")
 	githubIssue := fs.Int("github-issue", 0, "optional GitHub issue number for agent-environment gh and git push preflight")
@@ -63,14 +64,17 @@ func parseDoctorArgs(args []string) (doctor.Options, error) {
 	if *mode != "mock" && *mode != "real" {
 		return doctor.Options{}, fmt.Errorf("--mode must be mock or real")
 	}
+	if *deploy != "binary" && *deploy != "docker" {
+		return doctor.Options{}, fmt.Errorf("--deploy must be binary or docker")
+	}
 	if fs.NArg() > 1 {
-		return doctor.Options{}, fmt.Errorf("usage: worker --doctor [--mode=mock|real] [--dashboard-url=http://127.0.0.1:4000] [--go-test-dir=/repo-module] [--github-issue=N] [--github-repo=owner/name] [path-to-WORKFLOW.md]")
+		return doctor.Options{}, fmt.Errorf("usage: worker --doctor [--mode=mock|real] [--deploy=binary|docker] [--dashboard-url=http://127.0.0.1:4000] [--go-test-dir=/repo-module] [--github-issue=N] [--github-repo=owner/name] [path-to-WORKFLOW.md]")
 	}
 	var path string
 	if fs.NArg() == 1 {
 		path = fs.Arg(0)
 	}
-	return doctor.Options{WorkflowPath: path, Mode: *mode, DashboardURL: *dashboardURL, GoTestDir: *goTestDir, GitHubIssue: *githubIssue, GitHubRepo: *githubRepo, Stdout: os.Stdout, Stderr: os.Stderr}, nil
+	return doctor.Options{WorkflowPath: path, Mode: *mode, Deploy: *deploy, DashboardURL: *dashboardURL, GoTestDir: *goTestDir, GitHubIssue: *githubIssue, GitHubRepo: *githubRepo, Stdout: os.Stdout, Stderr: os.Stderr}, nil
 }
 func reorderDoctorFlags(args []string) []string {
 	flags, positional := make([]string, 0, len(args)), make([]string, 0, len(args))
@@ -80,7 +84,7 @@ func reorderDoctorFlags(args []string) []string {
 		case a == "--":
 			positional = append(positional, append([]string{"--"}, args[i+1:]...)...)
 			i = len(args)
-		case a == "--mode" || a == "-mode" || a == "--dashboard-url" || a == "-dashboard-url" || a == "--go-test-dir" || a == "-go-test-dir" || a == "--github-issue" || a == "-github-issue" || a == "--github-repo" || a == "-github-repo":
+		case a == "--mode" || a == "-mode" || a == "--deploy" || a == "-deploy" || a == "--dashboard-url" || a == "-dashboard-url" || a == "--go-test-dir" || a == "-go-test-dir" || a == "--github-issue" || a == "-github-issue" || a == "--github-repo" || a == "-github-repo":
 			flags = append(flags, a)
 			if i+1 < len(args) {
 				flags = append(flags, args[i+1])

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -2393,6 +2393,26 @@ func TestParseDoctorArgs_AllowsTrailingFlags(t *testing.T) {
 	}
 }
 
+func TestParseDoctorArgs_DeployFlag(t *testing.T) {
+	opts, err := parseDoctorArgs([]string{"/wf.md"})
+	if err != nil {
+		t.Fatalf("parseDoctorArgs(/wf.md) error: %v", err)
+	}
+	if opts.Deploy != "docker" {
+		t.Fatalf("default Deploy = %q; want docker", opts.Deploy)
+	}
+	opts, err = parseDoctorArgs([]string{"/wf.md", "--deploy", "binary"})
+	if err != nil {
+		t.Fatalf("parseDoctorArgs(--deploy binary) error: %v", err)
+	}
+	if opts.Deploy != "binary" {
+		t.Fatalf("Deploy = %q; want binary", opts.Deploy)
+	}
+	if _, err := parseDoctorArgs([]string{"--deploy", "k8s", "/wf.md"}); err == nil {
+		t.Fatalf("parseDoctorArgs(--deploy k8s) = nil error; want a validation error")
+	}
+}
+
 func TestParseDoctorArgs_HelpReturnsFlagErrHelp(t *testing.T) {
 	_, err := parseDoctorArgs([]string{"--help"})
 	if !errors.Is(err, flag.ErrHelp) {

--- a/docs/runbooks/binary-deployment.md
+++ b/docs/runbooks/binary-deployment.md
@@ -48,13 +48,11 @@ Install hints by platform:
 - **macOS:** `git` and `ssh` ship with the Xcode Command Line Tools
   (`xcode-select --install`); add ripgrep with `brew install ripgrep`.
 
-> **Note on `worker --doctor` wording.** Several doctor remediation
-> strings say "… in the worker image" (e.g. a missing `ssh` suggests
-> "Install ssh in the worker image"), and the run includes Docker
-> Compose checks. Those messages assume the container path; on a binary
-> host read them as "install the tool on this host and ensure it is on
-> `PATH`," and ignore the Compose checks. Making doctor
-> deployment-mode-aware is tracked separately.
+> **Run `worker --doctor` with `--deploy=binary`** on a binary host. That
+> skips the container-only Docker Compose checks (irrelevant without a
+> container, and they would otherwise FAIL in `--mode=real`) and phrases
+> install hints for a host `PATH` rather than a worker image. The default
+> `--deploy=docker` is for the container path (`first-run-docker-linear-codex.md`).
 
 ## 2. Obtain the binaries
 
@@ -133,23 +131,20 @@ the target repo.
 
 ## 4. Validate before running
 
-Run the operator preflight; it should pass with no Docker present (the
-Compose checks are advisory on this path — see §1):
+Run the operator preflight with `--deploy=binary` (see §1) so it skips the
+container-only Docker Compose checks and gives host-oriented install hints:
 
 ```bash
 export AIOPS_WORKFLOW_PATH=/etc/aiops-platform/WORKFLOW.md
-worker --doctor --mode=mock "$AIOPS_WORKFLOW_PATH"
+worker --doctor --deploy=binary --mode=mock "$AIOPS_WORKFLOW_PATH"
 # then, when the workflow should validate live tracker auth + a real agent:
-worker --doctor --mode=real "$AIOPS_WORKFLOW_PATH"
+worker --doctor --deploy=binary --mode=real "$AIOPS_WORKFLOW_PATH"
 ```
 
-On a Docker-less binary host, the "Docker Compose" check is a `WARN` in
-`--mode=mock` but is escalated to a `FAIL` (non-zero exit) in
-`--mode=real`. The Compose `FAIL` is expected on this deployment path —
-but read every *other* check on its own merits, since `--mode=real` also
-FAILs on genuine problems (e.g. a missing `gh`/deploy-key credential at
-the agent `git push` preflight) that are **not** safe to ignore. See §1
-on the doctor's container-centric wording.
+With `--deploy=binary` there is no spurious Docker Compose failure to
+discount, so any `FAIL` in `--mode=real` reflects a real problem on this
+path (e.g. a missing `gh`/deploy-key credential at the agent `git push`
+preflight).
 
 Inspect the effective config (secrets are masked with `***`):
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -46,6 +46,7 @@ type Check struct {
 type Options struct {
 	WorkflowPath string
 	Mode         string
+	Deploy       string
 	DashboardURL string
 	GoTestDir    string
 	GitHubIssue  int
@@ -112,6 +113,9 @@ func (r *reportBuilder) normalize() {
 	if r.opts.Mode == "" {
 		r.opts.Mode = "mock"
 	}
+	if r.opts.Deploy == "" {
+		r.opts.Deploy = "docker"
+	}
 	if r.opts.Runner == nil {
 		r.opts.Runner = defaultRunner
 	}
@@ -155,7 +159,7 @@ func (r *reportBuilder) checkHostBinaries(wf *workflow.Workflow) {
 		r.pass("ssh", "not required for configured repository clone URLs")
 	}
 	if _, err := exec.LookPath("rg"); err != nil {
-		r.warn("rg", "ripgrep not found on PATH", "Install rg in the worker image for faster agent code search.")
+		r.warn("rg", "ripgrep not found on PATH", r.installFix("rg")+" It speeds up agent code search.")
 	} else {
 		r.pass("rg", "found on PATH")
 	}
@@ -165,11 +169,19 @@ func (r *reportBuilder) checkProjectToolchain(ctx context.Context) { //nolint:go
 	if !r.realMode() {
 		return
 	}
+	if r.binaryDeploy() {
+		// The Go toolchain probes validate a dogfood/worker-image checkout
+		// (they run `go test` for --go-test-dir), not a binary-runtime
+		// prerequisite — a release-archive host ships only worker/tui and
+		// has no Go. Skip them so --deploy=binary --mode=real does not FAIL
+		// on an absent toolchain. #538.
+		return
+	}
 	modulePath, goModVersion := r.goModule()
 	moduleRoot := strings.TrimSpace(r.opts.GoTestDir)
 	out, err := r.run(ctx, "go", []string{"version"})
 	if err != nil {
-		r.fail("Go version", trimOutput(out, err), "Install the Go toolchain required by go.mod in the worker image.")
+		r.fail("Go version", trimOutput(out, err), r.installFix("the Go toolchain required by go.mod"))
 	} else if version := strings.TrimSpace(string(out)); goModVersion != "" && !goVersionCompatible(version, goModVersion) {
 		r.fail("Go version", version, "Install a Go toolchain compatible with go.mod version "+goModVersion+".")
 	} else {
@@ -182,9 +194,9 @@ func (r *reportBuilder) checkProjectToolchain(ctx context.Context) { //nolint:go
 	if err != nil {
 		r.fail("gofmt", err.Error(), "Create a writable temp directory for doctor preflight probes.")
 	} else if gofmtPath, out, err := r.gofmtPath(ctx); err != nil {
-		r.fail("gofmt", trimOutput(out, err), "Install the Go toolchain with gofmt in the worker image.")
+		r.fail("gofmt", trimOutput(out, err), r.installFix("the Go toolchain (gofmt)"))
 	} else if out, err := r.run(ctx, gofmtPath, []string{"-l", gofmtProbe}); err != nil {
-		r.fail("gofmt", trimOutput(out, err), "Install gofmt in the worker image.")
+		r.fail("gofmt", trimOutput(out, err), r.installFix("gofmt"))
 	} else {
 		r.pass("gofmt", "found at "+gofmtPath)
 	}
@@ -204,7 +216,7 @@ func (r *reportBuilder) checkProjectToolchain(ctx context.Context) { //nolint:go
 		return
 	}
 	if out, err := r.runWithTimeout(ctx, goTestProbeTimeout, "go", []string{"test", "-C", moduleRoot, "./internal/doctor", "-run", "TestDoctorGoToolchainProbe", "-count=1"}); err != nil {
-		r.fail("Go test", trimOutput(out, err), "Fix the project Go test prerequisites in the worker image or checkout.")
+		r.fail("Go test", trimOutput(out, err), "Fix the project Go test prerequisites in the targeted module checkout.")
 		return
 	}
 	r.pass("Go test", "go test ./internal/doctor -run TestDoctorGoToolchainProbe -count=1")
@@ -257,6 +269,12 @@ func writeGofmtProbe() (string, error) {
 }
 
 func (r *reportBuilder) checkDockerCompose(ctx context.Context) {
+	if r.binaryDeploy() {
+		// Docker Compose is irrelevant to a binary deployment; a
+		// Docker-less host is the expected case, so don't report it
+		// (and don't escalate to FAIL in real mode). #538.
+		return
+	}
 	if runningInContainer() {
 		r.warn("Docker Compose", "host Docker Compose check skipped inside the worker container", "Run docker compose config --quiet on the host before docker compose run/up.")
 		return
@@ -286,7 +304,7 @@ func (r *reportBuilder) checkLinear(ctx context.Context, cfg workflow.Config) {
 		return
 	}
 	if strings.TrimSpace(cfg.Tracker.APIKey) == "" {
-		r.fail("Linear API key", "tracker.api_key resolved empty", "Set LINEAR_API_KEY or mount it from a Docker secret into the workflow env.")
+		r.fail("Linear API key", "tracker.api_key resolved empty", "Provide LINEAR_API_KEY via the worker environment (a systemd EnvironmentFile, a Docker secret, or a shell export).")
 		return
 	}
 	if !r.realMode() {
@@ -360,7 +378,7 @@ func (r *reportBuilder) checkCodexAPIKeyAuth() {
 		status = Fail
 	}
 	r.add(status, "Codex auth mode", "OPENAI_API_KEY is in codex.env_passthrough but resolved empty",
-		"Mount the model API key from a Docker secret into OPENAI_API_KEY; never pass it on a command line.")
+		"Provide the model API key in OPENAI_API_KEY via the worker environment (a Docker secret or systemd EnvironmentFile); never pass it on a command line.")
 }
 
 func (r *reportBuilder) checkCodexLoginAuth(home string) {
@@ -626,7 +644,7 @@ func closeBody(body io.Closer) {
 
 func (r *reportBuilder) requiredBinary(name string) {
 	if _, err := exec.LookPath(name); err != nil {
-		r.fail(name, "not found on PATH", "Install "+name+" in the worker image.")
+		r.fail(name, "not found on PATH", r.installFix(name))
 		return
 	}
 	r.pass(name, "found on PATH")
@@ -634,6 +652,21 @@ func (r *reportBuilder) requiredBinary(name string) {
 
 func (r *reportBuilder) realMode() bool {
 	return r.opts.Mode == "real"
+}
+
+func (r *reportBuilder) binaryDeploy() bool {
+	return r.opts.Deploy == "binary"
+}
+
+// installFix renders an "install this tool" remediation matching the
+// deployment target: a host PATH for a binary deploy, the worker image
+// for a container deploy. A binary operator has no image to edit, so the
+// container-only phrasing misleads them (#538).
+func (r *reportBuilder) installFix(what string) string {
+	if r.binaryDeploy() {
+		return "Install " + what + " on this host and ensure it is on PATH."
+	}
+	return "Install " + what + " in the worker image."
 }
 
 func (r *reportBuilder) run(ctx context.Context, name string, args []string) ([]byte, error) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -125,6 +125,84 @@ func TestBuildReportRequiresSSHForSSHCloneURLs(t *testing.T) {
 	}
 }
 
+func TestBuildReportBinaryDeploySkipsDockerComposeChecks(t *testing.T) {
+	installFakeGitOnly(t)
+	path := writeWorkflow(t, "linear", "$AIOPS_TEST_LINEAR_KEY")
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin-test")
+
+	dockerReport := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "mock",
+		Deploy:       "docker",
+		Runner:       passingRunner,
+	})
+	if !hasCheck(dockerReport, "Docker Compose") {
+		t.Fatalf("Deploy=docker: missing Docker Compose check in %+v", dockerReport.Checks)
+	}
+
+	binaryReport := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "mock",
+		Deploy:       "binary",
+		Runner:       passingRunner,
+	})
+	for _, name := range []string{"Docker Compose", "Compose config"} {
+		if hasCheck(binaryReport, name) {
+			t.Errorf("Deploy=binary: %q check present; want it skipped in %+v", name, binaryReport.Checks)
+		}
+	}
+}
+
+func TestBuildReportInstallHintMatchesDeployTarget(t *testing.T) {
+	installFakeGitOnly(t) // git on PATH, ssh absent
+	path := writeWorkflowWithCloneURL(t, "git@example.com:o/r.git")
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin-test")
+
+	docker := findCheck(t, BuildReport(context.Background(), Options{
+		WorkflowPath: path, Mode: "mock", Deploy: "docker", Runner: passingRunner,
+	}), "ssh")
+	if docker.Status != Fail {
+		t.Fatalf("Deploy=docker ssh status = %s; want FAIL", docker.Status)
+	}
+	if !strings.Contains(docker.Fix, "in the worker image") {
+		t.Fatalf("Deploy=docker ssh fix = %q; want the container-image hint", docker.Fix)
+	}
+
+	binary := findCheck(t, BuildReport(context.Background(), Options{
+		WorkflowPath: path, Mode: "mock", Deploy: "binary", Runner: passingRunner,
+	}), "ssh")
+	if binary.Status != Fail {
+		t.Fatalf("Deploy=binary ssh status = %s; want FAIL", binary.Status)
+	}
+	if strings.Contains(binary.Fix, "worker image") {
+		t.Fatalf("Deploy=binary ssh fix = %q; should not mention a worker image", binary.Fix)
+	}
+	if !strings.Contains(binary.Fix, "on this host and ensure it is on PATH") {
+		t.Fatalf("Deploy=binary ssh fix = %q; want the host PATH hint", binary.Fix)
+	}
+}
+
+func TestCheckProjectToolchainSkippedForBinaryDeploy(t *testing.T) {
+	// docker real mode runs the Go toolchain probes...
+	dockerR := &reportBuilder{opts: Options{Mode: "real", Deploy: "docker", Runner: fakeRealRunner}}
+	dockerR.normalize()
+	dockerR.checkProjectToolchain(context.Background())
+	if !hasCheck(Report{Checks: dockerR.checks}, "Go version") {
+		t.Fatalf("Deploy=docker real: missing Go version probe in %+v", dockerR.checks)
+	}
+
+	// ...binary deploy skips them, so an absent Go toolchain is not a
+	// spurious real-mode FAIL on a release-archive host.
+	binaryR := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary", Runner: fakeRealRunner}}
+	binaryR.normalize()
+	binaryR.checkProjectToolchain(context.Background())
+	for _, name := range []string{"Go version", "gofmt", "Go test"} {
+		if hasCheck(Report{Checks: binaryR.checks}, name) {
+			t.Errorf("Deploy=binary real: %q probe present; want it skipped in %+v", name, binaryR.checks)
+		}
+	}
+}
+
 func TestBuildReportRealModeUsesCustomCodexCommandForAppServerProbe(t *testing.T) {
 	wrapper := installFakeCodexWrapper(t)
 	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server")
@@ -1009,6 +1087,15 @@ func dockerOnlyRunner(_ context.Context, name string, args []string, _ []string,
 		return []byte("/usr/local/go\n"), nil
 	}
 	return []byte("ok\n"), nil
+}
+
+func hasCheck(report Report, name string) bool {
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func findCheck(t *testing.T, report Report, name string) Check {


### PR DESCRIPTION
Closes #538.

## Problem

`worker --doctor` was built for the Docker first-run path: it always runs the Docker Compose checks (escalated to a `FAIL` in `--mode=real`) and phrases every missing-tool remediation as "… in the worker image". On a binary (non-Docker) host that FAILs spuriously and points operators at an image that does not exist — the gap documented as an interim caveat by the binary-deployment runbook (#537).

## Change

Add a `--deploy=binary|docker` flag to `worker --doctor`, **defaulting to `docker`** so the container path and its runbooks are unchanged. With `--deploy=binary` the doctor:

- **Skips the Docker Compose / Compose config checks entirely** — a Docker-less host is the expected case, so there is no spurious real-mode `FAIL`.
- **Skips the Go toolchain probes** (`go version` / `gofmt` / `go test`) — they validate a dogfood/worker-image checkout, not a binary runtime; a release-archive host ships only `worker`/`tui` and has no Go. (Added in response to the `@codex` P2 below.)
- **Renders install hints for a host `PATH`** instead of a worker image, via a single `installFix()` helper shared by the git / ssh / rg / Go-toolchain checks.

Reachable credential/prereq remediations on the binary `--mode=real` path (`Linear API key`, `Codex auth mode`, `Go test` prereq) are reworded to be deployment-neutral.

`docs/runbooks/binary-deployment.md` now uses `--deploy=binary` and drops the interim "discount the Compose FAIL" caveats.

## Acceptance criteria (#538)

- [x] On a Docker-less host, `worker --doctor --deploy=binary --mode=real` does not `FAIL` solely because of the Docker Compose check (nor the Go toolchain probes).
- [x] Host-tool remediation strings (`git`, `ssh`, `rg`, Go toolchain) read correctly for a binary deployment.
- [x] Regression tests assert the new paths, mutation-verified.
- [x] `binary-deployment.md` §1/§4 interim caveats removed.

## Verification

`gofmt -l`, `go vet`, `go test ./internal/doctor/... ./cmd/worker/...`, `golangci-lint` (0 issues), `go build` — all clean. Mutation (commit-first, against the committed artifact): removing each of the three `binaryDeploy()` early-returns / the `installFix` binary branch makes the matching test FAIL; restored → pass.

> The full `-race ./...` run is green except `internal/runner`'s `TestMockRunnerSetBaseToHeadWritesWorkspaceBaseConfig`, which fails only because of this sandbox's git commit-signing hook (HTTP 400); it reproduces on clean `main` and is unrelated to this diff.

## Review

- **Dual diff-only pre-push round** — Reviewer A: MERGE-READY; Reviewer B: NEEDS-CHANGES on residual container-only remediation (`doctor.go:211`/`299`/`373`) → reworded to deployment-neutral.
- **`@codex review` (head `f09052e`)** — P2 "Skip Go probes for binary-only installs": `--deploy=binary --mode=real` still ran `go version`/`gofmt` and FAILed when Go was absent. **Addressed in `3015d6c`**: `checkProjectToolchain` now early-returns for `--deploy=binary`, with a regression test (`TestCheckProjectToolchainSkippedForBinaryDeploy`). Re-triggered `@codex review` on the new head.

### Size gate
- [x] `within budget` — small diff across `internal/doctor`, `cmd/worker`, and one runbook; no `policy.deny_paths` touched.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
