### PR TITLE
security(workspace): mask clone_url basic-auth in mirror clone/fetch failures

### DIFF
--- a/docs/runbooks/gitea-bot-and-branch-protection.md
+++ b/docs/runbooks/gitea-bot-and-branch-protection.md
@@ -68,13 +68,12 @@ other on purpose:
    independently of `GITEA_TOKEN`; because it must both push branches and open
    PRs it needs repository **write** (a read-only deploy token is not enough).
    `workflow.MaskCloneURL` scrubs this credential from the diagnostics that
-   route through it, but masking is **not yet complete**: the workspace
-   mirror error paths (`internal/workspace/mirror.go` wraps a failed bare
-   clone with the raw clone URL, and `runGit` forwards git's stderr verbatim)
-   can still surface the embedded userinfo on a clone/fetch failure — tracked
-   in #595. Until that is fixed, prefer a clone-URL credential you can rotate
-   easily, and treat worker logs as potentially credential-bearing (restrict
-   and scrub them) rather than relying on full masking.
+   route through it, and the workspace-mirror clone/fetch paths now mask it too
+   (#595): `internal/workspace/mirror.go` wraps a failed bare clone with
+   `MaskCloneURL`, and clone/fetch git output is forwarded through
+   `runGitRedacted`, which strips embedded `user:token@` userinfo from git's
+   stderr. As with any credential, still prefer a clone-URL credential you can
+   rotate easily.
 
 Recommended `GITEA_TOKEN` scopes (Gitea 1.20+ scoped token model):
 
@@ -107,7 +106,7 @@ If the deployed Gitea version only exposes the legacy `repo` scope, prefer that 
 ## Token storage and rotation
 
 - Inject `GITEA_TOKEN` only as an environment variable on the worker process. Do not commit it. Do not add it to `codex.env_passthrough` / `claude.env_passthrough` — it is denied passthrough into the agent subprocess by design.
-- Keep the `repo.clone_url` push + PR credential in the same secret manager. `workflow.MaskCloneURL` scrubs it from most worker output, but not yet from the workspace-mirror clone/fetch error paths (#595) — treat worker logs as potentially credential-bearing until that lands.
+- Keep the `repo.clone_url` push + PR credential in the same secret manager. `workflow.MaskCloneURL` scrubs it from worker output, including the workspace-mirror clone/fetch error and stderr paths (#595).
 - Store the source of truth in a secret manager.
 - Rotate both credentials on a schedule (recommended: every 90 days) and immediately if a worker host or backup is suspected compromised.
 - Revoke a credential in Gitea before deleting it from the secret store, so any in-flight call fails closed.

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -565,6 +565,28 @@ func runGit(ctx context.Context, dir string, args ...string) error {
 	return cmd.Run()
 }
 
+// runGitRedacted runs git like runGit but scrubs basic-auth userinfo from the
+// forwarded stdout/stderr. Use it for clone/fetch against a credentialed
+// remote, where git can echo the `user:token@host` clone URL (the agent's push
+// credential) on failure — directly, when the URL is on the clone command line,
+// or via the stored remote.origin.url on a fetch. Without this, a failed
+// `git clone --bare <cloneURL>` / `git fetch` leaks the credential to the
+// worker's os.Stderr (#595, AGENTS.md secret-masking convention).
+func runGitRedacted(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	outW := &credentialRedactingWriter{w: os.Stdout}
+	errW := &credentialRedactingWriter{w: os.Stderr}
+	cmd.Stdout = outW
+	cmd.Stderr = errW
+	err := cmd.Run()
+	// Flush regardless of err: a failed clone/fetch is exactly when git emits
+	// the credentialed URL, and that output may not end in a newline.
+	_ = outW.Flush()
+	_ = errW.Flush()
+	return err
+}
+
 // runQuiet runs a command without forwarding stdout/stderr. We use it for
 // probe operations like `git rev-parse --verify` whose stderr is expected
 // noise on the unhappy path.

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -575,6 +575,16 @@ func runGit(ctx context.Context, dir string, args ...string) error {
 func runGitRedacted(ctx context.Context, dir string, args ...string) error {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	return runRedacted(cmd)
+}
+
+// runRedacted runs cmd with its stdout/stderr forwarded to os.Stdout/os.Stderr
+// through a credentialRedactingWriter, so embedded basic-auth userinfo never
+// reaches the worker's logs. It is split out from runGitRedacted so the
+// redaction wiring can be tested end-to-end with a command that emits a real
+// `user:token@` URL on stderr — git's own messages already sanitise the URL on
+// some versions, which would make a git-driven test a placebo (#595).
+func runRedacted(cmd *exec.Cmd) error {
 	outW := &credentialRedactingWriter{w: os.Stdout}
 	errW := &credentialRedactingWriter{w: os.Stderr}
 	cmd.Stdout = outW

--- a/internal/workspace/mirror.go
+++ b/internal/workspace/mirror.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 var (
@@ -167,8 +169,10 @@ func (m *Manager) ensureMirrorLocked(ctx context.Context, cloneURL, mirror strin
 		return "", fmt.Errorf("mkdir mirror parent: %w", err)
 	}
 	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err == nil {
-		// Existing mirror: refresh remote-tracking refs only.
-		if err := runGit(ctx, mirror, "fetch", "--prune", "--tags", "origin"); err != nil {
+		// Existing mirror: refresh remote-tracking refs only. `fetch origin`
+		// resolves the stored credentialed remote.origin.url, so its forwarded
+		// stderr is redacted (#595).
+		if err := runGitRedacted(ctx, mirror, "fetch", "--prune", "--tags", "origin"); err != nil {
 			return "", fmt.Errorf("refresh mirror %s: %w", mirror, err)
 		}
 		if err := runGit(ctx, mirror, "config", "extensions.worktreeConfig", "true"); err != nil {
@@ -179,8 +183,11 @@ func (m *Manager) ensureMirrorLocked(ctx context.Context, cloneURL, mirror strin
 	// First-time clone. Remove any partial directory left over from a prior
 	// failed attempt so `git clone` does not refuse to overwrite it.
 	_ = os.RemoveAll(mirror)
-	if err := runGit(ctx, filepath.Dir(mirror), "clone", "--bare", cloneURL, mirror); err != nil {
-		return "", fmt.Errorf("clone mirror %s: %w", cloneURL, err)
+	// The clone URL carries the agent's `user:token@` push credential on the
+	// command line, so both the forwarded git stderr (runGitRedacted) and the
+	// wrapped error string (MaskCloneURL) must mask it (#595).
+	if err := runGitRedacted(ctx, filepath.Dir(mirror), "clone", "--bare", cloneURL, mirror); err != nil {
+		return "", fmt.Errorf("clone mirror %s: %w", workflow.MaskCloneURL(cloneURL), err)
 	}
 	// `git clone --bare` defaults to a "do nothing" fetch refspec; rewrite
 	// it to the standard remote-tracking layout so subsequent fetches and
@@ -188,7 +195,7 @@ func (m *Manager) ensureMirrorLocked(ctx context.Context, cloneURL, mirror strin
 	if err := runGit(ctx, mirror, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
 		return "", fmt.Errorf("configure fetch refspec: %w", err)
 	}
-	if err := runGit(ctx, mirror, "fetch", "--prune", "--tags", "origin"); err != nil {
+	if err := runGitRedacted(ctx, mirror, "fetch", "--prune", "--tags", "origin"); err != nil {
 		return "", fmt.Errorf("initial fetch: %w", err)
 	}
 	if err := runGit(ctx, mirror, "config", "extensions.worktreeConfig", "true"); err != nil {

--- a/internal/workspace/redact.go
+++ b/internal/workspace/redact.go
@@ -1,0 +1,73 @@
+package workspace
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+	"sync"
+)
+
+// credentialURLRe matches the basic-auth `userinfo@` segment of a URL embedded
+// in arbitrary text — e.g. git's `fatal: unable to access
+// 'https://user:token@host/...'` stderr line. It captures the scheme through
+// `://` so redactCredentials can drop the userinfo while keeping the scheme and
+// host. This is the free-text analogue of workflow.MaskCloneURL: that helper
+// accepts a single well-formed URL string, whereas git interleaves the clone
+// URL with surrounding prose on one line, so a substring match is required
+// here. The userinfo class excludes `/` so a `@` in a path/query (e.g.
+// `https://host/a@b`) is never mistaken for basic-auth userinfo.
+var credentialURLRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/@\s]+@`)
+
+// redactCredentials strips basic-auth userinfo from every URL embedded in s so a
+// clone_url's `user:token@` (the agent's push credential) never reaches a log
+// or error string — AGENTS.md secret-masking convention, #595.
+func redactCredentials(s string) string {
+	return credentialURLRe.ReplaceAllString(s, "$1")
+}
+
+// credentialRedactingWriter forwards writes to w with basic-auth userinfo
+// stripped from any embedded URL. It buffers a trailing partial line so a clone
+// URL split across two Write calls is still redacted before it reaches w, and
+// Flush emits the final unterminated line. A URL never spans a newline, so
+// line-buffering is sufficient to catch every embedded credential. It is
+// concurrency-safe because git wires a command's stdout and stderr to the same
+// writer.
+type credentialRedactingWriter struct {
+	w   io.Writer
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (c *credentialRedactingWriter) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buf = append(c.buf, p...)
+	for {
+		i := bytes.IndexByte(c.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := c.buf[:i+1]
+		if _, err := io.WriteString(c.w, redactCredentials(string(line))); err != nil {
+			return len(p), err
+		}
+		c.buf = c.buf[i+1:]
+	}
+	return len(p), nil
+}
+
+// Flush writes any buffered partial line (with credentials redacted) to the
+// underlying writer. Callers must call it once the wrapped command has exited.
+func (c *credentialRedactingWriter) Flush() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.buf) == 0 {
+		return nil
+	}
+	_, err := io.WriteString(c.w, redactCredentials(string(c.buf)))
+	c.buf = nil
+	return err
+}
+
+// Compile-time check that credentialRedactingWriter satisfies io.Writer.
+var _ io.Writer = (*credentialRedactingWriter)(nil)

--- a/internal/workspace/redact.go
+++ b/internal/workspace/redact.go
@@ -11,12 +11,15 @@ import (
 // in arbitrary text — e.g. git's `fatal: unable to access
 // 'https://user:token@host/...'` stderr line. It captures the scheme through
 // `://` so redactCredentials can drop the userinfo while keeping the scheme and
-// host. This is the free-text analogue of workflow.MaskCloneURL: that helper
-// accepts a single well-formed URL string, whereas git interleaves the clone
-// URL with surrounding prose on one line, so a substring match is required
-// here. The userinfo class excludes `/` so a `@` in a path/query (e.g.
-// `https://host/a@b`) is never mistaken for basic-auth userinfo.
-var credentialURLRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/@\s]+@`)
+// host. This is the free-text analogue of workflow.MaskCloneURL and must agree
+// with its splitting rule: MaskCloneURL strips userinfo up to the *last* `@`
+// (url.Parse, RFC 3986), so a password that itself contains `@` is fully
+// removed. The userinfo class `[^/?#\s]*` includes `@` and is greedy, so the
+// trailing `@` matches the last `@` in the authority (before the first
+// `/`?`#`/whitespace that ends it) — matching MaskCloneURL rather than stopping
+// at the first `@` and leaking the password tail. A `@` in a path/query (after
+// the authority delimiter) is therefore never mistaken for basic-auth userinfo.
+var credentialURLRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/?#\s]*@`)
 
 // redactCredentials strips basic-auth userinfo from every URL embedded in s so a
 // clone_url's `user:token@` (the agent's push credential) never reaches a log
@@ -26,12 +29,17 @@ func redactCredentials(s string) string {
 }
 
 // credentialRedactingWriter forwards writes to w with basic-auth userinfo
-// stripped from any embedded URL. It buffers a trailing partial line so a clone
-// URL split across two Write calls is still redacted before it reaches w, and
-// Flush emits the final unterminated line. A URL never spans a newline, so
-// line-buffering is sufficient to catch every embedded credential. It is
-// concurrency-safe because git wires a command's stdout and stderr to the same
-// writer.
+// stripped from any embedded URL. It buffers a trailing partial segment so a
+// clone URL split across two Write calls is still redacted before it reaches w,
+// flushing each segment terminated by `\n` or `\r`; the `\r` boundary keeps git
+// progress (`Receiving objects: …\r`) streaming and bounds buffer growth. A URL
+// contains neither `\n` nor `\r`, so segment-flushing never splits a credential.
+// Flush emits the final unterminated segment.
+//
+// The mutex guards this instance's buffer against os/exec's per-stream copy
+// goroutine (one goroutine writes here while Flush may run from the caller).
+// runGitRedacted gives stdout and stderr separate instances, so the lock is
+// per-instance, not shared across the two streams.
 type credentialRedactingWriter struct {
 	w   io.Writer
 	mu  sync.Mutex
@@ -43,12 +51,12 @@ func (c *credentialRedactingWriter) Write(p []byte) (int, error) {
 	defer c.mu.Unlock()
 	c.buf = append(c.buf, p...)
 	for {
-		i := bytes.IndexByte(c.buf, '\n')
+		i := bytes.IndexAny(c.buf, "\n\r")
 		if i < 0 {
 			break
 		}
-		line := c.buf[:i+1]
-		if _, err := io.WriteString(c.w, redactCredentials(string(line))); err != nil {
+		segment := c.buf[:i+1]
+		if _, err := io.WriteString(c.w, redactCredentials(string(segment))); err != nil {
 			return len(p), err
 		}
 		c.buf = c.buf[i+1:]
@@ -56,7 +64,7 @@ func (c *credentialRedactingWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Flush writes any buffered partial line (with credentials redacted) to the
+// Flush writes any buffered partial segment (with credentials redacted) to the
 // underlying writer. Callers must call it once the wrapped command has exited.
 func (c *credentialRedactingWriter) Flush() error {
 	c.mu.Lock()

--- a/internal/workspace/redact_test.go
+++ b/internal/workspace/redact_test.go
@@ -1,0 +1,160 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestRedactCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "git clone failure line with user:token",
+			in:   "fatal: unable to access 'https://git:s3cr3t@example.com/owner/repo.git/': boom",
+			want: "fatal: unable to access 'https://example.com/owner/repo.git/': boom",
+		},
+		{
+			name: "bare token userinfo",
+			in:   "remote: https://x-access-token:ghp_abc123@github.com/o/r.git",
+			want: "remote: https://github.com/o/r.git",
+		},
+		{
+			name: "ssh scp-style is left untouched",
+			in:   "git@example.com:owner/repo.git",
+			want: "git@example.com:owner/repo.git",
+		},
+		{
+			name: "at-sign in path is not treated as userinfo",
+			in:   "https://example.com/a@b/c",
+			want: "https://example.com/a@b/c",
+		},
+		{
+			name: "no url",
+			in:   "fatal: repository not found",
+			want: "fatal: repository not found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redactCredentials(tc.in); got != tc.want {
+				t.Errorf("redactCredentials(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCredentialRedactingWriter_ScrubsAcrossWriteBoundary(t *testing.T) {
+	const secret = "s3cr3t-token"
+	var sink bytes.Buffer
+	w := &credentialRedactingWriter{w: &sink}
+
+	// Split the credentialed URL across two writes with no intervening newline
+	// to exercise the partial-line buffering path.
+	if _, err := io.WriteString(w, "fatal: unable to access 'https://git:"); err != nil {
+		t.Fatalf("write 1: %v", err)
+	}
+	if _, err := io.WriteString(w, secret+"@example.com/o/r.git/'\n"); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	got := sink.String()
+	if strings.Contains(got, secret) {
+		t.Errorf("redacted output %q leaked secret %q", got, secret)
+	}
+	if strings.Contains(got, "git:"+secret+"@") {
+		t.Errorf("redacted output %q leaked userinfo", got)
+	}
+	if !strings.Contains(got, "https://example.com/o/r.git") {
+		t.Errorf("redacted output %q dropped the masked host/path", got)
+	}
+}
+
+func TestCredentialRedactingWriter_FlushesUnterminatedLine(t *testing.T) {
+	const secret = "tok-9999"
+	var sink bytes.Buffer
+	w := &credentialRedactingWriter{w: &sink}
+
+	// No trailing newline: the credential only reaches the sink via Flush.
+	if _, err := io.WriteString(w, "cloning https://u:"+secret+"@host/x.git"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := sink.String(); got != "" {
+		t.Fatalf("partial line leaked before flush: %q", got)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	got := sink.String()
+	if strings.Contains(got, secret) {
+		t.Errorf("flushed output %q leaked secret %q", got, secret)
+	}
+	if !strings.Contains(got, "https://host/x.git") {
+		t.Errorf("flushed output %q dropped masked URL", got)
+	}
+}
+
+// TestEnsureMirror_FailedCloneMasksCredentials is the #595 regression: a clone
+// against a credentialed clone URL that fails must leak the `user:token@`
+// userinfo neither into the returned error string (vector 1, MaskCloneURL) nor
+// into the forwarded git stderr (vector 2, runGitRedacted). 127.0.0.1:1 refuses
+// the connection immediately, so the clone fails fast without network access.
+func TestEnsureMirror_FailedCloneMasksCredentials(t *testing.T) {
+	const secret = "s3cr3t-token-595"
+	cloneURL := "https://git:" + secret + "@127.0.0.1:1/owner/repo.git"
+
+	// Redirect os.Stderr so runGitRedacted's forwarded output is captured. The
+	// credentialRedactingWriter reads os.Stderr at call time, so reassigning it
+	// before EnsureMirror is enough.
+	origStderr := os.Stderr
+	r, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = pw
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		captured <- buf.String()
+	}()
+
+	mgr := &Manager{Root: t.TempDir(), MirrorRoot: t.TempDir()}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, cloneErr := mgr.EnsureMirror(ctx, cloneURL)
+
+	_ = pw.Close()
+	os.Stderr = origStderr
+	stderr := <-captured
+
+	if cloneErr == nil {
+		t.Fatalf("EnsureMirror(%q) = nil error; want clone failure", workflow.MaskCloneURL(cloneURL))
+	}
+	errStr := cloneErr.Error()
+
+	leaks := []string{secret, "git:" + secret + "@", "git:" + secret}
+	for _, leak := range leaks {
+		if strings.Contains(errStr, leak) {
+			t.Errorf("error string %q leaked secret fragment %q", errStr, leak)
+		}
+		if strings.Contains(stderr, leak) {
+			t.Errorf("forwarded stderr %q leaked secret fragment %q", stderr, leak)
+		}
+	}
+	if !strings.Contains(errStr, "127.0.0.1:1/owner/repo.git") {
+		t.Errorf("error string %q missing masked clone URL; want host/path present", errStr)
+	}
+}

--- a/internal/workspace/redact_test.go
+++ b/internal/workspace/redact_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +38,24 @@ func TestRedactCredentials(t *testing.T) {
 			name: "at-sign in path is not treated as userinfo",
 			in:   "https://example.com/a@b/c",
 			want: "https://example.com/a@b/c",
+		},
+		{
+			// Password containing '@' must be stripped up to the LAST '@' in the
+			// authority, matching workflow.MaskCloneURL (url.Parse, RFC 3986).
+			// Stopping at the first '@' would leak the password tail.
+			name: "password containing at-sign is fully stripped",
+			in:   "fatal: unable to access 'https://git:to@ken@example.com/o/r.git/'",
+			want: "fatal: unable to access 'https://example.com/o/r.git/'",
+		},
+		{
+			name: "at-sign in query is not treated as userinfo",
+			in:   "https://u:p@host/path?x=a@b",
+			want: "https://host/path?x=a@b",
+		},
+		{
+			name: "two credentialed urls on one line",
+			in:   "from https://a:b@h1/x to https://c:d@h2/y",
+			want: "from https://h1/x to https://h2/y",
 		},
 		{
 			name: "no url",
@@ -106,24 +125,61 @@ func TestCredentialRedactingWriter_FlushesUnterminatedLine(t *testing.T) {
 	}
 }
 
-// TestEnsureMirror_FailedCloneMasksCredentials is the #595 regression: a clone
-// against a credentialed clone URL that fails must leak the `user:token@`
-// userinfo neither into the returned error string (vector 1, MaskCloneURL) nor
-// into the forwarded git stderr (vector 2, runGitRedacted). 127.0.0.1:1 refuses
-// the connection immediately, so the clone fails fast without network access.
-func TestEnsureMirror_FailedCloneMasksCredentials(t *testing.T) {
+// TestEnsureMirror_FailedCloneMasksErrorString covers #595 vector 1: a failing
+// clone against a credentialed clone URL must mask the `user:token@` userinfo in
+// the returned error string. 127.0.0.1:1 refuses the connection immediately, so
+// the clone fails fast without network access. (Vector 2 — git stderr
+// forwarding — is covered deterministically by TestRunRedacted_ScrubsStderr,
+// because git itself sanitises the URL in its own messages on some versions, so
+// a clone-driven stderr assertion would be a placebo.)
+func TestEnsureMirror_FailedCloneMasksErrorString(t *testing.T) {
 	const secret = "s3cr3t-token-595"
 	cloneURL := "https://git:" + secret + "@127.0.0.1:1/owner/repo.git"
 
-	// Redirect os.Stderr so runGitRedacted's forwarded output is captured. The
-	// credentialRedactingWriter reads os.Stderr at call time, so reassigning it
-	// before EnsureMirror is enough.
+	mgr := &Manager{Root: t.TempDir(), MirrorRoot: t.TempDir()}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, cloneErr := mgr.EnsureMirror(ctx, cloneURL)
+
+	if cloneErr == nil {
+		t.Fatalf("EnsureMirror(%q) = nil error; want clone failure", workflow.MaskCloneURL(cloneURL))
+	}
+	errStr := cloneErr.Error()
+
+	for _, leak := range []string{secret, "git:" + secret + "@", "git:" + secret} {
+		if strings.Contains(errStr, leak) {
+			t.Errorf("error string %q leaked secret fragment %q", errStr, leak)
+		}
+	}
+	if !strings.Contains(errStr, "127.0.0.1:1/owner/repo.git") {
+		t.Errorf("error string %q missing masked clone URL; want host/path present", errStr)
+	}
+}
+
+// TestRunRedacted_ScrubsStderr covers #595 vector 2 end-to-end: runRedacted must
+// strip basic-auth userinfo from a subprocess's stderr before it reaches
+// os.Stderr. It feeds a command that prints a real `user:token@` URL to stderr
+// (git's own messages sanitise the URL on some versions, which would make a
+// git-driven assertion a placebo), then asserts the captured os.Stderr contains
+// the masked URL and none of the secret. Reverting runRedacted to forward raw
+// os.Stderr makes this fail.
+//
+// It reassigns the process-global os.Stderr, so it must never run in parallel
+// with another test in this package — do not add t.Parallel here.
+func TestRunRedacted_ScrubsStderr(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	const secret = "tok-vector2-595"
+	url := "https://git:" + secret + "@example.com/owner/repo.git"
+
 	origStderr := os.Stderr
 	r, pw, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
 	os.Stderr = pw
+	defer func() { os.Stderr = origStderr }()
 	captured := make(chan string, 1)
 	go func() {
 		var buf bytes.Buffer
@@ -131,30 +187,24 @@ func TestEnsureMirror_FailedCloneMasksCredentials(t *testing.T) {
 		captured <- buf.String()
 	}()
 
-	mgr := &Manager{Root: t.TempDir(), MirrorRoot: t.TempDir()}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	_, cloneErr := mgr.EnsureMirror(ctx, cloneURL)
+	// $0 carries the line so the credentialed URL needs no shell quoting.
+	line := "fatal: unable to access '" + url + "'\n"
+	cmd := exec.Command("sh", "-c", `printf '%s' "$0" 1>&2; exit 3`, line)
+	runErr := runRedacted(cmd)
 
 	_ = pw.Close()
 	os.Stderr = origStderr
 	stderr := <-captured
 
-	if cloneErr == nil {
-		t.Fatalf("EnsureMirror(%q) = nil error; want clone failure", workflow.MaskCloneURL(cloneURL))
+	if runErr == nil {
+		t.Fatalf("runRedacted(printf...; exit 3) = nil error; want non-nil exit")
 	}
-	errStr := cloneErr.Error()
-
-	leaks := []string{secret, "git:" + secret + "@", "git:" + secret}
-	for _, leak := range leaks {
-		if strings.Contains(errStr, leak) {
-			t.Errorf("error string %q leaked secret fragment %q", errStr, leak)
-		}
+	for _, leak := range []string{secret, "git:" + secret + "@", "git:" + secret} {
 		if strings.Contains(stderr, leak) {
 			t.Errorf("forwarded stderr %q leaked secret fragment %q", stderr, leak)
 		}
 	}
-	if !strings.Contains(errStr, "127.0.0.1:1/owner/repo.git") {
-		t.Errorf("error string %q missing masked clone URL; want host/path present", errStr)
+	if !strings.Contains(stderr, "https://example.com/owner/repo.git") {
+		t.Errorf("forwarded stderr %q missing masked URL; want host/path present", stderr)
 	}
 }


### PR DESCRIPTION
Closes #595

## Summary

The `repo.clone_url` basic-auth userinfo (the agent's push + PR credential) could leak into worker logs / error output on a bare-mirror clone or fetch failure, violating the AGENTS.md secret-masking convention (earned by #469/PR #483). Surfaced by Codex review on #591.

Two leak vectors, both in `internal/workspace`:

**Vector 1 — error wrapping with the raw clone URL.** `ensureMirrorLocked` wrapped a failed `git clone --bare <cloneURL>` with `clone mirror %s` using the credentialed URL verbatim. Now masked with `workflow.MaskCloneURL`. (The sibling wraps at that site use `mirror` — a path — so this was the one credentialed `%s`.)

**Vector 2 — verbatim git stderr forwarding.** `runGit` wires git's stderr straight to the worker's `os.Stderr`, so a failed clone/fetch could print the remote URL (with userinfo, git-version dependent) to the log. The clone/fetch calls now route through a new `runGitRedacted` (→ `runRedacted`), which forwards stdout/stderr through a segment-buffered `credentialRedactingWriter` that strips embedded `user:token@` userinfo before it reaches `os.Stderr`. The **fetch** paths are redacted too: `fetch origin` resolves the stored credentialed `remote.origin.url`, so it can leak the same way as the clone. Segment-flushing on `\n`/`\r` keeps git progress streaming and bounds the buffer; a URL contains neither, so a credential is never split across a flush.

## Pre-push dual review (subagents) + `@codex review`

Two adversarial subagent reviewers ran before push; their findings are fixed in commit 2:
- **HIGH** — the free-text regex stopped at the *first* `@`, leaking the password tail when the password contained `@` (disagreeing with `MaskCloneURL`, which splits on the last `@`). Regex now consumes up to the last `@` in the authority; covered by new `@`-in-password / `@`-in-query / multi-URL table cases.
- **MEDIUM** — the clone-driven stderr assertion was a placebo (modern git already sanitises the URL on connection-refused, so it passed even with redaction reverted). Vector 2 is now tested end-to-end via a `runRedacted` seam fed a real `user:token@` URL on stderr; reverting the wiring fails it.
- **LOW** — vector-2 test restores `os.Stderr` via `defer` and documents no-parallel.
- **Out of scope (pre-existing):** dead `CommitAndPush`/`remoteBranchExists` carry the same latent leak on the #76-forbidden handoff path → tracked in #599 for deletion (not hardened, per principle 6).

## SPEC alignment (AGENTS.md principle 6/7)

No SPEC surface touched. The bare-mirror cache is an aiops-platform extension (#228); this is a SPEC-neutral secret-masking hardening — no new config key/phase, no `DEVIATIONS.md` row needed. SPEC-sensitive paths changed: none.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Size budget (AGENTS.md)

Production diff: `redact.go` (new, ~75 LOC), `manager.go` (+~30), `mirror.go` (+~10) = 3 production files. Tests (`redact_test.go`) and the runbook doc are excluded from the count.

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing

- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate — `golangci-lint run ./internal/workspace/...` → 0 issues
- [x] additional validation noted below

Regression coverage is **mutation-verified** per clean-code rule 6: breaking the scrubber / reverting to the first-`@` regex fails the `redactCredentials` table; reverting the stderr wiring fails `TestRunRedacted_ScrubsStderr`; leaking the raw URL into the error string fails `TestEnsureMirror_FailedCloneMasksErrorString`; all restored green.

## Acceptance criteria

- [x] `mirror.go` clone error path masks the clone URL with `workflow.MaskCloneURL` (vector 1).
- [x] `runGit` no longer forwards raw git stderr for clone/fetch with a credentialed URL — clone + both fetch sites use `runGitRedacted` (vector 2).
- [x] Regression test asserting masked form present / raw secret absent in both error string and stderr (now end-to-end, not placebo).
- [x] #591 runbook caveat (`gitea-bot-and-branch-protection.md`) tightened — "not yet complete" wording removed now that masking covers the mirror clone/fetch error + stderr paths.

## Notes

Keeps all three `SPEC alignment` options present with exactly one checked (option 1: no new key/phase).
