### PR TITLE
perf: cache Gitea blocker lookups per poll tick (#677)

### DIFF
--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -106,6 +106,9 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	if len(wantedStates) == 0 {
 		return nil, nil
 	}
+	// Install a per-poll-tick blocker cache so buildBlockedBy fetches each
+	// `Depends on #N` blocker at most once per tick across all source issues (#677).
+	ctx = withBlockerCache(ctx)
 	labelNames := StateLabelNamesForStates(states, DefaultStateLabelMappings())
 	issueState := giteaAPIStateForWorkflowStates(states, c.Config.TerminalStates)
 
@@ -536,18 +539,72 @@ func extractGiteaLabels(labels []Label) []string {
 	return out
 }
 
+// giteaTrackerContextKey scopes context values set by this package so they
+// cannot collide with keys from other packages.
+type giteaTrackerContextKey int
+
+const blockerCacheContextKey giteaTrackerContextKey = iota
+
+// blockerCacheEntry memoizes one getIssueByNumber result so a `Depends on #N`
+// blocker referenced by multiple source issues is fetched at most once per poll
+// tick (#677). Only definitive results — a successful fetch or a 404 not-found —
+// are cached; a transient fetch error is deliberately not cached so a later
+// source issue referencing the same blocker can still retry it within the tick,
+// preserving the original best-effort skip behavior without dropping a blocker
+// on a transient error.
+type blockerCacheEntry struct {
+	issue Issue
+	found bool
+}
+
+// withBlockerCache installs a fresh per-poll-tick blocker memoization cache on
+// ctx. ListIssuesByStates calls it once per tick so buildBlockedBy dedupes
+// blocker fetches across every source issue in the tick; the cache lives only
+// for that context, so each blocker's state is re-read on the next tick.
+func withBlockerCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, blockerCacheContextKey, map[int]blockerCacheEntry{})
+}
+
+func blockerCacheFrom(ctx context.Context) map[int]blockerCacheEntry {
+	cache, _ := ctx.Value(blockerCacheContextKey).(map[int]blockerCacheEntry)
+	return cache
+}
+
+// cachedIssueByNumber fetches blocker issue n via getIssueByNumber at most once
+// per poll tick. A successful fetch and a definitive 404 are memoized; a
+// transient error returns a miss without caching so a later source issue can
+// retry. When no per-tick cache is installed (non-poll callers), it falls back
+// to a direct fetch.
+func (c *TrackerClient) cachedIssueByNumber(ctx context.Context, cache map[int]blockerCacheEntry, n int) (Issue, bool) {
+	if cache != nil {
+		if entry, ok := cache[n]; ok {
+			return entry.issue, entry.found
+		}
+	}
+	issue, found, err := c.getIssueByNumber(ctx, n)
+	if err != nil {
+		return Issue{}, false
+	}
+	if cache != nil {
+		cache[n] = blockerCacheEntry{issue: issue, found: found}
+	}
+	return issue, found
+}
+
 // buildBlockedBy parses `Depends on #N` references from issue.Body and looks
 // up each blocker's current workflow state via a follow-up Gitea fetch so the
 // §8.2 Todo blocker rule can compare against the blocker's State. Lookup
 // failures are silently skipped (best-effort): a missing or deleted blocker
-// drops out of the list rather than aborting candidate enumeration. Lookups
-// are O(distinct refs) per source issue; this is acceptable for typical
-// workflows (0–3 blockers per issue).
+// drops out of the list rather than aborting candidate enumeration. The
+// per-poll-tick blocker cache (installed by ListIssuesByStates) ensures each
+// distinct blocker is fetched at most once per tick across all source issues,
+// instead of O(distinct refs) per source issue (#677).
 func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string) []tracker.BlockerRef {
 	matches := dependsOnRegexp.FindAllStringSubmatch(body, -1)
 	if len(matches) == 0 {
 		return nil
 	}
+	cache := blockerCacheFrom(ctx)
 	seen := map[int]struct{}{}
 	var out []tracker.BlockerRef
 	for _, m := range matches {
@@ -559,8 +616,8 @@ func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string) []track
 			continue
 		}
 		seen[n] = struct{}{}
-		issue, found, err := c.getIssueByNumber(ctx, n)
-		if err != nil || !found {
+		issue, found := c.cachedIssueByNumber(ctx, cache, n)
+		if !found {
 			continue
 		}
 		state, _ := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -770,3 +770,168 @@ func mustTime(value string) time.Time {
 	}
 	return parsed
 }
