### PR TITLE
feat: add tracker.required_labels opt-in dispatch gate (#682)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ from SPEC are called out and tracked in [`DEVIATIONS.md`](DEVIATIONS.md):
 | `tracker.project_slug` | required for `tracker.kind: linear` | SPEC §6.4 |
 | `tracker.active_states` | `[Todo, In Progress]` | SPEC §6.4 |
 | `tracker.terminal_states` | `[Closed, Cancelled, Canceled, Duplicate, Done]` | SPEC §6.4 |
+| `tracker.required_labels` | `[]` (gate off) — opt-in dispatch filter: an issue must carry every listed label (matched case-insensitively after trimming) to dispatch or keep running. Removing a required label makes a running agent self-stop after its current turn (per-turn refresh) and releases retry/blocked work on the next poll. A blank entry matches no issue. | SPEC §4.1.1 / §6.4 |
 | `tracker.pagination_max_pages` | adapter default (`github`: 10 pages; `gitea`: 20 pages; `linear`: uncapped cursor walk) | implementation |
 | `workspace.root` | `<system-temp>/symphony_workspaces` (resolved via `os.TempDir()` at startup, typically `/tmp/symphony_workspaces` on Linux; per-boot — set explicitly to a long-lived path for persistence) | SPEC §6.4 |
 | `verify.commands` | none — surfaced to the agent's prompt as its own pre-handoff responsibility; the worker does not run them (SPEC §1 agent boundary) | implementation |

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -426,13 +426,14 @@ func run(ctx context.Context, args []string) error { //nolint:gocognit,funlen //
 	return orchestrator.RunPollLoopWithRuntime(ctx, poller, runtime, orchestrator.PollLoopRuntimeOptions{})
 }
 func reconciliationConfigForWorkflow(cfg workflow.Config) orchestrator.ReconciliationConfig {
-	return orchestrator.ReconciliationConfig{
-		ActiveStates:      cfg.Tracker.ActiveStates,
-		TerminalStates:    cfg.Tracker.TerminalStates,
-		InactiveStates:    inferredInactiveStates(cfg.Tracker),
-		WorkerExitTimeout: 30 * time.Second,
-		StallTimeoutMs:    cfg.Codex.StallTimeoutMs,
-	}
+	// Single source of truth for the field list lives in
+	// orchestrator.ReconciliationConfigFromWorkflow; the worker only re-derives
+	// InactiveStates (default candidates minus active/terminal, per
+	// inferredInactiveStates). Delegating here keeps fields such as
+	// RequiredLabels from being silently dropped in production (#682).
+	rc := orchestrator.ReconciliationConfigFromWorkflow(cfg)
+	rc.InactiveStates = inferredInactiveStates(cfg.Tracker)
+	return rc
 }
 func inferredInactiveStates(cfg workflow.TrackerConfig) []string {
 	candidates := cfg.InactiveStates

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -2029,6 +2029,29 @@ func TestWorkerReconciliationConfigUsesWorkflowInactiveStates(t *testing.T) {
 	}
 }
 
+func TestWorkerReconciliationConfigThreadsRequiredLabels(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.CloneURL = "git@example.com:o/r.git"
+	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress"}
+	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
+	cfg.Tracker.RequiredLabels = []string{"aiops-ready", "triaged"}
+
+	reconcile := reconciliationConfigForWorkflow(cfg)
+	if !reflect.DeepEqual(reconcile.RequiredLabels, cfg.Tracker.RequiredLabels) {
+		t.Fatalf("reconciliationConfigForWorkflow(required_labels=%v).RequiredLabels = %v; want %v", cfg.Tracker.RequiredLabels, reconcile.RequiredLabels, cfg.Tracker.RequiredLabels)
+	}
+}
+
+func TestWorkerReconciliationConfigDefaultsRequiredLabelsEmpty(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.CloneURL = "git@example.com:o/r.git"
+
+	reconcile := reconciliationConfigForWorkflow(cfg)
+	if len(reconcile.RequiredLabels) != 0 {
+		t.Fatalf("reconciliationConfigForWorkflow(no required_labels).RequiredLabels = %v; want empty (gate disabled by default)", reconcile.RequiredLabels)
+	}
+}
+
 func containsState(states []string, want string) bool {
 	for _, state := range states {
 		if state == want {

--- a/docs/workflows/company-cautious-WORKFLOW.md
+++ b/docs/workflows/company-cautious-WORKFLOW.md
@@ -17,6 +17,12 @@ tracker:
   terminal_states:
     - Done
     - Canceled
+  # SPEC §6.4 opt-in dispatch gate: an issue is only picked up once it carries
+  # EVERY label below (matched case-insensitively). Removing the label from a
+  # running issue stops the agent on the next poll. Omit or leave empty to
+  # dispatch every active issue. A blank entry matches no issue.
+  required_labels:
+    - aiops-ready
 
 polling:
   interval_ms: 30000

--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -153,11 +153,11 @@ func (c *TrackerClient) ListIssuesByStates(ctx context.Context, states []string)
 	return out, nil
 }
 
-func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]tracker.IssueState, error) {
 	return c.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(issueIDs))
 }
 
-func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]string, error) { //nolint:gocognit // baseline (#521)
+func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]tracker.IssueState, error) { //nolint:gocognit // baseline (#521)
 	if c.BaseURL == "" || c.Token == "" {
 		return nil, fmt.Errorf("GITEA_BASE_URL and Gitea tracker api_key are required")
 	}
@@ -165,9 +165,9 @@ func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []
 		return nil, fmt.Errorf("repo.owner and repo.name are required for Gitea tracker polling")
 	}
 	if len(issueRefs) == 0 {
-		return map[string]string{}, nil
+		return map[string]tracker.IssueState{}, nil
 	}
-	states := make(map[string]string, len(issueRefs))
+	states := make(map[string]tracker.IssueState, len(issueRefs))
 	seen := map[string]struct{}{}
 	for _, issueRef := range issueRefs {
 		issueID := strings.TrimSpace(issueRef.ID)
@@ -200,7 +200,9 @@ func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []
 		if state == "" {
 			continue
 		}
-		states[issueID] = state
+		// Carry the full label set (SPEC §6.4 required_labels gate) alongside the
+		// derived state; extractGiteaLabels lowercases/trims to match the gate.
+		states[issueID] = tracker.IssueState{State: state, Labels: extractGiteaLabels(issue.Labels)}
 	}
 	return states, nil
 }

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -120,7 +120,7 @@ func TestTrackerClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) 
 			})
 		case "/api/v1/repos/owner/repo/issues/1":
 			_ = json.NewEncoder(w).Encode(Issue{
-				ID: 101, Number: 1, Title: "done", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/done"}},
+				ID: 101, Number: 1, Title: "done", HTMLURL: "https://gitea.local/o/r/issues/1", Labels: []Label{{Name: "aiops/done"}, {Name: "Aiops-Ready"}},
 			})
 		case "/api/v1/repos/owner/repo/issues/2":
 			http.NotFound(w, r)
@@ -143,8 +143,11 @@ func TestTrackerClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIDs: %v", err)
 	}
-	if got, want := states, map[string]string{"101": "Done"}; len(got) != len(want) || got["101"] != want["101"] {
+	if got, want := states, map[string]string{"101": "Done"}; len(got) != len(want) || got["101"].State != want["101"] {
 		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	if got, want := states["101"].Labels, []string{"aiops/done", "aiops-ready"}; !slices.Equal(got, want) {
+		t.Fatalf("FetchIssueStatesByIDs(101).Labels = %v; want %v", got, want)
 	}
 	if got, want := strings.Join(requestedPaths, ","), "/api/v1/repos/owner/repo/issues,/api/v1/repos/owner/repo/issues/1,/api/v1/repos/owner/repo/issues/2"; got != want {
 		t.Fatalf("requested paths = %s, want %s", got, want)
@@ -174,7 +177,7 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 				Number:  7,
 				Title:   "done",
 				HTMLURL: "https://gitea.local/o/r/issues/7",
-				Labels:  []Label{{Name: "aiops/done"}},
+				Labels:  []Label{{Name: "aiops/done"}, {Name: "Aiops-Ready"}},
 			})
 		default:
 			t.Fatalf("unexpected request path %q", r.URL.Path)
@@ -189,8 +192,11 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs: %v", err)
 	}
-	if got, want := states, map[string]string{"987654": "Done"}; len(got) != len(want) || got["987654"] != want["987654"] {
+	if got, want := states, map[string]string{"987654": "Done"}; len(got) != len(want) || got["987654"].State != want["987654"] {
 		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	if got, want := states["987654"].Labels, []string{"aiops/done", "aiops-ready"}; !slices.Equal(got, want) {
+		t.Fatalf("FetchIssueStatesByRefs(987654).Labels = %v; want %v", got, want)
 	}
 	if got, want := strings.Join(requestedPaths, ","), "/api/v1/repos/owner/repo/issues/7"; got != want {
 		t.Fatalf("requested paths = %s, want %s", got, want)
@@ -199,7 +205,7 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIDs after successful ref refresh: %v", err)
 	}
-	if got := states["987654"]; got != "Done" {
+	if got := states["987654"].State; got != "Done" {
 		t.Fatalf("successful ref refresh cache state = %q, want Done", got)
 	}
 
@@ -214,7 +220,7 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs #number ID: %v", err)
 	}
-	if got := states["#7"]; got != "Done" {
+	if got := states["#7"].State; got != "Done" {
 		t.Fatalf("#number fallback state = %q, want Done", got)
 	}
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "#8", Identifier: "#7"}})
@@ -228,7 +234,7 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs numeric fallback ID: %v", err)
 	}
-	if got := states["7"]; got != "Done" {
+	if got := states["7"].State; got != "Done" {
 		t.Fatalf("numeric fallback ID state = %q, want Done", got)
 	}
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "5", Identifier: "#7"}})
@@ -251,14 +257,14 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs cached global ID with stale identifier: %v", err)
 	}
