### PR TITLE
docs: capture the subprocess pipe-drain deadlock as an earned rule (#666)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,13 +225,24 @@ specific observed failure per the "Earned rules" principle.
    - `Process.cancel_timer` is mandatory before reassigning a timer
      → store the `*time.Timer` on state and `Stop()` it before
      replacing.
+   - Elixir's `Port` drains a subprocess's stdout/stderr for you → a
+     Go `exec.Cmd` owner must drain each pipe to EOF *before*
+     `cmd.Wait`. `cmd.Wait` closing the pipe is **not** draining: a
+     child blocked writing to a full OS pipe never exits, so `Wait`
+     never returns and a post-`Wait` drain is never reached. The
+     goroutine that owns the pipe must keep reading until EOF, and the
+     shutdown path must drain (consume the channel) before `Wait`.
 
    A 1:1 port from Elixir without these compensations is a latent
    stuck-state bug. **Earned by:** PR #287 retry-fire fetch had no
    timeout (upstream relied on GenServer's implicit deadline), so a
    tracker client that ignored `ctx` could orphan a claim forever;
    PR #304 had to retrofit `recoverPanic` across actor + timer
-   goroutines after a panic in one path crashed the whole worker.
+   goroutines after a panic in one path crashed the whole worker; and
+   #666/PR #688 drained the codex app-server stdout reader's channel
+   *after* `cmd.Wait` — a latent deadlock whenever the child emits
+   output after the consumer stops reading, fixed by draining to EOF
+   before `Wait` (the `os/exec` `StdoutPipe` idiom).
 
 3. **Treat generated downstream protocol schemas as separate authorities.**
    Symphony's Elixir config schema is the reference for workflow/config shape,
@@ -266,9 +277,14 @@ specific observed failure per the "Earned rules" principle.
    tends to miss. Trigger it on the head commit before marking the
    PR ready, and for each finding either fix it or document in the
    PR body why it's deferred. Treat the agent's first draft as a
-   candidate, not a delivery. **Earned by:** PR #287's HIGH +
-   MEDIUM findings were both surfaced by `@codex review` after
-   submit; both could have been caught one round earlier.
+   candidate, not a delivery. An independent adversarial pass catches
+   what thorough first-party review does not — run it even when your
+   own review found nothing. **Earned by:** PR #287's HIGH + MEDIUM
+   findings were both surfaced by `@codex review` after submit; both
+   could have been caught one round earlier; and #666/PR #688's HIGH
+   stdout-reader deadlock (see checklist item 2) was surfaced by a
+   Codex review *after* an exhaustive first-party review found nothing
+   — the deadlock would otherwise have shipped.
 
 Rules for agents working on this repo:
 


### PR DESCRIPTION
Closes #690.

Settles the engineering lessons from #666/PR #688 into `AGENTS.md`, per the **Earned rules** principle (document a *new*, recurrence-prone failure class; reinforce — don't duplicate — what's already covered).

## What changed

**Cross-cutting checklist item 2** ("Replicate Elixir's implicit runtime guarantees explicitly in Go") gains a fourth BEAM-guarantee bullet:

> Elixir's `Port` drains a subprocess's stdout/stderr for you → a Go `exec.Cmd` owner must drain each pipe to EOF *before* `cmd.Wait`. `cmd.Wait` closing the pipe is **not** draining: a child blocked writing to a full OS pipe never exits, so `Wait` never returns and a post-`Wait` drain is never reached.

…with #666/PR #688 added to that item's **Earned by** (the codex app-server reader drained `readCh` after `cmd.Wait` — a latent deadlock when the child emits output after the consumer stops reading).

**Item 4** ("Run an adversarial pass before asking a human to look") records that #666/PR #688's HIGH deadlock was surfaced by an independent **Codex review after an exhaustive first-party review found nothing** — reinforcing that independent adversarial review catches what thorough first-party review misses.

## Why these two and not more

- The **os/exec pipe-drain deadlock** is a genuinely new, non-obvious, recurrence-prone class (any future subprocess-owning path can repeat it) → earns a rule.
- The **@codex-review-every-push** lesson already lives in item 4 → reinforced with a fresh example, not duplicated.
- The **mutation-testing `git checkout` trap** already lives in clean-code rule 6 (earned by #469/#483) → no new doc.

## SPEC alignment

Docs-only change to the engineering-rules file; no code, no new config key/phase, no SPEC-gated path, no `DEVIATIONS.md` change.

- [x] No new top-level key/phase that the SPEC config schema or `openai/symphony` Elixir reference defines is introduced.
- [ ] A new SPEC-surface behavior is justified by an Elixir reference citation in this body.
- [ ] The SPEC-relevant change is tracked by a DEVIATIONS.md row.

## Size gate

`within budget` — docs-only, two small additions to `AGENTS.md`.