### PR TITLE
fix: escape Gitea owner/repo path segments in PR API URLs (#669)

### DIFF
--- a/internal/gitea/client.go
+++ b/internal/gitea/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -121,7 +122,7 @@ func (c Client) FindOpenPullRequest(ctx context.Context, in FindOpenPullRequestI
 	if client == nil {
 		client = http.DefaultClient
 	}
-	base := strings.TrimRight(c.BaseURL, "/") + fmt.Sprintf("/api/v1/repos/%s/%s/pulls", in.Owner, in.Repo)
+	base := strings.TrimRight(c.BaseURL, "/") + fmt.Sprintf("/api/v1/repos/%s/%s/pulls", url.PathEscape(in.Owner), url.PathEscape(in.Repo))
 	for page := 1; page <= listPullsMaxPages; page++ {
 		u := fmt.Sprintf("%s?state=open&page=%d&limit=%d", base, page, listPullsPageSize)
 		reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
@@ -182,10 +183,10 @@ func (c Client) CreatePullRequest(ctx context.Context, in CreatePullRequestInput
 		"base":  in.Base,
 	}
 	b, _ := json.Marshal(payload)
-	url := strings.TrimRight(c.BaseURL, "/") + fmt.Sprintf("/api/v1/repos/%s/%s/pulls", in.Owner, in.Repo)
+	endpoint := strings.TrimRight(c.BaseURL, "/") + fmt.Sprintf("/api/v1/repos/%s/%s/pulls", url.PathEscape(in.Owner), url.PathEscape(in.Repo))
 	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
 	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(b))
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, bytes.NewReader(b))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitea/client_test.go
+++ b/internal/gitea/client_test.go
@@ -231,3 +231,70 @@ func TestFindOpenPullRequest_NonSuccessReturnsError(t *testing.T) {
 		t.Fatal("expected error on 500, got nil")
 	}
 }
