### PR TITLE
fix: validate Codex app-server JSON-RPC ids before int conversion (#671)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -621,26 +621,6 @@ func (c *appServerClient) request(ctx context.Context, method string, params any
 		c.handleNotification(msg)
 	}
 }
-
-// responseForID reports whether msg is the JSON-RPC response to request id. When
-// it is (matched=true), it returns the result map — defaulting a missing or null
-// result to an empty map — or a CategoryResponseError carrying the `error`
-// member. A non-matching msg (matched=false) is an interleaved notification the
-// caller must dispatch and keep reading past.
-func responseForID(msg map[string]any, id int) (result map[string]any, matched bool, err error) {
-	gotID, ok := numberID(msg["id"])
-	if !ok || gotID != id {
-		return nil, false, nil
-	}
-	if e, ok := msg["error"]; ok {
-		return nil, true, NewError(CategoryResponseError, fmt.Sprintf("rpc error: %v", e), nil)
-	}
-	result, _ = msg["result"].(map[string]any)
-	if result == nil {
-		result = map[string]any{}
-	}
-	return result, true, nil
-}
 func (c *appServerClient) notify(method string, params map[string]any) error {
 	return c.send(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
 }
@@ -882,16 +862,6 @@ func extractString(m map[string]any, outer, inner string) (string, error) {
 		return "", NewError(CategoryResponseError, fmt.Sprintf("missing %s.%s", outer, inner), nil)
 	}
 	return v, nil
-}
-func numberID(v any) (int, bool) {
-	switch x := v.(type) {
-	case float64:
-		return int(x), true
-	case int:
-		return x, true
-	default:
-		return 0, false
-	}
 }
 func writeAppServerArtifact(workdir string, buf *cappedWriter) {
 	dir := filepath.Join(workdir, ".aiops")

--- a/internal/runner/codex_app_server_request_test.go
+++ b/internal/runner/codex_app_server_request_test.go
@@ -9,6 +9,7 @@ package runner
 
 import (
 	"context"
+	"math"
 	"testing"
 )
 
@@ -99,5 +100,128 @@ func TestRequest_ReadErrorPropagates(t *testing.T) {
 	_, err := c.request(context.Background(), "initialize", nil)
 	if err == nil {
 		t.Fatalf("request() err = nil; want a read error on an empty stream")
+	}
+}
+
+func TestNumberID(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     any
+		want   int
+		wantOK bool
+	}{
+		{name: "integral float preserved", in: float64(7), want: 7, wantOK: true},
+		{name: "zero float preserved", in: float64(0), want: 0, wantOK: true},
+		{name: "negative integral float preserved", in: float64(-3), want: -3, wantOK: true},
+		{name: "int preserved", in: 42, want: 42, wantOK: true},
+		{name: "fractional rejected", in: 1.5, want: 0, wantOK: false},
+		{name: "NaN rejected", in: math.NaN(), want: 0, wantOK: false},
+		{name: "positive infinity rejected", in: math.Inf(1), want: 0, wantOK: false},
+		{name: "negative infinity rejected", in: math.Inf(-1), want: 0, wantOK: false},
+		{name: "out-of-range magnitude rejected", in: 1e19, want: 0, wantOK: false},
+		{name: "non-number rejected", in: "0", want: 0, wantOK: false},
+		{name: "nil rejected", in: nil, want: 0, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := numberID(tt.in)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("numberID(%v) = (%d, %v); want (%d, %v)", tt.in, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestRequest_FractionalIDRejectedNotTruncated(t *testing.T) {
+	// The old numberID truncated id 0.5 to 0 and wrongly matched this request
+	// (id 0), returning the stray result. A fractional id must now be surfaced as
+	// a malformed response instead of truncate-matching the wrong request (#671).
+	c, _ := newTurnLoopClient(t, []string{
+		`{"jsonrpc":"2.0","id":0.5,"result":{"stray":true}}`,
+	})
+	_, err := c.request(context.Background(), "thread/start", nil)
+	if err == nil {
+		t.Fatalf("request() err = nil; want a response error for a fractional id")
+	}
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryResponseError {
+		t.Errorf("ErrorCategory(%v) = (%v, %v); want (CategoryResponseError, true)", err, cat, ok)
+	}
+}
+
+func TestRequest_OutOfRangeIDReturnsResponseError(t *testing.T) {
+	c, _ := newTurnLoopClient(t, []string{
+		`{"jsonrpc":"2.0","id":1e19,"result":{"ok":true}}`,
+	})
+	_, err := c.request(context.Background(), "thread/start", nil)
+	if err == nil {
+		t.Fatalf("request() err = nil; want a response error for an out-of-range id")
+	}
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryResponseError {
+		t.Errorf("ErrorCategory(%v) = (%v, %v); want (CategoryResponseError, true)", err, cat, ok)
+	}
+}
+
+// TestResponseForID pins the extracted response-matching helper directly at its
+// own boundary (the request-loop tests above exercise it only indirectly): a
+// matching id returns the result or a CategoryResponseError, a mismatched
+// integer id and an absent id are both skipped as interleaved messages, and a
+// present-but-non-integer id is surfaced as a CategoryResponseError (#671).
+func TestResponseForID(t *testing.T) {
+	const id = 7
+	tests := []struct {
+		name        string
+		msg         map[string]any
+		wantMatched bool
+		wantResult  map[string]any
+		wantErrCat  RunnerErrorCategory // "" => want nil err
+	}{
+		{
+			name:        "matching id returns result",
+			msg:         map[string]any{"id": float64(7), "result": map[string]any{"ok": true}},
+			wantMatched: true,
+			wantResult:  map[string]any{"ok": true},
+		},
+		{
+			name:        "matching id with error member is a response error",
+			msg:         map[string]any{"id": float64(7), "error": map[string]any{"code": float64(-1)}},
+			wantMatched: true,
+			wantErrCat:  CategoryResponseError,
+		},
+		{
+			name:        "mismatched integer id is skipped",
+			msg:         map[string]any{"id": float64(99), "result": map[string]any{"stray": true}},
+			wantMatched: false,
+		},
+		{
+			name:        "absent id is skipped as a notification",
+			msg:         map[string]any{"method": "turn/progress"},
+			wantMatched: false,
+		},
+		{
+			name:        "present non-integer id is a response error",
+			msg:         map[string]any{"id": 1.5, "result": map[string]any{"stray": true}},
+			wantMatched: true,
+			wantErrCat:  CategoryResponseError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, matched, err := responseForID(tt.msg, id)
+			if matched != tt.wantMatched {
+				t.Fatalf("responseForID(%v, %d) matched = %v; want %v", tt.msg, id, matched, tt.wantMatched)
+			}
+			if tt.wantErrCat == "" {
+				if err != nil {
+					t.Fatalf("responseForID(%v, %d) err = %v; want nil", tt.msg, id, err)
+				}
+			} else if cat, ok := ErrorCategory(err); !ok || cat != tt.wantErrCat {
+				t.Fatalf("responseForID(%v, %d) ErrorCategory = (%v, %v); want (%v, true)", tt.msg, id, cat, ok, tt.wantErrCat)
+			}
+			for k, want := range tt.wantResult {
+				if result[k] != want {
+					t.Fatalf("responseForID(%v, %d) result[%q] = %v; want %v", tt.msg, id, k, result[k], want)
+				}
+			}
+		})
 	}
 }

--- a/internal/runner/codex_app_server_response.go
+++ b/internal/runner/codex_app_server_response.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"fmt"
+	"math"
+)
+
+// responseForID reports whether msg is the JSON-RPC response to request id. When
+// it is (matched=true), it returns the result map — defaulting a missing or null
+// result to an empty map — or a CategoryResponseError carrying the `error`
+// member. A non-matching msg (matched=false) is an interleaved notification the
+// caller must dispatch and keep reading past.
+func responseForID(msg map[string]any, id int) (result map[string]any, matched bool, err error) {
+	gotID, ok := numberID(msg["id"])
+	if !ok {
+		// A present-but-non-integer id is a malformed response: numberID will not
+		// truncate it (#671), so we cannot reliably tell which pending request it
+		// answers — surface it as a response error rather than skip-and-wait. An
+		// absent id is an interleaved notification the caller must dispatch.
+		if _, present := msg["id"]; present {
+			return nil, true, NewError(CategoryResponseError, fmt.Sprintf("codex app-server sent a non-integer JSON-RPC id: %v", msg["id"]), nil)
+		}
+		return nil, false, nil
+	}
+	if gotID != id {
+		return nil, false, nil
+	}
+	if e, ok := msg["error"]; ok {
+		return nil, true, NewError(CategoryResponseError, fmt.Sprintf("rpc error: %v", e), nil)
+	}
+	result, _ = msg["result"].(map[string]any)
+	if result == nil {
+		result = map[string]any{}
+	}
+	return result, true, nil
+}
+
+// numberID extracts an exact integer JSON-RPC id from a decoded protocol value.
+func numberID(v any) (int, bool) {
+	switch x := v.(type) {
+	case float64:
+		// JSON numbers decode to float64. A JSON-RPC id must be an exact integer
+		// that fits in int: reject NaN/Inf and fractional values (e.g. 1.5)
+		// instead of silently truncating to a plausible-but-wrong id that then
+		// matches the wrong pending request (#671).
+		if math.IsNaN(x) || math.IsInf(x, 0) || math.Trunc(x) != x {
+			return 0, false
+		}
+		// Reject magnitudes that would overflow int. float64(math.MaxInt) rounds
+		// up to 2^63 on 64-bit, so the upper bound is strict; math.MinInt
+		// (-2^63) is exactly representable, so its bound is inclusive.
+		if x < float64(math.MinInt) || x >= float64(math.MaxInt) {
+			return 0, false
+		}
+		return int(x), true
+	case int:
+		return x, true
+	default:
+		return 0, false
+	}
+}

--- a/scripts/file_size_budget_test.go
+++ b/scripts/file_size_budget_test.go
@@ -25,10 +25,12 @@ var oversizedProductionGoFileBaseline = map[string]int{
 	// codex_app_server.go's baseline rose from 840 under #666, which replaces the
 	// per-read goroutine with a single long-lived stdout reader (the reader
 	// lifecycle the #661 burn-down comment flags as this file's priority split).
-	// #661 then decomposes the file by responsibility, dropping it under budget
-	// and removing this baseline; the #666 reader tests are that split's
-	// characterization harness.
-	"internal/runner/codex_app_server.go": 907,
+	// #671 then extracts the JSON-RPC response-matching helpers (responseForID /
+	// numberID) into codex_app_server_response.go, dropping the baseline from 907
+	// to 877 — a first step toward the #661/#499 decomposition. #661 finishes the
+	// split by responsibility, dropping it under budget and removing this baseline;
+	// the #666 reader tests are that split's characterization harness.
+	"internal/runner/codex_app_server.go": 877,
 }
 
 func TestProductionGoFilesStayWithinSizeBudget(t *testing.T) {


### PR DESCRIPTION
Closes #671

## Summary
- `numberID` (the JSON-RPC id extractor for the Codex app-server) converted a
  JSON-decoded `float64` id with `int(x)`, **silently truncating** non-integers
  (`1.5` → `1`) and not guarding `NaN`/`Inf` or out-of-`int`-range magnitudes. A
  truncated id could match the **wrong pending request** in `responseForID`.
- **Fix (`numberID`):** for the `float64` case, reject `NaN`/`Inf`, fractional
  values (`math.Trunc(x) != x`), and out-of-`int`-range magnitudes; otherwise
  return the exact `int`. The range bounds account for float rounding
  (`float64(math.MaxInt)` rounds up to 2^63 → strict upper bound; `math.MinInt`
  is exactly representable → inclusive lower bound). The `int` case is unchanged.
- **Fix (`responseForID`):** a **present-but-non-integer** id is now surfaced as
  a `CategoryResponseError` (we can't reliably tell which request it answers, so
  reject rather than skip-and-wait — also removes a latent hang where the old
  skip looped to EOF). An **absent** id stays an interleaved notification (skip),
  so notification handling is unchanged.

### Scope: why these helpers are safe to harden
`numberID`/`responseForID` are used **only** by the synchronous
`(*appServerClient).request()` loop to match a client→server **response** by id.
Server→client requests (approvals) flow through a **separate** turn loop
(`handleServerRequest`, `codex_app_server_turn.go`) that echoes `msg["id"]`
directly and never calls `numberID`. The client only ever **sends** non-negative
integer ids, so negative integral ids remain valid JSON-RPC ids (they simply
mismatch and skip) rather than being rejected.

### File-size: extraction, not growth
The fix would have grown the already-oversized `codex_app_server.go` (over the
800-line budget). Per AGENTS rule 7 (decompose by responsibility; a reduction
must lower the baseline), I **extracted** the response-matching helpers
(`responseForID` + `numberID`) into a new `internal/runner/codex_app_server_response.go`,
lowering `codex_app_server.go`'s baseline **907 → 877** — a first step toward the
#661/#499 response-matching decomposition the budget comment cites.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Sub-SPEC hardening of the Codex runner path. The new file is `internal/runner/*`
(not `internal/orchestrator|worker`), so the PR-metadata SPEC gate does not apply;
no Codex turn/start payload changed (cross-cutting item 3 not engaged).

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production change is a `codex_app_server.go` → `codex_app_server_response.go` move plus ~10 LOC of validation; the test additions are excluded.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing — head `122cd84`
- [x] `gofmt -l` clean; `go vet ./...` clean; `go mod tidy` clean; golangci-lint `0 issues` on `internal/runner/...`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts` (baseline ratchet 907→877)
- [x] `go test -race -covermode=atomic ./...`; python unittests; `go build ./cmd/worker ./cmd/tui`
- [x] `TestNumberID` (table) — rejects `1.5`, `NaN`, `±Inf`, `1e19`; preserves `0`/`7`/`-3`/`int`. **Mutation-verified.**
- [x] `TestResponseForID` (table) — matching id → result / `CategoryResponseError`; mismatched-int & absent id → skip; present non-integer id → `CategoryResponseError`. **Mutation-verified.**
- [x] `TestRequest_FractionalIDRejectedNotTruncated` — the exact bug: id `0.5` (old code truncated → matched request `0`) now → `CategoryResponseError`. **Mutation-verified.**
- [x] `TestRequest_OutOfRangeIDReturnsResponseError`. Mutations restored via `git checkout`, tree==HEAD.

## Review — independent triple review, MERGE-READY
- **4-lens adversarial workflow** (Claude-family): numeric-correctness, protocol-semantics, scope/decomposition, test-quality — all MERGE-READY, `confirmedActionable: []`.
- **`codex:codex-rescue`** (Codex-family): MERGE-READY — no defects; confirmed range/rounding edges, no hang risk, clean extraction, mutation-verified non-placebo tests.
- Both flagged the same **optional** LOW: add direct `responseForID` unit tests for the unchanged skip branches → done (`TestResponseForID`).
- **Fresh `codex:codex-rescue` on the pushed head `122cd84`: MERGE-READY**, all NIT, no defects (numeric edges, no-hang, server-request isolation, baseline, SPEC all confirmed). (An earlier confirmation pass returned a *procedural* NEEDS-CHANGES from a wrong premise — it diffed vs main and re-flagged the production change as unreviewed; the production diff is byte-identical to the prior MERGE-READY head `2812b30`, and this fresh full-diff pass supersedes it.)
- `@codex` GitHub bot is externally unavailable batch-wide (origin "unknown error"; bytevane fork has no Codex env); merging on the compensating independent triple review per protocol §4 (operator-authorized this batch).

### Review threads
GraphQL `reviewThreads` count = 0.
