### PR TITLE
fix(orchestrator): cool down recurring sandbox-startup failures instead of hot re-dispatch (#550)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -105,7 +105,12 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		res.OutputHead = string(head)
 	}
 	res.OutputTail = tail
-	return classifyAppServerOutcome(ctx, res, runErr, waitErr, client.readTimeoutMs, start, elapsed)
+	res, outcomeErr := classifyAppServerOutcome(ctx, res, runErr, waitErr, client.readTimeoutMs, start, elapsed)
+	// Re-tag a recurring codex/bwrap sandbox-startup denial so the worker parks
+	// it on a cooldown instead of hot-retrying every poll (#550). Done here, not
+	// inside classifyAppServerOutcome, because the captured output (OutputHead/
+	// Tail, where bwrap's stderr lands) is only assembled above.
+	return res, classifySandboxStartupFailure(outcomeErr, res)
 }
 
 // setupAppServerCommand builds the `codex app-server` *exec.Cmd ready to start:

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
@@ -150,6 +151,33 @@ func (e *QuotaBackoffError) Error() string {
 func IsQuotaBackoff(err error) bool {
 	var quota *QuotaBackoffError
 	return errors.As(err, &quota)
+}
+
+// SandboxStartupError marks a run that failed because the coding agent's
+// sandbox could not start — most commonly codex's bwrap user namespace being
+// denied by the host (e.g. "bwrap: setting up uid map: Permission denied").
+// Unlike a generic turn failure, this recurs identically on every dispatch
+// until an operator reconfigures the host, so the worker routes it to the
+// external-blocker cooldown instead of the hot failure-retry loop that would
+// burn a full agent turn's tokens every poll (#550). The preflight equivalent
+// is internal/doctor's codex sandbox probe (#542); this is the runtime catch
+// for a host that regresses after preflight or an operator who skipped
+// --doctor. Detail carries a fixed, output-free description so the raw captured
+// subprocess text (which may hold secrets) never reaches an error string.
+type SandboxStartupError struct {
+	Detail string
+}
+
+func (e *SandboxStartupError) Error() string {
+	if e == nil || strings.TrimSpace(e.Detail) == "" {
+		return "agent sandbox failed to start"
+	}
+	return "agent sandbox failed to start: " + e.Detail
+}
+
+func IsSandboxStartup(err error) bool {
+	var se *SandboxStartupError
+	return errors.As(err, &se)
 }
 
 type RunnerErrorCategory string

--- a/internal/runner/sandbox_startup.go
+++ b/internal/runner/sandbox_startup.go
@@ -2,34 +2,53 @@ package runner
 
 import "strings"
 
-// sandboxStartupSignatures are substrings that mark a codex/bwrap sandbox
-// startup denial in the agent's failure reason or captured output. The failure
+// bubblewrap prints its own fatal line prefixed "bwrap: ..." and exits when it
+// cannot set up the sandbox, e.g. "bwrap: setting up uid map: Permission
+// denied", "bwrap: No permissions to creating new namespace ...", or
+// "bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted". The failure
 // originates inside codex's vendored bwrap subprocess, not our code, so there is
 // no typed error to match on — text classification of the external tool's output
-// is the only signal. This mirrors how the doctor preflight probe classifies the
-// same condition (#542) and how the quota-backoff path parses codex's message
-// text (codex_app_server_turn.go). The list is deliberately narrow to the
-// bubblewrap user-namespace setup phrases so an unrelated "permission denied" in
-// ordinary agent output cannot trip the cooldown. Earned by the #542 blast
-// radius: ~590k input tokens burned per failed turn, repeated every poll.
-var sandboxStartupSignatures = []string{
-	"setting up uid map",
-	"setting up gid map",
-	"creating new user namespace",
-}
+// is the only signal (the quota-backoff path matches codex's message text the
+// same way; see codex_app_server_turn.go). UNLIKE the doctor preflight probe,
+// which can deny-by-default on a controlled `codex sandbox -- /bin/true` probe
+// (#542), the runtime signal is arbitrary agent output, so we cannot deny by
+// default: we match bubblewrap's own fatal-line prefix co-occurring with a
+// permission-denial token. That stays broad across bwrap's failure variants
+// (uid/gid map, namespace creation, netns) while not tripping on ordinary agent
+// output that merely mentions bwrap. Earned by the #542 blast radius: ~590k
+// input tokens burned per failed turn, repeated every poll.
+var (
+	// bwrapDenialTokens are kernel/permission denials that, alongside bwrap's
+	// own "bwrap:" prefix, mark a sandbox-startup failure.
+	bwrapDenialTokens = []string{"permission denied", "operation not permitted", "no permissions"}
+	// bwrapStandaloneSignatures are emitted only by bubblewrap's sandbox setup,
+	// so they classify on their own even if codex strips the "bwrap:" prefix.
+	bwrapStandaloneSignatures = []string{"setting up uid map", "setting up gid map"}
+)
 
-// textHasSandboxStartupFailure reports whether any part contains a known
-// sandbox-startup signature (case-insensitive).
+// textHasSandboxStartupFailure reports whether any part shows a bubblewrap
+// sandbox-startup denial (case-insensitive).
 func textHasSandboxStartupFailure(parts ...string) bool {
 	for _, p := range parts {
-		if p == "" {
-			continue
+		if p != "" && hasBwrapDenial(strings.ToLower(p)) {
+			return true
 		}
-		lower := strings.ToLower(p)
-		for _, sig := range sandboxStartupSignatures {
-			if strings.Contains(lower, sig) {
-				return true
-			}
+	}
+	return false
+}
+
+func hasBwrapDenial(lower string) bool {
+	for _, sig := range bwrapStandaloneSignatures {
+		if strings.Contains(lower, sig) {
+			return true
+		}
+	}
+	if !strings.Contains(lower, "bwrap:") {
+		return false
+	}
+	for _, tok := range bwrapDenialTokens {
+		if strings.Contains(lower, tok) {
+			return true
 		}
 	}
 	return false
@@ -41,9 +60,9 @@ func textHasSandboxStartupFailure(parts ...string) bool {
 // is reconfigured (#550). The more specific outcomes (timeout, stall, read
 // timeout, turn timeout, input-required, quota backoff) keep their own routing:
 // they carry distinct worker handling, and none of them can legitimately contain
-// the bubblewrap user-namespace phrases. The returned error carries only a
-// fixed, output-free detail so raw captured subprocess text never leaks into an
-// error string.
+// bubblewrap's fatal-line denial. The returned error carries only a fixed,
+// output-free detail so raw captured subprocess text never leaks into an error
+// string.
 func classifySandboxStartupFailure(err error, res Result) error {
 	if err == nil || IsSandboxStartup(err) {
 		return err

--- a/internal/runner/sandbox_startup.go
+++ b/internal/runner/sandbox_startup.go
@@ -1,0 +1,58 @@
+package runner
+
+import "strings"
+
+// sandboxStartupSignatures are substrings that mark a codex/bwrap sandbox
+// startup denial in the agent's failure reason or captured output. The failure
+// originates inside codex's vendored bwrap subprocess, not our code, so there is
+// no typed error to match on — text classification of the external tool's output
+// is the only signal. This mirrors how the doctor preflight probe classifies the
+// same condition (#542) and how the quota-backoff path parses codex's message
+// text (codex_app_server_turn.go). The list is deliberately narrow to the
+// bubblewrap user-namespace setup phrases so an unrelated "permission denied" in
+// ordinary agent output cannot trip the cooldown. Earned by the #542 blast
+// radius: ~590k input tokens burned per failed turn, repeated every poll.
+var sandboxStartupSignatures = []string{
+	"setting up uid map",
+	"setting up gid map",
+	"creating new user namespace",
+}
+
+// textHasSandboxStartupFailure reports whether any part contains a known
+// sandbox-startup signature (case-insensitive).
+func textHasSandboxStartupFailure(parts ...string) bool {
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		lower := strings.ToLower(p)
+		for _, sig := range sandboxStartupSignatures {
+			if strings.Contains(lower, sig) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// classifySandboxStartupFailure re-tags an otherwise-generic run failure as a
+// *SandboxStartupError when the classified error or captured output shows a
+// codex/bwrap sandbox-startup denial that will recur identically until the host
+// is reconfigured (#550). The more specific outcomes (timeout, stall, read
+// timeout, turn timeout, input-required, quota backoff) keep their own routing:
+// they carry distinct worker handling, and none of them can legitimately contain
+// the bubblewrap user-namespace phrases. The returned error carries only a
+// fixed, output-free detail so raw captured subprocess text never leaks into an
+// error string.
+func classifySandboxStartupFailure(err error, res Result) error {
+	if err == nil || IsSandboxStartup(err) {
+		return err
+	}
+	if IsTimeout(err) || IsStall(err) || IsReadTimeout(err) || IsTurnTimeout(err) || IsInputRequired(err) || IsQuotaBackoff(err) {
+		return err
+	}
+	if !textHasSandboxStartupFailure(err.Error(), res.OutputHead, res.OutputTail) {
+		return err
+	}
+	return &SandboxStartupError{Detail: "host denied the codex bwrap user namespace"}
+}

--- a/internal/runner/sandbox_startup_test.go
+++ b/internal/runner/sandbox_startup_test.go
@@ -21,15 +21,20 @@ func TestClassifySandboxStartupFailure(t *testing.T) {
 			wantTag: true,
 		},
 		{
-			name:    "denial only in captured output tail",
+			name:    "gid-map denial only in captured output tail",
 			err:     NewError(CategoryPortExit, "codex app-server process exited", errors.New("exit status 1")),
 			res:     Result{OutputTail: "bwrap: setting up gid map: Permission denied\n"},
 			wantTag: true,
 		},
 		{
-			name:    "denial in captured output head",
+			name:    "namespace denial in captured output head",
 			err:     NewError(CategoryPortExit, "codex app-server process exited", errors.New("exit status 1")),
-			res:     Result{OutputHead: "creating new user namespace failed\n"},
+			res:     Result{OutputHead: "bwrap: No permissions to creating new namespace, likely because the kernel does not allow non-privileged user namespaces\n"},
+			wantTag: true,
+		},
+		{
+			name:    "bwrap netns denial (non uid-map variant)",
+			err:     NewError(CategoryTurnFailed, "turn/failed: bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted", nil),
 			wantTag: true,
 		},
 		{
@@ -39,8 +44,14 @@ func TestClassifySandboxStartupFailure(t *testing.T) {
 			wantTag: false,
 		},
 		{
-			name:    "unrelated permission denied is not a sandbox failure",
+			name:    "unrelated permission denied without bwrap prefix is not a sandbox failure",
 			err:     NewError(CategoryTurnFailed, "turn/failed: open /etc/shadow: permission denied", nil),
+			wantTag: false,
+		},
+		{
+			name:    "bwrap mentioned without a denial token is not a sandbox failure",
+			err:     NewError(CategoryTurnFailed, "turn/failed: edited internal/runner/sandbox.go to call bwrap: ok", nil),
+			res:     Result{OutputTail: "grep -n 'bwrap:' sandbox.go\n"},
 			wantTag: false,
 		},
 		{
@@ -87,6 +98,37 @@ func TestClassifySandboxStartupFailure_DoesNotMaskSpecificOutcomes(t *testing.T)
 				t.Fatalf("classifySandboxStartupFailure(%T) = %v; want original error unchanged", tc.err, got)
 			}
 		})
+	}
+}
+
+// TestCodexAppServerRunnerClassifiesBwrapTurnFailureAsSandboxStartup drives a
+// real turn/failed carrying bwrap's uid-map denial through CodexAppServerRunner.Run
+// and asserts it emerges as a *SandboxStartupError. This pins the load-bearing
+// wiring (Run → classifyAppServerOutcome → classifySandboxStartupFailure) and the
+// assumption that the bwrap denial reaches the classifier via the turn reason —
+// the unit tests above bypass Run with a synthetic error.
+func TestCodexAppServerRunnerClassifiesBwrapTurnFailureAsSandboxStartup(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+log=open(os.environ['CODEX_STDIN_LOG'], 'w')
+for line in sys.stdin:
+    log.write(line); log.flush()
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/failed', 'params': {'reason': 'bwrap: setting up uid map: Permission denied'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "bwrap sandbox startup")
+
+	_, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if !IsSandboxStartup(err) {
+		t.Fatalf("Run() err = %T %[1]v; want a *SandboxStartupError", err)
 	}
 }
 

--- a/internal/runner/sandbox_startup_test.go
+++ b/internal/runner/sandbox_startup_test.go
@@ -1,0 +1,107 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestClassifySandboxStartupFailure(t *testing.T) {
+	bwrapErr := NewError(CategoryTurnFailed, "turn/failed: bwrap: setting up uid map: Permission denied", nil)
+	cases := []struct {
+		name    string
+		err     error
+		res     Result
+		wantTag bool
+	}{
+		{
+			name:    "uid map denial in turn reason",
+			err:     bwrapErr,
+			wantTag: true,
+		},
+		{
+			name:    "denial only in captured output tail",
+			err:     NewError(CategoryPortExit, "codex app-server process exited", errors.New("exit status 1")),
+			res:     Result{OutputTail: "bwrap: setting up gid map: Permission denied\n"},
+			wantTag: true,
+		},
+		{
+			name:    "denial in captured output head",
+			err:     NewError(CategoryPortExit, "codex app-server process exited", errors.New("exit status 1")),
+			res:     Result{OutputHead: "creating new user namespace failed\n"},
+			wantTag: true,
+		},
+		{
+			name:    "generic turn failure is left untagged",
+			err:     NewError(CategoryTurnFailed, "turn/failed: tests failed", nil),
+			res:     Result{OutputTail: "FAIL ./...\n"},
+			wantTag: false,
+		},
+		{
+			name:    "unrelated permission denied is not a sandbox failure",
+			err:     NewError(CategoryTurnFailed, "turn/failed: open /etc/shadow: permission denied", nil),
+			wantTag: false,
+		},
+		{
+			name:    "nil error stays nil",
+			err:     nil,
+			wantTag: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifySandboxStartupFailure(tc.err, tc.res)
+			if IsSandboxStartup(got) != tc.wantTag {
+				t.Fatalf("classifySandboxStartupFailure(%v) IsSandboxStartup = %v; want %v (got err %v)", tc.err, IsSandboxStartup(got), tc.wantTag, got)
+			}
+			if !tc.wantTag && !errors.Is(got, tc.err) {
+				t.Fatalf("classifySandboxStartupFailure(%v) = %v; want the original error unchanged", tc.err, got)
+			}
+		})
+	}
+}
+
+// More-specific outcomes must not be masked even when their message or output
+// carries a sandbox signature: each keeps its own worker routing.
+func TestClassifySandboxStartupFailure_DoesNotMaskSpecificOutcomes(t *testing.T) {
+	signatureOutput := Result{OutputTail: "bwrap: setting up uid map: Permission denied\n"}
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"timeout", &TimeoutError{Timeout: time.Second, Elapsed: time.Second, Cause: errors.New("bwrap: setting up uid map: Permission denied")}},
+		{"stall", &StallError{Timeout: time.Second, Elapsed: time.Second}},
+		{"read timeout", &ReadTimeoutError{Timeout: time.Second}},
+		{"turn timeout", &TurnTimeoutError{Timeout: time.Second, Elapsed: time.Second}},
+		{"input required", &InputRequiredError{Method: "session/requestInput"}},
+		{"quota backoff", &QuotaBackoffError{Message: "usage limit"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifySandboxStartupFailure(tc.err, signatureOutput)
+			if IsSandboxStartup(got) {
+				t.Fatalf("classifySandboxStartupFailure(%T) was re-tagged as sandbox startup; want the original %T preserved", tc.err, tc.err)
+			}
+			if !errors.Is(got, tc.err) {
+				t.Fatalf("classifySandboxStartupFailure(%T) = %v; want original error unchanged", tc.err, got)
+			}
+		})
+	}
+}
+
+func TestSandboxStartupError_Message(t *testing.T) {
+	withDetail := &SandboxStartupError{Detail: "host denied the codex bwrap user namespace"}
+	if got, want := withDetail.Error(), "agent sandbox failed to start: host denied the codex bwrap user namespace"; got != want {
+		t.Fatalf("SandboxStartupError.Error() = %q; want %q", got, want)
+	}
+	if got, want := (&SandboxStartupError{}).Error(), "agent sandbox failed to start"; got != want {
+		t.Fatalf("empty SandboxStartupError.Error() = %q; want %q", got, want)
+	}
+	if !IsSandboxStartup(withDetail) {
+		t.Fatalf("IsSandboxStartup(%v) = false; want true", withDetail)
+	}
+	if IsSandboxStartup(context.Canceled) {
+		t.Fatalf("IsSandboxStartup(context.Canceled) = true; want false")
+	}
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -95,18 +95,24 @@ const (
 	EventPolicyFeedbackLoaded    = "policy_feedback_loaded"
 	EventPolicyFeedbackReadError = "policy_feedback_read_error"
 	EventExternalBlocker         = "external_blocker"
-	EventVerifyStart             = "verify_start"
-	EventVerifyEnd               = "verify_end"
-	EventPush                    = "push"
-	EventPRCreated               = "pr_created"
-	EventPRReused                = "pr_reused"
-	EventSucceeded               = "succeeded"
-	EventFailedAttempt           = "failed_attempt"
-	EventReconcileStart          = "reconcile_start"
-	EventReconcileWorkspace      = "reconcile_workspace"
-	EventReconcileEnd            = "reconcile_end"
-	EventWorkflowReloaded        = "workflow_reload"
-	EventWorkflowReloadFailed    = "workflow_reload_failed"
+	// EventSandboxStartupBlocked marks a run parked on a cooldown because the
+	// coding agent's sandbox could not start (codex/bwrap user-namespace denial),
+	// a failure that recurs identically until the host is reconfigured (#550).
+	// Distinct from external_blocker (an agent-declared dependency block) so an
+	// operator can tell a host sandbox regression apart from a normal BLOCKED.json.
+	EventSandboxStartupBlocked = "sandbox_startup_blocked"
+	EventVerifyStart           = "verify_start"
+	EventVerifyEnd             = "verify_end"
+	EventPush                  = "push"
+	EventPRCreated             = "pr_created"
+	EventPRReused              = "pr_reused"
+	EventSucceeded             = "succeeded"
+	EventFailedAttempt         = "failed_attempt"
+	EventReconcileStart        = "reconcile_start"
+	EventReconcileWorkspace    = "reconcile_workspace"
+	EventReconcileEnd          = "reconcile_end"
+	EventWorkflowReloaded      = "workflow_reload"
+	EventWorkflowReloadFailed  = "workflow_reload_failed"
 
 	// Tracker transition events are implementation extensions retained for
 	// operator visibility while tracker writes remain tool-driven.

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -356,23 +356,75 @@ func (rs *runState) runAgent() *RunTaskError {
 	rs.res = res
 	rs.sessionID = sessionIDFromRuntimeEvents(res.RuntimeEvents)
 	if runErr != nil {
-		if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterRun, rs.hooks.AfterRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
-			LogIssueSessionEventf(rs.t, rs.sessionID, "after_run_hook_failed", "after_runner_error=true error=%q", err)
-		}
-		// An eligibility reconcile-cancel is a supervised stop, not a runner
-		// failure: leave the agent's RUN_SUMMARY.md intact so the worker does
-		// not overwrite a successful handoff with "runner failed" (#543). The
-		// orchestrator releases the run via its ReconcileCancel flag.
-		if !isReconcileCancel(rs.ctx, runErr) {
-			WriteFailureArtifacts(rs.ctx, rs.workdir, nil, "runner failed: "+ErrSummary(runErr))
-		}
-		return &RunTaskError{Cfg: rs.wcfg, Err: runErr}
+		return rs.handleRunnerFailure(runErr)
 	}
 
 	if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterRun, rs.hooks.AfterRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
 		LogIssueSessionEventf(rs.t, rs.sessionID, "after_run_hook_failed", "error=%q", err)
 	}
 	return nil
+}
+
+// handleRunnerFailure runs the after_run hook on the runner-error path and
+// classifies the failure into the right terminal RunTaskError: a supervised
+// reconcile-cancel (RUN_SUMMARY preserved, #543), a recurring sandbox-startup
+// denial parked on a cooldown (#550), or a generic runner failure.
+func (rs *runState) handleRunnerFailure(runErr error) *RunTaskError {
+	if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterRun, rs.hooks.AfterRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
+		LogIssueSessionEventf(rs.t, rs.sessionID, "after_run_hook_failed", "after_runner_error=true error=%q", err)
+	}
+	// An eligibility reconcile-cancel is a supervised stop, not a runner
+	// failure: leave the agent's RUN_SUMMARY.md intact so the worker does not
+	// overwrite a successful handoff with "runner failed" (#543). The
+	// orchestrator releases the run via its ReconcileCancel flag.
+	if isReconcileCancel(rs.ctx, runErr) {
+		return &RunTaskError{Cfg: rs.wcfg, Err: runErr}
+	}
+	// A recurring codex sandbox-startup denial recurs identically every dispatch
+	// until the host is fixed, so park it on a cooldown instead of the hot
+	// failure-retry loop (#550).
+	if runner.IsSandboxStartup(runErr) {
+		return rs.sandboxStartupBlocked(runErr)
+	}
+	WriteFailureArtifacts(rs.ctx, rs.workdir, nil, "runner failed: "+ErrSummary(runErr))
+	return &RunTaskError{Cfg: rs.wcfg, Err: runErr}
+}
+
+// sandboxStartupRetryAfter is the cooldown a sandbox-startup failure parks on
+// before the next dispatch. The failure recurs identically until an operator
+// reconfigures the host (#550), so the cooldown only needs to be long enough to
+// stop the per-poll token burn the #542 blast radius quantified (~590k input
+// tokens per failed turn); an operator fix plus the normal poll/reconcile loop
+// re-dispatches sooner once the host recovers.
+const sandboxStartupRetryAfter = time.Hour
+
+// sandboxStartupBlocked routes a recurring codex sandbox-startup failure to the
+// external-blocker cooldown path instead of the hot failure-retry loop: the run
+// is parked blocked and only re-dispatched after the cooldown, reusing the same
+// orchestrator machinery as a BLOCKED.json external-dependency block (#550). It
+// emits a dedicated event so an operator can tell a host sandbox denial apart
+// from an agent-declared dependency block, and synthesizes the blocker in-memory
+// (it never writes/reads .aiops/BLOCKED.json) so the agent's own artifact is not
+// shadowed. The fixed reason points at `worker --doctor`, which detects the same
+// condition at preflight (#542); ErrSummary(runErr) is the output-free
+// SandboxStartupError text, so no raw subprocess output reaches the surface.
+func (rs *runState) sandboxStartupBlocked(runErr error) *RunTaskError {
+	const reason = "codex sandbox could not start on this host (denied bwrap user namespace); run worker --doctor and fix the host before retrying"
+	Emit(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, task.EventSandboxStartupBlocked, "codex sandbox startup failed; parking issue on cooldown", map[string]any{
+		"reason":              reason,
+		"retry_after_seconds": int(sandboxStartupRetryAfter / time.Second),
+	})
+	return &RunTaskError{
+		Cfg:             rs.wcfg,
+		Err:             runErr,
+		ExternalBlocked: true,
+		Blocker: BlockerArtifact{
+			Version:           blockerArtifactVersion,
+			Kind:              blockerArtifactKindExternal,
+			Reason:            reason,
+			RetryAfterSeconds: int(sandboxStartupRetryAfter / time.Second),
+		},
+	}
 }
 
 // resetStaleArtifacts deletes RUN_SUMMARY.md, the blocker artifact, and (in

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -414,6 +414,9 @@ func (rs *runState) sandboxStartupBlocked(runErr error) *RunTaskError {
 		"reason":              reason,
 		"retry_after_seconds": int(sandboxStartupRetryAfter / time.Second),
 	})
+	// Synthesized in-memory (never written to / read from .aiops/BLOCKED.json),
+	// so it does not pass through BlockerArtifact.validate(); the constants below
+	// are validation-safe by construction (1h is well within the 60s..24h bound).
 	return &RunTaskError{
 		Cfg:             rs.wcfg,
 		Err:             runErr,

--- a/internal/worker/sandbox_startup_test.go
+++ b/internal/worker/sandbox_startup_test.go
@@ -1,0 +1,94 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// errRunner returns a fixed error so a runState test can drive runAgent's
+// failure classification without a subprocess.
+type errRunner struct{ err error }
+
+func (r errRunner) Run(_ context.Context, _ runner.RunInput) (runner.Result, error) {
+	return runner.Result{}, r.err
+}
+
+func sandboxStartupRunState(t *testing.T, ev *fakeEmitter, runErr error) *runState {
+	t.Helper()
+	oldNew := newRunner
+	newRunner = func(string) (runner.Runner, error) { return errRunner{err: runErr}, nil }
+	t.Cleanup(func() { newRunner = oldNew })
+	dir := t.TempDir()
+	return &runState{
+		ctx: context.Background(), ev: ev, t: task.Task{ID: "tsk", Model: "x"}, cfg: Config{},
+		wf: &workflow.Workflow{}, wcfg: workflow.Config{},
+		workdir: dir, workspaceRoot: filepath.Dir(dir),
+	}
+}
+
+// TestRunAgentParksSandboxStartupFailureOnCooldown pins the #550 fix: a recurring
+// codex sandbox-startup failure is routed to the external-blocker cooldown path
+// (parked + re-dispatched after a backoff) instead of the hot failure-retry loop.
+func TestRunAgentParksSandboxStartupFailureOnCooldown(t *testing.T) {
+	ev := &fakeEmitter{}
+	rs := sandboxStartupRunState(t, ev, &runner.SandboxStartupError{Detail: "host denied the codex bwrap user namespace"})
+
+	rtErr := rs.runAgent()
+	if rtErr == nil {
+		t.Fatal("runAgent() = nil; want a RunTaskError for the sandbox-startup failure")
+	}
+	if !rtErr.ExternalBlocked {
+		t.Fatalf("runAgent() ExternalBlocked = false; want true so the orchestrator parks it on a cooldown")
+	}
+	if !runner.IsSandboxStartup(rtErr.Err) {
+		t.Fatalf("runAgent() Err = %T %[1]v; want a SandboxStartupError", rtErr.Err)
+	}
+	wantRetry := int(sandboxStartupRetryAfter / time.Second)
+	if got := rtErr.Blocker.RetryAfterSeconds; got != wantRetry {
+		t.Fatalf("Blocker.RetryAfterSeconds = %d; want %d (the sandbox cooldown)", got, wantRetry)
+	}
+	if got := (&ExternalBlockerError{Artifact: rtErr.Blocker}).RetryAfter(); got != sandboxStartupRetryAfter {
+		t.Fatalf("RetryAfter() = %v; want %v", got, sandboxStartupRetryAfter)
+	}
+
+	// Observability: a dedicated event fires, distinct from a normal external
+	// blocker so an operator can tell a host sandbox denial apart.
+	if got := len(ev.byKind(task.EventSandboxStartupBlocked)); got != 1 {
+		t.Fatalf("sandbox_startup_blocked events = %d; want 1; events=%#v", got, ev.events)
+	}
+	if got := len(ev.byKind(task.EventExternalBlocker)); got != 0 {
+		t.Fatalf("external_blocker events = %d; want 0 (sandbox uses its own event); events=%#v", got, ev.events)
+	}
+
+	// A parked run is not a failure: no RUN_SUMMARY artifact is written.
+	if _, err := os.Stat(filepath.Join(rs.workdir, ".aiops", "RUN_SUMMARY.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("RUN_SUMMARY.md stat error = %v; want not-exist (parked, not failed)", err)
+	}
+}
+
+// TestRunAgentGenericFailureSkipsSandboxCooldown guards the negative: the routing
+// must hinge on the typed error, so an ordinary turn failure keeps the standard
+// (non-blocked) failure path and emits no sandbox event.
+func TestRunAgentGenericFailureSkipsSandboxCooldown(t *testing.T) {
+	ev := &fakeEmitter{}
+	rs := sandboxStartupRunState(t, ev, runner.NewError(runner.CategoryTurnFailed, "turn/failed: tests failed", nil))
+
+	rtErr := rs.runAgent()
+	if rtErr == nil {
+		t.Fatal("runAgent() = nil; want a RunTaskError for the turn failure")
+	}
+	if rtErr.ExternalBlocked {
+		t.Fatalf("runAgent() ExternalBlocked = true; want false for a generic turn failure")
+	}
+	if got := len(ev.byKind(task.EventSandboxStartupBlocked)); got != 0 {
+		t.Fatalf("sandbox_startup_blocked events = %d; want 0 for a generic failure", got)
+	}
+}


### PR DESCRIPTION
Closes #550.

## Problem
When a dispatched run fails with a recurring codex/bwrap sandbox-startup denial (`bwrap: setting up uid map: Permission denied`), the issue stays in an active tracker state, so the worker re-dispatches it on the standard failure-retry backoff and burns a full agent turn's tokens (~590k input/turn, the #542 blast radius) every cycle until an operator notices. #542 catches this at **preflight** (`internal/doctor`); this is the **runtime** catch for a host that regresses after preflight or an operator who skipped `--doctor`.

## Approach
Classify the failure and route it to the **existing external-blocker cooldown machinery** instead of the hot failure-retry loop — no near-duplicate retry kind (harness principle: few sharp tools).

1. **`runner.SandboxStartupError`** (typed) + `classifySandboxStartupFailure` (`internal/runner/sandbox_startup.go`): the denial originates in codex's vendored bwrap subprocess, so there is no typed Go error to match — text classification of the external tool's output is the only signal (the AGENTS.md-sanctioned exception, same as the quota-backoff retry-after parser and the doctor probe). Matches bubblewrap's own fatal-line prefix (`bwrap:`) co-occurring with a denial token, plus the bwrap-only `setting up uid/gid map` phrases as a standalone signal. Runs only against the classified error + captured output and **does not** mask the more-specific outcomes (timeout, stall, read/turn timeout, input-required, quota backoff). `Detail` is a fixed, output-free string so raw subprocess output (potential secrets) never reaches an error string.
2. **Worker** (`internal/worker/runtask.go`): `handleRunnerFailure` → `sandboxStartupBlocked` parks the run on the `ExternalBlocked` cooldown (1h) with a synthesized in-memory blocker (never touches `.aiops/BLOCKED.json`, so the agent's own artifact is not shadowed) and emits a dedicated `task.EventSandboxStartupBlocked` so an operator can tell a host sandbox denial apart from an agent-declared dependency block. This goes through the **failure** path — it does **not** stamp `PhaseSucceeded`.
3. The orchestrator side (`applyExternalBlocked` → `scheduleExternalBlockerRetry` → `fireWakeSignal`) is reused unchanged: park blocked, re-check on the cooldown, re-dispatch via the poll loop; attempt budget is not consumed (a host problem must not exhaust the agent's failure-retry budget).

## SPEC alignment
Not a SPEC deviation — additive runtime hardening within the existing external-blocker/quota-backoff extension envelope (same class as those). No new `DEVIATIONS.md` row. Adjacent-path audit (AGENTS.md cross-cutting checklist item 1): `ExternalBlocked` / `RetryKindExternalBlocker` / `BlockerArtifact` consumers (`poller.go` Spawn, `actor_finalize.go` applyExternalBlocked, `actor_retry.go` fireWakeSignal) are generic on the flag and handle the new producer path correctly; `isReconcileCancel` keys on the context cause (not the error value), so the reconcile-cancel guard still wins.

## Acceptance criteria
- [x] Sandbox-startup failure classified as non-retryable-without-backoff in the runner outcome classifier (`internal/runner/codex_app_server.go` → `classifySandboxStartupFailure`) and the worker failure path.
- [x] Orchestrator applies an `external_blocker`/cooldown-style backoff (1h) instead of immediate re-dispatch.

## Validation
- `gofmt -l`, `go vet ./...`, `go mod tidy` clean; `go build ./cmd/worker ./cmd/tui`.
- `go test -race -covermode=atomic ./...` green; `golangci-lint` 0 issues (funlen/gocognit included — `runAgent` kept under budget by extracting `handleRunnerFailure`).
- **Mutation-verified** (against the committed artifact): blanking `hasBwrapDenial` fails the runner classification + `Run`-level tests; disabling the `IsSandboxStartup` worker branch fails the cooldown-routing test.
- Coverage: unit table (positive uid/gid-map + netns variant, negative `bwrap`-without-denial + unrelated permission-denied), precedence guard (6 specific outcomes not masked), a **`Run`-level** test driving a real `turn/failed` bwrap denial through `CodexAppServerRunner.Run` (pins the load-bearing wiring), and worker routing (ExternalBlocked + 1h + dedicated event + no RUN_SUMMARY/succeeded).

## Size gate
`size-gated: justified overage` (~438 added; ~243 is regression/`Run`-level/negative test coverage + earned comments, atomic to the change and not compressible without losing coverage). Surfaced for size-gate sign-off.

## Review notes
The local Claude pre-push review was applied (broadened signature to cover non-uid-map bwrap denials, dropped an over-generic phrase, added the `Run`-level + negative coverage, corrected a comment). `@codex review` will be triggered on the head commit.
