### PR TITLE
docs: codify recent workflow follow-through lessons

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -36,6 +36,7 @@ metadata:
 - 读 SPEC.md 相关章节 + 对应 Elixir 模块（`orchestrator.ex` / `codex/app_server.ex` / `tracker.ex` / `config/schema.ex`），歧义以 Elixir 为准。
 - **审查相邻路径**（AGENTS.md「Cross-cutting checklist」item 1）：grep 你要改的 SPEC 概念符号，列出其它 consumer；aiops 扩展（service routing `selectRoutedCandidates`、multi-tracker fan-out、per-state capacity caps、eligibility filter、reconcile hooks）要么也在你的新路径生效，要么写明为何不同。**踩坑实例**：blocked vs running 清理路径只兑现了一半契约。
 - **要在 worker/orchestrator 侧新增「消费 agent 产物」的 phase/gate/artifact/config（verify、secret-scan、run-summary、diff policy、push、PR、tracker 写…）前，先 grep Elixir 参考有没有等价物**（AGENTS.md 原则 6）。**upstream 没有 = 过度设计信号，不是功能缺口**：默认删除，别搬进 prompt 也别只记一行 DEVIATIONS。「交接前检查 agent 产物」的归宿是 WORKFLOW prompt（agent 自有、push 前、预防式），不是 worker post-turn phase（push 后只能 flag，且抢跑 D9 reconcile-cancel / §16.5 self-stop——#557 即此）。本仓库已建了又拆 6+ 次（#73/#407、#74、#76、#557/#561）。
+- **返工高发区先写短计划再动手**：如果要碰 codex schema / dynamic tools、worker post-turn gates、queue/webhook/PR-push/tracker-write 移除路径等历史上反复返工或删了重做的子系统，先在 worktree 内写清当前上游证据、要保留/删除的不变量、相邻路径 blast radius、测试/变异验证点，再改代码。计划给出技术结论，不把 SPEC 已经能裁定的问题做成多选题。
 - **DEVIATIONS.md 决策门**：研究到结论再提（AGENTS.md 原则 7）——别把「关闭既有 / 新开 / 回退」当多选题甩给用户，SPEC + Elixir 参考通常已能定论（最常见结论：upstream 缺失且 SPEC 归在别处的扩展应删除）。别为了让差异消失而新造「deliberate extension」。
 
 ### 3. 分支 + 实现
@@ -55,12 +56,12 @@ go build ./cmd/worker ./cmd/tui
 **暂存只 add 明确路径，绝不 `git add -A` / `git add .`**（会把 `.codex/` 等本地未跟踪文件卷入 PR）。commit 前 `git status --short` 核对只暂存了预期文件。
 
 ### 5. 提交 → 双审 → 开 PR
-1. 按协议 §2–§3 commit-first + pre-push 双 reviewer，§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
+1. 按协议 §2–§3 commit-first + pre-push 双 reviewer；review finding 先按当前 head、issue 计划、SPEC/Elixir 参考和相邻路径验证技术正确性，再修复 / 反证 / 延后。§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
 2. push 后开 **一个** PR 对应该 issue，body 引用 issue（`Closes #N`），列验收项、验证命令、变异验证、风险/deferral；PR body 是活账本（协议 §7）。
 3. **每条 finding 归入 ≥1 类**：算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试；然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。
 4. **Deferred 偏差必须开 issue**（AGENTS.md rule 2）：决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
 5. **Scope 分离**：治理/文档类改动从 main 开新分支**单独 PR**，不要塞进 fix PR。
