### PR TITLE
docs: require subagent-first reviewer routing

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -56,7 +56,7 @@ go build ./cmd/worker ./cmd/tui
 **暂存只 add 明确路径，绝不 `git add -A` / `git add .`**（会把 `.codex/` 等本地未跟踪文件卷入 PR）。commit 前 `git status --short` 核对只暂存了预期文件。
 
 ### 5. 提交 → 双审 → 开 PR
-1. 按协议 §2–§3 commit-first + pre-push 双 reviewer；review finding 先按当前 head、issue 计划、SPEC/Elixir 参考和相邻路径验证技术正确性，再修复 / 反证 / 延后。§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
+1. 按协议 §2–§3 commit-first + pre-push 双 reviewer；先执行协议里的 **subagent-first reviewer routing**，具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。review finding 先按当前 head、issue 计划、SPEC/Elixir 参考和相邻路径验证技术正确性，再修复 / 反证 / 延后。§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
 2. push 后开 **一个** PR 对应该 issue，body 引用 issue（`Closes #N`），列验收项、验证命令、变异验证、风险/deferral；PR body 是活账本（协议 §7）。
 3. **每条 finding 归入 ≥1 类**：算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试；然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。
 4. **Deferred 偏差必须开 issue**（AGENTS.md rule 2）：决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
 
 本仓库是 OpenAI Symphony SPEC 的 Go 端口，SPEC 对齐是硬要求。本 skill 覆盖 **已有 PR 的 SPEC 对齐审查轮**。
 
-> **审查 / 合并协议是共享的。** commit-first、pre-push 双 reviewer（含 Codex `codex exec review` 的 flag 互斥与 fallback）、`@codex review` 每 push 收敛、GraphQL review threads 判定、size-gate 三态 + PR-body checklist、合并/auto-merge 门槛与 hard stops、回归+变异测试纪律统一在
+> **审查 / 合并协议是共享的。** commit-first、pre-push 双 reviewer、`@codex review` 每 push 收敛、GraphQL review threads 判定、size-gate 三态 + PR-body checklist、合并/auto-merge 门槛与 hard stops、回归+变异测试纪律统一在
 > [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md)。本 skill 只写 **PR 审查阶段差异**，到 push/审查/合并步骤照那份协议执行。
 
 ## Upstream 已就位
@@ -31,7 +31,7 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
    - 测试是否安慰剂（assertion 真的读到新代码改的字段吗？）
    - 错位机制（在 §1 scheduler/runner 边界的错误一侧）：worker/orchestrator 侧「消费 agent 产物」的 phase/gate/artifact/config，先 grep Elixir 有没有等价物——没有就是过度设计信号，判**删除**（非搬进 prompt、非只记 DEVIATIONS），归宿默认是 WORKFLOW prompt（worker post-turn phase 在 push 后只能 flag 不能 prevent，且抢跑 D9 reconcile-cancel / §16.5 self-stop——#557 即此；AGENTS.md 原则 6；#557/#561 拆的就是这类）
 
-2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，HIGH/MEDIUM/Critical 先验证技术正确性，再决定修复 / 反证 / 延后；不要盲从，也不要把 finding 当噪音略过。若 finding 证明计划本身错了，同轮更新代码、测试、SPEC/deviation 文档和 PR body。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
+2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，并先执行协议里的 **subagent-first reviewer routing**；具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。HIGH/MEDIUM/Critical 先验证技术正确性，再决定修复 / 反证 / 延后；不要盲从，也不要把 finding 当噪音略过。若 finding 证明计划本身错了，同轮更新代码、测试、SPEC/deviation 文档和 PR body。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
 
 3. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria（AGENTS.md rule 2）。决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
 

--- a/.trellis/spec/backend/agent-workflow-guidelines.md
+++ b/.trellis/spec/backend/agent-workflow-guidelines.md
@@ -55,6 +55,10 @@ Before changing code or workflow behavior:
 4. Capture settled terminology in `CONTEXT.md` only when it is domain language,
    and capture durable trade-off decisions in `docs/adr/` only when they meet
    the ADR bar.
