### PR TITLE
security: contain git mirror paths against clone URL traversal (#665)

### DIFF
--- a/internal/workspace/mirror.go
+++ b/internal/workspace/mirror.go
@@ -78,23 +78,76 @@ func MirrorRoot(override string) string {
 
 // mirrorPathFor maps a clone URL to a stable on-disk location under root.
 // We do not need cryptographic uniqueness, just a deterministic, filesystem-
-// safe path keyed by host + path so two repos never collide. The trailing
-// ".git" is preserved to keep the layout recognisable when inspected by hand.
+// safe path keyed by the sanitized host + path. De-confliction is best-effort
+// and matches how sanitizeComponent is used for every other derived workspace
+// path: the shared sanitizer rewrites unsafe characters and caps each segment,
+// so two repos whose sanitized, length-capped segments coincide would share a
+// mirror directory. That is an accepted trade-off because clone_url is
+// operator-controlled config and real forge host/owner/repo names stay well
+// under the cap — not a "never collides" guarantee. The trailing ".git" is
+// preserved to keep the layout recognisable when inspected by hand.
 func mirrorPathFor(root, cloneURL string) string {
 	host, repoPath := splitCloneURL(cloneURL)
-	host = sanitizeMirrorComponent(host)
+	host = sanitizeComponent(host)
 	repoPath = strings.TrimSuffix(repoPath, ".git")
 	// Preserve owner/name structure so multiple repos under the same owner
-	// share a parent directory, which makes manual cleanup easier.
+	// share a parent directory, which makes manual cleanup easier. Each segment
+	// goes through the shared workspace component sanitizer, which maps
+	// ""/"."/".." to "unknown" and rewrites separators, backslashes, and control
+	// characters — so no segment can smuggle a path-traversal hop into the
+	// joined path (#665).
 	parts := strings.Split(repoPath, "/")
 	for i, p := range parts {
-		parts[i] = sanitizeMirrorComponent(p)
+		parts[i] = sanitizeComponent(p)
 	}
+	// strings.Split never yields an empty slice and sanitizeComponent maps the
+	// empty string to "unknown", so repoPath is always non-empty here; no
+	// empty-string fallback is needed (an empty clone URL is handled upstream in
+	// splitCloneURL, which returns "repo").
 	repoPath = strings.Join(parts, string(filepath.Separator))
-	if repoPath == "" {
-		repoPath = "repo"
+	candidate := filepath.Join(root, host, repoPath+".git")
+	return mirrorPathUnderRoot(root, candidate, cloneURL)
+}
+
+// mirrorPathUnderRoot returns candidate when it is contained under root, and a
+// deterministic, URL-keyed fallback path under root otherwise. The per-segment
+// sanitization in mirrorPathFor already neutralizes "."/".."/separators, so a
+// sanitized candidate cannot climb above root and this guard is a
+// defense-in-depth backstop: it guarantees mirror writes stay under the
+// configured root regardless of input shape, even if the sanitizer is later
+// weakened or splitCloneURL grows a new parsing branch (#665). clone_url is
+// operator-controlled config rather than an attacker channel, so this is
+// hardening, not a fix for an externally-triggerable escape.
+func mirrorPathUnderRoot(root, candidate, cloneURL string) string {
+	if pathContainedUnder(root, candidate) {
+		return candidate
 	}
-	return filepath.Join(root, host, repoPath+".git")
+	return filepath.Join(root, sanitizeComponent(cloneURL)+".git")
+}
+
+// pathContainedUnder reports whether path resolves to a location strictly below
+// root. It is a purely lexical check (filepath.Abs + filepath.Rel) because the
+// mirror directory does not exist yet at path-derivation time, so symlink
+// resolution is neither possible nor relevant here — the threat is a "../" hop
+// in the derived path, not a symlinked root. The root itself is not "contained"
+// (rel == "."): a mirror path is always a child, never the root directory.
+func pathContainedUnder(root, path string) bool {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return !filepath.IsAbs(rel)
 }
 
 // splitCloneURL extracts a host and path component from either an https://
@@ -123,16 +176,7 @@ func splitCloneURL(cloneURL string) (host, path string) {
 			return rest[:colon], rest[colon+1:]
 		}
 	}
-	return "unknown", sanitizeMirrorComponent(cloneURL)
-}
-
-func sanitizeMirrorComponent(s string) string {
-	s = strings.ReplaceAll(s, "/", "_")
-	s = strings.ReplaceAll(s, " ", "_")
-	if s == "" {
-		return "unknown"
-	}
-	return s
+	return "unknown", sanitizeComponent(cloneURL)
 }
 
 // EnsureMirror returns the local path to a bare mirror clone of cloneURL,

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -1233,3 +1233,150 @@ func TestMirrorPathFor_StableAcrossSchemes(t *testing.T) {
 		}
 	}
 }
