### PR TITLE
docs: add architecture document with Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ add a bridge that imports `AGENTS.md` rather than duplicating content.
 
 ## Architecture notes
 
+- [Architecture overview & diagrams](docs/architecture.md)
 - [SPEC deviations (D1–D24/D29)](DEVIATIONS.md)
 - [Decision: continue the Go port here](DECISION.md)
 - [Symphony integration guide](docs/symphony-integration.md)

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ branch/PR back through its own tools.
 Linear, Gitea, or GitHub issue
   -> cmd/worker  (poll + reconcile + dispatch)
   -> deterministic Git workspace
-  -> WORKFLOW.md policy + prompt
+  -> WORKFLOW.md config front matter + prompt
   -> mock / Codex / Claude runner
-  -> verification
-  -> agent-side branch push + PR handoff
+  -> agent-owned verify + branch push + PR + tracker write-back
 ```
 
 It is a Go implementation of [OpenAI Symphony](https://github.com/openai/symphony).
@@ -20,8 +19,8 @@ The upstream
 [`SPEC.md`](https://github.com/openai/symphony/blob/main/SPEC.md) is the
 contract; the Elixir reference implementation is the tie-breaker when the SPEC
 text is ambiguous. Why we continue the Go port here rather than forking is
-recorded in [`DECISION.md`](DECISION.md); the D1–D24/D29 deviation tracker lives
-in [`DEVIATIONS.md`](DEVIATIONS.md).
+recorded in [`DECISION.md`](DECISION.md); the current SPEC deviation ledger
+lives in [`DEVIATIONS.md`](DEVIATIONS.md).
 
 The goal is a practical loop, not a heavy enterprise platform: run `cmd/worker`
 as a Go-based, Gitea-friendly, locally customizable Symphony while the open
@@ -58,15 +57,16 @@ brand/UX rationale.
 
 - `internal/orchestrator` — single in-memory runtime state, serialized dispatch
   authority, retry bookkeeping, restart recovery, and the worker spawn bridge.
-- `internal/worker` — per-task run loop wiring the workflow, runner, workspace,
-  and verification together.
+- `internal/worker` — per-task run loop wiring workflow resolution, workspace
+  prep, prompt directives, and runner invocation.
 - `internal/workflow` — loads the repo-owned `WORKFLOW.md` configuration and
   prompt body, with defaults and normalization.
 - `internal/tracker` — tracker abstraction with Linear and GitHub clients.
 - `internal/gitea` — Gitea tracker client plus the Gitea PR-tool exposed through
   the agent/tool surface (not a worker-side PR handoff).
 - `internal/runner` — runner abstraction for `mock`, `codex-app-server`, and `claude`.
-- `internal/workspace` — deterministic Git workspace management and run artifacts.
+- `internal/workspace` — deterministic Git workspace management, task files, and
+  cached artifacts.
 - `internal/task` — task model and shared types.
 
 ## Quick start: worker-owned tracker polling path
@@ -416,7 +416,7 @@ add a bridge that imports `AGENTS.md` rather than duplicating content.
 ## Architecture notes
 
 - [Architecture overview & diagrams](docs/architecture.md)
-- [SPEC deviations (D1–D24/D29)](DEVIATIONS.md)
+- [SPEC deviation ledger](DEVIATIONS.md)
 - [Decision: continue the Go port here](DECISION.md)
 - [Symphony integration guide](docs/symphony-integration.md)
 - [Dashboard brand redesign & UX](docs/design/dashboard-brand-redesign.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,13 @@ opens PRs, or writes tracker state itself. Verification is appended to the
 prompt as a directive the agent runs before handing off, not executed as a
 worker phase.
 
+This boundary is structural, not just convention. A class-hierarchy callgraph
+(Go SSA + CHA) over the module finds no call path from any `worker` or
+`orchestrator` function into the Gitea pull-request client — because CHA
+over-approximates dynamic dispatch, the absence of an edge means the
+irreversible steps are reachable only through the agent's tools in the current
+tree. It is a property you can re-check, not a gate the CI enforces today.
+
 ## Package layout
 
 The `internal/` packages form an acyclic dependency graph. `task` and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,158 @@
+# Architecture
+
+`aiops-platform` is a personal-productivity AI coding orchestrator: it watches a
+tracker for issues that are ready for an agent, runs each one through a
+deterministic, repo-owned workflow, and hands the result back as a draft pull
+request for a human to review. It deliberately keeps the agent — not the
+platform — responsible for the irreversible steps (source edits, verification,
+push, PR creation, tracker state writes), so the platform stays a thin,
+auditable conductor.
+
+This document describes the **current** design. For the rationale behind the
+Symphony-style approach see [ADR 0001](adr/0001-symphony-style-personal-orchestrator.md).
+
+## System data flow
+
+A single long-lived process (`cmd/worker`) runs the orchestrator actor. It polls
+the tracker, reconciles in-memory state against what the tracker reports, claims
+issues that are ready, and dispatches each as a run. There is no external job
+queue — the claim/dispatch state lives in the actor and is rebuilt from tracker
+polling on startup.
+
+```mermaid
+flowchart TD
+    subgraph trackers["Trackers"]
+        LIN["Linear"]
+        GIT["Gitea"]
+        GH["GitHub"]
+    end
+
+    subgraph proc["cmd/worker process"]
+        ORCH["Orchestrator actor<br/>poll · reconcile · claim · dispatch"]
+        WORK["Worker run loop<br/>resolve workflow · build prompt · invoke runner"]
+        RUN["Runner<br/>mock · codex · claude"]
+    end
+
+    WS["Deterministic Git workspace<br/>clone · checkout · verify · policy checks"]
+    WF["WORKFLOW.md<br/>policy + prompt template"]
+    AGENT["Agent session"]
+
+    trackers -->|"active issues"| ORCH
+    ORCH -->|"claimed task"| WORK
+    WORK --> WS
+    WF -->|"resolved config + prompt"| WORK
+    WORK --> RUN
+    RUN --> AGENT
+    AGENT -->|"edits · verify · push · draft PR"| WS
+    AGENT -.->|"label / state write-back"| trackers
+
+    classDef ext fill:#eef,stroke:#88a;
+    class LIN,GIT,GH ext;
+```
+
+The dashed edges are **agent-owned**: per SPEC §1 the worker never pushes,
+opens PRs, or writes tracker state itself. Verification is appended to the
+prompt as a directive the agent runs before handing off, not executed as a
+worker phase.
+
+## Package layout
+
+The `internal/` packages form an acyclic dependency graph. `task` and
+`workflow` are dependency-free leaves; `orchestrator` sits at the top and wires
+everything together behind small, consumer-defined interfaces.
+
+```mermaid
+flowchart BT
+    task["task<br/>domain types"]
+    workflow["workflow<br/>WORKFLOW.md load/resolve"]
+    tracker["tracker<br/>Linear / GitHub / Gitea clients"]
+    workspace["workspace<br/>deterministic git workspaces"]
+    gitea["gitea<br/>REST client + label/state map"]
+    runner["runner<br/>mock / codex / claude"]
+    worker["worker<br/>RunTask pipeline"]
+    doctor["doctor<br/>preflight diagnostics"]
+    orchestrator["orchestrator<br/>actor + poller"]
+
+    tracker --> workflow
+    workspace --> task
+    workspace --> workflow
+    gitea --> tracker
+    gitea --> workflow
+    runner --> task
+    runner --> tracker
+    runner --> workflow
+    runner --> workspace
+    runner --> gitea
+    worker --> runner
+    worker --> task
+    worker --> tracker
+    worker --> workflow
+    worker --> workspace
+    doctor --> runner
+    doctor --> tracker
+    doctor --> workflow
+    orchestrator --> runner
+    orchestrator --> task
+    orchestrator --> tracker
+    orchestrator --> worker
+    orchestrator --> workflow
+    orchestrator --> workspace
+```
+
+## Run-attempt lifecycle
+
+Each claimed task moves through the SPEC §7.2 run-attempt phases. The terminal
+phases feed back into the orchestrator's retry/backoff/continuation scheduling.
+
+```mermaid
+stateDiagram-v2
+    [*] --> preparing_workspace
+    preparing_workspace --> building_prompt
+    building_prompt --> launching_agent_process
+    launching_agent_process --> initializing_session
+    initializing_session --> streaming_turn
+    streaming_turn --> finishing
+    finishing --> succeeded
+    streaming_turn --> failed
+    streaming_turn --> timed_out
+    streaming_turn --> stalled
+    streaming_turn --> canceled_by_reconciliation
+    succeeded --> [*]
+    failed --> [*]
+    timed_out --> [*]
+    stalled --> [*]
+    canceled_by_reconciliation --> [*]
+```
+
+The coarse task status reported externally is simpler: `queued → running →
+{succeeded | failed}`.
+
+## The orchestrator actor
+
+All mutations of the orchestrator's in-memory state run on a single goroutine.
+Callers never touch the state directly; they submit an operation onto a channel.
+The op's `apply` runs on the actor goroutine and returns an optional `followup`
+closure that runs on a fresh goroutine, so side effects (network calls, timers)
+never block the actor loop. This serializes state access without a web of
+mutexes.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant Ch as ops channel
+    participant A as Actor goroutine
+    participant S as OrchestratorState
+    participant F as followup goroutine
+
+    C->>Ch: submit(ctx, op)
+    Note over C,Ch: returns ctx.Err() if the actor is shutting down
+    Ch->>A: op
+    A->>S: op.apply(state)
+    S-->>A: followup func()
+    A->>F: go followup()
+    Note over F: network calls, timers,<br/>re-submitted ops
+```
+
+A small number of late-bound dependencies (the candidate lister, the terminal
+resolver) are swapped under a mutex rather than through the actor, which is why
+the design is a hybrid rather than a pure actor.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,8 @@ flowchart TD
         RUN["Runner<br/>mock · codex · claude"]
     end
 
