### PR TITLE
docs: fix stale README dashboard stack and CI job description

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ aiops-platform is licensed under the [Apache License 2.0](LICENSE).
 
 ### Web dashboard (`cmd/worker/dashboard`)
 
-A React 19 + Vite + Tailwind v4 single-page app, served by the worker at `/`
+A React 19 + Vite single-page app with self-contained, embedded CSS (no
+Tailwind, no external font/CDN), served by the worker at `/`
 (and assets under `/assets/`) on the same loopback listener as the state API.
 It is a read-only operator client for `/api/v1/state` (SPEC §13.7.1) with
 light/dark themes and Anthropic brand styling. The built output is generated in
@@ -381,19 +382,23 @@ in-flight run.
 
 Every push to `main` and every pull request targeting `main` runs
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml). CI is the safety net for
-all changes; PRs should not merge while it is red. It runs three jobs:
+all changes; PRs should not merge while it is red. It runs four jobs:
 
-- **`go`** — Node-based GitHub script tests
-  (`capture-unresolved-reviews.test.mjs`), `gofmt` check on all tracked Go files,
-  a Dockerfile/`go.mod` Go-version drift check, `go mod tidy` cleanliness,
-  the uncached production Go file-size budget check,
-  `go test -race -covermode=atomic ./...`, `go build` for `worker` and `tui`,
-  and an upload of those Linux binaries as build artifacts.
+- **`go`** — Node-based GitHub script tests (`.github/scripts/*.test.mjs`),
+  Trellis Python script tests, the dashboard `npm test` + build with a
+  dist-embed check, a `gofmt` check on all tracked Go files, the blocking
+  golangci-lint gate (including AGENTS.md rule 7's `funlen`/`gocognit` budgets),
+  a Dockerfile/`go.mod` Go-version drift check, `go mod tidy` cleanliness, the
+  production Go file-size budget check, `go test -race -covermode=atomic ./...`,
+  a short fuzz smoke, `go build` for `worker` and `tui`, and an upload of those
+  Linux binaries as build artifacts.
+- **`security`** — supply-chain checks: standalone `go vet ./...` plus
+  `govulncheck ./...` built against the `go.mod` toolchain floor.
 - **`e2e`** — the end-to-end Gitea mock loop (`go test -tags e2e ./test/e2e/...`)
   against a real `gitea` container.
 - **`docker`** — a Docker image build of the repository `Dockerfile` (depends on
-  `go`), plus a blocking Trivy scan for fixed CRITICAL/HIGH image
-  vulnerabilities.
+  `go`), a blocking Trivy scan for fixed CRITICAL/HIGH image vulnerabilities, and
+  a CycloneDX SBOM generated and uploaded as a build artifact.
 
 See the [CI/CD runbook](docs/runbooks/ci.md) for triggers, security posture,
 release flow, and local pre-push checks.

--- a/README.md
+++ b/README.md
@@ -384,14 +384,11 @@ Every push to `main` and every pull request targeting `main` runs
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml). CI is the safety net for
 all changes; PRs should not merge while it is red. It runs four jobs:
 
-- **`go`** — Node-based GitHub script tests (`.github/scripts/*.test.mjs`),
-  Trellis Python script tests, the dashboard `npm test` + build with a
-  dist-embed check, a `gofmt` check on all tracked Go files, the blocking
-  golangci-lint gate (including AGENTS.md rule 7's `funlen`/`gocognit` budgets),
-  a Dockerfile/`go.mod` Go-version drift check, `go mod tidy` cleanliness, the
-  production Go file-size budget check, `go test -race -covermode=atomic ./...`,
-  a short fuzz smoke, `go build` for `worker` and `tui`, and an upload of those
-  Linux binaries as build artifacts.
+- **`go`** — format and lint gates (`gofmt`, the blocking golangci-lint gate),
+  repo hygiene (`go mod tidy`, Dockerfile/`go.mod` Go-version drift, the Go
+  file-size budget), the test suite (`go test -race`, a short fuzz smoke, and the
+  dashboard / Trellis / GitHub-script tests), and the build (dashboard bundle
+  plus the `worker` and `tui` binaries, uploaded as artifacts).
 - **`security`** — supply-chain checks: standalone `go vet ./...` plus
   `govulncheck ./...` built against the `go.mod` toolchain floor.
 - **`e2e`** — the end-to-end Gitea mock loop (`go test -tags e2e ./test/e2e/...`)


### PR DESCRIPTION
Closes #717

## Summary
- **Dashboard stack:** README claimed "React 19 + Vite + Tailwind v4", but Tailwind was removed — `package.json` has no Tailwind/PostCSS dep or config, and `src/styles.css` is self-contained plain CSS with no external font/CDN. Updated the description to match.
- **CI section:** README said CI runs three jobs; `ci.yml` now has four. Documented the missing `security` job (`go vet ./...` + `govulncheck`), noted the `docker` job's CycloneDX SBOM artifact, and condensed the `go` job into grouped check classes (lint / hygiene / tests / build) so it conveys what runs without re-drifting step-by-step. Detail stays in the CI runbook.

Docs-only change; no code or SPEC-sensitive paths touched.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [ ] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [ ] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [ ] `go vet ./...`
- [ ] `go test -race -covermode=atomic ./...`
- [ ] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] Docs-only change — verified claims against `cmd/worker/dashboard/package.json`, `src/styles.css`, and `.github/workflows/ci.yml`.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.

---
_Generated by [Claude Code](https://claude.ai/code/session_017bfZgLQwKKz6yb3HkfXf8L)_