### PR TITLE
docs: add concurrent Linear lifecycle E2E runbook

### DIFF
--- a/docs/runbooks/concurrent-linear-codex-e2e.md
+++ b/docs/runbooks/concurrent-linear-codex-e2e.md
@@ -1,0 +1,376 @@
+# Concurrent Linear/Codex local binary E2E
+
+Use this runbook after the single-issue smoke in
+[`first-run-docker-linear-codex.md`](first-run-docker-linear-codex.md) proves
+the install can run one disposable task. This flow validates the real local
+binary path with two concurrent Codex agents, agent-owned Linear lifecycle
+writes, dashboard state, and TUI rendering.
+
+The worker is still only the scheduler/runner and tracker reader. Linear state
+updates must be performed by the agent through the advertised `linear_graphql`
+tool.
+
+## Contract
+
+The Linear project workflow must expose these visible states:
+
+```text
+Backlog, Todo, In Progress, In Review, Done
+```
+
+The active handoff path under test is:
+
+```text
+Todo -> In Progress -> In Review
+```
+
+Backlog and Done are schema checks, not required agent transitions. Create the
+disposable issues in Todo, require the agent to move each issue to In Progress
+when it starts, and require the agent to move each issue to In Review after it
+opens the draft PR and records completion evidence. Do not make the worker, a
+wrapper script, or an operator cleanup step move issues to Done.
+
+## 1. Prepare disposable work
+
+Create two disposable Linear issues in Todo in an isolated disposable project.
+Do not run this smoke against a shared Linear project: the worker polls every
+issue in `tracker.active_states`, so unrelated Todo or In Progress issues can
+dispatch real agents and can make `running: 2` pass for the wrong work. Before
+starting the worker, verify that exactly two active issues exist in the project,
+and that their identifiers are the two disposable issue ids for this run. Use
+the issue body as the task source of truth. The bodies can point at a disposable
+fixture repo, a temporary GitHub issue, or a tiny docs-only task, but they must
+not depend on copied task text in `WORKFLOW.md`.
+
+Before starting the worker, verify the project schema independently in Linear
+UI or through the API. The GraphQL query should inspect the project's team
+workflow states:
+
+```graphql
+query ProjectWorkflowStates($projectSlug: String!) {
+  projects(filter: { slugId: { eq: $projectSlug } }, first: 1) {
+    nodes {
+      name
+      slugId
+      teams {
+        nodes {
+          states {
+            nodes { name type }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Record sanitized evidence that the visible state names include Backlog, Todo,
+In Progress, In Review, Done. Do not store API keys in the evidence file.
+
+## 2. Render a generic workflow
+
+Use a fresh `WORKFLOW.md` for the run. Keep the prompt generic and issue-body
+driven so the validation cannot inherit stale issue numbers or old task text;
+do not copy issue-specific task text into WORKFLOW.md.
+
+```yaml
+---
+repo:
+  owner: OWNER
+  name: REPO
+  clone_url: https://github.com/OWNER/REPO.git
+  default_branch: main
+agent:
+  default: codex-app-server
+  max_concurrent_agents: 2
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: PROJECT-SLUG
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - In Review
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+codex:
+  linear_graphql:
+    allow_mutations: true
+    allowed_mutations:
+      - issueUpdate
+      - commentCreate
+---
+Use the issue body as the task source of truth.
+Do not copy issue-specific task text into WORKFLOW.md.
+
+On start:
+- Read the Linear issue body and comments.
+- Use linear_graphql issueUpdate to move this issue to In Progress.
+- Use linear_graphql commentCreate to record that work started.
+
+While working:
+- Implement only the task described in this issue body.
+- Open a draft PR when code or docs change.
+- Do not use shell curl for Linear writes.
+
+On finish:
+- Record validation evidence in the draft PR body or final issue comment.
+- Use linear_graphql commentCreate to summarize the result.
+- Use linear_graphql issueUpdate to move this issue to In Review.
+- Do not move the issue to Done.
+```
+
+Keep `tracker.active_states` limited to Todo and In Progress for this run. That
+lets the worker discover new Todo issues and continue already-started In
+Progress issues, while In Review is the agent-owned handoff state.
+
+## 3. Protect credentials
+
+Keep credentials in environment variables, restricted files, a keychain helper,
+or the existing launchd secret wrapper. Never pass Linear tokens as command-line arguments.
+`LINEAR_API_KEY` may be present in the worker environment or loaded from a
+restricted file, but it must not appear in repo files, launchd plist files,
+shell history, worker logs, dashboard captures, or TUI captures.
+
+For a file-backed run, export the two tokens into the current operator shell
+from restricted files before running `--doctor`, rendering curl config, or
+capturing the TUI. The worker and TUI read the environment, while the command
+line only carries file paths:
+
+```bash
+: "${LINEAR_API_KEY_FILE:?set LINEAR_API_KEY_FILE to a restricted token file}"
+: "${AIOPS_STATE_API_TOKEN_FILE:?set AIOPS_STATE_API_TOKEN_FILE to a restricted token file}"
+export LINEAR_API_KEY="$(cat "$LINEAR_API_KEY_FILE")"
+export AIOPS_STATE_API_TOKEN="$(cat "$AIOPS_STATE_API_TOKEN_FILE")"
+```
+
+Use the state API token only through headers or `AIOPS_STATE_API_TOKEN`:
+
+```bash
+mkdir -p /tmp/aiops-linear-e2e
+curl_cfg="/tmp/aiops-linear-e2e/curl.cfg"
+rm -f "$curl_cfg"
+(umask 077 && : > "$curl_cfg")
+chmod 600 "$curl_cfg"
+printf 'header = "Authorization: Bearer %s"\n' \
+  "$AIOPS_STATE_API_TOKEN" > "$curl_cfg"
+```
+
+After the run and closeout cleanup, scan the evidence paths for accidental token
+exposure before sharing or committing any report:
+
+```bash
+if [ -n "${LINEAR_API_KEY:-}" ] || [ -n "${AIOPS_STATE_API_TOKEN:-}" ]; then
+  {
+    [ -n "${LINEAR_API_KEY:-}" ] && printf '%s\n' "$LINEAR_API_KEY"
+    [ -n "${AIOPS_STATE_API_TOKEN:-}" ] && printf '%s\n' "$AIOPS_STATE_API_TOKEN"
+  } | rg -n --fixed-strings -f - \
+    docs/validation/smoke /tmp/aiops-linear-e2e || true
+fi
+```
+
+The scan command is for a local operator shell only; do not paste secrets into
+issue comments, PR bodies, or runbook output.
+
+## 4. Preflight and start the worker
+
+Build the local binary and run the same preflight checks used by the first-run
+guide:
+
+```bash
+go build -o /tmp/aiops-worker ./cmd/worker
+/tmp/aiops-worker --doctor --mode=real --deploy=binary WORKFLOW.md
+/tmp/aiops-worker --print-config "$(pwd)" >/tmp/aiops-linear-e2e-config.txt
+```
+
+Start a dedicated per-user launchd worker for this smoke. Do not reuse an
+already-loaded `com.aiops-platform.worker` job, because `launchctl kickstart`
+only restarts the loaded program and environment; it does not repoint the job at
+the local binary or workflow rendered for this run.
+
+```bash
+workflow_path="$(pwd)/WORKFLOW.md"
+wrapper_path="/tmp/aiops-linear-e2e/worker-launch"
+plist_path="$HOME/Library/LaunchAgents/com.aiops-platform.linear-e2e.plist"
+label="com.aiops-platform.linear-e2e"
+worker_port="${AIOPS_LINEAR_E2E_PORT:-4015}"
+worker_url="http://127.0.0.1:${worker_port}"
+
+: "${LINEAR_API_KEY_FILE:?set LINEAR_API_KEY_FILE to a restricted token file}"
+: "${AIOPS_STATE_API_TOKEN_FILE:?set AIOPS_STATE_API_TOKEN_FILE to a restricted token file}"
+
+launchctl bootout "gui/$(id -u)/$label" >/dev/null 2>&1 || true
+launchctl bootout "gui/$(id -u)" "$plist_path" >/dev/null 2>&1 || true
+sleep 1
+
+if lsof -nP -iTCP:"$worker_port" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "FAIL port $worker_port already has a listener; set AIOPS_LINEAR_E2E_PORT to an unused port" >&2
+  exit 1
+fi
+
+cat > "$wrapper_path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export LINEAR_API_KEY="\$(cat "$LINEAR_API_KEY_FILE")"
+export AIOPS_STATE_API_TOKEN="\$(cat "$AIOPS_STATE_API_TOKEN_FILE")"
+exec /tmp/aiops-worker --port="$worker_port" "$workflow_path"
+EOF
+chmod 700 "$wrapper_path"
+
+cat > "$plist_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$label</string>
+  <key>ProgramArguments</key><array><string>$wrapper_path</string></array>
+  <key>WorkingDirectory</key><string>$(pwd)</string>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>/tmp/aiops-linear-e2e/worker.out.log</string>
+  <key>StandardErrorPath</key><string>/tmp/aiops-linear-e2e/worker.err.log</string>
+</dict></plist>
+EOF
+chmod 600 "$plist_path"
+
+launchctl bootstrap "gui/$(id -u)" "$plist_path"
+launchctl kickstart -k "gui/$(id -u)/$label"
+launchctl print "gui/$(id -u)/$label" >/tmp/aiops-linear-e2e/launchd.txt
+grep -F "$wrapper_path" /tmp/aiops-linear-e2e/launchd.txt
+grep -F "$workflow_path" "$wrapper_path"
+
+worker_ready=false
+for attempt in $(seq 1 60); do
+  if curl --fail --silent --show-error "$worker_url/livez" >/dev/null 2>&1 &&
+    curl --fail --silent --show-error "$worker_url/readyz" >/dev/null 2>&1; then
+    worker_ready=true
+    break
+  fi
+  sleep 2
+done
+if [ "$worker_ready" != true ]; then
+  echo "FAIL worker did not become ready on $worker_url" >&2
+  tail -50 /tmp/aiops-linear-e2e/worker.err.log >&2 || true
+  exit 1
+fi
+```
+
+If the launchd job uses a secret wrapper, keep `LINEAR_API_KEY` and
+`AIOPS_STATE_API_TOKEN` out of the plist. The plist may point at a restricted
+wrapper path, but it must not inline secret values.
+
+## 5. Trigger and assert concurrency
+
+Trigger a poll after both disposable issues are in Todo:
+
+```bash
+curl --fail --silent --show-error --config "$curl_cfg" \
+  -H 'X-AIOPS-Refresh: true' \
+  -X POST "$worker_url/api/v1/refresh"
+```
+
+Poll `/api/v1/state` until it shows `running: 2` or an equivalent JSON count
+with two running rows from the two disposable issue ids:
+
+```bash
+saw_running_2=false
+for attempt in $(seq 1 60); do
+  curl --fail --silent --show-error --config "$curl_cfg" \
+    "$worker_url/api/v1/state" \
+    >/tmp/aiops-linear-e2e/state.json
+  jq '.counts.running // (.running | length)' \
+    /tmp/aiops-linear-e2e/state.json
+  if jq -e '(.counts.running == 2) or ((.running | length) == 2)' \
+    /tmp/aiops-linear-e2e/state.json; then
+    saw_running_2=true
+    break
+  fi
+  sleep 5
+done
+if [ "$saw_running_2" != true ]; then
+  echo "FAIL did not observe running: 2" >&2
+  exit 1
+fi
+```
+
+Keep the state snapshot as evidence. If the count never reaches two, record the
+worker log path and stop; do not reinterpret a serialized run as passing the
+concurrency requirement.
+
+## 6. Verify Linear lifecycle
+
+For each disposable issue, verify the Linear activity or API history shows the
+agent-owned path Todo -> In Progress -> In Review. The start transition must
+occur before the start comment, and the In Review transition must occur after
+the completion comment and draft PR link.
+
+Required evidence for each issue:
+
+- the issue started in Todo;
+- the agent moved it to In Progress through `linear_graphql`;
+- the agent posted a start comment;
+- the agent opened a draft PR for the issue body task;
+- the agent posted completion evidence;
+- the agent moved it to In Review through `linear_graphql`;
+- the worker did not move it to Done.
+
+Use independent Linear UI/API inspection for this step. Worker logs alone prove
+tool calls were advertised, not that Linear accepted the lifecycle changes.
+
+## 7. Verify dashboard and TUI
+
+Capture the dashboard state API and one raw TUI frame after the two runs finish:
+
+```bash
+curl --fail --silent --show-error --config "$curl_cfg" \
+  "$worker_url/api/v1/state" \
+  >/tmp/aiops-linear-e2e/final-state.json
+
+timeout_bin="${AIOPS_TIMEOUT_BIN:-$(command -v timeout || command -v gtimeout || true)}"
+if [ -z "$timeout_bin" ]; then
+  echo "FAIL install GNU coreutils or set AIOPS_TIMEOUT_BIN to timeout/gtimeout" >&2
+  exit 1
+fi
+
+"$timeout_bin" 15s env AIOPS_STATE_API_TOKEN="$AIOPS_STATE_API_TOKEN" \
+  go run ./cmd/tui --url "$worker_url/" --raw \
+  >/tmp/aiops-linear-e2e/tui-raw.txt \
+  || test "$?" -eq 124
+```
+
+The final state must be nonblank and error-free. The TUI capture must include
+the run rows or terminal handoff signal for the disposable issues; a connection
+error, authentication error, or empty frame fails the E2E.
+
+## 8. Closeout
+
+Write a sanitized report under `docs/validation/smoke/` or another local
+operator evidence directory. Include:
+
+- Linear project name and sanitized issue identifiers;
+- confirmation that the schema contained Backlog, Todo, In Progress, In Review,
+  Done;
+- `WORKFLOW.md` path and `max_concurrent_agents: 2`;
+- `/api/v1/state` evidence showing `running: 2`;
+- lifecycle evidence for both issues;
+- draft PR URLs;
+- dashboard and `cmd/tui --raw` evidence paths;
+- secret scan command and result.
+
+Dispose of the draft PRs and test issues according to the normal PR
+follow-through gate. Only move issues to Done as an explicit human cleanup
+action after validation is complete.
+
+Stop and remove the temporary LaunchAgent even when the smoke fails, so it
+cannot keep polling the disposable project or hold the E2E port:
+
+```bash
+label="com.aiops-platform.linear-e2e"
+plist_path="$HOME/Library/LaunchAgents/com.aiops-platform.linear-e2e.plist"
+wrapper_path="/tmp/aiops-linear-e2e/worker-launch"
+curl_cfg="/tmp/aiops-linear-e2e/curl.cfg"
+
+launchctl bootout "gui/$(id -u)" "$plist_path" >/dev/null 2>&1 || true
+rm -f "$plist_path" "$wrapper_path" "$curl_cfg"
+```

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -338,6 +338,15 @@ After a successful smoke, close or merge the disposable draft PR according to
 the normal PR follow-through gate, then close any intentionally disposable
 GitHub/Linear test issue that is not closed by the PR.
 
+## 7. Run a concurrent Linear lifecycle smoke
+
+After the single-issue path is healthy, use
+[`concurrent-linear-codex-e2e.md`](concurrent-linear-codex-e2e.md) to validate
+the local binary path with `max_concurrent_agents: 2`, the five visible Linear
+states, agent-owned `Todo -> In Progress -> In Review` transitions, dashboard
+`/api/v1/state`, and `cmd/tui --raw`. Keep that run generic and issue-body
+driven; do not copy disposable issue text into `WORKFLOW.md`.
+
 ## Troubleshooting
 
 | Symptom | Next action |

--- a/scripts/linear_lifecycle_docs_test.go
+++ b/scripts/linear_lifecycle_docs_test.go
@@ -1,0 +1,160 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestConcurrentLinearLifecycleRunbookPinsFiveStateHandoffContract(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "docs", "runbooks", "concurrent-linear-codex-e2e.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(body)
+
+	for _, want := range []string{
+		"Backlog, Todo, In Progress, In Review, Done",
+		"Todo -> In Progress -> In Review",
+		"Backlog and Done are schema checks, not required agent transitions",
+		"projects(filter: { slugId: { eq: $projectSlug } }, first: 1)",
+		"max_concurrent_agents: 2",
+		"Use the issue body as the task source of truth",
+		"do not copy issue-specific task text into WORKFLOW.md",
+		"Do not run this smoke against a shared Linear project",
+		"exactly two active issues",
+		"running: 2",
+		"/api/v1/state",
+		"cmd/tui --raw",
+		"AIOPS_STATE_API_TOKEN",
+		"LINEAR_API_KEY",
+		"api_key: $LINEAR_API_KEY",
+		"Never pass Linear tokens as command-line arguments",
+		"LINEAR_API_KEY_FILE",
+		`export LINEAR_API_KEY="$(cat "$LINEAR_API_KEY_FILE")"`,
+		"--deploy=binary",
+		"com.aiops-platform.linear-e2e",
+		"AIOPS_LINEAR_E2E_PORT",
+		`lsof -nP -iTCP:"$worker_port" -sTCP:LISTEN`,
+		`worker_url="http://127.0.0.1:${worker_port}"`,
+		`curl_cfg="/tmp/aiops-linear-e2e/curl.cfg"`,
+		`launchctl bootout "gui/$(id -u)/$label"`,
+		"worker_ready=false",
+		`"$worker_url/livez"`,
+		`"$worker_url/readyz"`,
+		"FAIL worker did not become ready",
+		"saw_running_2=false",
+		"FAIL did not observe running: 2",
+		"AIOPS_TIMEOUT_BIN",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("runbook missing %q", want)
+		}
+	}
+
+	for _, stale := range []string{"AIS-59", "AIS-60", "edit-support", "subtitle task"} {
+		if strings.Contains(text, stale) {
+			t.Fatalf("runbook contains stale manual-run text %q", stale)
+		}
+	}
+
+	if strings.Contains(extractWorkflowSnippet(t, text), "\ntools:\n") {
+		t.Fatalf("workflow snippet uses stale tools.linear_graphql nesting; want codex.linear_graphql")
+	}
+	startup := textAfter(t, text, "Start a dedicated per-user launchd worker")
+	assertInOrder(t, startup, []string{
+		`launchctl bootout "gui/$(id -u)/$label"`,
+		`lsof -nP -iTCP:"$worker_port" -sTCP:LISTEN`,
+		"launchctl bootstrap",
+		"worker_ready=false",
+		`"$worker_url/readyz"`,
+	})
+	teardown := textAfter(t, text, "Stop and remove the temporary LaunchAgent")
+	for _, want := range []string{
+		`launchctl bootout "gui/$(id -u)" "$plist_path"`,
+		`rm -f "$plist_path" "$wrapper_path" "$curl_cfg"`,
+	} {
+		if !strings.Contains(teardown, want) {
+			t.Fatalf("teardown section missing %q", want)
+		}
+	}
+
+	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(extractWorkflowSnippet(t, text)), 0o600); err != nil {
+		t.Fatalf("write extracted WORKFLOW.md: %v", err)
+	}
+	t.Setenv("LINEAR_API_KEY", "linear-docs-test-key")
+	loaded, err := workflow.Load(workflowPath)
+	if err != nil {
+		t.Fatalf("workflow.Load(extracted WORKFLOW.md) = %v; want nil", err)
+	}
+
+	cfg := loaded.Config
+	if cfg.Agent.Default != "codex-app-server" {
+		t.Fatalf("agent.default = %q; want %q", cfg.Agent.Default, "codex-app-server")
+	}
+	if cfg.Agent.MaxConcurrentAgents != 2 {
+		t.Fatalf("agent.max_concurrent_agents = %d; want 2", cfg.Agent.MaxConcurrentAgents)
+	}
+	if cfg.Tracker.Kind != "linear" {
+		t.Fatalf("tracker.kind = %q; want %q", cfg.Tracker.Kind, "linear")
+	}
+	if cfg.Tracker.APIKey != "linear-docs-test-key" {
+		t.Fatalf("tracker.api_key = %q; want env-expanded LINEAR_API_KEY", cfg.Tracker.APIKey)
+	}
+	if cfg.Tracker.ProjectSlug == "" {
+		t.Fatalf("tracker.project_slug = %q; want non-empty placeholder", cfg.Tracker.ProjectSlug)
+	}
+	if !cfg.Codex.LinearGraphQL.AllowMutations {
+		t.Fatalf("codex.linear_graphql.allow_mutations = false; want true")
+	}
+	wantMutations := []string{"issueUpdate", "commentCreate"}
+	if !reflect.DeepEqual(cfg.Codex.LinearGraphQL.AllowedMutations, wantMutations) {
+		t.Fatalf("codex.linear_graphql.allowed_mutations = %v; want %v", cfg.Codex.LinearGraphQL.AllowedMutations, wantMutations)
+	}
+}
+
+func assertInOrder(t *testing.T, text string, wants []string) {
+	t.Helper()
+
+	offset := 0
+	for _, want := range wants {
+		idx := strings.Index(text[offset:], want)
+		if idx == -1 {
+			t.Fatalf("runbook missing %q after offset %d", want, offset)
+		}
+		offset += idx + len(want)
+	}
+}
+
+func textAfter(t *testing.T, text, marker string) string {
+	t.Helper()
+
+	start := strings.Index(text, marker)
+	if start == -1 {
+		t.Fatalf("runbook missing section marker %q", marker)
+	}
+	return text[start:]
+}
+
+func extractWorkflowSnippet(t *testing.T, text string) string {
+	t.Helper()
+
+	const fence = "```yaml\n---\n"
+	start := strings.Index(text, fence)
+	if start == -1 {
+		t.Fatalf("runbook missing workflow YAML fence starting with %q", fence)
+	}
+	start += len("```yaml\n")
+	end := strings.Index(text[start:], "\n```")
+	if end == -1 {
+		t.Fatalf("runbook workflow YAML fence missing closing marker")
+	}
+	return text[start : start+end]
+}


