### PR TITLE
docs(agents): add harness principle 6 — upstream absence = over-design signal, delete don't relocate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,30 @@ govern *how* we evaluate components inside the SPEC-aligned envelope.
    focused tools (`linear_graphql`, one Gitea PR tool, etc.); resist
    the temptation to wrap every Gitea / Linear endpoint as a separate
    tool.
+6. **Upstream absence is an over-design signal; delete, don't relocate.**
+   Before adding any worker/orchestrator phase, gate, artifact, or config
+   that acts on the agent's output (verify, secret scan, run summary, diff
+   policy, push, PR, tracker write, …), `grep` the Elixir reference for an
+   equivalent *first*. **Upstream having no equivalent is a strong signal the
+   component is over-design, not a feature gap to fill.** The default home for
+   "check the agent's work before handoff" is the WORKFLOW prompt (agent-owned,
+   pre-push, *preventive*), not a worker post-turn phase — a worker phase runs
+   *after* the agent has already pushed (#76), so it can only flag, never
+   prevent, and it races the D9 reconcile-cancel / §16.5 self-stop, which is
+   exactly what caused #557. When a component is found on the wrong side of the
+   boundary, the fix is to **delete it**, not relocate it (move-to-prompt) or
+   merely document it (a new `DEVIATIONS.md` row); relocating or documenting
+   preserves scaffolding that no longer earns its place (principle 4). Keep a
+   piece only if you can name a behavior SPEC's scheduler/runner boundary
+   genuinely permits *and* that the prompt cannot replicate (e.g. the
+   `policy`-violation corrective retry loop). **Earned by:** this port has
+   built-then-unwound the same misplacement at least five times — Postgres
+   queue (#73/#407), Gitea webhook (#74), orchestrator PR/push/tracker-writes
+   (#76), the worker verify gate (#557), and the worker secret-scan gate
+   (#561; the RUN_SUMMARY gate is being unwound in the same #561 effort) — each
+   a dedicated removal on top of the original build, plus the bugs the
+   misplacement itself caused (the #557 reconcile-cancel race was a direct
+   consequence of running verify as a worker post-turn phase).
 
 ## Cross-cutting checklist when porting from the Elixir reference
 


### PR DESCRIPTION
## What & why

This port has **built-then-unwound the same class of misplacement repeatedly**: a worker/orchestrator phase took on a responsibility SPEC §1 assigns to the agent (or that SPEC excludes), it shipped, then it was removed — Postgres queue (#73/#407), Gitea webhook (#74), orchestrator PR/push/tracker-writes (#76), the worker verify gate (#557), and the worker secret-scan gate (#561; the RUN_SUMMARY gate is being unwound in the same #561 effort). Each was a dedicated removal on top of the original build, plus the bugs the misplacement caused — the #557 reconcile-cancel race was a *direct consequence* of running verify as a worker post-turn phase.

The existing harness principles (1 behavior-first, 2 earned-rules) evaluate a component *after* it exists; none is a **preventive up-front gate**. New **principle 6** adds that gate:

- Before adding any worker/orchestrator phase/gate/artifact/config that acts on the agent's output, `grep` the Elixir reference **first**; upstream absence is an over-design signal, not a feature gap.
- The default home for "check the agent's work before handoff" is the WORKFLOW prompt (agent-owned, pre-push, *preventive*), not a worker post-turn phase (post-push → can only flag, never prevent; and it races the D9 reconcile-cancel / §16.5 self-stop — exactly #557).
- When a component is on the wrong side of the boundary, **delete it** — don't relocate (move-to-prompt) or merely document (a DEVIATIONS row); that preserves scaffolding (principle 4). Keep only what names a behavior the scheduler/runner boundary genuinely permits *and* a prompt can't replicate (e.g. the `policy`-violation corrective retry loop).

## Scope

Governance-only; **no code change**. Single addition to AGENTS.md's "Harness engineering principles". Companion to #561 (the gate-removal work that earned the rule).

## Verification

Docs-only. Pre-push dual diff-only review (Codex `codex exec review` + Claude `feature-dev:code-reviewer`): final round **MERGE-READY from both**, zero findings. Earlier rounds caught and fixed a RUN_SUMMARY overclaim and a #561/D33 cross-doc divergence (the latter resolved by rebasing onto current main after #564 merged, so DEVIATIONS D33 now reads "#557 / #561"). Citations are issue-only and each resolves in DEVIATIONS.md (D6/D7/D8/D33).

Earned-by reflection prompted by the operator after the #561 session. Umbrella #67.