+5. Before pre-push review, follow
+   [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md)
+   as the single source of truth. Do not restate reviewer-routing mechanics in
+   Trellis specs or task notes.
 
 For small documentation-only edits, the Trellis task may be lightweight, but the
 source-of-truth runbook still wins over task notes.

--- a/docs/runbooks/dogfood-development.md
+++ b/docs/runbooks/dogfood-development.md
@@ -57,6 +57,11 @@ right fit: requirements are unclear, dependencies are unresolved, a change is
 too large, a sensitive path is involved, or you want a direct Claude Code/Codex
 session instead of worker dispatch.
 
+Reviewer tooling still follows the PR protocol in direct sessions. Use the
+protocol's subagent-first reviewer routing and keep concrete reviewer mechanics
+in [`pr-review-merge-protocol.md`](pr-review-merge-protocol.md) so the dogfood
+runbook does not become a second source of truth.
+
 ### 1. Disposable GitHub smoke
 
 Before using GitHub issue mode on this repository, prove it in a disposable

--- a/docs/runbooks/github-local-automation.md
+++ b/docs/runbooks/github-local-automation.md
@@ -41,16 +41,10 @@ This runbook wires the local macOS operator flow for resolving
 - `scripts/local-pr-follow-through.sh` serializes PR gates and auto-merge:
   local Go gates, independent Codex and Claude Code diff reviews, all GitHub checks,
   unresolved review-thread check, then `gh pr merge --squash --auto`.
-- The local review commands intentionally use structured-output modes:
-  Codex runs `codex exec --output-schema <schema-file> -`, and Claude Code runs
-  `claude -p --tools "" --output-format json --json-schema '<schema-json>'`
-  and reads `.structured_output`. `codex exec review --base` is not used for
-  this gate because the Codex CLI treats `--base` and custom review prompt
-  arguments as mutually exclusive. Claude Code receives the complete diff on
-  stdin and intentionally has no repository tools in this gate, so the
-  unattended run stays bounded to a structured-output review task. Review
-  sessions use Codex `--ephemeral` and Claude Code
-  `--no-session-persistence` to avoid retaining short-lived reviewer history.
+- The local review command contract lives in
+  [`pr-review-merge-protocol.md`](pr-review-merge-protocol.md) and is enforced
+  by `scripts/local-pr-follow-through.sh`; keep concrete reviewer mechanics
+  there so this automation runbook does not become a second source of truth.
 
 ## Prerequisites
 
@@ -247,12 +241,10 @@ scripts/uninstall-local-launchagents.sh
 - `AIOPS_PR_SCAN_LIMIT` bounds open-PR scans for duplicate issue claims. If the
   number of returned PRs reaches the limit, the sweep stops before local gates
   or reviews because the duplicate-PR guard may be incomplete.
-- Claude Code review defaults to `AIOPS_CLAUDE_REVIEW_MAX_TURNS=6`, disables
-  tools with `--tools ""`, and uses `--output-format json` with
-  `--json-schema`; the gate extracts `.structured_output` from Claude's JSON
-  wrapper as the review JSON. It reviews only the supplied diff; re-enabling
-  repository tools can make unattended runs hit turn limits before returning
-  JSON.
+- Claude Code review defaults to `AIOPS_CLAUDE_REVIEW_MAX_TURNS=6`; the concrete
+  diff-only reviewer command contract is owned by
+  [`pr-review-merge-protocol.md`](pr-review-merge-protocol.md) and
+  `scripts/local-pr-follow-through.sh`.
 - Treat unresolved non-outdated GitHub review threads as blocking. Follow-through
   paginates review threads until `hasNextPage=false`; checking only the first
   100 threads is not sufficient for merge.

--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -51,25 +51,50 @@ findings (keep each review ≤700 words) and a final verdict —
 SHA, changed files, intent (issue/PR), relevant SPEC/upstream pointers, and
 AGENTS.md policy.
 
