### PR TITLE
refactor: single source of truth for supported tracker kinds

### DIFF
--- a/docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md
+++ b/docs/superpowers/specs/2026-05-11-safe-codex-runner-design.md
@@ -38,7 +38,7 @@ The platform's M4 milestone is "switch from mock to codex for small personal tas
 | `bypass` | `exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd <workdir> -o <workdir>/.aiops/CODEX_LAST_MESSAGE.md` | For operators who run the worker inside an already-isolated environment (container, VM) and need codex to write outside the workspace cap. Documented as opt-in. |
 | `custom` | (n/a — falls back to `ShellRunner` with `sh -lc <codex.command>`) | Escape hatch. Operator-controlled string; no safety promises, but logs/timeout/output capture all still apply. |
 
-`safe` is the default supplied by `expandConfig`. An empty `Codex.Profile` after YAML load is normalized to `safe`. Unknown values fail load with a clear error path/value pair (same pattern as `supportedTrackerKinds` in `loader.go`).
+`safe` is the default supplied by `expandConfig`. An empty `Codex.Profile` after YAML load is normalized to `safe`. Unknown values fail load with a clear error path/value pair (same pattern as `supportedTrackerKinds` in `tracker_kind.go`).
 
 The `codex.command` field is consulted only when `profile=custom`. For `safe`/`bypass` it is ignored — runner-built argv is the source of truth. The default `codex.command: "codex exec"` stays in the schema so existing configs (which set `profile=custom` to keep their wording) keep working.
 

--- a/internal/orchestrator/preflight.go
+++ b/internal/orchestrator/preflight.go
@@ -9,16 +9,6 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
-// supportedTrackerKinds enumerates the tracker.kind values the orchestrator
-// can actually drive a poll tick against. Matches the loader's parse-time
-// validation (internal/workflow/loader.go) so the per-tick preflight does
-// not silently accept kinds the rest of the system rejects.
-var supportedTrackerKinds = map[string]struct{}{
-	"linear": {},
-	"gitea":  {},
-	"github": {},
-}
-
 // validateDispatchPreflight is the SPEC §8.1 step 2 / §6.3 per-tick
 // dispatch-preflight check. Startup loader validation only covers schema
 // shape; this function re-validates the *resolved* runtime view of the
