### PR TITLE
fix(doctor): probe the host user-namespace capability codex's sandbox needs (#542)

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -86,7 +87,7 @@ func BuildReport(ctx context.Context, opts Options) Report {
 		r.checkLinear(ctx, wf.Config)
 		r.checkCodex(ctx, wf.Config)
 		r.checkGitHubAgent(ctx, wf.Config)
-		r.checkSandbox(wf.Config)
+		r.checkSandbox(ctx, wf.Config)
 	}
 	r.checkDashboard(ctx)
 	if wf != nil && path != "" {
@@ -417,15 +418,136 @@ func (r *reportBuilder) checkCodexModelConfig(home string) {
 	r.pass("Codex model config", detail)
 }
 
-func (r *reportBuilder) checkSandbox(cfg workflow.Config) {
+// effectiveSandboxMode returns the policy the app-server actually applies per
+// turn: the explicit codex.turn_sandbox_policy when set (it overrides
+// thread_sandbox in startTurn), else the thread_sandbox-derived default. Gating
+// must follow the effective policy — e.g. a turn_sandbox_policy override to
+// dangerFullAccess or externalSandbox (with thread_sandbox left at
+// workspace-write) runs agent commands WITHOUT codex's own userns sandbox, so
+// probing would be a false FAIL (codex review #549).
+func effectiveSandboxMode(cfg workflow.Config) string {
+	switch cfg.Codex.TurnSandboxPolicy.Type {
+	case workflow.CodexSandboxDangerFullAccess:
+		return "danger-full-access"
+	case workflow.CodexSandboxExternalSandbox:
+		return "external"
+	case workflow.CodexSandboxReadOnly:
+		return "read-only"
+	case workflow.CodexSandboxWorkspaceWrite:
+		return "workspace-write"
+	}
+	switch cfg.Codex.ThreadSandbox {
+	case "danger-full-access":
+		return "danger-full-access"
+	case "read-only":
+		return "read-only"
+	default:
+		return "workspace-write"
+	}
+}
+
+// codexUsesUserNamespaceSandbox reports whether the effective mode makes codex
+// run agent commands in its own bwrap user-namespace sandbox (read-only or
+// workspace-write). danger-full-access (no sandbox) and external (host-provided
+// isolation; codex skips its own) do not, so the userns probe is moot for them.
+func codexUsesUserNamespaceSandbox(mode string) bool {
+	return mode == "read-only" || mode == "workspace-write"
+}
+
+func (r *reportBuilder) checkSandbox(ctx context.Context, cfg workflow.Config) {
 	if !requiresCodex(cfg) {
 		return
 	}
-	if runningInContainer() && cfg.Codex.ThreadSandbox != "danger-full-access" {
+	mode := effectiveSandboxMode(cfg)
+	if runningInContainerFn() && codexUsesUserNamespaceSandbox(mode) {
 		r.warn("Codex sandbox", "containerized Codex may not support workspace-write namespaces", "Use the documented Docker-isolated profile or enable the required kernel/userns support.")
 		return
 	}
-	r.pass("Codex sandbox", "selected profile is compatible with this preflight")
+	if !codexUsesUserNamespaceSandbox(mode) {
+		r.pass("Codex sandbox", "effective sandbox ("+mode+") runs agent commands without a user-namespace sandbox")
+		return
+	}
+	// The live probe is authoritative only for a real-mode binary deploy on
+	// Linux: codex sandboxes agent shell commands with a bwrap user namespace
+	// there, so a host that blocks unprivileged user namespaces is exactly what
+	// the agent will hit. On macOS codex uses the seatbelt sandbox (no user
+	// namespaces), under --deploy=docker the sandbox runs inside the container
+	// (a different userns policy than this host), and mock mode dispatches
+	// nothing — keep the static classification in those cases.
+	if !r.realMode() || !r.binaryDeploy() || runtime.GOOS != "linux" {
+		r.pass("Codex sandbox", "selected profile is compatible with this preflight")
+		return
+	}
+	r.probeCodexSandbox(ctx, cfg)
+}
+
+// userNamespaceRemediation explains how to restore the host capability codex's
+// bwrap sandbox needs. The safer options lead; the host-wide sysctl is last
+// because it weakens unprivileged user namespaces for every process. Phrased
+// "most commonly" because the probe runs codex's real sandbox and surfaces its
+// actual error, which is authoritative even if the cause is not the AppArmor
+// userns restriction.
+const userNamespaceRemediation = "codex sandboxes agent shell commands in a bubblewrap (bwrap) user namespace, which this host most commonly blocks because unprivileged user namespaces are restricted (Ubuntu 24.04+: kernel.apparmor_restrict_unprivileged_userns=1) — see the codex error above for the exact failure. Prefer: install an AppArmor profile that permits codex's bwrap user namespaces, or run the worker in a container that allows them, or set codex.thread_sandbox: danger-full-access only in an already-isolated environment. Last resort (weakens host security — re-enables unprivileged user namespaces process-wide): `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`, persisted via /etc/sysctl.d/99-userns.conf."
+
+// probeCodexSandbox runs a trivial command through codex's OWN sandbox
+// (`codex sandbox -- /bin/true`) so a host where codex cannot start a sandboxed
+// command fails preflight instead of after a full agent turn is dispatched and
+// tokens burned. The static check passes even when
+// kernel.apparmor_restrict_unprivileged_userns=1 blocks codex's bwrap, so every
+// agent command then dies at runtime (e.g. "bwrap: setting up uid map:
+// Permission denied") (#542).
+//
+// This drives codex's vendored bwrap with codex's exact flags — not a
+// hand-rolled system-bwrap proxy — so it is authoritative: it reproduces the
+// real failure mode (uid-map, netns, or an AppArmor profile that covers a
+// different binary path), which a system-bwrap proxy can miss (codex review
+// #549). codex 0.135's `sandbox` subcommand does not forward the root
+// `--sandbox` option, so the probe takes no mode argument; its default
+// sandboxed mode uses the same bwrap user namespace every sandboxed profile
+// needs, and checkSandbox has already skipped the only unsandboxed profile
+// (effective danger-full-access) before reaching here (codex review #549).
+// /bin/true needs no model turn, auth, or network. Routed through r.run so the
+// probe is unit-testable. A custom codex.command can't be assumed to support
+// `codex sandbox`, so it is WARN.
+func (r *reportBuilder) probeCodexSandbox(ctx context.Context, cfg workflow.Config) {
+	if !usesDefaultCodexCLI(cfg) {
+		r.warn("Codex sandbox", "custom codex.command: skipped the codex sandbox self-test",
+			"Verify the wrapper sandboxes agent commands, e.g. `codex sandbox -- /bin/true`.")
+		return
+	}
+	out, err := r.run(ctx, "codex", []string{"sandbox", "--", "/bin/true"})
+	detail := trimOutput(out, err)
+	switch {
+	case err == nil:
+		r.pass("Codex sandbox", "codex sandbox started a command on this host")
+	case errors.Is(err, exec.ErrNotFound):
+		r.warn("Codex sandbox", "codex not found on PATH; cannot run the codex sandbox self-test",
+			"Install Codex CLI on this host, then rerun worker --doctor --deploy=binary --mode=real.")
+	case errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled):
+		// A slow codex cold-start (not a sandbox denial) should not block
+		// preflight with a misleading userns remediation.
+		r.warn("Codex sandbox", "codex sandbox self-test timed out before completing; could not determine sandbox health",
+			"Re-run worker --doctor; if it persists, check codex startup time on this host.")
+	case codexLacksSandboxSubcommand(detail):
+		// An older/forked codex without `codex sandbox` is a version problem,
+		// not a host userns problem — warn to upgrade rather than FAIL.
+		r.warn("Codex sandbox", "this codex build does not support `codex sandbox`; cannot self-test the sandbox: "+detail,
+			"Upgrade Codex CLI to a build with the `sandbox` subcommand, or verify the sandbox manually: codex sandbox -- /bin/true.")
+	default:
+		r.fail("Codex sandbox", "codex sandbox cannot start commands: "+detail, userNamespaceRemediation)
+	}
+}
+
+// codexLacksSandboxSubcommand reports whether codex's output is a CLI usage
+// error for an unrecognized `sandbox` subcommand (an older/forked codex) rather
+// than a real sandbox-startup failure, so a version mismatch warns (upgrade
+// codex) instead of FAILing with the userns remediation.
+func codexLacksSandboxSubcommand(out string) bool {
+	out = strings.ToLower(out)
+	return strings.Contains(out, "unrecognized subcommand") ||
+		strings.Contains(out, "no such subcommand") ||
+		strings.Contains(out, "unknown command") ||
+		(strings.Contains(out, "unexpected argument") && strings.Contains(out, "sandbox"))
 }
 
 func (r *reportBuilder) checkGitHubAgent(ctx context.Context, cfg workflow.Config) {
@@ -1149,6 +1271,11 @@ func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }
+
+// runningInContainerFn is a seam so unit tests that construct a reportBuilder
+// and call checkSandbox directly are not skewed by the host's container markers
+// (the container branch precedes the mode/deploy/probe branches).
+var runningInContainerFn = runningInContainer
 
 func runningInContainer() bool {
 	return fileExists("/.dockerenv") || fileExists("/run/.containerenv")

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -87,6 +89,313 @@ func TestBuildReportRealModeAuthenticatesServiceLinearProject(t *testing.T) {
 	}
 	if len(gotSlugs) != 1 || gotSlugs[0] != "api-platform" {
 		t.Fatalf("Linear probe project slugs = %#v; want service project slug only", gotSlugs)
+	}
+}
+
+// codexSandboxCfg is a minimal codex-app-server workflow config with the given
+// thread sandbox, for the checkSandbox user-namespace probe tests (#542).
+func codexSandboxCfg(threadSandbox string) workflow.Config {
+	return workflow.Config{
+		Agent: workflow.AgentConfig{Default: "codex-app-server"},
+		Codex: workflow.CommandConfig{ThreadSandbox: threadSandbox},
+	}
+}
+
+// sandboxProbeRunner answers the `codex sandbox` self-test with out/err,
+// records whether codex was invoked (so a test can assert the probe was
+// skipped), and captures its argv into gotArgs (nil to ignore) so a test can
+// assert the load-bearing probe args survive refactors. Any other command is
+// unexpected on this path.
+func sandboxProbeRunner(out []byte, err error, called *bool, gotArgs *[]string) CommandRunner {
+	return func(_ context.Context, name string, args []string, _ []string, _ io.Reader) ([]byte, error) {
+		if name == "codex" {
+			*called = true
+			if gotArgs != nil {
+				*gotArgs = args
+			}
+			return out, err
+		}
+		return nil, fmt.Errorf("unexpected command %q", name)
+	}
+}
+
+// assertCodexSandboxProbeArgs pins the exact load-bearing invocation (the
+// validated `--sandbox <mode>` selecting the configured profile, the `sandbox`
+// subcommand, the `--` separator, and `/bin/true`) so a weaker probe — omitting
+// the mode, dropping `--`, reordering — is caught by tests.
+func assertCodexSandboxProbeArgs(t *testing.T, args []string) {
+	t.Helper()
+	want := []string{"sandbox", "--", "/bin/true"}
+	if !slices.Equal(args, want) {
+		t.Errorf("codex sandbox probe args = %v; want %v", args, want)
+	}
+}
+
+// noContainer pins runningInContainerFn to false so a checkSandbox unit test is
+// not skewed by the host's container markers (the container branch precedes the
+// mode/deploy/probe branches).
+func noContainer(t *testing.T) {
+	t.Helper()
+	old := runningInContainerFn
+	runningInContainerFn = func() bool { return false }
+	t.Cleanup(func() { runningInContainerFn = old })
+}
+
+// requireLinuxProbe skips a test that depends on the live probe running, which
+// happens only on a Linux binary deploy (codex sandboxes agent commands with
+// bwrap user namespaces there; macOS uses seatbelt).
+func requireLinuxProbe(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skipf("codex sandbox probe runs only on linux; GOOS=%s", runtime.GOOS)
+	}
+}
+
+func TestCheckSandboxWarnsInContainer(t *testing.T) {
+	old := runningInContainerFn
+	runningInContainerFn = func() bool { return true }
+	t.Cleanup(func() { runningInContainerFn = old })
+	var called bool
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, nil)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	if called {
+		t.Fatal("checkSandbox ran the host probe inside a container; the container branch must short-circuit first")
+	}
+	if c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox"); c.Status != Warn {
+		t.Errorf("checkSandbox(container) status = %s; want WARN", c.Status)
+	}
+}
+
+func TestCheckSandboxBinaryRealFailsWhenUserNamespaceBlocked(t *testing.T) {
+	requireLinuxProbe(t)
+	noContainer(t)
+	var called bool
+	var args []string
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte("bwrap: setting up uid map: Permission denied\n"), errors.New("exit status 1"), &called, &args)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	if !called {
+		t.Fatal("checkSandbox(real,binary) did not run the codex sandbox probe")
+	}
+	assertCodexSandboxProbeArgs(t, args)
+	c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox")
+	if c.Status != Fail {
+		t.Errorf("checkSandbox(real,binary,userns-blocked) status = %s; want FAIL", c.Status)
+	}
+	if !strings.Contains(c.Detail, "uid map") {
+		t.Errorf("detail = %q; want codex's sandbox error surfaced", c.Detail)
+	}
+	if !strings.Contains(c.Fix, "apparmor_restrict_unprivileged_userns") {
+		t.Errorf("fix = %q; want the AppArmor unprivileged-userns remediation", c.Fix)
+	}
+}
+
+func TestCheckSandboxBinaryRealPassesWhenSandboxStarts(t *testing.T) {
+	requireLinuxProbe(t)
+	noContainer(t)
+	var called bool
+	var args []string
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, &args)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	if !called {
+		t.Fatal("checkSandbox(real,binary) did not run the codex sandbox probe")
+	}
+	assertCodexSandboxProbeArgs(t, args)
+	c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox")
+	if c.Status != Pass {
+		t.Errorf("checkSandbox(real,binary,sandbox-ok) status = %s; want PASS (detail=%q)", c.Status, c.Detail)
+	}
+	if !strings.Contains(c.Detail, "codex sandbox") {
+		t.Errorf("detail = %q; want it to confirm codex sandbox started a command", c.Detail)
+	}
+}
+
+// TestCheckSandboxFailsAuthoritativelyOnNonUidmapError pins that probing codex's
+// REAL sandbox is authoritative: a failure that is NOT the uid-map message (e.g.
+// the netns/loopback denial that the same AppArmor restriction surfaces) is
+// still a hard FAIL, because the agent will hit it too — no false-PASS, and no
+// signature guessing.
+func TestCheckSandboxFailsAuthoritativelyOnNonUidmapError(t *testing.T) {
+	requireLinuxProbe(t)
+	noContainer(t)
+	var called bool
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte("bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted\n"), errors.New("exit status 1"), &called, nil)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox")
+	if c.Status != Fail {
+		t.Errorf("checkSandbox(real,binary,non-uidmap-error) status = %s; want FAIL (codex sandbox is authoritative)", c.Status)
+	}
+	if !strings.Contains(c.Detail, "RTM_NEWADDR") {
+		t.Errorf("detail = %q; want codex's actual sandbox error surfaced", c.Detail)
+	}
+}
+
+func TestCheckSandboxWarnsOnProbeTimeout(t *testing.T) {
+	requireLinuxProbe(t)
+	noContainer(t)
+	// A slow codex cold-start (context deadline) is not a sandbox denial — it
+	// must WARN, not FAIL with the userns remediation.
+	var called bool
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner(nil, context.DeadlineExceeded, &called, nil)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox")
+	if c.Status != Warn {
+		t.Errorf("checkSandbox(real,binary,probe-timeout) status = %s; want WARN", c.Status)
+	}
+	if strings.Contains(c.Fix, "apparmor_restrict_unprivileged_userns") {
+		t.Errorf("fix = %q; a probe timeout must not assert the userns cause", c.Fix)
+	}
+}
+
+func TestCheckSandboxWarnsWhenCodexLacksSandboxSubcommand(t *testing.T) {
+	requireLinuxProbe(t)
+	noContainer(t)
+	// An older codex that does not know `codex sandbox` is a version problem,
+	// not a host userns problem — WARN to upgrade, do not FAIL.
+	var called bool
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte("error: unrecognized subcommand 'sandbox'\n"), errors.New("exit status 2"), &called, nil)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox")
+	if c.Status != Warn {
+		t.Errorf("checkSandbox(real,binary,no-sandbox-subcommand) status = %s; want WARN", c.Status)
+	}
+	if !strings.Contains(c.Fix, "Upgrade") {
+		t.Errorf("fix = %q; want an upgrade hint", c.Fix)
+	}
+}
+
+func TestCheckSandboxBinaryRealWarnsWhenCodexMissing(t *testing.T) {
+	requireLinuxProbe(t)
+	noContainer(t)
+	var called bool
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner(nil, &exec.Error{Name: "codex", Err: exec.ErrNotFound}, &called, nil)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox")
+	if c.Status != Warn {
+		t.Errorf("checkSandbox(real,binary,codex-missing) status = %s; want WARN", c.Status)
+	}
+	if !strings.Contains(c.Detail, "codex not found") {
+		t.Errorf("detail = %q; want it to note codex could not be run", c.Detail)
+	}
+}
+
+func TestCheckSandboxWarnsForCustomCodexCommand(t *testing.T) {
+	requireLinuxProbe(t)
+	noContainer(t)
+	var called bool
+	cfg := codexSandboxCfg("workspace-write")
+	cfg.Codex.Command = "/opt/mycodex app-server" // custom wrapper, not bare codex
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, nil)}}
+	r.checkSandbox(context.Background(), cfg)
+	if called {
+		t.Fatal("checkSandbox ran `codex sandbox` for a custom codex.command; cannot assume the wrapper supports it")
+	}
+	if c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox"); c.Status != Warn {
+		t.Errorf("checkSandbox(custom codex.command) status = %s; want WARN", c.Status)
+	}
+}
+
+func TestCheckSandboxSkipsProbeWhenTurnPolicyOverridesToFullAccess(t *testing.T) {
+	noContainer(t)
+	// thread_sandbox stays workspace-write, but an explicit turn_sandbox_policy
+	// override to dangerFullAccess means the agent's turns run unsandboxed — the
+	// probe must follow the effective policy and skip, not false-FAIL (#549).
+	var called bool
+	cfg := codexSandboxCfg("workspace-write")
+	cfg.Codex.TurnSandboxPolicy = workflow.CodexSandboxPolicy{Type: workflow.CodexSandboxDangerFullAccess}
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, nil)}}
+	r.checkSandbox(context.Background(), cfg)
+	if called {
+		t.Fatal("checkSandbox ran the probe though turn_sandbox_policy overrides to danger-full-access")
+	}
+	if c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox"); c.Status != Pass {
+		t.Errorf("checkSandbox(turn-policy=dangerFullAccess) status = %s; want PASS", c.Status)
+	}
+}
+
+func TestCheckSandboxSkipsProbeForExternalSandbox(t *testing.T) {
+	noContainer(t)
+	// turn_sandbox_policy: externalSandbox means codex skips its own bwrap
+	// (host-provided isolation), so the userns probe is moot — skip, don't FAIL.
+	var called bool
+	cfg := codexSandboxCfg("workspace-write")
+	cfg.Codex.TurnSandboxPolicy = workflow.CodexSandboxPolicy{Type: workflow.CodexSandboxExternalSandbox}
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, nil)}}
+	r.checkSandbox(context.Background(), cfg)
+	if called {
+		t.Fatal("checkSandbox ran the probe for externalSandbox (codex runs no userns sandbox)")
+	}
+	if c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox"); c.Status != Pass {
+		t.Errorf("checkSandbox(externalSandbox) status = %s; want PASS", c.Status)
+	}
+}
+
+func TestCheckSandboxProbesEffectiveReadOnlyTurnPolicy(t *testing.T) {
+	requireLinuxProbe(t)
+	noContainer(t)
+	// read-only is still a sandboxed (bwrap-userns) profile, so the probe runs;
+	// the codex sandbox subcommand ignores a passed mode, so no mode arg.
+	var args []string
+	var called bool
+	cfg := codexSandboxCfg("workspace-write")
+	cfg.Codex.TurnSandboxPolicy = workflow.CodexSandboxPolicy{Type: workflow.CodexSandboxReadOnly}
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, &args)}}
+	r.checkSandbox(context.Background(), cfg)
+	if !called {
+		t.Fatal("checkSandbox(read-only effective) did not run the probe")
+	}
+	assertCodexSandboxProbeArgs(t, args)
+}
+
+func TestCheckSandboxSkipsProbeInMockMode(t *testing.T) {
+	noContainer(t)
+	var called bool
+	r := &reportBuilder{opts: Options{Mode: "mock", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, nil)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	if called {
+		t.Fatal("checkSandbox(mock) ran the codex sandbox probe; mock mode must keep the static check")
+	}
+	if c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox"); c.Status != Pass {
+		t.Errorf("checkSandbox(mock) status = %s; want static PASS", c.Status)
+	}
+}
+
+func TestCheckSandboxSkipsProbeForDockerDeploy(t *testing.T) {
+	noContainer(t)
+	var called bool
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "docker",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, nil)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("workspace-write"))
+	if called {
+		t.Fatal("checkSandbox(real,docker) ran the host probe; it is not authoritative for a container deploy")
+	}
+	if c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox"); c.Status != Pass {
+		t.Errorf("checkSandbox(real,docker) status = %s; want static PASS", c.Status)
+	}
+}
+
+func TestCheckSandboxDangerFullAccessSkipsProbe(t *testing.T) {
+	noContainer(t)
+	var called bool
+	r := &reportBuilder{opts: Options{Mode: "real", Deploy: "binary",
+		Runner: sandboxProbeRunner([]byte(""), nil, &called, nil)}}
+	r.checkSandbox(context.Background(), codexSandboxCfg("danger-full-access"))
+	if called {
+		t.Fatal("checkSandbox(danger-full-access) ran the probe; that profile has no userns sandbox")
+	}
+	if c := findCheck(t, Report{Checks: r.checks}, "Codex sandbox"); c.Status != Pass {
+		t.Errorf("checkSandbox(danger-full-access) status = %s; want PASS", c.Status)
 	}
 }
 


