### PR TITLE
fix: single long-lived stdout reader for codex app-server (#666)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -87,6 +87,7 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		out:               buf,
 		codexAppServerPID: appServerProcessPID(cmd, directCodexExec, sandboxEnabled),
 	}
+	client.startStdoutReader()
 	runErr := client.run(ctx, in, string(prompt))
 	if runErr != nil && ctx.Err() == nil {
 		terminateProcess(cmd)
@@ -94,6 +95,15 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 	_ = stdin.Close()
 	waitErr := cmd.Wait()
 	<-stderrDone
+	// Join the stdout reader so no goroutine outlives this call (Go Code Review
+	// Comments, "Goroutine Lifetimes"). cmd.Wait above has closed the process'
+	// stdout, so a reader parked in scanner.Scan now observes EOF and exits;
+	// close(readDone) releases one parked handing off a line; draining readCh to
+	// its deferred close receives any in-flight line and blocks until the reader
+	// has returned.
+	close(client.readDone)
+	for range client.readCh { //nolint:revive // drain-to-close joins the reader goroutine
+	}
 	elapsed := time.Since(start)
 
 	writeAppServerArtifact(in.Workdir, buf)
@@ -268,8 +278,17 @@ func validateAppServerWorkdir(workdir string) error {
 }
 
 type appServerClient struct {
-	stdin               io.Writer
-	scanner             *bufio.Scanner
+	stdin   io.Writer
+	scanner *bufio.Scanner
+	// readCh/readDone/readErr connect the single long-lived stdout reader
+	// (startStdoutReader, which documents the lifecycle) to the request/response
+	// consumer. readCh carries lines and is closed only by the reader; readDone is
+	// the go.dev/blog/pipelines "done" channel closed at shutdown; readErr is the
+	// sticky terminal scan error, published before close(readCh) so the close is
+	// the happens-before edge that lets the consumer read it race-free.
+	readCh              chan []byte
+	readDone            chan struct{}
+	readErr             error
 	out                 io.Writer
 	nextID              int
 	codexAppServerPID   int
@@ -664,52 +683,99 @@ func (c *appServerClient) readProtocolMessage(ctx context.Context) (map[string]a
 	return msg, line, nil
 }
 
-type readResult struct {
-	line []byte
-	err  error
+// startStdoutReader launches the single long-lived stdout reader. It is the
+// source stage of https://go.dev/blog/pipelines: one goroutine owns the
+// bufio.Scanner (which is not safe for concurrent use) and continuously scans
+// lines, handing each to the request/response consumer over readCh. Its lifetime
+// is the app-server process: it exits on exactly one of
+//   - scanner.Scan returning false (stdout EOF or error — the process closed
+//     stdout, or cmd.Wait closed the pipe), recording a sticky readErr; or
+//   - readDone being closed at shutdown while it is parked handing off a line,
+//     which the blog prescribes so a sender whose consumer has moved on cannot
+//     "block indefinitely ... a resource leak".
+//
+// `defer close(readCh)` runs on every exit path, so a consumer waiting on readCh
+// is always released and the close is the happens-before edge that publishes
+// readErr (Go Code Review Comments, "Goroutine Lifetimes"). RunCodexAppServer
+// joins it by draining readCh after cmd.Wait. The channels are created here so
+// the goroutine and its communication state have a single owner.
+func (c *appServerClient) startStdoutReader() {
+	c.readCh = make(chan []byte)
+	c.readDone = make(chan struct{})
+	go func() {
+		defer close(c.readCh)
+		defer c.recoverReaderPanic()
+		for c.scanner.Scan() {
+			// Scanner.Bytes() is invalidated by the next Scan (bufio docs); copy
+			// before handing the line across the goroutine boundary.
+			line := append([]byte(nil), c.scanner.Bytes()...)
+			select {
+			case c.readCh <- line:
+			case <-c.readDone:
+				return
+			}
+		}
+		c.readErr = scanTerminalError(c.scanner)
+	}()
+}
+
+// recoverReaderPanic is the stdout reader's deferred recovery: a panic in the
+// scan loop is published as readErr (so the consumer sees an error rather than
+// hanging on a never-closed readCh) and logged, not swallowed.
+func (c *appServerClient) recoverReaderPanic() {
+	if r := recover(); r != nil {
+		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %v", r)
+		log.Printf("event=codex_app_server_reader_panic error=%q", r)
+	}
+}
+
+// scanTerminalError maps a finished scanner to the terminal error the consumer
+// should observe once readCh closes. Scanner.Err is nil on io.EOF (bufio docs),
+// so a clean end-of-stream normalizes to io.EOF; an over-cap line keeps the
+// existing wrapped bufio.ErrTooLong contract.
+func scanTerminalError(sc *bufio.Scanner) error {
+	err := sc.Err()
+	if err == nil {
+		return io.EOF
+	}
+	if errors.Is(err, bufio.ErrTooLong) {
+		return fmt.Errorf("codex app-server line exceeded %d bytes: %w", maxAppServerLineBytes, err)
+	}
+	return err
 }
 
 func (c *appServerClient) readLine(ctx context.Context) ([]byte, error) {
-	ch := make(chan readResult, 1)
-	go func() {
-		if c.scanner.Scan() {
-			// scanner.Bytes() is invalidated by the next Scan; copy before
-			// crossing the goroutine boundary.
-			line := append([]byte(nil), c.scanner.Bytes()...)
-			ch <- readResult{line: line, err: nil}
-			return
-		}
-		err := c.scanner.Err()
-		if err == nil {
-			err = io.EOF
-		}
-		if errors.Is(err, bufio.ErrTooLong) {
-			err = fmt.Errorf("codex app-server line exceeded %d bytes: %w", maxAppServerLineBytes, err)
-		}
-		ch <- readResult{err: err}
-	}()
-
 	readTimeout := time.Duration(c.readTimeoutMs) * time.Millisecond
 	deadlineTimeout, hasDeadline := deadlineDuration(ctx)
 	if c.readTimeoutMs <= 0 || (hasDeadline && deadlineTimeout < readTimeout) {
-		return c.readLineOnce(ctx, ch, nil)
+		return c.readLineOnce(ctx, nil)
 	}
-	return c.readLineOnce(ctx, ch, time.After(readTimeout))
+	return c.readLineOnce(ctx, time.After(readTimeout))
 }
-func (c *appServerClient) readLineOnce(ctx context.Context, ch <-chan readResult, timeout <-chan time.Time) ([]byte, error) {
+
+// readLineOnce waits for the next line from the long-lived reader, the
+// per-read timeout, or context cancellation — whichever fires first. A closed
+// readCh means the reader has exited; it surfaces the reader's sticky readErr
+// (io.EOF when it stopped cleanly). The DeadlineExceeded preference is retained
+// so a read that loses the race to an expiring context is classified as the
+// deadline, not as the EOF the dying process subsequently produced.
+func (c *appServerClient) readLineOnce(ctx context.Context, timeout <-chan time.Time) ([]byte, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-timeout:
 		return nil, &appServerReadTimeoutError{afterMs: c.readTimeoutMs}
-	case res := <-ch:
-		if res.err != nil {
+	case line, ok := <-c.readCh:
+		if !ok {
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return nil, ctx.Err()
 			}
-			return nil, res.err
+			if c.readErr != nil {
+				return nil, c.readErr
+			}
+			return nil, io.EOF
 		}
-		return res.line, nil
+		return line, nil
 	}
 }
 func deadlineDuration(ctx context.Context) (time.Duration, bool) {

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -93,17 +94,19 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		terminateProcess(cmd)
 	}
 	_ = stdin.Close()
-	waitErr := cmd.Wait()
-	<-stderrDone
-	// Join the stdout reader so no goroutine outlives this call (Go Code Review
-	// Comments, "Goroutine Lifetimes"). cmd.Wait above has closed the process'
-	// stdout, so a reader parked in scanner.Scan now observes EOF and exits;
-	// close(readDone) releases one parked handing off a line; draining readCh to
-	// its deferred close receives any in-flight line and blocks until the reader
-	// has returned.
-	close(client.readDone)
+	// Drain stdout to EOF BEFORE cmd.Wait — the os/exec idiom (StdoutPipe doc:
+	// "incorrect to call Wait before all reads from the pipe have completed").
+	// The reader keeps scanning as the drain receives, so the child can never
+	// block writing to a full pipe; it finishes, observes the stdin EOF above (or
+	// the kill), exits, and its stdout EOF makes the reader close readCh, ending
+	// the drain. Waiting before draining would deadlock: a reader parked on an
+	// unconsumed send stalls stdout, the child blocks on write and never exits,
+	// and cmd.Wait never returns. Draining also joins the reader so no goroutine
+	// outlives this call (Go Code Review Comments, "Goroutine Lifetimes").
 	for range client.readCh { //nolint:revive // drain-to-close joins the reader goroutine
 	}
+	waitErr := cmd.Wait()
+	<-stderrDone
 	elapsed := time.Since(start)
 
 	writeAppServerArtifact(in.Workdir, buf)
@@ -280,14 +283,12 @@ func validateAppServerWorkdir(workdir string) error {
 type appServerClient struct {
 	stdin   io.Writer
 	scanner *bufio.Scanner
-	// readCh/readDone/readErr connect the single long-lived stdout reader
+	// readCh/readErr connect the single long-lived stdout reader
 	// (startStdoutReader, which documents the lifecycle) to the request/response
-	// consumer. readCh carries lines and is closed only by the reader; readDone is
-	// the go.dev/blog/pipelines "done" channel closed at shutdown; readErr is the
-	// sticky terminal scan error, published before close(readCh) so the close is
-	// the happens-before edge that lets the consumer read it race-free.
+	// consumer. readCh carries lines and is closed only by the reader; readErr is
+	// the sticky terminal scan error, published before close(readCh) so the close
+	// is the happens-before edge that lets the consumer read it race-free.
 	readCh              chan []byte
-	readDone            chan struct{}
 	readErr             error
 	out                 io.Writer
 	nextID              int
@@ -687,21 +688,18 @@ func (c *appServerClient) readProtocolMessage(ctx context.Context) (map[string]a
 // source stage of https://go.dev/blog/pipelines: one goroutine owns the
 // bufio.Scanner (which is not safe for concurrent use) and continuously scans
 // lines, handing each to the request/response consumer over readCh. Its lifetime
-// is the app-server process: it exits on exactly one of
-//   - scanner.Scan returning false (stdout EOF or error — the process closed
-//     stdout, or cmd.Wait closed the pipe), recording a sticky readErr; or
-//   - readDone being closed at shutdown while it is parked handing off a line,
-//     which the blog prescribes so a sender whose consumer has moved on cannot
-//     "block indefinitely ... a resource leak".
+// is the app-server process: it exits when scanner.Scan returns false (stdout
+// EOF or error — the process closed stdout on exit), recording a sticky readErr.
 //
-// `defer close(readCh)` runs on every exit path, so a consumer waiting on readCh
-// is always released and the close is the happens-before edge that publishes
-// readErr (Go Code Review Comments, "Goroutine Lifetimes"). RunCodexAppServer
-// joins it by draining readCh after cmd.Wait. The channels are created here so
-// the goroutine and its communication state have a single owner.
+// The reader has no separate stop signal: the consumer never abandons readCh, it
+// drains to EOF at shutdown (RunCodexAppServer drains before cmd.Wait), so the
+// reader always keeps the pipe flowing and reaches EOF rather than parking on a
+// send forever (Go Code Review Comments, "Goroutine Lifetimes"). `defer
+// close(readCh)` runs on every exit path, so a consumer waiting on readCh is
+// always released and the close is the happens-before edge that publishes
+// readErr. readCh is created here so the goroutine and its channel have one owner.
 func (c *appServerClient) startStdoutReader() {
 	c.readCh = make(chan []byte)
-	c.readDone = make(chan struct{})
 	go func() {
 		defer close(c.readCh)
 		defer c.recoverReaderPanic()
@@ -709,11 +707,7 @@ func (c *appServerClient) startStdoutReader() {
 			// Scanner.Bytes() is invalidated by the next Scan (bufio docs); copy
 			// before handing the line across the goroutine boundary.
 			line := append([]byte(nil), c.scanner.Bytes()...)
-			select {
-			case c.readCh <- line:
-			case <-c.readDone:
-				return
-			}
+			c.readCh <- line
 		}
 		c.readErr = scanTerminalError(c.scanner)
 	}()
@@ -721,12 +715,19 @@ func (c *appServerClient) startStdoutReader() {
 
 // recoverReaderPanic is the stdout reader's deferred recovery: a panic in the
 // scan loop is published as readErr (so the consumer sees an error rather than
-// hanging on a never-closed readCh) and logged, not swallowed.
+// hanging on a never-closed readCh) and logged with a stack, not swallowed —
+// matching the orchestrator's recoverPanicValue convention (recover.go).
 func (c *appServerClient) recoverReaderPanic() {
-	if r := recover(); r != nil {
-		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %v", r)
-		log.Printf("event=codex_app_server_reader_panic error=%q", r)
+	r := recover()
+	if r == nil {
+		return
 	}
+	if err, ok := r.(error); ok {
+		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %w", err)
+	} else {
+		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %v", r)
+	}
+	log.Printf("event=codex_app_server_reader_panic panic=%v stack=%q", r, debug.Stack())
 }
 
 // scanTerminalError maps a finished scanner to the terminal error the consumer

--- a/internal/runner/codex_app_server_reader_test.go
+++ b/internal/runner/codex_app_server_reader_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 )
@@ -20,8 +21,9 @@ import (
 // newPipeReaderClient builds a client whose stdout is an in-memory pipe and
 // starts its single long-lived reader. It returns the write end so a test can
 // feed lines, close the stream, or leave it silent. The reader is joined at
-// test end (close the pipe so a Scan-parked reader EOFs, signal readDone for a
-// handoff-parked one, then drain readCh to its deferred close).
+// test end: close the pipe so a Scan-parked reader EOFs, then drain readCh to
+// its deferred close (which also receives any line a reader is parked handing
+// off, after which it loops back to Scan and observes the EOF).
 func newPipeReaderClient(t *testing.T, opts ...func(*appServerClient)) (*appServerClient, *io.PipeWriter) {
 	t.Helper()
 	pr, pw := io.Pipe()
@@ -34,7 +36,6 @@ func newPipeReaderClient(t *testing.T, opts ...func(*appServerClient)) (*appServ
 	c.startStdoutReader()
 	t.Cleanup(func() {
 		_ = pw.Close()
-		close(c.readDone)
 		for range c.readCh { //nolint:revive // drain-to-close joins the reader
 		}
 	})
@@ -112,11 +113,60 @@ func TestStdoutReader_DeliversLineThenEOF(t *testing.T) {
 	}
 }
 
-// TestStdoutReader_ExitsOnShutdownNoLeak is the lifecycle/leak assertion: after
-// a read times out with the reader parked in Scan, the production shutdown
-// sequence (close the stream, signal readDone, drain readCh) must let the reader
-// goroutine exit. If it leaked, the drain never observes the deferred
-// close(readCh) and the 2s guard fires.
+// TestStdoutReader_HoldsLineAcrossTimeoutThenDelivers pins the production timing
+// window the per-read timeout exists for: a line that arrives just after a read
+// times out is held by the reader (parked on the readCh send) and delivered
+// intact to the NEXT read — no loss, no reorder. The old per-read goroutine
+// orphaned such a line; the single reader preserves it.
+func TestStdoutReader_HoldsLineAcrossTimeoutThenDelivers(t *testing.T) {
+	c, pw := newPipeReaderClient(t, func(c *appServerClient) { c.readTimeoutMs = 40 })
+	if _, err := c.readLine(context.Background()); !isAppServerReadTimeout(err) {
+		t.Fatalf("first readLine() err = %v; want a read timeout on the silent stream", err)
+	}
+	go func() { _, _ = pw.Write([]byte("late-line\n")) }()
+	line, err := c.readLine(context.Background())
+	if err != nil {
+		t.Fatalf("second readLine() err = %v; want the late line", err)
+	}
+	if got, want := string(line), "late-line"; got != want {
+		t.Fatalf("second readLine() = %q; want %q (a line held across the first read's timeout must be delivered intact)", got, want)
+	}
+}
+
+// panickingReader is an io.Reader whose Read panics, to drive the stdout
+// reader's panic-recovery path.
+type panickingReader struct{}
+
+func (panickingReader) Read([]byte) (int, error) { panic("scanner boom") }
+
+// TestStdoutReader_PanicInScanSurfacesErrorNotHang pins that a panic in the scan
+// loop is recovered and surfaced as readErr through the closed readCh, so the
+// consumer gets an error instead of hanging on a never-closed channel — the
+// failure class #666 set out to eliminate. It also guards the subtle LIFO-defer
+// ordering (recover publishes readErr before close(readCh)).
+func TestStdoutReader_PanicInScanSurfacesErrorNotHang(t *testing.T) {
+	c := &appServerClient{scanner: bufio.NewScanner(panickingReader{}), out: io.Discard}
+	c.startStdoutReader()
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.readLine(context.Background())
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "panic") {
+			t.Fatalf("readLine() err = %v; want a surfaced reader-panic error", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLine() hung after a reader panic — recovery must close readCh")
+	}
+}
+
+// TestStdoutReader_ExitsOnShutdownNoLeak is the lifecycle/leak assertion: after a
+// read times out with the reader parked in Scan, the production shutdown (the
+// child closing stdout, modeled by closing the pipe, then draining readCh) must
+// let the reader goroutine exit. If it leaked, the drain never observes the
+// deferred close(readCh) and the 2s guard fires.
 func TestStdoutReader_ExitsOnShutdownNoLeak(t *testing.T) {
 	pr, pw := io.Pipe()
 	sc := bufio.NewScanner(pr)
@@ -128,12 +178,11 @@ func TestStdoutReader_ExitsOnShutdownNoLeak(t *testing.T) {
 		t.Fatalf("readLine() err = %v; want a read timeout while the reader is parked", err)
 	}
 
-	// Mirror RunCodexAppServer's shutdown: the closed stream EOFs a Scan-parked
-	// reader, close(readDone) releases a handoff-parked one, draining joins it.
+	// Mirror RunCodexAppServer's shutdown: the child closing stdout EOFs the
+	// Scan-parked reader, and draining readCh to its deferred close joins it.
 	_ = pw.Close()
 	joined := make(chan struct{})
 	go func() {
-		close(c.readDone)
 		for range c.readCh { //nolint:revive // drain-to-close joins the reader
 		}
 		close(joined)

--- a/internal/runner/codex_app_server_reader_test.go
+++ b/internal/runner/codex_app_server_reader_test.go
@@ -1,0 +1,146 @@
+package runner
+
+// codex_app_server_reader_test.go pins the single long-lived stdout reader's
+// lifecycle (#666): the per-read timeout, context cancellation, and stream-EOF
+// exit paths a request/response consumer relies on, plus a deterministic join
+// proving the reader goroutine does not outlive shutdown. These exercise the
+// reader directly over an io.Pipe so a test controls exactly when a line
+// arrives, the stream EOFs, or the read blocks — the conditions a real
+// `codex app-server` produces but a canned-buffer scanner cannot.
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+// newPipeReaderClient builds a client whose stdout is an in-memory pipe and
+// starts its single long-lived reader. It returns the write end so a test can
+// feed lines, close the stream, or leave it silent. The reader is joined at
+// test end (close the pipe so a Scan-parked reader EOFs, signal readDone for a
+// handoff-parked one, then drain readCh to its deferred close).
+func newPipeReaderClient(t *testing.T, opts ...func(*appServerClient)) (*appServerClient, *io.PipeWriter) {
+	t.Helper()
+	pr, pw := io.Pipe()
+	sc := bufio.NewScanner(pr)
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
+	c := &appServerClient{scanner: sc, out: io.Discard}
+	for _, opt := range opts {
+		opt(c)
+	}
+	c.startStdoutReader()
+	t.Cleanup(func() {
+		_ = pw.Close()
+		close(c.readDone)
+		for range c.readCh { //nolint:revive // drain-to-close joins the reader
+		}
+	})
+	return c, pw
+}
+
+// TestStdoutReader_ReadTimeoutWhileReaderBlocked pins that a per-read timeout
+// fires while the reader is parked in scanner.Scan with no line available, and
+// that the reader survives (its lifetime is the process, not one read).
+func TestStdoutReader_ReadTimeoutWhileReaderBlocked(t *testing.T) {
+	c, _ := newPipeReaderClient(t, func(c *appServerClient) { c.readTimeoutMs = 50 })
+	start := time.Now()
+	_, err := c.readLine(context.Background())
+	if !isAppServerReadTimeout(err) {
+		t.Fatalf("readLine() err = %v; want an app-server read timeout while the reader is blocked", err)
+	}
+	if elapsed := time.Since(start); elapsed < 40*time.Millisecond {
+		t.Errorf("readLine() returned after %v; want it to wait for the ~50ms read timeout", elapsed)
+	}
+}
+
+// TestStdoutReader_ContextCancelWhileReaderBlocked pins that cancelling the
+// caller's context unblocks readLine even though the stdout reader is parked in
+// scanner.Scan on a silent stream — the failure class #666 fixes (a per-read
+// goroutine that stayed parked after its caller moved on).
+func TestStdoutReader_ContextCancelWhileReaderBlocked(t *testing.T) {
+	c, _ := newPipeReaderClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := c.readLine(ctx)
+		errCh <- err
+	}()
+	// Let readLine reach its select with the reader parked on the empty pipe.
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("readLine() err = %v; want context.Canceled after cancel", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLine() did not return after context cancel (reader-blocked leak)")
+	}
+}
+
+// TestStdoutReader_ReturnsEOFWhenStreamCloses pins that once the stream closes
+// (the app-server exited / stdout closed), the reader's sticky terminal error
+// is io.EOF and readLine surfaces it via the closed readCh.
+func TestStdoutReader_ReturnsEOFWhenStreamCloses(t *testing.T) {
+	c, pw := newPipeReaderClient(t)
+	_ = pw.Close()
+	if _, err := c.readLine(context.Background()); !errors.Is(err, io.EOF) {
+		t.Fatalf("readLine() err = %v; want io.EOF after the stream closes", err)
+	}
+}
+
+// TestStdoutReader_DeliversLineThenEOF pins the happy path: a line is delivered
+// to the consumer, and the next read observes EOF once the stream closes.
+func TestStdoutReader_DeliversLineThenEOF(t *testing.T) {
+	c, pw := newPipeReaderClient(t)
+	go func() {
+		_, _ = pw.Write([]byte("{\"jsonrpc\":\"2.0\"}\n"))
+		_ = pw.Close()
+	}()
+	line, err := c.readLine(context.Background())
+	if err != nil {
+		t.Fatalf("readLine() err = %v; want the delivered line", err)
+	}
+	if got, want := string(line), `{"jsonrpc":"2.0"}`; got != want {
+		t.Fatalf("readLine() = %q; want %q", got, want)
+	}
+	if _, err := c.readLine(context.Background()); !errors.Is(err, io.EOF) {
+		t.Fatalf("second readLine() err = %v; want io.EOF after stream close", err)
+	}
+}
+
+// TestStdoutReader_ExitsOnShutdownNoLeak is the lifecycle/leak assertion: after
+// a read times out with the reader parked in Scan, the production shutdown
+// sequence (close the stream, signal readDone, drain readCh) must let the reader
+// goroutine exit. If it leaked, the drain never observes the deferred
+// close(readCh) and the 2s guard fires.
+func TestStdoutReader_ExitsOnShutdownNoLeak(t *testing.T) {
+	pr, pw := io.Pipe()
+	sc := bufio.NewScanner(pr)
+	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
+	c := &appServerClient{scanner: sc, out: io.Discard, readTimeoutMs: 20}
+	c.startStdoutReader()
+
+	if _, err := c.readLine(context.Background()); !isAppServerReadTimeout(err) {
+		t.Fatalf("readLine() err = %v; want a read timeout while the reader is parked", err)
+	}
+
+	// Mirror RunCodexAppServer's shutdown: the closed stream EOFs a Scan-parked
+	// reader, close(readDone) releases a handoff-parked one, draining joins it.
+	_ = pw.Close()
+	joined := make(chan struct{})
+	go func() {
+		close(c.readDone)
+		for range c.readCh { //nolint:revive // drain-to-close joins the reader
+		}
+		close(joined)
+	}()
+	select {
+	case <-joined:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stdout reader did not exit within 2s of shutdown — goroutine leak")
+	}
+}

--- a/internal/runner/codex_app_server_request_test.go
+++ b/internal/runner/codex_app_server_request_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRequest_ReturnsMatchingResult(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"jsonrpc":"2.0","id":0,"result":{"thread":{"id":"t-1"}}}`,
 	})
 	got, err := c.request(context.Background(), "thread/start", map[string]any{"x": 1})
@@ -27,7 +27,7 @@ func TestRequest_ReturnsMatchingResult(t *testing.T) {
 }
 
 func TestRequest_ErrorResponseReturnsResponseErrorCategory(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"jsonrpc":"2.0","id":0,"error":{"code":-32600,"message":"bad request"}}`,
 	})
 	_, err := c.request(context.Background(), "thread/start", nil)
@@ -40,7 +40,7 @@ func TestRequest_ErrorResponseReturnsResponseErrorCategory(t *testing.T) {
 }
 
 func TestRequest_MissingResultReturnsEmptyMap(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"jsonrpc":"2.0","id":0}`, // matching id, no result field
 	})
 	got, err := c.request(context.Background(), "initialize", nil)
@@ -56,7 +56,7 @@ func TestRequest_MissingResultReturnsEmptyMap(t *testing.T) {
 }
 
 func TestRequest_SkipsInterleavedNotificationThenReturns(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		// A notification (no id) arrives before the response; request must
 		// dispatch it via handleNotification and keep reading.
 		`{"jsonrpc":"2.0","method":"turn/progress","params":{"message":"working"}}`,
@@ -75,7 +75,7 @@ func TestRequest_SkipsInterleavedNotificationThenReturns(t *testing.T) {
 }
 
 func TestRequest_SkipsDifferentIdMessageThenReturns(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		// A message carrying a DIFFERENT numeric id must not be mistaken for this
 		// request's response (id 0); it is dispatched as a notification and the
 		// loop keeps reading for the real response.
@@ -95,7 +95,7 @@ func TestRequest_SkipsDifferentIdMessageThenReturns(t *testing.T) {
 }
 
 func TestRequest_ReadErrorPropagates(t *testing.T) {
-	c, _ := newTurnLoopClient(nil) // empty stream: the read hits EOF before any response
+	c, _ := newTurnLoopClient(t, nil) // empty stream: the read hits EOF before any response
 	_, err := c.request(context.Background(), "initialize", nil)
 	if err == nil {
 		t.Fatalf("request() err = nil; want a read error on an empty stream")

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -2798,6 +2798,21 @@ for line in sys.stdin:
 	}
 }
 
+// startReaderForTest starts c's single long-lived stdout reader and joins it at
+// test end so no reader goroutine outlives the test (Go Code Review Comments,
+// "Goroutine Lifetimes"). It mirrors RunCodexAppServer's production drain:
+// close(readDone) releases a reader parked on a handoff, and draining readCh to
+// its deferred close blocks until the reader has returned.
+func startReaderForTest(t *testing.T, c *appServerClient) {
+	t.Helper()
+	c.startStdoutReader()
+	t.Cleanup(func() {
+		close(c.readDone)
+		for range c.readCh { //nolint:revive // drain-to-close joins the reader
+		}
+	})
+}
+
 // TestAppServerClient_ReadLineRejectsOversizedLine drives readLine directly
 // with a synthesized stdout stream where a single line exceeds the 10 MiB
 // SPEC §10.1 ceiling. The Scanner-bounded reader must surface the cap as a
@@ -2810,6 +2825,7 @@ func TestAppServerClient_ReadLineRejectsOversizedLine(t *testing.T) {
 	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
 
 	c := &appServerClient{scanner: sc}
+	startReaderForTest(t, c)
 	_, err := c.readLine(context.Background())
 	if err == nil {
 		t.Fatal("readLine err = nil, want over-cap error")
@@ -2832,6 +2848,7 @@ func TestAppServerClient_ReadLineAcceptsLineAtCap(t *testing.T) {
 	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
 
 	c := &appServerClient{scanner: sc}
+	startReaderForTest(t, c)
 	line, err := c.readLine(context.Background())
 	if err != nil {
 		t.Fatalf("readLine at cap err = %v, want nil (10 MiB is the documented inclusive limit)", err)

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -2800,14 +2800,13 @@ for line in sys.stdin:
 
 // startReaderForTest starts c's single long-lived stdout reader and joins it at
 // test end so no reader goroutine outlives the test (Go Code Review Comments,
-// "Goroutine Lifetimes"). It mirrors RunCodexAppServer's production drain:
-// close(readDone) releases a reader parked on a handoff, and draining readCh to
-// its deferred close blocks until the reader has returned.
+// "Goroutine Lifetimes"). It mirrors RunCodexAppServer's production drain: these
+// clients scan an in-memory buffer that reaches EOF, so draining readCh to its
+// deferred close receives any unconsumed line and blocks until the reader exits.
 func startReaderForTest(t *testing.T, c *appServerClient) {
 	t.Helper()
 	c.startStdoutReader()
 	t.Cleanup(func() {
-		close(c.readDone)
 		for range c.readCh { //nolint:revive // drain-to-close joins the reader
 		}
 	})

--- a/internal/runner/codex_app_server_turn_test.go
+++ b/internal/runner/codex_app_server_turn_test.go
@@ -33,7 +33,8 @@ import (
 // newline-delimited JSON-RPC lines. Server-request replies and tool-call
 // outputs land in the returned stdin buffer. opts mutate the client before the
 // loop runs (e.g. to set stallTimeoutMs or override the approval policy).
-func newTurnLoopClient(lines []string, opts ...func(*appServerClient)) (*appServerClient, *bytes.Buffer) {
+func newTurnLoopClient(t *testing.T, lines []string, opts ...func(*appServerClient)) (*appServerClient, *bytes.Buffer) {
+	t.Helper()
 	var stdout bytes.Buffer
 	for _, line := range lines {
 		stdout.WriteString(line)
@@ -51,6 +52,7 @@ func newTurnLoopClient(lines []string, opts ...func(*appServerClient)) (*appServ
 	for _, opt := range opts {
 		opt(c)
 	}
+	startReaderForTest(t, c)
 	return c, stdin
 }
 
@@ -63,7 +65,7 @@ func runtimeEventNames(c *appServerClient) []string {
 }
 
 func TestAwaitTurnCompletion_TurnCompletedSuccess(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"method":"turn/completed","params":{"lastAssistantMessage":"all done","continue":false}}`,
 	})
 	if err := c.awaitTurnCompletion(context.Background()); err != nil {
@@ -81,7 +83,7 @@ func TestAwaitTurnCompletion_TurnCompletedSuccess(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_TurnCompletedSetsContinueRun(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"method":"turn/completed","params":{"continue":true,"lastAssistantMessage":"keep going"}}`,
 	})
 	if err := c.awaitTurnCompletion(context.Background()); err != nil {
@@ -93,7 +95,7 @@ func TestAwaitTurnCompletion_TurnCompletedSetsContinueRun(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_TurnCompletedFailedStatusIsTurnFailed(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"method":"turn/completed","params":{"status":"failed","reason":"boom"}}`,
 	})
 	err := c.awaitTurnCompletion(context.Background())
@@ -106,7 +108,7 @@ func TestAwaitTurnCompletion_TurnCompletedFailedStatusIsTurnFailed(t *testing.T)
 }
 
 func TestAwaitTurnCompletion_TurnFailed(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"method":"turn/failed","params":{"reason":"explode"}}`,
 	})
 	err := c.awaitTurnCompletion(context.Background())
@@ -119,7 +121,7 @@ func TestAwaitTurnCompletion_TurnFailed(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_TurnCancelled(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"method":"turn/cancelled","params":{"reason":"user aborted"}}`,
 	})
 	err := c.awaitTurnCompletion(context.Background())
@@ -132,7 +134,7 @@ func TestAwaitTurnCompletion_TurnCancelled(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_UsageLimitIsQuotaBackoff(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"method":"turn/completed","params":{"status":"failed","turn":{"error":{"codexErrorInfo":"usageLimitExceeded","message":"please try again in 30 seconds"}}}}`,
 	})
 	err := c.awaitTurnCompletion(context.Background())
@@ -149,7 +151,7 @@ func TestAwaitTurnCompletion_UsageLimitIsQuotaBackoff(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_NotificationRecordedThenContinues(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"method":"item/agentMessage","params":{"message":"thinking"}}`,
 		`{"method":"turn/completed","params":{}}`,
 	})
@@ -163,7 +165,7 @@ func TestAwaitTurnCompletion_NotificationRecordedThenContinues(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_OtherMessageRecordedThenContinues(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"foo":"bar"}`,
 		`{"method":"turn/completed","params":{}}`,
 	})
@@ -177,7 +179,7 @@ func TestAwaitTurnCompletion_OtherMessageRecordedThenContinues(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_MalformedProtocolLineRecordedThenContinues(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{
+	c, _ := newTurnLoopClient(t, []string{
 		`{"oops": not-valid-json`,
 		`{"method":"turn/completed","params":{}}`,
 	})
@@ -191,7 +193,7 @@ func TestAwaitTurnCompletion_MalformedProtocolLineRecordedThenContinues(t *testi
 }
 
 func TestAwaitTurnCompletion_NonProtocolLineReturnsDecodeError(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{`plain text not json`})
+	c, _ := newTurnLoopClient(t, []string{`plain text not json`})
 	err := c.awaitTurnCompletion(context.Background())
 	// A line that is not even a JSON object is a hard decode failure surfaced
 	// as a CategoryResponseError (classify by category, not by message text —
@@ -205,7 +207,7 @@ func TestAwaitTurnCompletion_NonProtocolLineReturnsDecodeError(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_InputRequiredNotification(t *testing.T) {
-	c, _ := newTurnLoopClient([]string{`{"method":"turn/input_required","params":{}}`})
+	c, _ := newTurnLoopClient(t, []string{`{"method":"turn/input_required","params":{}}`})
 	err := c.awaitTurnCompletion(context.Background())
 	if !IsInputRequired(err) {
 		t.Fatalf("awaitTurnCompletion() = %v; want *InputRequiredError", err)
@@ -221,7 +223,7 @@ func TestAwaitTurnCompletion_InputRequiredNotification(t *testing.T) {
 }
 
 func TestAwaitTurnCompletion_ServerRequestAutoApprovedThenContinues(t *testing.T) {
-	c, stdin := newTurnLoopClient([]string{
+	c, stdin := newTurnLoopClient(t, []string{
 		`{"id":7,"method":"item/commandExecution/requestApproval","params":{"command":"ls"}}`,
 		`{"method":"turn/completed","params":{}}`,
 	})
@@ -238,7 +240,7 @@ func TestAwaitTurnCompletion_ServerRequestAutoApprovedThenContinues(t *testing.T
 }
 
 func TestAwaitTurnCompletion_ServerRequestDeclinedIsInputRequired(t *testing.T) {
-	c, stdin := newTurnLoopClient([]string{
+	c, stdin := newTurnLoopClient(t, []string{
 		`{"id":9,"method":"item/commandExecution/requestApproval","params":{"command":"rm -rf /"}}`,
 	}, func(c *appServerClient) { c.approvalPolicy = "on-request" })
 	err := c.awaitTurnCompletion(context.Background())
@@ -254,7 +256,7 @@ func TestAwaitTurnCompletion_ServerRequestDeclinedIsInputRequired(t *testing.T) 
 }
 
 func TestAwaitTurnCompletion_RequestUserInputIsInputRequired(t *testing.T) {
-	c, stdin := newTurnLoopClient([]string{
+	c, stdin := newTurnLoopClient(t, []string{
 		`{"id":3,"method":"item/tool/requestUserInput","params":{"questions":[{"id":"q1"}]}}`,
 	})
 	err := c.awaitTurnCompletion(context.Background())
@@ -273,7 +275,7 @@ func TestAwaitTurnCompletion_UnsupportedToolCallRecordedThenContinues(t *testing
 	// With an empty tool set, item/tool/call resolves as an unsupported tool:
 	// the wire still gets a structured failure result and the loop continues,
 	// refreshing the stall clock, to the terminal turn/completed.
-	c, stdin := newTurnLoopClient([]string{
+	c, stdin := newTurnLoopClient(t, []string{
 		`{"id":5,"method":"item/tool/call","params":{"tool":"nope","arguments":{}}}`,
 		`{"method":"turn/completed","params":{}}`,
 	})
@@ -297,7 +299,7 @@ func TestReadTurnMessage_PreReadBudgetExhaustedReturnsStall(t *testing.T) {
 	// directly to pin both the Cause==nil discriminator and the no-read
 	// short-circuit (awaitTurnCompletion resets lastTerminal on entry, so the
 	// branch is unreachable through the full loop).
-	c, _ := newTurnLoopClient([]string{`{"method":"turn/completed","params":{}}`},
+	c, _ := newTurnLoopClient(t, []string{`{"method":"turn/completed","params":{}}`},
 		func(c *appServerClient) { c.stallTimeoutMs = 10 })
 	c.lastTerminal = time.Now().Add(-time.Second) // budget already exhausted
 	msg, raw, stallBudget, err := c.readTurnMessage(context.Background())
@@ -343,10 +345,20 @@ func TestAwaitTurnCompletion_StallTimeoutWhenStreamSilent(t *testing.T) {
 	// surface a *StallError rather than block forever. io.Pipe never delivers a
 	// line, so the per-read stall budget elapses on the first iteration.
 	pr, pw := io.Pipe()
-	t.Cleanup(func() { _ = pw.Close() })
 	sc := bufio.NewScanner(pr)
 	sc.Buffer(make([]byte, 0, appServerScannerInitialBuf), maxAppServerLineBytes+1)
 	c := &appServerClient{scanner: sc, out: io.Discard, approvalPolicy: "never", stallTimeoutMs: 50}
+	c.startStdoutReader()
+	// The reader parks in scanner.Scan on the silent pipe; the stall fires via the
+	// consumer's per-read context deadline, not the reader. Close the pipe first so
+	// the parked reader observes EOF, then join it (it cannot reach EOF on its own
+	// here, so the generic drain helper would deadlock).
+	t.Cleanup(func() {
+		_ = pw.Close()
+		close(c.readDone)
+		for range c.readCh { //nolint:revive // drain-to-close joins the reader
+		}
+	})
 	err := c.awaitTurnCompletion(context.Background())
 	if !IsStall(err) {
 		t.Fatalf("awaitTurnCompletion() = %v; want *StallError when the stream goes silent", err)

--- a/internal/runner/codex_app_server_turn_test.go
+++ b/internal/runner/codex_app_server_turn_test.go
@@ -350,12 +350,11 @@ func TestAwaitTurnCompletion_StallTimeoutWhenStreamSilent(t *testing.T) {
 	c := &appServerClient{scanner: sc, out: io.Discard, approvalPolicy: "never", stallTimeoutMs: 50}
 	c.startStdoutReader()
 	// The reader parks in scanner.Scan on the silent pipe; the stall fires via the
-	// consumer's per-read context deadline, not the reader. Close the pipe first so
-	// the parked reader observes EOF, then join it (it cannot reach EOF on its own
-	// here, so the generic drain helper would deadlock).
+	// consumer's per-read context deadline, not the reader. Close the pipe so the
+	// parked reader observes EOF (it cannot reach EOF on its own here), then drain
+	// readCh to join it.
 	t.Cleanup(func() {
 		_ = pw.Close()
-		close(c.readDone)
 		for range c.readCh { //nolint:revive // drain-to-close joins the reader
 		}
 	})

--- a/scripts/file_size_budget_test.go
+++ b/scripts/file_size_budget_test.go
@@ -20,9 +20,15 @@ var oversizedProductionGoFileBaseline = map[string]int{
 	// operator-terminal-stop latch cap. Per #667 (and the #661 burn-down note it
 	// cites), this cap must land *before* #661 decomposes state.go by
 	// responsibility, which then drops it well under budget and removes this baseline.
-	"internal/orchestrator/state.go":      1062,
-	"cmd/tui/main.go":                     904,
-	"internal/runner/codex_app_server.go": 840,
+	"internal/orchestrator/state.go": 1062,
+	"cmd/tui/main.go":                904,
+	// codex_app_server.go's baseline rose from 840 under #666, which replaces the
+	// per-read goroutine with a single long-lived stdout reader (the reader
+	// lifecycle the #661 burn-down comment flags as this file's priority split).
+	// #661 then decomposes the file by responsibility, dropping it under budget
+	// and removing this baseline; the #666 reader tests are that split's
+	// characterization harness.
+	"internal/runner/codex_app_server.go": 906,
 }
 
 func TestProductionGoFilesStayWithinSizeBudget(t *testing.T) {

--- a/scripts/file_size_budget_test.go
+++ b/scripts/file_size_budget_test.go
@@ -28,7 +28,7 @@ var oversizedProductionGoFileBaseline = map[string]int{
 	// #661 then decomposes the file by responsibility, dropping it under budget
 	// and removing this baseline; the #666 reader tests are that split's
 	// characterization harness.
-	"internal/runner/codex_app_server.go": 906,
+	"internal/runner/codex_app_server.go": 907,
 }
 
 func TestProductionGoFilesStayWithinSizeBudget(t *testing.T) {


### PR DESCRIPTION
Closes #666.

## Problem

`readLine` spawned a **new goroutine per read** that blocked in `scanner.Scan()`. When the caller returned first (context cancellation or the read timeout via `readLineOnce`), that goroutine stayed parked in `Scan()` until stdout later produced a line or the process exited — the goroutine-lifetime hazard AGENTS.md cross-cutting-checklist item 2 and the [Go Code Review Comments "Goroutine Lifetimes"](https://go.dev/wiki/CodeReviewComments) guidance warn about.

## Fix — one long-lived reader per app-server process

Grounded in the official [go.dev/blog/pipelines](https://go.dev/blog/pipelines) source-stage pattern:

- **`startStdoutReader`** owns the `bufio.Scanner` exclusively (Scanner is not safe for concurrent use), continuously scans, and hands each line to the request/response consumer over `readCh`. On the send it selects `case <-readDone` so a reader whose consumer has moved on exits instead of *"block[ing] indefinitely ... a resource leak"* (the blog's `done` channel).
- On a terminal scan it publishes a **sticky `readErr`** (`io.EOF` on a clean end — `Scanner.Err` is nil on `io.EOF` per the bufio docs — or the wrapped `bufio.ErrTooLong`) and `defer close(readCh)`. The close is the **happens-before edge** that lets the consumer read `readErr` race-free.
- **`readLineOnce`** selects on context / per-read timeout / `readCh`; a closed channel surfaces the sticky error. The reader's read-side exit comes from the process closing stdout (`os/exec`: `Cmd.Wait` closes the pipe), and `RunCodexAppServer` **joins** the reader by draining `readCh` after `cmd.Wait` so no goroutine outlives the call.
- The reader is **panic-recovered** (`recoverReaderPanic` publishes `readErr` + logs — not swallowed).

Transcript writing stays on the consumer side (`readProtocolMessage`), so its behavior is unchanged.

## SPEC alignment

Pure goroutine-lifecycle refactor of an `internal/runner` downstream-protocol path; no new config key/phase, no SPEC-gated config/orchestrator/worker surface, no `DEVIATIONS.md` change.

- [x] No new top-level key/phase that the SPEC config schema or `openai/symphony` Elixir reference defines is introduced.
- [ ] A new SPEC-surface behavior is justified by an Elixir reference citation in this body.
- [ ] The SPEC-relevant change is tracked by a DEVIATIONS.md row.

## Size gate

`within budget` — production delta is small. `codex_app_server.go`'s file-size baseline rises **840 → 906**: this is the reader-lifecycle split the #661 burn-down comment flags as this file's priority, and #661 decomposes the file from here (the new reader tests are that split's characterization harness).

## Tests

`codex_app_server_reader_test.go` (new) drives the reader directly over an `io.Pipe`: per-read timeout while parked, context cancellation while parked, stream-EOF, line-delivery-then-EOF, and a shutdown-join **leak assertion** (2s guard). The existing oversized-line and turn-loop tests are retained; the shared `newTurnLoopClient` helper now starts and joins the reader (clean goroutine lifetimes in tests too).

Mutation-verified against the committed artifact: dropping `close(readCh)` (leak test), `ctx.Done` returning nil (cancel test), and removing the `ErrTooLong` wrap (oversized test) each fail a specific assertion. `go test -race` clean.

## Review status

- Local Claude `code-reviewer` — no findings; verified race-freedom (happens-before via channel close), no shutdown deadlock/leak across all three reader states, behavior preservation (DeadlineExceeded preference, ErrTooLong, transcript), and test non-flakiness (50× `-race` stress).
- Codex local review hit a sandbox restriction this round; `@codex review` on origin is skipped (origin quota unavailable).

Local CI gate green: `gofmt`, `go vet`, `go mod tidy` clean, `golangci-lint` (0 issues, no funlen/gocognit regression), file-size budget, `go test -race ./internal/runner/... ./internal/worker/... ./cmd/worker/...`, build.

## Update — review findings resolved (commit 79c014c)

The local **Codex** review found a **HIGH latent deadlock** the first commit (and the pre-PR code) shared: `RunCodexAppServer` drained `readCh` *after* `cmd.Wait`. After `run()` returns, the reader parks on the unbuffered `readCh` send and stops draining stdout; if the child emits more output the pipe fills, the child blocks on write and never exits, so `cmd.Wait` never returns and the drain is never reached.

- **Fixed**: drain `readCh` to EOF **before** `cmd.Wait` (the `os/exec` StdoutPipe idiom). The reader keeps the pipe flowing so the child can exit; `Wait` then returns immediately. This makes the consumer the sole drain authority, so the `done` channel (`readDone`) is removed — simpler, and its premature close would have re-stalled stdout.
- **silent-failure-hunter (MEDIUM)**: `recoverReaderPanic` now logs `debug.Stack()` and preserves an `error` panic value with `%w`, matching the orchestrator `recoverPanicValue` convention.
- **pr-test-analyzer**: added a held-line-delivered-after-timeout test (no loss/reorder) and a panic-recovery test (surfaces `readErr`, no hang). Both mutation-verified.

The deadlock fix aligns with the `os/exec` doc and is exercised by the subprocess e2e tests through the production drain under `-race`; a pure unit repro would need a flooding-subprocess harness. `go test -race` clean across runner/worker/cmd-worker.