### PR TITLE
docs(agents): add clean-code rule 10 — fix the class, not the instance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,6 +398,21 @@ failure per the "Earned rules" principle above.
    **Earned by:** repository tests using `t.Errorf("expected ...")` without the
    actual value left reviewers guessing which state transition regressed.
 
+10. **Fix the class, not the instance.** A bug, review comment, or CI failure
+    is usually one visible member of a broader class. Before pushing, name the
+    class and sweep its blast radius. When changing a shared value or contract
+    (version pin granularity, renamed field, removed config, changed default),
+    `grep` every consumer, derivation, fixture, doc, and CI copy and update them
+    atomically. When replacing a mechanism (assertion, gate, guard, retry), list
+    the invariants the old mechanism guaranteed and prove the new one preserves
+    each required invariant, including failure and deadline paths. Do not let
+    `@codex review` discover siblings one push at a time. **Earned by:** a
+    standard-library security bump first updated only the module patch pin, so
+    later review rounds found the matching container base-image pin, lint-cache
+    exposure, and version-doctor granularity one by one; and #602's test
+    refactor replaced an external deadline bound with a typed-error assertion
+    that initially dropped the "did not wait for the outer deadline" invariant.
+
 ## Conventions
 
 - **gofmt is non-negotiable**: CI fails on any diff. Always run before committing. A PostToolUse hook (`.claude/scripts/format-go.sh`) auto-runs `gofmt -w` on `.go` files edited via the Edit/Write tools; files changed through Bash (e.g. `sed`, heredocs) are not covered, so always verify with `gofmt -l` before pushing — CI's `gofmt -l` gate is the backstop.


### PR DESCRIPTION
Closes #608

**Head SHA:** `418c5e6` (rebased onto `main`@`bd3b089`, 2026-06-03).

## Summary
Adds **Clean-code rule 10 — "Fix the class, not the instance"** to `AGENTS.md`.
A bug/review-comment/CI failure is usually one member of a broader class; before
pushing, name the class and sweep its blast radius (every consumer/derivation/
fixture/doc/CI copy), and when replacing a mechanism enumerate the invariants the
old form guaranteed. Don't let `@codex review` discover siblings one push at a
time.

## Earned by
The #605 Go-1.25.11 security bump shipped the `go.mod` patch pin alone, so
successive `@codex review` rounds surfaced the Dockerfile base-image pin, a
golangci-cache-exposed staticcheck SA5011 false positive, and the doctor's
major.minor-only version check **one at a time**; and #602's test refactor
replaced an external wall-clock bound with a typed-error assertion that initially
dropped the "did not wait for the outer deadline" invariant. Documenting the rule
so the next change sweeps the class up front.

## SPEC alignment (AGENTS.md principle 6/7)
Docs-only change to `AGENTS.md`; no SPEC-sensitive path, no key/phase/gate/artifact.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Review ledger (protocol §7)
- **Rebase:** `c087d69` → `418c5e6` onto `main`@`bd3b089`; AGENTS.md untouched by the intervening `main` commits, so the rebase was conflict-free and the diff is unchanged (15 insertions, AGENTS.md only).
- **Pre-push dual review (diff-only, on `418c5e6`):**
  - Claude `feature-dev:code-reviewer` → **MERGE-READY** (verified both Earned-by citations accurate; rule 10 distinct from clean-code rule 3 and the cross-cutting "audit adjacent paths" item; numbering/markdown correct).
  - Codex `codex:codex-rescue` → **MERGE-READY** (only conditional LOW notes, all satisfied by the committed text). An earlier Codex pass flagged two MEDIUMs that were a misread of the diff's trailing `+` blank line and the already-quoted `"did not wait for the outer deadline"` invariant name; re-reviewed against the exact file region, both retracted.
- **`@codex review`:** triggered on `418c5e6` (comment `4608226353`, 01:08:02Z) → Codex Review comment `4608235324` (01:09:55Z, after the trigger) **"Didn't find any major issues. Nice work!"**; `reviewThreads.totalCount == 0`.
- **CI:** green on `418c5e6` — Go build and test, Security and supply-chain, Validate PR metadata, Docker image build, E2E Gitea mock loop all pass.

## Size gate
- [x] `within budget` — 1 file, docs-only (~15 lines).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