-	if got := states["555"]; got != "Done" {
+	if got := states["555"].State; got != "Done" {
 		t.Fatalf("cached global ID state = %q, want Done", got)
 	}
 	states, err = client.FetchIssueStatesByIDs(context.Background(), []string{"987654"})
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIDs after fallback cache: %v", err)
 	}
-	if got := states["987654"]; got != "Done" {
+	if got := states["987654"].State; got != "Done" {
 		t.Fatalf("cached fallback state = %q, want Done", got)
 	}
 }

--- a/internal/orchestrator/actor_cleanup.go
+++ b/internal/orchestrator/actor_cleanup.go
@@ -278,14 +278,14 @@ func (o *Orchestrator) verifyReconciledWorkspaceStillTerminal(w ReconciledWorksp
 		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_refresh_failed error=%q", w.IssueID, w.Identifier, err.Error())
 		return "", false, false
 	}
-	state, ok := states[string(w.IssueID)]
+	st, ok := states[string(w.IssueID)]
 	if !ok {
 		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_missing", w.IssueID, w.Identifier)
 		return "", false, false
 	}
-	if !isTerminalTrackerState(state, terminalStates) {
-		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_not_terminal state=%q", w.IssueID, w.Identifier, state)
-		return state, false, true
+	if !isTerminalTrackerState(st.State, terminalStates) {
+		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_not_terminal state=%q", w.IssueID, w.Identifier, st.State)
+		return st.State, false, true
 	}
-	return state, true, true
+	return st.State, true, true
 }

--- a/internal/orchestrator/actor_retry.go
+++ b/internal/orchestrator/actor_retry.go
@@ -389,7 +389,7 @@ func resolveRetryTerminalState(o *Orchestrator, id IssueID, identifier string) (
 	if rerr != nil {
 		return false, ""
 	}
-	s := strings.TrimSpace(statesByID[string(id)])
+	s := strings.TrimSpace(statesByID[string(id)].State)
 	if s == "" || !isTerminalTrackerState(s, terminalStates) {
 		return false, ""
 	}

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -2322,7 +2322,7 @@ type countingFailRefresher struct {
 	calls int
 }
 
-func (f *countingFailRefresher) FetchIssueStatesByIDs(_ context.Context, _ []string) (map[string]string, error) {
+func (f *countingFailRefresher) FetchIssueStatesByIDs(_ context.Context, _ []string) (map[string]tracker.IssueState, error) {
 	f.mu.Lock()
 	f.calls++
 	f.mu.Unlock()
@@ -2340,7 +2340,7 @@ type flakyStateRefresher struct {
 	calls  int
 }
 
-func (f *flakyStateRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]string, error) {
+func (f *flakyStateRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]tracker.IssueState, error) {
 	f.calls++
 	if f.calls == 1 {
 		return nil, errors.New("temporary tracker refresh failure")
@@ -2348,15 +2348,15 @@ func (f *flakyStateRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []s
 	return f.states.FetchIssueStatesByIDs(ctx, ids)
 }
 
-func (r *redispatchDuringCleanupRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]string, error) {
+func (r *redispatchDuringCleanupRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]tracker.IssueState, error) {
 	return r.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(ids))
 }
 
-func (r *redispatchDuringCleanupRefresher) FetchIssueStatesByRefs(ctx context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+func (r *redispatchDuringCleanupRefresher) FetchIssueStatesByRefs(ctx context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
 	r.attempted <- r.orch.RequestDispatch(ctx, r.issue, nil)
-	out := make(map[string]string, len(refs))
+	out := make(map[string]tracker.IssueState, len(refs))
 	for _, ref := range refs {
-		out[ref.ID] = r.state
+		out[ref.ID] = tracker.IssueState{State: r.state}
 	}
 	return out, nil
 }
@@ -3788,11 +3788,11 @@ func TestRetryFire_ReleasesClaimWhenIssueAbsentFromCandidates(t *testing.T) {
 // mutates it after construction.
 type staticStateRefresher map[string]string
 
-func (s staticStateRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]string, error) {
-	out := make(map[string]string, len(ids))
+func (s staticStateRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]tracker.IssueState, error) {
+	out := make(map[string]tracker.IssueState, len(ids))
 	for _, id := range ids {
 		if state, ok := s[id]; ok {
-			out[id] = state
+			out[id] = tracker.IssueState{State: state}
 		}
 	}
 	return out, nil
@@ -3803,16 +3803,16 @@ type recordingRefStateRefresher struct {
 	refs   [][]tracker.IssueRef
 }
 
-func (r *recordingRefStateRefresher) FetchIssueStatesByIDs(context.Context, []string) (map[string]string, error) {
+func (r *recordingRefStateRefresher) FetchIssueStatesByIDs(context.Context, []string) (map[string]tracker.IssueState, error) {
 	return nil, errors.New("legacy ID-only retry terminal refresh should not be used")
 }
 
-func (r *recordingRefStateRefresher) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+func (r *recordingRefStateRefresher) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
 	r.refs = append(r.refs, append([]tracker.IssueRef(nil), refs...))
-	out := make(map[string]string, len(refs))
+	out := make(map[string]tracker.IssueState, len(refs))
 	for _, ref := range refs {
 		if state, ok := r.states[ref.ID]; ok {
-			out[ref.ID] = state
+			out[ref.ID] = tracker.IssueState{State: state}
 		}
 	}
 	return out, nil

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -34,16 +34,16 @@ type IssueStateLister interface {
 // When present, reconciliation refreshes in-flight issue states by explicit ID
 // instead of relying on a wide active-state listing.
 type IssueStateRefresher interface {
-	FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error)
+	FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]tracker.IssueState, error)
 }
 
 type issueStateRefresherByRefs interface {
-	FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]string, error)
+	FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]tracker.IssueState, error)
 }
 
