### PR TITLE
fix(runner): default GOCACHE/GOMODCACHE to a sandbox-writable temp dir for the agent (#544)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -116,6 +116,10 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 // sandbox wraps it — both feed appServerProcessPID's PID-emission guard.
 func setupAppServerCommand(ctx context.Context, in RunInput) (cmd *exec.Cmd, directCodexExec, sandboxEnabled bool, err error) {
 	env := agentEnv(in.Workflow.Config.Codex.EnvPassthrough, in.Workflow.Config)
+	// Pin the agent's Go toolchain caches to a sandbox-writable, per-workspace
+	// path so its first `go test` does not fail on the default $HOME-based
+	// caches that lie outside codex's workspace-write sandbox (#544).
+	env = withSandboxGoToolchainCaches(env, in.Workdir)
 	cmd, directCodexExec, err = buildCodexAppServerCmd(ctx, in, env)
 	if err != nil {
 		return nil, false, false, err

--- a/internal/runner/go_cache.go
+++ b/internal/runner/go_cache.go
@@ -1,0 +1,124 @@
+package runner
+
+import (
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// withSandboxGoToolchainCaches returns env with GOCACHE/GOMODCACHE defaulted to
+// sandbox-writable directories under the host temp dir, unless the caller
+// already set a non-empty value. It is applied only on the sandboxed codex
+// app-server path.
+//
+// Why: Go derives GOCACHE from $HOME/.cache/go-build and GOMODCACHE from
+// $GOPATH/pkg/mod, both outside codex's workspace-write sandbox writable roots,
+// so the agent's first `go test ./...` fails with a cache-write error until it
+// rediscovers a writable GOCACHE — a wasted turn on every Go workflow (#544).
+//
+// Isolation differs by cache, by trust model (codex review #548):
+//   - GOCACHE (build cache) is keyed by action ID and is NOT re-verified on
+//     reuse, so a shared writable one is a poisoning surface across trust
+//     boundaries. It is isolated PER WORKSPACE (an issue's own retries reuse the
+//     same workspace and keep their cache; different repos/issues do not share).
+//   - GOMODCACHE (module cache) is SHARED (workspace-independent). go.sum
+//     verification covers the download path but not reuse of an
+//     already-extracted module tree, so sharing rests on the single-operator
+//     trust model plus read-only (0444) cache entries raising the tampering
+//     bar — not on cryptographic re-verification. Sharing also avoids
+//     re-fetching the whole dependency graph on every issue's first turn.
+//
+// Anchor: os.TempDir() — /tmp on a default Linux worker (codex's workspace-write
+// sandbox grants it; empirically confirmed in #544) and the platform temp dir
+// ($TMPDIR, e.g. /var/folders/...) on macOS (#539). The load-bearing assumption
+// is host-temp ≡ sandbox-writable-temp; it holds for the documented default
+// worker env but NOT if an operator points the worker's TMPDIR at a directory
+// the sandbox cannot write — that operator must override GOCACHE/GOMODCACHE via
+// codex.env_passthrough, which wins because a default is applied only when the
+// name is not already set to a non-empty value.
+//
+// These cache dirs live outside the workspace tree, so workspace GC does not
+// reap them; a TTL/size-cap reaper is tracked as tech-debt in #551. The claude
+// ShellRunner does not use this — it runs unsandboxed, where Go's $HOME-based
+// defaults already work.
+// goToolchainCaches is the single source for the Go cache env vars the worker
+// injects on the codex sandboxed path: GOCACHE is isolated per workspace (build
+// cache, unverified → poisoning vector); GOMODCACHE is shared (subdir only).
+// sandboxEnv reads goCacheNames() from this list to carry the injected defaults
+// through the optional aiops bubblewrap/firejail allowlist.
+var goToolchainCaches = []struct {
+	name         string
+	subdir       string
+	perWorkspace bool
+}{
+	{name: "GOCACHE", subdir: "build", perWorkspace: true},
+	{name: "GOMODCACHE", subdir: "mod", perWorkspace: false},
+}
+
+// aiopsGoCacheRoot is the parent of the worker-injected Go cache dirs.
+func aiopsGoCacheRoot() string { return filepath.Join(os.TempDir(), "aiops-go-cache") }
+
+// isWorkerInjectedGoCache reports whether value is a worker-injected Go cache
+// path (under aiopsGoCacheRoot). sandboxEnv carries only those through its
+// allowlist, never re-exporting an operator's own GOCACHE/GOMODCACHE that the
+// operator intentionally kept out of sandbox.env_allowlist (codex review #548).
+func isWorkerInjectedGoCache(value string) bool {
+	root := aiopsGoCacheRoot()
+	return value == root || strings.HasPrefix(value, root+string(os.PathSeparator))
+}
+
+func withSandboxGoToolchainCaches(env []string, workdir string) []string {
+	root := aiopsGoCacheRoot()
+	for _, c := range goToolchainCaches {
+		if envHasValue(env, c.name) {
+			continue
+		}
+		path := filepath.Join(root, c.subdir)
+		if c.perWorkspace {
+			path = filepath.Join(path, workspaceCacheKey(workdir))
+		}
+		env = append(env, c.name+"="+path)
+	}
+	return env
+}
+
+// goCacheNames returns the names of the Go cache env vars the worker injects, so
+// the aiops sandbox env builder can preserve them past its allowlist.
+func goCacheNames() []string {
+	names := make([]string, len(goToolchainCaches))
+	for i, c := range goToolchainCaches {
+		names[i] = c.name
+	}
+	return names
+}
+
+// workspaceCacheKey is a stable, collision-resistant token for a workspace path
+// so two different repos/issues never share a GOCACHE directory while an issue's
+// own retries (same workspace) reuse theirs. An empty workdir resolves to the
+// worker CWD via filepath.Abs, collapsing all such runs onto one key — harmless
+// because the codex path always supplies a per-issue workspace.
+func workspaceCacheKey(workdir string) string {
+	key := workdir
+	if abs, err := filepath.Abs(workdir); err == nil && abs != "" {
+		key = abs
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+// envHasValue reports whether env already defines name with a NON-EMPTY value.
+// An empty "name=" entry counts as absent so the default still applies — Go
+// treats an empty GOCACHE as unset and falls back to the sandbox-invisible
+// $HOME cache, which is the failure this fixes (codex review #548 P2).
+func envHasValue(env []string, name string) bool {
+	prefix := name + "="
+	for _, kv := range env {
+		if v, ok := strings.CutPrefix(kv, prefix); ok && v != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/go_cache_test.go
+++ b/internal/runner/go_cache_test.go
@@ -1,0 +1,129 @@
+package runner
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestSandboxEnvCarriesWorkerInjectedGoCaches(t *testing.T) {
+	// The aiops sandbox allowlist (PATH only here) must not strip the
+	// worker-injected GOCACHE/GOMODCACHE — else the agent's first `go test`
+	// re-breaks under the optional bubblewrap/firejail wrapper (#548 review).
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	gocache := "GOCACHE=" + filepath.Join(aiopsGoCacheRoot(), "build", "k")
+	gomod := "GOMODCACHE=" + filepath.Join(aiopsGoCacheRoot(), "mod")
+	body := strings.Join(sandboxEnv([]string{"PATH=/login", gocache, gomod}, []string{"PATH"}, workflow.Config{}), "\n")
+	for _, want := range []string{"PATH=/login", gocache, gomod} {
+		if !strings.Contains(body, want) {
+			t.Errorf("sandboxEnv dropped %q from the sandbox env; got:\n%s", want, body)
+		}
+	}
+}
+
+func TestSandboxEnvDoesNotCarryOperatorOrHostGoCaches(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	// A non-codex runner injects nothing -> nothing fabricated from the host env.
+	body := strings.Join(sandboxEnv([]string{"PATH=/login"}, []string{"PATH"}, workflow.Config{}), "\n")
+	if strings.Contains(body, "GOCACHE") {
+		t.Errorf("sandboxEnv fabricated GOCACHE when not worker-injected; got:\n%s", body)
+	}
+	// An operator's own GOCACHE (NOT under aiopsGoCacheRoot) that they kept out
+	// of env_allowlist must NOT be re-exported by the carry-through (#548).
+	body = strings.Join(sandboxEnv([]string{"PATH=/login", "GOCACHE=/operator/cache"}, []string{"PATH"}, workflow.Config{}), "\n")
+	if strings.Contains(body, "GOCACHE=/operator/cache") {
+		t.Errorf("sandboxEnv carried an operator GOCACHE past the allowlist boundary; got:\n%s", body)
+	}
+}
+
+func TestWithSandboxGoToolchainCachesDefaults(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	got := withSandboxGoToolchainCaches([]string{"PATH=/login"}, "/ws/issue-1")
+	base := filepath.Join("/sandbox-tmp", "aiops-go-cache")
+	wantCache := "GOCACHE=" + filepath.Join(base, "build", workspaceCacheKey("/ws/issue-1"))
+	wantMod := "GOMODCACHE=" + filepath.Join(base, "mod") // shared, workspace-independent
+	body := strings.Join(got, "\n")
+	for _, want := range []string{wantCache, wantMod} {
+		if !strings.Contains(body, want) {
+			t.Errorf("withSandboxGoToolchainCaches() missing %q; got:\n%s", want, body)
+		}
+	}
+}
+
+func TestWithSandboxGoToolchainCachesIsolatesGocacheButSharesGomodcache(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	a := goCacheEnv(t, withSandboxGoToolchainCaches(nil, "/ws/repo-a/issue-1"))
+	b := goCacheEnv(t, withSandboxGoToolchainCaches(nil, "/ws/repo-b/issue-1"))
+
+	// GOCACHE (build cache, unverified) is isolated across repos/issues...
+	if a["GOCACHE"] == b["GOCACHE"] {
+		t.Errorf("different workspaces shared a GOCACHE dir: %q", a["GOCACHE"])
+	}
+	// ...but GOMODCACHE (checksum-verified) is shared to avoid re-downloads.
+	if a["GOMODCACHE"] != b["GOMODCACHE"] {
+		t.Errorf("GOMODCACHE not shared across workspaces: %q vs %q", a["GOMODCACHE"], b["GOMODCACHE"])
+	}
+	// An issue's retry (same workspace) reuses its GOCACHE.
+	again := goCacheEnv(t, withSandboxGoToolchainCaches(nil, "/ws/repo-a/issue-1"))
+	if again["GOCACHE"] != a["GOCACHE"] {
+		t.Errorf("same workspace produced a different GOCACHE: %q vs %q", a["GOCACHE"], again["GOCACHE"])
+	}
+}
+
+func TestWithSandboxGoToolchainCachesRespectsOperatorOverride(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	got := goCacheEnv(t, withSandboxGoToolchainCaches([]string{"GOCACHE=/operator/cache"}, "/ws/issue-1"))
+	if got["GOCACHE"] != "/operator/cache" {
+		t.Errorf("operator GOCACHE override = %q; want /operator/cache to win", got["GOCACHE"])
+	}
+	if got["GOMODCACHE"] == "" {
+		t.Errorf("GOMODCACHE default not applied alongside an operator GOCACHE override")
+	}
+}
+
+func TestWithSandboxGoToolchainCachesTreatsEmptyValueAsAbsent(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	// A value-less "GOCACHE=" (e.g. a passthrough of an unset host var) must NOT
+	// suppress the default — Go treats empty GOCACHE as unset and reverts to the
+	// sandbox-invisible $HOME cache, reviving the bug (codex review #548 P2).
+	got := goCacheEnv(t, withSandboxGoToolchainCaches([]string{"GOCACHE="}, "/ws/issue-1"))
+	if got["GOCACHE"] == "" {
+		t.Errorf("empty GOCACHE= suppressed the default; want the sandbox-writable path applied")
+	}
+}
+
+// TestSetupAppServerCommandPinsPerWorkspaceGoCache pins the wiring: the codex
+// app-server command's env must actually carry the per-workspace GOCACHE, so
+// deleting the withSandboxGoToolchainCaches call (helper still passing) is
+// caught here.
+func TestSetupAppServerCommandPinsPerWorkspaceGoCache(t *testing.T) {
+	codexAppServerStubScript(t, "\n") // installs codex stub + login PATH
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	in := appServerInput(codexWorkdir(t, "issue-42"))
+
+	cmd, _, _, err := setupAppServerCommand(context.Background(), in)
+	if err != nil {
+		t.Fatalf("setupAppServerCommand: %v", err)
+	}
+	want := "GOCACHE=" + filepath.Join("/sandbox-tmp", "aiops-go-cache", "build", workspaceCacheKey(in.Workdir))
+	if !strings.Contains(strings.Join(cmd.Env, "\n"), want) {
+		t.Errorf("setupAppServerCommand cmd.Env missing %q; got:\n%s", want, strings.Join(cmd.Env, "\n"))
+	}
+}
+
+// goCacheEnv extracts GOCACHE/GOMODCACHE values from an env slice for assertions.
+func goCacheEnv(t *testing.T, env []string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, kv := range env {
+		for _, name := range []string{"GOCACHE", "GOMODCACHE"} {
+			if v, ok := strings.CutPrefix(kv, name+"="); ok {
+				out[name] = v
+			}
+		}
+	}
+	return out
+}

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -123,6 +123,23 @@ func sandboxEnv(primary []string, allow []string, cfg workflow.Config) []string 
 			env = append(env, name+"="+value)
 		}
 	}
+	// Carry the worker-injected Go toolchain cache defaults (#544) through the
+	// allowlist: setupAppServerCommand sets GOCACHE/GOMODCACHE as agent-runtime
+	// requirements, not operator passthrough, so the operator should not have to
+	// allowlist them for the agent's first `go test` to find a writable cache.
+	// Only WORKER-INJECTED values (under aiopsGoCacheRoot) are carried — an
+	// operator's own GOCACHE/GOMODCACHE that they kept out of env_allowlist still
+	// respects that boundary (codex review #548). The bwrap/firejail tmpfs /tmp
+	// keeps the default writable.
+	for _, name := range goCacheNames() {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		if value, ok := primaryByName[name]; ok && isWorkerInjectedGoCache(value) {
+			seen[name] = struct{}{}
+			env = append(env, name+"="+value)
+		}
+	}
 	return env
 }
 


### PR DESCRIPTION
## What & why

Closes #544.

On a binary deploy with the `codex-app-server` runner under codex's
`workspace-write` sandbox, the agent's first `go test ./...` fails because Go's
default build cache (`$HOME/.cache/go-build`) and module cache
(`$GOPATH/pkg/mod`) are **outside** the sandbox's writable roots — a wasted turn
on every Go workflow until the agent rediscovers a writable `GOCACHE`.

This defaults `GOCACHE`/`GOMODCACHE` to sandbox-writable paths under
`os.TempDir()`, scoped to the **codex app-server (sandboxed) path** only
(`setupAppServerCommand`). The claude `ShellRunner` runs unsandboxed, where the
`$HOME`-based defaults already work, so it is untouched.

### Isolation by trust model (from review)
- **GOCACHE** (build cache, action-ID keyed, not re-verified on reuse) →
  isolated **per workspace** (`.../aiops-go-cache/build/<hash(workdir)>`), so a
  malicious repo can't poison another's build cache; an issue's own retries
  reuse theirs.
- **GOMODCACHE** (module cache, read-only `0444` entries) → **shared**
  (`.../aiops-go-cache/mod`). Sharing rests on the single-operator trust model +
  read-only entries (not cryptographic re-verification), and avoids
  re-downloading the dependency graph on every issue's first turn.

Defaults apply only when the name is **not already set to a non-empty value**, so
an operator `env_passthrough` overrides them and a value-less `GOCACHE=` does not
suppress the default.

## Acceptance criteria (#544)
- [x] Pick one fix and document it — env defaults scoped to the codex sandbox
      path, documented in `internal/runner/go_cache.go`.

## Review history & resolutions
GitHub `@codex` (head `088bbe1`) raised two findings; both fixed in `2eb0822`:
- **P1 (shared cache across runs/repos)** → per-workspace GOCACHE isolation;
  GOMODCACHE shared only because its entries are read-only + same-operator trust.
- **P2 (value-less passthrough suppressed the default)** → default now keyed on
  actual non-empty env presence (`envHasValue`), with a regression test.

Local Claude reviewers additionally drove: scoping to the codex path; sharing
GOMODCACHE (per-workspace would re-download the dep graph each issue); and
filing the unbounded-cache-growth reaper as tracked tech-debt **#551** (with a
chmod-before-remove note for its 0444 entries). The Codex local reviewer
(`codex:codex-rescue`) is unreliable on this AppArmor-restricted host (the #542
bug), so the cloud `@codex` bot is the Codex-family gate.

## Verification
- `gofmt`, `go vet ./...`, `go build`, `go mod tidy`, `go test -race ./...` green.
- 5 regression tests (`internal/runner/go_cache_test.go`): defaults, GOCACHE
  isolation + GOMODCACHE sharing + retry stability, operator override,
  empty-value-as-absent, and the `setupAppServerCommand` **wiring** test.
  **Mutation-verified** against the committed artifact: dropping the wiring call,
  and treating empty-as-present, each make the matching test FAIL; restored →
  green, `git diff HEAD` empty.

### Size gate
- [x] `within budget` — 4 files (`go_cache.go` +`_test`, `codex_app_server.go`
      wiring, `env.go` revert), no `policy.deny_paths` touched.