-6. 收敛后交给 `gh-pr-follow-through`（私有 `xrf9268-hue/yy-skills`；云端容器通常没装）盯 CI + 线程到 merge-ready。**该 skill 不可用时就地内联**：`gh pr checks <pr> --watch --fail-fast` 等 CI → GraphQL `reviewThreads` 解决所有未决 actionable thread → merge-ready。期间推了修复就对新 head 重跑协议 §3–§5。
+6. 收敛后交给 `gh-pr-follow-through`（私有 `xrf9268-hue/yy-skills`；云端容器通常没装）盯 CI + 线程到 merge-ready。**该 skill 不可用时就地内联**：`gh pr checks <pr> --watch --fail-fast` 等 CI → GraphQL `reviewThreads` 解决所有未决 actionable thread → 最后一次 PR body 更新后等新的 `PR Metadata` 终态并做 warning audit → merge-ready。期间推了修复就对新 head 重跑协议 §3–§5。
 
 ### 6. 合并
 按协议 §8：**必须等用户明确许可**；squash + 删分支，commit message 写最终状态；`--force-with-lease=<branch>:<known-sha>`。批次/scope 显式授权下的 opt-in 自动合并见 [`docs/runbooks/batch-issue-processing.md`](../../../docs/runbooks/batch-issue-processing.md)。
@@ -88,6 +89,7 @@ go build ./cmd/worker ./cmd/tui
 
 ## 默认行为
 - 中文回复，简洁；每次只汇报变化，不复述。
+- Claude Code 若同一工具动作连续 2 次 malformed / stall / 中断，停止第 3 次原地重试，升级给 `codex:codex-rescue`，附当前 head、目标动作、失败 transcript、已验证事实；这是运行时故障，不是技术 finding 通过或失败。
 - worker 永不 push/合并 PR 或写 tracker 状态（D8/#76）。
 - Go 版本由 go.mod 锁定，别顺手改 `go` 指令。
 - **批处理多个 issue 时**（`/goal` over a set）：并行/串行依赖判定、deferral 时机、live ledger、pause/resume、opt-in 授权合并等批处理纪律全部见 [`docs/runbooks/batch-issue-processing.md`](../../../docs/runbooks/batch-issue-processing.md)，不在此复述（与本 skill 顶部「不复述共享协议」一致，避免内联规则与 runbook 漂移）。

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -31,16 +31,17 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
    - 测试是否安慰剂（assertion 真的读到新代码改的字段吗？）
    - 错位机制（在 §1 scheduler/runner 边界的错误一侧）：worker/orchestrator 侧「消费 agent 产物」的 phase/gate/artifact/config，先 grep Elixir 有没有等价物——没有就是过度设计信号，判**删除**（非搬进 prompt、非只记 DEVIATIONS），归宿默认是 WORKFLOW prompt（worker post-turn phase 在 push 后只能 flag 不能 prevent，且抢跑 D9 reconcile-cancel / §16.5 self-stop——#557 即此；AGENTS.md 原则 6；#557/#561 拆的就是这类）
 
-2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，HIGH/MEDIUM/Critical 先修再 amend 重审；一般 2–3 轮收敛。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
+2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，HIGH/MEDIUM/Critical 先验证技术正确性，再决定修复 / 反证 / 延后；不要盲从，也不要把 finding 当噪音略过。若 finding 证明计划本身错了，同轮更新代码、测试、SPEC/deviation 文档和 PR body。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
 
 3. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria（AGENTS.md rule 2）。决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
 
 4. **Scope 分离**：治理 / 文档改动从 main 开新分支单独 PR，不要塞进 fix PR。
 
-5. **PR body 是活账本**（协议 §7）：每次重大 push 后更新 head SHA、验收项、验证命令、mutation check、CI、双 reviewer、`@codex review`、thread、size-gate 三态 checklist、deferral 状态，避免 stale body 误导合并判断。
+5. **PR body 是活账本**（协议 §7）：每次重大 push 后更新 head SHA、验收项、验证命令、mutation check、CI、双 reviewer、`@codex review`、thread、size-gate 三态 checklist、deferral 状态，避免 stale body 误导合并判断。最后一次 body 更新后重新等 `PR Metadata` 终态；`@codex review` 的 clean issue comment 只作为人工可审计信号，自动化不可解析自然语言。
 
 ## 默认行为
 
 - 工作分支：系统会告诉你具体名字。
