### PR TITLE
orchestrator: log dropped reschedule submit errors

### DIFF
--- a/internal/orchestrator/actor_cleanup.go
+++ b/internal/orchestrator/actor_cleanup.go
@@ -216,7 +216,7 @@ func (o *Orchestrator) continueAfterSkippedTerminalCleanup(continuation *continu
 		o.queuePollWake()
 		return
 	}
-	_ = o.scheduleContinuationRetry(o.runCtx, continuation.issue, continuation.identifier, continuation.attempt, continuation.continuationTurnCount, continuation.workspace)
+	o.logRescheduleErr(o.scheduleContinuationRetry(o.runCtx, continuation.issue, continuation.identifier, continuation.attempt, continuation.continuationTurnCount, continuation.workspace), IssueID(continuation.issue.ID), continuation.identifier)
 }
 func (o *Orchestrator) retryReconciledWorkspaceCleanup(w ReconciledWorkspace, continuation *continuationAfterSkippedCleanup) {
 	safeGo("orchestrator.reconcile_cleanup_retry", func() {

--- a/internal/orchestrator/actor_finalize.go
+++ b/internal/orchestrator/actor_finalize.go
@@ -139,9 +139,10 @@ func (f *finalizeRunOp) applyCleanExit(st *OrchestratorState, elapsed time.Durat
 	// transient failure straight to the max backoff.
 	nextAttempt := nextContinuationAttempt
 	o := f.o
+	id := f.id
 	identifier := f.identifier
 	return func() {
-		_ = o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt, nextContinuationTurnCount, workspace)
+		o.logRescheduleErr(o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt, nextContinuationTurnCount, workspace), id, identifier)
 	}
 }
 
@@ -310,9 +311,10 @@ func (f *finalizeRunOp) applyFailureRetry(st *OrchestratorState, elapsed time.Du
 	st.ClaimedIssues[f.id] = issue
 	close(f.done)
 	o := f.o
+	id := f.id
 	identifier := f.identifier
 	return func() {
-		_ = o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace)
+		o.logRescheduleErr(o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace), id, identifier)
 	}
 }
 
@@ -337,8 +339,9 @@ func (f *finalizeRunOp) applyQuotaBackoff(st *OrchestratorState, elapsed time.Du
 	st.ClaimedIssues[f.id] = issue
 	close(f.done)
 	o := f.o
+	id := f.id
 	identifier := f.identifier
 	return func() {
-		_ = o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, attempt, runErr, quota.RetryAfter, workspace)
+		o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, attempt, runErr, quota.RetryAfter, workspace), id, identifier)
 	}, true
 }

--- a/internal/orchestrator/actor_retry.go
+++ b/internal/orchestrator/actor_retry.go
@@ -7,6 +7,8 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
+	"log"
 	"strings"
 	"time"
 
@@ -135,6 +137,22 @@ func (o *Orchestrator) scheduleFailureRetry(ctx context.Context, issue tracker.I
 }
 func (o *Orchestrator) scheduleQuotaBackoffRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string, retryAfter time.Duration, workspace Workspace) error {
 	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindQuotaBackoff, Attempt: attempt, DelayOverride: retryAfter}, attempt, runErr, workspace, 0)
+}
+
+// logRescheduleErr records a dropped reschedule submit from a deferred
+// followup closure. submit returns context.Canceled when the actor is tearing
+// down (the benign shutdown path), so that case is intentionally silent. Any
+// other error means the issue silently fell off the retry chain, so it is
+// surfaced as a structured log line rather than discarded (#636).
+func (o *Orchestrator) logRescheduleErr(err error, id IssueID, identifier string) {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return
+	}
+	if strings.TrimSpace(identifier) == "" {
+		log.Printf("event=reschedule_submit_failed issue_id=%s error=%q", id, err)
+		return
+	}
+	log.Printf("event=reschedule_submit_failed issue_id=%s issue_identifier=%s error=%q", id, identifier, err)
 }
 
 // scheduleContinuationRetry queues the short SPEC §16.6 wake after a clean
@@ -468,10 +486,10 @@ func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, 
 		// Carry the workspace across the reschedule so the §18.1 terminal
 		// cleanup gate still has a path on a later attempt (#341).
 		if kind == RetryKindQuotaBackoff {
-			_ = o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, 0, workspace)
+			o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, 0, workspace), id, identifier)
 			return
 		}
-		_ = o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace)
+		o.logRescheduleErr(o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace), id, identifier)
 	}
 }
 func findIssueByID(issues []tracker.Issue, id IssueID) *tracker.Issue {
@@ -534,10 +552,10 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 	})
 	return func() {
 		if r.kind == RetryKindQuotaBackoff {
-			_ = o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, 0, workspace)
+			o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, 0, workspace), r.id, identifier)
 			return
 		}
-		_ = o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace)
+		o.logRescheduleErr(o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace), r.id, identifier)
 	}
 }
 