+
+// ownerRepoEscapeCases pins the wire-escaping of owner/repo path segments so the
+// PR API URLs stay consistent with the already-escaped sibling call sites
+// (gitea_tools.go, tracker_client.go). Expected paths are asserted via
+// r.URL.EscapedPath() so a "/" in a segment is observable as "%2F" rather than
+// silently decoding into an extra path component (#669).
+var ownerRepoEscapeCases = []struct {
+	name     string
+	owner    string
+	repo     string
+	wantPath string
+}{
+	{name: "normal ascii unchanged", owner: "o", repo: "r", wantPath: "/api/v1/repos/o/r/pulls"},
+	{name: "spaces escaped", owner: "my org", repo: "my repo", wantPath: "/api/v1/repos/my%20org/my%20repo/pulls"},
+	{name: "slashes escaped", owner: "a/b", repo: "c/d", wantPath: "/api/v1/repos/a%2Fb/c%2Fd/pulls"},
+	{name: "percent escaped", owner: "a%b", repo: "c%d", wantPath: "/api/v1/repos/a%25b/c%25d/pulls"},
+}
+
+func TestCreatePullRequest_EscapesOwnerRepoPathSegments(t *testing.T) {
+	for _, tc := range ownerRepoEscapeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.EscapedPath()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"number": 1, "html_url": "http://gitea.local/pulls/1", "title": "t"}`))
+			}))
+			defer srv.Close()
+
+			c := Client{BaseURL: srv.URL, Token: "fake"}
+			if _, err := c.CreatePullRequest(context.Background(), CreatePullRequestInput{
+				Owner: tc.owner, Repo: tc.repo, Title: "t", Body: "b", Head: "feat", Base: "main",
+			}); err != nil {
+				t.Fatalf("CreatePullRequest(owner=%q, repo=%q) error = %v; want nil", tc.owner, tc.repo, err)
+			}
+			if gotPath != tc.wantPath {
+				t.Fatalf("CreatePullRequest(owner=%q, repo=%q) request path = %q; want %q", tc.owner, tc.repo, gotPath, tc.wantPath)
+			}
+		})
+	}
+}
+
+func TestFindOpenPullRequest_EscapesOwnerRepoPathSegments(t *testing.T) {
+	for _, tc := range ownerRepoEscapeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.EscapedPath()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			defer srv.Close()
+
+			c := Client{BaseURL: srv.URL, Token: "fake"}
+			if _, err := c.FindOpenPullRequest(context.Background(), FindOpenPullRequestInput{
+				Owner: tc.owner, Repo: tc.repo, Head: "ai/tsk_1",
+			}); err != nil {
+				t.Fatalf("FindOpenPullRequest(owner=%q, repo=%q) error = %v; want nil", tc.owner, tc.repo, err)
+			}
+			if gotPath != tc.wantPath {
+				t.Fatalf("FindOpenPullRequest(owner=%q, repo=%q) request path = %q; want %q", tc.owner, tc.repo, gotPath, tc.wantPath)
+			}
+		})
+	}
+}

--- a/test/e2e/gitea.go
+++ b/test/e2e/gitea.go
@@ -208,7 +208,7 @@ func (g *giteaEnv) putFile(ctx context.Context, owner, repo, path string, conten
 		Content string `json:"content"`
 	}
 	resp, body, err := g.doJSON(ctx, "POST",
-		fmt.Sprintf("/api/v1/repos/%s/%s/contents/%s", owner, repo, path),
+		fmt.Sprintf("/api/v1/repos/%s/%s/contents/%s", url.PathEscape(owner), url.PathEscape(repo), path),
 		req{Message: msg, Content: encodeBase64(content)},
 		false)
 	if err != nil {
@@ -226,7 +226,7 @@ func (g *giteaEnv) createIssue(ctx context.Context, owner, repo, title, body str
 		Body  string `json:"body"`
 	}
 	resp, respBody, err := g.doJSON(ctx, "POST",
-		fmt.Sprintf("/api/v1/repos/%s/%s/issues", owner, repo),
+		fmt.Sprintf("/api/v1/repos/%s/%s/issues", url.PathEscape(owner), url.PathEscape(repo)),
 		req{Title: title, Body: body}, false)
 	if err != nil {
 		return 0, err
@@ -248,7 +248,7 @@ func (g *giteaEnv) commentIssue(ctx context.Context, owner, repo string, issue i
 		Body string `json:"body"`
 	}
 	resp, respBody, err := g.doJSON(ctx, "POST",
-		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments", owner, repo, issue),
+		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments", url.PathEscape(owner), url.PathEscape(repo), issue),
 		req{Body: body}, false)
 	if err != nil {
 		return err
@@ -266,7 +266,7 @@ func (g *giteaEnv) ensureLabels(ctx context.Context, owner, repo string, labels 
 	}
 	for _, label := range labels {
 		resp, respBody, err := g.doJSON(ctx, "POST",
-			fmt.Sprintf("/api/v1/repos/%s/%s/labels", owner, repo),
+			fmt.Sprintf("/api/v1/repos/%s/%s/labels", url.PathEscape(owner), url.PathEscape(repo)),
 			req{Name: label, Color: "ededed"}, false)
 		if err != nil {
 			return err
@@ -286,7 +286,7 @@ func (g *giteaEnv) addIssueLabels(ctx context.Context, owner, repo string, issue
 		Labels []string `json:"labels"`
 	}
 	resp, respBody, err := g.doJSON(ctx, "POST",
-		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/labels", owner, repo, issue),
+		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/labels", url.PathEscape(owner), url.PathEscape(repo), issue),
 		req{Labels: labels}, false)
 	if err != nil {
 		return err
@@ -302,7 +302,7 @@ func (g *giteaEnv) replaceIssueLabels(ctx context.Context, owner, repo string, i
 		Labels []string `json:"labels"`
 	}
 	resp, respBody, err := g.doJSON(ctx, "PUT",
-		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/labels", owner, repo, issue),
+		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/labels", url.PathEscape(owner), url.PathEscape(repo), issue),
 		req{Labels: labels}, false)
 	if err != nil {
 		return err
@@ -325,7 +325,7 @@ type prSummary struct {
 
 func (g *giteaEnv) listOpenPRs(ctx context.Context, owner, repo string) ([]prSummary, error) {
 	resp, body, err := g.doJSON(ctx, "GET",
-		fmt.Sprintf("/api/v1/repos/%s/%s/pulls?state=open", owner, repo),
+		fmt.Sprintf("/api/v1/repos/%s/%s/pulls?state=open", url.PathEscape(owner), url.PathEscape(repo)),
 		nil, false)
 	if err != nil {
 		return nil, err
@@ -342,7 +342,7 @@ func (g *giteaEnv) listOpenPRs(ctx context.Context, owner, repo string) ([]prSum
 
 func (g *giteaEnv) getBranch(ctx context.Context, owner, repo, branch string) (bool, error) {
 	resp, _, err := g.doJSON(ctx, "GET",
-		fmt.Sprintf("/api/v1/repos/%s/%s/branches/%s", owner, repo, url.PathEscape(branch)),
+		fmt.Sprintf("/api/v1/repos/%s/%s/branches/%s", url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(branch)),
 		nil, false)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Closes #669

## Summary
- `internal/gitea/client.go` built PR API URLs by interpolating `owner`/`repo`
  straight into `/api/v1/repos/%s/%s/pulls` with **no escaping**, in
  `FindOpenPullRequest` and `CreatePullRequest`. This was inconsistent with the
  already-escaped sibling call sites (`runner/gitea_tools.go`,
  `gitea/tracker_client.go`, `tracker/github.go`).
- **Fix:** wrap both segments in `url.PathEscape` so values containing spaces,
  slashes, or `%` map to a single well-formed path component. Renamed the local
  `url` variable in `CreatePullRequest` to `endpoint` to avoid shadowing the
  `net/url` package (matching the `tracker_client.go` convention).
- Owner/repo normally come from operator workflow config (low-risk → P3), so
  this is consistency + hardening, not a live-exploit fix.

### Fix-the-class (AGENTS rule 10)
`grep`'d every `repos/%s/%s` owner/repo path interpolation in the repo. All
production sites already escaped except these two; both are now fixed. I also
swept the **e2e** Gitea helper (`test/e2e/gitea.go`), which already escaped
`botUser`/`branch` but interpolated `owner`/`repo` raw across 8 call sites — now
consistently escaped. Only single-component `owner`/`repo` are escaped; the
multi-segment `path` (contents API) and the already-escaped `branch` are left
as-is. After this PR, **no raw owner/repo path interpolation remains anywhere**.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Sub-SPEC hardening of an existing aiops-platform Gitea client path; no SPEC-sensitive
path touched (no `internal/workflow/config.go`, no new `internal/orchestrator|worker` file).

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff is `internal/gitea/client.go` only (~+4 net LOC). `client_test.go` and `test/e2e/gitea.go` are test files (excluded).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing — head `0eedf78`
- [x] `gofmt -l` clean; `go vet ./...` clean; `go vet -tags e2e ./test/e2e/` clean; `go build -tags e2e ./test/e2e/` OK
- [x] `go mod tidy` clean; golangci-lint `0 issues` on `internal/gitea/...`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] python unittests
- [x] new `TestCreatePullRequest_EscapesOwnerRepoPathSegments` + `TestFindOpenPullRequest_EscapesOwnerRepoPathSegments` (table-driven, httptest) assert exact `r.URL.EscapedPath()` for ascii / spaces / slashes / `%` owner&repo (so `/`→`%2F` is observable, not silently decoded). **Mutation-verified** against the committed artifact: reverting each call site to raw interpolation makes its test FAIL (slash → wrong path, `%` → `url.Parse` error); restored via `git checkout`, tree==HEAD.

## Review — independent dual review, MERGE-READY
- **4-lens adversarial workflow** (Claude-family): correctness, security/path-injection, fix-the-class, test-quality — all MERGE-READY, `confirmedActionable: []`.
- **`code-reviewer`** (Claude-family): MERGE-READY; confirmed path-only escaping, query untouched, no double-escaping, e2e scoping correct, tests mutation-verified non-placebos; one sub-threshold NIT (the `spaces` case is non-discriminating because `http.NewRequest` re-encodes a literal space anyway — the slash/% cases carry the regression assertion).
- **`codex:codex-rescue`** (Codex-family): the first pass flagged the e2e helper as a rule-10 gap (NEEDS-CHANGES); this PR addresses it by sweeping the e2e helper.
- **`codex:codex-rescue` re-review on the pushed head: MERGE-READY** — the prior e2e rule-10 finding is RESOLVED, no new findings.
- `@codex` GitHub bot: re-triggered on origin (comment 4639085725) but still returns `An unknown error occurred` — externally unavailable **batch-wide** (origin errors; bytevane fork has no Codex env). Operator authorized merging on the compensating independent triple review per protocol §4.

### Review threads
GraphQL `reviewThreads` count = 0.