@@ -34,7 +24,7 @@ func validateDispatchPreflight(cfg workflow.Config) error {
 	kind := strings.TrimSpace(cfg.Tracker.Kind)
 	if kind == "" {
 		errs = append(errs, errors.New("tracker.kind missing"))
-	} else if _, ok := supportedTrackerKinds[kind]; !ok {
+	} else if !workflow.IsSupportedTrackerKind(kind) {
 		errs = append(errs, fmt.Errorf("tracker.kind unsupported: %q", kind))
 	}
 	if strings.TrimSpace(cfg.Tracker.APIKey) == "" {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -279,6 +279,15 @@ var supportedTrackerKinds = map[string]struct{}{
 	"linear": {},
 }
 
+// IsSupportedTrackerKind reports whether kind is a tracker integration the
+// platform wires up today. It is the single source of truth for the supported
+// set: the loader's schema validation and the orchestrator's per-tick dispatch
+// preflight both consult it, so the two cannot drift.
+func IsSupportedTrackerKind(kind string) bool {
+	_, ok := supportedTrackerKinds[kind]
+	return ok
+}
+
 // supportedAgentDefaults mirrors the runner registry in
 // internal/runner.New. Keeping the two lists in sync at the schema layer
 // turns "unknown runner: X" — which today only surfaces after a task is

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -269,25 +269,6 @@ func migratePollingInterval(frontBytes []byte, cfg *Config) {
 	}
 }
 
-// supportedTrackerKinds enumerates the tracker integrations the platform
-// actually wires up today.
-// Anything outside this set would parse as a typed config but could not be
-// claimed by the worker.
-var supportedTrackerKinds = map[string]struct{}{
-	"gitea":  {},
-	"github": {},
-	"linear": {},
-}
-
-// IsSupportedTrackerKind reports whether kind is a tracker integration the
-// platform wires up today. It is the single source of truth for the supported
-// set: the loader's schema validation and the orchestrator's per-tick dispatch
-// preflight both consult it, so the two cannot drift.
-func IsSupportedTrackerKind(kind string) bool {
-	_, ok := supportedTrackerKinds[kind]
-	return ok
-}
-
 // supportedAgentDefaults mirrors the runner registry in
 // internal/runner.New. Keeping the two lists in sync at the schema layer
 // turns "unknown runner: X" — which today only surfaces after a task is

--- a/internal/workflow/tracker_kind.go
+++ b/internal/workflow/tracker_kind.go
@@ -1,0 +1,19 @@
+package workflow
+
+// supportedTrackerKinds enumerates the tracker integrations the platform
+// actually wires up today. Anything outside this set would parse as a typed
+// config but could not be claimed by the worker.
+var supportedTrackerKinds = map[string]struct{}{
+	"gitea":  {},
+	"github": {},
+	"linear": {},
+}
+
+// IsSupportedTrackerKind reports whether kind is a tracker integration the
+// platform wires up today. It is the single source of truth for the supported
+// set: the loader's schema validation and the orchestrator's per-tick dispatch
+// preflight both consult it, so the two cannot drift.
+func IsSupportedTrackerKind(kind string) bool {
+	_, ok := supportedTrackerKinds[kind]
+	return ok
+}


### PR DESCRIPTION
Fixes #644.

## Summary
- `supportedTrackerKinds` was duplicated in `workflow/loader.go` and `orchestrator/preflight.go`, kept in sync only by a hand-written "Matches the loader" comment.
- Move the supported tracker-kind set to `internal/workflow/tracker_kind.go` and export `workflow.IsSupportedTrackerKind(kind)` as the single source of truth; the orchestrator preflight now calls it and drops its local copy.
- Pure dedup — both maps already held `{gitea, github, linear}`, so no behavior change.
- Follow-up for Codex P2 review: the helper no longer lives in the over-budget `loader.go`; the stale design-doc pointer now names `tracker_kind.go`.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Modifies existing validation/preflight wiring only. `IsSupportedTrackerKind` exposes the existing supported set; it does not add a tracker kind or new runtime behavior.

## Size gate
- [x] `within budget` — 4 files total, 3 production files; production diff is 20 insertions / 21 deletions.
- [ ] `size-gated: justified overage` — rationale: n/a
- [ ] `size-gated: split recommended` — rationale: n/a

## Review ledger
- Head SHA: `75d91f6651f719730efc8ada95eb2afd416d4fbe`
- Base SHA: `8a6dc980b27faa378ef2071bedcab384cbcdb61d`
- CI: run `26993348159` passed (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`).
- PR Metadata: body-refresh runs `26993407078` and `26993527238` passed. This final body-only sync may start one newer metadata run; wait for any newer run to pass before merge.
- Warning audit: `gh run view 26993348159 --log | grep -niE "warning:" | head -40` and `gh run view 26993407078 --log | grep -niE "warning:" | head -40` produced no warning lines.
- Local verification: `gofmt -l internal/workflow/loader.go internal/workflow/tracker_kind.go internal/orchestrator/preflight.go`; `go vet ./internal/orchestrator ./internal/workflow`; `go test -race ./internal/orchestrator ./internal/workflow`.
- Mutation check: changed `IsSupportedTrackerKind` to return `!ok`; `go test ./internal/orchestrator ./internal/workflow` failed on preflight happy-path / unsupported-kind assertions, then restored from HEAD and reran local verification.
- Pre-push reviewers: `codex exec review --base origin/main --title "PR #649 tracker kind helper move"` reported no findings; Claude diff-only reviewer reported **No findings** and `MERGE-READY`.
- Post-push Codex: trigger comment `4627800286` for head `75d91f6651f719730efc8ada95eb2afd416d4fbe`; clean completion comment `4627809319` said no major issues.
- Review threads: original Codex P2 thread is addressed, outdated, and resolved via GraphQL (`PRRT_kwDOSN-Foc6HOfkj`).

## Testing
- [x] `gofmt -l internal/workflow/loader.go internal/workflow/tracker_kind.go internal/orchestrator/preflight.go`
- [x] `go vet ./internal/orchestrator ./internal/workflow`
- [x] `go test -race ./internal/orchestrator ./internal/workflow`
- [x] mutation check described above
- [x] remote CI green on latest head
- [x] fresh `@codex review` clean on latest head

