### PR TITLE
docs: document networkAccess opt-in for package-manager workflows (#684)

### DIFF
--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -314,6 +314,53 @@ above governs every turn — you no longer have to restate it under
 `turn_sandbox_policy`. Setting `turn_sandbox_policy` explicitly still overrides
 the derived value for callers that need a different per-turn policy (#472).
 
+## Network access for package-manager workflows
+
+The shell commands the **agent runs inside the turn sandbox** — `npm install`,
+`pip install`, `go mod download`, `git clone` of an external repo, `curl`/`wget`
+of remote resources — need network. Whether they get it depends on the per-turn
+sandbox policy:
+
+- **The Docker profile above (`thread_sandbox: danger-full-access`)** already
+  permits network in the turn sandbox, so package-manager commands work with no
+  extra config. **Do not** add a `workspaceWrite` `turn_sandbox_policy` to that
+  workflow to "enable network": it overrides the derived `dangerFullAccess`
+  policy and re-imposes the per-turn sandbox that fails inside the restricted
+  container with the bwrap namespace error shown above. Keep the
+  `danger-full-access` path in the container.
+- **Host-direct `workspace-write` setups** block network in the turn sandbox by
+  default (`networkAccess: false`, matching Codex's safe default and
+  `docs/security-posture.md`). Package-manager workflows need to write (install),
+  so `workspace-write` is the relevant policy — set `networkAccess: true` on it,
+  keeping `type: workspaceWrite`. That policy is fully typed, so the example must
+  carry every field the loader requires (`writableRoots`, `networkAccess`,
+  `excludeTmpdirEnvVar`, `excludeSlashTmp`) or `WORKFLOW.md` fails to load before
+  the worker starts:
+
+  ```yaml
+  codex:
+    turn_sandbox_policy:
+      type: workspaceWrite
+      writableRoots: []
+      networkAccess: true
+      excludeTmpdirEnvVar: false
+      excludeSlashTmp: false
+  ```
+
+  A `read-only` workflow likewise blocks network by default; if it only needs to
+  *fetch* (not install), opt in on its **own** `type: readOnly` policy
+  (`type: readOnly` + `networkAccess: true`) — do not switch it to
+  `workspaceWrite`, which would also grant workspace writes it intentionally
+  forbids.
+
+Scope: `networkAccess` gates **only** commands the agent runs inside the turn
+sandbox. It does not affect the model's reasoning, the `linear_graphql` (and
+equivalent) dynamic tools, or the orchestrator's tracker polling — those run
+outside the sandbox and reach the network regardless. Enabling it widens the
+sandbox's blast radius, so turn it on only for workflows that genuinely need it,
+and prefer running such workflows on an already-isolated worker (container or
+dedicated VM), consistent with the `thread_sandbox` guidance above.
+
 ## Validation reference
 
 See `docs/validation/2026-05-26-docker-linear-e2e.md` for the live Linear todo


### PR DESCRIPTION
Closes #684

## Summary

Docs-only backport of the operator-facing clarification from upstream Symphony
[`#65`](https://github.com/openai/symphony/commit/0d85c27c9abe94ce23f63a2c7ad0b687ab8d44d5).
The `codex-app-server-docker` runbook now documents that the per-turn sandbox
blocks network by default (`networkAccess: false`), what that blocks (the agent's
in-sandbox `npm install` / `pip install` / `go mod download` / external
`git clone` / `curl`/`wget`), the per-workflow opt-in snippet, and the scope
(it does **not** affect model reasoning, `linear_graphql`, or tracker polling,
which run outside the sandbox).

Not a code or SPEC change: `NetworkAccess` is already at parity via
`codex.turn_sandbox_policy` (default `false`), and #65 did not touch `SPEC.md` —
it changed an operator-owned reference `WORKFLOW.md` default plus docs. We keep
`false` as the safe default (`docs/security-posture.md`); enabling sandbox
network is a per-workflow operator opt-in, not a SPEC requirement.

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs only — no config key, no worker/orchestrator phase/gate/artifact, no
`DEVIATIONS.md` row. The `networkAccess` field already exists
(`internal/workflow/codex_schema.go`); this PR only documents it.

## PR diff size budget (AGENTS.md)

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Docs-only: 1 file, +27 lines, 0 production Go LOC.

## Testing

- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] additional validation noted below when needed

No code change. The documented opt-in snippet (`type: workspaceWrite` /
`networkAccess: true`) uses the camelCase keys the `CodexSandboxPolicy`
YAML unmarshaler accepts — verified against the existing
`internal/workflow/config_test.go` turn-sandbox-policy fixtures.
