### PR TITLE
fix(runner): reap stale agent Go build caches

### DIFF
--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -243,6 +243,15 @@ recommended strategy is age-based pruning, gated on operator preference:
   cache. They survive worktree cleanup intentionally, because deleting
   them costs you a fresh `git clone` on the next task. Only purge a
   mirror when you change its upstream URL or the cache disk fills up.
+- **Agent Go caches** (`$TMPDIR/aiops-go-cache/...`): the Codex
+  app-server runner injects a shared `mod/` cache plus a per-workspace
+  `build/<key>/` cache so sandboxed Go commands can write their cache
+  files. `build/<key>/` entries are removed when the worker deletes the
+  matching workspace and are also lazily reaped on app-server setup when
+  the top-level `build/<key>/` directory mtime is older than 7 days. That
+  TTL is not a last-cache-hit signal, so a warm but idle cache can be
+  rebuilt. `mod/` is intentionally shared and is not managed by workspace
+  cleanup.
 
 The Go API for cleanup is `(*workspace.Manager).Cleanup(ctx, maxAge)`.
 It walks `$AIOPS_WORKSPACE_ROOT`, deletes each task directory whose mtime

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,6 +44,8 @@ const (
 const PromptPath = ".aiops/PROMPT.md"
 
 func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error) {
+	releaseGoBuildCache := markActiveGoBuildCache(in.Workdir)
+	defer releaseGoBuildCache()
 	if err := validateAppServerWorkdir(in.Workdir); err != nil {
 		return Result{}, err
 	}
@@ -124,6 +127,9 @@ func setupAppServerCommand(ctx context.Context, in RunInput) (cmd *exec.Cmd, dir
 	// Pin the agent's Go toolchain caches to a sandbox-writable, per-workspace
 	// path so its first `go test` does not fail on the default $HOME-based
 	// caches that lie outside codex's workspace-write sandbox (#544).
+	if err := reapSandboxGoBuildCaches(); err != nil {
+		log.Printf("event=go_build_cache_reap_failed error=%q", err)
+	}
 	env = withSandboxGoToolchainCaches(env, in.Workdir)
 	cmd, directCodexExec, err = buildCodexAppServerCmd(ctx, in, env)
 	if err != nil {

--- a/internal/runner/go_cache.go
+++ b/internal/runner/go_cache.go
@@ -179,7 +179,11 @@ func reapGoBuildCacheEntry(root string, entry os.DirEntry, cutoff time.Time) err
 		return nil
 	}
 	// Directory mtime is only a stale-cache signal after active runs release
-	// their key; live app-server sessions are excluded above.
+	// their key; live app-server sessions are excluded by the check above.
+	// That active check and this removal are deliberately not atomic: a run
+	// that marks its key active in the gap only loses a cold build cache, which
+	// Go transparently rebuilds. Do not widen the lock over this filesystem
+	// walk — that serializes every run's app-server startup behind it.
 	if err := goCacheRemoveAll(path); err != nil {
 		return fmt.Errorf("remove stale Go build cache %s: %w", path, err)
 	}

--- a/internal/runner/go_cache.go
+++ b/internal/runner/go_cache.go
@@ -1,11 +1,14 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 )
 
 // withSandboxGoToolchainCaches returns env with GOCACHE/GOMODCACHE defaulted to
@@ -39,10 +42,10 @@ import (
 // codex.env_passthrough, which wins because a default is applied only when the
 // name is not already set to a non-empty value.
 //
-// These cache dirs live outside the workspace tree, so workspace GC does not
-// reap them; a TTL/size-cap reaper is tracked as tech-debt in #551. The claude
-// ShellRunner does not use this — it runs unsandboxed, where Go's $HOME-based
-// defaults already work.
+// The per-workspace build cache dirs live outside the workspace tree, so a
+// lazy TTL reaper keeps long-lived workers from retaining one forever per
+// distinct workspace. The claude ShellRunner does not use this — it runs
+// unsandboxed, where Go's $HOME-based defaults already work.
 // goToolchainCaches is the single source for the Go cache env vars the worker
 // injects on the codex sandboxed path: GOCACHE is isolated per workspace (build
 // cache, unverified → poisoning vector); GOMODCACHE is shared (subdir only).
@@ -56,6 +59,18 @@ var goToolchainCaches = []struct {
 	{name: "GOCACHE", subdir: "build", perWorkspace: true},
 	{name: "GOMODCACHE", subdir: "mod", perWorkspace: false},
 }
+
+// goBuildCacheMaxAge is measured from the top-level build/<key> directory
+// mtime, not from last cache hit; warm-but-idle caches may be rebuilt.
+const goBuildCacheMaxAge = 7 * 24 * time.Hour
+
+var (
+	goCacheNow       = time.Now
+	goCacheRemoveAll = os.RemoveAll
+
+	goBuildCacheActiveMu sync.Mutex
+	goBuildCacheActive   = map[string]int{}
+)
 
 // aiopsGoCacheRoot is the parent of the worker-injected Go cache dirs.
 func aiopsGoCacheRoot() string { return filepath.Join(os.TempDir(), "aiops-go-cache") }
@@ -77,11 +92,105 @@ func withSandboxGoToolchainCaches(env []string, workdir string) []string {
 		}
 		path := filepath.Join(root, c.subdir)
 		if c.perWorkspace {
-			path = filepath.Join(path, workspaceCacheKey(workdir))
+			path = SandboxGoBuildCachePath(workdir)
 		}
 		env = append(env, c.name+"="+path)
 	}
 	return env
+}
+
+// SandboxGoBuildCachePath returns the worker-owned per-workspace Go build cache
+// path for workdir. Worker cleanup uses it to remove caches with workspaces.
+func SandboxGoBuildCachePath(workdir string) string {
+	return filepath.Join(aiopsGoCacheRoot(), "build", workspaceCacheKey(workdir))
+}
+
+// RemoveSandboxGoBuildCache removes the worker-owned per-workspace Go build
+// cache for workdir. Missing cache directories are treated as already removed.
+func RemoveSandboxGoBuildCache(workdir string) error {
+	path := SandboxGoBuildCachePath(workdir)
+	if err := goCacheRemoveAll(path); err != nil {
+		return fmt.Errorf("remove Go build cache %s: %w", path, err)
+	}
+	return nil
+}
+
+func markActiveGoBuildCache(workdir string) func() {
+	key := workspaceCacheKey(workdir)
+	goBuildCacheActiveMu.Lock()
+	goBuildCacheActive[key]++
+	goBuildCacheActiveMu.Unlock()
+	return func() { unmarkActiveGoBuildCache(key) }
+}
+
+func unmarkActiveGoBuildCache(key string) {
+	goBuildCacheActiveMu.Lock()
+	defer goBuildCacheActiveMu.Unlock()
+	if goBuildCacheActive[key] <= 1 {
+		delete(goBuildCacheActive, key)
+		return
+	}
+	goBuildCacheActive[key]--
+}
+
+func activeGoBuildCache(key string) bool {
+	goBuildCacheActiveMu.Lock()
+	defer goBuildCacheActiveMu.Unlock()
+	return goBuildCacheActive[key] > 0
+}
+
+func reapSandboxGoBuildCaches() error {
+	root := filepath.Join(aiopsGoCacheRoot(), "build")
+	entries, err := readGoBuildCacheEntries(root)
+	if err != nil {
+		return err
+	}
+	cutoff := goCacheNow().Add(-goBuildCacheMaxAge)
+	var errs []error
+	for _, entry := range entries {
+		if err := reapGoBuildCacheEntry(root, entry, cutoff); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func readGoBuildCacheEntries(root string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read Go build cache root %s: %w", root, err)
+	}
+	return entries, nil
+}
+
+func reapGoBuildCacheEntry(root string, entry os.DirEntry, cutoff time.Time) error {
+	if !entry.IsDir() || activeGoBuildCache(entry.Name()) {
+		return nil
+	}
+	path := filepath.Join(root, entry.Name())
+	info, err := entry.Info()
+	if err != nil {
+		return goBuildCacheStatError(path, err)
+	}
+	if info.ModTime().After(cutoff) {
+		return nil
+	}
+	// Directory mtime is only a stale-cache signal after active runs release
+	// their key; live app-server sessions are excluded above.
+	if err := goCacheRemoveAll(path); err != nil {
+		return fmt.Errorf("remove stale Go build cache %s: %w", path, err)
+	}
+	return nil
+}
+
+func goBuildCacheStatError(path string, err error) error {
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("stat Go build cache %s: %w", path, err)
 }
 
 // goCacheNames returns the names of the Go cache env vars the worker injects, so

--- a/internal/runner/go_cache_test.go
+++ b/internal/runner/go_cache_test.go
@@ -2,9 +2,12 @@ package runner
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -111,6 +114,121 @@ func TestSetupAppServerCommandPinsPerWorkspaceGoCache(t *testing.T) {
 	want := "GOCACHE=" + filepath.Join("/sandbox-tmp", "aiops-go-cache", "build", workspaceCacheKey(in.Workdir))
 	if !strings.Contains(strings.Join(cmd.Env, "\n"), want) {
 		t.Errorf("setupAppServerCommand cmd.Env missing %q; got:\n%s", want, strings.Join(cmd.Env, "\n"))
+	}
+}
+
+func TestSetupAppServerCommandReapsStaleGoBuildCaches(t *testing.T) {
+	codexAppServerStubScript(t, "\n") // installs codex stub + login PATH
+	t.Setenv("TMPDIR", t.TempDir())
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	oldNow := goCacheNow
+	goCacheNow = func() time.Time { return now }
+	t.Cleanup(func() { goCacheNow = oldNow })
+
+	buildRoot := filepath.Join(aiopsGoCacheRoot(), "build")
+	stale := filepath.Join(buildRoot, "stale")
+	recent := filepath.Join(buildRoot, "recent")
+	modCache := filepath.Join(aiopsGoCacheRoot(), "mod")
+	for _, dir := range []string{stale, recent, modCache} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	staleTime := now.Add(-goBuildCacheMaxAge - time.Hour)
+	if err := os.Chtimes(stale, staleTime, staleTime); err != nil {
+		t.Fatalf("backdate stale cache %s: %v", stale, err)
+	}
+	recentTime := now.Add(-time.Hour)
+	if err := os.Chtimes(recent, recentTime, recentTime); err != nil {
+		t.Fatalf("backdate recent cache %s: %v", recent, err)
+	}
+
+	in := appServerInput(codexWorkdir(t, "issue-42"))
+	if _, _, _, err := setupAppServerCommand(context.Background(), in); err != nil {
+		t.Fatalf("setupAppServerCommand: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale Go build cache stat err = %v; want not exist", err)
+	}
+	if _, err := os.Stat(recent); err != nil {
+		t.Fatalf("recent Go build cache stat err = %v; want nil", err)
+	}
+	if _, err := os.Stat(modCache); err != nil {
+		t.Fatalf("shared Go module cache stat err = %v; want nil", err)
+	}
+}
+
+func TestReapSandboxGoBuildCachesSkipsActiveCache(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	oldNow := goCacheNow
+	goCacheNow = func() time.Time { return now }
+	t.Cleanup(func() { goCacheNow = oldNow })
+
+	workdir := filepath.Join(t.TempDir(), "issue-42")
+	cache := filepath.Join(aiopsGoCacheRoot(), "build", workspaceCacheKey(workdir))
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatalf("mkdir active Go build cache %s: %v", cache, err)
+	}
+	old := now.Add(-goBuildCacheMaxAge - time.Hour)
+	if err := os.Chtimes(cache, old, old); err != nil {
+		t.Fatalf("backdate active Go build cache %s: %v", cache, err)
+	}
+
+	release := markActiveGoBuildCache(workdir)
+	if err := reapSandboxGoBuildCaches(); err != nil {
+		t.Fatalf("reapSandboxGoBuildCaches(active) err = %v; want nil", err)
+	}
+	if _, err := os.Stat(cache); err != nil {
+		t.Fatalf("active Go build cache stat err = %v; want nil", err)
+	}
+	release()
+	if err := reapSandboxGoBuildCaches(); err != nil {
+		t.Fatalf("reapSandboxGoBuildCaches(released) err = %v; want nil", err)
+	}
+	if _, err := os.Stat(cache); !os.IsNotExist(err) {
+		t.Fatalf("released stale Go build cache stat err = %v; want not exist", err)
+	}
+}
+
+func TestReapSandboxGoBuildCachesContinuesAfterRemoveError(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	oldNow := goCacheNow
+	goCacheNow = func() time.Time { return now }
+	t.Cleanup(func() { goCacheNow = oldNow })
+	removeErr := errors.New("remove denied")
+	oldRemoveAll := goCacheRemoveAll
+	t.Cleanup(func() { goCacheRemoveAll = oldRemoveAll })
+
+	buildRoot := filepath.Join(aiopsGoCacheRoot(), "build")
+	blocked := filepath.Join(buildRoot, "00-blocked")
+	later := filepath.Join(buildRoot, "10-later")
+	for _, dir := range []string{blocked, later} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		old := now.Add(-goBuildCacheMaxAge - time.Hour)
+		if err := os.Chtimes(dir, old, old); err != nil {
+			t.Fatalf("backdate Go build cache %s: %v", dir, err)
+		}
+	}
+	goCacheRemoveAll = func(path string) error {
+		if path == blocked {
+			return removeErr
+		}
+		return os.RemoveAll(path)
+	}
+
+	err := reapSandboxGoBuildCaches()
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("reapSandboxGoBuildCaches() err = %v; want %v", err, removeErr)
+	}
+	if _, err := os.Stat(blocked); err != nil {
+		t.Fatalf("blocked Go build cache stat err = %v; want nil after injected remove failure", err)
+	}
+	if _, err := os.Stat(later); !os.IsNotExist(err) {
+		t.Fatalf("later stale Go build cache stat err = %v; want not exist", err)
 	}
 }
 

