### PR TITLE
feat: expose tracker issue_url on state-API rows (#683)

### DIFF
--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -54,6 +54,92 @@ func TestApiRunningRowAlwaysEmitsSpec13_7_2StatusKeys(t *testing.T) {
 	}
 }
 
+// TestApiStateRowsEmitIssueURLWhenAvailable pins SPEC §13.7's SHOULD-level
+// `issue_url`: running/retrying/blocked rows must surface the tracker-provided
+// URL when present and omit the key (omitempty) when absent. The URL is already
+// carried in *Entry.Issue.URL; this is the projection layer the state API was
+// missing. Mutation: dropping IssueURL from any DTO/builder fails the matching
+// "present" case; dropping omitempty fails the matching "absent" case.
+func TestApiStateRowsEmitIssueURLWhenAvailable(t *testing.T) {
+	const url = "https://tracker.example/issues/MT-649"
+	keyPresent := func(t *testing.T, raw []byte, want string) {
+		t.Helper()
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		v, ok := got["issue_url"]
+		if !ok {
+			t.Fatalf("issue_url missing; want %q in %s", want, raw)
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			t.Fatalf("issue_url unmarshal: %v", err)
+		}
+		if s != want {
+			t.Fatalf("issue_url = %q; want %q", s, want)
+		}
+	}
+	keyAbsent := func(t *testing.T, raw []byte) {
+		t.Helper()
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if _, ok := got["issue_url"]; ok {
+			t.Fatalf("issue_url present; want omitted (omitempty) in %s", raw)
+		}
+	}
+	rows := map[string]struct {
+		withURL any
+		noURL   any
+	}{
+		"running": {
+			withURL: apiRunningFromView(orchestrator.RunningView{IssueID: "i1", Identifier: "MT-649", IssueURL: url}),
+			noURL:   apiRunningFromView(orchestrator.RunningView{IssueID: "i1", Identifier: "MT-649"}),
+		},
+		"retry": {
+			withURL: apiRetryFromView(orchestrator.RetryView{IssueID: "i1", Identifier: "MT-649", IssueURL: url}),
+			noURL:   apiRetryFromView(orchestrator.RetryView{IssueID: "i1", Identifier: "MT-649"}),
+		},
+	}
+	for name, tc := range rows {
+		t.Run(name+" present", func(t *testing.T) {
+			raw, err := json.Marshal(tc.withURL)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			keyPresent(t, raw, url)
+		})
+		t.Run(name+" absent", func(t *testing.T) {
+			raw, err := json.Marshal(tc.noURL)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			keyAbsent(t, raw)
+		})
+	}
+
+	// Blocked rows are projected through apiStateFromView, not a standalone
+	// builder, so exercise that path.
+	resp := apiStateFromView(orchestrator.StateView{
+		Blocked: []orchestrator.BlockedView{{IssueID: "i1", Identifier: "MT-649", IssueURL: url}},
+	})
+	rawBlocked, err := json.Marshal(resp.Blocked[0])
+	if err != nil {
+		t.Fatalf("marshal blocked: %v", err)
+	}
+	keyPresent(t, rawBlocked, url)
+	respNo := apiStateFromView(orchestrator.StateView{
+		Blocked: []orchestrator.BlockedView{{IssueID: "i1", Identifier: "MT-649"}},
+	})
+	rawBlockedNo, err := json.Marshal(respNo.Blocked[0])
+	if err != nil {
+		t.Fatalf("marshal blocked no-url: %v", err)
+	}
+	keyAbsent(t, rawBlockedNo)
+}
+
 func TestApiIssueFromViewFindsRecentTerminalEventByIdentifier(t *testing.T) {
 	view := orchestrator.StateView{
 		Completed: []orchestrator.IssueID{"linear-global-id"},

--- a/cmd/worker/runbook_drift_test.go
+++ b/cmd/worker/runbook_drift_test.go
@@ -108,6 +108,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 		Running: []apiStateRunning{{
 			IssueID:       "issue-1",
 			Identifier:    "ENG-1",
+			IssueURL:      "https://tracker.example/issues/ENG-1",
 			State:         "In Progress",
 			SessionID:     "thread-1-turn-1",
 			TurnCount:     7,
@@ -127,6 +128,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 		Blocked: []apiStateBlocked{{
 			IssueID:           "issue-2",
 			Identifier:        "ENG-2",
+			IssueURL:          "https://tracker.example/issues/ENG-2",
 			State:             "AI Ready",
 			BlockedAt:         &blockedAt,
 			WorkspacePath:     "/var/aiops/workspaces/acme/repo/issue-2",
@@ -139,6 +141,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 		Retrying: []apiStateRetry{{
 			IssueID:    "issue-3",
 			Identifier: "ENG-3",
+			IssueURL:   "https://tracker.example/issues/ENG-3",
 			Attempt:    2,
 			DueAt:      &dueAt,
 			Error:      "retry soon",

--- a/cmd/worker/stateapi.go
+++ b/cmd/worker/stateapi.go
@@ -101,6 +101,9 @@ type apiStateCounts struct {
 type apiStateRunning struct {
 	IssueID    orchestrator.IssueID `json:"issue_id"`
 	Identifier string               `json:"issue_identifier,omitempty"`
+	// IssueURL is the tracker-provided issue URL, emitted only when available
+	// (SPEC §13.7 SHOULD). omitempty keeps URL-less rows (mock tracker) clean.
+	IssueURL string `json:"issue_url,omitempty"`
 	// State / SessionID / TurnCount / LastEvent / LastMessage are part of
 	// the SPEC §13.7.2 running-row contract — the sample literally shows
 	// `"last_message": ""` and `"turn_count": 7`, so a freshly-dispatched
@@ -128,6 +131,7 @@ type apiRunningTokens struct {
 type apiStateBlocked struct {
 	IssueID           orchestrator.IssueID `json:"issue_id"`
 	Identifier        string               `json:"issue_identifier,omitempty"`
+	IssueURL          string               `json:"issue_url,omitempty"`
 	State             string               `json:"state,omitempty"`
 	BlockedAt         *time.Time           `json:"blocked_at,omitempty"`
 	WorkspacePath     string               `json:"workspace_path,omitempty"`
@@ -140,6 +144,7 @@ type apiStateBlocked struct {
 type apiStateRetry struct {
 	IssueID    orchestrator.IssueID   `json:"issue_id"`
 	Identifier string                 `json:"issue_identifier,omitempty"`
+	IssueURL   string                 `json:"issue_url,omitempty"`
 	Attempt    int                    `json:"attempt"`
 	DueAt      *time.Time             `json:"due_at,omitempty"`
 	Error      string                 `json:"error,omitempty"`
@@ -485,6 +490,7 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 	return apiStateRunning{
 		IssueID:       row.IssueID,
 		Identifier:    row.Identifier,
+		IssueURL:      row.IssueURL,
 		State:         row.State,
 		SessionID:     row.SessionID,
 		TurnCount:     row.TurnCount,
@@ -511,6 +517,7 @@ func apiRetryFromView(row orchestrator.RetryView) apiStateRetry {
 	return apiStateRetry{
 		IssueID:    row.IssueID,
 		Identifier: row.Identifier,
+		IssueURL:   row.IssueURL,
 		Attempt:    row.Attempt,
 		DueAt:      dueAt,
 		Error:      row.Error,
@@ -566,6 +573,7 @@ func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 		blocked = append(blocked, apiStateBlocked{
 			IssueID:           row.IssueID,
 			Identifier:        row.Identifier,
+			IssueURL:          row.IssueURL,
 			State:             row.State,
 			BlockedAt:         blockedAt,
 			WorkspacePath:     row.WorkspacePath,

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -153,6 +153,7 @@ the shape here without updating the handler — or vice versa — fails the buil
     {
       "issue_id": "issue-1",
       "issue_identifier": "ENG-1",
+      "issue_url": "https://tracker.example/issues/ENG-1",
       "state": "In Progress",
       "session_id": "thread-1-turn-1",
       "turn_count": 7,
@@ -174,6 +175,7 @@ the shape here without updating the handler — or vice versa — fails the buil
     {
       "issue_id": "issue-2",
       "issue_identifier": "ENG-2",
+      "issue_url": "https://tracker.example/issues/ENG-2",
       "state": "AI Ready",
       "blocked_at": "2026-05-20T06:05:38Z",
       "workspace_path": "/var/aiops/workspaces/acme/repo/issue-2",
@@ -188,6 +190,7 @@ the shape here without updating the handler — or vice versa — fails the buil
     {
       "issue_id": "issue-3",
       "issue_identifier": "ENG-3",
+      "issue_url": "https://tracker.example/issues/ENG-3",
       "attempt": 2,
       "kind": "failure",
       "due_at": "2026-05-21T09:11:00Z",
@@ -284,6 +287,8 @@ Two consequences for dashboard authors:
 Each entry in the `running` array follows SPEC §13.7.2:
 
 - `issue_id` / `issue_identifier` — the tracker identity.
+- `issue_url` — the tracker-provided issue URL (SPEC §13.7); present on
+  running/blocked/retrying rows when the tracker supplied one, omitted otherwise.
 - `state` — the tracker state at dispatch (e.g. `In Progress`).
 - `session_id` — the live Codex session id (SPEC §4.1.6); absent until the
   runner emits a `session_started` event.

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -847,72 +847,9 @@ type StateView struct {
 	RecentEvents []RuntimeEvent
 }
 
-// RunningView is the per-running-entry projection in StateView. It
-// omits unexported / non-serializable fields like CancelWorker and Done.
-// SPEC §13.7.2 dictates the exposed field set; State / SessionID /
-// TurnCount / LastEvent / LastMessage / Tokens were added per #209 so
-// operators inspecting `/api/v1/state` or `/api/v1/<id>` can see live
-// coding-agent activity without tailing logs.
-type RunningView struct {
-	IssueID           IssueID
-	Identifier        string
-	State             string
-	SessionID         string
-	TurnCount         int
-	LastEvent         string
-	LastMessage       string
-	StartedAt         time.Time
-	LastEventAt       time.Time
-	RetryAttempt      *int
-	WorkspacePath     string
-	Tokens            TokensView
-	CodexAppServerPID int
-}
-
-// TokensView mirrors the SPEC §13.7.2 per-issue `tokens` object: the
-// input/output/total triple of cumulative codex tokens observed for the
-// active session.
-type TokensView struct {
-	InputTokens  int64
-	OutputTokens int64
-	TotalTokens  int64
-}
-
-// BlockedView is the public projection of a blocked claim.
-type BlockedView struct {
-	IssueID           IssueID
-	Identifier        string
-	State             string
-	BlockedAt         time.Time
-	WorkspacePath     string
-	SessionID         string
-	LastEventAt       time.Time
-	Method            string
-	Error             string
-	CodexAppServerPID int
-}
-
-// RetryView is the per-retry-entry projection in StateView. Omits the
-// *time.Timer handle because it is not meaningful outside the process.
-type RetryView struct {
-	IssueID    IssueID
-	Identifier string
-	Attempt    int
-	DueAt      time.Time
-	Error      string
-	Kind       RetryKind
-}
-
-type OperatorTerminalStopView struct {
-	IssueID               IssueID
-	Identifier            string
-	State                 string
-	StoppedAt             time.Time
-	SuppressedDispatches  int
-	FirstSuppressedAt     time.Time
-	FirstSuppressedState  string
-	FirstSuppressedReason string
-}
+// The StateView projection types (RunningView, BlockedView, RetryView,
+// TokensView, OperatorTerminalStopView) live in views.go; their builders stay
+// here next to Snapshot.
 
 // Snapshot returns a read-only view of the orchestrator state. The
 // returned slices are freshly allocated so the caller may sort or
@@ -934,6 +871,7 @@ func (s *OrchestratorState) snapshotRunningViews() []RunningView {
 		rows = append(rows, RunningView{
 			IssueID:       id,
 			Identifier:    r.Identifier,
+			IssueURL:      r.Issue.URL,
 			State:         r.Issue.State,
 			SessionID:     r.Session.SessionID,
 			TurnCount:     r.Session.TurnCount,
@@ -1007,6 +945,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 		view.Blocked = append(view.Blocked, BlockedView{
 			IssueID:           id,
 			Identifier:        b.Identifier,
+			IssueURL:          b.Issue.URL,
 			State:             b.Issue.State,
 			BlockedAt:         b.BlockedAt,
 			WorkspacePath:     b.Workspace.Path,
@@ -1021,6 +960,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 		view.Retrying = append(view.Retrying, RetryView{
 			IssueID:    id,
 			Identifier: r.Identifier,
+			IssueURL:   r.Issue.URL,
 			Attempt:    r.Attempt,
 			DueAt:      r.DueAt,
 			Error:      r.Error,

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -34,6 +34,62 @@ func runningEntry(t *testing.T, iss tracker.Issue) *RunningEntry {
 	}
 }
 
+// TestSnapshotViewsCarryIssueURL pins SPEC §13.7's issue_url projection: the
+// running / retrying / blocked views surface Entry.Issue.URL (empty when the
+// tracker provided none), and the URL survives the running->blocked transition
+// because the whole tracker.Issue is carried forward — no plumbing drops it.
+// Mutation: dropping IssueURL from any view builder fails this.
+func TestSnapshotViewsCarryIssueURL(t *testing.T) {
+	const runURL = "https://tracker.example/issues/ENG-1"
+	const retryURL = "https://tracker.example/issues/ENG-2"
+	st := NewOrchestratorState(15000, 4)
+
+	run := issue("ENG-1")
+	run.URL = runURL
+	runID := IssueID(run.ID)
+	entry := runningEntry(t, run)
+	st.BeginDispatch(runID, entry)
+
+	ret := issue("ENG-2")
+	ret.URL = retryURL
+	st.ScheduleRetry(&RetryEntry{IssueID: IssueID(ret.ID), Identifier: ret.Identifier, Issue: ret, Attempt: 1, DueAt: time.Unix(1_700_000_000, 0)})
+
+	// A third running issue with NO URL must project an empty IssueURL (the
+	// builder must not fabricate one; omitempty then drops it at the API).
+	noURL := issue("ENG-3")
+	st.BeginDispatch(IssueID(noURL.ID), runningEntry(t, noURL))
+
+	view := st.Snapshot()
+	if got := runningViewURL(view, runID); got != runURL {
+		t.Fatalf("Running[ENG-1].IssueURL = %q; want %q", got, runURL)
+	}
+	if got := runningViewURL(view, IssueID(noURL.ID)); got != "" {
+		t.Fatalf("Running[ENG-3].IssueURL = %q; want empty (no tracker URL)", got)
+	}
+	if len(view.Retrying) != 1 || view.Retrying[0].IssueURL != retryURL {
+		t.Fatalf("Retrying view = %+v; want one row with IssueURL %q", view.Retrying, retryURL)
+	}
+
+	// Survival: running -> blocked carries the whole Issue, so the blocked view
+	// still surfaces the URL.
+	if !st.BlockRun(runID, entry, time.Now().UTC(), "input required", time.Second) {
+		t.Fatal("BlockRun(ENG-1) = false; want it to move the running entry to blocked")
+	}
+	blockedView := st.Snapshot()
+	if len(blockedView.Blocked) != 1 || blockedView.Blocked[0].IssueURL != runURL {
+		t.Fatalf("Blocked view after BlockRun = %+v; want one row with IssueURL %q (URL must survive running->blocked)", blockedView.Blocked, runURL)
+	}
+}
+
+func runningViewURL(view StateView, id IssueID) string {
+	for _, row := range view.Running {
+		if row.IssueID == id {
+			return row.IssueURL
+		}
+	}
+	return "<not found>"
+}
+
 func TestNewOrchestratorState_MatchesSpec16_1Initializer(t *testing.T) {
 	// SPEC §16.1: state = { running: {}, claimed: set(),
 	// retry_attempts: {}, completed: set(), codex_totals: {...},

--- a/internal/orchestrator/views.go
+++ b/internal/orchestrator/views.go
@@ -1,0 +1,79 @@
+package orchestrator
+
+import "time"
+
+// This file holds the public projection types that StateView exposes for the
+// SPEC §13.7 observability surface (the /api/v1/state and /api/v1/<id>
+// handlers). They are split from state.go so the orchestrator state machine and
+// its read-only projections stay separately legible (#521 burn-down); the
+// builders live alongside Snapshot in state.go.
+
+// RunningView is the per-running-entry projection in StateView. It
+// omits unexported / non-serializable fields like CancelWorker and Done.
+// SPEC §13.7.2 dictates the exposed field set; State / SessionID /
+// TurnCount / LastEvent / LastMessage / Tokens were added per #209 so
+// operators inspecting `/api/v1/state` or `/api/v1/<id>` can see live
+// coding-agent activity without tailing logs.
+type RunningView struct {
+	IssueID           IssueID
+	Identifier        string
+	IssueURL          string
+	State             string
+	SessionID         string
+	TurnCount         int
+	LastEvent         string
+	LastMessage       string
+	StartedAt         time.Time
+	LastEventAt       time.Time
+	RetryAttempt      *int
+	WorkspacePath     string
+	Tokens            TokensView
+	CodexAppServerPID int
+}
+
+// TokensView mirrors the SPEC §13.7.2 per-issue `tokens` object: the
+// input/output/total triple of cumulative codex tokens observed for the
+// active session.
+type TokensView struct {
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+}
+
+// BlockedView is the public projection of a blocked claim.
+type BlockedView struct {
+	IssueID           IssueID
+	Identifier        string
+	IssueURL          string
+	State             string
+	BlockedAt         time.Time
+	WorkspacePath     string
+	SessionID         string
+	LastEventAt       time.Time
+	Method            string
+	Error             string
+	CodexAppServerPID int
+}
+
+// RetryView is the per-retry-entry projection in StateView. Omits the
+// *time.Timer handle because it is not meaningful outside the process.
+type RetryView struct {
+	IssueID    IssueID
+	Identifier string
+	IssueURL   string
+	Attempt    int
+	DueAt      time.Time
+	Error      string
+	Kind       RetryKind
+}
+
+type OperatorTerminalStopView struct {
+	IssueID               IssueID
+	Identifier            string
+	State                 string
+	StoppedAt             time.Time
+	SuppressedDispatches  int
+	FirstSuppressedAt     time.Time
+	FirstSuppressedState  string
+	FirstSuppressedReason string
+}

--- a/scripts/file_size_budget_test.go
+++ b/scripts/file_size_budget_test.go
@@ -20,7 +20,9 @@ var oversizedProductionGoFileBaseline = map[string]int{
 	// operator-terminal-stop latch cap. Per #667 (and the #661 burn-down note it
 	// cites), this cap must land *before* #661 decomposes state.go by
 	// responsibility, which then drops it well under budget and removes this baseline.
-	"internal/orchestrator/state.go": 1062,
+	// #683 extracts the StateView projection types into views.go (a first
+	// responsibility split), dropping the baseline from 1062 to 1002.
+	"internal/orchestrator/state.go": 1002,
 	"cmd/tui/main.go":                904,
 	// codex_app_server.go's baseline rose from 840 under #666, which replaces the
 	// per-read goroutine with a single long-lived stdout reader (the reader


### PR DESCRIPTION
Closes #683

## Summary

Backports the SPEC §13.7 `SHOULD`-level observability addition from upstream
Symphony [`#89`](https://github.com/openai/symphony/commit/b4ccf7b55327821ca6d9b1b8b9e4ab5ac7f30e15):
running, retrying, and blocked state-API rows now surface the tracker-provided
`issue_url` when available (omitted via `omitempty` when not).

The URL was already preserved end-to-end in `*Entry.Issue.URL` (the entries embed
the full `tracker.Issue`, and Linear maps `url` / GitHub maps `html_url`), so this
is purely the missing **projection layer** — no metadata threading.

## SPEC alignment (AGENTS.md principle 6/7)

- [ ] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [x] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This adds a SPEC §13.7 state-row field (`issue_url`), and introduces a new
orchestrator file (`internal/orchestrator/views.go` — a refactor extraction, see
below), so the PR-metadata gate flags the path. It is a gap-closing backport
*toward* SPEC, not a deviation. Upstream Elixir reference:
`elixir/lib/symphony_elixir/orchestrator.ex` serializes the state rows with the
issue URL via `pick_retry_issue_url/2` and `blocked_issue_url/1` (added in
upstream #89). SPEC §13.7: *"session and retry rows SHOULD include the
tracker-provided issue URL when available"*.

## Design

- `internal/orchestrator/state.go`: add `IssueURL` to `RunningView` / `BlockedView`
  / `RetryView`, populated from `entry.Issue.URL` in the existing snapshot builders.
- `cmd/worker/stateapi.go`: add `IssueURL string \`json:"issue_url,omitempty"\``
  to `apiStateRunning` / `apiStateBlocked` / `apiStateRetry` and map it from the
  view. The per-issue endpoint reuses these DTOs, so it inherits the field.
- `internal/orchestrator/views.go` (**new**): the five `StateView` projection
  types (`RunningView`, `BlockedView`, `RetryView`, `TokensView`,
  `OperatorTerminalStopView`) are extracted from `state.go` into a focused file.
  This is a first #521/#661 responsibility split — it drops `state.go` from 1062
  to 1002 lines and **lowers** its file-size baseline accordingly (ratchet down).
- Docs: `runtime-status.md` example rows + field list gain `issue_url`; the
  bidirectional runbook-drift fixture is updated so the field is drift-checked.
- TUI/dashboard link rendering is intentionally deferred (the TUI ignores the new
  field; upstream gates link rendering on `http(s)` scheme — a separate concern).

## PR diff size budget (AGENTS.md)

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff is 3 files / ~27 net LOC (the `views.go` extraction offsets the
state.go reduction).

## Testing

- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] additional validation noted below when needed

New tests (mutation-verified): `TestApiStateRowsEmitIssueURLWhenAvailable`
(DTO present-with-URL / omitted-without, for running/retry/blocked);
`TestSnapshotViewsCarryIssueURL` (view builders populate from `Entry.Issue.URL`,
empty when absent, and the URL **survives** a running→blocked transition — the
acceptance-criteria re-dispatch-survival check). Mutations verified: dropping the
view-builder population, the DTO mapping, and the `omitempty` tag each fail the
matching assertion. The runbook-drift test now covers `issue_url` bidirectionally.