+
+// newSharedBlockerTrackerClient builds a Gitea mock whose issue-list endpoint
+// returns the given source issues and whose per-issue endpoint serves a single
+// shared blocker (#3, "AI Ready"), counting how many times the blocker is
+// fetched. It is the harness for the #677 per-poll-tick blocker-cache tests.
+func newSharedBlockerTrackerClient(t *testing.T, sources []Issue, blockerFetches *int) *TrackerClient {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(sources)
+		case "/api/v1/repos/owner/repo/issues/3":
+			*blockerFetches++
+			_ = json.NewEncoder(w).Encode(Issue{ID: 103, Number: 3, Title: "blocker", HTMLURL: "https://gitea.local/o/r/issues/3", Labels: []Label{{Name: "aiops/todo"}}})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"AI Ready"}}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	return client
+}
+
+func TestTrackerClientListIssuesByStatesFetchesSharedBlockerOncePerTick(t *testing.T) {
+	var blockerFetches int
+	client := newSharedBlockerTrackerClient(t, []Issue{
+		{ID: 101, Number: 1, Title: "a", Body: "Depends on #3", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/todo"}}},
+		{ID: 102, Number: 2, Title: "b", Body: "Depends on #3", HTMLURL: "https://gitea.local/o/r/issues/2", Labels: []Label{{Name: "aiops/todo"}}},
+	}, &blockerFetches)
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("ListIssuesByStates returned %d issues; want 2", len(issues))
+	}
+	if blockerFetches != 1 {
+		t.Fatalf("shared blocker #3 fetched %d times; want 1 (cached across both source issues in one tick)", blockerFetches)
+	}
+	for _, iss := range issues {
+		if len(iss.BlockedBy) != 1 || iss.BlockedBy[0].Identifier != "#3" || iss.BlockedBy[0].State != "AI Ready" {
+			t.Fatalf("issue %s BlockedBy = %#v; want one blocker #3 in state AI Ready", iss.Identifier, iss.BlockedBy)
+		}
+	}
+}
+
+func TestTrackerClientListIssuesByStatesRereadsBlockerOnNextTick(t *testing.T) {
+	var blockerFetches int
+	blockerLabel := "aiops/todo" // "AI Ready" on tick 1
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]Issue{
+				{ID: 101, Number: 1, Title: "a", Body: "Depends on #3", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/todo"}}},
+			})
+		case "/api/v1/repos/owner/repo/issues/3":
+			blockerFetches++
+			_ = json.NewEncoder(w).Encode(Issue{ID: 103, Number: 3, Title: "blocker", HTMLURL: "https://gitea.local/o/r/issues/3", Labels: []Label{{Name: blockerLabel}}})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"AI Ready"}}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	tick1, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates tick 1: %v", err)
+	}
+	blockerLabel = "aiops/done" // blocker transitions to "Done" between ticks
+	tick2, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates tick 2: %v", err)
+	}
+
+	if blockerFetches != 2 {
+		t.Fatalf("blocker #3 fetched %d times across two ticks; want 2 (once per tick, no cross-tick cache leak)", blockerFetches)
+	}
+	if len(tick1) != 1 || len(tick1[0].BlockedBy) != 1 || tick1[0].BlockedBy[0].State != "AI Ready" {
+		t.Fatalf("tick 1 BlockedBy = %#v; want blocker #3 in state AI Ready", tick1)
+	}
+	if len(tick2) != 1 || len(tick2[0].BlockedBy) != 1 || tick2[0].BlockedBy[0].State != "Done" {
+		t.Fatalf("tick 2 BlockedBy = %#v; want blocker #3 re-read in state Done", tick2)
+	}
+}
+
+// TestCachedIssueByNumberNilCacheFallsBackToDirectFetch pins the defensive
+// fallback for callers that reach buildBlockedBy without ListIssuesByStates
+// installing a cache: with a nil cache, each lookup is a direct getIssueByNumber
+// (no memoization, no nil-map write panic) (#677).
+func TestCachedIssueByNumberNilCacheFallsBackToDirectFetch(t *testing.T) {
+	var blockerFetches int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v1/repos/owner/repo/issues/3" {
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+		blockerFetches++
+		_ = json.NewEncoder(w).Encode(Issue{ID: 103, Number: 3, Title: "blocker", HTMLURL: "https://gitea.local/o/r/issues/3", Labels: []Label{{Name: "aiops/todo"}}})
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	issue, found := client.cachedIssueByNumber(context.Background(), nil, 3)
+	if !found || issue.Number != 3 {
+		t.Fatalf("cachedIssueByNumber(nil cache, 3) = (%#v, %v); want issue #3, true", issue, found)
+	}
+	if _, found = client.cachedIssueByNumber(context.Background(), nil, 3); !found {
+		t.Fatalf("cachedIssueByNumber(nil cache, 3) second call found = false; want true")
+	}
+	if blockerFetches != 2 {
+		t.Fatalf("blocker #3 fetched %d times with a nil cache; want 2 (no memoization without a cache)", blockerFetches)
+	}
+}
+
+func TestTrackerClientListIssuesByStatesRetriesBlockerAfterTransientError(t *testing.T) {
+	var blockerFetches int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]Issue{
+				{ID: 101, Number: 1, Title: "a", Body: "Depends on #3", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/todo"}}},
+				{ID: 102, Number: 2, Title: "b", Body: "Depends on #3", HTMLURL: "https://gitea.local/o/r/issues/2", Labels: []Label{{Name: "aiops/todo"}}},
+			})
+		case "/api/v1/repos/owner/repo/issues/3":
+			blockerFetches++
+			if blockerFetches == 1 {
+				// Transient failure on the first source issue's fetch: must NOT be
+				// cached, so the second source issue still retries (#677).
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(Issue{ID: 103, Number: 3, Title: "blocker", HTMLURL: "https://gitea.local/o/r/issues/3", Labels: []Label{{Name: "aiops/todo"}}})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"AI Ready"}}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v; a best-effort blocker error must not abort listing", err)
+	}
+	if blockerFetches != 2 {
+		t.Fatalf("blocker #3 fetched %d times; want 2 (transient error not cached, retried for the second source issue)", blockerFetches)
+	}
+	withBlocker := 0
+	for _, iss := range issues {
+		if len(iss.BlockedBy) == 1 && iss.BlockedBy[0].Identifier == "#3" {
+			withBlocker++
+		}
+	}
+	if withBlocker != 1 {
+		t.Fatalf("issues carrying blocker #3 = %d; want 1 (first source errored+skipped, second retried+found)", withBlocker)
+	}
+}


