### PR TITLE
fix: timeout Trellis lifecycle hooks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ PR size-gate is human-signed, not CI-blocked):
 - [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.
 
 ## Testing
+- [ ] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
 - [ ] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
 - [ ] `go test -race -covermode=atomic ./...`
 - [ ] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Run GitHub script tests
         run: node --test .github/scripts/*.test.mjs
 
+      - name: Run Trellis script tests
+        run: PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'
+
       - name: Install dashboard dependencies
         working-directory: cmd/worker/dashboard
         run: npm ci

--- a/.trellis/scripts/common/task_utils.py
+++ b/.trellis/scripts/common/task_utils.py
@@ -12,12 +12,90 @@ Provides:
 
 from __future__ import annotations
 
+import os
+import signal
 import shutil
+import subprocess
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
 from .paths import get_repo_root, get_tasks_dir
+
+HOOK_TIMEOUT_SECONDS = 30
+HOOK_TERMINATION_GRACE_SECONDS = 1
+
+
+def _run_hook_command(cmd: str, repo_root: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    kwargs: dict[str, object] = {
+        "shell": True,
+        "cwd": repo_root,
+        "env": env,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+    if os.name == "posix":
+        kwargs["start_new_session"] = True
+
+    process = subprocess.Popen(cmd, **kwargs)
+    try:
+        stdout, stderr = process.communicate(timeout=HOOK_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as exc:
+        _terminate_hook_process_tree(process)
+        _close_hook_output(process)
+        exc.output = ""
+        exc.stderr = ""
+        raise
+    return subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)
+
+
+def _terminate_hook_process_tree(process: subprocess.Popen[str]) -> None:
+    _terminate_hook_process(process)
+    time.sleep(HOOK_TERMINATION_GRACE_SECONDS)
+    _kill_hook_process_tree(process)
+    _wait_for_hook_process(process)
+
+
+def _terminate_hook_process(process: subprocess.Popen[str]) -> None:
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except OSError:
+            process.terminate()
+    else:
+        process.terminate()
+
+
+def _kill_hook_process_tree(process: subprocess.Popen[str]) -> None:
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        except OSError:
+            process.kill()
+    else:
+        process.kill()
+
+
+def _wait_for_hook_process(process: subprocess.Popen[str]) -> None:
+    try:
+        process.wait(timeout=HOOK_TERMINATION_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        return
+
+
+def _close_hook_output(process: subprocess.Popen[str]) -> None:
+    if process.stdout:
+        process.stdout.close()
+    if process.stderr:
+        process.stderr.close()
 
 
 # =============================================================================
@@ -223,9 +301,6 @@ def run_task_hooks(event: str, task_json_path: Path, repo_root: Path) -> None:
         task_json_path: Absolute path to the task's task.json.
         repo_root: Repository root for cwd and config lookup.
     """
-    import os
-    import subprocess
-
     from .config import get_hooks
     from .log import Colors, colored
 
@@ -237,16 +312,7 @@ def run_task_hooks(event: str, task_json_path: Path, repo_root: Path) -> None:
 
     for cmd in commands:
         try:
-            result = subprocess.run(
-                cmd,
-                shell=True,
-                cwd=repo_root,
-                env=env,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-            )
+            result = _run_hook_command(cmd, repo_root, env)
             if result.returncode != 0:
                 print(
                     colored(f"[WARN] Hook failed ({event}): {cmd}", Colors.YELLOW),
@@ -254,6 +320,14 @@ def run_task_hooks(event: str, task_json_path: Path, repo_root: Path) -> None:
                 )
                 if result.stderr.strip():
                     print(f"  {result.stderr.strip()}", file=sys.stderr)
+        except subprocess.TimeoutExpired:
+            print(
+                colored(
+                    f"[WARN] Hook timed out ({event}): {cmd} after {HOOK_TIMEOUT_SECONDS:g}s",
+                    Colors.YELLOW,
+                ),
+                file=sys.stderr,
+            )
         except Exception as e:
             print(
                 colored(f"[WARN] Hook error ({event}): {cmd} — {e}", Colors.YELLOW),

--- a/.trellis/scripts/tests/test_task_hooks_timeout.py
+++ b/.trellis/scripts/tests/test_task_hooks_timeout.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import shlex
+import signal
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from common import task_utils
+
+
+MAX_HOOK_TEST_SECONDS = 2.0
+
+
+class TaskHookTimeoutTests(unittest.TestCase):
+    def test_timed_out_hook_warns_without_raising(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            trellis = repo / ".trellis"
+            trellis.mkdir()
+            marker = repo / "leaked"
+            continued_marker = repo / "continued"
+            child_code = (
+                "import pathlib, signal, sys, time; "
+                "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "time.sleep(0.8); "
+                "pathlib.Path(sys.argv[1]).write_text('leaked')"
+            )
+            hook_cmd = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(child_code)} "
+                f"{shlex.quote(str(marker))} & wait"
+            )
+            continue_code = "import pathlib, sys; pathlib.Path(sys.argv[1]).write_text('continued')"
+            continue_cmd = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(continue_code)} "
+                f"{shlex.quote(str(continued_marker))}"
+            )
+            (trellis / "config.yaml").write_text(
+                "hooks:\n"
+                "  after_create:\n"
+                f"    - {hook_cmd}\n"
+                f"    - {continue_cmd}\n",
+                encoding="utf-8",
+            )
+            task_json = trellis / "tasks" / "demo" / "task.json"
+            task_json.parent.mkdir(parents=True)
+            task_json.write_text("{}", encoding="utf-8")
+
+            previous_timeout = task_utils.HOOK_TIMEOUT_SECONDS
+            previous_grace = task_utils.HOOK_TERMINATION_GRACE_SECONDS
+            task_utils.HOOK_TIMEOUT_SECONDS = 0.05
+            task_utils.HOOK_TERMINATION_GRACE_SECONDS = 0.05
+            stderr = io.StringIO()
+            start = time.monotonic()
+            try:
+                with contextlib.redirect_stderr(stderr):
+                    task_utils.run_task_hooks("after_create", task_json, repo)
+            finally:
+                task_utils.HOOK_TIMEOUT_SECONDS = previous_timeout
+                task_utils.HOOK_TERMINATION_GRACE_SECONDS = previous_grace
+
+            elapsed = time.monotonic() - start
+            output = stderr.getvalue()
+            self.assertIn("[WARN] Hook timed out (after_create):", output)
+            self.assertIn("after 0.05s", output)
+            self.assertLess(elapsed, MAX_HOOK_TEST_SECONDS)
+            self.assertTrue(continued_marker.exists())
+            time.sleep(0.9)
+            self.assertFalse(marker.exists())
+
+    def test_background_hook_child_holding_stdout_is_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            trellis = repo / ".trellis"
+            trellis.mkdir()
+            marker = repo / "background-leaked"
+            continued_marker = repo / "background-continued"
+            child_code = (
+                "import pathlib, signal, sys, time; "
+                "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "sighup = getattr(signal, 'SIGHUP', None); "
+                "signal.signal(sighup, signal.SIG_IGN) if sighup is not None else None; "
+                "time.sleep(0.8); "
+                "pathlib.Path(sys.argv[1]).write_text('leaked')"
+            )
+            hook_cmd = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(child_code)} "
+                f"{shlex.quote(str(marker))} &"
+            )
+            continue_code = "import pathlib, sys; pathlib.Path(sys.argv[1]).write_text('continued')"
+            continue_cmd = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(continue_code)} "
+                f"{shlex.quote(str(continued_marker))}"
+            )
+            (trellis / "config.yaml").write_text(
+                "hooks:\n"
+                "  after_create:\n"
+                f"    - {hook_cmd}\n"
+                f"    - {continue_cmd}\n",
+                encoding="utf-8",
+            )
+            task_json = trellis / "tasks" / "demo" / "task.json"
+            task_json.parent.mkdir(parents=True)
+            task_json.write_text("{}", encoding="utf-8")
+
+            previous_timeout = task_utils.HOOK_TIMEOUT_SECONDS
+            previous_grace = task_utils.HOOK_TERMINATION_GRACE_SECONDS
+            task_utils.HOOK_TIMEOUT_SECONDS = 0.05
+            task_utils.HOOK_TERMINATION_GRACE_SECONDS = 0.05
+            stderr = io.StringIO()
+            start = time.monotonic()
+            try:
+                with contextlib.redirect_stderr(stderr):
+                    task_utils.run_task_hooks("after_create", task_json, repo)
+            finally:
+                task_utils.HOOK_TIMEOUT_SECONDS = previous_timeout
+                task_utils.HOOK_TERMINATION_GRACE_SECONDS = previous_grace
+
+            elapsed = time.monotonic() - start
+            self.assertIn("[WARN] Hook timed out (after_create):", stderr.getvalue())
+            self.assertLess(elapsed, MAX_HOOK_TEST_SECONDS)
+            self.assertTrue(continued_marker.exists())
+            time.sleep(0.9)
+            self.assertFalse(marker.exists())
+
+    def test_sigterm_responsive_hook_still_exits_without_leaking(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            trellis = repo / ".trellis"
+            trellis.mkdir()
+            marker = repo / "responsive-leaked"
+            child_code = (
+                "import pathlib, sys, time; "
+                "time.sleep(0.8); "
+                "pathlib.Path(sys.argv[1]).write_text('leaked')"
+            )
+            hook_cmd = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(child_code)} "
+                f"{shlex.quote(str(marker))} & wait"
+            )
+            (trellis / "config.yaml").write_text(
+                "hooks:\n"
+                "  after_create:\n"
+                f"    - {hook_cmd}\n",
+                encoding="utf-8",
+            )
+            task_json = trellis / "tasks" / "demo" / "task.json"
+            task_json.parent.mkdir(parents=True)
+            task_json.write_text("{}", encoding="utf-8")
+
+            previous_timeout = task_utils.HOOK_TIMEOUT_SECONDS
+            previous_grace = task_utils.HOOK_TERMINATION_GRACE_SECONDS
+
+            task_utils.HOOK_TIMEOUT_SECONDS = 0.05
+            task_utils.HOOK_TERMINATION_GRACE_SECONDS = 0.05
+            stderr = io.StringIO()
+            start = time.monotonic()
+            try:
+                with contextlib.redirect_stderr(stderr):
+                    task_utils.run_task_hooks("after_create", task_json, repo)
+            finally:
+                task_utils.HOOK_TIMEOUT_SECONDS = previous_timeout
+                task_utils.HOOK_TERMINATION_GRACE_SECONDS = previous_grace
+
+            elapsed = time.monotonic() - start
+            self.assertIn("[WARN] Hook timed out (after_create):", stderr.getvalue())
+            self.assertLess(elapsed, MAX_HOOK_TEST_SECONDS)
+            time.sleep(0.9)
+            self.assertFalse(marker.exists())
+
+    def test_escaped_child_holding_stdout_does_not_block_later_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            trellis = repo / ".trellis"
+            trellis.mkdir()
+            child_pid_file = repo / "child.pid"
+            continued_marker = repo / "escaped-continued"
+            child_code = (
+                "import os, pathlib, sys, time; "
+                "os.setsid(); "
+                "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+                "time.sleep(3)"
+            )
+            hook_cmd = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(child_code)} "
+                f"{shlex.quote(str(child_pid_file))} & "
+                f"while [ ! -s {shlex.quote(str(child_pid_file))} ]; do sleep 0.01; done; "
+                "wait"
+            )
+            continue_code = "import pathlib, sys; pathlib.Path(sys.argv[1]).write_text('continued')"
+            continue_cmd = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(continue_code)} "
+                f"{shlex.quote(str(continued_marker))}"
+            )
+            (trellis / "config.yaml").write_text(
+                "hooks:\n"
+                "  after_create:\n"
+                f"    - {hook_cmd}\n"
+                f"    - {continue_cmd}\n",
+                encoding="utf-8",
+            )
+            task_json = trellis / "tasks" / "demo" / "task.json"
+            task_json.parent.mkdir(parents=True)
+            task_json.write_text("{}", encoding="utf-8")
+
+            previous_timeout = task_utils.HOOK_TIMEOUT_SECONDS
+            previous_grace = task_utils.HOOK_TERMINATION_GRACE_SECONDS
+            task_utils.HOOK_TIMEOUT_SECONDS = 0.05
+            task_utils.HOOK_TERMINATION_GRACE_SECONDS = 0.05
+            stderr = io.StringIO()
+            start = time.monotonic()
+            try:
+                with contextlib.redirect_stderr(stderr):
+                    task_utils.run_task_hooks("after_create", task_json, repo)
+            finally:
+                task_utils.HOOK_TIMEOUT_SECONDS = previous_timeout
+                task_utils.HOOK_TERMINATION_GRACE_SECONDS = previous_grace
+                if child_pid_file.exists():
+                    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+                    try:
+                        os.kill(child_pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
+            elapsed = time.monotonic() - start
+            self.assertIn("[WARN] Hook timed out (after_create):", stderr.getvalue())
+            self.assertLess(elapsed, MAX_HOOK_TEST_SECONDS)
+            self.assertTrue(continued_marker.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,6 +329,7 @@ gofmt -l $(git ls-files '*.go')         # must be empty
 go mod tidy && git diff --exit-code -- go.mod go.sum
 go vet ./...
 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'
 go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts
 go test -race -covermode=atomic ./...
 go build ./cmd/worker ./cmd/tui

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -28,6 +28,8 @@ Checks:
 - blocking `golangci-lint` gate for all enabled linters in one pass:
   `contextcheck`, `errcheck`, `errorlint`, `funlen`, `gocognit`, `gocritic`,
   `govet`, `ineffassign`, `revive`, `staticcheck`, `unparam`, and `unused`
+- Trellis script regression tests:
+  `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
 - `go mod tidy` check
 - uncached production Go file-size baseline check:
   `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
@@ -114,6 +116,7 @@ Run:
 go mod tidy
 gofmt -w cmd internal
 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'
 cd cmd/worker/dashboard && npm ci && npm test && npm run build && cd -
 go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts
 go test ./...


### PR DESCRIPTION
Closes #656.

## Summary
- run Trellis lifecycle hooks through a bounded subprocess wrapper instead of unbounded `subprocess.run`
- terminate hook process groups on timeout, close captured pipes, warn, and continue to later hooks
- add Trellis script regression tests and wire them into CI/checklist docs

## SPEC alignment
- [x] No new top-level `WORKFLOW.md` / config key / worker behavior; this is repo workflow tooling outside the Symphony scheduler boundary.
- [ ] Matches SPEC + Elixir reference behavior (include concrete citations below).
- [ ] Deliberate deviation or harness hardening; tracked by a `DEVIATIONS.md row` below.

## Size budget
- [x] `within budget` — production diff is scoped to Trellis hook handling plus CI/checklist wiring; test files excluded from production LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py' -v` (5 tests OK)
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `python3 - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml') ... PY`
- [x] `node --test .github/scripts/*.test.mjs`
- [x] `git diff --check origin/main...HEAD`

## Mutation checks
- removing POSIX `start_new_session` leaks the timeout child marker and fails the hook timeout regression
- removing `_kill_hook_process_tree(process)` lets a SIGTERM-resistant child write the leak marker
- returning immediately after timeout warning prevents later hooks from running and fails the continuation assertions
- replacing timeout pipe close with a second `communicate()` blocks on escaped stdout holders and fails the elapsed assertion

## Review ledger
- pre-push subagent reviewer: Sagan, clean / MERGE-READY for `c4c47597e4d564017adc1c0efec1eff3851b3297`
- pre-push Codex-family reviewer: clean / MERGE-READY for `c4c47597e4d564017adc1c0efec1eff3851b3297`
- pre-push Claude-family reviewer: clean / MERGE-READY for `c4c47597e4d564017adc1c0efec1eff3851b3297`
- #655 preservation check: branch base is `origin/main` at `e7df3213e3013276e9062de28615323b915b5993`; no diff to `.trellis/scripts/common/task_store.py` or duplicate-create regression test

## Post-push gate ledger
- CI: green on run `27019226108` (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`)
- PR Metadata: latest run `27019270068` green after PR body checklist anchor fix
- GraphQL reviewThreads: `[]`
- Warning audit: only harmless checkout default-branch hints, tar `--warning=no-unknown-keyword` command text, and Vite `--disable-warning=DEP0205` command text
- GitHub Codex review: **not clean**. Two fresh `@codex review` triggers (`4632354200`, `4632422372`) both returned `An unknown error occurred`; PR remains draft and deferred, not auto-mergeable under the batch gate.

## Notes
- Timeout hooks intentionally discard partial stdout/stderr on the timeout path so escaped or background children holding pipes cannot block hook processing.