-    WS["Deterministic Git workspace<br/>clone · checkout · verify · policy checks"]
-    WF["WORKFLOW.md<br/>policy + prompt template"]
+    WS["Deterministic Git workspace<br/>clone · checkout · task files · artifacts"]
+    WF["WORKFLOW.md<br/>config front-matter + prompt template"]
     AGENT["Agent session"]
 
     trackers -->|"active issues"| ORCH
@@ -43,7 +43,7 @@ flowchart TD
     WF -->|"resolved config + prompt"| WORK
     WORK --> RUN
     RUN --> AGENT
-    AGENT -->|"edits · verify · push · draft PR"| WS
+    AGENT -.->|"edits · verify · push · draft PR"| WS
     AGENT -.->|"label / state write-back"| trackers
 
     classDef ext fill:#eef,stroke:#88a;
@@ -60,19 +60,23 @@ This boundary is structural, not just convention. A class-hierarchy callgraph
 `orchestrator` function into the Gitea pull-request client — because CHA
 over-approximates dynamic dispatch, the absence of an edge means the
 irreversible steps are reachable only through the agent's tools in the current
-tree. It is a property you can re-check, not a gate the CI enforces today.
+tree. This is separate from package imports: `runner` imports `gitea` to build
+the agent-visible tool proxy, while worker/orchestrator code does not call the
+PR client directly. It is a property you can re-check, not a gate the CI
+enforces today.
 
 ## Package layout
 
 The `internal/` packages form an acyclic dependency graph. `task` and
