### PR TITLE
worker: drop orphaned ResolveWorkflow doc comment

### DIFF
--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -40,10 +40,6 @@ type RunTaskResult struct {
 	IssueExitState *runner.IssueStateSnapshot
 }
 
-// ResolveWorkflow emits the workflow_resolved event for the service-level
-// WORKFLOW.md that was loaded at process startup. Returning the workflow_source
-// string lets callers stamp it onto the runner_start payload as a quick-look
-// field; the full provenance lives on the workflow_resolved event itself.
 // issueRenderVarsForTask returns the SPEC §4.1.1 normalized issue snapshot
 // for the prompt template's `issue` variable. The orchestrator's
 // TaskFromIssue precomputes IssueRender at dispatch; this helper falls back


### PR DESCRIPTION
Fixes #637.

## Summary
- The doc comment describing `ResolveWorkflow` sat directly above the `issueRenderVarsForTask` declaration, so `go doc issueRenderVarsForTask` rendered the ResolveWorkflow text. `ResolveWorkflow` already carries its own correct comment at its real definition (~line 72); this stranded block was a refactor leftover. Removed it.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs-only comment deletion in an existing file.

## Size budget (AGENTS.md)
- [x] `within budget` — 1 production file / -4 LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `gofmt -l` clean + `go build ./internal/worker/` passes (Go 1.25.11)
- [ ] `go test -race ...` (n/a — comment-only)
- [ ] additional validation noted below when needed

## Notes
- Authored via external code review.