### PR TITLE
perf: batch Linear blocker lookups per poll page (#672)

### DIFF
--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -270,11 +270,14 @@ func (c *LinearClient) fetchLinearIssuesPage(ctx context.Context, vars map[strin
 	}
 	var issues []Issue
 	for _, n := range out.Data.Issues.Nodes {
-		iss, err := c.mapLinearIssueNode(ctx, n)
+		iss, err := mapLinearIssueNode(n)
 		if err != nil {
 			return nil, linearPageInfo{}, err
 		}
 		issues = append(issues, iss)
+	}
+	if err := c.attachLinearBlockers(ctx, issues); err != nil {
+		return nil, linearPageInfo{}, err
 	}
 	pageInfo := linearPageInfo{
 		HasNextPage: out.Data.Issues.PageInfo.HasNextPage,
@@ -283,10 +286,11 @@ func (c *LinearClient) fetchLinearIssuesPage(ctx context.Context, vars map[strin
 	return issues, pageInfo, nil
 }
 
-// mapLinearIssueNode maps one ListIssues node to a domain Issue. Blockers are
-// fetched only for Todo-state issues; createdAt is parsed before updatedAt so
-// the first malformed timestamp wins.
-func (c *LinearClient) mapLinearIssueNode(ctx context.Context, n linearIssueNode) (Issue, error) {
+// mapLinearIssueNode maps one ListIssues node to a domain Issue. createdAt is
+// parsed before updatedAt so the first malformed timestamp wins. Blockers are
+// not resolved here: attachLinearBlockers fills BlockedBy for the page's
+// Todo-state issues in one batched query (#672).
+func mapLinearIssueNode(n linearIssueNode) (Issue, error) {
 	createdAt, err := parseLinearIssueTime("createdAt", n.CreatedAt)
 	if err != nil {
 		return Issue{}, err
@@ -294,13 +298,6 @@ func (c *LinearClient) mapLinearIssueNode(ctx context.Context, n linearIssueNode
 	updatedAt, err := parseLinearIssueTime("updatedAt", n.UpdatedAt)
 	if err != nil {
 		return Issue{}, err
-	}
-	var blockers []BlockerRef
-	if isTodoState(n.State.Name) {
-		blockers, err = c.linearBlockersForIssue(ctx, n.ID)
-		if err != nil {
-			return Issue{}, err
-		}
 	}
 	labels := make([]string, 0, len(n.Labels.Nodes))
 	for _, label := range n.Labels.Nodes {
@@ -311,7 +308,7 @@ func (c *LinearClient) mapLinearIssueNode(ctx context.Context, n linearIssueNode
 	// Issue.CustomFields stays nil — Linear's GraphQL schema does not
 	// expose any custom-field data on Issue (introspection confirms
 	// only `customerTicketCount` matches `custom*`). See #326.
-	return Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, BranchName: n.BranchName, CreatedAt: createdAt, UpdatedAt: updatedAt, Labels: labels, State: n.State.Name, BlockedBy: blockers}, nil
+	return Issue{ID: n.ID, Identifier: n.Identifier, Title: n.Title, Description: n.Description, URL: n.URL, Priority: n.Priority, BranchName: n.BranchName, CreatedAt: createdAt, UpdatedAt: updatedAt, Labels: labels, State: n.State.Name}, nil
 }
 
 func parseLinearIssueTime(field, value string) (time.Time, error) {
@@ -389,10 +386,55 @@ func isTodoState(state string) bool {
 	return strings.EqualFold(strings.TrimSpace(state), "Todo")
 }
 
-func (c *LinearClient) linearBlockersForIssue(ctx context.Context, issueID string) ([]BlockerRef, error) {
-	var out struct {
-		Data struct {
-			Issue struct {
+// attachLinearBlockers resolves blocker (inverse-relation) data for the page's
+// Todo-state issues in one batched query instead of one query per issue (#672).
+// Non-Todo issues never carry blockers, matching the prior per-issue behavior,
+// so their BlockedBy stays nil. Pagination of any single issue's
+// inverseRelations beyond the first page is preserved deeper in the call chain
+// by fetchLinearBlockerChunk -> linearBlockersFromInverseRelations.
+func (c *LinearClient) attachLinearBlockers(ctx context.Context, issues []Issue) error {
+	ids := make([]string, 0, len(issues))
+	for _, iss := range issues {
+		if isTodoState(iss.State) {
+			ids = append(ids, iss.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	blockers, err := c.linearBlockersForIssues(ctx, ids)
+	if err != nil {
+		return err
+	}
+	for i := range issues {
+		if isTodoState(issues[i].State) {
+			issues[i].BlockedBy = blockers[issues[i].ID]
+		}
+	}
+	return nil
+}
+
+// listLinearIssuesInverseRelationsQuery fetches the first inverseRelations page
+// for a batch of issue ids in a single request. It is a separate query from
+// listLinearIssuesQuery so the candidate-list query's complexity does not grow
+// per poll; the inverseRelations page size matches the per-issue overflow query
+// in linearBlockersFromInverseRelations.
+const listLinearIssuesInverseRelationsQuery = `query ListIssuesInverseRelations($ids: [ID!]!, $first: Int!) {
+  issues(filter: { id: { in: $ids } }, first: $first) {
+    nodes {
+      id
+      inverseRelations(first: 50) { nodes { type issue { id identifier state { name } } } pageInfo { hasNextPage endCursor } }
+    }
+  }
+}`
+
+// linearBatchInverseRelationsResponse is the batched first-page inverse-relations
+// payload returned by listLinearIssuesInverseRelationsQuery for a chunk of ids.
+type linearBatchInverseRelationsResponse struct {
+	Data struct {
+		Issues struct {
+			Nodes []struct {
+				ID               string `json:"id"`
 				InverseRelations struct {
 					Nodes    []linearRelationNode `json:"nodes"`
 					PageInfo struct {
@@ -400,22 +442,53 @@ func (c *LinearClient) linearBlockersForIssue(ctx context.Context, issueID strin
 						EndCursor   string `json:"endCursor"`
 					} `json:"pageInfo"`
 				} `json:"inverseRelations"`
-			} `json:"issue"`
-		} `json:"data"`
-		Errors []map[string]any `json:"errors"`
+			} `json:"nodes"`
+		} `json:"issues"`
+	} `json:"data"`
+	Errors []map[string]any `json:"errors"`
+}
+
+// linearBlockersForIssues fetches first-page inverse relations for every id in
+// one batched query per linearIssuePageSize chunk, then continues per-issue
+// pagination only for ids whose blockers overflow the first page. Every
+// requested id is present in the result (empty slice when it has no blockers)
+// so callers see the same non-nil empty BlockedBy the per-issue path produced.
+func (c *LinearClient) linearBlockersForIssues(ctx context.Context, ids []string) (map[string][]BlockerRef, error) {
+	result := make(map[string][]BlockerRef, len(ids))
+	for _, id := range ids {
+		result[id] = []BlockerRef{}
 	}
-	query := `query ListIssueInverseRelations($id: String!, $after: String) {
-  issue(id: $id) {
-    inverseRelations(first: 50, after: $after) { nodes { type issue { id identifier state { name } } } pageInfo { hasNextPage endCursor } }
-  }
-}`
-	if err := c.graphql(ctx, query, map[string]any{"id": issueID, "after": nil}, &out); err != nil {
-		return nil, err
+	for start := 0; start < len(ids); start += linearIssuePageSize {
+		end := start + linearIssuePageSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if err := c.fetchLinearBlockerChunk(ctx, ids[start:end], result); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+// fetchLinearBlockerChunk runs one batched inverse-relations query for chunk and
+// records each returned issue's blockers into result, paginating any single
+// issue's overflow pages via linearBlockersFromInverseRelations.
+func (c *LinearClient) fetchLinearBlockerChunk(ctx context.Context, chunk []string, result map[string][]BlockerRef) error {
+	var out linearBatchInverseRelationsResponse
+	if err := c.graphql(ctx, listLinearIssuesInverseRelationsQuery, map[string]any{"ids": chunk, "first": len(chunk)}, &out); err != nil {
+		return err
 	}
 	if len(out.Errors) > 0 {
-		return nil, linearGraphQLErrors(out.Errors)
+		return linearGraphQLErrors(out.Errors)
 	}
-	return c.linearBlockersFromInverseRelations(ctx, issueID, out.Data.Issue.InverseRelations.Nodes, out.Data.Issue.InverseRelations.PageInfo.HasNextPage, out.Data.Issue.InverseRelations.PageInfo.EndCursor)
+	for _, n := range out.Data.Issues.Nodes {
+		blockers, err := c.linearBlockersFromInverseRelations(ctx, n.ID, n.InverseRelations.Nodes, n.InverseRelations.PageInfo.HasNextPage, n.InverseRelations.PageInfo.EndCursor)
+		if err != nil {
+			return err
+		}
+		result[n.ID] = blockers
+	}
+	return nil
 }
 
 func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, issueID string, nodes []linearRelationNode, hasNextPage bool, endCursor string) ([]BlockerRef, error) { //nolint:gocognit // baseline (#521)

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -593,8 +593,8 @@ func TestListIssuesByStatesPaginates(t *testing.T) {
 		}
 		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		if op == "ListIssueInverseRelations" {
-			_, _ = io.WriteString(w, `{"data":{"issue":{"inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"blocker-1","identifier":"LIN-0","state":{"name":"In Progress"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`)
+		if op == "ListIssuesInverseRelations" {
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"blocker-1","identifier":"LIN-0","state":{"name":"In Progress"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}]}}}`)
 			return
 		}
 		if idx >= len(pages) {
@@ -630,8 +630,8 @@ func TestListIssuesByStatesPaginates(t *testing.T) {
 	if requests[0].Variables["after"] != nil {
 		t.Fatalf("first request after = %v, want nil", requests[0].Variables["after"])
 	}
-	if requests[1].Variables["id"] != "issue-1" {
-		t.Fatalf("blocker request id = %v, want issue-1", requests[1].Variables["id"])
+	if ids, ok := requests[1].Variables["ids"].([]any); !ok || len(ids) != 1 || ids[0] != "issue-1" {
+		t.Fatalf("blocker request ids = %v, want [issue-1]", requests[1].Variables["ids"])
 	}
 	if requests[2].Variables["after"] != "cursor-1" {
 		t.Fatalf("second ListIssues request after = %v, want cursor-1", requests[2].Variables["after"])
@@ -646,7 +646,7 @@ func TestListIssuesByStatesPaginates(t *testing.T) {
 		t.Fatalf("ListIssues query should not fetch relation metadata for every candidate: %s", requests[0].Query)
 	}
 	if !strings.Contains(requests[1].Query, "inverseRelations") || !strings.Contains(requests[1].Query, "issue { id identifier state") {
-		t.Fatalf("ListIssueInverseRelations query = %s, want inverse relation blocker issue fields", requests[1].Query)
+		t.Fatalf("ListIssuesInverseRelations query = %s, want inverse relation blocker issue fields", requests[1].Query)
 	}
 }
 
@@ -670,7 +670,9 @@ func TestListIssuesByStatesPaginatesLinearInverseRelationsBeforeMappingBlockers(
 		case 1:
 			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
 		case 2:
-			_, _ = io.WriteString(w, `{"data":{"issue":{"inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"blocker-1","identifier":"LIN-0","state":{"name":"Done"}}}],"pageInfo":{"hasNextPage":true,"endCursor":"relation-cursor"}}}}}`)
+			// Batched first page (one request for all Todo ids): blocker-1 with a
+			// next page so the per-issue overflow query (case 3) must still run.
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"blocker-1","identifier":"LIN-0","state":{"name":"Done"}}}],"pageInfo":{"hasNextPage":true,"endCursor":"relation-cursor"}}}]}}}`)
 		case 3:
 			_, _ = io.WriteString(w, `{"data":{"issue":{"inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"blocker-2","identifier":"LIN-2","state":{"name":"In Progress"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`)
 		default:
@@ -693,11 +695,146 @@ func TestListIssuesByStatesPaginatesLinearInverseRelationsBeforeMappingBlockers(
 	if got := len(requests); got != 3 {
 		t.Fatalf("requests = %d, want candidate page plus inverse relation pages", got)
 	}
-	if requests[1].Variables["id"] != "issue-1" || requests[1].Variables["after"] != nil {
-		t.Fatalf("first relation request variables = %#v, want issue id and nil cursor", requests[1].Variables)
+	if ids, ok := requests[1].Variables["ids"].([]any); !ok || len(ids) != 1 || ids[0] != "issue-1" {
+		t.Fatalf("first relation request ids = %#v, want batched [issue-1]", requests[1].Variables["ids"])
 	}
 	if requests[2].Variables["id"] != "issue-1" || requests[2].Variables["after"] != "relation-cursor" {
-		t.Fatalf("second relation request variables = %#v, want issue id and relation cursor", requests[2].Variables)
+		t.Fatalf("overflow relation request variables = %#v, want issue id and relation cursor", requests[2].Variables)
+	}
+}
+
+// TestListIssuesByStatesBatchesBlockerLookupsForManyTodoIssues pins #672: three
+// Todo issues on one page resolve their blockers in a single batched query
+// (2 requests total) rather than one query per issue (the prior N+1 = 4
+// requests), while every issue still receives its own correct blockers.
+func TestListIssuesByStatesBatchesBlockerLookupsForManyTodoIssues(t *testing.T) {
+	var mu sync.Mutex
+	var requests []fakeLinearRequest
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		op := opNameFromQuery(payload.Query)
+		mu.Lock()
+		requests = append(requests, fakeLinearRequest{OpName: op, Query: payload.Query, Variables: payload.Variables})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch op {
+		case "ListIssues":
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[`+
+				`{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"u1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}},`+
+				`{"id":"issue-2","identifier":"LIN-2","title":"Two","description":"","url":"u2","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}},`+
+				`{"id":"issue-3","identifier":"LIN-3","title":"Three","description":"","url":"u3","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}}`+
+				`],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case "ListIssuesInverseRelations":
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[`+
+				`{"id":"issue-1","inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"b1","identifier":"LIN-91","state":{"name":"In Progress"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}},`+
+				`{"id":"issue-2","inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"b2","identifier":"LIN-92","state":{"name":"Done"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}},`+
+				`{"id":"issue-3","inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}`+
+				`]}}}`)
+		default:
+			t.Fatalf("unexpected op %q", op)
+		}
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if got, want := len(requests), 2; got != want {
+		t.Fatalf("requests = %d, want %d (one candidate page + one batched blocker query, not N+1)", got, want)
+	}
+	if requests[1].OpName != "ListIssuesInverseRelations" {
+		t.Fatalf("second op = %q, want ListIssuesInverseRelations", requests[1].OpName)
+	}
+	ids, ok := requests[1].Variables["ids"].([]any)
+	if !ok || len(ids) != 3 || ids[0] != "issue-1" || ids[1] != "issue-2" || ids[2] != "issue-3" {
+		t.Fatalf("batched blocker ids = %#v, want [issue-1 issue-2 issue-3]", requests[1].Variables["ids"])
+	}
+	if got := len(issues[0].BlockedBy); got != 1 || issues[0].BlockedBy[0].Identifier != "LIN-91" {
+		t.Fatalf("issue-1 blockers = %#v, want one LIN-91", issues[0].BlockedBy)
+	}
+	if got := len(issues[1].BlockedBy); got != 1 || issues[1].BlockedBy[0].Identifier != "LIN-92" {
+		t.Fatalf("issue-2 blockers = %#v, want one LIN-92", issues[1].BlockedBy)
+	}
+	if got := len(issues[2].BlockedBy); got != 0 {
+		t.Fatalf("issue-3 blockers = %d, want 0", got)
+	}
+}
+
+// TestListIssuesByStatesChunksBlockerBatchAcrossPageSize pins the #672 chunk
+// loop: when a page carries more Todo issues than linearIssuePageSize, the
+// blocker batch is split into linearIssuePageSize-sized ListIssuesInverseRelations
+// requests (mirroring FetchIssueStatesByIDs), and an issue in the trailing chunk
+// still receives its blocker.
+func TestListIssuesByStatesChunksBlockerBatchAcrossPageSize(t *testing.T) {
+	const todoCount = 55 // > linearIssuePageSize (50): forces a second chunk
+	var mu sync.Mutex
+	var batchChunkSizes []int
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		w.Header().Set("Content-Type", "application/json")
+		switch opNameFromQuery(payload.Query) {
+		case "ListIssues":
+			var b strings.Builder
+			b.WriteString(`{"data":{"issues":{"nodes":[`)
+			for i := 1; i <= todoCount; i++ {
+				if i > 1 {
+					b.WriteString(",")
+				}
+				fmt.Fprintf(&b, `{"id":"issue-%d","identifier":"LIN-%d","title":"T","description":"","url":"u","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}}`, i, i)
+			}
+			b.WriteString(`],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+			_, _ = io.WriteString(w, b.String())
+		case "ListIssuesInverseRelations":
+			ids, _ := payload.Variables["ids"].([]any)
+			mu.Lock()
+			batchChunkSizes = append(batchChunkSizes, len(ids))
+			mu.Unlock()
+			var b strings.Builder
+			b.WriteString(`{"data":{"issues":{"nodes":[`)
+			for i, raw := range ids {
+				id, _ := raw.(string)
+				if i > 0 {
+					b.WriteString(",")
+				}
+				fmt.Fprintf(&b, `{"id":%q,"inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"b-%s","identifier":"BLK-%s","state":{"name":"In Progress"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}`, id, id, id)
+			}
+			b.WriteString(`]}}}`)
+			_, _ = io.WriteString(w, b.String())
+		default:
+			t.Fatalf("unexpected op %q", opNameFromQuery(payload.Query))
+		}
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if got, want := len(issues), todoCount; got != want {
+		t.Fatalf("issues = %d, want %d", got, want)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	wantChunks := []int{linearIssuePageSize, todoCount - linearIssuePageSize}
+	if len(batchChunkSizes) != len(wantChunks) || batchChunkSizes[0] != wantChunks[0] || batchChunkSizes[1] != wantChunks[1] {
+		t.Fatalf("blocker batch chunk sizes = %v, want %v (one query per linearIssuePageSize chunk)", batchChunkSizes, wantChunks)
+	}
+	// An issue in the trailing chunk (issue-55) must still receive its blocker.
+	if got := issues[todoCount-1]; len(got.BlockedBy) != 1 || got.BlockedBy[0].Identifier != "BLK-issue-55" {
+		t.Fatalf("issues[%d].BlockedBy = %#v, want one BLK-issue-55", todoCount-1, got.BlockedBy)
 	}
 }
 
@@ -737,11 +874,16 @@ func TestListIssuesByStatesErrorsWhenInverseRelationMaxPagesExceeded(t *testing.
 		}
 		_ = json.Unmarshal(body, &payload)
 		w.Header().Set("Content-Type", "application/json")
-		if opNameFromQuery(payload.Query) == "ListIssues" {
+		switch opNameFromQuery(payload.Query) {
+		case "ListIssues":
 			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
-			return
+		case "ListIssuesInverseRelations":
+			// Batched first page reports a next page, forcing per-issue overflow.
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"same-relation-cursor"}}}]}}}`)
+		default:
+			// Per-issue overflow query keeps reporting the same cursor until the cap.
+			_, _ = io.WriteString(w, `{"data":{"issue":{"inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"same-relation-cursor"}}}}}`)
 		}
-		_, _ = io.WriteString(w, `{"data":{"issue":{"inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"same-relation-cursor"}}}}}`)
 	}))
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
@@ -869,7 +1011,7 @@ func TestListIssuesByStatesEmptyShortCircuitsWithoutAPICall(t *testing.T) {
 // TestListIssuesByStatesSkipsBlockerFetchForNonTodoIssue pins the isTodoState
 // gate (#521 decomposition characterization): blockers are fetched ONLY for
 // Todo-state issues, so a non-Todo issue must end with empty BlockedBy AND must
-// not trigger a ListIssueInverseRelations request. The existing pagination test
+// not trigger a ListIssuesInverseRelations request. The existing pagination test
 // only asserts the positive (Todo) branch; flipping the gate would survive it.
 func TestListIssuesByStatesSkipsBlockerFetchForNonTodoIssue(t *testing.T) {
 	var mu sync.Mutex
@@ -905,8 +1047,10 @@ func TestListIssuesByStatesSkipsBlockerFetchForNonTodoIssue(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	for _, op := range ops {
-		if op == "ListIssueInverseRelations" {
-			t.Fatalf("server ops = %v, want no ListIssueInverseRelations (blockers fetched only for Todo state)", ops)
+		// Post-#672 a flipped gate fetches blockers via the batched op
+		// ListIssuesInverseRelations (plural); a non-Todo issue must emit none.
+		if op == "ListIssuesInverseRelations" {
+			t.Fatalf("server ops = %v, want no ListIssuesInverseRelations (blockers fetched only for Todo state)", ops)
 		}
 	}
 	if got, want := len(ops), 1; got != want {


### PR DESCRIPTION
Closes #672

## Summary
- Linear polling resolved blockers with one `inverseRelations` GraphQL query **per Todo-state issue** (`mapLinearIssueNode` → `linearBlockersForIssue`), an N+1 pattern when many Todo issues are active each poll cycle.
- Now `fetchLinearIssuesPage` maps a page's nodes without blockers, then `attachLinearBlockers` resolves **all** of the page's Todo-issue ids in **one batched query** (`listLinearIssuesInverseRelationsQuery` = `issues(filter:{id:{in:$ids}})`), chunked by `linearIssuePageSize` (50). This mirrors the existing `FetchIssueStatesByIDs` batched-chunk pattern (cross-cutting checklist item 1).
- The candidate-list query (`listLinearIssuesQuery`) is **unchanged**, so its per-poll GraphQL complexity does not grow — the batch is a separate query. Per-issue `inverseRelations` overflow pagination (>50 relations) is preserved via `fetchLinearBlockerChunk` → `linearBlockersFromInverseRelations`.
- Removed the now-dead per-issue `linearBlockersForIssue`. `mapLinearIssueNode` is now a pure mapping function.

**Call-count impact:** for a page of N Todo issues each with ≤50 blockers, blocker resolution drops from N requests to 1 (plus the list request). Total request count and complexity both stay ≤ the old approach; rate-limit/pagination behavior is preserved.

**BlockedBy semantics preserved:** every requested Todo id is pre-seeded with a non-nil empty slice, so a Todo issue with no blockers (or one omitted from the batch response) keeps the same non-nil-empty `BlockedBy` the per-issue path produced; non-Todo issues stay `nil`. Both downstream consumers (`todoIssueBlockedByOpenDependency`, `IssueRenderVars`) range over the slice, so behavior is identical.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

This only optimizes the call shape of an existing aiops-platform extension (Linear blocker resolution during multi-state polling). No new SPEC behavior, no new worker/orchestrator surface; it stays within SPEC's scheduler/runner-as-tracker-reader boundary. Touches `internal/tracker/linear.go` only (not a SPEC-gated path).

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file (`internal/tracker/linear.go`), ~95 production LOC; the rest is test coverage (excluded).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] **Mutation-verified** against the committed artifact: degrading batching to one id/call, mis-attributing blockers, dropping the trailing chunk, and flipping the `isTodoState` gate each make the matching test fail; restored to HEAD after each.

### Tests
- `TestListIssuesByStatesBatchesBlockerLookupsForManyTodoIssues` — 3 Todo issues resolve in **2 requests** (not N+1=4), with correct per-issue blocker routing.
- `TestListIssuesByStatesChunksBlockerBatchAcrossPageSize` — 55 Todo issues split into `[50, 5]` batched requests; a trailing-chunk issue still receives its blocker.
- Updated `TestListIssuesByStatesPaginates`, `...PaginatesLinearInverseRelationsBeforeMappingBlockers`, `...ErrorsWhenInverseRelationMaxPagesExceeded`, and `...SkipsBlockerFetchForNonTodoIssue` for the batched op (`ListIssuesInverseRelations`), keeping the overflow + max-pages + negative-path coverage.

## Notes
- Independent reviews (multi-lens adversarial workflow + Codex-family + Claude-family) converged; adjudicated findings folded in: corrected a stale singular-op placebo guard in the non-Todo test, fixed a doc pointer, and added the >50-issue chunk-loop coverage. No remaining open findings.