-func fetchIssueStates(ctx context.Context, refresher IssueStateRefresher, refs []tracker.IssueRef) (map[string]string, error) {
+func fetchIssueStates(ctx context.Context, refresher IssueStateRefresher, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
 	if refresher == nil || len(refs) == 0 {
-		return map[string]string{}, nil
+		return map[string]tracker.IssueState{}, nil
 	}
 	if refRefresher, ok := refresher.(issueStateRefresherByRefs); ok {
 		return refRefresher.FetchIssueStatesByRefs(ctx, refs)
@@ -63,6 +63,14 @@ type ReconciliationConfig struct {
 	ActiveStates   []string
 	TerminalStates []string
 	InactiveStates []string
+
+	// RequiredLabels is the SPEC §6.4 opt-in dispatch gate
+	// (workflow.TrackerConfig.RequiredLabels): an issue must carry every
+	// label here (matched case-insensitively after trimming) to be
+	// dispatched or to keep running. Empty disables the gate. Already
+	// normalized at config load; issueHasRequiredLabels re-normalizes both
+	// sides defensively.
+	RequiredLabels []string
 
 	// WorkerExitTimeout bounds how long a poll tick waits after issuing a
 	// reconciliation cancel. Zero means the poll tick only requests cancellation;
@@ -158,7 +166,7 @@ func (p *Poller) PollOnce(ctx context.Context) error { //nolint:gocognit // base
 			pollErr = errors.Join(pollErr, err)
 		}
 	}
-	candidates := filterEligibleCandidates(mergeOverflowCandidates(p.overflow, issues), p.reconcile.TerminalStates)
+	candidates := filterEligibleCandidates(mergeOverflowCandidates(p.overflow, issues), p.reconcile.TerminalStates, p.reconcile.RequiredLabels)
 	if len(reconciledInactive) > 0 {
 		candidates = filterIssuesNotInMap(candidates, reconciledInactive)
 	}
@@ -260,10 +268,7 @@ func (p *Poller) deriveInactiveIssues(ctx context.Context, activeIssuesByID, ref
 	activeByID := issueMapIDSet(activeIssuesByID)
 	inactiveByID := make(map[string]tracker.Issue)
 	for id, issue := range refreshedIssuesByID {
-		if isActiveTrackerState(issue.State, activeStateKeys) {
-			continue
-		}
-		if !p.isConfiguredInactiveState(issue.State) {
+		if !p.refreshedIssueIsInactive(issue, activeStateKeys) {
 			continue
 		}
 		delete(activeByID, id)
@@ -271,6 +276,22 @@ func (p *Poller) deriveInactiveIssues(ctx context.Context, activeIssuesByID, ref
 	}
 	groupErr := p.appendInactiveFromStateGroups(ctx, inactiveByID, activeByID)
 	return inactiveByID, groupErr
+}
+
+// refreshedIssueIsInactive reports whether a narrow-refreshed in-flight issue
+// should be reconciled as inactive. Two SPEC paths converge here: an issue that
+// left the active set for a configured inactive/terminal state (SPEC §16.3), and
+// an issue still in an active state but no longer carrying every required label
+// (SPEC §6.4 "continue" gate). Sourcing the label check from the refreshed set —
+// which the narrow refresh queries by claimed ref — covers running/blocked/retry
+// issues even when they sit beyond the active-listing page, and only acts on
+// rows the tracker actually returned, preserving the no-information-on-absence
+// invariant. The label clause is a no-op when required_labels is empty.
+func (p *Poller) refreshedIssueIsInactive(issue tracker.Issue, activeStateKeys map[string]struct{}) bool {
+	if isActiveTrackerState(issue.State, activeStateKeys) {
+		return !issueHasRequiredLabels(issue, p.reconcile.RequiredLabels)
+	}
+	return p.isConfiguredInactiveState(issue.State)
 }
 
 // appendInactiveFromStateGroups fetches the explicit terminal/inactive
@@ -321,8 +342,8 @@ func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID
 		refsByID[ref.ID] = ref
 	}
 	refreshed := make(map[string]tracker.Issue, len(statesByID))
-	for id, state := range statesByID {
-		if strings.TrimSpace(id) == "" || strings.TrimSpace(state) == "" {
+	for id, st := range statesByID {
+		if strings.TrimSpace(id) == "" || strings.TrimSpace(st.State) == "" {
 			continue
 		}
 		issue, ok := activeIssuesByID[id]
@@ -330,7 +351,13 @@ func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID
 			issue = tracker.Issue{ID: id, Identifier: refsByID[id].Identifier}
 		}
 		issue.ID = id
-		issue.State = state
+		issue.State = st.State
+		// Carry refreshed labels so deriveInactiveIssues can observe SPEC §6.4
+		// label removal on in-flight issues that sit beyond the active-listing
+		// page (the narrow refresh queries them by claimed ref, the listing may
+		// not). Only rows the tracker actually returned with a non-empty state
+		// reach here, so absence stays "no information" (never a mass-cancel).
+		issue.Labels = st.Labels
 		refreshed[id] = issue
 	}
 	return refreshed, err
@@ -397,7 +424,7 @@ func filterIssuesNotInMap(issues []tracker.Issue, excluded map[string]tracker.Is
 	return out
 }
 
-func filterEligibleCandidates(issues []tracker.Issue, terminalStates []string) []tracker.Issue {
+func filterEligibleCandidates(issues []tracker.Issue, terminalStates, requiredLabels []string) []tracker.Issue {
 	// Honor exactly what the caller supplied per SPEC §5.3.1. Callers that
 	// want the SPEC 5-state default get it from workflow.DefaultConfig at
 	// construction time (NewPoller seeds it; workflow.Load supplies it for
@@ -413,9 +440,41 @@ func filterEligibleCandidates(issues []tracker.Issue, terminalStates []string) [
 		if todoIssueBlockedByOpenDependency(issue, terminal) {
 			continue
 		}
+		if !issueHasRequiredLabels(issue, requiredLabels) {
+			continue
+		}
 		out = append(out, issue)
 	}
 	return out
+}
+
+// issueHasRequiredLabels reports whether issue carries every label in required
+// (SPEC §4.1.1 / §6.4). See labelsSatisfyRequired for the matching semantics.
+func issueHasRequiredLabels(issue tracker.Issue, required []string) bool {
+	return labelsSatisfyRequired(issue.Labels, required)
+}
+
+// labelsSatisfyRequired reports whether labels contains every entry in required
+// (SPEC §4.1.1 / §6.4). Both sides are trimmed and lowercased so matching is
+// case-insensitive regardless of tracker label casing. Empty required disables
+// the gate (returns true); a blank required entry ("") can never match a
+// tracker's non-empty labels, so it blocks every issue as SPEC mandates. Shared
+// by the dispatch/reconcile predicate and the §16.5 per-turn continue gate so
+// they cannot diverge.
+func labelsSatisfyRequired(labels, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	have := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		have[strings.ToLower(strings.TrimSpace(label))] = struct{}{}
+	}
+	for _, label := range required {
+		if _, ok := have[strings.ToLower(strings.TrimSpace(label))]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func issueHasRequiredCandidateFields(issue tracker.Issue) bool {

--- a/internal/orchestrator/poller_reconciletick_test.go
+++ b/internal/orchestrator/poller_reconciletick_test.go
@@ -22,7 +22,7 @@ type fixedStateTracker struct {
 	// issues".
 	fixedListIssues []tracker.Issue
 
-	fetchStates map[string]string
+	fetchStates map[string]tracker.IssueState
 }
 
 func (f *fixedStateTracker) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
@@ -40,23 +40,23 @@ func (f *fixedStateTracker) ListIssuesByStates(_ context.Context, _ []string) ([
 	return out, nil
 }
 
-func (f *fixedStateTracker) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+func (f *fixedStateTracker) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	wanted := make(map[string]struct{}, len(refs))
 	for _, ref := range refs {
 		wanted[ref.ID] = struct{}{}
 	}
-	out := make(map[string]string, len(refs))
-	for id, state := range f.fetchStates {
+	out := make(map[string]tracker.IssueState, len(refs))
+	for id, st := range f.fetchStates {
 		if _, ok := wanted[id]; ok {
-			out[id] = state
+			out[id] = st
 		}
 	}
 	return out, nil
 }
 
-func (f *fixedStateTracker) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]string, error) {
+func (f *fixedStateTracker) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]tracker.IssueState, error) {
 	return f.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(ids))
 }
 
@@ -123,7 +123,7 @@ func TestReconcileTickDropsNonActiveNonInactiveRefreshedIssueFromInactiveSet(t *
 	defer cancel()
 
 	trackerClient := &fixedStateTracker{
-		fetchStates: map[string]string{"issue-1": "Triage"},
+		fetchStates: map[string]tracker.IssueState{"issue-1": {State: "Triage"}},
 	}
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
@@ -157,6 +157,205 @@ func TestReconcileTickDropsNonActiveNonInactiveRefreshedIssueFromInactiveSet(t *
 	}
 	if _, present := got["issue-1"]; present {
 		t.Fatalf("reconcileTick inactive map[issue-1] present = %v; want false (Triage is not a configured inactive state)", got)
+	}
+}
+
+// TestReconcileTickTreatsActiveIssueMissingRequiredLabelAsInactive pins the
+// SPEC §6.4 label-removal release path: an issue still in an active state but
+// missing a configured required label must be added to inactiveByID so the
+// reconcile cancels its running worker / releases its retry+blocked claim. The
+// narrow state refresh carries no labels, so this relies on the active listing
+// (passed to reconcileTick) surfacing the reduced label set.
+func TestReconcileTickTreatsActiveIssueMissingRequiredLabelAsInactive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Narrow refresh reports the running issue is STILL in an active state but
+	// WITHOUT the required label (label removed mid-run). The §6.4 gate now reads
+	// labels from the refresh, so only label removal (not a state change) makes it
+	// ineligible here.
+	trackerClient := &fixedStateTracker{fetchStates: map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"backend"}}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		RequiredLabels:    []string{"aiops-ready"},
+		WorkerExitTimeout: time.Second,
+	})
+
+	if err := orch.RequestDispatch(ctx, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress", Labels: []string{"aiops-ready"}}, nil); err != nil {
+		t.Fatalf("request dispatch: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher)
+
+	// The narrow refresh (above) shows issue-1 still In Progress but missing the
+	// required label, so reconcileTick must classify it inactive and cancel the
+	// running worker. The active-listing arg still carries the label here; the
+	// dedicated out-of-page test proves the refresh path independently.
+	got, err := poller.reconcileTick(ctx, []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress", Labels: []string{"backend"}}})
+	if err != nil {
+		t.Fatalf("reconcileTick err = %v; want nil", err)
+	}
+	if _, present := got["issue-1"]; !present {
+		t.Fatalf("reconcileTick inactive map[issue-1] present = false; want true (active issue missing required label must be reconciled inactive), map=%#v", got)
+	}
+}
+
+// TestReconcileTickKeepsActiveIssueRetainingRequiredLabel is the negative
+// counterpart: an active issue that still carries the required label must NOT be
+// treated as inactive.
+func TestReconcileTickKeepsActiveIssueRetainingRequiredLabel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Narrow refresh shows issue-1 still In Progress and STILL carrying the
+	// required label, so it must NOT be reconciled inactive.
+	trackerClient := &fixedStateTracker{fetchStates: map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"aiops-ready", "backend"}}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		RequiredLabels:    []string{"aiops-ready"},
+		WorkerExitTimeout: time.Second,
+	})
+	if err := orch.RequestDispatch(ctx, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress", Labels: []string{"aiops-ready"}}, nil); err != nil {
+		t.Fatalf("request dispatch: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher)
+
+	got, err := poller.reconcileTick(ctx, []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress", Labels: []string{"aiops-ready", "backend"}}})
+	if err != nil {
+		t.Fatalf("reconcileTick err = %v; want nil", err)
+	}
+	if _, present := got["issue-1"]; present {
+		t.Fatalf("reconcileTick inactive map[issue-1] present = true; want false (active issue still has required label), map=%#v", got)
+	}
+}
+
+// newRunningLabelReconcilePoller dispatches a single running issue-1 (carrying
+// the required label at dispatch time) and returns a poller whose reconcile
+// config gates on requiredLabels and whose narrow refresh reports refresh. It is
+// shared by the SPEC §6.4 label-removal reconcile tests below. The returned ctx
+// is cancelled via t.Cleanup.
+func newRunningLabelReconcilePoller(t *testing.T, refresh map[string]tracker.IssueState, requiredLabels []string) (*Poller, context.Context) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	trackerClient := &fixedStateTracker{fetchStates: refresh}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled"},
+		RequiredLabels:    requiredLabels,
+		WorkerExitTimeout: time.Second,
+	})
+	if err := orch.RequestDispatch(ctx, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress", Labels: []string{"aiops-ready"}}, nil); err != nil {
+		t.Fatalf("request dispatch: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher)
+	return poller, ctx
+}
+
+// TestReconcileTickCancelsOutOfPageRunningIssueMissingRequiredLabel is the P2-b
+// proof: a running issue absent from the active listing (beyond its page) whose
+// narrow refresh shows it still active but missing a required label must be
+// reconciled inactive. The label evidence comes only from the refresh (the
+// active-listing arg is empty here), which the old active-listing-only sweep
+// could not observe.
+func TestReconcileTickCancelsOutOfPageRunningIssueMissingRequiredLabel(t *testing.T) {
+	poller, ctx := newRunningLabelReconcilePoller(t,
+		map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"backend"}}},
+		[]string{"aiops-ready"})
+
+	// Active listing is EMPTY (issue-1 is out of page); only the refresh carries it.
+	got, err := poller.reconcileTick(ctx, nil)
+	if err != nil {
+		t.Fatalf("reconcileTick err = %v; want nil", err)
+	}
+	if _, present := got["issue-1"]; !present {
+		t.Fatalf("reconcileTick inactive map[issue-1] present = false; want true (out-of-page running issue missing required label must be reconciled inactive via refresh), map=%#v", got)
+	}
+}
+
+// TestReconcileTickKeepsOutOfPageRunningIssueRetainingRequiredLabel pins that
+// the refresh's labels (not the active listing's) are authoritative for an
+// out-of-page in-flight issue: issue-1 is absent from the active listing, and
+// only the narrow refresh reports it — still active and STILL carrying the
+// required label — so it must NOT be reconciled inactive. Without carrying the
+// refreshed labels onto the refreshed issue, it would be seen as label-less and
+// wrongly cancelled (false cancel).
+func TestReconcileTickKeepsOutOfPageRunningIssueRetainingRequiredLabel(t *testing.T) {
+	poller, ctx := newRunningLabelReconcilePoller(t,
+		map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"aiops-ready", "backend"}}},
+		[]string{"aiops-ready"})
+
+	got, err := poller.reconcileTick(ctx, nil) // issue-1 out of page; only refresh has it
+	if err != nil {
+		t.Fatalf("reconcileTick err = %v; want nil", err)
+	}
+	if _, present := got["issue-1"]; present {
+		t.Fatalf("reconcileTick inactive map[issue-1] present = true; want false (out-of-page running issue still carries the required label per the refresh), map=%#v", got)
+	}
+}
+
+// TestReconcileTickKeepsRunningIssueAbsentFromRefresh pins the
+// no-information-on-absence invariant: when the narrow refresh returns NO row
+// for a running issue (transient/partial fetch) and the active listing is empty,
+// reconcileTick must NOT treat it as label-ineligible and must NOT cancel it.
+func TestReconcileTickKeepsRunningIssueAbsentFromRefresh(t *testing.T) {
+	poller, ctx := newRunningLabelReconcilePoller(t,
+		map[string]tracker.IssueState{}, // refresh returns no row for issue-1
+		[]string{"aiops-ready"})
+
+	got, err := poller.reconcileTick(ctx, nil)
+	if err != nil {
+		t.Fatalf("reconcileTick err = %v; want nil", err)
+	}
+	if _, present := got["issue-1"]; present {
+		t.Fatalf("reconcileTick inactive map[issue-1] present = true; want false (a refresh that returns no row is no-information, not label removal), map=%#v", got)
+	}
+}
+
+// TestReconcileTickEmptyRequiredLabelsKeepsLabellessRunningIssue pins the
+// gate-off default: with no required_labels, a running issue carrying no matching
+// label must NOT be reconciled inactive on label grounds.
+func TestReconcileTickEmptyRequiredLabelsKeepsLabellessRunningIssue(t *testing.T) {
+	poller, ctx := newRunningLabelReconcilePoller(t,
+		map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"backend"}}},
+		nil) // gate off
+
+	got, err := poller.reconcileTick(ctx, nil)
+	if err != nil {
+		t.Fatalf("reconcileTick err = %v; want nil", err)
+	}
+	if _, present := got["issue-1"]; present {
+		t.Fatalf("reconcileTick inactive map[issue-1] present = true; want false (empty required_labels disables the label gate), map=%#v", got)
 	}
 }
 

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -182,11 +182,11 @@ func (f *fakeIssueStateTracker) ListIssuesByStates(_ context.Context, states []s
 	return defaultTrackerIssueTitles(out), nil
 }
 
