### PR TITLE
cleanup: drop speculative pre-#229 'form 3' rework-key fallback (#679)

### DIFF
--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -193,21 +193,26 @@ rm -rf "$AIOPS_WORKSPACE_ROOT"/*
 ```
 
 Active *rework* workspaces survive the cutover even without a manual
-sweep: `reworkWorkspaceKeyPrefixes` emits three prefix forms for each
+sweep: `reworkWorkspaceKeyPrefixes` emits two prefix forms for each
 extracted base key so it matches every aiops-platform sanitizer
 vintage that may have written to disk
 (`internal/worker/reconcile.go`):
 
 1. `<base>_rework_…` — current SPEC §4.2 sanitizer.
-2. `<base>-rework-…` — interim case-preserved layout with dash
-   separators.
-3. `<lowercased-pre-spec-base>-rework-…` — pre-#229 sanitizer, which
-   lowercased the workspace key and collapsed non-letter/digit runes
-   into a single `-` separator. This matches dirs named e.g.
+2. `<base>-rework-…` — interim/pre-#229 case-preserved layout with dash
+   separators. Because every shipped tracker builds the Rework key from
+   the all-lowercase `issue.ID` (a UUID or numeric value), this form
+   also matches the pre-#229 lowercased directories, e.g.
    `linear_issue/issue-3-rework-2026-05-16t10-00-00z` produced by an
-   older worker for an active Linear Rework issue, where the base of
-   the dir name was the issue ID (`issue-3`) rather than the
-   human-facing identifier (`LIN-123`).
+   older worker for an active Linear Rework issue, where the base of the
+   dir name was the issue ID (`issue-3`) rather than the human-facing
+   identifier (`LIN-123`).
+
+(#679 removed a speculative third `<lowercased-pre-spec-base>-rework-…`
+form: since form 2 is case-preserving and the shipped trackers' keys are
+already lowercase, it never matched a directory form 2 did not. Re-add it
+only when a tracker actually emits an `issue.ID` containing uppercase or
+`[^a-zA-Z0-9._-]` characters.)
 
 Plain (non-rework) per-issue dirs created under the old sanitizer are
 not back-compat-matched and will be reconciled away.

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
@@ -468,35 +467,27 @@ func reworkWorkspaceKeyPrefixes(issue tracker.Issue) []string { //nolint:gocogni
 		if key == "" {
 			continue
 		}
-		// Emit three prefix forms so reconciliation recognizes Rework
+		// Emit two prefix forms so reconciliation recognizes Rework
 		// workspaces from every sanitizer vintage that aiops-platform
 		// has shipped:
 		//   1. `<base>_rework_…` — current SPEC §4.2 sanitizer, which
 		//      maps `|` and `:` to `_` and preserves case.
-		//   2. `<base>-rework-…` — interim layout where the base was
-		//      already case-preserved but the rework separator was the
-		//      dash form left over from an earlier `_rework_`/`-rework-`
-		//      split.
-		//   3. `<lowercased-base>-rework-…` — pre-#229 sanitizer, which
-		//      lowercased the workspace key and collapsed any
-		//      non-letter/digit rune into a `-` separator. For the
-		//      Linear, Gitea, and GitHub trackers shipped today the
-		//      Rework key is composed from `issue.ID` — an
-		//      all-lowercase UUID or numeric value — so form 2 already
-		//      covers every directory shape any released worker actually
-		//      wrote to disk and form 3 is dead defensive code for the
-		//      current set of trackers. It is kept (rather than deleted)
-		//      to absorb a hypothetical future tracker whose `issue.ID`
-		//      contains uppercase letters or characters in
-		//      `[^a-zA-Z0-9._-]` that the pre-#229 sanitizer would have
-		//      collapsed; without form 3 such an in-flight Rework
-		//      workspace would be removed as `unknown` on the first
-		//      reconcile after upgrading past #229.
-		preSpec := sanitizePreSpecWorkspaceKey(key)
+		//   2. `<base>-rework-…` — interim/pre-#229 layout where the base
+		//      was already case-preserved (or already lowercase) and the
+		//      rework separator was the dash form left over from an
+		//      earlier `_rework_`/`-rework-` split.
+		// #679 removed a speculative third `<lowercased-base>-rework-…`
+		// form (the pre-#229 sanitizer lowercased the key): for the Linear,
+		// Gitea, and GitHub trackers shipped today the Rework key is
+		// composed from `issue.ID` — an all-lowercase UUID or numeric value
+		// — so form 2 already covers every directory shape any released
+		// worker actually wrote to disk, and form 3 never matched a real
+		// directory. Re-add it only when a tracker actually emits an
+		// `issue.ID` with uppercase or `[^a-zA-Z0-9._-]` characters (an
+		// earned rule with a real failure behind it).
 		for _, prefix := range []string{
 			key + "_rework_",
 			key + "-rework-",
-			preSpec + "-rework-",
 		} {
 			if _, ok := seen[prefix]; ok {
 				continue
@@ -507,38 +498,6 @@ func reworkWorkspaceKeyPrefixes(issue tracker.Issue) []string { //nolint:gocogni
 	}
 	return prefixes
 }
-
-// sanitizePreSpecWorkspaceKey reproduces the pre-#229 workspace-key
-// sanitizer (lowercased input, only `unicode.IsLetter` and
-// `unicode.IsDigit` runes preserved, any other rune collapsed into a
-// single `-` separator, edge `-` trimmed, 120-rune cap). It exists
-// purely so reconciliation can recognize Rework directories that were
-// created on disk before the SPEC §4.2 realignment landed; nothing in
-// the worker writes new dirs with this name.
-func sanitizePreSpecWorkspaceKey(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	inSeparator := false
-	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			b.WriteRune(r)
-			inSeparator = false
-			continue
-		}
-		if !inSeparator && b.Len() > 0 {
-			b.WriteByte('-')
-			inSeparator = true
-		}
-	}
-	out := strings.Trim(b.String(), "-")
-	runes := []rune(out)
-	if len(runes) > maxPreSpecSanitizedLength {
-		out = strings.TrimRight(string(runes[:maxPreSpecSanitizedLength]), "-")
-	}
-	return out
-}
-
-const maxPreSpecSanitizedLength = 120
 
 func nonEmptyStates(states []string) []string {
 	out := make([]string, 0, len(states))

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -575,11 +575,11 @@ func TestReconcileStartupKeepsReworkWorkspaceWithLegacyOffsetTimestampSuffix(t *
 func TestReworkWorkspaceKeyPrefixesMatchCanonicalAndLegacyOffsetSuffixes(t *testing.T) {
 	issue := tracker.Issue{ID: "issue-3", State: "Rework", UpdatedAt: mustTime("2026-05-08T12:30:00+02:00")}
 
-	// reworkWorkspaceKeyPrefixes emits three prefix forms so
-	// reconciliation matches workspaces from every aiops-platform
-	// sanitizer vintage on disk: the canonical SPEC §4.2 `_rework_`,
-	// the interim case-preserved `-rework-`, and the pre-#229
-	// lowercased-base `-rework-`.
+	// reworkWorkspaceKeyPrefixes emits two prefix forms so reconciliation
+	// matches workspaces from every aiops-platform sanitizer vintage on disk:
+	// the canonical SPEC §4.2 `_rework_` and the interim/pre-#229 case-preserved
+	// `-rework-`. (#679 removed the speculative lowercased-base third form; for
+	// an all-lowercase ID like "issue-3" it was always a duplicate of form 2.)
 	got := reworkWorkspaceKeyPrefixes(issue)
 	want := []string{"issue-3_rework_", "issue-3-rework-"}
 	if !reflect.DeepEqual(got, want) {
@@ -593,7 +593,10 @@ func TestReworkWorkspaceKeyPrefixesMatchCanonicalAndLegacyOffsetSuffixes(t *test
 // throughout, lowercased timestamp) must still be classified as
 // `active_rework` on the first reconcile after the upgrade, instead of
 // being removed as `unknown` once a terminal fetch unlocks the
-// unknown-removal path.
+// unknown-removal path. The shipped trackers' Rework key is the
+// all-lowercase `issue.ID`, so the case-preserving form 2 (`<id>-rework-`)
+// matches the on-disk directory — this is exactly why #679 could drop the
+// speculative lowercased-base third form without regressing the promise.
 func TestReconcileStartupKeepsPreSpecLowercasedReworkWorkspace(t *testing.T) {
 	root := t.TempDir()
 	// Pre-#229 actual on-disk shape for a Linear Rework workspace, mirroring
@@ -627,22 +630,27 @@ func TestReconcileStartupKeepsPreSpecLowercasedReworkWorkspace(t *testing.T) {
 	}
 }
 
-// TestReworkWorkspaceKeyPrefixesIncludesPreSpecLowercaseForm guards the
-// production code that powers the migration test above.
-func TestReworkWorkspaceKeyPrefixesIncludesPreSpecLowercaseForm(t *testing.T) {
+// TestReworkWorkspaceKeyPrefixesOmitsPreSpecLowercaseForm pins #679: the
+// speculative pre-#229 lowercased-base `-rework-` form is no longer emitted, so
+// even an uppercase Identifier yields only the case-preserving SPEC and interim
+// forms. Form 2 already covers every shipped tracker, whose Rework key is built
+// from an all-lowercase `issue.ID`.
+func TestReworkWorkspaceKeyPrefixesOmitsPreSpecLowercaseForm(t *testing.T) {
 	issue := tracker.Issue{ID: "issue-3", Identifier: "LIN-123", State: "Rework", UpdatedAt: mustTime("2026-05-16T10:00:00Z")}
 
 	got := reworkWorkspaceKeyPrefixes(issue)
 	for _, want := range []string{
 		"LIN-123_rework_", // SPEC §4.2 form
 		"LIN-123-rework-", // interim dash form
-		"lin-123-rework-", // pre-#229 lowercased form
 		"issue-3_rework_", // SPEC form for ID
-		"issue-3-rework-", // interim form for ID (deduped against pre-spec)
+		"issue-3-rework-", // interim form for ID
 	} {
 		if !containsStringWorker(got, want) {
 			t.Fatalf("reworkWorkspaceKeyPrefixes = %#v, missing %q", got, want)
 		}
+	}
+	if containsStringWorker(got, "lin-123-rework-") {
+		t.Fatalf("reworkWorkspaceKeyPrefixes = %#v, must not emit the removed pre-#229 lowercased form %q", got, "lin-123-rework-")
 	}
 }
 


### PR DESCRIPTION
Closes #679

## Summary
- `reworkWorkspaceKeyPrefixes` (`internal/worker/reconcile.go`) emitted a **third** Rework-key prefix form — `<lowercased-base>-rework-`, built via `sanitizePreSpecWorkspaceKey` — that was **self-documented as dead defensive code**. Every shipped tracker (Linear/Gitea/GitHub) builds the Rework key from `issue.ID` (an all-lowercase UUID or numeric value), so the case-preserving form 2 (`<base>-rework-`) already matches every directory shape any released worker wrote to disk, and form 3 never matched a real directory.
- This is the speculative scaffolding **AGENTS.md harness principles 2 & 4** argue against ("leave a rule out until you have a failure that demands it"; "remove scaffolding that is no longer earning its keep").

## What changed
- Removed form 3, the `sanitizePreSpecWorkspaceKey` helper, the `maxPreSpecSanitizedLength` const, and the now-unused `unicode` import.
- Rewrote the production comment (forms 1–2; re-add form 3 only when a tracker actually emits an `issue.ID` with uppercase / `[^a-zA-Z0-9._-]` chars — an earned rule).
- Replaced the form-3 *guard* test with a **negative** test (`TestReworkWorkspaceKeyPrefixesOmitsPreSpecLowercaseForm`) that pins the lowercased form is no longer emitted, and updated two adjacent test comments.
- Updated `docs/runbooks/workspace-cache.md` (it still documented "three prefix forms" + form 3) — the documented derivation of this function, swept atomically per clean-code rule 10.
- Kept `//nolint:gocognit // baseline (#521)` on `reworkWorkspaceKeyPrefixes` — it is still gocognit 13 (>10) after the change, so the baseline must remain.

**Migration safety (#229/#290 promise preserved):** for shipped trackers the on-disk Rework dir key is the all-lowercase `issue.ID`, so form 2 matches it. `TestReconcileStartupKeepsPreSpecLowercasedReworkWorkspace` still drives the real on-disk shape (`linear_issue/issue-3-rework-…`) through `ReconcileStartup` and confirms it is kept (not removed as `unknown`).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Pure removal of speculative scaffolding; touches an existing `internal/worker` file (not a new file), so no SPEC-metadata gate applies.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file (`reconcile.go`, net −36 production LOC) + a runbook + test updates.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...` (ALL PASS)
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] **Mutation-verified** against the committed artifact: re-adding form 3 makes `TestReworkWorkspaceKeyPrefixesOmitsPreSpecLowercaseForm` fail on the absence assertion; restored to HEAD.

## Notes
- Independent reviews (multi-lens adversarial workflow + Codex-family + Claude-family in an isolated worktree) converged. The read-only workflow lens caught the stale runbook (rule 10 "fix the class"), now folded in; both code reviewers confirmed migration safety across all three trackers and that the negative test is mutation-proof. No remaining open findings.