+- Claude Code 若同一工具动作连续 2 次 malformed / stall / 中断，停止第 3 次原地重试，升级给 `codex:codex-rescue`，附 PR 号、当前 head/base、目标动作、失败 transcript、已验证事实；这是运行时故障，不是 review finding 的技术裁定。
 - 合并、force-push、auto-merge 门槛、hard stops：全部按协议 §8。merge 前必须等用户明确许可；批次/scope 显式授权下的 opt-in 自动合并见 [`docs/runbooks/batch-issue-processing.md`](../../../docs/runbooks/batch-issue-processing.md)，授权不跨批次/scope 沿用。
 - 中文回复，简洁；每次只汇报变化不复述。

--- a/docs/runbooks/batch-issue-processing.md
+++ b/docs/runbooks/batch-issue-processing.md
@@ -25,6 +25,12 @@ runs:
   thread-aware review closure, the three-state size-gate classification with
   explicit sign-off paths) plus the batch-level pause/resume state recovery and
   follow-up capture for late unresolved review threads.
+- **2026-06 continuation / operator-stop follow-through** (#621 / PR #628 and
+  #622 / PR #631, with the upstream comparison in PR #625). This run sharpened
+  the distinction between "upstream also behaves this way" and "this repo
+  accepts a tracked deviation", and exposed two PR-gate edge cases: Codex may
+  finish a manual review with a bot issue comment rather than a trigger
+  reaction, and a final PR-body update can start a fresh `PR Metadata` run.
 
 Per the "Earned rules" principle in [`AGENTS.md`](../../AGENTS.md), do not
 generalize beyond what those runs actually taught.
@@ -107,7 +113,8 @@ transition:
 ```text
 issue → branch/worktree → PR → head → state
 (triaged | in-progress | draft | CI green | bot-review-pending | review clean |
- threads-resolved | within budget | size-gated: justified overage |
+ threads-resolved | body-updated | metadata-pending | metadata-green |
+ warnings-audited | within budget | size-gated: justified overage |
  size-gated: split recommended | mergeable | merged | merged-by-user |
  deferred→#NNN | skipped)
 ```
@@ -119,15 +126,17 @@ For each PR, also track the per-PR ledger facts the protocol already requires
 ([protocol §7](pr-review-merge-protocol.md#7-pr-body-is-a-living-ledger)) —
 current head SHA, local validation commands, CI conclusion/run id,
 `@codex review` trigger id + reaction state, unresolved review-thread ids (and
-whether each is outdated), size-gate classification, and deferral/follow-up
-links — and keep the PR body in sync as the public copy of the same facts.
+whether each is resolved/outdated), final `PR Metadata` run id, warning-audit
+result, size-gate classification, and deferral/follow-up links — and keep the
+PR body in sync as the public copy of the same facts.
 
 ## Pause, resume, and external merges
 
 Long batches may cross model quota windows or human intervention. Before
 pausing, write down the live ledger: issue, branch/worktree, PR, head SHA, CI
-state, trigger comment id, unresolved thread ids, size-gate state, and next
-action. Schedule the wakeup only after that state exists.
+state, trigger comment id, unresolved thread ids, PR-body freshness,
+`PR Metadata` state, warning-audit state, size-gate state, and next action.
+Schedule the wakeup only after that state exists.
 
 On resume, do not trust the paused snapshot. Re-fetch `origin/main`, refresh
 each live issue/PR with `gh`, and reclassify externally changed work:

--- a/docs/runbooks/concurrent-linear-codex-e2e.md
+++ b/docs/runbooks/concurrent-linear-codex-e2e.md
@@ -10,6 +10,29 @@ The worker is still only the scheduler/runner and tracker reader. Linear state
 updates must be performed by the agent through the advertised `linear_graphql`
 tool.
 
+## Operator boundary and upstream comparison
+
+For autonomous validation, the operator prepares the disposable repo, tracker
+issues, workflow, credentials, and capture tools, then observes. Do not edit the
+agent workspace, advance tracker state, merge draft PRs, or patch the worker
+mid-run to "help" the scenario pass. Operator actions after the run, such as
+canceling pathological issues or stopping a temporary worker, belong in the
+closeout report as observations, not hidden cleanup.
+
+When a finding may be inherited from Symphony rather than introduced by this
+port, run the same prep-from-zero flow against a freshly refreshed
+`openai/symphony` checkout and compare behavior before assigning root cause.
+"Upstream does this too" is not the end of the analysis: if the behavior is
+operationally unsafe here, track the accepted hardening as a SPEC deviation
+rather than silently matching the defect.
+
+Interactive Codex approval prompts are environment-sensitive. They were
+observed in the Codex app / CLI-aware local environment used for the June 2026
+run; a plain CLI or upstream reference run may not show the same popup even for
+the same tool choice. Do not classify "no popup appeared" as an aiops/upstream
+behavior difference by itself — compare the tool call, approval policy, runtime
+events, and logs.
+
 ## Contract
 
 The Linear project workflow must expose these visible states:

--- a/docs/runbooks/github-local-automation.md
+++ b/docs/runbooks/github-local-automation.md
@@ -250,6 +250,11 @@ scripts/uninstall-local-launchagents.sh
   The completion gate requires a `+1` reaction from
   `chatgpt-codex-connector` on that head/base-bound trigger and no active `eyes`
   reaction; unrelated/manual reactions do not satisfy the gate.
+  This unattended script intentionally fails closed if GitHub Codex instead
+  finishes by posting a clean issue comment; manual follow-through may treat
+  that as a human-audited completion signal per
+  [`pr-review-merge-protocol.md`](pr-review-merge-protocol.md), but automation
+  must not parse Codex natural-language output to decide merge readiness.
 - Merge uses `gh pr merge --match-head-commit <reviewed-head>` so GitHub rejects
   auto-merge setup if the PR branch changes between the last local check and the
   merge request.

--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -73,6 +73,11 @@ AGENTS.md policy.
 
 Triage:
 
+- **First validate the finding technically.** Compare it against the current
+  head, the issue plan, SPEC/Elixir references, and adjacent code paths before
+  changing code. A wrong review comment should be answered with evidence; a
+  right comment that exposes a plan flaw should update code, tests, and any
+  SPEC/deviation docs in the same review round.
 - **HIGH / MEDIUM / Critical block the push.** Fix, amend, rerun the local
   gate and both reviewers. Keep an unfixed item only if the human explicitly
   signs off on the risk before push.
@@ -92,7 +97,7 @@ Triage:
 Run it **on every pushed head**, not once per PR.
 
 1. `gh pr comment <pr> --body "@codex review"`; record that trigger
-   comment's id.
+   comment's id plus the head SHA, base SHA, and base branch at trigger time.
 2. **Poll** its reactions summary —
    `gh api repos/<owner>/<repo>/issues/comments/<id> --jq '.reactions.eyes'`
    (the issue-comment object carries the `.reactions` counts; no separate
@@ -100,7 +105,14 @@ Run it **on every pushed head**, not once per PR.
    have no watch/subscribe API (REST is GET/POST/DELETE only), so polling is the
    only option. **`eyes==0` alone is not done** (it may not have started): wait
    for 👀 to **appear then disappear**, **and** for a positive completion
-   signal — Codex posted a review/comment for that head, or 👍'd the trigger.
+   signal:
+   - a `chatgpt-codex-connector` `+1` reaction on the trigger,
+   - a `chatgpt-codex-connector` PR review for the recorded head, or
+   - for manual follow-through only, a later `chatgpt-codex-connector` issue
+     comment that the operator reads as a clean review result while the PR head
+     and base still match the recorded trigger refs.
+   Do not automate the last case by parsing Codex natural-language output; an
+   unattended gate that lacks a structured clean signal should fail closed.
 3. **CI green** uses native `gh pr checks <pr> --watch --fail-fast` (blocks to
    completion) — never `sleep`-poll.
 4. Local review **does not replace** this gate: the GitHub Codex bot and the
@@ -119,8 +131,10 @@ holds:
 - the human asked you to handle the PR, the fresh trigger completed, and a
   thread-aware recheck confirms it is no longer actionable.
 
-**Merge requires zero unresolved, non-outdated actionable threads.** After
-merging a PR with non-trivial bot activity, sanity-check the next
+**Merge requires zero unresolved, non-outdated actionable threads.** A resolved
+thread is closed even when it is still non-outdated; do not resurrect it merely
+because the diff line still exists. After merging a PR with non-trivial bot
+activity, sanity-check the next
 `Capture unresolved reviews` workflow run / linked follow-up issues — that
 workflow is a backstop, not a merge substitute.
 
@@ -156,6 +170,13 @@ verification commands, mutation check, CI conclusion/run id, dual-reviewer
 verdicts, `@codex review` trigger id + reaction/thread state, size-gate
 classification (one of the three states; rationale if over budget), and
 deferral/follow-up links. A stale body misleads the merge decision.
+
+The final body edit is itself part of the gate: it can start a fresh
+`PR Metadata` run. After the last body update, re-read the status rollup and
+wait for any new metadata run to reach a terminal passing state before calling
+remote checks final. When you inspect CI/metadata logs for warnings, record the
+warning audit alongside the final head SHA rather than relying on an earlier
+run.
 
 Include a size-gate checklist (exactly one box checked):
 


### PR DESCRIPTION
Closes #633

## Summary
- Fold the #625/#628/#629/#631 follow-through lessons into the shared PR review/merge protocol: verify review findings technically before changing code, record trigger refs, distinguish manual Codex clean comments from unattended automation, keep resolved review threads closed, and wait for final `PR Metadata` after the last body edit.
- Extend the batch issue ledger with PR-body freshness, metadata, and warning-audit states learned from the June 2026 continuation/operator-stop follow-through.
- Update `.claude/skills/handle-issue` and `handle-pr` so Claude Code sessions inherit the same review-finding, final-gate, runtime-escalation, and high-rework planning discipline without duplicating the full protocol.
- Add autonomous E2E validation guidance for observe-only operator boundaries, upstream comparison, and Codex approval-popup caveats.
- Document that `scripts/local-pr-follow-through.sh` intentionally fails closed when GitHub Codex finishes via a clean issue comment, because unattended automation must not parse Codex natural-language output.

Historical sources referenced: #625, #628, #629, #631, plus Claude Code session digest `/tmp/aiops-claude-session-distill-2026-06-04.md`.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs/skills/runbooks only. No code path, config key, worker/orchestrator phase, or SPEC deviation changes.

## Size budget (AGENTS.md)
Classify into exactly one (review discipline; the size-gate is human-signed, not CI-blocked):

- [x] `within budget` — <=12 production files / <=300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

0 production LOC; documentation and Claude skill files only.

## Testing
- [x] `git diff --check`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go test ./scripts`

## Remote follow-through
- [x] Head SHA: `6218cdfb49a6b59ddb85eec5817e6497d83def76`
- [x] CI run `26948893492`: Go build and test, Security and supply-chain, E2E Gitea mock loop, and Docker image build passed.
- [x] PR Metadata run `26948910264` passed after the current-head PR body update.
- [x] Warning audit: latest current-head CI and PR Metadata logs had no `warning:` or `::warning` matches.
- [x] GitHub `@codex review` trigger `4621710102` on head/base refs completed with clean bot issue comment `4621728128`.
- [x] GraphQL review threads: 0 unresolved/non-outdated actionable threads.

## Notes
- This PR intentionally does not change `scripts/local-pr-follow-through.sh`; accepting a clean Codex issue comment in unattended mode would need a structured signal, not natural-language parsing.
- This final ledger edit intentionally starts one more `PR Metadata` run; wait for that run to pass before marking the PR ready.