-func (f *fakeIssueStateTracker) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+func (f *fakeIssueStateTracker) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]tracker.IssueState, error) {
 	return f.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(issueIDs))
 }
 
-func (f *fakeIssueStateTracker) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+func (f *fakeIssueStateTracker) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.fetchRefCalls = append(f.fetchRefCalls, append([]tracker.IssueRef(nil), refs...))
@@ -197,18 +197,20 @@ func (f *fakeIssueStateTracker) FetchIssueStatesByRefs(_ context.Context, refs [
 	for _, ref := range refs {
 		wanted[ref.ID] = struct{}{}
 	}
-	out := make(map[string]string, len(refs))
+	out := make(map[string]tracker.IssueState, len(refs))
 	if f.fetchIDStates != nil {
 		for id, state := range f.fetchIDStates {
 			if _, ok := wanted[id]; ok {
-				out[id] = state
+				out[id] = tracker.IssueState{State: state}
 			}
 		}
 		return out, f.fetchIDErr
 	}
+	// Carry the fixture issue's labels into the refresh so reconcile sees the
+	// same labels the real narrow refresh surfaces (SPEC §6.4 gate).
 	for _, issue := range f.issues {
 		if _, ok := wanted[issue.ID]; ok {
-			out[issue.ID] = issue.State
+			out[issue.ID] = tracker.IssueState{State: issue.State, Labels: issue.Labels}
 		}
 	}
 	return out, nil
@@ -1047,7 +1049,7 @@ func TestFilterEligibleCandidatesExplicitEmptyTerminalStatesBlocksAll(t *testing
 	issues := []tracker.Issue{
 		{ID: "todo-done", Identifier: "LIN-1", Title: "Done blocker", State: "Todo", BlockedBy: []tracker.BlockerRef{{ID: "blk", Identifier: "LIN-0", State: "Done"}}},
 	}
-	out := filterEligibleCandidates(issues, []string{})
+	out := filterEligibleCandidates(issues, []string{}, nil)
 	if len(out) != 0 {
 		t.Fatalf("filterEligibleCandidates with explicit [] = %d issues, want 0 (no states are terminal → all blockers open → Todo blocked); got=%#v", len(out), out)
 	}
@@ -1063,12 +1065,58 @@ func TestFilterEligibleCandidatesUsesOnlyConfiguredTerminalSet(t *testing.T) {
 		{ID: "todo-closed", Identifier: "LIN-1", Title: "Closed blocker", State: "Todo", BlockedBy: []tracker.BlockerRef{{ID: "blk", Identifier: "LIN-0", State: "Closed"}}},
 		{ID: "todo-released", Identifier: "LIN-2", Title: "Released blocker", State: "Todo", BlockedBy: []tracker.BlockerRef{{ID: "blk", Identifier: "LIN-9", State: "Released"}}},
 	}
-	out := filterEligibleCandidates(issues, []string{"Released"})
+	out := filterEligibleCandidates(issues, []string{"Released"}, nil)
 	if len(out) != 1 {
 		t.Fatalf("filterEligibleCandidates = %d issues, want 1; got=%#v", len(out), out)
 	}
 	if out[0].ID != "todo-released" {
 		t.Fatalf("passed issue = %q, want todo-released (its blocker is in operator-configured terminal state)", out[0].ID)
+	}
+}
+
+// TestFilterEligibleCandidatesRequiredLabels pins the SPEC §6.4 opt-in gate:
+// only issues carrying every configured label (case-insensitively) pass.
+func TestFilterEligibleCandidatesRequiredLabels(t *testing.T) {
+	issues := []tracker.Issue{
+		{ID: "has-both", Identifier: "LIN-1", Title: "both", State: "Todo", Labels: []string{"aiops-ready", "backend"}},
+		{ID: "missing-one", Identifier: "LIN-2", Title: "missing", State: "Todo", Labels: []string{"aiops-ready"}},
+		{ID: "case-insensitive", Identifier: "LIN-3", Title: "case", State: "Todo", Labels: []string{"AIOps-Ready", "Backend"}},
+		{ID: "no-labels", Identifier: "LIN-4", Title: "none", State: "Todo"},
+	}
+	out := filterEligibleCandidates(issues, []string{"Done"}, []string{"aiops-ready", "backend"})
+	gotIDs := make([]string, 0, len(out))
+	for _, issue := range out {
+		gotIDs = append(gotIDs, issue.ID)
+	}
+	want := []string{"has-both", "case-insensitive"}
+	if !reflect.DeepEqual(gotIDs, want) {
+		t.Fatalf("filterEligibleCandidates(requiredLabels) = %v; want %v (only issues with every required label, case-insensitive)", gotIDs, want)
+	}
+}
+
+// TestIssueHasRequiredLabels is the direct unit test for the gate predicate,
+// including the empty-disables and blank-required-blocks-all SPEC rules.
+func TestIssueHasRequiredLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   []string
+		required []string
+		want     bool
+	}{
+		{name: "empty required disables gate", labels: nil, required: nil, want: true},
+		{name: "all present", labels: []string{"a", "b"}, required: []string{"a", "b"}, want: true},
+		{name: "subset present", labels: []string{"a", "b", "c"}, required: []string{"a", "c"}, want: true},
+		{name: "missing one", labels: []string{"a"}, required: []string{"a", "b"}, want: false},
+		{name: "case and whitespace insensitive", labels: []string{" A ", "B"}, required: []string{"a", "b"}, want: true},
+		{name: "blank required matches no issue", labels: []string{"a"}, required: []string{""}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := issueHasRequiredLabels(tracker.Issue{Labels: tt.labels}, tt.required)
+			if got != tt.want {
+				t.Fatalf("issueHasRequiredLabels(%q, %q) = %v; want %v", tt.labels, tt.required, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -149,7 +149,7 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 		tracker: trackerClient,
 		states:  snap.Reconciliation.ActiveStates,
 	}
-	retryLister = eligibleActiveIssueLister{inner: retryLister, terminalStates: snap.Reconciliation.TerminalStates}
+	retryLister = eligibleActiveIssueLister{inner: retryLister, terminalStates: snap.Reconciliation.TerminalStates, requiredLabels: snap.Reconciliation.RequiredLabels}
 	p.orchestrator.SetCandidateLister(retryLister)
 	// The candidate lister above is active-only, so a fired failure-retry whose
 	// issue moved to a terminal state sees found==nil — indistinguishable there
@@ -178,22 +178,24 @@ func (p *RuntimePoller) trackerClientForSnapshot(snap WorkflowSnapshot) (IssueSt
 // eligibleActiveIssueLister wraps an ActiveIssueLister with the same
 // eligibility filter the poll loop applies between routing and dispatch
 // (filterEligibleCandidates in poller.go). The filter drops issues
-// missing required SPEC §4.1.1 fields (ID / Identifier / Title / State)
-// and Todo-state issues whose BlockedBy carries a non-terminal blocker.
-// Without this wrap a queued failure-retry whose Todo issue gained a
-// fresh non-terminal blocker between schedule and fire would still be
-// dispatched, while the poll loop would refuse the same issue on the
-// next tick. The fetch error is propagated unchanged because an empty
-// post-filter result is meaningful (genuine absence) but only if the
-// fetch itself succeeded.
+// missing required SPEC §4.1.1 fields (ID / Identifier / Title / State),
+// Todo-state issues whose BlockedBy carries a non-terminal blocker, and
+// (when requiredLabels is set) issues lacking every configured
+// tracker.required_labels label. Without this wrap a queued failure-retry
+// whose Todo issue gained a fresh non-terminal blocker or lost a required
+// label between schedule and fire would still be dispatched, while the
+// poll loop would refuse the same issue on the next tick. The fetch error
+// is propagated unchanged because an empty post-filter result is meaningful
+// (genuine absence) but only if the fetch itself succeeded.
 type eligibleActiveIssueLister struct {
 	inner          ActiveIssueLister
 	terminalStates []string
+	requiredLabels []string
 }
 
 func (l eligibleActiveIssueLister) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
 	issues, fetchErr := l.inner.ListActiveIssues(ctx)
-	return filterEligibleCandidates(issues, l.terminalStates), fetchErr
+	return filterEligibleCandidates(issues, l.terminalStates, l.requiredLabels), fetchErr
 }
 
 func snapshotWorkflowKey(snap WorkflowSnapshot) string {
@@ -337,6 +339,7 @@ func (d *RuntimeDispatcher) configForSnapshot(snap WorkflowSnapshot) worker.Conf
 				return nil
 			}
 			terminalStates := normalizedStateSet(wcfg.Tracker.TerminalStates)
+			requiredLabels := wcfg.Tracker.RequiredLabels
 			issueRef := tracker.IssueRef{ID: issueID, Identifier: taskIssueIdentifier(t)}
 			return func(ctx context.Context) (runner.IssueStateSnapshot, error) {
 				if stopped, ok := d.operatorTerminalStopSnapshot(ctx, issueID); ok {
@@ -347,17 +350,24 @@ func (d *RuntimeDispatcher) configForSnapshot(snap WorkflowSnapshot) worker.Conf
 					return runner.IssueStateSnapshot{}, err
 				}
 				state, ok := statesByID[issueID]
-				if !ok || strings.TrimSpace(state) == "" {
+				if !ok || strings.TrimSpace(state.State) == "" {
 					// SPEC §16.5 "issue = refreshed_issue[0] or
 					// issue": no row means we treat the issue as
 					// still in its prior (active) state rather
-					// than aborting on a benign absence.
+					// than aborting on a benign absence. Leave this
+					// branch label-blind so a transient empty refresh
+					// never self-stops a healthy run.
 					return runner.IssueStateSnapshot{Found: false, Active: true}, nil
 				}
-				normalized := strings.ToLower(strings.TrimSpace(state))
+				normalized := strings.ToLower(strings.TrimSpace(state.State))
 				_, active := activeStates[normalized]
 				_, terminal := terminalStates[normalized]
-				return runner.IssueStateSnapshot{Found: true, State: state, Active: active, Terminal: terminal}, nil
+				// SPEC §6.4 "continue" gate: an issue still in an active state
+				// but no longer carrying every required label is not routable,
+				// so the runner must self-stop (it stops on !Active). Applied
+				// only on a present row, so absence stays no-information above.
+				routable := active && labelsSatisfyRequired(state.Labels, requiredLabels)
+				return runner.IssueStateSnapshot{Found: true, State: state.State, Active: routable, Terminal: terminal}, nil
 			}
 		}
 	}

--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -14,18 +14,19 @@ import (
 type stubRefresher struct {
 	calls   [][]string
 	states  map[string]string
+	labels  map[string][]string
 	fetchEr error
 }
 
-func (s *stubRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]string, error) {
+func (s *stubRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]tracker.IssueState, error) {
 	s.calls = append(s.calls, append([]string(nil), ids...))
 	if s.fetchEr != nil {
 		return nil, s.fetchEr
 	}
-	out := map[string]string{}
+	out := map[string]tracker.IssueState{}
 	for _, id := range ids {
 		if state, ok := s.states[id]; ok {
-			out[id] = state
+			out[id] = tracker.IssueState{State: state, Labels: s.labels[id]}
 		}
 	}
 	return out, nil
@@ -36,16 +37,16 @@ type stubRefAwareRefresher struct {
 	states map[string]string
 }
 
-func (s *stubRefAwareRefresher) FetchIssueStatesByIDs(context.Context, []string) (map[string]string, error) {
+func (s *stubRefAwareRefresher) FetchIssueStatesByIDs(context.Context, []string) (map[string]tracker.IssueState, error) {
 	return nil, errors.New("legacy ID-only refresh should not be used")
 }
 
-func (s *stubRefAwareRefresher) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]string, error) {
+func (s *stubRefAwareRefresher) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
 	s.refs = append(s.refs, append([]tracker.IssueRef(nil), refs...))
-	out := map[string]string{}
+	out := map[string]tracker.IssueState{}
 	for _, ref := range refs {
 		if state, ok := s.states[ref.ID]; ok {
-			out[ref.ID] = state
+			out[ref.ID] = tracker.IssueState{State: state}
 		}
 	}
 	return out, nil
@@ -126,6 +127,73 @@ func TestRuntimeDispatcherConfigForSnapshotBuildsRefresherClosure(t *testing.T) 
 		}
 		if !errors.Is(err, boom) {
 			t.Fatalf("err = %v, want wrapped tracker boom", err)
+		}
+	})
+}
+
+// TestRuntimeDispatcherContinueGateAppliesRequiredLabels pins the SPEC §6.4
+// "continue" gate (P2-a): the per-turn refresher closure must mark an issue
+// that is still in an active state but missing a required label as NOT routable
+// (Active=false), so the runner self-stops instead of starting another
+// continuation turn. A present row with the label stays Active; a missing/absent
+// row stays Active regardless of labels (no-information); an empty required_labels
+// disables the gate. Mutation: dropping the labelsSatisfyRequired clause from the
+// routable computation (or RequiredLabels from the closure) fails the first case.
+func TestRuntimeDispatcherContinueGateAppliesRequiredLabels(t *testing.T) {
+	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
+	stub := &stubRefresher{
+		states: map[string]string{"issue-1": "In Progress"},
+		labels: map[string][]string{"issue-1": {"backend"}},
+	}
+	d.SetIssueStateRefresher(stub)
+	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
+		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress"}, RequiredLabels: []string{"aiops-ready"}},
+	}}}
+	cfg := d.configForSnapshot(snap)
+	wcfg := snap.Workflow.Config
+
+	t.Run("active state missing required label is not routable", func(t *testing.T) {
+		fn := cfg.IssueStateRefresher(task.Task{ID: "issue-1"}, wcfg)
+		snapshot, err := fn(context.Background())
+		if err != nil {
+			t.Fatalf("refresher err = %v, want nil", err)
+		}
+		if snapshot.Active {
+			t.Fatalf("snapshot.Active = true for active issue missing required label %v; want false (continue gate must self-stop), snapshot=%+v", wcfg.Tracker.RequiredLabels, snapshot)
+		}
+		if !snapshot.Found || snapshot.State != "In Progress" {
+			t.Fatalf("snapshot = %+v, want found In Progress (raw state preserved)", snapshot)
+		}
+	})
+
+	t.Run("active state retaining required label stays routable", func(t *testing.T) {
+		labeled := &stubRefresher{
+			states: map[string]string{"issue-1": "In Progress"},
+			labels: map[string][]string{"issue-1": {"aiops-ready", "backend"}},
+		}
+		d.SetIssueStateRefresher(labeled)
+		fn := d.configForSnapshot(snap).IssueStateRefresher(task.Task{ID: "issue-1"}, wcfg)
+		snapshot, err := fn(context.Background())
+		if err != nil {
+			t.Fatalf("refresher err = %v, want nil", err)
+		}
+		if !snapshot.Active {
+			t.Fatalf("snapshot.Active = false for active issue with required label; want true, snapshot=%+v", snapshot)
+		}
+	})
+
+	t.Run("empty required_labels disables the gate", func(t *testing.T) {
+		offSnap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
+			Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress"}},
+		}}}
+		d.SetIssueStateRefresher(stub) // labels lack aiops-ready, but no required_labels
+		fn := d.configForSnapshot(offSnap).IssueStateRefresher(task.Task{ID: "issue-1"}, offSnap.Workflow.Config)
+		snapshot, err := fn(context.Background())
+		if err != nil {
+			t.Fatalf("refresher err = %v, want nil", err)
+		}
+		if !snapshot.Active {
+			t.Fatalf("snapshot.Active = false with empty required_labels; want true (gate off), snapshot=%+v", snapshot)
 		}
 	})
 }

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -461,6 +461,72 @@ func TestRuntimePollerRetryListerWrapsEligibilityFilter(t *testing.T) {
 	}
 }
 
