### PR TITLE
ci: exempt Dependabot PRs from the SPEC-alignment metadata gate

### DIFF
--- a/.github/scripts/validate-pr-metadata.mjs
+++ b/.github/scripts/validate-pr-metadata.mjs
@@ -53,6 +53,18 @@ const closingKeywordPattern =
 // `not_a_real.ex` cannot satisfy the gate.
 const elixirCitationPattern = /elixir\/[\w./-]+\.ex(?::\d+)?/i;
 
+// exemptAuthorLogins are automation accounts whose PRs cannot satisfy the gate
+// and never author SPEC deviations: Dependabot opens dependency bumps with no
+// closing keyword and no SPEC-alignment checklist, so without an exemption the
+// required check blocks every routine update indefinitely. Scoped to the known
+// Dependabot logins rather than any `[bot]` so a future bot has to be added
+// deliberately (earned-rule principle).
+const exemptAuthorLogins = new Set(['dependabot[bot]', 'dependabot-preview[bot]']);
+
+export function isExemptAuthor(login) {
+  return exemptAuthorLogins.has(String(login ?? ''));
+}
+
 export function extractClosingIssueNumbers(body) {
   const numbers = new Set();
   for (const match of String(body ?? '').matchAll(closingKeywordPattern)) {
@@ -202,6 +214,11 @@ async function main() {
   const pullRequest = event.pull_request;
   if (!pullRequest) {
     throw new Error('This script must run from a pull_request_target workflow event.');
+  }
+  const author = pullRequest.user?.login ?? '';
+  if (isExemptAuthor(author)) {
+    console.log(`Skipping SPEC-alignment metadata gate for exempt author ${author}.`);
+    return;
   }
   const owner = process.env.REPO_OWNER ?? event.repository.owner.login;
   const repo = process.env.REPO_NAME ?? event.repository.name;

--- a/.github/scripts/validate-pr-metadata.test.mjs
+++ b/.github/scripts/validate-pr-metadata.test.mjs
@@ -6,6 +6,7 @@ import {
   classifySpecSensitivity,
   extractClosingIssueNumbers,
   hasElixirCitation,
+  isExemptAuthor,
   parseSpecAlignmentChecklist,
   touchesDeviations,
   validatePullRequestMetadata,
@@ -28,6 +29,14 @@ function body({ closes = 'Closes #573', selected = 0, extra = '' } = {}) {
 
 const CONFIG = [{ filename: 'internal/workflow/config.go', status: 'modified' }];
 const NON_SENSITIVE = [{ filename: 'internal/tracker/linear.go', status: 'modified' }];
+
+test('isExemptAuthor exempts Dependabot logins but no one else', () => {
+  assert.equal(isExemptAuthor('dependabot[bot]'), true);
+  assert.equal(isExemptAuthor('dependabot-preview[bot]'), true);
+  assert.equal(isExemptAuthor('echo-yvan'), false, 'a human author is never exempt');
+  assert.equal(isExemptAuthor('some-other[bot]'), false, 'an arbitrary bot is not exempt');
+  assert.equal(isExemptAuthor(undefined), false);
+});
 
 test('extractClosingIssueNumbers parses every closing keyword and dedupes', () => {
   assert.deepEqual(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,9 @@ These rules apply to every PR. Each is earned by a specific observed failure —
   new key/phase — cite an upstream Elixir reference or track a `DEVIATIONS.md` row
   (principle 6/7). It also requires every PR body to carry a `Closes #N` keyword.
   Fill the `SPEC alignment` checklist in the PR template; required-check wiring is
-  in `.github/governance/main-ruleset.json`.
+  in `.github/governance/main-ruleset.json`. Dependabot-authored PRs are exempt
+  (they cannot write a closing keyword or the checklist and never author SPEC
+  deviations); the exemption list lives in `validate-pr-metadata.mjs`.
   ([provenance](docs/engineering-rules-rationale.md#conventions))
 
 ## WORKFLOW.md discovery (worker side)


### PR DESCRIPTION
## What

The required `Validate PR metadata` check fails on **every** Dependabot PR (e.g. #680): dependency bumps carry no `Closes #N` keyword and no `SPEC alignment` checklist, so the gate blocks routine dependency updates indefinitely. This short-circuits the validator for the known Dependabot logins while keeping the same check context reporting success — human/agent PRs are unaffected.

This is a class fix (AGENTS.md clean-code rule 10), not a one-off PR-body edit on #680.

## Changes

- `.github/scripts/validate-pr-metadata.mjs` — add `isExemptAuthor()` and short-circuit `main()` for `dependabot[bot]` / `dependabot-preview[bot]`. Scoped to known Dependabot logins (not any `[bot]`) so a future bot must be added deliberately (earned-rule principle).
- `.github/scripts/validate-pr-metadata.test.mjs` — test exempt logins vs. humans/arbitrary bots.
- `AGENTS.md` — document the exemption in the PR-metadata conventions bullet.

## Why this is safe

The gate exists to make a new SPEC deviation cost something before merge. Dependabot never authors a SPEC deviation (it bumps versions in manifests/lockfiles), so exempting it removes no real protection. The job still runs and reports `Validate PR metadata` as success, so required-check wiring in `.github/governance/main-ruleset.json` is unaffected.

## Follow-up

Once merged, #680 needs an update/rebase (it's currently "behind") for its own checked-out validator to include the exemption and go green.

## SPEC alignment

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream Elixir reference cited below.
- [ ] Adds one, tracked as a DEVIATIONS.md row + `area:spec-alignment` issue.

This only touches CI metadata validation; no SPEC-sensitive path is changed.

Closes #680

https://claude.ai/code/session_01ARE1rsyUxGNtNmUtsZbNHX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARE1rsyUxGNtNmUtsZbNHX)_