--- a/internal/orchestrator/actor_retry_test.go
+++ b/internal/orchestrator/actor_retry_test.go
@@ -1,0 +1,50 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestLogRescheduleErrSuppressesBenignShutdown(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "nil", err: nil},
+		{name: "context canceled", err: context.Canceled},
+		{name: "wrapped context canceled", err: fmt.Errorf("submit stopped: %w", context.Canceled)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var o Orchestrator
+			got := captureOrchestratorLog(t, func() {
+				o.logRescheduleErr(tt.err, IssueID("issue-636"), "ENG-636")
+			})
+			if got != "" {
+				t.Fatalf("logRescheduleErr(%v) log = %q; want empty", tt.err, got)
+			}
+		})
+	}
+}
+
+func TestLogRescheduleErrEmitsDroppedRetryDiagnostic(t *testing.T) {
+	var o Orchestrator
+	got := captureOrchestratorLog(t, func() {
+		o.logRescheduleErr(errors.New("actor unavailable"), IssueID("issue-636"), "ENG-636")
+	})
+
+	for _, want := range []string{
+		"event=reschedule_submit_failed",
+		"issue_id=issue-636",
+		"issue_identifier=ENG-636",
+		`error="actor unavailable"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("logRescheduleErr unexpected log = %q; want substring %q", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #636.

## Summary
- Reschedule followup closures discarded the error from `scheduleFailureRetry` / `scheduleQuotaBackoffRetry` / `scheduleContinuationRetry` via `_ =`. `submit()` (`actor.go:339`) only returns the provided context error when the actor is shutting down; any unexpected submit failure could leave the issue silently off the retry chain.
- Adds `Orchestrator.logRescheduleErr(err, issueID, identifier)`: silent on nil / `context.Canceled` (including wrapped cancellation), otherwise emits `event=reschedule_submit_failed issue_id=... issue_identifier=... error=...`. If the identifier is empty, the log keeps the stable `issue_id` and omits `issue_identifier`.
- Applied to all 8 production reschedule followup sites: the 6 failure/quota-backoff sites named in #636 plus 2 sibling `scheduleContinuationRetry` sites (`actor_finalize.go`, `actor_cleanup.go`) of the same class.
- Adds focused tests for shutdown silence and the diagnostic payload, including the stable `issue_id` field.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Only modifies existing retry/finalize/cleanup code; this is observability on previously-silent submit errors, not a new scheduler phase, gate, artifact, or config surface.

## Size gate
- [x] `within budget` — 3 production files / +29 -8 production LOC; tests excluded from the review guideline.
- [ ] `size-gated: justified overage` — rationale: n/a
- [ ] `size-gated: split recommended` — rationale: n/a

## Validation ledger
- Head SHA: `2c89376e086a3ff0a97db4301205ef2087693e4f`
- Base SHA: `4c384fd767a4917af355b87714a3d8166fc43746`
- Local checks:
  - `gofmt -l $(git ls-files '*.go')` clean
  - `git diff --check` clean
  - `go vet ./internal/orchestrator/` clean
  - `go test ./internal/orchestrator/ -run 'TestLogRescheduleErr' -count=1` passes
  - `go test -race ./internal/orchestrator/` passes
  - `go test ./...` passes
- Mutation checks:
  - changed `event=reschedule_submit_failed` to a wrong event name; `TestLogRescheduleErrEmitsDroppedRetryDiagnostic` failed as expected, then restored.
  - removed `issue_id` from the non-empty identifier log; `TestLogRescheduleErrEmitsDroppedRetryDiagnostic` failed as expected, then restored.
- Class sweep:
  - `rg -n "_ = o\.schedule.*Retry|logRescheduleErr\(" internal/orchestrator -g'*.go'` shows no remaining production `_ = o.schedule*Retry` drops; remaining direct schedule calls are definitions or tests.
- Pre-push reviewers:
  - Claude diff-only review: `MERGE-READY`; non-blocking empty-identifier branch coverage suggestion noted.
  - Codex `codex exec review --base origin/main`: first P2 (`issue_id` missing) fixed; rerun reported no actionable correctness issues.
- Post-push gates:
  - CI run `26990106758`: Go build/test, Security and supply-chain, E2E Gitea mock loop, and Docker image build all passed.
  - PR Metadata run `26990135445`: passed after the prior body refresh.
  - Warning audit: `gh run view 26990106758 --log | grep -niE "warning:"` and `gh run view 26990135445 --log | grep -niE "warning:"` returned no warnings.
  - `@codex review` trigger comment `4627386499`: eyes appeared then cleared; clean completion comment `4627394832` from `chatgpt-codex-connector` for head `2c89376e086a3ff0a97db4301205ef2087693e4f` / base `4c384fd767a4917af355b87714a3d8166fc43746`.
  - Review threads: GraphQL `reviewThreads` returned zero nodes.
  - Merge state after checks/review: `CLEAN`.
