### PR TITLE
test(runner): decouple stall-window + turn-timeout tests from subprocess boot (#598)

### DIFF
--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -2115,7 +2115,12 @@ for line in sys.stdin:
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
 	in.Workflow.Config.Codex.StallTimeoutMs = 1000
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// The outer ctx is only a hang-guard, not the assertion: what is under test
+	// is that periodic item/updated events reset the StallTimeoutMs clock so the
+	// turn completes. Keep it generous enough that Python interpreter boot under
+	// full-suite -race contention never eats the budget before the turn runs
+	// (#587/#598) — the turn still completes in well under a second once up.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	res, err := (CodexAppServerRunner{}).Run(ctx, in)
@@ -2153,7 +2158,10 @@ for line in sys.stdin:
 	in.Workflow.Config.Tracker.ProjectSlug = "http://127.0.0.1:1"
 	in.Workflow.Config.Repo.Owner = "o"
 	in.Workflow.Config.Repo.Name = "r"
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// Hang-guard only; the assertion is that the dynamic tool call + its output
+	// count as activity that resets the StallTimeoutMs clock. Generous so Python
+	// interpreter boot under -race contention never eats it (#587/#598).
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	res, err := (CodexAppServerRunner{}).Run(ctx, in)
@@ -2187,7 +2195,10 @@ for line in sys.stdin:
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
 	in.Workflow.Config.Codex.StallTimeoutMs = 500
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// Hang-guard only; the assertion is that an inbound server request counts as
+	// activity that resets the StallTimeoutMs clock. Generous so Python
+	// interpreter boot under -race contention never eats it (#587/#598).
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	res, err := (CodexAppServerRunner{}).Run(ctx, in)
@@ -2210,23 +2221,45 @@ for line in sys.stdin:
         print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
     elif msg.get('method') == 'turn/start':
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
-        time.sleep(2)
+        time.sleep(30)
         break
 `)
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Codex.TurnTimeoutMs = 25
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
-	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	// The 25ms per-turn deadline is the load-bearing value, not the outer ctx.
+	// classifyTurnError only yields a *TurnTimeoutError when the per-turn deadline
+	// fires while the outer ctx is still alive (codex_app_server.go), so
+	// IsTurnTimeout below already proves the turn timeout — not the outer ctx —
+	// ended the run.
+	//
+	// The stub sleeps 30s after turn/start — longer than the 10s outer ctx — so
+	// the ONLY way Run can return a *TurnTimeoutError is genuine 25ms preemption:
+	// a runner that ignored the per-turn deadline and blocked on the subprocess
+	// would instead hit the 10s outer ctx and surface a context-deadline error
+	// (IsTurnTimeout=false), failing the test. There is no subprocess-exit point
+	// inside the window that a non-preemptive runner could ride to a passing
+	// turn-timeout result.
+	//
+	// The outer ctx stays generous (a hang-guard) so Python interpreter boot under
+	// -race contention never expires it during the handshake; the old 1.5s ctx vs
+	// <1s elapsed bound coupled the assertion to boot latency, which is the
+	// #587/#598 flake class.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	start := time.Now()
 	_, err := (CodexAppServerRunner{}).Run(ctx, in)
 	elapsed := time.Since(start)
-	if err == nil || !strings.Contains(err.Error(), "turn timeout") {
+	if !IsTurnTimeout(err) {
 		t.Fatalf("Run error = %v, want app-server turn timeout", err)
 	}
-	if elapsed >= time.Second {
+	// Returned well before the outer deadline. The 5s bound sits far above any
+	// realistic interpreter boot yet far below the 10s ctx, so it still catches a
+	// runner that wrongly waited for the outer context without re-coupling to
+	// subprocess startup latency.
+	if elapsed >= 5*time.Second {
 		t.Fatalf("Run elapsed %s, want return before outer context deadline", elapsed)
 	}
 }


### PR DESCRIPTION
Closes #598

## Problem
Four `internal/runner` tests pair a Python `codex app-server` stub with a tight
outer `context.WithTimeout` that must contain the full
`initialize → thread/start → turn/start` handshake. Under full-suite
`go test -race ./...` CPU contention the Python interpreter boot + handshake can
eat the whole outer budget, so the ctx deadline fires during `initialize` before
the turn ever runs — the same fixed-wall-clock-window flake class as #587,
surfaced (not caused) by landing #594.

```
--- FAIL: TestCodexAppServerRunnerActivityWithinStallWindowKeepsTurnAlive (3.01s)
    Run: runner timed out after 3.001s (budget 2.999s): codex app-server
    initialize: context deadline exceeded
```

## Fix (test-only; no production code touched)
- **Three stall-clock tests** (`...ActivityWithinStallWindowKeepsTurnAlive`,
  `...DynamicToolCallsRefreshStallClock`, `...ServerRequestsRefreshStallClock`):
  the outer ctx is only a hang-guard, not the assertion — the behavior under test
  is that periodic events reset the `StallTimeoutMs` clock so the turn completes.
  Widen the outer ctx `3s → 30s`; the turn still completes in well under a second
  once the subprocess is up, so nothing asserted changes.
- **`...ReturnsTurnTimeoutWithoutWaitingForOuterContext`**: keeps the
  load-bearing `TurnTimeoutMs=25ms`. `classifyTurnError` only yields a
  `*TurnTimeoutError` when the per-turn deadline fires *while the outer ctx is
  still alive*, so `IsTurnTimeout` already proves the turn timeout — not the
  outer ctx — ended the run. Widen the outer ctx `1.5s → 10s` and the stub sleep
  `2s → 30s` (**longer than the outer ctx**) so the *only* path to a
  `*TurnTimeoutError` is genuine 25ms preemption: a non-preemptive runner hits
  the 10s outer ctx and surfaces a context-deadline error (`IsTurnTimeout=false`).
  Assertion switched from `strings.Contains(err.Error(),"turn timeout")` +
  `elapsed<1s` to `IsTurnTimeout(err)` (AGENTS.md clean-code rule 8) +
  `elapsed<5s` (far above realistic boot, far below the 10s ctx).

## SPEC alignment (AGENTS.md principle 6/7)
Test-only change to `internal/runner/codex_app_server_test.go`; touches no
SPEC-sensitive path and adds no key/phase/gate/artifact.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Size budget (AGENTS.md)
- [x] `within budget` — production diff is 0 files / 0 LOC (test-only change).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] target tests stable at `-race -count=20`

## Acceptance criteria
- [x] `go test -race ./internal/runner/...` green locally (incl. full-suite
  `-race ./...`) and target tests stable at `-count=20`.
- [x] Stall-window tests no longer fail their outer ctx because of Python
  interpreter startup latency.
- [x] `...ReturnsTurnTimeoutWithoutWaitingForOuterContext` still asserts a turn
  timeout fires without waiting for the outer ctx (intent preserved, not widened
  away — the `sleep(30) > 10s ctx` inversion makes genuine 25ms preemption the
  only passing path).

## Verification
- Full local gate green: `gofmt -l`, `go mod tidy`, `go vet ./...`,
  `go test -race -covermode=atomic ./...`, `go build ./cmd/worker ./cmd/tui`.
- **Mutation-verified non-placebo** (against the committed artifact, tree
  restored after each):
  - Disable the `classifyTurnError` turn-timeout branch → test FAILS
    (`context deadline exceeded`, not a turn timeout).
  - Disable the per-turn deadline entirely → test FAILS (stall-timeout fallback,
    not a turn timeout) — confirms a fully non-preemptive runner cannot pass.

## Review (head a593560)
- **GitHub `@codex review` is externally unavailable** — both triggers returned
  the `chatgpt-codex-connector` usage-limit message (no review posted, zero
  review threads). Per the PR review/merge protocol §4.4, compensated with an
  equivalent independent local dual review and disclosed here.
- **Local dual diff-only review (committed range `origin/main...a593560`):**
  - Codex (`codex:codex-rescue`): **MERGE-READY**, no findings.
  - Claude (`feature-dev:code-reviewer`): initially **NEEDS-CHANGES** on a MEDIUM
    — "default `StallTimeoutMs=3000` could fire a `*StallError` during Python boot
    in `...ReturnsTurnTimeout...`". **Verified false against production source and
    the reviewer conceded:** the stall clock is consumed only in
    `readTurnMessage` (`codex_app_server_turn.go`), which runs only inside
    `awaitTurnCompletion` *after* `turn/start`; the handshake reads via
    `request → readMessage` under `readTimeoutMs`, with no stall machinery armed.
    Inside the 25ms `turnCtx` the effective read deadline is `min(25ms, 3000ms) =
    25ms` and `elapsed (≈25ms) < stallBudget (3000ms)`, so no reclassification —
    `StallTimeoutMs=3000` is structurally inert for `turnTimeoutMs < stallTimeoutMs`.
    Final verdict **MERGE-READY**.
  - Shared **LOW** (both reviewers, accepted as non-defect): `elapsed < 5s`
    retains mild boot-latency coupling, but `IsTurnTimeout(err)` is the
    load-bearing discriminator and 5s gives ample headroom over realistic boot.

## Size gate
- [x] `within budget` — diff fits the ~12-file / ~300-LOC review guideline (test-only; 0 production LOC)
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