+// TestRuntimePollerRetryListerThreadsRequiredLabels pins the retry-fire
+// (SPEC §16.6 candidate-fetch) routability site for tracker.required_labels:
+// the eligibleActiveIssueLister the orchestrator receives must carry
+// snap.Reconciliation.RequiredLabels so a fired failure/quota retry whose
+// issue lost a required label is refused the same way the poll loop refuses it.
+// Without it the retry-fire gate silently no-ops — the production-no-op class
+// the dispatch + cmd/worker fixes in this PR close. Mutation: drop
+// `requiredLabels:` from runtime_poller.go's eligibleActiveIssueLister literal
+// (or RequiredLabels from ReconciliationConfigFromWorkflow) and this fails.
+func TestRuntimePollerRetryListerThreadsRequiredLabels(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "gitea", 30000)
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	initial.Config.Repo = workflow.RepoConfig{Owner: "acme", Name: "fallback", CloneURL: "git@example.com:acme/fallback.git", DefaultBranch: "main"}
+	initial.Config.Tracker.RequiredLabels = []string{"aiops-ready"}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeIssueStateTracker{}
+	dispatcher := &recordingDispatcher{}
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+
+	lister := orch.currentCandidateLister()
+	if lister == nil {
+		t.Fatal("orchestrator candidate lister not installed by RuntimePoller")
+	}
+
+	// An active-state issue missing the required label must be dropped on the
+	// retry-fire seam: a queued retry whose issue lost the label is ineligible.
+	trackerClient.issues = []tracker.Issue{{
+		ID: "gitea-unlabeled", Identifier: "UNLABELED-1", Title: "missing required label", State: "AI Ready",
+	}}
+	got, err := lister.ListActiveIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveIssues(unlabeled) error = %v, want nil", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("retry-fire lister.ListActiveIssues(active issue missing %v) = %+v; want none (required-label gate must thread to the retry-fire lister)", initial.Config.Tracker.RequiredLabels, got)
+	}
+
+	// Positive control: the same active issue carrying the required label passes.
+	trackerClient.issues = []tracker.Issue{{
+		ID: "gitea-labeled", Identifier: "LABELED-1", Title: "has required label", State: "AI Ready",
+		Labels: []string{"aiops-ready"},
+	}}
+	got, err = lister.ListActiveIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveIssues(labeled) error = %v, want nil", err)
+	}
+	if len(got) != 1 || got[0].ID != "gitea-labeled" {
+		t.Fatalf("retry-fire lister.ListActiveIssues(active issue with %v) = %+v; want exactly gitea-labeled", initial.Config.Tracker.RequiredLabels, got)
+	}
+}
+
 func TestWorkflowRuntimeReloadFailureKeepsPreviousConfigAndEmitsFailureEvent(t *testing.T) {
 	path := writeWorkflowForReloadTest(t, "linear", 30000)
 	initial, err := workflow.Load(path)

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -177,6 +177,25 @@ func (r *WorkflowRuntime) emit(ctx context.Context, kind, msg string, payload an
 	}
 }
 
