### PR TITLE
docs: sync workflow skills with AGENTS.md principles 6-7; drop hand-maintained deviation ranges

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -35,7 +35,8 @@ metadata:
 ### 2. SPEC / upstream 调研（写代码之前）
 - 读 SPEC.md 相关章节 + 对应 Elixir 模块（`orchestrator.ex` / `codex/app_server.ex` / `tracker.ex` / `config/schema.ex`），歧义以 Elixir 为准。
 - **审查相邻路径**（AGENTS.md「Cross-cutting checklist」item 1）：grep 你要改的 SPEC 概念符号，列出其它 consumer；aiops 扩展（service routing `selectRoutedCandidates`、multi-tracker fan-out、per-state capacity caps、eligibility filter、reconcile hooks）要么也在你的新路径生效，要么写明为何不同。**踩坑实例**：blocked vs running 清理路径只兑现了一半契约。
-- **DEVIATIONS.md 决策门**（D1–D30）：本 issue 是关闭既有 deviation、需新开 deviation、还是回退？不要为了让差异消失而新造「deliberate extension」。
+- **要在 worker/orchestrator 侧新增「消费 agent 产物」的 phase/gate/artifact/config（verify、secret-scan、run-summary、diff policy、push、PR、tracker 写…）前，先 grep Elixir 参考有没有等价物**（AGENTS.md 原则 6）。**upstream 没有 = 过度设计信号，不是功能缺口**：默认删除，别搬进 prompt 也别只记一行 DEVIATIONS。「交接前检查 agent 产物」的归宿是 WORKFLOW prompt（agent 自有、push 前、预防式），不是 worker post-turn phase（push 后只能 flag，且抢跑 D9 reconcile-cancel / §16.5 self-stop——#557 即此）。本仓库已建了又拆 6+ 次（#73/#407、#74、#76、#557/#561）。
+- **DEVIATIONS.md 决策门**：研究到结论再提（AGENTS.md 原则 7）——别把「关闭既有 / 新开 / 回退」当多选题甩给用户，SPEC + Elixir 参考通常已能定论（最常见结论：upstream 缺失且 SPEC 归在别处的扩展应删除）。别为了让差异消失而新造「deliberate extension」。
 
 ### 3. 分支 + 实现
 - 从 `main` 开 `fix/<n>-<slug>`（如 `fix/331-active-transition-workspace-cleanup`）。
@@ -89,4 +90,4 @@ go build ./cmd/worker ./cmd/tui
 - 中文回复，简洁；每次只汇报变化，不复述。
 - worker 永不 push/合并 PR 或写 tracker 状态（D8/#76）。
 - Go 版本由 go.mod 锁定，别顺手改 `go` 指令。
-- **批处理多个 issue 时**（`/goal` over a set）：独立 issue **默认并行**开分支推进，只在有真实依赖（共享文件 / migration 顺序 / 后者消费前者的 API）时串行；决定某条 acceptance criterion 延后时**当场**告知用户并立即开 follow-up issue。完整批处理纪律见 [`docs/runbooks/batch-issue-processing.md`](../../../docs/runbooks/batch-issue-processing.md)。
+- **批处理多个 issue 时**（`/goal` over a set）：并行/串行依赖判定、deferral 时机、live ledger、pause/resume、opt-in 授权合并等批处理纪律全部见 [`docs/runbooks/batch-issue-processing.md`](../../../docs/runbooks/batch-issue-processing.md)，不在此复述（与本 skill 顶部「不复述共享协议」一致，避免内联规则与 runbook 漂移）。

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -29,6 +29,7 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
    - 跨模块一致性漏镜像（grep 同概念其他 consumer，列出 aiops-platform 扩展 routing / fan-out / capacity caps / eligibility filter 是否都镜像了）
    - Go 运行时硬化（followup goroutine 是否 `context.WithTimeout` / `defer recoverPanic` / `Timer.Stop()`——Elixir BEAM 隐式给的保证 Go 必须显式补）
    - 测试是否安慰剂（assertion 真的读到新代码改的字段吗？）