-`workflow` are dependency-free leaves; `orchestrator` sits at the top and wires
-everything together behind small, consumer-defined interfaces.
+`workflow` are dependency-free leaves; `orchestrator` is the coordinating
+package that wires everything together behind small, consumer-defined
+interfaces.
 
 ```mermaid
 flowchart BT
     task["task<br/>domain types"]
     workflow["workflow<br/>WORKFLOW.md load/resolve"]
-    tracker["tracker<br/>Linear / GitHub / Gitea clients"]
+    tracker["tracker<br/>Linear / GitHub clients"]
     workspace["workspace<br/>deterministic git workspaces"]
     gitea["gitea<br/>REST client + label/state map"]
     runner["runner<br/>mock / codex / claude"]
@@ -110,29 +114,34 @@ flowchart BT
 
 Each claimed task moves through the SPEC §7.2 run-attempt phases. The terminal
 phases feed back into the orchestrator's retry/backoff/continuation scheduling.
+The diagram keeps terminal edges readable; setup and prompt-building errors are
+also emitted as `Failed` from the phase in progress.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> preparing_workspace
-    preparing_workspace --> building_prompt
-    building_prompt --> launching_agent_process
-    launching_agent_process --> initializing_session
-    initializing_session --> streaming_turn
-    streaming_turn --> finishing
-    finishing --> succeeded
-    streaming_turn --> failed
-    streaming_turn --> timed_out
-    streaming_turn --> stalled
-    streaming_turn --> canceled_by_reconciliation
-    succeeded --> [*]
-    failed --> [*]
-    timed_out --> [*]
-    stalled --> [*]
-    canceled_by_reconciliation --> [*]
+    [*] --> PreparingWorkspace
+    PreparingWorkspace --> BuildingPrompt
+    BuildingPrompt --> LaunchingAgentProcess
+    LaunchingAgentProcess --> InitializingSession
+    InitializingSession --> StreamingTurn
+    StreamingTurn --> Finishing
+    Finishing --> Succeeded
+    StreamingTurn --> Failed
+    StreamingTurn --> TimedOut
+    StreamingTurn --> Stalled
+    StreamingTurn --> CanceledByReconciliation
+    Succeeded --> [*]
+    Failed --> [*]
+    TimedOut --> [*]
+    Stalled --> [*]
+    CanceledByReconciliation --> [*]
 ```
 
