### PR TITLE
test(runner): assert turn-timeout promptness on TurnTimeoutError.Elapsed (#602)

### DIFF
--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -2252,6 +2252,20 @@ for line in sys.stdin:
 	if !errors.As(err, &te) {
 		t.Fatalf("Run error = %v, want app-server turn timeout", err)
 	}
+	// Run must return BEFORE the outer ctx fires — that is the "without waiting
+	// for the outer context" property in the test name. te.Elapsed (below) proves
+	// the turn deadline preempted promptly, but it is measured from turn start and
+	// cannot see time Run spends AFTER the turn in process termination /
+	// cmd.Wait(): if that cleanup rode the 10s outer ctx to expiry,
+	// classifyAppServerOutcome would wrap the same *TurnTimeoutError in a
+	// *TimeoutError (codex_app_server.go), whose Unwrap still satisfies the
+	// errors.As above — so the run could wait the full outer budget yet still pass
+	// the type + elapsed checks. Assert the outer ctx never fired to close that
+	// gap. This is boot-independent: interpreter boot only delays the 25ms turn,
+	// it never advances the 10s deadline, so a healthy run leaves ctx.Err() nil.
+	if ctx.Err() != nil {
+		t.Fatalf("ctx.Err() = %v after Run; want nil — Run waited for the outer context instead of returning on the 25ms turn deadline", ctx.Err())
+	}
 	// Assert promptness on TurnTimeoutError.Elapsed, which the runner measures as
 	// time.Since(turnStarted) (codex_app_server.go) — turnStarted is captured
 	// AFTER the initialize/thread/turn handshake, not before Run, so this bound

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -2230,37 +2230,40 @@ for line in sys.stdin:
 	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
 	// The 25ms per-turn deadline is the load-bearing value, not the outer ctx.
 	// classifyTurnError only yields a *TurnTimeoutError when the per-turn deadline
-	// fires while the outer ctx is still alive (codex_app_server.go), so
-	// IsTurnTimeout below already proves the turn timeout — not the outer ctx —
-	// ended the run.
+	// fires while the outer ctx is still alive (codex_app_server.go), so the
+	// errors.As(err, &te) check below already proves the turn timeout — not the
+	// outer ctx — ended the run.
 	//
 	// The stub sleeps 30s after turn/start — longer than the 10s outer ctx — so
 	// the ONLY way Run can return a *TurnTimeoutError is genuine 25ms preemption:
 	// a runner that ignored the per-turn deadline and blocked on the subprocess
 	// would instead hit the 10s outer ctx and surface a context-deadline error
-	// (IsTurnTimeout=false), failing the test. There is no subprocess-exit point
+	// (errors.As=false), failing the test. There is no subprocess-exit point
 	// inside the window that a non-preemptive runner could ride to a passing
 	// turn-timeout result.
 	//
 	// The outer ctx stays generous (a hang-guard) so Python interpreter boot under
-	// -race contention never expires it during the handshake; the old 1.5s ctx vs
-	// <1s elapsed bound coupled the assertion to boot latency, which is the
-	// #587/#598 flake class.
+	// -race contention never expires it during the handshake.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	start := time.Now()
 	_, err := (CodexAppServerRunner{}).Run(ctx, in)
-	elapsed := time.Since(start)
-	if !IsTurnTimeout(err) {
+	var te *TurnTimeoutError
+	if !errors.As(err, &te) {
 		t.Fatalf("Run error = %v, want app-server turn timeout", err)
 	}
-	// Returned well before the outer deadline. The 5s bound sits far above any
-	// realistic interpreter boot yet far below the 10s ctx, so it still catches a
-	// runner that wrongly waited for the outer context without re-coupling to
-	// subprocess startup latency.
-	if elapsed >= 5*time.Second {
-		t.Fatalf("Run elapsed %s, want return before outer context deadline", elapsed)
+	// Assert promptness on TurnTimeoutError.Elapsed, which the runner measures as
+	// time.Since(turnStarted) (codex_app_server.go) — turnStarted is captured
+	// AFTER the initialize/thread/turn handshake, not before Run, so this bound
+	// excludes Python interpreter boot + handshake latency. The old before-Run
+	// elapsed bound rode subprocess startup (the #587/#598 flake class, #602); a
+	// turn-start-relative measurement verifies only that the 25ms deadline
+	// preempts the 10s outer ctx. The deadline fires almost immediately once the
+	// turn is live, so a 2s bound is ~80x the budget (ample -race headroom) yet
+	// far below the 10s ctx — it still catches a runner that detected the turn
+	// timeout but returned late instead of preempting promptly.
+	if te.Elapsed >= 2*time.Second {
+		t.Fatalf("TurnTimeoutError.Elapsed = %s, want 25ms turn-deadline preemption measured from turn start (< 2s, well under the 10s outer ctx)", te.Elapsed)
 	}
 }
 


### PR DESCRIPTION
Closes #602

## Problem
#602 is the auto-filed follow-up for an unresolved Codex review thread on merged
PR #601 (`internal/runner/codex_app_server_test.go`):
`TestCodexAppServerRunnerReturnsTurnTimeoutWithoutWaitingForOuterContext`
measured `elapsed := time.Since(start)` from **before** `Run`, so the promptness
bound included Python interpreter boot + the `initialize → thread/start →
turn/start` handshake. Under full-suite `go test -race ./...` contention that
boot can exceed the bound even when the runner correctly returns a
`*TurnTimeoutError` — the #587/#598 flake class.

## Fix (test-only; no production code touched)
Two boot-independent assertions replace the external before-`Run` stopwatch:

1. **`errors.As(err, &te)`** — the load-bearing proof that the 25ms per-turn
   deadline (not the outer ctx) ended the run: `classifyTurnError` only builds a
   `*TurnTimeoutError` when the per-turn deadline fires *while the outer ctx is
   still alive* (`codex_app_server.go:510`).
2. **`ctx.Err() == nil` after `Run`** — proves `Run` returned *before* the 10s
   outer deadline (the "without waiting for the outer context" property).
   Boot-independent: interpreter boot delays only the 25ms turn, never the 10s
   deadline.
3. **`te.Elapsed < 2s`** — promptness of the turn preemption, measured by the
   runner from `turnStarted` (captured *after* the handshake,
   `codex_app_server.go:418`), so it excludes boot/handshake latency.

### Why `ctx.Err()` is needed (the @codex P2 on this PR)
`te.Elapsed` is turn-start-relative, so it cannot see time `Run` spends *after*
the turn in process termination / `cmd.Wait()`. If that cleanup rode the 10s
outer ctx to expiry, `classifyAppServerOutcome` wraps the `*TurnTimeoutError` in
a `*TimeoutError` (`codex_app_server.go:230`) whose `Unwrap` returns the cause
(`runner.go:258`), so `errors.As(err, &te)` still succeeds and `te.Elapsed`
stays ~25ms — the run could wait the full 10s yet pass. The `ctx.Err() == nil`
assertion closes that gap (the bot's "reject an expired context" option).

## Verification
- Local gate green: `gofmt -l`, `go vet ./...`,
  `go test -race -covermode=atomic ./internal/runner/...` (ok, 83.5%),
  `go build ./cmd/worker ./cmd/tui`. Target test stable at `-race -count=10`.
- **Mutation-verified non-placebo** (against committed artifact 6af21d8, tree
  restored after each):
  - Disable the `classifyTurnError` turn-timeout branch → test FAILS (`errors.As`).
  - Hardcode `Elapsed: 3 * time.Second` → test FAILS on `te.Elapsed >= 2s`.
  - Disable the `terminateProcess` guard (`codex_app_server.go:91`) so cleanup
    rides the outer ctx → test runs **10.01s** and FAILS on `ctx.Err()`, while
    the `errors.As` + `te.Elapsed` checks alone passed — confirms `ctx.Err()`
    catches the P2 regression the others miss.

## Review (head 6af21d8)
- Pre-push local dual review: Codex `codex:codex-rescue` **MERGE-READY** (both
  rounds); Claude `feature-dev:code-reviewer` substantive verdict MERGE-READY —
  its only flag was a "lone `/` compile error" on comment lines 2238/2259,
  **verified false** (both are `\t//`; the package compiles and the test passes
  `-race -count=10`, dispositive — a single-slash comment cannot build).
- `@codex review`: the P2 ("preserve a wall-clock return assertion") is **fixed**
  in 6af21d8 (`ctx.Err()` assertion), thread resolved; no other threads.

## SPEC alignment (AGENTS.md principle 6/7)
Test-only; no SPEC-sensitive path, no new key/phase/gate/artifact.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Size gate
- [x] `within budget` — test-only; 0 production LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

> Note: this branch's `Security and supply-chain` gate is red on GO-2026-5037/5039
> (stdlib, fixed in 1.25.11) — a repo-wide failure unrelated to this test change,
> fixed by #605. This PR goes green on that gate once #605 merges and this branch
> rebases onto main.
