### PR TITLE
docs: clarify Go file size budget policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,6 +420,12 @@ failure per the "Earned rules" principle above.
    production Go files are listed with exact line-count baselines, new
    oversized production files fail, and any reduction of an existing oversized
    file must lower or remove that baseline in the same PR.
+   This is an aiops-platform repo-specific maintainability budget, not an
+   official Go file-length limit. The file gate counts raw physical lines in
+   non-test, non-generated Go files and uses the baseline/ratchet to burn down
+   existing debt gradually. Decompose oversized files by responsibility first;
+   introduce `internal` helper packages only when a cohesive package boundary
+   exists, and do not create public API solely to satisfy the line budget.
    **Earned by:** #410 found `RunTask` at 244 lines, `validateConfig` at 186
    lines, and `actor.go` at 2138 lines; PR #342 showed that one concept rename
    had to touch four files partly because large files hid the domain boundary.

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -72,6 +72,25 @@ lines unless they are in the exact oversized-file baseline. If an existing
 oversized file shrinks, update or remove its baseline in the same PR so the
 budget ratchets downward instead of allowing silent regrowth.
 
+The 800-line file gate is an aiops-platform repo-specific maintainability
+budget, not an official Go file-length limit. Effective Go delegates formatting
+to `gofmt` and explicitly says Go has no **line length** limit
+(`https://go.dev/doc/effective_go`); that line-length guidance should not be
+misread as a file-length recommendation. The custom test counts raw physical
+lines in each tracked Go file, excluding `_test.go` files and generated files
+with the standard `Code generated` / `DO NOT EDIT` header. A generic linter rule
+would not encode this repository's exact oversized-file baseline/ratchet:
+new unbaselined oversized production files fail, existing oversized files are
+grandfathered only at their recorded line count, and any shrink must ratchet the
+baseline down in the same PR.
+
+Decompose oversized files by responsibility during burn-down rather than keep
+baselines permanently. Split within the same package when that is enough; move
+code into `internal/...` helper packages only when there is a cohesive subsystem
+boundary, matching the Go module layout guidance for server/internal packages
+(`https://go.dev/doc/modules/layout`). Do not introduce public API surface just
+to satisfy the line budget.
+
 When comparing local lint output to CI, use an isolated cache if multiple
 worktrees for this repository are open under the same parent directory:
 

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -92,6 +92,32 @@ func TestCIEnforcesProductionGoFileSizeBudgetUncached(t *testing.T) {
 	}
 }
 
+func TestFileSizeBudgetDocsDescribeRepoPolicy(t *testing.T) {
+	docs := []string{
+		"../AGENTS.md",
+		"../docs/runbooks/ci.md",
+	}
+	for _, doc := range docs {
+		body, err := os.ReadFile(doc)
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", doc, err)
+		}
+		text := strings.ToLower(strings.Join(strings.Fields(string(body)), " "))
+		for _, want := range []string{
+			"repo-specific maintainability budget",
+			"not an official Go file-length limit",
+			"raw physical lines",
+			"non-test, non-generated Go files",
+			"baseline/ratchet",
+			"Decompose oversized files by responsibility",
+		} {
+			if !strings.Contains(text, strings.ToLower(want)) {
+				t.Fatalf("%s missing file-size budget policy text %q", doc, want)
+			}
+		}
+	}
+}
+
 func TestCIDashboardBuildFeedsGoEmbedWithoutCommittedDist(t *testing.T) {
 	body, err := os.ReadFile("../.github/workflows/ci.yml")
 	if err != nil {


### PR DESCRIPTION
Closes #660

## Summary
- Audits the production Go file-size budget language against official Go guidance and documents it as an aiops-platform repo-specific maintainability budget, not an official Go file-length limit.
- Clarifies raw physical-line counting, non-test/non-generated exclusions, baseline/ratchet behavior, and burn-down through responsibility-based decomposition.
- Adds a regression-style doc/process test so AGENTS.md and the CI runbook keep the policy wording aligned.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — 0 changed production Go files / 0 changed production LOC; docs plus one test file only.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

## Additional validation
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `node --test .github/scripts/*.test.mjs`
- `go test -count=1 ./scripts`
- `go build ./cmd/worker ./cmd/tui`
- Mutation check: deleting the "not an official Go file-length limit" wording made `TestFileSizeBudgetDocsDescribeRepoPolicy` fail, then restoration made the focused test pass.

## Official Go guidance consulted
- Effective Go: `https://go.dev/doc/effective_go` — line length is formatting/gofmt guidance, not a file-length policy.
- Go Code Review Comments: `https://go.dev/wiki/CodeReviewComments` — checked the custom test against ordinary Go review expectations such as useful failures and simple test structure.
- Organizing a Go module: `https://go.dev/doc/modules/layout` — decomposition guidance should favor cohesive file/package boundaries, including `internal/...` only when a real subsystem boundary exists.

## Pre-push review ledger
- Subagent independent reviewer: MERGE-READY; no blocking findings.
- Codex-family local reviewer: clean; no introduced correctness, build, or test issues.
- Claude-family reviewer: MERGE-READY; no blocking findings.

## Post-push gate ledger
- Head: `4898445de23ce27bac1e6ce90093aa2951be555c`.
- CI: green (`CI` run `27042765243`; `PR Metadata` run `27042765272`).
- GraphQL reviewThreads: clean (`[]`).
- Warning audit: clean; `gh run view 27042765243 --log | grep -niE 'warning:'` and `gh run view 27042765272 --log | grep -niE 'warning:'` returned no matches.
- GitHub Codex review: not clean. First trigger `4635973663` and second trigger `4635997269` both ended with `Codex Review: Something went wrong` / `An unknown error occurred`.
- State: deferred, kept draft/open; not marked ready and not auto-merged because a fresh GitHub Codex review did not return clean.

## Policy verdict for #661
#660 does not change the file-size policy or enforcement strategy. #661 should proceed only after this #660 policy PR is accepted/merged or manually waived by the operator; the intended policy remains the existing 800 raw-physical-line, non-test/non-generated production Go file baseline/ratchet with burn-down by cohesive responsibility and no public API created solely to satisfy the budget.
