### PR TITLE
docs: add Clean-code rule 11 (mutation-test the wiring seam) + 2026-06-07 journal

### DIFF
--- a/.trellis/workspace/yvan/journal-1.md
+++ b/.trellis/workspace/yvan/journal-1.md
@@ -127,3 +127,50 @@ Per-issue pipeline (don't skip steps):
 Start with #670. Auto-merge the clean, uncontroversial PRs and keep going;
 pause and report only when something is debatable, uncertain, or needs sign-off.
 ```
+
+## 2026-06-07 — SPEC-alignment backports: #682 / #683 / #684
+
+Finished the 2026-06-06 queue's backport tail (the P2 fixes #670–#673/#677–#679
+had already merged). All three closed; `main` advanced to `92c5d67`.
+
+### Shipped
+- **#682 (PR #706)** — `tracker.required_labels` opt-in gate (SPEC §4.1.1/§6.4,
+  upstream #88). First cut gated dispatch/retry/reconcile but had a production
+  no-op (`reconciliationConfigForWorkflow` dropped the field) and, per the Codex
+  bot, two P2 gaps: the §16.5 per-turn **continue** gate and **out-of-page**
+  reconcile couldn't see label removal (labels were sourced only from the active
+  listing). Operator chose "complete it (size-gated)." Final design (verified by a
+  design Workflow's 2 adversarial passes + a Codex plan review, no fatal flaws):
+  new `tracker.IssueState{State,Labels}` refresh contract carries labels across
+  all 3 trackers; continue gate folds the label check into `Active` (no runner
+  change); `appendLabelIneligibleActive` replaced by one `refreshedIssueIsInactive`
+  helper that also covers out-of-page in-flight issues; Linear label cap 50→250.
+  `size-gated: justified overage` (signed off).
+- **#683 (PR #707)** — `issue_url` on running/retrying/blocked state-API rows
+  (SPEC §13.7 SHOULD, upstream #89). Projection-only (URL already in
+  `*Entry.Issue.URL`). Bonus: extracted the StateView projection structs into
+  `internal/orchestrator/views.go`, burning state.go 1062→1002 (a #521/#661 split,
+  baseline ratcheted down). Both reviews clean first pass.
+- **#684 (PR #708)** — docs-only `networkAccess` note (upstream #65). Bot found 4
+  real defects across 3 rounds in the YAML snippet (incomplete `workspaceWrite`
+  fields → load error; wrong for the Docker `danger-full-access` profile;
+  read-only→workspace-write escalation). Fixed snippets verified via
+  `--print-config`.
+
+### Earned this run (durable; also saved to assistant memory)
+1. **Mutation-test the wiring seam, not just the leaf** — #682 retry-fire +
+   production builder and #683's label-carry were unwired no-ops the leaf tests
+   passed. Now AGENTS.md Clean-code rule 11.
+2. **Validate doc config snippets through the real loader** before committing —
+   the #684 3-round bot saga. A docs PR carrying a config snippet is not low-risk.
+3. **Bot review is posted as a PR review + inline comments**, not issue comments —
+   poll `/pulls/<n>/reviews` + `/comments` by head SHA (a wrong endpoint cost a
+   20-min false timeout). Updated the codex-review-every-push memory.
+4. **PR-metadata gate trips on a new orchestrator/worker file even for a pure
+   refactor extraction** (views.go) — satisfy with the Elixir-reference option.
+
+### Follow-up
+- **#705 (open)** — Linear `labels(first:N)` cap could false-cancel an issue with
+  a required label beyond the cap. Mitigated by the 250 raise; kept open for true
+  label pagination.
+- Deferred #464 / #547 untouched, as planned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,6 +476,21 @@ failure per the "Earned rules" principle above.
     refactor replaced an external deadline bound with a typed-error assertion
     that initially dropped the "did not wait for the outer deadline" invariant.
 
+11. **Mutation-test the wiring seam, not just the leaf.** When a field or
+    behavior is threaded through a construction seam (config →
+    `ReconciliationConfig` → snapshot → lister/closure, or a view → DTO mapper),
+    add a test that drives the *real* construction path and mutation-verify by
+    deleting the field **at the seam**. A leaf predicate can be correct and
+    unit-tested while the production wiring silently drops the field — a no-op the
+    leaf tests still pass. Prefer a compiling mutation (`&&`→`||`, drop the
+    assignment, flip `omitempty`) so the test fails on an assertion, not a build
+    error. When one concept has two builders, collapse to one source of truth
+    (rule 3) so a field cannot be wired in one and dropped in the other. **Earned
+    by:** #682's retry-fire `requiredLabels` thread and the production
+    `reconciliationConfigForWorkflow` builder were both unwired no-ops that the
+    leaf `issueHasRequiredLabels` tests passed; #683's refresh label-carry
+    (`issue.Labels = st.Labels`) had no positive test until one was added.
+
 ## Conventions
 
 - **gofmt is non-negotiable**: CI fails on any diff. Always run before committing. A PostToolUse hook (`.claude/scripts/format-go.sh`) auto-runs `gofmt -w` on `.go` files edited via the Edit/Write tools; files changed through Bash (e.g. `sed`, heredocs) are not covered, so always verify with `gofmt -l` before pushing — CI's `gofmt -l` gate is the backstop.


### PR DESCRIPTION
Closes #710

## Summary
- AGENTS.md **Clean code rule 11** — mutation-test the *wiring seam*, not just the leaf predicate. Earned by #682 (retry-fire `requiredLabels` + production `reconciliationConfigForWorkflow` were unwired no-ops the leaf tests passed) and #683 (refresh label-carry had no positive test).
- `.trellis/workspace/yvan/journal-1.md` — 2026-06-07 batch entry for #682/#683/#684 (outcomes, earned lessons, #705 follow-up).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs/governance only — no code, no config key, no SPEC surface touched.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

0 production Go LOC (2 docs files).

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] additional validation noted below when needed

Docs-only change; no behavior. A broader AGENTS.md reorganization (index method per agents.md best practices) is planned separately and will relocate this rule along with the rest.