+// ReconciliationConfigFromWorkflow builds the reconciliation config a snapshot
+// carries from a workflow config. It is the single source of truth for which
+// tracker/codex fields flow into ReconciliationConfig, so adding a new field
+// here propagates to every consumer (the inline snapshot default and the
+// cmd/worker production override, which delegates here and re-derives only
+// InactiveStates). Earlier the inline default and the production override each
+// listed the fields independently, so tracker.required_labels was wired into
+// the snapshot path but silently dropped from the live worker (#682).
+func ReconciliationConfigFromWorkflow(cfg workflow.Config) ReconciliationConfig {
+	return ReconciliationConfig{
+		ActiveStates:      cfg.Tracker.ActiveStates,
+		TerminalStates:    cfg.Tracker.TerminalStates,
+		InactiveStates:    cfg.Tracker.InactiveStates,
+		RequiredLabels:    cfg.Tracker.RequiredLabels,
+		WorkerExitTimeout: 30 * time.Second,
+		StallTimeoutMs:    cfg.Codex.StallTimeoutMs,
+	}
+}
+
 func (r *WorkflowRuntime) snapshotFromWorkflow(wf *workflow.Workflow, fingerprints ...string) *WorkflowSnapshot {
 	if wf == nil {
 		return &WorkflowSnapshot{}
@@ -187,13 +206,7 @@ func (r *WorkflowRuntime) snapshotFromWorkflow(wf *workflow.Workflow, fingerprin
 	} else if wf.Path != "" && wf.Source != workflow.SourceDefault {
 		fingerprint, _ = workflowFileFingerprint(wf.Path)
 	}
-	reconcile := ReconciliationConfig{
-		ActiveStates:      wf.Config.Tracker.ActiveStates,
-		TerminalStates:    wf.Config.Tracker.TerminalStates,
-		InactiveStates:    wf.Config.Tracker.InactiveStates,
-		WorkerExitTimeout: 30 * time.Second,
-		StallTimeoutMs:    wf.Config.Codex.StallTimeoutMs,
-	}
+	reconcile := ReconciliationConfigFromWorkflow(wf.Config)
 	if r != nil && r.reconciliationConfig != nil {
 		reconcile = r.reconciliationConfig(wf.Config)
 	}

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -380,6 +380,18 @@ func (c *GitHubClient) listOpenPullRequestsPage(ctx context.Context, page int) (
 	return pulls, githubHasNextPage(resp.Header.Values("Link")), nil
 }
 
+// githubIssueLabels returns the issue's label names lowercased and trimmed
+// (SPEC §11.3 normalization), the form the required_labels gate matches against.
+func githubIssueLabels(issue githubIssue) []string {
+	labels := make([]string, 0, len(issue.Labels))
+	for _, label := range issue.Labels {
+		if name := strings.ToLower(strings.TrimSpace(label.Name)); name != "" {
+			labels = append(labels, name)
+		}
+	}
+	return labels
+}
+
 func mapGitHubIssue(issue githubIssue, mappedState string) (Issue, error) {
 	id := strconv.FormatInt(issue.ID, 10)
 	if id == "0" && issue.Number != 0 {
@@ -393,12 +405,7 @@ func mapGitHubIssue(issue githubIssue, mappedState string) (Issue, error) {
 	if err != nil {
 		return Issue{}, err
 	}
-	labels := make([]string, 0, len(issue.Labels))
-	for _, label := range issue.Labels {
-		if name := strings.ToLower(strings.TrimSpace(label.Name)); name != "" {
-			labels = append(labels, name)
-		}
-	}
+	labels := githubIssueLabels(issue)
 	state := strings.TrimSpace(mappedState)
 	if state == "" {
 		state = strings.TrimSpace(issue.State)
@@ -533,22 +540,22 @@ func (c *GitHubClient) recordPaginationCapHit(label string, maxPages int) {
 // matched label is returned (lowercased, matching mapGitHubIssue's
 // normalization). Otherwise the issue's open/closed state is returned. This
 // matches the GitHub convention where workflow position is encoded as labels.
-func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]IssueState, error) {
 	return c.FetchIssueStatesByRefs(ctx, IssueRefsFromIDs(issueIDs))
 }
 
-func (c *GitHubClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef) (map[string]string, error) { //nolint:gocognit // baseline (#521)
+func (c *GitHubClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef) (map[string]IssueState, error) { //nolint:gocognit // baseline (#521)
 	if strings.TrimSpace(c.Token) == "" {
 		return nil, fmt.Errorf("GitHub tracker api_key is required")
 	}
 	if len(issueRefs) == 0 {
-		return map[string]string{}, nil
+		return map[string]IssueState{}, nil
 	}
 	if strings.TrimSpace(c.Owner) == "" || strings.TrimSpace(c.Repo) == "" {
 		return nil, fmt.Errorf("repo.owner and repo.name are required for GitHub tracker polling")
 	}
 	configuredStates := githubConfiguredStates(c.Config)
-	states := make(map[string]string, len(issueRefs))
+	states := make(map[string]IssueState, len(issueRefs))
 	seen := map[string]struct{}{}
 	for _, issueRef := range issueRefs {
 		issueID := strings.TrimSpace(issueRef.ID)
@@ -584,7 +591,9 @@ func (c *GitHubClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []I
 		if state == "" {
 			continue
 		}
-		states[issueID] = state
+		// Carry the full label set (SPEC §6.4 required_labels gate) alongside the
+		// resolved state so label removal can stop/release already-claimed work.
+		states[issueID] = IssueState{State: state, Labels: githubIssueLabels(issue)}
 	}
 	return states, nil
 }

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -454,7 +455,7 @@ func TestGitHubClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) {
 				{ID: 303, Number: 3, Title: "third", HTMLURL: "https://github.com/acme/api/issues/3", State: "open", CreatedAt: "2026-05-20T01:02:03Z", UpdatedAt: "2026-05-20T01:02:03Z", Labels: []githubLabel{{Name: "priority:p2"}}},
 			})
 		case "/repos/acme/api/issues/1":
-			_ = json.NewEncoder(w).Encode(githubIssue{ID: 101, Number: 1, State: "closed", CreatedAt: "2026-05-20T01:02:03Z", UpdatedAt: "2026-05-20T02:03:04Z", Labels: []githubLabel{{Name: "Done"}}})
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 101, Number: 1, State: "closed", CreatedAt: "2026-05-20T01:02:03Z", UpdatedAt: "2026-05-20T02:03:04Z", Labels: []githubLabel{{Name: "Done"}, {Name: "Aiops-Ready"}}})
 		case "/repos/acme/api/issues/2":
 			http.NotFound(w, r)
 		case "/repos/acme/api/issues/3":
@@ -479,8 +480,11 @@ func TestGitHubClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIDs: %v", err)
 	}
-	if got, want := states, map[string]string{"101": "done"}; len(got) != len(want) || got["101"] != want["101"] {
+	if got, want := states, map[string]string{"101": "done"}; len(got) != len(want) || got["101"].State != want["101"] {
 		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	if got, want := states["101"].Labels, []string{"done", "aiops-ready"}; !slices.Equal(got, want) {
+		t.Fatalf("FetchIssueStatesByIDs(101).Labels = %v; want %v", got, want)
 	}
 	wantPathPrefix := "/repos/acme/api/issues/1,/repos/acme/api/issues/2,/repos/acme/api/issues/3"
 	gotJoined := strings.Join(requestedPaths[2:], ",")
@@ -511,7 +515,7 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 				State:     "open",
 				CreatedAt: "2026-05-20T01:02:03Z",
 				UpdatedAt: "2026-05-20T02:03:04Z",
-				Labels:    []githubLabel{{Name: "Done"}},
+				Labels:    []githubLabel{{Name: "Done"}, {Name: "Aiops-Ready"}},
 			})
 		default:
 			t.Fatalf("unexpected request path %q", r.URL.Path)
@@ -529,8 +533,11 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs: %v", err)
 	}
-	if got, want := states, map[string]string{"987654": "done"}; len(got) != len(want) || got["987654"] != want["987654"] {
+	if got, want := states, map[string]string{"987654": "done"}; len(got) != len(want) || got["987654"].State != want["987654"] {
 		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	if got, want := states["987654"].Labels, []string{"done", "aiops-ready"}; !slices.Equal(got, want) {
+		t.Fatalf("FetchIssueStatesByRefs(987654).Labels = %v; want %v", got, want)
 	}
 	if got, want := strings.Join(requestedPaths, ","), "/repos/acme/api/issues/7"; got != want {
 		t.Fatalf("requested paths = %s, want %s", got, want)
@@ -547,7 +554,7 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs #number ID: %v", err)
 	}
-	if got := states["#7"]; got != "done" {
+	if got := states["#7"].State; got != "done" {
 		t.Fatalf("#number fallback state = %q, want done", got)
 	}
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "#8", Identifier: "#7"}})
@@ -561,7 +568,7 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs numeric fallback ID: %v", err)
 	}