### PR DESCRIPTION
Closes #677

## Summary
- `buildBlockedBy` (`internal/gitea/tracker_client.go`) resolved each
  `Depends on #N` reference by calling `getIssueByNumber` **once per distinct ref
  per source issue with no caching**. So within a single poll tick a blocker
  referenced by multiple source issues was fetched once **per source issue**
  (O(distinct refs) per source issue). Each serial `GET /repos/{o}/{r}/issues/{n}`
  delays dispatch of newly-eligible issues and adds Gitea rate-limit load.
- **Fix:** install a **per-poll-tick blocker cache** — created once at the top of
  `ListIssuesByStates` (the per-tick entrypoint) and carried on the call
  `context` (via a typed `giteaTrackerContextKey`, matching the
  `internal/runner/tools.go` precedent) — and consume it in `buildBlockedBy` via a
  new `cachedIssueByNumber` helper. Each distinct blocker is now fetched **at most
  once per tick** across all source issues.
- The cache lives only for the tick's `context` (re-created each call), so a
  blocker's state is **re-read on the next tick** (no cross-tick staleness).

### Best-effort semantics preserved (the key design choice)
`cachedIssueByNumber` caches only **definitive** results — a successful fetch or a
404 not-found (both `err == nil`). A **transient** fetch error (`5xx`/network) is
**not** cached, so a later source issue referencing the same blocker can still
retry it within the tick. This preserves the original `err != nil || !found →
skip` semantics exactly, and avoids the dangerous failure mode of caching a
transient error and **dropping a still-valid blocker** for the rest of the tick
(which could let a blocked issue dispatch).

### Scope / adjacency
`getIssueByNumber` is also called by `FetchIssueStatesByRefs` (the reconcile
entrypoint), which does **not** install the cache and does not call
`buildBlockedBy`, so it is unaffected (falls back to a direct fetch). Sibling of
#672 (Linear N+1), tracked separately per the issue.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Scheduler/runner-internal read-path memoization in the tracker reader (deduping
redundant GETs within one poll tick) — squarely the scheduler's job, invisible to
the agent, no SPEC boundary concern; no SPEC-sensitive path touched.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff is `internal/gitea/tracker_client.go` (~+62 LOC); test additions excluded.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing — head `79ec47d`
- [x] `gofmt -l` clean; `go vet ./...` clean; `go mod tidy` clean; golangci-lint `0 issues` on `internal/gitea/...`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`; `go test -race -covermode=atomic ./...`; python unittests; `go build ./cmd/worker ./cmd/tui`
- [x] **AC1 call-count:** `…FetchesSharedBlockerOncePerTick` — 2 source issues sharing blocker #3 fetch it **once**. **Mutation-verified** (bypass cache → 2 fetches → FAIL).
- [x] **AC3 no cross-tick leak:** `…RereadsBlockerOnNextTick` — blocker fetched twice across two ticks and its `Done` transition is re-read on tick 2.
- [x] **AC2 best-effort error skip:** `…RetriesBlockerAfterTransientError` — 500-then-200 → fetched twice, second source issue retries and gets the blocker. **Mutation-verified** (cache errors → 1 fetch, blocker dropped → FAIL).
- [x] `TestCachedIssueByNumberNilCacheFallsBackToDirectFetch` — defensive nil-cache path does a direct fetch (no memoization, no nil-map panic).

## Review — independent triple review, MERGE-READY
- **4-lens adversarial workflow** (Claude-family): correctness/lifecycle, error-semantics, design/idiom, test-quality — all MERGE-READY, `confirmedActionable: []`.
- **`codex:codex-rescue`** (Codex-family): MERGE-READY — no defects across lifecycle, concurrency, error-handling, design, and test axes.
- Addressed the two concrete NITs: fixed a stale test-helper doc-comment name (clean-code rule 5) and added the nil-cache fallback test. (Left the `iota` vs `iota+1` key NIT as-is — harmless; distinct typed key, no collision.)
- `@codex` GitHub bot is externally unavailable batch-wide (origin "unknown error"; bytevane fork has no Codex env); merging on the compensating independent review per protocol §4 (operator-authorized this batch).

### Review threads
GraphQL `reviewThreads` count = 0.
