### PR TITLE
reliability: bound dynamic-tool HTTP calls and enforce Gitea response cap (#668)

### DIFF
--- a/internal/runner/dynamic_tool_io_test.go
+++ b/internal/runner/dynamic_tool_io_test.go
@@ -1,0 +1,314 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// decodeToolResult unwraps a dynamic-tool result envelope into its success flag
+// and inner output payload so tests can assert on the agent-visible body.
+func decodeToolResult(t *testing.T, result string) (success bool, output string) {
+	t.Helper()
+	var payload struct {
+		Success bool   `json:"success"`
+		Output  string `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("decode tool result %q: %v", result, err)
+	}
+	return payload.Success, payload.Output
+}
+
+// hangingServer never responds, so the only thing that can end a request is the
+// client's own per-request deadline — which is exactly what the timeout tests
+// assert. The handler parks on a stop channel (not r.Context().Done()) because
+// server-side request-context cancellation does not reliably propagate on a
+// client POST disconnect; closing stop before srv.Close() guarantees Cleanup
+// cannot deadlock on a parked handler.
+func hangingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	stop := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-stop
+	}))
+	t.Cleanup(func() {
+		close(stop)
+		srv.Close()
+	})
+	return srv
+}
+
+func TestLinearGraphQLRequestTimesOut(t *testing.T) {
+	srv := hangingServer(t)
+	proxy := linearGraphQLProxy{
+		apiKey:      "secret-linear-key",
+		baseURL:     srv.URL,
+		http:        srv.Client(),
+		httpTimeout: 20 * time.Millisecond,
+	}
+
+	start := time.Now()
+	result, err := proxy.call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("call(hung server) returned Go error: %v", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("call(hung server) took %v; want it bounded by the 20ms per-request timeout", elapsed)
+	}
+	success, output := decodeToolResult(t, result)
+	if success {
+		t.Fatalf("call(hung server) success = true; want a transport-timeout failure (output=%q)", output)
+	}
+	if !strings.Contains(output, "transport") {
+		t.Errorf("call(hung server) output = %q; want it to report the transport failure", output)
+	}
+}
+
+func TestGiteaIssueLabelsRequestTimesOut(t *testing.T) {
+	srv := hangingServer(t)
+	proxy := giteaIssueLabelsProxy{
+		token:       "secret-gitea-token",
+		baseURL:     srv.URL,
+		owner:       "owner",
+		repo:        "repo",
+		http:        srv.Client(),
+		httpTimeout: 20 * time.Millisecond,
+	}
+
+	start := time.Now()
+	result, err := proxy.call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/todo"}})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("call(hung server) returned Go error: %v", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("call(hung server) took %v; want it bounded by the 20ms per-request timeout", elapsed)
+	}
+	success, output := decodeToolResult(t, result)
+	if success {
+		t.Fatalf("call(hung server) success = true; want a transport-timeout failure (output=%q)", output)
+	}
+	if !strings.Contains(output, "transport") {
+		t.Errorf("call(hung server) output = %q; want it to report the transport failure", output)
+	}
+}
+
+func TestGiteaIssueLabelsRejectsOversizedResponse(t *testing.T) {
+	oversized := strings.Repeat("a", maxLinearGraphQLResponseBytes+10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, oversized)
+	}))
+	defer srv.Close()
+
+	proxy := giteaIssueLabelsProxy{token: "token", baseURL: srv.URL, owner: "owner", repo: "repo", http: srv.Client()}
+	result, err := proxy.call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/todo"}})
+	if err != nil {
+		t.Fatalf("call(oversized response) returned Go error: %v", err)
+	}
+	success, output := decodeToolResult(t, result)
+	if success {
+		t.Fatalf("call(oversized response) success = true; want a size-cap failure (output=%q)", output)
+	}
+	if !strings.Contains(output, "exceeded maximum size") {
+		t.Errorf("call(oversized response) output = %q; want it to report the size-cap failure", output)
+	}
+	if strings.Contains(output, "aaaa") {
+		t.Errorf("call(oversized response) leaked the oversized body into the tool result")
+	}
+}
+
+func TestGiteaIssueLabelsTruncatesAndRedactsErrorBody(t *testing.T) {
+	const token = "super-secret-gitea-token"
+	filler := strings.Repeat("x", maxToolErrorBodyRunes+1000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "gitea error echoing token "+token+" then "+filler)
+	}))
+	defer srv.Close()
+
+	proxy := giteaIssueLabelsProxy{token: token, baseURL: srv.URL, owner: "owner", repo: "repo", http: srv.Client()}
+	result, err := proxy.call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/todo"}})
+	if err != nil {
+		t.Fatalf("call(500) returned Go error: %v", err)
+	}
+	if strings.Contains(result, token) {
+		t.Fatalf("call(500) leaked the gitea token into the tool result")
+	}
+	success, output := decodeToolResult(t, result)
+	if success {
+		t.Fatalf("call(500) success = true; want a failure")
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Errorf("call(500) output did not redact the token: %q", clip(output))
+	}
+	if !strings.Contains(output, "[truncated]") {
+		t.Errorf("call(500) output was not truncated (len=%d): %q", len(output), clip(output))
+	}
+}
+
+func TestLinearGraphQLTruncatesAndRedactsErrorBody(t *testing.T) {
+	const token = "super-secret-linear-key"
+	filler := strings.Repeat("x", maxToolErrorBodyRunes+1000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, "upstream error token="+token+" then "+filler)
+	}))
+	defer srv.Close()
+
+	proxy := linearGraphQLProxy{apiKey: token, baseURL: srv.URL, http: srv.Client()}
+	result, err := proxy.call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	if err != nil {
+		t.Fatalf("call(502) returned Go error: %v", err)
+	}
+	if strings.Contains(result, token) {
+		t.Fatalf("call(502) leaked the linear token into the tool result")
+	}
+	success, output := decodeToolResult(t, result)
+	if success {
+		t.Fatalf("call(502) success = true; want a failure")
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Errorf("call(502) output did not redact the token: %q", clip(output))
+	}
+	if !strings.Contains(output, "[truncated]") {
+		t.Errorf("call(502) output was not truncated (len=%d): %q", len(output), clip(output))
+	}
+}
+
+func TestSanitizeToolErrorBody(t *testing.T) {
+	// Every occurrence of a secret is replaced; the secret never survives.
+	if got := sanitizeToolErrorBody([]byte("a SECRET b SECRET c"), "SECRET"); strings.Contains(got, "SECRET") || !strings.Contains(got, "[REDACTED]") {
+		t.Errorf("sanitizeToolErrorBody(redaction) = %q; want SECRET replaced by [REDACTED]", got)
+	}
+	// Empty/whitespace secrets are ignored — no spurious substitution.
+	if got := sanitizeToolErrorBody([]byte("hello world"), "", "   "); got != "hello world" {
+		t.Errorf("sanitizeToolErrorBody(empty secrets) = %q; want %q", got, "hello world")
+	}
+	// Ordering is load-bearing: a secret straddling the truncation boundary must
+	// be redacted in full BEFORE truncation. A truncate-first implementation
+	// would retain the secret's head fragment ("SEC") in the kept prefix;
+	// redact-first leaves only "[RE…". The body also exceeds the cap, so the
+	// truncation marker is appended.
+	straddle := strings.Repeat("y", maxToolErrorBodyRunes-3) + "SECRET" + strings.Repeat("z", 100)
+	got := sanitizeToolErrorBody([]byte(straddle), "SECRET")
+	if strings.Contains(got, "SEC") {
+		t.Errorf("sanitizeToolErrorBody leaked a secret fragment across the truncation boundary (truncate-before-redact?): tail=%q", got[max(0, len(got)-40):])
+	}
+	if !strings.HasSuffix(got, "…[truncated]") {
+		t.Errorf("sanitizeToolErrorBody did not append the truncation marker: tail=%q", got[max(0, len(got)-20):])
+	}
+	// A short body is returned verbatim (no marker).
+	if got := sanitizeToolErrorBody([]byte("brief"), "nope"); got != "brief" {
+		t.Errorf("sanitizeToolErrorBody(short) = %q; want %q", got, "brief")
+	}
+}
+
+// The acceptance criterion is "no tracker token appears in ANY tool result",
+// so redaction must cover the success and unparseable-2xx paths too, not only
+// non-2xx — a fronting proxy can echo the Authorization value at any status.
+
+func TestLinearGraphQLRedactsTokenInSuccessBody(t *testing.T) {
+	const token = "super-secret-linear-key"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// A valid-JSON 200 body that echoes the request's Authorization value.
+		_, _ = io.WriteString(w, `{"data":{"viewer":{"id":"`+token+`"}}}`)
+	}))
+	defer srv.Close()
+
+	proxy := linearGraphQLProxy{apiKey: token, baseURL: srv.URL, http: srv.Client()}
+	result, err := proxy.call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	if err != nil {
+		t.Fatalf("call(success echo) returned Go error: %v", err)
+	}
+	if strings.Contains(result, token) {
+		t.Fatalf("call(success echo) leaked the linear token into the tool result: %q", clip(result))
+	}
+	success, output := decodeToolResult(t, result)
+	if !success {
+		t.Fatalf("call(success echo) success = false; want success (output=%q)", clip(output))
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Errorf("call(success echo) output did not redact the echoed token: %q", clip(output))
+	}
+}
+
+func TestLinearGraphQLRedactsAndTruncatesUnparseableBody(t *testing.T) {
+	const token = "super-secret-linear-key"
+	filler := strings.Repeat("x", maxToolErrorBodyRunes+1000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// 200 OK but NOT valid JSON (e.g. a proxy interstitial) echoing the token.
+		_, _ = io.WriteString(w, "<html>proxy 200 reflecting token "+token+" "+filler+"</html>")
+	}))
+	defer srv.Close()
+
+	proxy := linearGraphQLProxy{apiKey: token, baseURL: srv.URL, http: srv.Client()}
+	result, err := proxy.call(context.Background(), ToolCall{Query: "query { viewer { id } }"})
+	if err != nil {
+		t.Fatalf("call(unparseable 200) returned Go error: %v", err)
+	}
+	if strings.Contains(result, token) {
+		t.Fatalf("call(unparseable 200) leaked the linear token into the tool result: %q", clip(result))
+	}
+	success, output := decodeToolResult(t, result)
+	if success {
+		t.Fatalf("call(unparseable 200) success = true; want a not-valid-JSON failure")
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Errorf("call(unparseable 200) output did not redact the token: %q", clip(output))
+	}
+	if !strings.Contains(output, "[truncated]") {
+		t.Errorf("call(unparseable 200) output was not truncated (len=%d): %q", len(output), clip(output))
+	}
+}
+
+func TestGiteaIssueLabelsRedactsTokenInSuccessBody(t *testing.T) {
+	const token = "super-secret-gitea-token"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":5,"name":"bug"}]`)
+		case http.MethodPost:
+			// 2xx label-add body that also echoes the Authorization token.
+			_, _ = io.WriteString(w, `{"labels":[{"id":1,"name":"aiops/todo"}],"echo":"`+token+`"}`)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	}))
+	defer srv.Close()
+
+	proxy := giteaIssueLabelsProxy{token: token, baseURL: srv.URL, owner: "owner", repo: "repo", http: srv.Client()}
+	result, err := proxy.call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/todo"}})
+	if err != nil {
+		t.Fatalf("call(success echo) returned Go error: %v", err)
+	}
+	if strings.Contains(result, token) {
+		t.Fatalf("call(success echo) leaked the gitea token into the tool result: %q", clip(result))
+	}
+	success, output := decodeToolResult(t, result)
+	if !success {
+		t.Fatalf("call(success echo) success = false; want success (output=%q)", clip(output))
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Errorf("call(success echo) output did not redact the echoed token: %q", clip(output))
+	}
+}
+
+// clip bounds an error-message excerpt so a multi-kilobyte body does not flood
+// test output.
+func clip(s string) string {
+	const n = 200
+	if len(s) > n {
+		return s[:n] + "…"
+	}
+	return s
+}

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -21,6 +23,10 @@ type giteaIssueLabelsProxy struct {
 	owner   string
 	repo    string
 	http    *http.Client
+	// httpTimeout overrides the per-request deadline applied to each Gitea API
+	// round trip. Zero uses defaultDynamicToolHTTPTimeout; tests set a tiny
+	// value to exercise the timeout path.
+	httpTimeout time.Duration
 }
 
 type giteaIssueLabel struct {
@@ -161,7 +167,10 @@ func (p giteaIssueLabelsProxy) addIssueLabels(ctx context.Context, client *http.
 	if failure != "" {
 		return "", failure
 	}
-	result, _ := dynamicToolResult(true, string(respBody))
+	// Redact the token from the 2xx body too: SPEC token isolation (#76/#298)
+	// holds regardless of status, so a Gitea/proxy that echoes the
+	// Authorization value in a success response must not reach the agent.
+	result, _ := dynamicToolResult(true, redactToolSecrets(string(respBody), p.token))
 	return result, ""
 }
 
@@ -198,6 +207,8 @@ func (p giteaIssueLabelsProxy) deleteIssueLabel(ctx context.Context, client *htt
 }
 
 func (p giteaIssueLabelsProxy) doGiteaRequest(ctx context.Context, client *http.Client, method, endpoint string, body []byte) (int, []byte, string) {
+	ctx, cancel := context.WithTimeout(ctx, dynamicToolRequestTimeout(p.httpTimeout))
+	defer cancel()
 	var reader io.Reader
 	if body != nil {
 		reader = bytes.NewReader(body)
@@ -221,21 +232,26 @@ func (p giteaIssueLabelsProxy) doGiteaRequest(ctx context.Context, client *http.
 		return 0, nil, failure
 	}
 	defer func() { _ = resp.Body.Close() }()
-	var respBody bytes.Buffer
-	_, readErr := respBody.ReadFrom(io.LimitReader(resp.Body, maxLinearGraphQLResponseBytes+1))
+	respBody, readErr := readDynamicToolResponseBody(resp.Body)
 	if readErr != nil {
+		if errors.Is(readErr, errDynamicToolResponseTooLarge) {
+			failure, _ := dynamicToolFailure(map[string]any{
+				"error": map[string]any{"message": "Gitea label response exceeded maximum size", "limit": maxLinearGraphQLResponseBytes},
+			})
+			return resp.StatusCode, nil, failure
+		}
 		failure, _ := dynamicToolFailure(map[string]any{
 			"error": map[string]any{"message": "Gitea label response body could not be read", "reason": readErr.Error()},
 		})
-		return resp.StatusCode, respBody.Bytes(), failure
+		return resp.StatusCode, nil, failure
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		failure, _ := dynamicToolFailure(map[string]any{
-			"error": map[string]any{"message": "Gitea label request failed", "status": resp.Status, "body": respBody.String()},
+			"error": map[string]any{"message": "Gitea label request failed", "status": resp.Status, "body": sanitizeToolErrorBody(respBody, p.token)},
 		})
-		return resp.StatusCode, respBody.Bytes(), failure
+		return resp.StatusCode, respBody, failure
 	}
-	return resp.StatusCode, respBody.Bytes(), ""
+	return resp.StatusCode, respBody, ""
 }
 
 func (p giteaIssueLabelsProxy) decodeIssueLabelsFromToolResult(result, source string) ([]giteaIssueLabel, string) {

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -316,12 +317,68 @@ func giteaIssueLabelsInputSchema() map[string]any {
 
 const maxLinearGraphQLResponseBytes = 1 << 20
 
+// defaultDynamicToolHTTPTimeout bounds a single dynamic-tool HTTP round trip
+// (linear_graphql, gitea_issue_labels). The surrounding agent-turn context is
+// far larger, so without a tight per-request deadline a hung tracker endpoint
+// would stall the whole turn — exactly the failure class the repo's "all
+// external I/O is timeout-bounded" rule exists to prevent (#287/#405). A proxy
+// may override via its httpTimeout field; zero means use this default.
+const defaultDynamicToolHTTPTimeout = 30 * time.Second
+
+func dynamicToolRequestTimeout(override time.Duration) time.Duration {
+	if override > 0 {
+		return override
+	}
+	return defaultDynamicToolHTTPTimeout
+}
+
+// maxToolErrorBodyRunes caps how much of a diagnostic response body (a non-2xx
+// status or an unparseable success body) is surfaced in an agent-facing tool
+// result. A valid success body is the agent's requested payload and is returned
+// in full (still bounded by maxLinearGraphQLResponseBytes); a diagnostic body
+// is truncated to keep a large error page from flooding agent context.
+const maxToolErrorBodyRunes = 2048
+
+// redactToolSecrets replaces every occurrence of each non-empty secret with a
+// placeholder. EVERY response body placed in an agent-facing tool result —
+// success, failure, or unparseable — passes through it, so a tracker server or
+// a fronting proxy that echoes the Authorization value cannot leak the
+// credential to the agent, which SPEC token isolation (#76/#298) forbids
+// regardless of HTTP status. Real tracker tokens are long, high-entropy
+// strings, so a match means an actual echo, not legitimate response content.
+func redactToolSecrets(s string, secrets ...string) string {
+	for _, secret := range secrets {
+		if secret = strings.TrimSpace(secret); secret != "" {
+			s = strings.ReplaceAll(s, secret, "[REDACTED]")
+		}
+	}
+	return s
+}
+
+// sanitizeToolErrorBody redacts secrets and then truncates to
+// maxToolErrorBodyRunes. It is for diagnostic bodies (non-2xx or unparseable)
+// that are surfaced only to help the agent understand a failure, so unlike a
+// success body they are bounded to keep a large error page from flooding agent
+// context. Redaction runs before truncation so a token straddling the
+// truncation boundary cannot leave an un-redacted head fragment behind.
+func sanitizeToolErrorBody(body []byte, secrets ...string) string {
+	s := redactToolSecrets(string(body), secrets...)
+	if runes := []rune(s); len(runes) > maxToolErrorBodyRunes {
+		return string(runes[:maxToolErrorBodyRunes]) + "…[truncated]"
+	}
+	return s
+}
+
 const defaultLinearGraphQLEndpoint = tracker.DefaultLinearEndpoint
 
 type linearGraphQLProxy struct {
 	apiKey  string
 	baseURL string
 	http    *http.Client
+	// httpTimeout overrides the per-request deadline applied to each Linear
+	// GraphQL round trip. Zero uses defaultDynamicToolHTTPTimeout; tests set a
+	// tiny value to exercise the timeout path.
+	httpTimeout time.Duration
 	// allowMutations toggles the SPEC §15.5 harness narrowing (#298).
 	// When false (the zero value), the proxy refuses every mutation the
 	// agent submits before any HTTP request is built. Harness-internal
@@ -483,7 +540,10 @@ func (p linearGraphQLProxy) dispatch(ctx context.Context, query string, op linea
 		})
 	}
 
-	req, err := p.linearGraphQLRequest(ctx, body)
+	reqCtx, cancel := context.WithTimeout(ctx, dynamicToolRequestTimeout(p.httpTimeout))
+	defer cancel()
+
+	req, err := p.linearGraphQLRequest(reqCtx, body)
 	if err != nil {
 		return dynamicToolFailure(map[string]any{
 			"error": map[string]any{
@@ -503,9 +563,9 @@ func (p linearGraphQLProxy) dispatch(ctx context.Context, query string, op linea
 		})
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, err := readLinearGraphQLResponseBody(resp.Body)
+	respBody, err := readDynamicToolResponseBody(resp.Body)
 	if err != nil {
-		if errors.Is(err, errLinearGraphQLResponseTooLarge) {
+		if errors.Is(err, errDynamicToolResponseTooLarge) {
 			return dynamicToolFailure(map[string]any{
 				"error": map[string]any{
 					"message": "Linear GraphQL response exceeded maximum size.",
@@ -525,11 +585,11 @@ func (p linearGraphQLProxy) dispatch(ctx context.Context, query string, op linea
 			"error": map[string]any{
 				"message": "Linear GraphQL request failed before receiving a successful response.",
 				"status":  resp.Status,
-				"body":    string(respBody),
+				"body":    sanitizeToolErrorBody(respBody, p.apiKey),
 			},
 		})
 	}
-	result, toolErr := linearGraphQLToolResponse(respBody)
+	result, toolErr := linearGraphQLToolResponse(respBody, p.apiKey)
 	if toolErr == nil && op.Kind == linearGraphQLOperationMutation && toolResultSucceeded(result) {
 		if p.currentIssueGuard.postOperatorTerminalStop(ctx) {
 			if sink := linearGraphQLPostStopMutationSinkFrom(ctx); sink != nil {
@@ -585,16 +645,21 @@ func (p linearGraphQLProxy) linearHTTPClient() *http.Client {
 	return http.DefaultClient
 }
 
-var errLinearGraphQLResponseTooLarge = errors.New("linear GraphQL response exceeded maximum size")
+var errDynamicToolResponseTooLarge = errors.New("dynamic tool response exceeded maximum size")
 
-func readLinearGraphQLResponseBody(r io.Reader) ([]byte, error) {
+// readDynamicToolResponseBody reads up to maxLinearGraphQLResponseBytes from r,
+// returning errDynamicToolResponseTooLarge when the cap is exceeded so the
+// caller can fail loud instead of silently truncating an oversized body into a
+// tool result. Shared by the linear_graphql and gitea_issue_labels proxies so
+// the cap is enforced in exactly one place.
+func readDynamicToolResponseBody(r io.Reader) ([]byte, error) {
 	var body bytes.Buffer
 	n, err := body.ReadFrom(io.LimitReader(r, maxLinearGraphQLResponseBytes+1))
 	if err != nil {
 		return nil, err
 	}
 	if n > maxLinearGraphQLResponseBytes {
-		return nil, fmt.Errorf("%w: %d", errLinearGraphQLResponseTooLarge, maxLinearGraphQLResponseBytes)
+		return nil, fmt.Errorf("%w: %d", errDynamicToolResponseTooLarge, maxLinearGraphQLResponseBytes)
 	}
 	return body.Bytes(), nil
 }
@@ -658,14 +723,22 @@ func toolResultSucceeded(result string) bool {
 	return envelope.Success
 }
 
-func linearGraphQLToolResponse(body []byte) (string, error) {
+// linearGraphQLToolResponse wraps a 2xx Linear body into a tool result. secret
+// is the workspace token: it is redacted from every body surfaced to the agent
+// — the valid-JSON success/GraphQL-errors payload and the unparseable-body
+// diagnostic alike — so a proxy that echoes the Authorization value in a 200
+// response cannot leak the credential past the token-isolation boundary
+// (#76/#298). The unparseable body is also truncated; a success body is the
+// agent's requested payload and is preserved in full (still bounded by the
+// readDynamicToolResponseBody size cap).
+func linearGraphQLToolResponse(body []byte, secret string) (string, error) {
 	var decoded map[string]any
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		return dynamicToolFailure(map[string]any{
 			"error": map[string]any{
 				"message": "Linear GraphQL response was not valid JSON.",
 				"reason":  err.Error(),
-				"body":    string(body),
+				"body":    sanitizeToolErrorBody(body, secret),
 			},
 		})
 	}
@@ -673,7 +746,7 @@ func linearGraphQLToolResponse(body []byte) (string, error) {
 	if errors, ok := decoded["errors"].([]any); ok && len(errors) > 0 {
 		success = false
 	}
-	return dynamicToolResult(success, string(body))
+	return dynamicToolResult(success, redactToolSecrets(string(body), secret))
 }
 
 func dynamicToolFailure(payload any) (string, error) {


### PR DESCRIPTION
Closes #668

## Summary
The `linear_graphql` and `gitea_issue_labels` dynamic-tool proxies run during agent turns and need tight, explicit I/O bounds. Three gaps, all fixed:

1. **No per-request transport timeout.** Both proxies used `http.DefaultClient` (no `Timeout`) and inherited only the much larger agent-turn context, so a hung tracker endpoint could stall a whole turn — the failure class the repo's *"all external I/O is timeout-bounded"* rule exists to prevent (#287/#405). Added a per-request `context.WithTimeout` (default 30s, overridable via a new `httpTimeout` proxy field) at each HTTP call site.
2. **Gitea response-size cap read but not enforced.** `doGiteaRequest` read `io.LimitReader(body, max+1)` but **discarded the byte count**, silently truncating an oversized body into the tool result. Consolidated onto Linear's reader — renamed `readLinearGraphQLResponseBody` → `readDynamicToolResponseBody` (sentinel `errDynamicToolResponseTooLarge`) so the cap lives in one place — and Gitea now returns a structured *"exceeded maximum size"* failure like Linear.
3. **Bodies surfaced to the agent could leak the tracker token.** The acceptance criterion is *"no tracker token / Authorization header in **any** tool result"*, so redaction must cover every body, not just non-2xx (a fronting proxy can echo the `Authorization` value at any status). Split redaction from truncation:
   - `redactToolSecrets` strips the token from **every** body placed in a result — 2xx success (`linearGraphQLToolResponse`, Gitea `addIssueLabels`), unparseable-2xx, and non-2xx — per SPEC token isolation (#76/#298);
   - `sanitizeToolErrorBody` = redact **then** truncate to 2048 runes, for diagnostic bodies only, so a large error page cannot flood agent context. Success bodies are redacted but preserved in full. Redaction runs before truncation so a token straddling the truncation boundary cannot leave an un-redacted head fragment.

## Testing notes
- Tests cover all acceptance criteria: per-request timeout firing (both proxies — bounded + structured transport failure), oversized Gitea response → size-cap failure, non-2xx truncation + redaction (both proxies), plus the 2xx-success and unparseable-2xx token-redaction paths, and `sanitizeToolErrorBody` directly with a **boundary-straddling** secret that distinguishes redact-before-truncate from truncate-first.
- Every new behavior was **mutation-verified against the committed artifact** (cap-off, redaction-off on each path, order-swap, timeout-off — each fails its test). Existing Linear behavior preserved (full runner suite green).

## Adversarial review
Ran a 4-lens adversarial-review workflow (secret-leak / timeout-correctness / spec-clean / test-placebo) with per-finding verification (origin `@codex` quota down → independent Codex runs on the bytevane fork). 9 findings, **3 confirmed, all folded into this commit**:
- **HIGH** — the 2xx-but-unparseable Linear body bypassed redaction+truncation (`linearGraphQLToolResponse` dumped raw `string(body)`); now sanitized. *Fix the class, not the instance.*
- **MEDIUM** — success 2xx bodies were returned verbatim without token redaction (both proxies); now redacted.
- **MEDIUM** — the original redaction-before-truncation test was a placebo (secret at both ends passed under either order); replaced with a straddling-secret case that genuinely fails under truncate-first.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Internal `internal/runner` hardening of the existing dynamic-tool proxies: the `httpTimeout` field carries a fixed default (no new `WORKFLOW.md`/`Config` key), and there is no new worker/orchestrator phase or gate. Reinforces SPEC token isolation (#76/#298) and the "all external I/O is timeout-bounded" rule (#287/#405).

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 2 production files, ~89 net production LOC (test files excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [ ] additional validation noted below when needed