-	if got := states["7"]; got != "done" {
+	if got := states["7"].State; got != "done" {
 		t.Fatalf("numeric fallback ID state = %q, want done", got)
 	}
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "5", Identifier: "#7"}})
@@ -584,14 +591,14 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs cached global ID with stale identifier: %v", err)
 	}
-	if got := states["555"]; got != "done" {
+	if got := states["555"].State; got != "done" {
 		t.Fatalf("cached global ID state = %q, want done", got)
 	}
 	states, err = client.FetchIssueStatesByIDs(context.Background(), []string{"987654"})
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIDs after fallback cache: %v", err)
 	}
-	if got := states["987654"]; got != "done" {
+	if got := states["987654"].State; got != "done" {
 		t.Fatalf("cached fallback state = %q, want done", got)
 	}
 }

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -137,6 +137,12 @@ func (c *LinearClient) ListActiveIssues(ctx context.Context) ([]Issue, error) {
 // HTTP 400 GRAPHQL_VALIDATION_FAILED on every poll (#326). The
 // upstream Elixir reference (elixir/lib/symphony_elixir/linear/client.ex)
 // also omits any custom-field fragment for the same reason.
+//
+// labels are projected at first:250 (Linear's connection maximum). The SPEC
+// §6.4 required_labels gate matches against exactly this projection, and the
+// IssueStatesByIDs refresh below now also cancels running work on label
+// removal, so the cap must be high enough that a required label cannot sort
+// past it and look removed (#705). Keep both label projections in step.
 const listLinearIssuesQuery = `query ListIssues($projectSlug: String!, $states: [String!], $first: Int!, $after: String) {
   issues(filter: { project: { slugId: { eq: $projectSlug } }, state: { name: { in: $states } } }, first: $first, after: $after) {
     nodes {
@@ -149,7 +155,7 @@ const listLinearIssuesQuery = `query ListIssues($projectSlug: String!, $states: 
       branchName
       createdAt
       updatedAt
-      labels(first: 50) { nodes { name } }
+      labels(first: 250) { nodes { name } }
       state { name }
     }
     pageInfo { hasNextPage endCursor }
@@ -323,22 +329,28 @@ func parseLinearIssueTime(field, value string) (time.Time, error) {
 	return parsed, nil
 }
 
-func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) { //nolint:gocognit // baseline (#521)
-	if c.APIKey == "" {
-		return nil, NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
-	}
-	if len(issueIDs) == 0 {
-		return map[string]string{}, nil
-	}
-	query := `query IssueStatesByIDs($ids: [ID!]!, $first: Int!) {
+// labels(first:250) mirrors listLinearIssuesQuery: the SPEC §6.4 required_labels
+// gate consults the refresh's label set to stop/release already-claimed work on
+// label removal, so the projection must be wide enough that a required label
+// cannot sort past the cap and look removed (#705).
+const issueStatesByIDsQuery = `query IssueStatesByIDs($ids: [ID!]!, $first: Int!) {
   issues(filter: { id: { in: $ids } }, first: $first) {
     nodes {
       id
       state { name }
+      labels(first: 250) { nodes { name } }
     }
   }
 }`
-	states := make(map[string]string, len(issueIDs))
+
+func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]IssueState, error) { //nolint:gocognit // baseline (#521)
+	if c.APIKey == "" {
+		return nil, NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
+	}
+	if len(issueIDs) == 0 {
+		return map[string]IssueState{}, nil
+	}
+	states := make(map[string]IssueState, len(issueIDs))
 	for start := 0; start < len(issueIDs); start += linearIssuePageSize {
 		end := start + linearIssuePageSize
 		if end > len(issueIDs) {
@@ -353,19 +365,30 @@ func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []str
 						State struct {
 							Name string `json:"name"`
 						} `json:"state"`
+						Labels struct {
+							Nodes []struct {
+								Name string `json:"name"`
+							} `json:"nodes"`
+						} `json:"labels"`
 					} `json:"nodes"`
 				} `json:"issues"`
 			} `json:"data"`
 			Errors []map[string]any `json:"errors"`
 		}
-		if err := c.graphql(ctx, query, map[string]any{"ids": chunk, "first": len(chunk)}, &out); err != nil {
+		if err := c.graphql(ctx, issueStatesByIDsQuery, map[string]any{"ids": chunk, "first": len(chunk)}, &out); err != nil {
 			return nil, err
 		}
 		if len(out.Errors) > 0 {
 			return nil, linearGraphQLErrors(out.Errors)
 		}
 		for _, n := range out.Data.Issues.Nodes {
-			states[n.ID] = n.State.Name
+			labels := make([]string, 0, len(n.Labels.Nodes))
+			for _, label := range n.Labels.Nodes {
+				if name := strings.ToLower(strings.TrimSpace(label.Name)); name != "" {
+					labels = append(labels, name)
+				}
+			}
+			states[n.ID] = IssueState{State: n.State.Name, Labels: labels}
 		}
 	}
 	return states, nil

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -97,7 +98,7 @@ func TestListIssuesByStatesMapsSpecDomainFields(t *testing.T) {
 			Query string `json:"query"`
 		}
 		_ = json.Unmarshal(body, &payload)
-		for _, fragment := range []string{"priority", "branchName", "createdAt", "updatedAt", "labels(first: 50)"} {
+		for _, fragment := range []string{"priority", "branchName", "createdAt", "updatedAt", "labels(first: 250)"} {
 			if !strings.Contains(payload.Query, fragment) {
 				t.Fatalf("ListIssues query = %s, want fragment %q", payload.Query, fragment)
 			}
@@ -237,7 +238,7 @@ func TestFetchIssueStatesByIDsUsesIDListQuery(t *testing.T) {
 		_ = json.Unmarshal(body, &payload)
 		recorded = fakeLinearRequest{OpName: opNameFromQuery(payload.Query), Query: payload.Query, Variables: payload.Variables}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Todo"}},{"id":"issue-2","state":{"name":"Done"}}]}}}`)
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Todo"},"labels":{"nodes":[{"name":"Aiops-Ready"}]}},{"id":"issue-2","state":{"name":"Done"}}]}}}`)
 	}))
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
@@ -246,8 +247,11 @@ func TestFetchIssueStatesByIDsUsesIDListQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIDs: %v", err)
 	}
