### PR TITLE
fix(orchestrator): record an agent-handoff reconcile-cancel as stopped, not runner failed (#543)

### DIFF
--- a/internal/orchestrator/actor_cleanup.go
+++ b/internal/orchestrator/actor_cleanup.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 )
 
 // beginReconcileWorkspaceCleanup atomically reserves issue id for an
@@ -97,7 +98,10 @@ func (o *Orchestrator) reconcileCancelFollowup(cancelEntries []*RunningEntry, cl
 	return func() {
 		for _, entry := range cancelEntries {
 			if entry.CancelWorker != nil {
-				entry.CancelWorker()
+				// Cause = ErrReconcileCancel so the worker records this as a
+				// supervised stop (runner_stopped), not a runner failure, and
+				// keeps the agent's RUN_SUMMARY.md (#543).
+				entry.CancelWorker(worker.ErrReconcileCancel)
 			}
 		}
 		for _, c := range cleanups {

--- a/internal/orchestrator/actor_dispatch.go
+++ b/internal/orchestrator/actor_dispatch.go
@@ -169,7 +169,7 @@ func resolveDispatchClaim(st *OrchestratorState, id IssueID, trackerRechecked bo
 // spawn is invoked from a followup goroutine, never from inside an
 // apply method, so its calls into o.submit are safe.
 func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, continuationAttempt int) {
-	runCtx, cancel := context.WithCancel(o.runCtx)
+	runCtx, cancel := context.WithCancelCause(o.runCtx)
 	startedAt := time.Now()
 	workerDone := make(chan struct{})
 	entry := &RunningEntry{
@@ -188,14 +188,14 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 		close(registered)
 		return nil
 	})); err != nil {
-		cancel()
+		cancel(nil)
 		close(workerDone)
 		return
 	}
 	select {
 	case <-registered:
 	case <-o.runCtx.Done():
-		cancel()
+		cancel(nil)
 		close(workerDone)
 		return
 	}
@@ -205,7 +205,7 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 		var res WorkerResult
 		select {
 		case r, ok := <-resultCh:
-			cancel()
+			cancel(nil)
 			if ok {
 				res = r
 			} else {
@@ -215,7 +215,7 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 				res = WorkerResult{Err: context.Canceled, Elapsed: time.Since(startedAt)}
 			}
 		case <-o.runCtx.Done():
-			cancel()
+			cancel(nil)
 			close(workerDone)
 			return
 		}

--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -8,6 +8,7 @@ package orchestrator
 
 import (
 	"context"
+	"log"
 	"strings"
 	"time"
 
@@ -285,7 +286,10 @@ func (r *reconcileStalledRunsOp) cancelStalledFollowup(canceled []*RunningEntry)
 	return func() {
 		for _, entry := range canceled {
 			if entry.CancelWorker != nil {
-				entry.CancelWorker()
+				// A stall cancel is a genuine failure (the run is stuck), not an
+				// eligibility stop, so it carries no ErrReconcileCancel cause and
+				// keeps its existing failure classification (#543).
+				entry.CancelWorker(nil)
 			}
 		}
 		if r.result != nil {
@@ -355,7 +359,12 @@ func (r *reconcileTrackerIssuesOp) reconcileActiveRun(st *OrchestratorState, id 
 	}
 	st.ReleaseClaim(id)
 	run.ReconcileCancel = true
+	fromState := run.Issue.State
 	r.flagTerminalRunCleanup(run, id)
+	// Log the stop reason at the reconcile site so an operator sees why the run
+	// was cancelled (otherwise only a bare "context canceled" surfaces). #543.
+	log.Printf("event=reconcile_stopping_run issue_id=%s issue_identifier=%s reason=state_left_active from=%q to=%q",
+		id, run.Identifier, fromState, run.Issue.State)
 	return run
 }
 

--- a/internal/orchestrator/actor_reconcile_ops_test.go
+++ b/internal/orchestrator/actor_reconcile_ops_test.go
@@ -95,7 +95,7 @@ func TestReconcileStalledRunsOpTimingReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			st := NewOrchestratorState(15000, 10)
-			st.Running[IssueID("S")] = &RunningEntry{Identifier: "S", LastEventAt: tt.last, StartedAt: tt.started, CancelWorker: func() {}}
+			st.Running[IssueID("S")] = &RunningEntry{Identifier: "S", LastEventAt: tt.last, StartedAt: tt.started, CancelWorker: func(error) {}}
 			result := make(chan []*RunningEntry, 1)
 			op := &reconcileStalledRunsOp{timeout: time.Minute, now: now, result: result}
 			op.apply(st)()

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -142,7 +142,11 @@ type RunningEntry struct {
 	InputRequiredAt     time.Time
 	InputRequiredMethod string
 
-	CancelWorker context.CancelFunc
+	// CancelWorker cancels the run's context. The cause distinguishes a
+	// supervised eligibility stop (worker.ErrReconcileCancel — the worker then
+	// records runner_stopped, not runner_failed, #543) from a stall/shutdown
+	// cancel (nil cause), which keep their existing classification.
+	CancelWorker context.CancelCauseFunc
 	Done         <-chan struct{}
 
 	// ReconcileCancel is set by per-tick reconciliation before it cancels a

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -22,7 +22,7 @@ func issue(id string) tracker.Issue {
 
 func runningEntry(t *testing.T, iss tracker.Issue) *RunningEntry {
 	t.Helper()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancelCause(context.Background())
 	done := make(chan struct{})
 	return &RunningEntry{
 		Issue:        iss,

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -76,13 +76,18 @@ const (
 	EventOtherMessage     = "other_message"
 	EventMalformed        = "malformed"
 
-	EventEnqueued                = "enqueued"
-	EventClaimed                 = "claimed"
-	EventWorkflowResolved        = "workflow_resolved"
-	EventWorkspaceHookStart      = "hook_start"
-	EventWorkspaceHookEnd        = "hook_end"
-	EventRunnerStart             = "runner_start"
-	EventRunnerEnd               = "runner_end"
+	EventEnqueued           = "enqueued"
+	EventClaimed            = "claimed"
+	EventWorkflowResolved   = "workflow_resolved"
+	EventWorkspaceHookStart = "hook_start"
+	EventWorkspaceHookEnd   = "hook_end"
+	EventRunnerStart        = "runner_start"
+	EventRunnerEnd          = "runner_end"
+	// EventRunnerStopped marks a run the orchestrator stopped because its
+	// tracker issue left the active set (eligibility reconcile / agent PR
+	// handoff), distinct from runner_end's success/failure so it is not counted
+	// as either (SPEC §7.3 supervised stop; #543).
+	EventRunnerStopped           = "runner_stopped"
 	EventRunnerTimeout           = "runner_timeout"
 	EventStalled                 = "stalled"
 	EventAnalysisOnlyViolation   = "analysis_only_violation"

--- a/internal/worker/reconcile_cancel.go
+++ b/internal/worker/reconcile_cancel.go
@@ -1,0 +1,32 @@
+package worker
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrReconcileCancel is the cancellation cause the orchestrator attaches when
+// per-tick eligibility reconciliation stops a run whose tracker issue left the
+// active set — e.g. the agent's own PR handoff moved the issue to In Review.
+// The worker detects it via context.Cause so it classifies the stop as a
+// superseded run (PhaseCanceledByReconciliation, runner_stopped) rather than a
+// runner failure, and preserves the agent's .aiops/RUN_SUMMARY.md (#543).
+//
+// It is deliberately distinct from a stall cancel or a shutdown cancel, which
+// the orchestrator triggers without this cause and which keep their existing
+// failure/cancel classification.
+var ErrReconcileCancel = errors.New("run stopped: tracker issue left the active set")
+
+// isReconcileCancel reports whether a failed run was stopped by an eligibility
+// reconcile. The authoritative signal is the run context's cancellation CAUSE
+// (ErrReconcileCancel), not the runner's error value: the codex app-server
+// returns context.Canceled, but the claude ShellRunner surfaces a killed
+// subprocess as a bare exec error ("signal: terminated"), so keying on
+// context.Canceled would miss it. A genuine local timeout (DeadlineExceeded) is
+// excluded — it is classified by the timeout branch — as is a nil error.
+func isReconcileCancel(ctx context.Context, err error) bool {
+	if err == nil || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return errors.Is(context.Cause(ctx), ErrReconcileCancel)
+}

--- a/internal/worker/reconcile_cancel_test.go
+++ b/internal/worker/reconcile_cancel_test.go
@@ -1,0 +1,146 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// summaryThenCancelRunner writes the agent's RUN_SUMMARY.md (as a successful
+// handoff would) and then returns context.Canceled, simulating the agent being
+// cut off by an eligibility reconcile-cancel after it finished its work.
+type summaryThenCancelRunner struct{ summary string }
+
+func (r summaryThenCancelRunner) Run(_ context.Context, in runner.RunInput) (runner.Result, error) {
+	dir := filepath.Join(in.Workdir, ".aiops")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return runner.Result{}, err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "RUN_SUMMARY.md"), []byte(r.summary), 0o644); err != nil {
+		return runner.Result{}, err
+	}
+	return runner.Result{}, context.Canceled
+}
+
+// TestRunAgentPreservesRunSummaryOnReconcileCancel pins the #543 headline fix:
+// on an eligibility reconcile-cancel the worker must NOT overwrite the agent's
+// RUN_SUMMARY.md with a "runner failed" artifact (the artifact-skip wiring, a
+// separate path from the event classification).
+func TestRunAgentPreservesRunSummaryOnReconcileCancel(t *testing.T) {
+	const agentSummary = "# Run summary\n\nagent handoff: opened draft PR, moved issue to In Review.\n"
+	oldNew := newRunner
+	newRunner = func(string) (runner.Runner, error) { return summaryThenCancelRunner{summary: agentSummary}, nil }
+	t.Cleanup(func() { newRunner = oldNew })
+
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(ErrReconcileCancel)
+	rs := &runState{
+		ctx: ctx, ev: &fakeEmitter{}, t: task.Task{ID: "tsk", Model: "x"}, cfg: Config{},
+		wf: &workflow.Workflow{}, wcfg: workflow.Config{},
+		workdir: dir, workspaceRoot: filepath.Dir(dir),
+	}
+
+	rtErr := rs.runAgent()
+	if rtErr == nil || !errors.Is(rtErr.Err, context.Canceled) {
+		t.Fatalf("runAgent() = %v; want a RunTaskError wrapping context.Canceled", rtErr)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".aiops", "RUN_SUMMARY.md"))
+	if err != nil {
+		t.Fatalf("RUN_SUMMARY.md missing after reconcile cancel: %v", err)
+	}
+	if !strings.Contains(string(got), "agent handoff") {
+		t.Errorf("RUN_SUMMARY.md = %q; want the agent's summary preserved", got)
+	}
+	if strings.Contains(string(got), "runner failed") {
+		t.Errorf("RUN_SUMMARY.md was overwritten with a runner-failed artifact: %q", got)
+	}
+}
+
+func TestIsReconcileCancel(t *testing.T) {
+	reconcile := func() context.Context {
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(ErrReconcileCancel)
+		return ctx
+	}
+	genericCause := func() context.Context {
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(nil) // shutdown-style cancel: no reconcile cause
+		return ctx
+	}
+	plainCancel := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{"reconcile cancel, codex context.Canceled", reconcile(), context.Canceled, true},
+		{"reconcile cancel, claude shell killed error", reconcile(), errors.New("signal: terminated"), true},
+		{"generic (shutdown) cancel", genericCause(), context.Canceled, false},
+		{"plain cancel, no cause", plainCancel(), context.Canceled, false},
+		{"deadline excluded even under reconcile ctx", reconcile(), context.DeadlineExceeded, false},
+		{"nil error", reconcile(), nil, false},
+		{"live ctx, canceled err but ctx not reconcile-canceled", context.Background(), context.Canceled, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isReconcileCancel(tt.ctx, tt.err); got != tt.want {
+				t.Errorf("isReconcileCancel(%s) = %v; want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunRunnerWithTimeoutReconcileCancelRecordsStopped pins the #543 fix: an
+// eligibility reconcile-cancel (ctx canceled with ErrReconcileCancel, runner
+// returns context.Canceled) is recorded as a supervised stop (runner_stopped,
+// ok=true, reason=reconcile_ineligible, phase CanceledByReconciliation), NOT as
+// a runner failure (runner_end "runner failed").
+func TestRunRunnerWithTimeoutReconcileCancelRecordsStopped(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(ErrReconcileCancel) // the orchestrator's eligibility stop
+	em := &fakeEmitter{}
+
+	_, err := RunRunnerWithTimeout(ctx, em, runner.MockRunner{Sleep: time.Second},
+		runner.RunInput{Task: task.Task{ID: "tsk", Model: "mock"}, Workflow: workflow.Workflow{}, Workdir: t.TempDir()},
+		time.Minute, "test")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunRunnerWithTimeout() err = %v; want context.Canceled", err)
+	}
+
+	stopped := em.byKind(task.EventRunnerStopped)
+	if len(stopped) != 1 {
+		t.Fatalf("runner_stopped events = %d; want 1", len(stopped))
+	}
+	payload, ok := stopped[0].Payload.(map[string]any)
+	if !ok || payload["ok"] != true || payload["reason"] != "reconcile_ineligible" {
+		t.Errorf("runner_stopped payload = %#v; want ok=true reason=reconcile_ineligible", stopped[0].Payload)
+	}
+	for _, e := range em.byKind(task.EventRunnerEnd) {
+		if e.Message == "runner failed" {
+			t.Errorf("emitted runner_end %q for a reconcile cancel; want runner_stopped only", e.Message)
+		}
+	}
+	sawPhase := false
+	for _, e := range em.byKind(task.EventRunPhaseTransition) {
+		if e.Message == string(task.PhaseCanceledByReconciliation) {
+			sawPhase = true
+		}
+	}
+	if !sawPhase {
+		t.Errorf("no phase transition to %s among %d transitions", task.PhaseCanceledByReconciliation, len(em.byKind(task.EventRunPhaseTransition)))
+	}
+}

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -327,9 +327,14 @@ func (rs *runState) buildPrompt() *RunTaskError {
 
 // runAgent resets stale post-run artifacts so the gates cannot pass on leftover
 // files, runs the before_run hook, invokes the runner under its timeout, and
+// newRunner constructs the runner for a model. It is a package var so tests can
+// inject a runner that returns context.Canceled to exercise the reconcile-cancel
+// artifact-skip path (#543) without standing up a real agent subprocess.
+var newRunner = runner.New
+
 // runs the after_run hook on both the success and failure paths.
 func (rs *runState) runAgent() *RunTaskError {
-	r, err := runner.New(rs.t.Model)
+	r, err := newRunner(rs.t.Model)
 	if err != nil {
 		return &RunTaskError{Cfg: rs.wcfg, Err: err}
 	}
@@ -354,7 +359,13 @@ func (rs *runState) runAgent() *RunTaskError {
 		if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterRun, rs.hooks.AfterRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
 			LogIssueSessionEventf(rs.t, rs.sessionID, "after_run_hook_failed", "after_runner_error=true error=%q", err)
 		}
-		WriteFailureArtifacts(rs.ctx, rs.workdir, nil, "runner failed: "+ErrSummary(runErr))
+		// An eligibility reconcile-cancel is a supervised stop, not a runner
+		// failure: leave the agent's RUN_SUMMARY.md intact so the worker does
+		// not overwrite a successful handoff with "runner failed" (#543). The
+		// orchestrator releases the run via its ReconcileCancel flag.
+		if !isReconcileCancel(rs.ctx, runErr) {
+			WriteFailureArtifacts(rs.ctx, rs.workdir, nil, "runner failed: "+ErrSummary(runErr))
+		}
 		return &RunTaskError{Cfg: rs.wcfg, Err: runErr}
 	}
 
@@ -639,6 +650,23 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 			}
 			addOutputFields(timeoutPayload, res)
 			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, te.Error(), timeoutPayload)
+			return res, runErr
+		}
+		if isReconcileCancel(ctx, runErr) {
+			// The orchestrator stopped this run because its tracker issue left
+			// the active set (e.g. the agent's own PR handoff to In Review).
+			// That is a supervised stop, not a runner failure: record it as
+			// stopped, do not count it as a failure, and (in runAgent) leave the
+			// agent's RUN_SUMMARY.md intact (#543).
+			in.PhaseTransitionSink(currentPhase, task.PhaseCanceledByReconciliation)
+			stoppedPayload := map[string]any{
+				"model":       in.Task.Model,
+				"duration_ms": elapsed.Milliseconds(),
+				"ok":          true,
+				"reason":      "reconcile_ineligible",
+			}
+			addOutputFields(stoppedPayload, res)
+			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerStopped, "runner stopped: reconcile ineligible", stoppedPayload)
 			return res, runErr
 		}
 		in.PhaseTransitionSink(currentPhase, task.PhaseFailed)


### PR DESCRIPTION
## What & why

Closes #543.

When the coding agent performs its **intended PR handoff** — open the draft PR,
then move the tracker issue out of the active states (Linear `In Progress` →
`In Review`) via `linear_graphql` — per-tick eligibility reconciliation cancels
the still-finishing run. The worker classified the resulting `context.Canceled`
as the generic failure path: `runner_end "runner failed"`, phase
`StreamingTurn → Failed`, and it **overwrote the agent's `.aiops/RUN_SUMMARY.md`**
with `runner failed: context canceled`. The canonical **success** path was
recorded as a failure.

## Fix
Thread the cancel **intent** through the run context:
- `spawn` uses `context.WithCancelCause`; the **eligibility-reconcile** cancel
  attaches `worker.ErrReconcileCancel` as the cause. A **stall** cancel and
  **shutdown** keep a `nil` cause and their existing classification (so a stuck
  run is still a failure — only the agent-handoff stop is reclassified).
- The worker detects it via `context.Cause` and:
  - emits a distinct `task.EventRunnerStopped` (`ok=true`,
    `reason=reconcile_ineligible`) and transitions to the existing SPEC §7.2
    `PhaseCanceledByReconciliation` instead of `PhaseFailed` — counted as
    neither success nor failure;
  - **does not overwrite `RUN_SUMMARY.md`** (skips `WriteFailureArtifacts`).
- Logs the stop reason at the reconcile site:
  `event=reconcile_stopping_run reason=state_left_active from=.. to=..`.

The orchestrator-side release (no retry) was already handled by the existing
`ReconcileCancel` flag (`actor_finalize.applyReconcileCancel`); this PR fixes the
**worker-side classification** the flag never reached.

## Acceptance criteria (#543)
- [x] Classify an orchestrator-initiated cancel distinctly (runner_stopped,
      `reason=reconcile_ineligible`); do not overwrite `RUN_SUMMARY.md`.
- [x] Log the cancel reason at the reconcile site.
- [ ] **Deferred** — a *grace window* that lets the agent's own handoff turn
      finish before the cancel (a separable policy change needing
      agent-initiated-transition detection). To be filed as a follow-up.

## SPEC alignment
`PhaseCanceledByReconciliation` already exists in the SPEC §7.2 vocabulary
(`internal/task`); it was simply never emitted. `context.WithCancelCause`
replicates the BEAM supervisor's reason-carrying stop in Go (AGENTS.md
cross-cutting item 2). The eligibility-vs-stall distinction mirrors upstream
`orchestrator.ex` (a non-active transition stops the agent; a stall is a
failure).

## Verification
- `gofmt`, `go vet ./...`, `go build`, `go mod tidy`, `go test -race ./...` green.
- `TestIsReconcileCancel` (predicate: reconcile-cause→true; shutdown/plain
  cancel/deadline/other→false) and
  `TestRunRunnerWithTimeoutReconcileCancelRecordsStopped` (emits `runner_stopped`
  ok=true reason + `PhaseCanceledByReconciliation`, never `runner failed`).
  **Mutation-verified** against the committed artifact (neutralizing the
  detection makes the test FAIL; restored → green).

### Size gate
- [x] `within budget` — 10 files / ~197 changed LOC (< 12 files / 300 LOC). The
      8 non-test files are one atomic state-machine concept (context cause +
      worker classification + reconcile log); no `policy.deny_paths` touched.
