### PR TITLE
test(runner): avoid post-return ctx assertion (#610)

### DIFF
--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -2257,14 +2257,13 @@ for line in sys.stdin:
 	// the turn deadline preempted promptly, but it is measured from turn start and
 	// cannot see time Run spends AFTER the turn in process termination /
 	// cmd.Wait(): if that cleanup rode the 10s outer ctx to expiry,
-	// classifyAppServerOutcome would wrap the same *TurnTimeoutError in a
+	// classifyAppServerOutcome wraps the same *TurnTimeoutError in a
 	// *TimeoutError (codex_app_server.go), whose Unwrap still satisfies the
-	// errors.As above — so the run could wait the full outer budget yet still pass
-	// the type + elapsed checks. Assert the outer ctx never fired to close that
-	// gap. This is boot-independent: interpreter boot only delays the 25ms turn,
-	// it never advances the 10s deadline, so a healthy run leaves ctx.Err() nil.
-	if ctx.Err() != nil {
-		t.Fatalf("ctx.Err() = %v after Run; want nil — Run waited for the outer context instead of returning on the 25ms turn deadline", ctx.Err())
+	// errors.As above. Rejecting that returned error shape closes the gap without
+	// racing a ctx.Err() read after Run has already returned.
+	var runTimeout *TimeoutError
+	if errors.As(err, &runTimeout) {
+		t.Fatalf("Run error = %T %[1]v, want bare *TurnTimeoutError without outer-run *TimeoutError wrapper", err)
 	}
 	// Assert promptness on TurnTimeoutError.Elapsed, which the runner measures as
 	// time.Since(turnStarted) (codex_app_server.go) — turnStarted is captured


### PR DESCRIPTION
Closes #610

## What & why

The follow-up from merged PR #604 flagged that `TestCodexAppServerRunnerReturnsTurnTimeoutWithoutWaitingForOuterContext` read `ctx.Err()` after `Run` returned. That post-return read can race the outer deadline if the test goroutine is paused after `Run` returns.

This keeps the same invariant in-band through the returned error: the test still requires a `*TurnTimeoutError`, and now also rejects any outer-run `*TimeoutError` wrapper. `classifyAppServerOutcome` is the path that wraps a turn timeout in `*TimeoutError` once the outer run context has fired, so the assertion still catches cleanup that rides the 10s outer deadline without observing `ctx.Err()` after return.

## Acceptance criteria

- [x] Address unresolved review thread from PR #604 discussion `r3345332215`.
- [x] Avoid reading `ctx.Err()` after `Run` returns.
- [x] Preserve the "did not wait for outer context" invariant with returned-error classification.
- [x] Test-only change; no production code.

## Verification

Local gates on head `f66ee7fc4255a7772fb817eb92d12f885b5d06e2`:

```bash
gofmt -l $(git ls-files '*.go')
go mod tidy && git diff --exit-code -- go.mod go.sum
go vet ./...
go test -race -covermode=atomic ./internal/runner -run TestCodexAppServerRunnerReturnsTurnTimeoutWithoutWaitingForOuterContext -count=10 -v
go test -race -covermode=atomic ./...
go build ./cmd/worker ./cmd/tui
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0
```

Results: all passed; lint reported `0 issues`.

## Mutation check

Committed artifact first, then mutated `internal/runner/codex_app_server.go` to disable the early `terminateProcess` guard:

```go
if runErr != nil && false {
```

Then ran:

```bash
go test -race -covermode=atomic ./internal/runner -run TestCodexAppServerRunnerReturnsTurnTimeoutWithoutWaitingForOuterContext -count=1 -v
```

Expected failure observed after ~10s outer ctx ride:

```text
Run error = *runner.TimeoutError runner timed out after 10.002s (budget 9.999170583s): runner turn timeout after 26.165ms (budget 25ms): context deadline exceeded, want bare *TurnTimeoutError without outer-run *TimeoutError wrapper
```

Restored with `git checkout -- internal/runner/codex_app_server.go`; targeted race test passed afterward.

## Review

- Pre-push Claude diff-only review: `MERGE-READY` (LOW confirmation request satisfied by inspecting `classifyAppServerOutcome` and by mutation).
- Pre-push Codex diff-only review: `MERGE-READY`, no findings.
- Post-push `@codex review`: trigger comment `4608340178` for head `f66ee7fc4255a7772fb817eb92d12f885b5d06e2`, pending.
- Review threads: pending GraphQL check after bot review.

## SPEC alignment (AGENTS.md principle 6/7)

Test-only on the Codex app-server runner path. No new worker/orchestrator phase, gate, artifact, config key, tracker write, or deviation. Upstream SPEC requires `turn_timeout_ms` failure handling for active turns; the Elixir app-server reference returns `:turn_timeout` from `receive_loop` after the turn timeout.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Size budget (AGENTS.md)

- [x] `within budget` — test-only, 1 file changed, 0 production LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
