### PR TITLE
fix: correct sandbox root containment for "..":prefixed child paths (#670)

### DIFF
--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -80,10 +80,18 @@ func ensurePathWithinRoot(path, root string) error {
 	if rel == "." {
 		return fmt.Errorf("workspace path %q must be under workspace root %q, not the workspace root itself", path, root)
 	}
-	if rel != "" && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel) {
-		return nil
+	// Reject genuine parent-directory escapes: rel is exactly ".." or its first
+	// path component is ".." (rel begins with "../"). A child whose name merely
+	// begins with ".." (e.g. "..foo", "..foo/inside") is a legitimate descendant
+	// and must not be over-rejected (#670). The rel == "" and filepath.IsAbs(rel)
+	// clauses are fail-closed guards: filepath.Rel on two absolute,
+	// symlink-resolved paths returns a non-empty relative path or an error
+	// (already handled above), so they are defensive belt-and-suspenders rather
+	// than reachable branches.
+	if rel == "" || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("workspace path %q is outside workspace root %q", path, root)
 	}
-	return fmt.Errorf("workspace path %q is outside workspace root %q", path, root)
+	return nil
 }
 
 func scopedEnv(allow []string, cfg workflow.Config) []string {

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -380,6 +380,58 @@ func TestSandboxAllowsWorkdirUnderRuntimeWorkspaceRootWhenWorkflowRootDiffers(t 
 	}
 }
 
