### PR TITLE
docs: note networkAccess opt-in for package-manager workflows

### DIFF
--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -314,6 +314,33 @@ above governs every turn — you no longer have to restate it under
 `turn_sandbox_policy`. Setting `turn_sandbox_policy` explicitly still overrides
 the derived value for callers that need a different per-turn policy (#472).
 
+### Network access for package-manager workflows
+
+`networkAccess` defaults to `false` in the per-turn `sandboxPolicy`, matching
+Codex's safe default. With it off, the agent's own shell/exec commands inside the
+turn sandbox cannot reach the network — so `npm install`, `pip install`,
+`go mod download`, `curl`/`wget` of external docs, and cloning external
+repositories are denied. This does not affect the model's reasoning, the
+`linear_graphql` tool, or tracker polling, which run outside the turn sandbox.
+
+Workflows that run package managers or other commands that resolve external
+hosts should opt in explicitly by setting `networkAccess: true` under
+`codex.turn_sandbox_policy`:
+
+```yaml
+codex:
+  turn_sandbox_policy:
+    type: workspaceWrite
+    networkAccess: true
+```
+
+Keep it off by default and enable it only for workflows that need it: opening
+network from the sandbox widens the attack surface (the agent can exfiltrate or
+fetch from arbitrary hosts), so weigh it against the posture in
+[`docs/security-posture.md`](../security-posture.md). This mirrors upstream
+Symphony, which enables `networkAccess` in its reference `WORKFLOW.md` only for
+its package-installing FSS runs (openai/symphony #65).
+
 ## Validation reference
 
 See `docs/validation/2026-05-26-docker-linear-e2e.md` for the live Linear todo


### PR DESCRIPTION
Closes #684

## Summary
- Document that the per-turn `sandboxPolicy.networkAccess` defaults to `false` (Codex's safe default) and that this blocks the agent's **in-sandbox shell/exec commands** from the network — `npm install`, `pip install`, `go mod download`, `curl`/`wget` of external docs, and external `git clone` are denied.
- Clarify scope: it does **not** affect the model's reasoning, the `linear_graphql` tool, or orchestrator tracker polling, which run outside the turn sandbox.
- Tell operators that network-needing workflows must opt in with `networkAccess: true` under `codex.turn_sandbox_policy` (with a YAML snippet) and weigh the widened attack surface against `docs/security-posture.md`.
- Mirrors upstream Symphony #65, which enables `networkAccess` in its reference `WORKFLOW.md` only for package-installing FSS runs. Capability was already at parity (`internal/workflow/codex_schema.go`); this is the operator-facing doc that was missing. No code or `SPEC.md` change.

Docs-only follow-up from the 2026-06 upstream Symphony review pass (companions: #682 / upstream #88, #683 / upstream #89).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs-only: `networkAccess` already exists in `codex_schema.go`; no new key or gate is introduced, and the default is unchanged (`false`).

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

1 file, +27 lines, docs only.

## Testing
- [ ] not applicable — docs-only change, no Go/Python sources touched.

## Notes
- No `DEVIATIONS.md` row — not a deviation, operator-facing documentation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXySTZciWJGjNnnAKhMYRH)_