### PR TITLE
runner: disable inherited Codex app tools

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -506,9 +506,31 @@ func buildInitializeParams() map[string]any {
 func buildThreadStartParams(in RunInput, approvalPolicy any) map[string]any {
 	return map[string]any{
 		"approvalPolicy": approvalPolicy,
+		"config":         appServerThreadConfig(),
 		"sandbox":        in.Workflow.Config.Codex.ThreadSandbox,
 		"cwd":            in.Workdir,
 		"dynamicTools":   appServerDynamicToolSpecs(in.Workflow.Config),
+	}
+}
+
+func appServerThreadConfig() map[string]any {
+	return map[string]any{
+		"apps": map[string]any{
+			"_default": map[string]any{
+				// Unattended worker sessions own PR/tracker handoff through
+				// WORKFLOW-prescribed CLI commands plus explicit dynamicTools.
+				"enabled":             false,
+				"open_world_enabled":  false,
+				"destructive_enabled": false,
+			},
+		},
+		"features": map[string]any{
+			// The app default does not override host config that explicitly
+			// enables a connector, so disable the app feature for the session.
+			// Codex also accepts `connectors` as the legacy alias for Apps.
+			"apps":       false,
+			"connectors": false,
+		},
 	}
 }
 

--- a/internal/runner/codex_app_server_schema_test.go
+++ b/internal/runner/codex_app_server_schema_test.go
@@ -100,6 +100,13 @@ func TestCodexAppServerThreadStartPayloadMatchesSchema(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerThreadConfigMatchesSchema(t *testing.T) {
+	sch := compileCodexDef(t, codexSchemaCompiler(t), "Config")
+	if err := validateWire(t, sch, appServerThreadConfig()); err != nil {
+		t.Errorf("appServerThreadConfig() failed Config schema: %v", err)
+	}
+}
+
 func TestCodexAppServerTurnStartPayloadMatchesSchema(t *testing.T) {
 	in := codexSchemaTestInput(t)
 	approval := codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -278,6 +278,50 @@ for line in sys.stdin:
 	}
 }
 
+func TestBuildThreadStartParamsDisablesInheritedCodexAppTools(t *testing.T) {
+	in := appServerInput(codexWorkdir(t, "disable app tools"))
+	in.Workflow.Config.Tracker.Kind = "linear"
+	in.Workflow.Config.Tracker.APIKey = "linear-secret"
+	approval := codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
+
+	payload := buildThreadStartParams(in, approval)
+
+	config, ok := payload["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("thread/start config = %#v; want object disabling inherited app tools", payload["config"])
+	}
+	apps, ok := config["apps"].(map[string]any)
+	if !ok {
+		t.Fatalf("thread/start config.apps = %#v; want object", config["apps"])
+	}
+	features, ok := config["features"].(map[string]any)
+	if !ok {
+		t.Fatalf("thread/start config.features = %#v; want object", config["features"])
+	}
+	if features["apps"] != false {
+		t.Fatalf("thread/start config.features.apps = %#v; want false", features["apps"])
+	}
+	if features["connectors"] != false {
+		t.Fatalf("thread/start config.features.connectors = %#v; want false", features["connectors"])
+	}
+	defaultApp, ok := apps["_default"].(map[string]any)
+	if !ok {
+		t.Fatalf("thread/start config.apps._default = %#v; want object", apps["_default"])
+	}
+	if defaultApp["enabled"] != false {
+		t.Fatalf("thread/start config.apps._default.enabled = %#v; want false", defaultApp["enabled"])
+	}
+	if defaultApp["open_world_enabled"] != false {
+		t.Fatalf("thread/start config.apps._default.open_world_enabled = %#v; want false", defaultApp["open_world_enabled"])
+	}
+	if defaultApp["destructive_enabled"] != false {
+		t.Fatalf("thread/start config.apps._default.destructive_enabled = %#v; want false", defaultApp["destructive_enabled"])
+	}
+	if tools, _ := payload["dynamicTools"].([]map[string]any); len(tools) == 0 {
+		t.Fatalf("thread/start dynamicTools = %#v; want explicit runner tools still advertised", payload["dynamicTools"])
+	}
+}
+
 func TestCodexAppServerRunnerDoesNotInheritWorkerSecretsByDefault(t *testing.T) {
 	codexAppServerEnvStubScript(t, `
 import json
@@ -381,6 +425,42 @@ for line in sys.stdin:
 	}
 	if got := runtimeEventField(t, res.RuntimeEvents[3], "turn_id"); got != "turn-1" {
 		t.Fatalf("turn_completed turn_id = %#v, want turn-1", got)
+	}
+}
+
+func TestCodexAppServerRunnerIgnoresDeprecationNoticeForSummary(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif method == 'initialized':
+        pass
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'deprecationNotice', 'params': {'summary': 'deprecated connector alias'}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'turnId': 'turn-1'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "deprecation notice summary")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Summary != "codex app-server completed" {
+		t.Fatalf("Summary = %q, want fallback summary instead of deprecation notice", res.Summary)
+	}
+	events := runtimeEventsNamed(res.RuntimeEvents, task.EventNotification)
+	if len(events) != 1 {
+		t.Fatalf("notification events = %d, want deprecation notice preserved as runtime event; events=%#v", len(events), res.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, events[0], "summary"); got != "deprecated connector alias" {
+		t.Fatalf("notification summary = %#v, want deprecation notice payload preserved", got)
 	}
 }
 

--- a/internal/runner/codex_app_server_turn.go
+++ b/internal/runner/codex_app_server_turn.go
@@ -203,6 +203,9 @@ func (c *appServerClient) handleTurnNotification(msg map[string]any, method stri
 	return false, nil
 }
 func (c *appServerClient) handleNotification(msg map[string]any) {
+	if msg["method"] == "deprecationNotice" {
+		return
+	}
 	params, _ := msg["params"].(map[string]any)
 	if v, ok := params["continue"].(bool); ok {
 		c.continueRun = v


### PR DESCRIPTION
Closes #624

## Summary
- Disable inherited Codex app/connector tools for unattended app-server threads via `thread/start.config`: `apps._default.* = false`, `features.apps = false`, and the legacy `features.connectors = false` alias.
- Preserve explicit runner-owned `dynamicTools` such as `linear_graphql`.
- Keep Codex `deprecationNotice` notifications out of run summaries while still recording the runtime notification event.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This PR only constrains the Codex app-server thread's inherited tool surface. It keeps the explicit `dynamicTools` startup surface permitted by SPEC §10.5 and does not add orchestrator PR creation, tracker writes, worker phases, gates, or artifacts.

## Size budget (AGENTS.md)
Classify into exactly one (review discipline; the size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

2 production files and 2 test files changed; production delta is below the review guideline.

## Testing
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- Red test: `TestBuildThreadStartParamsDisablesInheritedCodexAppTools` failed before implementation with `thread/start config = <nil>`.
- Focused tests: `go test ./internal/runner -run 'TestCodexAppServerRunnerIgnoresDeprecationNoticeForSummary|TestBuildThreadStartParamsDisablesInheritedCodexAppTools|TestCodexAppServer(ThreadStartPayloadMatchesSchema|ThreadConfigMatchesSchema|PayloadKeysKnownToSchema)' -count=1 -v`
- Full gates: `gofmt -l $(git ls-files '*.go')`, `go mod tidy && git diff --exit-code -- go.mod go.sum`, `go vet ./...`, `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`, `go test -race -covermode=atomic ./...`, `go build ./cmd/worker ./cmd/tui`.
- Runtime smoke: with host `features.apps=true`, `features.connectors=true`, and `apps.github.enabled=true`, thread-scoped `experimentalFeature/list` reported Apps disabled after this override.
- Runtime smoke: with host legacy `features.connectors=true`, `features.apps=false` alone left Apps enabled, while `features.apps=false` plus `features.connectors=false` disabled Apps.
- Mutation checks: flipping `features.connectors` to true failed the thread-config regression test; breaking the `deprecationNotice` guard failed the summary regression test.
- Reviewer: Codex review on `0b052934bf527fa32d1224a3f77c90d928cb9328` found no actionable correctness issues.
- Reviewer limitation: Claude review timed out after 180s; `--bare` fallback could not use the existing login, so no Claude PASS is claimed.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