+Reviewer routing is environment-dependent:
+
+- **Claude Code Agent.** Prefer the Agent tool subagents named below for
+  family-specific review. Use the hardened CLI fallback only when the Agent
+  tool or requested subagent is unavailable or fails.
+- **Codex inline.** When the environment hints that subagents or multi-agent
+  tools are available, call `tool_search` for `multi_agent` / `spawn_agent`
+  before CLI fallback. If `spawn_agent` is available, use it for an independent
+  final-diff reviewer or quality-check sidecar only when the current user
+  request explicitly authorizes subagent delegation and the tool contract allows
+  spawning for that request. A workflow prompt or runbook instruction alone is
+  not sufficient authorization to spawn. Record the agent id/verdict in review
+  notes. If subagent use is not authorized for the current session, do not
+  spawn; record that eligibility result and continue with the family reviewer
+  fallback. Do not wait for a human reminder to discover the tool.
+- **codex-sub-agent.** If the current session is already a spawned sub-agent,
+  obey the parent assignment and the sub-agent notice first. Do not recursively
+  spawn reviewers unless the parent task explicitly asks for that; return the
+  requested review or implementation result to the parent.
+- **CLI fallback.** Use CLI reviewers only after the relevant subagent path is
+  unavailable, fails, or is inappropriate for the current role. Record the
+  discovery/fallback evidence in review notes and later in the PR body.
+
+Subagent review complements the two-family gate. It does not replace the
+required Codex-family and Claude-family coverage unless the invoked subagent is
+explicitly the Codex-family or Claude-family reviewer for that environment.
+
 - **Codex reviewer.** When the main agent is Claude Code, **prefer** the
   `codex:codex-rescue` subagent from
   [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) (`Agent` tool,
   `subagent_type: "codex:codex-rescue"`); pass the full brief in the prompt. It
-  wraps `codex exec review`'s CLI flag mutex (`--base` / `--commit` / `PROMPT`
-  are pairwise exclusive — see `codex exec review --help`) and returns
-  structured output via `codex:codex-result-handling`. **Only when** the main
-  agent is Codex itself or the plugin is unavailable, fall back to
-  `codex exec review --base origin/main --title "…"` — the `review` subcommand
-  takes no custom PROMPT and runs Codex's generic review heuristic, so
-  repo-specific context (issue intent, SPEC refs, acceptance criteria) is lost.
-  If the fallback still needs a repo-specific prompt, use plain `codex exec`
-  (free PROMPT, diff as a `<stdin>` block) at the cost of the `review`
-  subcommand's built-in review structure.
+  wraps the Codex CLI review contract and returns structured output via
+  `codex:codex-result-handling`. **Only when** no authorized and appropriate
+  Codex-family subagent path is available, fall back to plain `codex exec
+  --output-schema` with the repo-specific review prompt and diff on stdin.
+  Do not use `codex exec review --base` for this gate: the `review` subcommand
+  cannot accept the repo-specific prompt/schema that the machine-validated local
+  review contract requires.
 - **Claude Code reviewer.** Prefer the `Agent` tool with
   `subagent_type: "feature-dev:code-reviewer"`. In a restricted environment use
   a hardened `claude -p` that receives the diff on stdin and cannot read the
   mutable working tree or inherit the session:
-  `--permission-mode bypassPermissions --no-session-persistence --tools "" --max-turns 2`.
+  `--permission-mode bypassPermissions --no-session-persistence --tools "" --output-format json --json-schema <schema> --max-turns 6`.
+  Read `.structured_output` from Claude's JSON wrapper as the review JSON.
 
 Triage:
 

--- a/examples/github-local-WORKFLOW.md
+++ b/examples/github-local-WORKFLOW.md
@@ -86,20 +86,9 @@ Hard requirements:
 - Run the configured verify commands before pushing.
 - Before opening or updating a PR, run two independent local reviews of the
   final diff: Codex review and Claude Code review. Both are mandatory gates.
-- Use machine-validated JSON for both local reviews. The expected shape is:
-  `{"blocking_findings":[{"severity":"high|medium|low","file":"path","line":1,"issue":"text"}]}`.
-- For Codex, use `codex exec --ephemeral --output-schema <schema-file> -` with
-  the prompt and diff on stdin. Do not combine `codex exec review --base
-  <branch>` with a custom prompt; that CLI mode treats `--base` and `PROMPT` as
-  mutually exclusive.
-- For Claude Code, use `claude -p --permission-mode bypassPermissions
-  --no-session-persistence --tools "" --output-format json
-  --json-schema '<schema-json>'
-  --max-turns 6` and feed the complete review prompt plus diff on stdin. Claude
-  must review only the supplied diff for this gate. The higher turn budget is
-  still bounded by the outer review timeout and prevents structured-output
-  retries from failing the gate before Claude can emit schema-valid JSON. Read
-  `.structured_output` from Claude's JSON wrapper as the review JSON.
+- Follow `docs/runbooks/pr-review-merge-protocol.md` for subagent-first reviewer
+  routing, machine-validated review shape, Codex/Claude family coverage, and CLI
+  fallback conditions. Do not inline reviewer command mechanics here.
 - Treat non-JSON output, command failure, or any non-empty
   `blocking_findings` list from either local reviewer as blocking. Fix findings
   with tests before push.