-The coarse task status reported externally is simpler: `queued → running →
-{succeeded | failed}`.
+The internal `task.Status` enum is simpler: `queued → running → {succeeded |
+failed}`. Runtime status endpoints expose richer observability buckets such as
+`running`, `retrying`, `blocked`, `completed`, and the handoff /
+reconcile-stopped rows described in the
+[runtime-status runbook](runbooks/runtime-status.md).
 
 ## The orchestrator actor
 


### PR DESCRIPTION
Fixes #642.

## Summary
- Adds `docs/architecture.md` with four Mermaid diagrams: system data flow, the `internal/` package dependency DAG, the SPEC §7.2 run-attempt lifecycle, and the orchestrator actor model.
- Refreshes `README.md` so the first-screen flow and package list no longer imply worker-owned verification / policy gates, and links the new architecture overview.
- Diagrams are drawn from the current source: in-process poll/claim/dispatch, `cmd` = `tui` + `worker`, `tracker` = Linear/GitHub clients, `gitea` as its own adapter/tool package, and agent-owned edits/verify/push/PR/tracker-write edges per SPEC §1.

## Acceptance checklist (#642)
- [x] Current system data-flow Mermaid diagram.
- [x] `internal/` package dependency DAG Mermaid diagram cross-checked against `go list` imports.
- [x] SPEC §7.2 run-attempt lifecycle Mermaid diagram using the current `task.RunAttemptPhase` vocabulary.
- [x] Orchestrator actor / followup goroutine Mermaid sequence diagram.
- [x] README links to `docs/architecture.md` and no longer carries the stale `D1-D24/D29` deviation range.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs-only change; no code, no new key/phase/gate/artifact.

## Size budget (AGENTS.md)
- [x] `within budget` — docs-only (`README.md` + `docs/architecture.md`), 0 changed production files.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Local verification at head `4085dcb6b0c0b400ada43771296ca792dbda0333`
- [x] `go mod tidy`
- [x] `gofmt -l $(git ls-files '*.go')` (empty)
- [x] `git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (`0 issues.`)
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] Mermaid structural check: 4 fenced Mermaid blocks with expected diagram headers and current phase tokens.
- [x] README stale-text check: no `WORKFLOW.md policy + prompt`, standalone `-> verification`, or `D1-D24/D29` deviation range remains.
- [x] Relative link/status checks: `docs/runbooks/runtime-status.md` exists; `task.Status` constants match `queued/running/succeeded/failed`.

Headless Mermaid render was not run locally; GitHub-native Mermaid rendering remains the preview surface.

## Review gates
- [x] Pre-push Codex CLI review on final head: no actionable regression; docs align with current worker/agent ownership boundary and package structure.
- [x] Pre-push Claude Code diff-only review on final head: `MERGE-READY`; only non-blocking LOW notes about the CHA claim being diff-only unverifiable and Mermaid syntax scan being non-render evidence.
- [x] Post-push GitHub `@codex review`: trigger comment `4627731857`; Codex connector completed for head `4085dcb6b0c0b400ada43771296ca792dbda0333` with "Didn't find any major issues."
- [x] GitHub Actions / PR Metadata: CI run `26992791709` all success; PR Metadata status rollup is all success after body refreshes.
- [x] Warning audit: CI run `26992791709` produced no warning output; PR Metadata logs checked during final refresh produced no warning output.
- [x] Review threads: GraphQL `reviewThreads` final check returned no unresolved, non-outdated threads (`[]`).
