### PR TITLE
fix: reject duplicate Trellis task creation

### DIFF
--- a/.trellis/scripts/common/task_store.py
+++ b/.trellis/scripts/common/task_store.py
@@ -225,9 +225,11 @@ def cmd_create(args: argparse.Namespace) -> int:
         return 1
 
     if task_dir.exists():
-        print(colored(f"Warning: Task directory already exists: {dir_name}", Colors.YELLOW), file=sys.stderr)
-    else:
-        task_dir.mkdir(parents=True)
+        print(colored(f"Error: Task directory already exists: {dir_name}", Colors.RED), file=sys.stderr)
+        print(f"Existing task: {_repo_relative_path(task_dir, repo_root)}", file=sys.stderr)
+        print("Use a new slug if you intend to create a new task.", file=sys.stderr)
+        return 1
+    task_dir.mkdir(parents=True)
 
     today = datetime.now().strftime("%Y-%m-%d")
 

--- a/.trellis/scripts/tests/test_task_create_duplicates.py
+++ b/.trellis/scripts/tests/test_task_create_duplicates.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TaskCreateDuplicateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tempdir.name)
+        (self.repo / ".trellis").mkdir()
+        (self.repo / ".trellis" / ".developer").write_text("name=tester\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=self.repo, check=True)
+        self.task_py = Path(__file__).resolve().parents[1] / "task.py"
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_duplicate_create_fails_without_overwriting_metadata(self) -> None:
+        first = self.run_task_create()
+        self.assertEqual(first.returncode, 0, first.stderr)
+
+        task_dir = self.created_task_dir(first.stdout)
+        task_json = task_dir / "task.json"
+        task_data = json.loads(task_json.read_text(encoding="utf-8"))
+        task_data.update({
+            "status": "in_progress",
+            "assignee": "original-assignee",
+            "parent": "parent-task",
+            "children": ["child-task"],
+            "pr_url": "https://example.invalid/pr/1",
+            "notes": "must survive duplicate create",
+        })
+        task_json.write_text(json.dumps(task_data, indent=2, ensure_ascii=False), encoding="utf-8")
+        before = task_json.read_text(encoding="utf-8")
+
+        duplicate = self.run_task_create()
+
+        self.assertNotEqual(duplicate.returncode, 0, duplicate.stderr)
+        self.assertIn(f"Task directory already exists: {task_dir.name}", duplicate.stderr)
+        self.assertIn("Use a new slug", duplicate.stderr)
+        self.assertEqual(task_json.read_text(encoding="utf-8"), before)
+
+    def run_task_create(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(self.task_py),
+                "create",
+                "Duplicate Example",
+                "--slug",
+                "duplicate-example",
+                "--assignee",
+                "tester",
+                "--priority",
+                "P2",
+            ],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    def created_task_dir(self, stdout: str) -> Path:
+        for line in stdout.splitlines():
+            if line.startswith(".trellis/tasks/"):
+                return self.repo / line
+        self.fail(f"task.py create did not print task path; stdout={stdout!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #655

## Summary

- Makes duplicate active Trellis task creation fail before `task.json` is written.
- Preserves existing task metadata instead of overwriting status, assignee, parent/child links, PR fields, or notes.
- Adds a deterministic unittest that exercises the real `task.py create` CLI in a temporary repo.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Acceptance criteria

- [x] Duplicate active task create exits non-zero before writing task metadata.
- [x] Existing `task.json` content remains unchanged after a duplicate create.
- [x] Error output names the duplicate task directory and suggests a new slug.
- [x] Regression test fails when the production guard is reverted to the original warning/continue behavior.
- [x] #656 remains untouched and serialized; this PR does not edit `.trellis/scripts/common/task_utils.py`.

## Living ledger

- Issue: #655 `Follow up unresolved review thread from PR #650`
- Originating PR/thread: #650, `https://github.com/xrf9268-hue/aiops-platform/pull/650#discussion_r3360287672`
- Branch: `fix/655-task-create-duplicates`
- Worktree: `/Users/yvan/.codex/worktrees/655/aiops-platform`
- Base: `main` @ `eff46e0faad5a6b6d3c8f49af84814c94b9b8e74`
- Head: `dd8b066047ed70ef71ce3240ac802f64600dc3f8`
- Scope guard: no #656 lifecycle hook timeout changes.
- Batch state: deferred for merge because GitHub Codex review failed twice with connector `An unknown error occurred`; PR intentionally remains draft.

## Local verification

- [x] `python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `python3 -m py_compile .trellis/scripts/task.py .trellis/scripts/common/task_store.py .trellis/scripts/tests/test_task_create_duplicates.py`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

## Mutation check

- [x] Reverted the duplicate active task guard to the original warning/continue shape; `test_duplicate_create_fails_without_overwriting_metadata` failed because the duplicate command returned 0, then `task_store.py` was restored from committed HEAD.

## Pre-push reviewers

- [x] Subagent reviewer: `Russell` / `019e97cd-ba66-7c33-bbd9-f1c293fb0681`, head `dd8b066047ed70ef71ce3240ac802f64600dc3f8`, verdict `merge-ready`, findings none.
- [x] Codex-family local reviewer: `codex exec --output-schema`, head `dd8b066047ed70ef71ce3240ac802f64600dc3f8`, JSON `{"blocking_findings":[]}`.
- [x] Claude-family local reviewer: `claude -p --json-schema --max-turns 6`, head `dd8b066047ed70ef71ce3240ac802f64600dc3f8`, JSON `{"blocking_findings":[]}`.

## Post-push gates

- [x] CI: passed, run `27015678121` on head `dd8b066047ed70ef71ce3240ac802f64600dc3f8`.
- [x] PR Metadata: passed, run `27015678076`.
- [ ] Fresh `@codex review`: blocked. Trigger `4631667163` failed with `An unknown error occurred`; retry trigger `4631700907` failed with the same connector result.
- [x] GraphQL `reviewThreads`: empty (`[]`).
- [x] Warning audit: no `warning:` lines in logs for CI run `27015678121` or metadata run `27015678076`.

## Size gate

- [x] `within budget` — production diff is 1 file / 8 changed LOC; test diff is excluded from production budget.
- [ ] `size-gated: justified overage` — rationale: n/a
- [ ] `size-gated: split recommended` — rationale: n/a

## Deferrals / follow-ups

- Deferred merge: GitHub Codex review connector failed twice on this head. No code follow-up issue was created because the #655 acceptance criteria are satisfied and the blocker is the external GitHub Codex gate, not a known repo defect.
