### PR TITLE
test(runner): decouple InitializeTimeoutDiagnostics from subprocess timing (#587)

### DIFF
--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -1459,23 +1459,33 @@ for line in sys.stdin:
 }
 
 func TestCodexAppServerInitializeTimeoutDiagnostics(t *testing.T) {
-	// Route the started-log evidence and a JSON-RPC handshake through a fast
-	// shell preamble instead of the Python interpreter's startup. The runner
-	// reads the handshake line — which the stub prints only after it has
-	// written the started-log to disk — so by the time the next read hits the
-	// initialize read timeout, the started-log is guaranteed present. And even
-	// if the handshake read itself were to time out, the shell has already
-	// written the started-log within a few milliseconds of exec, so the
-	// process-start evidence holds either way. This removes the race where a
-	// tight read timeout fired before Python startup wrote the file (#476); the
-	// runtime read-timeout behavior is unchanged — the stub simply never answers
-	// initialize, so the initialize request still times out.
-	installCodexStub(t, `#!/bin/sh
-printf 'started\n' > "$CODEX_STARTED_LOG"
-printf '%s\n' '{"jsonrpc":"2.0","method":"session/started"}'
-# Stay initialized-but-silent so the runner's next read hits the read timeout.
+	// The stub stays initialized-but-silent — it never answers initialize — so the
+	// runner's initialize request always hits the read timeout, regardless of when
+	// (or whether) the OS schedules the subprocess. That makes the read-timeout
+	// error deterministic.
+	//
+	// The diagnostics assertion is the part that used to flake: codex writes its
+	// started-log on launch, and the old test made the *fake* stub write that
+	// marker, then asserted the diagnostics carried it. Under a constrained local
+	// sandbox the subprocess was not scheduled to write the marker until ~350ms
+	// after exec, so the tight read timeout tore the process down before the file
+	// landed (#476/#587). The fix decouples the two concerns: the marker is seeded
+	// up front as a fixture rather than raced out of the live subprocess. What is
+	// under test is that the diagnostics *formatter* surfaces process-start
+	// evidence on an initialize timeout — not that the OS scheduled the subprocess
+	// in time, which is not our behavior to assert.
+	binDir := installCodexStub(t, `#!/bin/sh
 cat > /dev/null
 `)
+	// Seed both diagnostic source files (the started-log and the stdin transcript)
+	// so each content assertion below is non-vacuous: a missing file would leave
+	// only the label, which a label-only check would still satisfy.
+	if err := os.WriteFile(filepath.Join(binDir, "started.txt"), []byte("started\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "stdin.txt"), []byte(`{"jsonrpc":"2.0","id":0,"method":"initialize"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.ReadTimeoutMs = 200
@@ -1494,8 +1504,8 @@ cat > /dev/null
 	if !strings.Contains(diagnostics, "started log") || !strings.Contains(diagnostics, "started\n") {
 		t.Fatalf("Run() diagnostics = %q; want started-log process-start evidence", diagnostics)
 	}
-	if !strings.Contains(diagnostics, "stdin log") {
-		t.Fatalf("Run() diagnostics = %q; want stdin-log status line", diagnostics)
+	if !strings.Contains(diagnostics, "stdin log") || !strings.Contains(diagnostics, `"method":"initialize"`) {
+		t.Fatalf("Run() diagnostics = %q; want stdin-log transcript", diagnostics)
 	}
 }
 


### PR DESCRIPTION
Closes #587

## Summary
`TestCodexAppServerInitializeTimeoutDiagnostics` flaked locally: the fake codex
stub wrote its `started.txt` marker ~350ms after exec under a constrained
sandbox, but the test's 200ms read timeout tore the subprocess down before the
marker landed, so the diagnostics assertion failed with `started log …: no such
file or directory`. CI is green (subprocess startup <200ms there) — so the flake
is environment-driven, not a regression. Production runner code is untouched.

Root cause / design delta: the runner kills the subprocess at `read_timeout_ms`,
so **any** approach that awaits a *live-subprocess* marker still races a fixed
wall-clock window — only wider. (An earlier draft using a goroutine + adaptive
poll + 1.5s read timeout was rejected for exactly this: the 1.5s was still a
fixed file-creation window, and the goroutine could outlive `t.TempDir` cleanup.)

The fix **decouples the two concerns**:
- The runner still really runs and really hits the initialize read timeout (the
  stub `cat > /dev/null` never answers initialize) — the read-timeout error
  assertion is preserved end-to-end through the real
  `runCodexAppServerWithDiagnostics` helper.
- The `started.txt` (and `stdin.txt`) markers are **seeded up front as
  fixtures** rather than raced out of the live subprocess, so the diagnostics
  assertions no longer depend on a fixed file-creation window. What is under
  test is that the diagnostics *formatter* surfaces process-start evidence on an
  initialize timeout — not that the OS scheduled the subprocess in time, which
  is not our behavior to assert.

No goroutine, no poll, ~0.2s, deterministic.

## Acceptance criteria (#587)
- [x] `go test -race ./internal/runner/...` green locally (under the sandbox)
  AND CI, across repeated runs — verified 30× `-race` green locally on the core
  design; 10× on the final head.
- [x] The test no longer depends on a fixed wall-clock window for subprocess
  file creation — the markers are synchronous test fixtures.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** …
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue …

Test-only change; touches no SPEC-sensitive path.

## Size budget (AGENTS.md)
- [x] `within budget` — production diff is **0 LOC** (test-only: one file,
  `internal/runner/codex_app_server_test.go`).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `go test -race -covermode=atomic ./...` — green.
- [x] `gofmt -l` clean + blocking golangci gate (`contextcheck,errcheck,errorlint,funlen,gocognit,gocritic,govet,ineffassign,revive,staticcheck,unparam,unused`) — 0 issues.
- [x] `go build ./cmd/worker ./cmd/tui` — ok.

### Mutation verification (against committed artifact, restored to HEAD clean)
1. Break `appendFileDiagnostic` (drop file content) → started-log content assertion **FAILS**.
2. Break `startThread`'s `"codex app-server initialize: %w"` wrap → error assertion **FAILS**.
3. Remove the `stdin.txt` fixture seed → stdin-log content assertion **FAILS**.
All three assertions bite; not a placebo.

## Review notes
- Pre-push dual diff-only review (per `docs/runbooks/pr-review-merge-protocol.md` §3):
  - v1 (goroutine + poll + 1.5s): both reviewers **NEEDS-CHANGES** (residual fixed
    window; goroutine outliving test cleanup) → redesigned.
  - v2 (decouple + seed started-log): Codex **MERGE-READY** (no findings);
    Claude **MERGE-READY** with one LOW (label-only `stdin log` assertion).
  - v3 (this head: seed `stdin.txt` + content assertion, closing the LOW):
    both reviewers **MERGE-READY**, no findings. (Codex's `codex exec review`
    was sandbox-blocked; it fell back to a direct diff-only read — same family.)

---
### Live ledger (final)
- Head: `f427410` — CI **all green** (Validate PR metadata, Docker image build, E2E Gitea mock loop, Go build and test, Security and supply-chain).
- `@codex review` (trigger `4602596819`): **converged, no findings** — "Codex Review: Didn't find any major issues. 🚀" (issue-comment path).
- GraphQL review threads: **0 total / 0 unresolved actionable**.
- Status: **merge-ready**, awaiting explicit human merge permission (protocol §8).