--- a/internal/runner/go_cache_test.go
+++ b/internal/runner/go_cache_test.go
@@ -3,9 +3,11 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -229,6 +231,96 @@ func TestReapSandboxGoBuildCachesContinuesAfterRemoveError(t *testing.T) {
 	}
 	if _, err := os.Stat(later); !os.IsNotExist(err) {
 		t.Fatalf("later stale Go build cache stat err = %v; want not exist", err)
+	}
+}
+
+// TestReapSandboxGoBuildCachesConcurrentWithActiveChurnIsRaceFree pins the
+// invariant the goBuildCacheActiveMu guard exists for: a workspace marked active
+// is never reaped out from under a live app-server, even while concurrent sweeps
+// race a stream of mark/unmark calls. goBuildCacheActive is package-shared state
+// mutated from per-run goroutines and read by the reaper, so this exercises the
+// mark/active/reap paths under -race; without the mutex the detector trips on the
+// map and counter, and a dropped active check would delete heldCache.
+func TestReapSandboxGoBuildCachesConcurrentWithActiveChurnIsRaceFree(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	oldNow := goCacheNow
+	goCacheNow = func() time.Time { return now }
+	t.Cleanup(func() { goCacheNow = oldNow })
+
+	// One workspace stays continuously marked for the whole run; its stale-mtime
+	// cache must survive every concurrent reap.
+	held := filepath.Join(t.TempDir(), "held")
+	heldCache := filepath.Join(aiopsGoCacheRoot(), "build", workspaceCacheKey(held))
+	staleGoBuildCacheDir(t, heldCache, now)
+	releaseHeld := markActiveGoBuildCache(held)
+	t.Cleanup(releaseHeld)
+
+	const churnKeys = 8
+	churn := make([]string, churnKeys)
+	for i := range churn {
+		churn[i] = filepath.Join(t.TempDir(), fmt.Sprintf("churn-%d", i))
+		staleGoBuildCacheDir(t, filepath.Join(aiopsGoCacheRoot(), "build", workspaceCacheKey(churn[i])), now)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 4; i++ { // reapers hammer the sweep against active-set churn
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = reapSandboxGoBuildCaches()
+				}
+			}
+		}()
+	}
+	for _, w := range churn { // mark/unmark distinct keys, racing the reapers
+		wg.Add(1)
+		go func(workdir string) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				select {
+				case <-stop:
+					return
+				default:
+					markActiveGoBuildCache(workdir)()
+				}
+			}
+		}(w)
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if _, err := os.Stat(heldCache); err != nil {
+		t.Fatalf("held active Go build cache stat err = %v; want nil (never reaped while marked)", err)
+	}
+	// Balanced mark/unmark must drain every churn key, leaving only the held key.
+	heldKey := workspaceCacheKey(held)
+	goBuildCacheActiveMu.Lock()
+	defer goBuildCacheActiveMu.Unlock()
+	for key, n := range goBuildCacheActive {
+		if key != heldKey {
+			t.Errorf("active set leaked key %q = %d; want only held key %q", key, n, heldKey)
+		}
+	}
+}
+
+// staleGoBuildCacheDir creates dir and backdates its mtime past goBuildCacheMaxAge
+// relative to now, so the reaper treats it as eligible for eviction.
+func staleGoBuildCacheDir(t *testing.T, dir string, now time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir Go build cache %s: %v", dir, err)
+	}
+	old := now.Add(-goBuildCacheMaxAge - time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatalf("backdate Go build cache %s: %v", dir, err)
 	}
 }
 

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -429,6 +430,9 @@ func RemoveIssueWorkspace(ctx context.Context, ev EventEmitter, req RemoveWorksp
 	}
 	if err := workspace.SafeRemove(req.WorkspaceRoot, req.Path); err != nil {
 		return false, fmt.Errorf("remove %s workspace %s: %w", req.Reason, req.Path, err)
+	}
+	if err := runner.RemoveSandboxGoBuildCache(req.Path); err != nil {
+		log.Printf("event=go_build_cache_remove_failed task_id=%s issue_id=%s issue_identifier=%s reason=%s workspace=%q error=%q", req.TaskID, req.IssueID, req.Identifier, req.Reason, req.Path, err)
 	}
 	Emit(ctx, ev, req.TaskID, "", task.EventReconcileWorkspace, "removed workspace", map[string]any{
 		"path":       req.Path,

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -92,6 +93,41 @@ func TestReconcileStartupRemovesTerminalWorkspaces(t *testing.T) {
 	}
 	if got := len(emitter.byKind(task.EventReconcileEnd)); got != 1 {
 		t.Fatalf("reconcile_end events = %d, want 1", got)
+	}
+}
+
+func TestRemoveIssueWorkspaceRemovesGoBuildCache(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	root := t.TempDir()
+	workdir := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-2")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir workspace %s: %v", workdir, err)
+	}
+	cache := runner.SandboxGoBuildCachePath(workdir)
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatalf("mkdir Go build cache %s: %v", cache, err)
+	}
+
+	removed, err := RemoveIssueWorkspace(context.Background(), &fakeEmitter{}, RemoveWorkspaceRequest{
+		WorkspaceRoot: root,
+		TaskID:        "reconcile-startup",
+		Path:          workdir,
+		IssueID:       "issue-2",
+		Identifier:    "LIN-2",
+		State:         "Done",
+		Reason:        "terminal",
+	})
+	if err != nil {
+		t.Fatalf("RemoveIssueWorkspace() err = %v; want nil", err)
+	}
+	if !removed {
+		t.Fatalf("RemoveIssueWorkspace() removed = %v; want true", removed)
+	}
+	if _, err := os.Stat(workdir); !os.IsNotExist(err) {
+		t.Fatalf("removed workspace stat err = %v; want not exist", err)
+	}
+	if _, err := os.Stat(cache); !os.IsNotExist(err) {
+		t.Fatalf("removed Go build cache stat err = %v; want not exist", err)
 	}
 }
 

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -140,6 +140,9 @@ func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID,
 	if err := workspace.SafeRemove(workspaceRoot, workdir); err != nil {
 		LogTaskIDEventf(taskID, identifier, "workspace_remove_failed", "reason=%s workdir=%q error=%q", reason, workdir, err)
 	}
