### PR TITLE
fix(orchestrator): drop per-notification stream from operator log (#559)

### DIFF
--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -995,6 +995,46 @@ func TestRuntimeEventForwardingEmitterPreservesBaseEmitterAndUpdatesOrchestrator
 	}
 }
 
+// TestRuntimeEventForwardingEmitterDropsNotificationFromOperatorLog pins #559:
+// the high-frequency per-notification stream must reach the live state surface
+// (/api/v1/state + TUI) via RecordRuntimeEvent but must NOT be echoed to the
+// worker's process log (the wrapped EventEmitter), where it otherwise drowns
+// the orchestrator lifecycle events. A non-notification event is still
+// delegated to the log, so the suppression is scoped to EventNotification only.
+func TestRuntimeEventForwardingEmitterDropsNotificationFromOperatorLog(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-559")
+	defer cancel()
+
+	base := &recordingWorkerEmitter{}
+	emitter := runtimeEventForwardingEmitter{EventEmitter: base, Orchestrator: o, IssueID: issueID}
+
+	notif := map[string]any{"message": "Working on it..."}
+	if err := emitter.AddEventWithPayload(context.Background(), "task-1", task.EventNotification, task.EventNotification, notif); err != nil {
+		t.Fatalf("AddEventWithPayload(notification): %v", err)
+	}
+	// A non-notification event must still be logged.
+	if err := emitter.AddEventWithPayload(context.Background(), "task-1", task.EventTurnCompleted, task.EventTurnCompleted, map[string]any{"usage": map[string]any{"total_tokens": 3}}); err != nil {
+		t.Fatalf("AddEventWithPayload(turn_completed): %v", err)
+	}
+
+	// Operator log: notification suppressed, turn_completed delegated.
+	if len(base.kinds) != 1 || base.kinds[0] != task.EventTurnCompleted {
+		t.Fatalf("operator-log kinds = %v; want only [%s] (notification must not reach the process log, #559)", base.kinds, task.EventTurnCompleted)
+	}
+
+	// Live state surface: the suppressed notification still updated the running row.
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 1 {
+		t.Fatalf("running rows = %d, want 1", len(view.Running))
+	}
+	if got := view.Running[0].LastMessage; got != "Working on it..." {
+		t.Errorf("Running[0].LastMessage = %q; want %q (notification still forwarded to /api/v1/state despite being dropped from the log)", got, "Working on it...")
+	}
+}
+
 // TestRecordRuntimeEventPropagatesCodexAppServerPID pins the SPEC §4.1.6 /
 // §10.4 round-trip: a `session_started` event carrying
 // `codex_app_server_pid` populates RunningView.CodexAppServerPID so

--- a/internal/orchestrator/runtime_events.go
+++ b/internal/orchestrator/runtime_events.go
@@ -334,6 +334,17 @@ func (e runtimeEventForwardingEmitter) AddEventWithPayload(ctx context.Context, 
 	if _, ok := runtimeEventKinds[typ]; ok && e.Orchestrator != nil && e.IssueID != "" {
 		_ = e.Orchestrator.RecordRuntimeEvent(ctx, e.IssueID, task.RuntimeEvent{Event: typ, Payload: payload})
 	}
+	// The generic per-notification stream (SPEC §10.4 agent-driven notifications:
+	// delta, reasoning, exec output, token_usage, rate_limits, …) is high-frequency
+	// and already surfaced live through RecordRuntimeEvent → /api/v1/state + TUI —
+	// the same recipient upstream feeds via send_codex_update. Upstream keeps it out
+	// of the operator log (Logger.debug, method name only, filtered at the default
+	// level); the worker's stdlib log has no levels, so echoing every notification
+	// payload here drowned the orchestrator lifecycle events (~80:1 on a trivial
+	// issue, #559). Forward it to the live state surface only, not the process log.
+	if typ == task.EventNotification {
+		return nil
+	}
 	if e.EventEmitter == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Closes #559.

The `codex app-server` runner records every SPEC §10.4 agent-driven notification
(delta, reasoning, exec output, `token_usage`, `rate_limits`, …) as
`task.EventNotification`. `runtimeEventForwardingEmitter.AddEventWithPayload`
forwarded each one to **both**:

1. the live state surface — `RecordRuntimeEvent` → `/api/v1/state` + TUI (correct), and
2. the worker's process log — the wrapped `EventEmitter` (`LogEventEmitter` → `log.Printf` → **stderr**), with the **full payload**.

The worker's stdlib `log` has no levels, so every notification payload was echoed,
drowning the orchestrator lifecycle events.

**This PR**: forward `EventNotification` to the live state surface only; do not
delegate it to the operator-log emitter. All other event kinds
(`run_phase_transition`, `session_started`, `turn_completed`,
`tool_call_mutation`, …) are unchanged.

## SPEC alignment

Upstream Symphony routes this stream only to the recipient
(`send_codex_update`, `agent_runner.ex`) and logs notifications at
`Logger.debug("Codex notification: #{inspect(method)}")` — **method name only, at
DEBUG, filtered out at the default level** (`codex/app_server.ex:520`). The full
per-notification payload never reaches the operator log upstream. This PR makes the
Go port match: payload to the live state surface only, not the process log.

No data is lost: the stream stays available live (`/api/v1/state` + TUI), the
running row's `last_message` (SPEC §13.7.2), and the runner's captured output
artifact (`writeAppServerArtifact` + `runner_end` head/tail).

The issue's suggested `--verbose` flag is intentionally **not** added: upstream
gates this by log level, not a bespoke config knob, and the aligned fix is simply
to stop logging the payload at the default level.

## Evidence (real binary-deploy combat test, current `main`, split stdout/stderr)

Single trivial issue (Linear → `codex app-server` → real draft PR on `xrf9268-hue/todo-cli`):

| stream | lines |
| --- | --- |
| `worker.out.log` (stdout) | **1** (only workspace `git` output) |
| `worker.err.log` (stderr) | **5,207** — `event=notification` **1,543**, **208** lines carrying code/diff content, lifecycle signal **≈18** |

Three concurrent agents: **27,832** stderr lines, signal:noise **≈1.4%**.

This also **corrects the issue's mechanism description**: the noise is not codex's
stdout forwarded verbatim — codex's stdout/stderr are piped + captured by the
runner. It is aiops's own `event=notification` structured logging on **stderr**,
double-written alongside the dashboard forward.

## Verification

- `gofmt -l`, `go vet ./internal/orchestrator/`, `go mod tidy` (clean), `go build ./cmd/worker ./cmd/tui` — all clean.
- `go test -race -covermode=atomic ./internal/orchestrator/ ./internal/worker/` — pass.
- New regression test `TestRuntimeEventForwardingEmitterDropsNotificationFromOperatorLog` mutation-verified against the committed artifact: removing the guard makes it fail (`operator-log kinds = [notification turn_completed]; want only [turn_completed]`); restored → pass.
- Independent code-review pass (correctness, scope, placebo-check, SPEC alignment) — no findings.
- Known sandbox-flaky `TestCodexAppServerInitializeTimeoutDiagnostics` (runner) fails locally under the sandbox (process-spawn writes blocked); unrelated to this change (no runner code touched) — trust CI.

## Size

`within budget` — 2 files, ~10 prod LOC + 1 regression test.