+func TestEnsurePathWithinRoot(t *testing.T) {
+	// EvalSymlinks requires every path to exist, so materialize a real tree.
+	root := t.TempDir()
+	sibling := t.TempDir() // shares root's parent → rel begins with "../"
+
+	child := filepath.Join(root, "child")
+	if err := os.Mkdir(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A descendant whose first component merely begins with ".." is legitimate,
+	// not a parent-directory escape (#670).
+	dotPrefixedChild := filepath.Join(root, "..foo", "inside")
+	if err := os.MkdirAll(dotPrefixedChild, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(sibling, "outside")
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		path      string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "root itself rejected", path: root, wantErr: true, errSubstr: "not the workspace root itself"},
+		{name: "child accepted", path: child, wantErr: false},
+		{name: "dot-dot-prefixed child accepted", path: dotPrefixedChild, wantErr: false},
+		{name: "immediate parent rejected", path: filepath.Dir(root), wantErr: true, errSubstr: "outside workspace root"},
+		{name: "sibling rejected", path: sibling, wantErr: true, errSubstr: "outside workspace root"},
+		{name: "parent-escape path rejected", path: outside, wantErr: true, errSubstr: "outside workspace root"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ensurePathWithinRoot(tt.path, root)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ensurePathWithinRoot(%q, %q) = nil; want error", tt.path, root)
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("ensurePathWithinRoot(%q, %q) error = %q; want substring %q", tt.path, root, err, tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ensurePathWithinRoot(%q, %q) = %v; want nil", tt.path, root, err)
+			}
+		})
+	}
+}
+
 func TestSandboxNetworkAllowlistRequiresFirejail(t *testing.T) {
 	requireLinuxSandboxHost(t)
 	binDir := t.TempDir()


### PR DESCRIPTION
Closes #670

## Summary
- `ensurePathWithinRoot` (`internal/runner/sandbox.go`) over-rejected any relative
  path whose **first component merely began** with `..` (e.g. `..foo/bar`),
  treating a legitimately-named descendant as a parent-directory escape. This was
  a correctness false-negative (over-rejection), **not** a containment hole.
- **Root cause:** the accept predicate used `!strings.HasPrefix(rel, "..")`, which
  also rejects names like `..foo`.
- **Fix:** reject only genuine escapes — `rel == ".."`, `rel` begins with `../`
  (`".."+string(filepath.Separator)`), or `filepath.IsAbs(rel)`; accept everything
  else. Behavior stays **symlink-aware** via `filepath.EvalSymlinks` (unchanged).
  The `rel == ""` / `IsAbs(rel)` clauses are documented as fail-closed defensive
  guards (`filepath.Rel` on two absolute, symlink-resolved paths returns a
  non-empty relative path or an error that is already handled).

### Containment is preserved (the critical question)
The fix only flips the **dot-prefixed-descendant** class from reject→accept.
`filepath.Rel` returns a `Clean`-ed relative path, so any genuine escape surfaces
in the first component and is still rejected:

| input class | example `rel` | result |
|---|---|---|
| root itself | `.` | rejected (earlier branch) |
| exact parent | `..` | rejected |
| any deeper/lateral escape | `../x`, `../../x` | rejected (`HasPrefix(rel, "../")`) |
| absolute (cross-volume Rel) | `/abs` | rejected (`IsAbs`, fail-closed) |
| legitimate `..`-prefixed child | `..foo`, `..foo/inside` | **accepted** (the #670 fix) |

### Adjacent consumer audit (cross-cutting checklist item 1)
`ensurePathWithinRoot` has two callers — `applySandbox` (`sandbox.go:47`) and
`validateAgentWorkdir` (`workspace_cwd.go:50`). Both pass `filepath.Abs` results
and want identical "strictly inside root" semantics; neither layers an extra
`..`-prefix filter, so both benefit equally and no divergent handling is needed.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Pure Go-port correctness/safety fix in `internal/runner`; not a SPEC-sensitive
path (no `internal/workflow/config.go`, no new `internal/orchestrator|worker`
file). No deviation.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff is `internal/runner/sandbox.go` (+12/-4, comment + predicate); the +52 in `sandbox_test.go` is test-only (excluded).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing — head `e903cbe`, all green
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`0 issues` on `internal/runner/...`)
- [x] CI: `Validate PR metadata`, `Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build` all **pass** (run 27060694781).
- [x] new `TestEnsurePathWithinRoot` (table-driven) covers all #670 acceptance criteria — root rejected, child accepted, `..foo/inside` accepted under root, immediate parent / sibling / parent-escape rejected — and is **mutation-verified** against the committed artifact (reverting to the old `HasPrefix(rel, "..")` predicate makes `dot-dot-prefixed child accepted` FAIL; restored via `git checkout`, tree==HEAD).

## Review — independent dual review, MERGE-READY
Three independent reviewers on the committed head, none told a prior conclusion;
**all MERGE-READY, zero confirmed-actionable findings**:
1. **4-lens adversarial workflow** (Claude-family): security/containment,
   correctness/edge, test-quality, spec-alignment — each finding adversarially
   re-verified; `confirmedActionable: []`.
2. **`code-reviewer`** (Claude-family) — MERGE-READY; mutation-re-verified the test.
3. **`codex:codex-rescue`** (Codex-family, local Codex CLI 0.137) — MERGE-READY,
   no findings; confirmed containment SAFE and the test is not a placebo.

Two NIT comments (doc-example precision) were folded into the in-code comment; the
fail-closed `rel==""`/`IsAbs` guards are now documented.

### `@codex review` GitHub bot — externally unavailable (compensated)
The GitHub `@codex` bot could not run on this head: origin returned
`Codex Review: Something went wrong … An unknown error occurred` on **two**
triggers (comments 4638332559, 4638362571), and the `bytevane` fork (PR
bytevane/aiops-platform#5) has **no Codex cloud environment** configured. Per
[protocol §4](docs/runbooks/pr-review-merge-protocol.md), an externally
unavailable Codex bot is compensated with an equivalent independent dual review
(including a Codex-family reviewer) — done above. **This affects the whole batch**,
so the operator is deciding the bot-gate policy before merge.

### Review threads
GraphQL `reviewThreads` count = 0 (no unresolved, non-outdated actionable threads).

## Notes
- Acceptance criteria from #670 all met; failure messages follow the
  `Foo(%q) = %v; want %v` shape (clean-code rule 9).