+   - 错位机制（在 §1 scheduler/runner 边界的错误一侧）：worker/orchestrator 侧「消费 agent 产物」的 phase/gate/artifact/config，先 grep Elixir 有没有等价物——没有就是过度设计信号，判**删除**（非搬进 prompt、非只记 DEVIATIONS），归宿默认是 WORKFLOW prompt（worker post-turn phase 在 push 后只能 flag 不能 prevent，且抢跑 D9 reconcile-cancel / §16.5 self-stop——#557 即此；AGENTS.md 原则 6；#557/#561 拆的就是这类）
 
 2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，HIGH/MEDIUM/Critical 先修再 amend 重审；一般 2–3 轮收敛。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,8 +270,8 @@ Rules for agents working on this repo:
    working Elixir reference. If you are unsure how a subsystem should behave,
    read the corresponding Elixir module first; the answer is usually there.
 
-The current set of tracked deviations is in `DEVIATIONS.md` (D1–D24, with
-status showing whether each row is open, partial, reverting, or closed). Any
+The current set of tracked deviations is in `DEVIATIONS.md` (each row carries a
+status showing whether it is open, partial, reverting, or closed). Any
 new SPEC-violating change you make must either (a) close an existing deviation,
 (b) be tracked as a new deviation with an issue, or (c) be reverted.
 


### PR DESCRIPTION
## What & why

The `handle-issue` / `handle-pr` skills were last touched at #485 (2026-05-29), **predating** AGENTS.md harness principles **6** (upstream absence = over-design signal; delete, don't relocate) and **7** (research to a verdict, no keep/relocate/document menu) and the entire **#557/#561** worker-gate-removal wave (verify / secret-scan / RUN_SUMMARY / policy gates). That wave is precisely the lesson this repo spent five PRs unwinding — yet the agent's own entry-point skills did not encode it.

This PR brings the skills up to date and, applying the *smallest-useful-asset* lens, trims one cross-layer duplication that had already drifted.

## Changes (docs/governance only — no code paths touched)

- **`handle-issue` §2** — add a principle-6 reflex: before adding any worker/orchestrator phase/gate/artifact/config that consumes the agent's output, `grep` the Elixir reference first; **upstream absence = delete, not relocate-to-prompt or merely document**. Reframe the *DEVIATIONS decision gate* per principle 7 (research to a verdict, not a close/open/revert menu).
- **`handle-issue` defaults** — collapse the inline batch-parallelism restatement to a pointer to `batch-issue-processing.md`. It had **drifted** (narrower "dependency" definition than the runbook: missing shared package / atomic rename / `go.mod`) and violated the skill's own "don't restate shared protocol" rule (one source of truth; clean-code rule 3).
- **`handle-pr` §1** — add a fifth review finding-category: *misplaced machinery on the wrong side of the §1 scheduler/runner boundary* (principle 6).
- **`AGENTS.md`** — drop the stale hand-maintained `D1–D24` deviation range (actual is **D33**) in favor of a drift-proof "each row carries a status" phrasing; same fix applied to the skill's `D1–D30`.

## Acceptance / verification

- No Go code touched; CI Go gates unaffected.
- The two stale deviation ranges are the concrete drift this fixes; replacing hand-maintained enumerations with status-phrasing removes the drift surface rather than re-pinning a number that will drift again.

### Size gate
- [x] \`within budget\` — 3 files, docs-only, well under the ~12-file / ~300-LOC guideline.

## Review log

- **Independent diff review (Claude code-reviewer), 2 rounds.** Round 1 → NEEDS-CHANGES: (a) the handle-issue `6+ times` history list omitted #407 (the dedicated Postgres-queue removal PR named in AGENTS.md principle 6); (b) handle-pr's new finding category lacked the D9 reconcile-cancel / §16.5 self-stop race rationale that handle-issue carries. Both fixed on head `ac0b6e1`; round 2 → **MERGE-READY**.
- **Rejected (LOW):** reviewer suggested re-adding `currently D1–D33` to the AGENTS.md deviation paragraph. Declined — that reintroduces the exact hand-maintained drift surface this PR removes (stale again at D34). `each row carries a status` + DEVIATIONS.md itself preserve the "finite numbered set" signal.
- `@codex review` re-triggered on `ac0b6e1` per protocol §4 (per-push gate).