### PR DESCRIPTION
## What & why

Closes #542.

`worker --doctor --deploy=binary --mode=real` printed `Codex sandbox: selected
profile is compatible` from a **static** check that never exercised codex's
sandbox. On Ubuntu 24.04+ (`kernel.apparmor_restrict_unprivileged_userns=1`)
codex's bwrap sandbox for the agent's shell commands then failed **every**
command at runtime — after a full agent turn was dispatched and tokens burned,
re-dispatched every poll.

This makes the check **self-test codex's own sandbox**: `codex sandbox -- /bin/true`.

### Why `codex sandbox` (not a hand-rolled bwrap probe)
codex 0.135 ships its **own vendored bwrap** with its own flags. A system-`bwrap`
proxy can diverge from codex's real behavior — verified on a restricted host:
`codex sandbox` fails at `bwrap: loopback: Failed RTM_NEWADDR: Operation not
permitted` (a netns stage), a *different* failure than a raw
`bwrap --unshare-user` uid-map error. And AppArmor userns profiles are keyed by
binary **path**, so the "install an AppArmor profile" remediation only helps if
the probe tests codex's actual binary. Driving `codex sandbox` is therefore
**authoritative** (codex review #549). `/bin/true` needs no model turn, auth, or
network.

### Outcomes
| result | status |
| --- | --- |
| codex sandbox started the command | PASS |
| codex sandbox failed (any cause) | FAIL — codex's error surfaced + safer-options-first remediation |
| codex absent from PATH | WARN |
| custom `codex.command` | WARN (can't assume `codex sandbox`) |

Gated to **real + `--deploy=binary` + linux**: macOS codex uses seatbelt,
`--deploy=docker` sandboxes in-container, mock dispatches nothing.

## Acceptance criteria (#542)
- [x] Doctor (real, codex path) actually executes a command through the sandbox
      the runner uses, and FAILs with a remediation hint.
- [ ] Secondary "avoid hot re-dispatch on recurring sandbox-startup error" —
      **deferred** to **#550** (reconcile/retry path; overlaps #543).

## Review history
GitHub `@codex` (head `c4495a2`) raised P2 "probe the Codex bwrap path, not PATH
bwrap" — fixed in `6680a3a` by switching to `codex sandbox` (authoritative).
Earlier local dual-review rounds drove: Linux gate (macOS seatbelt), real-binary
gating, and surfacing codex's actual error. `codex:codex-rescue` is unreliable
on this AppArmor-restricted host (the #542 bug itself), so the cloud `@codex` bot
is the Codex-family gate.

## Verification
- `gofmt`, `go vet ./...`, `go build`, `go test -race ./internal/doctor` green.
- 8 regression tests (`TestCheckSandbox*`): blocked→FAIL, starts→PASS,
  non-uid-map error→FAIL (authoritative), codex-missing→WARN,
  custom-command→WARN, and mock/docker/danger skip the probe. The probe args
  (`codex sandbox -- /bin/true`) are pinned. **Mutation-verified** against the
  committed artifact (FAIL→WARN flips the FAIL tests; restored → green).

### Size gate
- [x] `within budget` — 2 files (`internal/doctor/{doctor,doctor_test}.go`).