+
+// TestMirrorPathFor_ContainsHostileCloneURLs is the #665 regression: a
+// malformed clone URL path (path-traversal hops, backslashes, empty/garbage
+// input) must never let mirrorPathFor escape the mirror root. clone_url is
+// operator-controlled config, so this is defense-in-depth containment rather
+// than an externally-triggerable escape — but the derived filesystem path must
+// stay under root regardless of input shape.
+func TestMirrorPathFor_ContainsHostileCloneURLs(t *testing.T) {
+	const root = "/cache"
+	// want is the exact structured path each hostile URL maps to. Asserting the
+	// precise path (not merely "is it contained") pins down layer 1: every "."
+	// or ".." segment becomes "unknown" and the readable host/owner/repo layout
+	// survives, so a hostile URL gets a sane structured path rather than the
+	// containment backstop's flat fallback. Reverting the per-segment sanitizer
+	// would route these through the fallback and fail the exact match.
+	cases := []struct {
+		in   string
+		want string // forward-slash form; converted per-OS below
+	}{
+		{"https://host/../../evil.git", "/cache/host/unknown/unknown/evil.git"},
+		{"git@host:../../evil.git", "/cache/host/unknown/unknown/evil.git"},
+		{"https://host/a/../evil.git", "/cache/host/a/unknown/evil.git"},
+		{"https://../owner/repo.git", "/cache/unknown/owner/repo.git"},
+		{`..\evil.git`, "/cache/unknown/.._evil.git"},
+		{`https://host/..\..\evil.git`, "/cache/host/.._.._evil.git"},
+		{"https://host/../../../../../../etc/passwd", "/cache/host/unknown/unknown/unknown/unknown/unknown/unknown/etc/passwd.git"},
+		{"", "/cache/unknown/repo.git"},
+		{"   ", "/cache/unknown/repo.git"},
+		{"not a url", "/cache/unknown/not_a_url.git"},
+	}
+	for _, tc := range cases {
+		want := filepath.FromSlash(tc.want)
+		got := mirrorPathFor(root, tc.in)
+		if got != want {
+			t.Errorf("mirrorPathFor(%q) = %q; want %q", tc.in, got, want)
+		}
+		// Independently of the exact-path assertion above, the result must stay
+		// strictly under root for every input shape (#665).
+		assertMirrorUnderRoot(t, root, tc.in, got)
+		// Derivation is deterministic: the same clone URL maps to the same path.
+		if again := mirrorPathFor(root, tc.in); again != got {
+			t.Errorf("mirrorPathFor(%q) not deterministic: %q then %q", tc.in, got, again)
+		}
+	}
+}
+
+// assertMirrorUnderRoot fails the test unless got resolves to a location
+// strictly below root. It recomputes containment independently of the
+// production helper (filepath.Rel on absolute paths) so a bug in
+// pathContainedUnder cannot mask an actual escape, and it uses Rel rather than
+// a string prefix so a sibling like "<root>-evil" is correctly rejected.
+func assertMirrorUnderRoot(t *testing.T, root, in, got string) {
+	t.Helper()
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("Abs(%q): %v", root, err)
+	}
+	gotAbs, err := filepath.Abs(got)
+	if err != nil {
+		t.Fatalf("Abs(%q): %v", got, err)
+	}
+	rel, err := filepath.Rel(rootAbs, gotAbs)
+	if err != nil {
+		t.Fatalf("mirrorPathFor(%q) = %q; Rel(%q, %q): %v", in, got, rootAbs, gotAbs, err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		t.Errorf("mirrorPathFor(%q) = %q; want a path strictly under root %q (rel = %q)", in, got, rootAbs, rel)
+	}
+}
+
+func TestPathContainedUnder(t *testing.T) {
+	root := filepath.FromSlash("/cache/mirrors")
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"direct child", filepath.Join(root, "host", "repo.git"), true},
+		{"deep child", filepath.Join(root, "a", "b", "c.git"), true},
+		{"root itself", root, false},
+		{"parent escape", filepath.Join(root, "..", "evil.git"), false},
+		{"grandparent escape", filepath.Join(root, "..", "..", "evil.git"), false},
+		{"sibling sharing prefix", root + "-evil", false},
+		{"unrelated absolute path", filepath.FromSlash("/etc/passwd"), false},
+	}
+	for _, tc := range cases {
+		if got := pathContainedUnder(root, tc.path); got != tc.want {
+			t.Errorf("pathContainedUnder(%q, %q) [%s] = %v; want %v", root, tc.path, tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestMirrorPathUnderRoot_FallsBackOnEscape drives the containment backstop
+// directly. The per-segment sanitizer in mirrorPathFor means a real clone URL
+// never produces an escaping candidate, so this is the only path that exercises
+// the fallback branch — without it, that branch would be an untested placebo.
+func TestMirrorPathUnderRoot_FallsBackOnEscape(t *testing.T) {
+	root := t.TempDir()
+
+	good := filepath.Join(root, "host", "owner", "repo.git")
+	if got := mirrorPathUnderRoot(root, good, "https://host/owner/repo.git"); got != good {
+		t.Errorf("mirrorPathUnderRoot(root, contained) = %q; want %q unchanged", got, good)
+	}
+
+	escape := filepath.Join(root, "..", "..", "evil.git")
+	url := "https://host/../../evil.git"
+	got := mirrorPathUnderRoot(root, escape, url)
+	if !pathContainedUnder(root, got) {
+		t.Errorf("mirrorPathUnderRoot(root, escaping %q) = %q; want a path under root %q", escape, got, root)
+	}
+	if again := mirrorPathUnderRoot(root, escape, url); again != got {
+		t.Errorf("mirrorPathUnderRoot fallback not deterministic for %q: %q then %q", url, got, again)
+	}
+	if other := mirrorPathUnderRoot(root, escape, "https://host/../../other.git"); other == got {
+		t.Errorf("mirrorPathUnderRoot collapsed distinct clone URLs onto the same fallback %q", got)
+	}
+}
+
+// TestMirrorPathFor_NormalEdgeComponents pins intentional, non-hostile
+// sanitization behaviour that the #665 switch to the shared sanitizeComponent
+// changed or exposed: a host with an explicit port has its ":" rewritten (the
+// old mirror sanitizer left it intact — the new behaviour is also Windows-safe);
+// dots/uppercase in owner/repo names are preserved (no behaviour change); and an
+// empty path component maps to "unknown" rather than relying on the (now
+// removed) empty-repoPath fallback branch.
+func TestMirrorPathFor_NormalEdgeComponents(t *testing.T) {
+	const root = "/cache"
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Host with an explicit port: ":" is now sanitized to "_".
+		{"https://gitea.example.com:8443/acme/demo.git", "/cache/gitea.example.com_8443/acme/demo.git"},
+		// Dots and uppercase in owner/repo are valid path chars, kept verbatim.
+		{"https://github.com/My.Org/My.Repo.git", "/cache/github.com/My.Org/My.Repo.git"},
+		// Empty trailing path component -> "unknown" (exercises the path the
+		// removed `if repoPath == ""` branch used to guard).
+		{"https://host/owner/.git", "/cache/host/owner/unknown.git"},
+		{"https://host/.git", "/cache/host/unknown.git"},
+	}
+	for _, tc := range cases {
+		want := filepath.FromSlash(tc.want)
+		if got := mirrorPathFor(root, tc.in); got != want {
+			t.Errorf("mirrorPathFor(%q) = %q; want %q", tc.in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #665

## Summary
- `mirrorPathFor` mapped a clone URL into a local bare-mirror path with `sanitizeMirrorComponent`, which only rewrote `/` and spaces — so `.`/`..`/`\`/control chars survived and `filepath.Join(root, host, repoPath+".git")` could normalize a path *outside* the mirror root (e.g. `https://host/../../evil.git`). `clone_url` is operator-controlled config, so this is **defense-in-depth containment hardening** (matching #595's `clone_url` masking posture), not an externally-triggerable escape.
- **Layer 1 — stronger sanitizer:** replace the weak duplicate `sanitizeMirrorComponent` with the existing shared `sanitizeComponent` (maps `""`/`"."`/`".."`→`"unknown"`, rewrites every char outside `[A-Za-z0-9._-]`). Removes a duplicate sanitizer (one source of truth) and neutralizes traversal at the segment level. Valid URLs are unaffected — `gitea.example.com`/`acme`/`demo` sanitize to themselves, so the host/owner/repo layout stays stable and readable.
- **Layer 2 — containment backstop:** `pathContainedUnder` (`filepath.Abs`+`filepath.Rel`, **not** a string prefix, so a `<root>-evil` sibling is correctly rejected) routes any escaping candidate to a deterministic URL-keyed fallback under root — guaranteeing mirror writes stay under the configured root regardless of input shape, even if sanitization is later weakened or `splitCloneURL` grows a new parsing branch.

## Testing notes
- Regression tests for every acceptance-criteria URL (https/scp `..`, mid-path `..`, authority `..`, windows `..\`, deep `../../etc/passwd`, empty/whitespace/garbage), asserting **exact structured paths** + an independent `filepath.Rel` containment cross-check. Exact-path assertions matter: with the backstop present, a containment-only test would still pass if layer-1 sanitization were reverted (the backstop silently catches it). Pinning the structured path makes layer 1 mutation-detectable.
- Both layers were **mutation-verified against the committed artifact**: reverting per-segment sanitization fails the exact-path test; making the backstop a no-op fails the fallback test.

## Adversarial review
Ran a 4-lens adversarial-review workflow (security / spec-alignment / go-correctness / test-placebo) with per-finding verification — substituting for origin `@codex review`, currently unavailable. 9 findings, **2 confirmed (both LOW)**, folded into this commit:
- **Removed** the now-unreachable `if repoPath == ""` branch (`sanitizeComponent` maps `""`→`"unknown"`, so `repoPath` is always non-empty; empty clone URLs are handled in `splitCloneURL`). Clean-code rule 5.
- **Corrected the `mirrorPathFor` doc comment**: the 120-rune-capped sanitizer is *best-effort* de-confliction (consistent with every other `SanitizeComponent`-derived path in the repo), not a "two repos never collide" guarantee. The only residual collision is two distinct **>120-char** segments sharing a mirror dir — cache confusion, **not** a traversal escape, unreachable with real forge name limits (≤100 chars), and the same trade-off the repo already accepts for issue-id workspace paths (documented in `workspace-cache.md`). A hash-disambiguator only for mirrors would be unearned scaffolding inconsistent with repo norms, so it was deliberately not added.
- **Pinned intentional non-hostile behavior** with a new test: `host:port`→`host_port` (colon sanitized — Windows-safe), dots/uppercase in owner/repo preserved, empty path components → `unknown`.

The verifier independently confirmed containment holds for every hostile input tried (percent-encoded `%2e%2e`, `..%2f`, embedded `/etc/passwd`, UNC `\\server\share`, NUL/control bytes, `file://`, deep `../../`, relative roots); the URL-keyed fallback can itself never escape (separators are stripped into a single child segment).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Internal workspace path-derivation hardening: no SPEC config key, no worker/orchestrator phase, no tracker-write / post-push gate. Stays strictly inside the Symphony scheduler/runner boundary; `internal/workspace/mirror.go` is not a SPEC-sensitive path.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file, ~24 net production LOC (test files excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [ ] additional validation noted below when needed
