### PR TITLE
runner: expose codex turn-start stalls

### DIFF
--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -247,8 +247,11 @@ Each entry in the `running` array follows SPEC §13.7.2:
   runner emits a `session_started` event.
 - `turn_count` — running count of `turn_completed` events observed in the
   session.
-- `last_event` — the most-recent runtime event kind (SPEC §10.4 vocabulary,
-  e.g. `turn_completed`, `notification`).
+- `last_event` — the most-recent runner runtime event kind, including
+  app-server events from SPEC §10.4 (for example `notification` and
+  `turn_completed`) plus runner-synthesized markers. `turn_started` means Codex
+  accepted `turn/start` and the runner is waiting for the first streaming
+  app-server update.
 - `last_message` — the most-recent `payload.message` string from a runtime
   event; sticky across later events that do not include one.
 - `started_at` — RFC3339 timestamp the worker spawned at.

--- a/docs/runbooks/task-api.md
+++ b/docs/runbooks/task-api.md
@@ -59,6 +59,10 @@ log.
 Important task event kinds emitted into the worker log/event emitter include:
 
 - `run_phase_transition` — SPEC run-attempt phase transitions
+- `session_started`, `turn_started`, `notification`, `turn_completed` — Codex
+  runner runtime events; `turn_started` is synthesized after a successful
+  `turn/start` response, while notifications and completions are app-server
+  stream events
 - `runner_start`, `runner_end`, `runner_timeout`
 - `workflow_resolved`, `hook_start`, `hook_end`
 

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -294,6 +294,7 @@ type appServerClient struct {
 	stallTimeoutMs    int
 	approvalPolicy    any
 	lastTerminal      time.Time
+	lastRuntimeEvent  string
 }
 type codexAppServerTextInput struct {
 	Type         string `json:"type"`
@@ -409,6 +410,7 @@ func (c *appServerClient) runSingleTurn(ctx context.Context, in RunInput, thread
 	if turn == 1 {
 		c.recordFirstTurnStarted(threadID, turnID)
 	}
+	c.recordTurnStarted(threadID, turnID, turn)
 	c.continueRun = false
 	turnCtx := ctx
 	var cancel context.CancelFunc
@@ -496,6 +498,15 @@ func (c *appServerClient) recordFirstTurnStarted(threadID, turnID string) {
 	}
 	c.recordRuntimeEvent(task.EventSessionStarted, payload)
 	c.recordPhaseTransition(task.PhaseInitializingSession, task.PhaseStreamingTurn)
+}
+
+func (c *appServerClient) recordTurnStarted(threadID, turnID string, turn int) {
+	c.recordRuntimeEvent(task.EventTurnStarted, map[string]any{
+		"session_id":  threadID + "-" + turnID,
+		"thread_id":   threadID,
+		"turn_id":     turnID,
+		"turn_number": turn,
+	})
 }
 
 // classifyTurnError maps an awaitTurnCompletion failure to the run's returned

--- a/internal/runner/codex_app_server_events.go
+++ b/internal/runner/codex_app_server_events.go
@@ -66,6 +66,7 @@ func (c *appServerClient) recordInputRequiredMessage(method string, msg map[stri
 func (c *appServerClient) recordRuntimeEvent(event string, payload map[string]any) {
 	runtimeEvent := task.RuntimeEvent{Event: event, Payload: payload}
 	c.runtimeEvents = append(c.runtimeEvents, runtimeEvent)
+	c.lastRuntimeEvent = event
 	if c.runtimeEventSink != nil {
 		c.runtimeEventSink(runtimeEvent)
 	}

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -402,8 +402,8 @@ for line in sys.stdin:
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(res.RuntimeEvents) != 3 {
-		t.Fatalf("RuntimeEvents len = %d, want session_started/notification/turn_completed: %#v", len(res.RuntimeEvents), res.RuntimeEvents)
+	if len(res.RuntimeEvents) != 4 {
+		t.Fatalf("RuntimeEvents len = %d, want session_started/turn_started/notification/turn_completed: %#v", len(res.RuntimeEvents), res.RuntimeEvents)
 	}
 	if res.RuntimeEvents[0].Event != task.EventSessionStarted {
 		t.Fatalf("first event = %q, want %q", res.RuntimeEvents[0].Event, task.EventSessionStarted)
@@ -424,13 +424,22 @@ for line in sys.stdin:
 	if n, _ := pid.(int); n <= 0 {
 		t.Fatalf("session_started codex_app_server_pid = %#v, want positive int (real codex subprocess PID)", pid)
 	}
-	if res.RuntimeEvents[1].Event != task.EventNotification {
-		t.Fatalf("second event = %q, want %q", res.RuntimeEvents[1].Event, task.EventNotification)
+	if res.RuntimeEvents[1].Event != task.EventTurnStarted {
+		t.Fatalf("second event = %q, want %q", res.RuntimeEvents[1].Event, task.EventTurnStarted)
 	}
-	if res.RuntimeEvents[2].Event != task.EventTurnCompleted {
-		t.Fatalf("third event = %q, want %q", res.RuntimeEvents[2].Event, task.EventTurnCompleted)
+	if got := runtimeEventField(t, res.RuntimeEvents[1], "session_id"); got != "thread-1-turn-1" {
+		t.Fatalf("turn_started session_id = %#v, want thread-1-turn-1", got)
 	}
-	if got := runtimeEventField(t, res.RuntimeEvents[2], "turn_id"); got != "turn-1" {
+	if got := runtimeEventField(t, res.RuntimeEvents[1], "turn_id"); got != "turn-1" {
+		t.Fatalf("turn_started turn_id = %#v, want turn-1", got)
+	}
+	if res.RuntimeEvents[2].Event != task.EventNotification {
+		t.Fatalf("third event = %q, want %q", res.RuntimeEvents[2].Event, task.EventNotification)
+	}
+	if res.RuntimeEvents[3].Event != task.EventTurnCompleted {
+		t.Fatalf("fourth event = %q, want %q", res.RuntimeEvents[3].Event, task.EventTurnCompleted)
+	}
+	if got := runtimeEventField(t, res.RuntimeEvents[3], "turn_id"); got != "turn-1" {
 		t.Fatalf("turn_completed turn_id = %#v, want turn-1", got)
 	}
 }
@@ -2091,6 +2100,40 @@ for line in sys.stdin:
 	}
 	if !IsStall(err) {
 		t.Fatalf("Run error = %T %[1]v, want runner.IsStall=true", err)
+	}
+}
+
+func TestCodexAppServerRunnerStallReportsTurnStartedAsLastEvent(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json, time
+for line in sys.stdin:
+    msg=json.loads(line)
+    if msg.get('method') == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif msg.get('method') == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif msg.get('method') == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        time.sleep(2)
+        break
+`)
+	wd := codexWorkdir(t, "x")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
+	in.Workflow.Config.Codex.StallTimeoutMs = 25
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := (CodexAppServerRunner{}).Run(ctx, in)
+	var stall *StallError
+	if !errors.As(err, &stall) {
+		t.Fatalf("Run error = %T %[1]v, want *StallError after turn/start", err)
+	}
+	if stall.LastEvent != task.EventTurnStarted {
+		t.Fatalf("StallError.LastEvent = %q; want %q", stall.LastEvent, task.EventTurnStarted)
+	}
+	if !strings.Contains(err.Error(), `after last event "turn_started"`) {
+		t.Fatalf("Run error = %q; want last-event diagnostic context", err.Error())
 	}
 }
 

--- a/internal/runner/codex_app_server_turn.go
+++ b/internal/runner/codex_app_server_turn.go
@@ -57,7 +57,7 @@ func (c *appServerClient) readTurnMessage(ctx context.Context) (map[string]any, 
 		stallBudget = time.Duration(c.stallTimeoutMs) * time.Millisecond
 		remaining := stallBudget - time.Since(c.lastTerminal)
 		if remaining <= 0 {
-			return nil, nil, stallBudget, &StallError{Timeout: stallBudget, Elapsed: time.Since(c.lastTerminal)}
+			return nil, nil, stallBudget, &StallError{Timeout: stallBudget, Elapsed: time.Since(c.lastTerminal), LastEvent: c.lastRuntimeEvent}
 		}
 		readCtx, cancel = context.WithTimeout(ctx, remaining)
 	}
@@ -99,7 +99,7 @@ func (c *appServerClient) classifyTurnReadError(ctx context.Context, err error, 
 	elapsed := time.Since(c.lastTerminal)
 	if stallBudget > 0 && ctx.Err() == nil && elapsed >= stallBudget {
 		if errors.Is(err, context.DeadlineExceeded) || isAppServerReadTimeout(err) {
-			return &StallError{Timeout: stallBudget, Elapsed: elapsed, Cause: err}, false
+			return &StallError{Timeout: stallBudget, Elapsed: elapsed, LastEvent: c.lastRuntimeEvent, Cause: err}, false
 		}
 	}
 	return err, false
@@ -194,7 +194,7 @@ func (c *appServerClient) handleTurnNotification(msg map[string]any, method stri
 	if c.stallTimeoutMs > 0 {
 		elapsed := time.Since(c.lastTerminal)
 		if elapsed > time.Duration(c.stallTimeoutMs)*time.Millisecond {
-			return true, &StallError{Timeout: time.Duration(c.stallTimeoutMs) * time.Millisecond, Elapsed: elapsed}
+			return true, &StallError{Timeout: time.Duration(c.stallTimeoutMs) * time.Millisecond, Elapsed: elapsed, LastEvent: c.lastRuntimeEvent}
 		}
 	}
 	c.lastTerminal = time.Now()

--- a/internal/runner/errors_test.go
+++ b/internal/runner/errors_test.go
@@ -67,6 +67,18 @@ func TestTimeoutTypesExposeRunnerCategories(t *testing.T) {
 	}
 }
 
+func TestStallErrorIncludesLastRuntimeEvent(t *testing.T) {
+	err := (&StallError{
+		Timeout:   time.Second,
+		Elapsed:   2 * time.Second,
+		LastEvent: "turn_started",
+		Cause:     context.DeadlineExceeded,
+	}).Error()
+	if !strings.Contains(err, `after last event "turn_started"`) {
+		t.Fatalf("StallError.Error() = %q; want last runtime event context", err)
+	}
+}
+
 func TestCodexAppServerRunnerStillReadsPromptForValidWorkspace(t *testing.T) {
 	wd := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(wd, ".aiops"), 0o755); err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -270,15 +270,21 @@ type StallError struct {
 	Timeout time.Duration
 	// Elapsed is how long the runner was silent since the last event.
 	Elapsed time.Duration
+	// LastEvent is the last runtime event the runner emitted before silence.
+	LastEvent string
 	// Cause is the wrapped underlying error, when available.
 	Cause error
 }
 
 func (e *StallError) Error() string {
-	if e.Cause != nil {
-		return fmt.Sprintf("runner stall timeout after %s without events (budget %s): %v", e.Elapsed, e.Timeout, e.Cause)
+	last := ""
+	if strings.TrimSpace(e.LastEvent) != "" {
+		last = fmt.Sprintf(" after last event %q", e.LastEvent)
 	}
-	return fmt.Sprintf("runner stall timeout after %s without events (budget %s)", e.Elapsed, e.Timeout)
+	if e.Cause != nil {
+		return fmt.Sprintf("runner stall timeout after %s without events%s (budget %s): %v", e.Elapsed, last, e.Timeout, e.Cause)
+	}
+	return fmt.Sprintf("runner stall timeout after %s without events%s (budget %s)", e.Elapsed, last, e.Timeout)
 }
 
 func (e *StallError) Unwrap() error { return e.Cause }

--- a/internal/task/spec_events_test.go
+++ b/internal/task/spec_events_test.go
@@ -31,10 +31,11 @@ func TestRunAttemptPhasesMatchSymphonySpec(t *testing.T) {
 	}
 }
 
-func TestRuntimeEventVocabularyIncludesSpecAppServerEvents(t *testing.T) {
+func TestRuntimeEventVocabularyIncludesRunnerAppServerEvents(t *testing.T) {
 	want := []string{
 		task.EventSessionStarted,
 		task.EventStartupFailed,
+		task.EventTurnStarted,
 		task.EventTurnCompleted,
 		task.EventTurnFailed,
 		task.EventTurnCancelled,

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -58,6 +58,7 @@ const (
 
 	EventSessionStarted       = "session_started"
 	EventStartupFailed        = "startup_failed"
+	EventTurnStarted          = "turn_started"
 	EventTurnCompleted        = "turn_completed"
 	EventTurnFailed           = "turn_failed"
 	EventTurnCancelled        = "turn_cancelled"
@@ -106,12 +107,13 @@ const (
 	EventTrackerComment         = "tracker_comment"
 )
 
-// RuntimeEvents returns the SPEC §10.4 app-server event vocabulary this
-// implementation forwards into task events.
+// RuntimeEvents returns the app-server runtime event vocabulary this
+// implementation forwards or synthesizes into task events.
 func RuntimeEvents() []string {
 	return []string{
 		EventSessionStarted,
 		EventStartupFailed,
+		EventTurnStarted,
 		EventTurnCompleted,
 		EventTurnFailed,
 		EventTurnCancelled,
@@ -136,8 +138,9 @@ func PhaseTransitionEvent(from, to RunAttemptPhase) PhaseTransition {
 	return PhaseTransition{Event: EventRunPhaseTransition, From: from, To: to}
 }
 
-// RuntimeEvent is a SPEC §10.4 app-server event emitted by an agent runtime
-// and forwarded into the task event stream by the worker.
+// RuntimeEvent is an app-server event emitted by an agent runtime, or a
+// runner-synthesized marker for the same live session, forwarded into the task
+// event stream by the worker.
 type RuntimeEvent struct {
 	Event   string `json:"event"`
 	Payload any    `json:"payload,omitempty"`


### PR DESCRIPTION
Closes #613

## Summary
- Classifies #613 as runner diagnostics / observability hardening, preserving the upstream-aligned stall contract instead of changing timeout semantics.
- Emits a runner-synthesized `turn_started` runtime event after successful `turn/start`, so first-turn app-server stalls have a precise last-event breadcrumb.
- Threads the last runtime event into `StallError` and documents the runner-synthesized event in runtime/API runbooks.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

SPEC / upstream checked before implementation:
- SPEC §5.3.6 `stall_timeout_ms`, §8.5 stale-running reconciliation, §10.2 session startup, §10.4 runtime event handling, §10.6 timeout mapping.
- `openai/symphony` Elixir `orchestrator.ex` stall reconciliation / last activity timestamp behavior and `codex/app_server.ex` long-running app-server turn handling.
- Verdict: this is runner diagnostics hardening only. It does not add worker post-turn gates, does not move agent-owned writes into the worker, and does not change stall eligibility.

## Size budget (AGENTS.md)
Classify into exactly one (review discipline; the size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production scope: 5 production files, under 300 production LOC. Tests/docs excluded per AGENTS.md.

## Testing
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Commands run locally:
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/tui`

Mutation checks:
- Removed `recordTurnStarted`; runtime event capture test failed missing `turn_started`.
- Removed `LastEvent: c.lastRuntimeEvent` from the read-timeout stall path; first-turn stall integration test failed with empty `LastEvent` instead of `turn_started`.

Pre-push reviewers:
- `codex exec review` on head `93f9d97507423c2beecc8d51aa1fee9d9a65ec28`: MERGE-READY, no HIGH/MEDIUM/LOW findings.
- `claude` review on head `93f9d97507423c2beecc8d51aa1fee9d9a65ec28`: MERGE-READY; informational LOW notes only.

PR follow-through:
- CI: all checks SUCCESS (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`, `Validate PR metadata`).
- fresh `@codex review`: clean, "Did not find any major issues".
- GraphQL reviewThreads: 0 actionable, 0 outdated.
- merge state: CLEAN while draft; pending non-draft / final merge evaluation.

## Live ledger
- issue: #613
- PR: #616
- branch/worktree: `codex/613-codex-stall-diagnostics` / `/Users/yvan/.config/superpowers/worktrees/aiops-platform/codex-613-codex-stall-diagnostics`
- head: `93f9d97507423c2beecc8d51aa1fee9d9a65ec28`
- state: CI green; fresh @codex review clean; reviewThreads clean; ready for non-draft / merge evaluation.
- deferrals: none

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
