### PR TITLE
fix(orchestrator): defer reconcile-cancel to the §16.5 self-stop for agent handoffs (#557)

### DIFF
--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -357,6 +357,19 @@ func (r *reconcileTrackerIssuesOp) reconcileActiveRun(st *OrchestratorState, id 
 		st.ClaimedIssues[id] = issue
 		return nil
 	}
+	if refreshed, ok := r.refreshedByID[string(id)]; ok &&
+		!isActiveTrackerState(refreshed.State, r.activeStates) &&
+		reconcileDefersToSelfStop(r.o.runnerEnforcesMaxTurns, run.Issue, refreshed, r.terminalStates) {
+		// Agent self-handoff to a non-terminal inactive state on a self-stopping
+		// runner: defer to its SPEC §16.5 self-stop rather than hard-cancelling
+		// mid-turn (#557). Leave run.Issue and the ClaimedIssues snapshot at their
+		// dispatch-time ACTIVE state — the worker is still an in-flight agent
+		// finishing its current turn, so per-state capacity gates must keep
+		// counting it under that state; refreshing to the inactive state would
+		// over/under-count until the worker self-stops (a turn later) through the
+		// clean-exit path.
+		return nil
+	}
 	st.ReleaseClaim(id)
 	run.ReconcileCancel = true
 	fromState := run.Issue.State
@@ -464,6 +477,40 @@ func sameServiceRoute(previous, current tracker.Issue) bool {
 	return strings.TrimSpace(previous.ServiceName) == strings.TrimSpace(current.ServiceName)
 }
 
+// reconcileDefersToSelfStop reports whether per-tick reconciliation should leave
+// a running entry to its SPEC §16.5 per-turn self-stop instead of hard-cancelling
+// it. It is true only for a self-stopping runner (codex app-server — the runner
+// whose in-session loop runs the §16.5 issue-state refresh after every turn, gated
+// by runner.EnforcesMaxTurnsInternally) whose issue moved to a NON-terminal
+// inactive state on the same service route: the agent's own PR handoff (e.g. moving
+// the issue to In Review as its final turn action).
+//
+// Without this, reconcile-cancel races the §16.5 self-stop on the same "issue left
+// the active set" observation (#557): a cancel win stops the run mid-turn and
+// finalizes it as PhaseCanceledByReconciliation, which finishRunAborted drops from
+// /api/v1/state entirely — so an agent that opened a PR and handed off shows up as
+// neither completed nor failed. Deferring lets the worker's next §16.5 refresh stop
+// the run through the clean-exit path (recorded completed, true terminal status).
+// The current turn is bounded by turn/agent timeouts, and a wedged turn is still
+// reaped by stall detection, so deferral cannot strand the claim.
+//
+// A terminal transition (the issue is genuinely done/cancelled — typically an
+// operator action, not an agent handoff), a route change, or a non-self-stopping
+// runner (mock / shell-based claude exit after a single turn with no §16.5 loop)
+// keeps the existing prompt hard-cancel.
+//
+// `current` must already be a non-active observation — the function does not
+// re-check it (the active vs non-active split is the caller's domain): the
+// inactive pass only feeds entries from its inactive/terminal listing, and the
+// active pass guards the call with an explicit
+// `!isActiveTrackerState(refreshed.State, …)`. A new call site MUST establish the
+// same precondition (AGENTS.md cross-cutting checklist item 1).
+func reconcileDefersToSelfStop(selfStopRunner bool, prev, current tracker.Issue, terminalStates map[string]struct{}) bool {
+	return selfStopRunner &&
+		sameServiceRoute(prev, current) &&
+		!isTerminalTrackerState(current.State, terminalStates)
+}
+
 type reconcileInactiveTrackerIssuesOp struct {
 	o              *Orchestrator
 	issuesByID     map[string]tracker.Issue
@@ -514,6 +561,18 @@ func (r *reconcileInactiveTrackerIssuesOp) apply(st *OrchestratorState) func() {
 func (r *reconcileInactiveTrackerIssuesOp) reconcileInactiveRun(st *OrchestratorState, id IssueID, run *RunningEntry) *RunningEntry {
 	issue, ok := r.issuesByID[string(id)]
 	if !ok {
+		return nil
+	}
+	if reconcileDefersToSelfStop(r.o.runnerEnforcesMaxTurns, run.Issue, issue, r.terminalStates) {
+		// Agent self-handoff to a non-terminal inactive state on a self-stopping
+		// runner: defer to the worker's SPEC §16.5 self-stop so the run finalizes
+		// through the clean-exit path (recorded completed) instead of
+		// CanceledByReconciliation, which is invisible in /api/v1/state (#557).
+		// Leave run.Issue and the ClaimedIssues snapshot at their dispatch-time
+		// ACTIVE state so per-state capacity gates keep counting this still-running
+		// agent under that state (refreshing to the inactive state would
+		// over/under-count until the worker self-stops a turn later). A
+		// non-terminal transition keeps the workspace.
 		return nil
 	}
 	st.ReleaseClaim(id)

--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -359,7 +359,7 @@ func (r *reconcileTrackerIssuesOp) reconcileActiveRun(st *OrchestratorState, id 
 	}
 	if refreshed, ok := r.refreshedByID[string(id)]; ok &&
 		!isActiveTrackerState(refreshed.State, r.activeStates) &&
-		reconcileDefersToSelfStop(r.o.runnerEnforcesMaxTurns, run.Issue, refreshed, r.terminalStates) {
+		reconcileDefersToSelfStop(r.o.runnerEnforcesMaxTurns, refreshed, r.terminalStates) {
 		// Agent self-handoff to a non-terminal inactive state on a self-stopping
 		// runner: defer to its SPEC §16.5 self-stop rather than hard-cancelling
 		// mid-turn (#557). Leave run.Issue and the ClaimedIssues snapshot at their
@@ -479,11 +479,11 @@ func sameServiceRoute(previous, current tracker.Issue) bool {
 
 // reconcileDefersToSelfStop reports whether per-tick reconciliation should leave
 // a running entry to its SPEC §16.5 per-turn self-stop instead of hard-cancelling
-// it. It is true only for a self-stopping runner (codex app-server — the runner
-// whose in-session loop runs the §16.5 issue-state refresh after every turn, gated
-// by runner.EnforcesMaxTurnsInternally) whose issue moved to a NON-terminal
-// inactive state on the same service route: the agent's own PR handoff (e.g. moving
-// the issue to In Review as its final turn action).
+// it. It is true for a self-stopping runner (codex app-server — the runner whose
+// in-session loop runs the §16.5 issue-state refresh after every turn, gated by
+// runner.EnforcesMaxTurnsInternally) whose issue moved to a NON-terminal inactive
+// state: the agent's own PR handoff (e.g. moving the issue to In Review as its
+// final turn action).
 //
 // Without this, reconcile-cancel races the §16.5 self-stop on the same "issue left
 // the active set" observation (#557): a cancel win stops the run mid-turn and
@@ -494,21 +494,27 @@ func sameServiceRoute(previous, current tracker.Issue) bool {
 // The current turn is bounded by turn/agent timeouts, and a wedged turn is still
 // reaped by stall detection, so deferral cannot strand the claim.
 //
-// A terminal transition (the issue is genuinely done/cancelled — typically an
-// operator action, not an agent handoff), a route change, or a non-self-stopping
-// runner (mock / shell-based claude exit after a single turn with no §16.5 loop)
-// keeps the existing prompt hard-cancel.
+// A terminal transition (genuinely done/cancelled — typically an operator action,
+// not an agent handoff) or a non-self-stopping runner (mock / shell-based claude
+// exit after a single turn with no §16.5 loop) keeps the existing prompt
+// hard-cancel.
 //
-// `current` must already be a non-active observation — the function does not
-// re-check it (the active vs non-active split is the caller's domain): the
-// inactive pass only feeds entries from its inactive/terminal listing, and the
-// active pass guards the call with an explicit
-// `!isActiveTrackerState(refreshed.State, …)`. A new call site MUST establish the
-// same precondition (AGENTS.md cross-cutting checklist item 1).
-func reconcileDefersToSelfStop(selfStopRunner bool, prev, current tracker.Issue, terminalStates map[string]struct{}) bool {
-	return selfStopRunner &&
-		sameServiceRoute(prev, current) &&
-		!isTerminalTrackerState(current.State, terminalStates)
+// Route (ServiceName) is deliberately NOT checked here: the narrow state refresh
+// (FetchIssueStatesByIDs) that feeds both call sites returns only id/identifier/
+// state for an issue that left the active listing, so `current.ServiceName` is
+// empty for a routed run and a route comparison would always fail — wrongly
+// hard-cancelling every routed handoff (Codex P1 on PR #562). It is also
+// unnecessary: a route-change to an *active* state is excluded by the active
+// pass's own `!isActiveTrackerState` guard before this is called, and the worker's
+// §16.5 refresh self-stops on ANY non-active state regardless of route. `current`
+// must already be a non-active observation — the function does not re-check it
+// (the active/non-active split is the caller's domain): the inactive pass only
+// feeds entries from its inactive/terminal listing, and the active pass guards the
+// call with an explicit `!isActiveTrackerState(refreshed.State, …)`. A new call
+// site MUST establish the same precondition (AGENTS.md cross-cutting checklist
+// item 1).
+func reconcileDefersToSelfStop(selfStopRunner bool, current tracker.Issue, terminalStates map[string]struct{}) bool {
+	return selfStopRunner && !isTerminalTrackerState(current.State, terminalStates)
 }
 
 type reconcileInactiveTrackerIssuesOp struct {
@@ -563,7 +569,7 @@ func (r *reconcileInactiveTrackerIssuesOp) reconcileInactiveRun(st *Orchestrator
 	if !ok {
 		return nil
 	}
-	if reconcileDefersToSelfStop(r.o.runnerEnforcesMaxTurns, run.Issue, issue, r.terminalStates) {
+	if reconcileDefersToSelfStop(r.o.runnerEnforcesMaxTurns, issue, r.terminalStates) {
 		// Agent self-handoff to a non-terminal inactive state on a self-stopping
 		// runner: defer to the worker's SPEC §16.5 self-stop so the run finalizes
 		// through the clean-exit path (recorded completed) instead of

--- a/internal/orchestrator/actor_reconcile_self_stop_test.go
+++ b/internal/orchestrator/actor_reconcile_self_stop_test.go
@@ -1,0 +1,189 @@
+package orchestrator
+
+// actor_reconcile_self_stop_test.go pins the #557 fix: per-tick reconciliation
+// must DEFER to a self-stopping runner's SPEC §16.5 self-stop when the agent
+// moves its own issue to a non-terminal inactive state (PR handoff, e.g. In
+// Review), instead of racing it with a mid-turn hard-cancel that finalizes the
+// run as PhaseCanceledByReconciliation (invisible in /api/v1/state). The deferral
+// is scoped: only a self-stopping runner (RunnerEnforcesMaxTurns) + a
+// non-terminal inactive transition + same service route qualifies; everything
+// else keeps the existing prompt hard-cancel.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// dispatchActiveRun dispatches one issue and waits until the worker is running,
+// returning the fake dispatcher slot index (always 0 for the first dispatch).
+func dispatchActiveRun(t *testing.T, o *Orchestrator, disp *fakeDispatcher, iss tracker.Issue) {
+	t.Helper()
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+}
+
+// assertNotCanceled fails if the run's context is cancelled within a short grace
+// window; the reconcile wait has already returned, so a clean window means the
+// worker was left to self-stop.
+func assertNotCanceled(t *testing.T, ctx context.Context) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+		t.Fatal("run was hard-cancelled by reconcile; want deferral to the §16.5 self-stop")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestReconcileInactiveDefersSelfStopRunnerToCleanExit is the core #557 case: a
+// self-stopping runner whose issue moved to a non-terminal inactive state is NOT
+// cancelled; once the worker self-stops (clean exit), it is recorded as completed
+// rather than vanishing as CanceledByReconciliation.
+func TestReconcileInactiveDefersSelfStopRunnerToCleanExit(t *testing.T) {
+	disp := &fakeDispatcher{}
+	enforces := true
+	o, cancel := startActor(t, Deps{
+		Dispatcher:             disp,
+		Scheduler:              RetryScheduler{MaxBackoff: time.Minute},
+		RunnerEnforcesMaxTurns: &enforces,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-SS1", Identifier: "ENG-SS1", State: "In Progress"}
+	dispatchActiveRun(t, o, disp, iss)
+
+	// Agent handoff: issue now in a non-terminal inactive state (In Review).
+	inactive := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "In Review"}}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), inactive, normalizedStates([]string{"done"}), 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	assertNotCanceled(t, disp.contexts[0])
+	v, _ := o.Snapshot(context.Background())
+	if len(v.Running) != 1 {
+		t.Fatalf("Running after deferral = %d; want 1 (run kept for §16.5 self-stop)", len(v.Running))
+	}
+	// The deferred run must keep its dispatch-time ACTIVE state, not the inactive
+	// handoff state, so per-state capacity gates keep counting it correctly until
+	// the worker self-stops (a refresh to "In Review" here would mis-bucket it).
+	if got := v.Running[0].State; got != "In Progress" {
+		t.Fatalf("deferred run State = %q; want %q (kept at dispatch-time active state for capacity accounting)", got, "In Progress")
+	}
+	if len(v.Completed) != 0 {
+		t.Fatalf("Completed before worker exit = %d; want 0", len(v.Completed))
+	}
+
+	// Worker self-stops (SPEC §16.5: refresh saw the inactive issue → clean exit).
+	disp.finishAt(0, WorkerResult{Err: nil, Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.Completed) == 1
+	}, time.Second)
+}
+
+// TestReconcileInactiveCancelsNonSelfStopRunner pins that the deferral is scoped
+// to self-stopping runners: a one-shot runner (mock / shell claude, no §16.5
+// loop) whose issue went non-terminal-inactive is still hard-cancelled, since
+// nothing else would stop it.
+func TestReconcileInactiveCancelsNonSelfStopRunner(t *testing.T) {
+	disp := &fakeDispatcher{}
+	enforces := false
+	o, cancel := startActor(t, Deps{
+		Dispatcher:             disp,
+		Scheduler:              RetryScheduler{MaxBackoff: time.Minute},
+		RunnerEnforcesMaxTurns: &enforces,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-SS2", Identifier: "ENG-SS2", State: "In Progress"}
+	dispatchActiveRun(t, o, disp, iss)
+
+	inactive := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "In Review"}}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), inactive, normalizedStates([]string{"done"}), 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	select {
+	case <-disp.contexts[0].Done():
+	case <-time.After(time.Second):
+		t.Fatal("non-self-stop run on inactive issue was not cancelled; want hard-cancel")
+	}
+	disp.finishAt(0, WorkerResult{Err: context.Canceled, Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0
+	}, time.Second)
+}
+
+// TestReconcileInactiveCancelsSelfStopRunnerOnTerminalState pins that the
+// deferral is scoped to NON-terminal transitions: a self-stopping runner whose
+// issue went to a terminal state (genuinely done/cancelled — typically an
+// operator action, not a handoff) is still hard-cancelled promptly.
+func TestReconcileInactiveCancelsSelfStopRunnerOnTerminalState(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	enforces := true
+	o, cancel := startActor(t, Deps{
+		Dispatcher:             disp,
+		Scheduler:              RetryScheduler{MaxBackoff: time.Minute},
+		RunnerEnforcesMaxTurns: &enforces,
+		WorkspaceCleaner:       cleaner,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-SS3", Identifier: "ENG-SS3", State: "In Progress"}
+	dispatchActiveRun(t, o, disp, iss)
+
+	terminal := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "Done"}}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), terminal, normalizedStates([]string{"done"}), 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	select {
+	case <-disp.contexts[0].Done():
+	case <-time.After(time.Second):
+		t.Fatal("self-stop run on a TERMINAL issue was not cancelled; want prompt hard-cancel")
+	}
+	disp.finishAt(0, WorkerResult{Err: context.Canceled, Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0
+	}, time.Second)
+}
+
+// TestReconcileActiveDefersSelfStopRunnerOnNonTerminalInactive covers the
+// routing-aware active pass (reconcileTrackerIssuesOp): a self-stopping run whose
+// refreshed state left the active set for a non-terminal inactive state on the
+// same route is deferred, not cancelled.
+func TestReconcileActiveDefersSelfStopRunnerOnNonTerminalInactive(t *testing.T) {
+	disp := &fakeDispatcher{}
+	enforces := true
+	o, cancel := startActor(t, Deps{
+		Dispatcher:             disp,
+		Scheduler:              RetryScheduler{MaxBackoff: time.Minute},
+		RunnerEnforcesMaxTurns: &enforces,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-SS4", Identifier: "ENG-SS4", State: "In Progress", ServiceName: "api"}
+	dispatchActiveRun(t, o, disp, iss)
+
+	// Active listing no longer contains the issue (it left active); the narrow
+	// refresh observed it in a non-terminal inactive state on the same route.
+	refreshed := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "In Review", ServiceName: "api"}}
+	if err := o.ReconcileTrackerIssuesAndWait(context.Background(),
+		map[string]tracker.Issue{}, normalizedStates([]string{"in progress"}),
+		normalizedStates([]string{"done"}), refreshed, 0); err != nil {
+		t.Fatalf("ReconcileTrackerIssuesAndWait: %v", err)
+	}
+
+	assertNotCanceled(t, disp.contexts[0])
+	v, _ := o.Snapshot(context.Background())
+	if len(v.Running) != 1 {
+		t.Fatalf("Running after active-pass deferral = %d; want 1", len(v.Running))
+	}
+}

--- a/internal/orchestrator/actor_reconcile_self_stop_test.go
+++ b/internal/orchestrator/actor_reconcile_self_stop_test.go
@@ -173,8 +173,11 @@ func TestReconcileActiveDefersSelfStopRunnerOnNonTerminalInactive(t *testing.T) 
 	dispatchActiveRun(t, o, disp, iss)
 
 	// Active listing no longer contains the issue (it left active); the narrow
-	// refresh observed it in a non-terminal inactive state on the same route.
-	refreshed := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "In Review", ServiceName: "api"}}
+	// refresh observed it in a non-terminal inactive state. The real refresh
+	// (FetchIssueStatesByIDs) returns only id/identifier/state, so ServiceName is
+	// empty here even though the run was dispatched on "api" — deferral must still
+	// apply (route is not part of the decision; Codex P1 on #562).
+	refreshed := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "In Review"}}
 	if err := o.ReconcileTrackerIssuesAndWait(context.Background(),
 		map[string]tracker.Issue{}, normalizedStates([]string{"in progress"}),
 		normalizedStates([]string{"done"}), refreshed, 0); err != nil {


### PR DESCRIPTION
## What & why — the run-accounting half of #557

The verify-skip (safety) half of #557 shipped in #560 (worker verify gate removed). This PR fixes the second harm: **misleading run accounting.**

When the agent moves its own issue to a non-terminal inactive state (PR handoff, e.g. `In Review`) as its final turn action, the SPEC §16.5 per-turn self-stop (in the codex runner's in-session loop) and the D9 reconcile-cancel race the same "issue left the active set" observation. A reconcile-cancel win stops the run **mid-turn** → finalized as `PhaseCanceledByReconciliation` → `finishRunAborted`, which records the run in **neither** Completed nor Failed → it's invisible in `/api/v1/state`. So a deployment that opened 3 PRs reports `completed: 1`, and operators can't tell a genuine cancel from a completed-but-reaped handoff.

## Fix

New `reconcileDefersToSelfStop` predicate. For a **self-stopping runner** (`runner.EnforcesMaxTurnsInternally` — codex app-server, whose in-session loop runs the §16.5 refresh after every turn) whose issue moved to a **non-terminal inactive** state on the **same service route**, reconcile **defers** to the self-stop instead of hard-cancelling: it keeps the claim and the run, and lets the worker finish its current turn and exit through the clean-exit path (`applyCleanExit` → `recordCompleted`, true terminal status). Applied in both reconcile passes — `reconcileActiveRun` (routing deployments) and `reconcileInactiveRun` (the non-routing path the #557 repro hit).

The current turn is bounded by turn/agent timeouts and a wedged turn is still reaped by stall detection, so deferral cannot strand the claim.

With #560 merged this is **not** patching a deviation: §16.5 is the SPEC agent-completion mechanism and is now authoritative for an agent's own handoff.

## Scope — D9 prompt-cancel preserved where it matters

Terminal transitions (genuinely done/cancelled — typically operator action), route changes, and non-self-stopping runners (mock / shell claude exit after one turn, no §16.5 loop) all keep the existing **mid-turn hard-cancel**. Verified by tests.

## Pre-push review (adversarial) — addressed

- **HIGH (capacity accounting):** an early draft refreshed the deferred run's stored issue to the inactive state, which would mis-bucket it in `RunningCountByState` (over-count the inactive state, under-count the active state) every tick until self-stop. Fixed: the deferral leaves `run.Issue` / `ClaimedIssues` at the dispatch-time **active** state — the worker is still an in-flight agent finishing its turn, so it must keep counting under that state. Pinned by a `Running[0].State` assertion (mutation-verified).
- **MEDIUM:** documented the non-active precondition `reconcileDefersToSelfStop` relies on at both call sites (AGENTS.md checklist item 1).

## Known residual (out of scope)

In a **routing** deployment, if the narrow state-refresh misses an in-handoff issue entirely (absent from both the active listing and `refreshedByID`), the routing active pass still treats absence as inactivity and hard-cancels it — the §557 race can recur for that low-frequency tracker-timing edge. The non-routing repro path is fully covered. Tracked as a residual; the worker's own §16.5 refresh (independent of the poller) usually self-stops it first.

## Verification

```
gofmt / go vet ./... / go build / golangci (blocking, orchestrator): clean, 0 issues
go test -race ./...                       # all pass except the documented
                                          #   sandbox-flaky codex app-server
                                          #   timeout test (untouched, passes in CI)
```
4 new tests in `actor_reconcile_self_stop_test.go` (defer→completed, non-self-stop→cancel, terminal→cancel, routing-active→defer); **mutation-verified** — forcing `reconcileDefersToSelfStop` false fails the defer tests, and re-introducing the issue-refresh fails the capacity-state assertion.

## Size-gate

`within budget` — 2 files, focused (+1 predicate, 2 guard sites, 4 tests).

Closes #557.