### PR TITLE
reliability: bound terminal-cleanup state-refresh retry with backoff + cap (#675)

### DIFF
--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -104,7 +104,6 @@ type Orchestrator struct {
 
 	state      *OrchestratorState
 	dispatcher Dispatcher
-	scheduler  Scheduler
 	retryWake  chan struct{}
 
 	// workspaceCleaner removes the workspace of a terminal-state run after its
@@ -130,6 +129,15 @@ type Orchestrator struct {
 	retryTerminalResolverMu sync.Mutex
 	retryTerminalResolver   IssueStateRefresher
 	retryTerminalStates     map[string]struct{}
+
+	// scheduler computes retry backoff (SPEC §8.4/§16.6). It is read on every
+	// retry fire — including the off-actor terminal-cleanup state-refresh retry
+	// (#675) — and swapped on-actor by UpdateRetryScheduler when the runtime
+	// poller reloads workflow timing, so a mutex guards the swap (same discipline
+	// as candidateLister / retryTerminalResolver). currentScheduler is the only
+	// read path.
+	schedulerMu sync.Mutex
+	scheduler   Scheduler
 
 	// runCtx is captured by Run so followup goroutines can cancel
 	// their work when the actor stops. Set once at the top of Run
@@ -265,6 +273,15 @@ func (o *Orchestrator) currentRetryTerminalResolver() (IssueStateRefresher, map[
 	o.retryTerminalResolverMu.Lock()
 	defer o.retryTerminalResolverMu.Unlock()
 	return o.retryTerminalResolver, o.retryTerminalStates
+}
+
+// currentScheduler returns the live retry scheduler under schedulerMu so the
+// off-actor terminal-cleanup retry can read it without racing an on-actor
+// UpdateRetryScheduler swap (#675).
+func (o *Orchestrator) currentScheduler() Scheduler {
+	o.schedulerMu.Lock()
+	defer o.schedulerMu.Unlock()
+	return o.scheduler
 }
 
 func (o *Orchestrator) LookupOperatorTerminalStop(ctx context.Context, id IssueID) (OperatorTerminalStopEntry, bool, error) {

--- a/internal/orchestrator/actor_cleanup.go
+++ b/internal/orchestrator/actor_cleanup.go
@@ -171,6 +171,15 @@ func terminalWorkspaceForCleanup(id IssueID, identifier, path, root, state strin
 // hardening). Callers must invoke it from a followup goroutine, never inside
 // an apply.
 func (o *Orchestrator) runReconciledWorkspaceCleanup(w ReconciledWorkspace, continuation *continuationAfterSkippedCleanup) {
+	o.runReconciledWorkspaceCleanupAttempt(w, continuation, 0)
+}
+
+// runReconciledWorkspaceCleanupAttempt is one pass of the deletion-time recheck.
+// attempt is 0 for the initial pass and N for the Nth backed-off retry after a
+// failed or absent tracker state refresh; on an unknown refresh it schedules the
+// next attempt through retryReconciledWorkspaceCleanup (exponential backoff +
+// give-up bound) instead of re-probing on a fixed interval forever (#675).
+func (o *Orchestrator) runReconciledWorkspaceCleanupAttempt(w ReconciledWorkspace, continuation *continuationAfterSkippedCleanup, attempt int) {
 	if o.workspaceCleaner == nil || strings.TrimSpace(w.Path) == "" {
 		return
 	}
@@ -185,7 +194,7 @@ func (o *Orchestrator) runReconciledWorkspaceCleanup(w ReconciledWorkspace, cont
 	defer o.endReconcileWorkspaceCleanup(w.IssueID)
 	currentState, terminal, known := o.verifyReconciledWorkspaceStillTerminal(w)
 	if !known {
-		o.retryReconciledWorkspaceCleanup(w, continuation)
+		o.retryReconciledWorkspaceCleanup(w, continuation, attempt+1)
 		return
 	}
 	if !terminal {
@@ -218,13 +227,41 @@ func (o *Orchestrator) continueAfterSkippedTerminalCleanup(continuation *continu
 	}
 	o.logRescheduleErr(o.scheduleContinuationRetry(o.runCtx, continuation.issue, continuation.identifier, continuation.attempt, continuation.continuationTurnCount, continuation.workspace), IssueID(continuation.issue.ID), continuation.identifier)
 }
-func (o *Orchestrator) retryReconciledWorkspaceCleanup(w ReconciledWorkspace, continuation *continuationAfterSkippedCleanup) {
+
+// retryReconciledWorkspaceCleanup reschedules the deletion-time state recheck
+// after a failed or absent tracker refresh. It uses the same exponential
+// backoff as the failure-retry path (RetryScheduler.NextDelay with
+// RetryKindFailure) so a persistently unavailable tracker is probed on a growing
+// interval rather than every fixed second, and it gives up after
+// maxReconciledCleanupStateRetries attempts: the orphaned workspace is then left
+// for the next worker start's reconcile sweep to re-discover, which bounds both
+// the goroutine churn and the extra load on an already-unhealthy tracker (#675).
+// attempt is 1-based (the first retry after the initial pass).
+func (o *Orchestrator) retryReconciledWorkspaceCleanup(w ReconciledWorkspace, continuation *continuationAfterSkippedCleanup, attempt int) {
+	if attempt > maxReconciledCleanupStateRetries {
+		// Give up rather than probe an unavailable tracker forever. A carried
+		// continuation is deliberately NOT rescheduled here: resuming it would
+		// bypass the deletion-time state recheck this loop could not complete,
+		// defeating the §18.1 stale-terminal-deletion guard and the D35
+		// operator-terminal-stop fail-closed gate. The clean-turn budget is
+		// instead re-derived on the next poll re-dispatch — the same non-durable
+		// recovery as a worker restart (SPEC §14.3). The drop is logged (not
+		// silent) so the budget reset is observable (#675, AGENTS.md "no silent
+		// caps").
+		droppedTurns := 0
+		if continuation != nil {
+			droppedTurns = continuation.continuationTurnCount
+		}
+		log.Printf("event=reconcile_workspace_cleanup_giveup issue_id=%s issue_identifier=%s attempts=%d continuation_dropped=%t continuation_turns=%d reason=state_refresh_unavailable", w.IssueID, w.Identifier, attempt-1, continuation != nil, droppedTurns)
+		return
+	}
+	delay := o.currentScheduler().NextDelay(RetryRequest{Kind: RetryKindFailure, Attempt: attempt})
 	safeGo("orchestrator.reconcile_cleanup_retry", func() {
-		timer := time.NewTimer(terminalCleanupStateRetryDelay)
+		timer := time.NewTimer(delay)
 		defer timer.Stop()
 		select {
 		case <-timer.C:
-			o.runReconciledWorkspaceCleanup(w, continuation)
+			o.runReconciledWorkspaceCleanupAttempt(w, continuation, attempt)
 		case <-o.runCtx.Done():
 		}
 	})

--- a/internal/orchestrator/actor_config.go
+++ b/internal/orchestrator/actor_config.go
@@ -160,7 +160,9 @@ func (o *Orchestrator) UpdateRetryScheduler(ctx context.Context, scheduler Sched
 	}
 	done := make(chan struct{}, 1)
 	op := opFunc(func(*OrchestratorState) func() {
+		o.schedulerMu.Lock()
 		o.scheduler = scheduler
+		o.schedulerMu.Unlock()
 		done <- struct{}{}
 		return nil
 	})

--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -54,7 +54,15 @@ var reconcileWorkspaceCleanupTimeout = 60 * time.Second
 // prevents a stale terminal observation from deleting a workspace after the
 // issue has already returned to active work.
 var terminalCleanupStateFetchTimeout = 45 * time.Second
-var terminalCleanupStateRetryDelay = continuationRetryDelay
+
+// maxReconciledCleanupStateRetries bounds how many times the deletion-time
+// state recheck is rescheduled after a failed/absent tracker refresh before the
+// orchestrator gives up and leaves the orphaned workspace for the next worker
+// start's reconcile sweep. Without a cap, every terminal issue awaiting cleanup
+// would re-probe an already-unhealthy tracker forever during an outage (#675).
+// The retry delay itself comes from RetryScheduler.NextDelay (failure backoff),
+// not a fixed interval. A package var so tests can shrink it.
+var maxReconciledCleanupStateRetries = 8
 
 // ReconcileStalledRuns implements SPEC §8.5 Part A / §16.3
 // reconcile_stalled_runs: for each running issue compute elapsed time

--- a/internal/orchestrator/actor_retry.go
+++ b/internal/orchestrator/actor_retry.go
@@ -199,7 +199,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 	issue := s.issue
 	attempt := s.attempt
 	kind := s.kind
-	delay := o.scheduler.NextDelay(s.req)
+	delay := o.currentScheduler().NextDelay(s.req)
 	// time.AfterFunc schedules immediately and is cheap (no goroutine
 	// until fire), so we can safely create the timer on the actor
 	// without blocking. ScheduleRetry needs the Timer set on the entry

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -113,6 +113,12 @@ func (s *recordingScheduler) lastRequest() (RetryRequest, bool) {
 	return s.requests[len(s.requests)-1], true
 }
 
+func (s *recordingScheduler) snapshotRequests() []RetryRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]RetryRequest(nil), s.requests...)
+}
+
 func (f *fakeDispatcher) Spawn(ctx context.Context, issue tracker.Issue, attempt *int, opts DispatchOptions) <-chan WorkerResult {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -2043,9 +2049,8 @@ func TestReconcileTerminalRunAfterTurnCompletedCancelsWorkerButRecordsSuccess(t 
 func TestReconcileTerminalRunAfterTurnCompletedErrorDoesNotRetry(t *testing.T) {
 	disp := &fakeDispatcher{}
 	cleaner := &recordingWorkspaceCleaner{}
-	oldRetryDelay := terminalCleanupStateRetryDelay
-	terminalCleanupStateRetryDelay = time.Millisecond
-	defer func() { terminalCleanupStateRetryDelay = oldRetryDelay }()
+	// MaxBackoff: time.Millisecond keeps the failure-backoff retry delay tiny so
+	// the single flaky refresh failure is re-probed almost immediately.
 	o, cancel := startActor(t, Deps{
 		Dispatcher:       disp,
 		Scheduler:        RetryScheduler{MaxBackoff: time.Millisecond},
@@ -2139,11 +2144,195 @@ func TestReconcileTerminalRunAfterTurnCompletedRecordsStickyStopAndSkipsStaleCle
 	}
 }
 
+// TestReconcileTerminalCleanupGivesUpAfterPersistentStateRefreshFailure is the
+// #675 regression: when the deletion-time state recheck fails persistently (an
+// unavailable tracker), the cleanup retry must back off and give up after a
+// bounded number of attempts instead of re-probing every fixed second forever.
+// The existing flakyStateRefresher only covers fail-once-then-succeed.
+func TestReconcileTerminalCleanupGivesUpAfterPersistentStateRefreshFailure(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	// The cap is read, never mutated: a retry goroutine reads
+	// maxReconciledCleanupStateRetries off-actor, so writing it from the test
+	// would race the running loop (the -race detector flags exactly that). With
+	// MaxBackoff: time.Millisecond every backed-off retry is near-instant, so
+	// exercising the real default cap completes in milliseconds.
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Millisecond},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+	refresher := &countingFailRefresher{}
+	o.SetRetryTerminalStateResolver(refresher, []string{"Done"})
+
+	issue := tracker.Issue{ID: "ENG-GU1", Identifier: "ENG-GU1", State: "In Progress"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-GU1"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+
+	// 1 initial recheck + maxReconciledCleanupStateRetries backed-off retries,
+	// then the loop gives up rather than probing forever.
+	wantCalls := maxReconciledCleanupStateRetries + 1
+	waitFor(t, func() bool { return refresher.count() >= wantCalls }, 2*time.Second)
+	settled := refresher.count()
+	time.Sleep(50 * time.Millisecond)
+	if got := refresher.count(); got != settled {
+		t.Fatalf("resolver kept being probed after give-up: count went %d -> %d; want it to stop", settled, got)
+	}
+	if got := refresher.count(); got != wantCalls {
+		t.Errorf("resolver call count = %d; want %d (1 initial recheck + %d backed-off retries)", got, wantCalls, maxReconciledCleanupStateRetries)
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Errorf("workspace cleaner called %d times; want 0 (state never confirmed terminal)", len(calls))
+	}
+}
+
+// TestReconcileTerminalCleanupRetryUsesFailureBackoffSchedule asserts the #675
+// acceptance criterion "backoff schedule matches the failure-retry path": each
+// cleanup retry asks the scheduler for RetryKindFailure with an incrementing
+// 1-based attempt (1..cap), i.e. the same exponential schedule as a failure
+// retry — not the fixed-1s RetryKindContinuation delay the old loop used.
+func TestReconcileTerminalCleanupRetryUsesFailureBackoffSchedule(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	scheduler := &recordingScheduler{delay: time.Millisecond}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        scheduler,
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+	refresher := &countingFailRefresher{}
+	o.SetRetryTerminalStateResolver(refresher, []string{"Done"})
+
+	issue := tracker.Issue{ID: "ENG-BK1", Identifier: "ENG-BK1", State: "In Progress"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-BK1"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+
+	wantRetries := maxReconciledCleanupStateRetries
+	waitFor(t, func() bool { return refresher.count() >= wantRetries+1 }, 2*time.Second)
+	time.Sleep(50 * time.Millisecond) // let the give-up settle before reading requests
+
+	var failureAttempts []int
+	for _, req := range scheduler.snapshotRequests() {
+		if req.Kind != RetryKindFailure {
+			// This flow carries a non-nil continuation into the give-up (verified:
+			// the giveup log reports continuation_dropped=true). A give-up must
+			// DROP that continuation, never reschedule it — resuming onto a
+			// workspace whose state the recheck never confirmed would defeat the
+			// §18.1 stale-terminal guard and the D35 operator-stop gate (#675).
+			t.Errorf("cleanup retry scheduled a %s request %+v; want only failure-backoff retries (the carried continuation must be dropped on give-up, not resumed)", req.Kind, req)
+			continue
+		}
+		failureAttempts = append(failureAttempts, req.Attempt)
+	}
+	want := make([]int, 0, wantRetries)
+	for i := 1; i <= wantRetries; i++ {
+		want = append(want, i)
+	}
+	if !reflect.DeepEqual(failureAttempts, want) {
+		t.Errorf("cleanup retry scheduler requests = RetryKindFailure attempts %v; want %v (failure backoff schedule, 1..cap)", failureAttempts, want)
+	}
+}
+
+// TestReconcileTerminalCleanupRetryRaceFreeWithSchedulerSwap is the #675
+// race regression: the off-actor cleanup retry reads o.scheduler while
+// UpdateRetryScheduler swaps it on the actor goroutine. Without the schedulerMu
+// guard this fails under -race. The test drives a persistently-failing recheck
+// (so the retry loop runs) while continuously swapping the scheduler.
+func TestReconcileTerminalCleanupRetryRaceFreeWithSchedulerSwap(t *testing.T) {
+	disp := &fakeDispatcher{}
+	cleaner := &recordingWorkspaceCleaner{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:       disp,
+		Scheduler:        RetryScheduler{MaxBackoff: time.Millisecond},
+		WorkspaceCleaner: cleaner,
+	})
+	defer cancel()
+	refresher := &countingFailRefresher{}
+	o.SetRetryTerminalStateResolver(refresher, []string{"Done"})
+
+	issue := tracker.Issue{ID: "ENG-RC1", Identifier: "ENG-RC1", State: "In Progress"}
+	const wsPath = "/var/aiops/workspaces/acme/repo/linear_issue/ENG-RC1"
+	dispatchRunningIssue(t, o, disp, issue, wsPath, 1)
+	if err := o.RecordRuntimeEvent(context.Background(), issue.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), map[string]tracker.Issue{
+		issue.ID: {ID: issue.ID, Identifier: issue.Identifier, State: "Done"},
+	}, map[string]struct{}{"done": {}}, 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+
+	// Continuously swap the scheduler on the actor while the off-actor cleanup
+	// retry loop reads it — maximizing overlap so -race reliably catches an
+	// unsynchronized o.scheduler access.
+	stop := make(chan struct{})
+	swapDone := make(chan struct{})
+	go func() {
+		defer close(swapDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = o.UpdateRetryScheduler(context.Background(), RetryScheduler{MaxBackoff: time.Millisecond})
+			}
+		}
+	}()
+
+	disp.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
+	waitFor(t, func() bool { return refresher.count() >= maxReconciledCleanupStateRetries+1 }, 2*time.Second)
+	close(stop)
+	<-swapDone
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Errorf("workspace cleaner called %d times; want 0 (state never confirmed terminal)", len(calls))
+	}
+}
+
 type redispatchDuringCleanupRefresher struct {
 	orch      *Orchestrator
 	issue     tracker.Issue
 	state     string
 	attempted chan error
+}
+
+// countingFailRefresher fails every state refresh and counts calls, so a test
+// can assert the cleanup retry loop is bounded.
+type countingFailRefresher struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *countingFailRefresher) FetchIssueStatesByIDs(_ context.Context, _ []string) (map[string]string, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	return nil, errors.New("persistent tracker refresh failure")
+}
+
+func (f *countingFailRefresher) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
 }
 
 type flakyStateRefresher struct {


### PR DESCRIPTION
Closes #675

## Summary
The SPEC §18.1 terminal-workspace-cleanup path rechecks the issue's tracker state before deleting the deterministic workspace. When that refresh **failed** (or the issue was absent), `retryReconciledWorkspaceCleanup` re-armed a **fixed 1s timer** and re-ran forever — no attempt counter, no backoff growth, no give-up bound. While a tracker was unavailable, every terminal issue awaiting cleanup spun a fresh goroutine + one extra state fetch **every 1s indefinitely**, hammering an already-unhealthy tracker and pinning the workspace un-reclaimable for the whole outage. It was the one reschedule loop that bypassed the §8.4/§16.6 backoff discipline every other retry path uses.

**Fix:**
- Thread a 1-based attempt count through the retry. The delay now comes from `RetryScheduler.NextDelay(RetryKindFailure, attempt)` — the **same exponential backoff as the failure-retry path** — instead of a fixed 1s interval.
- Cap retries at `maxReconciledCleanupStateRetries` (8); on exhaustion log `event=reconcile_workspace_cleanup_giveup` and stop. The next worker start's reconcile sweep re-discovers the orphaned workspace, so giving up is safe and bounds both the goroutine churn and the tracker load.
- Split `runReconciledWorkspaceCleanup` into a thin attempt-0 entry + `runReconciledWorkspaceCleanupAttempt(attempt)` so existing call sites are unchanged and only the retry path carries the counter. Removed the now-unused `terminalCleanupStateRetryDelay`.

## Adversarial review
Ran a 4-lens workflow (concurrency / logic-edge / spec-clean / test-placebo) with per-finding verification (origin `@codex` quota down → independent Codex on the bytevane fork). **1 confirmed MEDIUM**, adjudicated and folded in:

> The give-up path can carry a non-nil §16.6 continuation; dropping it resets the D34 clean-turn budget on tracker recovery.

I rejected the finding's *primary* fix (reschedule the continuation on give-up) as **unsafe** — resuming would bypass the deletion-time state recheck this loop could not complete, defeating the §18.1 stale-terminal-deletion guard and the D35 operator-stop fail-closed gate. The drop itself is correct: the D34 budget is process-local/non-durable by design (SPEC §14.3), so re-derivation on the next poll re-dispatch is the same recovery as a worker restart. I applied the finding's **safe** recommendation instead: document the deliberate no-reschedule, and **log the drop** (`continuation_dropped` + `continuation_turns`) so it is no longer silent (AGENTS.md "no silent caps"). (Two other lenses' takes on the same behavior were verifier-dismissed as either an accepted §14.3 semantic or an unsafe fix; this synthesis matches the SPEC-grounded reading.)

## Testing notes
- **Give-up test** (persistent-failure resolver): asserts the loop backs off and terminates at exactly `cap+1` fetches, then stops probing, and never cleans the workspace.
- **Schedule test** (recording scheduler): asserts each retry asks for `RetryKindFailure` attempts `1..cap` (matching the failure-retry path) **and** that the give-up schedules **no** continuation retry — guarding against the unsafe resume. The flow carries a non-nil continuation (verified: the giveup log reports `continuation_dropped=true`).
- The existing fail-once `flakyStateRefresher` test covers the success exit, unchanged.
- **Mutation-verified against the committed artifact:** removing the cap → give-up test fails; reverting `RetryKindFailure`→`RetryKindContinuation` (the original fixed-1s bug) → schedule test fails; adding an unsafe reschedule-on-give-up → the no-continuation guard fails.
- A `-race`-caught bug during development: mutating the package-global cap from the test raced the off-actor retry goroutine reading it → the test reads the production default instead (concurrent reads don't race).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Brings the one outlier reschedule loop onto the existing §8.4/§16.6 backoff seam (`RetryScheduler.NextDelay`); no new config key, no new phase/gate — modifies existing `internal/orchestrator` cleanup files. Reinforces the backoff discipline of #287/#405.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 2 production files, ~50 net production LOC (test files excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [ ] additional validation noted below when needed