+	if err := runner.RemoveSandboxGoBuildCache(workdir); err != nil {
+		LogTaskIDEventf(taskID, identifier, "go_build_cache_remove_failed", "reason=%s workdir=%q error=%q", reason, workdir, err)
+	}
 }
 
 // runState threads one task's lifecycle state across RunTask's phase helpers


### PR DESCRIPTION
## Summary
- Remove per-workspace Codex agent Go build caches when the matching worker workspace is removed.
- Add a lazy `TMPDIR/aiops-go-cache/build/<key>` TTL sweep on Codex app-server setup that skips currently active app-server cache keys and aggregates per-entry cleanup errors.
- Document the agent Go cache lifecycle, including that the 7-day TTL uses top-level `build/<key>/` directory mtime rather than last cache hit.

Closes #551

## Acceptance criteria
- [x] `aiops-go-cache/build/<key>` entries are bounded by workspace teardown plus a lazy 7-day TTL sweep.
- [x] Bounded growth is verified by tests for stale eviction, active-cache skipping, continued cleanup after one removal error, and workspace-removal cache teardown.
- [x] `docs/runbooks/workspace-cache.md` documents the agent Go cache lifecycle.

## Verification
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/tui`

## Mutation checks
- Disabled the setup-time reaper call; `TestSetupAppServerCommandReapsStaleGoBuildCaches` failed as expected, then passed after restore.
- Changed workspace teardown to remove the wrong cache key; `TestRemoveIssueWorkspaceRemovesGoBuildCache` failed as expected, then passed after restore.

## Pre-push review
- Codex diff-only review on `77a5b08`: `MERGE-READY`, no findings.
- Claude diff-only review found TTL wording ambiguity; addressed by documenting mtime-based TTL semantics. Final Claude rerun is still pending because this PR was opened immediately per maintainer request.

## Size gate
- [x] `within budget` — 7 files, 295 changed LOC; fits default `policy.max_changed_files` 12 / `policy.max_changed_loc` 300.
- [ ] `size-gated: justified overage` — rationale: n/a
- [ ] `size-gated: split recommended` — rationale: n/a