--- a/scripts/reviewer_workflow_docs_test.go
+++ b/scripts/reviewer_workflow_docs_test.go
@@ -1,0 +1,211 @@
+package scripts
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestReviewerProtocolDocumentsSubagentDiscoveryBeforeCLIFallback(t *testing.T) {
+	protocol := readReviewerDoc(t, "../docs/runbooks/pr-review-merge-protocol.md")
+
+	for _, want := range []string{
+		"Codex inline",
+		"codex-sub-agent",
+		"Claude Code Agent",
+		"tool_search",
+		"spawn_agent",
+		"before CLI fallback",
+		"current user request explicitly authorizes subagent delegation and the tool contract allows spawning for that request",
+		"workflow prompt or runbook instruction alone is not sufficient authorization",
+		"If subagent use is not authorized",
+		"do not spawn",
+		"Do not recursively spawn reviewers unless the parent task explicitly asks",
+		"no authorized and appropriate Codex-family subagent path is available",
+		"codex exec --output-schema",
+		"Do not use",
+		"codex exec review --base",
+		"for this gate",
+		"--output-format json",
+		"--json-schema",
+		"--max-turns 6",
+		".structured_output",
+		"Subagent review complements the two-family gate",
+		"Codex-family and Claude-family",
+	} {
+		if !containsReviewerDocText(protocol, want) {
+			t.Fatalf("pr-review-merge-protocol.md missing %q", want)
+		}
+	}
+}
+
+func TestIssueAndPRSkillsPointToSubagentFirstReviewerRouting(t *testing.T) {
+	for _, path := range []string{
+		"../.claude/skills/handle-issue/SKILL.md",
+		"../.claude/skills/handle-pr/SKILL.md",
+	} {
+		body := readReviewerDoc(t, path)
+		for _, want := range []string{
+			"subagent-first reviewer routing",
+			"pr-review-merge-protocol.md",
+		} {
+			if !containsReviewerDocText(body, want) {
+				t.Fatalf("%s missing %q", path, want)
+			}
+		}
+	}
+}
+
+func TestDogfoodGuidancePointsToCanonicalReviewerProtocol(t *testing.T) {
+	body := readReviewerDoc(t, "../docs/runbooks/dogfood-development.md")
+
+	for _, want := range []string{
+		"subagent-first reviewer routing",
+		"pr-review-merge-protocol.md",
+		"second source of truth",
+	} {
+		if !containsReviewerDocText(body, want) {
+			t.Fatalf("dogfood-development.md missing %q", want)
+		}
+	}
+}
+
+func TestGitHubLocalWorkflowPromptPointsToCanonicalReviewerProtocol(t *testing.T) {
+	body := workflowPromptBody(t, "../examples/github-local-WORKFLOW.md", readReviewerDoc(t, "../examples/github-local-WORKFLOW.md"))
+
+	for _, want := range []string{
+		"pr-review-merge-protocol.md",
+		"subagent-first reviewer routing",
+		"CLI fallback conditions",
+		"Do not inline reviewer command mechanics here",
+	} {
+		if !containsReviewerDocText(body, want) {
+			t.Fatalf("github-local-WORKFLOW.md prompt missing %q", want)
+		}
+	}
+}
+
+func TestTrellisGuidancePointsToCanonicalReviewerProtocol(t *testing.T) {
+	body := readReviewerDoc(t, "../.trellis/spec/backend/agent-workflow-guidelines.md")
+
+	for _, want := range []string{
+		"pr-review-merge-protocol.md",
+		"single source of truth",
+		"Do not restate reviewer-routing mechanics",
+	} {
+		if !containsReviewerDocText(body, want) {
+			t.Fatalf("agent-workflow-guidelines.md missing %q", want)
+		}
+	}
+}
+
+func TestConcreteReviewerRoutingMechanicsStayInProtocol(t *testing.T) {
+	nonCanonicalDocs := []string{
+		"../.claude/skills/handle-issue/SKILL.md",
+		"../.claude/skills/handle-pr/SKILL.md",
+		"../docs/runbooks/dogfood-development.md",
+		"../docs/runbooks/github-local-automation.md",
+		"../examples/github-local-WORKFLOW.md",
+		"../.trellis/spec/backend/agent-workflow-guidelines.md",
+	}
+	for _, path := range nonCanonicalDocs {
+		body := reviewerMechanicsSearchText(t, path)
+		for _, forbidden := range []string{
+			"tool_search",
+			"spawn_agent",
+			"multi_agent",
+			"codex exec review",
+			"flag 互斥",
+			"codex exec --output-schema",
+			"claude -p",
+			`--tools ""`,
+			"--json-schema",
+			"--ephemeral",
+			"--no-session-persistence",
+		} {
+			if strings.Contains(body, forbidden) {
+				t.Fatalf("%s duplicates protocol-only reviewer mechanic %q", path, forbidden)
+			}
+		}
+	}
+}
+
+func TestLocalPRFollowThroughCodexReviewerUsesStructuredExec(t *testing.T) {
+	body := readReviewerDoc(t, "local-pr-follow-through.sh")
+	fn := shellFunctionBody(t, body, "run_codex_review")
+
+	for _, want := range []string{
+		`run_with_timeout "$review_timeout" codex exec`,
+		"--output-schema \"$schema_file\"",
+		`-o "$review_file"`,
+		"--sandbox read-only",
+		"--ephemeral",
+	} {
+		if !strings.Contains(fn, want) {
+			t.Fatalf("run_codex_review missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"codex exec review",
+		"review --base",
+	} {
+		if strings.Contains(fn, forbidden) {
+			t.Fatalf("run_codex_review uses forbidden Codex review path %q", forbidden)
+		}
+	}
+}
+
+func readReviewerDoc(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(body)
+}
+
+func reviewerMechanicsSearchText(t *testing.T, path string) string {
+	t.Helper()
+	body := readReviewerDoc(t, path)
+	if strings.HasSuffix(path, "WORKFLOW.md") {
+		return workflowPromptBody(t, path, body)
+	}
+	return body
+}
+
+func workflowPromptBody(t *testing.T, path, body string) string {
+	t.Helper()
+	if !strings.HasPrefix(body, "---\n") {
+		return body
+	}
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---\n")
+	if end < 0 {
+		t.Fatalf("%s front matter is not terminated", path)
+	}
+	return rest[end+len("\n---\n"):]
+}
+
+func shellFunctionBody(t *testing.T, body, name string) string {
+	t.Helper()
+	startMarker := name + "() {\n"
+	start := strings.Index(body, startMarker)
+	if start < 0 {
+		t.Fatalf("shell function %s not found", name)
+	}
+	body = body[start+len(startMarker):]
+	endMarker := "\n}\n\n"
+	end := strings.Index(body, endMarker)
+	if end < 0 {
+		t.Fatalf("shell function %s end not found", name)
+	}
+	return body[:end]
+}
+
+func containsReviewerDocText(body, want string) bool {
+	return strings.Contains(normalizeReviewerDocText(body), normalizeReviewerDocText(want))
+}
+
+func normalizeReviewerDocText(text string) string {
+	return strings.Join(strings.Fields(text), " ")
+}


### PR DESCRIPTION
Closes #658

## Summary

- Centralizes multi-agent/subagent reviewer routing in `docs/runbooks/pr-review-merge-protocol.md`.
- Updates issue/PR skills, dogfood docs, GitHub-local automation notes, Trellis workflow guidance, and the GitHub-local workflow example to point at the canonical protocol instead of duplicating mechanics.
- Adds regression-style docs/process tests that pin the protocol and executable `scripts/local-pr-follow-through.sh` Codex reviewer contract.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Acceptance criteria

- [x] Pre-push review docs explicitly require subagent/multi-agent discovery before CLI fallback when available.
- [x] Codex inline sessions are told to use `tool_search` for `multi_agent` / `spawn_agent` discovery when the environment hints at subagent capability.
- [x] Docs distinguish Codex inline, codex-sub-agent, Claude Code Agent, and CLI fallback paths.
- [x] The reviewer protocol still requires Codex-family + Claude-family coverage, and explains how subagent review complements those gates.
- [x] Regression-style docs/process checks added in `scripts/reviewer_workflow_docs_test.go`.

## Living ledger

- Issue: #658 `docs: require multi-agent reviewer usage in issue and PR workflows`
- Branch: `fix/658-multi-agent-reviewers`
- Worktree: `/Users/yvan/.codex/worktrees/658/aiops-platform`
- Base: `main` @ `4db4d3c8faa34018b03d1767de501a60f8b9dc8e`
- Head: `b8e181de0e75ac3df31d6e96752705414e45b7af`
- Root `WORKFLOW.md`: absent on `main`; reviewed `examples/github-local-WORKFLOW.md` as the project workflow example.
- SPEC/upstream posture: docs/process-only; no worker/orchestrator tracker-writer or post-turn gate behavior added.
- Batch state: deferred for merge because GitHub Codex review failed twice with connector environment/unknown-error output; PR intentionally remains draft.

## Local verification

- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] Extra docs/workflow/scripts check: `go test -run 'TestReviewerProtocolDocumentsSubagentDiscoveryBeforeCLIFallback|TestIssueAndPRSkillsPointToSubagentFirstReviewerRouting|TestDogfoodGuidancePointsToCanonicalReviewerProtocol|TestGitHubLocalWorkflowPromptPointsToCanonicalReviewerProtocol|TestTrellisGuidancePointsToCanonicalReviewerProtocol|TestConcreteReviewerRoutingMechanicsStayInProtocol|TestLocalPRFollowThroughCodexReviewerUsesStructuredExec' -count=1 ./scripts`

## Mutation checks

- [x] Replaced `tool_search` with `tool search` in `docs/runbooks/pr-review-merge-protocol.md`; `TestReviewerProtocolDocumentsSubagentDiscoveryBeforeCLIFallback` failed as expected, then restored.
- [x] Replaced `--output-schema "$schema_file"` with `--experimental-schema "$schema_file"` in `scripts/local-pr-follow-through.sh`; `TestLocalPRFollowThroughCodexReviewerUsesStructuredExec` failed as expected, then restored.

## Pre-push reviewers

- [x] Subagent reviewer: `Plato` / `019e97b1-d967-77b0-adef-08062cbbc3e9`, head `b8e181de0e75ac3df31d6e96752705414e45b7af`, verdict `merge-ready`, findings none.
- [x] Codex-family local reviewer: `codex exec --output-schema`, head `b8e181de0e75ac3df31d6e96752705414e45b7af`, JSON `{"blocking_findings":[]}`.
- [x] Claude-family local reviewer: `claude -p --json-schema --max-turns 6`, head `b8e181de0e75ac3df31d6e96752705414e45b7af`, JSON `{"blocking_findings":[]}`.

## Post-push gates

- [x] CI: passed, run `27014282779` on head `b8e181de0e75ac3df31d6e96752705414e45b7af`.
- [x] PR Metadata after body update: passed, run `27014357979`.
- [ ] Fresh `@codex review`: blocked. Trigger `4631453015` failed with `An unknown error occurred`; retry trigger `4631497084` failed with the same connector result.
- [x] GraphQL `reviewThreads`: empty (`[]`).
- [x] Warning audit: no `warning:` lines in logs for CI run `27014282779` or metadata run `27014357979`.

## Size gate

- [x] `within budget` — 8 changed files total; production Go diff is 0 files / 0 LOC. The large added file is a scripts test file.
- [ ] `size-gated: justified overage` — rationale: n/a
- [ ] `size-gated: split recommended` — rationale: n/a

## Deferrals / follow-ups

- Deferred merge: GitHub Codex review connector failed twice on this head. No code follow-up issue was created because the #658 acceptance criteria are satisfied and the blocker is the external GitHub Codex gate, not a known repo defect.