### PR DESCRIPTION
Closes #615

## Summary
- Add a concurrent Linear/Codex local binary E2E runbook for two disposable Linear issues.
- Pin the five visible Linear states while testing the agent-owned Todo -> In Progress -> In Review handoff.
- Add a docs test that loads the embedded WORKFLOW.md sample through internal/workflow and protects project isolation, file-backed token export, binary doctor mode, reusable launchd startup, readiness polling, fail-closed concurrency polling, teardown, and stale issue text.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs-only/runbook hardening. Keeps Linear writes agent-owned through advertised `linear_graphql`; does not add worker tracker writes, worker completion transitions to Done, or new worker phases/config keys.

## Size budget (AGENTS.md)
Classify into exactly one (review discipline; the size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Docs/test only, 0 production LOC.

## Testing
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- go test ./scripts -run TestConcurrentLinearLifecycleRunbookPinsFiveStateHandoffContract -count=1
- go test ./scripts -count=1
- go mod tidy
- git diff --exit-code -- go.mod go.sum
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0
- go build ./cmd/worker ./cmd/tui

## Mutation check
- Changed `codex.linear_graphql.allow_mutations: true` to `false`; focused docs test failed because `allowed_mutations` requires `allow_mutations: true`.
- Removed `api_key: $LINEAR_API_KEY`; focused docs test failed.
- Changed `saw_running_2=false` to `true`; focused docs test failed.
- Removed `--deploy=binary`; focused docs test failed.
- Removed the teardown `launchctl bootout`; after tightening the test to inspect the teardown section, focused docs test failed.
- Restored each mutation and reran the focused docs test successfully.

## Review
- Local Codex review against origin/main: clean, no discrete correctness issue.
- Local Claude review was attempted but the CLI produced no output for several minutes and was terminated; PR follow-through still uses CI plus GitHub Codex review.

## Deferrals
None.