-	if got, want := states, map[string]string{"issue-1": "Todo", "issue-2": "Done"}; len(got) != len(want) || got["issue-1"] != want["issue-1"] || got["issue-2"] != want["issue-2"] {
+	if got, want := states, map[string]string{"issue-1": "Todo", "issue-2": "Done"}; len(got) != len(want) || got["issue-1"].State != want["issue-1"] || got["issue-2"].State != want["issue-2"] {
 		t.Fatalf("states = %#v, want %#v", got, want)
+	}
+	if got, want := states["issue-1"].Labels, []string{"aiops-ready"}; !slices.Equal(got, want) {
+		t.Fatalf("FetchIssueStatesByIDs(issue-1).Labels = %v; want %v", got, want)
 	}
 	if recorded.OpName != "IssueStatesByIDs" {
 		t.Fatalf("op = %q, want IssueStatesByIDs", recorded.OpName)

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -21,6 +21,16 @@ type Issue struct {
 	BlockedBy   []BlockerRef
 }
 
+// IssueState is the narrow SPEC §11.2 state-refresh fact: an issue's current
+// workflow state plus its normalized labels. Labels are carried so the SPEC §6.4
+// required_labels "continue" gate can observe label removal on already-claimed
+// issues that may sit beyond the active-listing page (#682). Producing clients
+// lowercase/trim each label so matching is case-insensitive.
+type IssueState struct {
+	State  string
+	Labels []string
+}
+
 // IssueRef carries the stable tracker ID plus the human identifier captured at
 // dispatch time. GitHub and Gitea need the identifier as a repo issue-number
 // fallback because their REST state-refresh endpoints cannot address issues by
@@ -70,5 +80,5 @@ type StateIssueLister interface {
 // Poll-tick reconciliation uses this to refresh already-running issues without
 // relying on candidate pagination side effects.
 type IssueStateRefresher interface {
-	FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error)
+	FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]IssueState, error)
 }

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -154,11 +154,52 @@ type TrackerConfig struct {
 	// operator pauses such as Backlog/Human Review cancel in-flight workers
 	// without treating issues missing from partial tracker listings as inactive.
 	InactiveStates []string `yaml:"inactive_states" json:"inactive_states"`
+	// RequiredLabels is the SPEC §4.1.1 / §6.4 opt-in dispatch gate
+	// (upstream Symphony #88): an issue MUST carry every configured label
+	// (matched case-insensitively after trimming) to be dispatched or to
+	// keep running; removing a required label stops/releases in-flight work
+	// on the next poll. Default `[]` disables the gate. A blank configured
+	// label matches no issue. Normalized (trim + lowercase + de-dupe) at
+	// load by normalizeRequiredLabels.
+	RequiredLabels []string `yaml:"required_labels" json:"required_labels"`
 	PollIntervalMs int      `yaml:"poll_interval_ms" json:"poll_interval_ms"`
 	// PaginationMaxPages caps one tracker pagination scan. Zero keeps the
 	// selected adapter's default budget.
 	PaginationMaxPages int                 `yaml:"pagination_max_pages" json:"pagination_max_pages,omitempty"`
 	Statuses           TrackerStatusConfig `yaml:"statuses" json:"statuses"`
+}
+
+// normalizeLoadedConfig applies the post-parse normalizations that run after
+// front-matter merge regardless of whether front matter was present: the
+// per-state concurrency-limit canonicalization and the SPEC §6.4
+// required-labels trim/lowercase/de-dupe gate normalization.
+func normalizeLoadedConfig(cfg *Config) {
+	cfg.Agent.MaxConcurrentAgentsByState = NormalizeStateConcurrencyLimits(cfg.Agent.MaxConcurrentAgentsByState)
+	cfg.Tracker.RequiredLabels = normalizeRequiredLabels(cfg.Tracker.RequiredLabels)
+}
+
+// normalizeRequiredLabels mirrors the Elixir reference's
+// config/schema.ex update_change for `required_labels`: trim, lowercase, and
+// de-dupe each entry so the gate matches the equally-normalized issue labels.
+// A configured blank is preserved as "" (SPEC: "a blank configured label
+// matches no issue") rather than dropped, so `["" ]` keeps the gate active and
+// blocks every issue instead of silently disabling it. A nil/empty input is
+// returned unchanged so the default `[]` keeps the gate off.
+func normalizeRequiredLabels(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, label := range in {
+		norm := strings.ToLower(strings.TrimSpace(label))
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		out = append(out, norm)
+	}
+	return out
 }
 
 type PollingConfig struct {

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -42,6 +42,63 @@ Prompt body
 	}
 }
 
+func TestLoadParsesAndNormalizesRequiredLabels(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: git@example.com:owner/repo.git
+tracker:
+  kind: linear
+  project_slug: acme
+  required_labels:
+    - "  AIOps-Ready  "
+    - aiops-ready
+    - Needs-Triage
+---
+Prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// trim + lowercase + de-dupe: the padded "AIOps-Ready" and "aiops-ready"
+	// collapse to one entry; "Needs-Triage" lowercases.
+	got := wf.Config.Tracker.RequiredLabels
+	want := []string{"aiops-ready", "needs-triage"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Tracker.RequiredLabels = %#v; want %#v", got, want)
+	}
+}
+
+func TestLoadDefaultsRequiredLabelsEmpty(t *testing.T) {
+	path := writeTempWorkflow(t, `---
+repo:
+  clone_url: git@example.com:owner/repo.git
+tracker:
+  kind: linear
+  project_slug: acme
+---
+Prompt body
+`)
+	wf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := wf.Config.Tracker.RequiredLabels; len(got) != 0 {
+		t.Fatalf("Tracker.RequiredLabels = %#v; want empty (gate disabled by default)", got)
+	}
+}
+
+func TestNormalizeRequiredLabelsKeepsBlankSoGateBlocksEverything(t *testing.T) {
+	// SPEC: "a blank configured label matches no issue." A blank entry must be
+	// preserved (as "") rather than dropped, so the gate stays active and
+	// blocks every issue instead of silently disabling itself.
+	got := normalizeRequiredLabels([]string{"  ", "Ready"})
+	want := []string{"", "ready"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeRequiredLabels = %#v; want %#v", got, want)
+	}
+}
+
 func TestDefaultConfigEnablesStateServerOnPrivateLoopbackPort(t *testing.T) {
 	cfg := DefaultConfig()
 	if got := cfg.Server.Port; got != 4000 {

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -81,7 +81,7 @@ func Load(path string) (*Workflow, error) { //nolint:gocognit // baseline (#521)
 			return nil, err
 		}
 	}
-	cfg.Agent.MaxConcurrentAgentsByState = NormalizeStateConcurrencyLimits(cfg.Agent.MaxConcurrentAgentsByState)
+	normalizeLoadedConfig(&cfg)
 	source := SourceFile
 	if !hasFrontMatter {
 		source = SourcePromptOnly


### PR DESCRIPTION
Closes #682

## Summary

Backports the upstream Symphony `tracker.required_labels` opt-in gate (upstream
[`#88`](https://github.com/openai/symphony/commit/54b456b347bba0212a290430eec886def341342d),
SPEC §4.1.1 / §6.4: *"An issue MUST contain every configured label to dispatch
**or continue**"*). Unset/empty (the default) ⇒ gate off, behavior unchanged.

This is the **complete** backport: the gate is enforced at every routability site
the SPEC names, including the per-turn **continue** path. To do that, the narrow
state-refresh now carries labels (it previously carried only state), so label
removal is observed on already-claimed work regardless of active-listing
pagination.

## SPEC alignment (AGENTS.md principle 6/7)

- [ ] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [x] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

`tracker.required_labels` is a **normative** SPEC field; this closes a gap *toward*
SPEC, so no `DEVIATIONS.md` row is needed. Concrete Elixir references (tiebreaker):

- `elixir/lib/symphony_elixir/config/schema.ex` — `field(:required_labels, {:array, :string}, default: [])` + an `update_change` that trims, downcases, de-dupes.
- `elixir/lib/symphony_elixir/linear/issue.ex` — `routable?/2` = `assigned_to_worker AND (required_labels ⊆ normalized issue labels)`; normalize = trim + downcase.
- `elixir/lib/symphony_elixir/linear/client.ex` — the issue-state-refresh query **includes labels**, so the refresh can observe label removal on running work (motivates this PR's refresh-contract change).
- `elixir/lib/symphony_elixir/orchestrator.ex` — `issue_routable?` applied at `candidate_issue?` (dispatch), retry lookup, running-state reconcile, blocked-issue reconcile, **and** the per-turn `continue_with_issue?` continuation gate.

## Design

- **Config** (`internal/workflow/config.go`): `TrackerConfig.RequiredLabels`
  (`required_labels`, default `[]`); `normalizeRequiredLabels` (trim + lowercase +
  dedupe, **preserves a blank `""`** so a blank entry matches nothing per SPEC).
- **Refresh contract** (`tracker.IssueState{State, Labels}`): `FetchIssueStatesByIDs/ByRefs`
  now return state **and** normalized labels. Linear's `IssueStatesByIDs` query
  gains `labels(first: 250){nodes{name}}`; Gitea/GitHub already fetch the full
  issue and reuse `extractGiteaLabels` / `githubIssueLabels`.
- **Dispatch + retry-fire**: `filterEligibleCandidates` (+ `eligibleActiveIssueLister`) drop label-less issues.
- **Continue gate (§16.5/§6.4)**: the per-turn refresher closure
  (`runtime_poller.go`) computes `Active = isActiveState && labelsSatisfyRequired(...)`
  on a present row, so a running agent self-stops after its current turn when a
  required label is removed. The absent/empty-state branch stays
  `{Found:false, Active:true}` (no-information never self-stops). No runner-package
  change — it already stops on `!Active`; the tool-mutation guard maps the same.
- **Reconcile**: `refreshRunningIssueStates` attaches the refreshed labels;
  `deriveInactiveIssues` routes an in-flight issue that is active-but-label-less
  through one helper, `refreshedIssueIsInactive`. This **replaces** the prior
  active-listing-only sweep (`appendLabelIneligibleActive`) — one source of truth
  that also covers running/blocked/retry issues **beyond the active-listing page**,
  while only acting on rows the tracker actually returned (no mass-cancel on a
  transient/empty refresh).
- **Single builder**: `ReconciliationConfigFromWorkflow` remains the one source of
  truth for the reconciliation field list (the production override delegates to it).

## Continue + reconcile gap fix (from bot review)

The first revision sourced labels only from the active listing, so the per-turn
continue gate and out-of-page reconcile couldn't see label removal (two P2s from
the Codex review). This revision fixes the class at the root: labels flow through
the refresh, so all SPEC routability sites — including `continue` — honor the gate.

## #705 (Linear label cap)

Linear `labels(first:50)` → `250` (the connection max) in **both** the listing and
the new refresh query, since the refresh now cancels running work and a truncated
label set must not look like a removed label. #705 stays open for true label
pagination as the theoretical complete fix; 250 makes the hole practically
impossible.

## PR diff size budget (AGENTS.md)

- [ ] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [x] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff is 12 files / ~168 net LOC (tests excluded) — at the file ceiling.
The overage is the `IssueStateRefresher` contract change rippling through all three
tracker clients plus the continue-gate + reconcile wiring; splitting it would ship
a half-wired contract (won't compile) or an inert continue gate. Requesting
size-gate sign-off.

## Testing

- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] additional validation noted below when needed

New/updated tests (each mutation-verified against the committed artifact):
continue-gate routability (`runtime_poller_test.go`); out-of-page reconcile
cancel + retain + transient-empty-refresh no-cancel + empty-required gate-off
(`poller_reconciletick_test.go`); refresh label-carry positive case; tracker-client
label normalization (`github_test.go`/`linear_test.go`/`tracker_client_test.go`).
Mutations verified: continue-gate `&&`→`||` fails the gate test; reconcile
label-branch disabled fails the cancel tests; dropping the refresh label-carry
fails the out-of-page retain test.
