### PR TITLE
refactor: extract codex app-server stdio transport into its own file (#722)

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,23 +10,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime/debug"
 	"strings"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
-)
-
-const (
-	// appServerScannerInitialBuf is the Scanner's starting buffer size; it grows
-	// as needed up to maxAppServerLineBytes.
-	appServerScannerInitialBuf = 64 << 10
-	// maxAppServerLineBytes caps each Codex app-server stdio line per SPEC §10.1
-	// ("Max line size: 10 MB"). Lines exceeding this surface as bufio.ErrTooLong
-	// instead of growing the buffer unbounded and OOMing the worker.
-	maxAppServerLineBytes = 10 * 1024 * 1024
 )
 
 // CodexAppServerRunner talks to `codex app-server` over JSON-RPC 2.0 stdio.
@@ -603,199 +591,6 @@ func (c *appServerClient) classifyTurnError(ctx context.Context, err error, turn
 		return &TurnTimeoutError{Timeout: time.Duration(c.turnTimeoutMs) * time.Millisecond, Elapsed: time.Since(turnStarted), Cause: err}
 	}
 	return err
-}
-func (c *appServerClient) request(ctx context.Context, method string, params any) (map[string]any, error) {
-	id := c.nextID
-	c.nextID++
-	if err := c.send(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params}); err != nil {
-		return nil, err
-	}
-	for {
-		msg, err := c.readMessage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if result, matched, rpcErr := responseForID(msg, id); matched {
-			return result, rpcErr
-		}
-		c.handleNotification(msg)
-	}
-}
-func (c *appServerClient) notify(method string, params map[string]any) error {
-	return c.send(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
-}
-func (c *appServerClient) send(msg map[string]any) error {
-	b, err := json.Marshal(msg)
-	if err != nil {
-		return err
-	}
-	b = append(b, '\n')
-	_, err = c.stdin.Write(b)
-	return err
-}
-func (c *appServerClient) readMessage(ctx context.Context) (map[string]any, error) {
-	msg, raw, err := c.readProtocolMessage(ctx)
-	if err != nil {
-		if raw != nil {
-			return nil, fmt.Errorf("decode codex app-server message: %w", err)
-		}
-		return nil, err
-	}
-	return msg, nil
-}
-func (c *appServerClient) readProtocolMessage(ctx context.Context) (map[string]any, []byte, error) {
-	select {
-	case <-ctx.Done():
-		return nil, nil, ctx.Err()
-	default:
-	}
-	line, err := c.readLine(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	// Scanner strips the line terminator; restore one in the transcript so
-	// successive JSON-RPC messages remain visually separated.
-	_, _ = c.out.Write(line)
-	_, _ = c.out.Write([]byte{'\n'})
-	var msg map[string]any
-	if err := json.Unmarshal(line, &msg); err != nil {
-		return nil, line, NewError(CategoryResponseError, "decode codex app-server message", err)
-	}
-	return msg, line, nil
-}
-
-// startStdoutReader launches the single long-lived stdout reader. It is the
-// source stage of https://go.dev/blog/pipelines: one goroutine owns the
-// bufio.Scanner (which is not safe for concurrent use) and continuously scans
-// lines, handing each to the request/response consumer over readCh. Its lifetime
-// is the app-server process: it exits when scanner.Scan returns false (stdout
-// EOF or error — the process closed stdout on exit), recording a sticky readErr.
-//
-// The reader has no separate stop signal: the consumer never abandons readCh, it
-// drains to EOF at shutdown (RunCodexAppServer drains before cmd.Wait), so the
-// reader always keeps the pipe flowing and reaches EOF rather than parking on a
-// send forever (Go Code Review Comments, "Goroutine Lifetimes"). `defer
-// close(readCh)` runs on every exit path, so a consumer waiting on readCh is
-// always released and the close is the happens-before edge that publishes
-// readErr. readCh is created here so the goroutine and its channel have one owner.
-func (c *appServerClient) startStdoutReader() {
-	c.readCh = make(chan []byte)
-	go func() {
-		defer close(c.readCh)
-		defer c.recoverReaderPanic()
-		for c.scanner.Scan() {
-			// Scanner.Bytes() is invalidated by the next Scan (bufio docs); copy
-			// before handing the line across the goroutine boundary.
-			line := append([]byte(nil), c.scanner.Bytes()...)
-			c.readCh <- line
-		}
-		c.readErr = scanTerminalError(c.scanner)
-	}()
-}
-
-// recoverReaderPanic is the stdout reader's deferred recovery: a panic in the
-// scan loop is published as readErr (so the consumer sees an error rather than
-// hanging on a never-closed readCh) and logged with a stack, not swallowed —
-// matching the orchestrator's recoverPanicValue convention (recover.go).
-func (c *appServerClient) recoverReaderPanic() {
-	r := recover()
-	if r == nil {
-		return
-	}
-	if err, ok := r.(error); ok {
-		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %w", err)
-	} else {
-		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %v", r)
-	}
-	log.Printf("event=codex_app_server_reader_panic panic=%v stack=%q", r, debug.Stack())
-}
-
-// scanTerminalError maps a finished scanner to the terminal error the consumer
-// should observe once readCh closes. Scanner.Err is nil on io.EOF (bufio docs),
-// so a clean end-of-stream normalizes to io.EOF; an over-cap line keeps the
-// existing wrapped bufio.ErrTooLong contract.
-func scanTerminalError(sc *bufio.Scanner) error {
-	err := sc.Err()
-	if err == nil {
-		return io.EOF
-	}
-	if errors.Is(err, bufio.ErrTooLong) {
-		return fmt.Errorf("codex app-server line exceeded %d bytes: %w", maxAppServerLineBytes, err)
-	}
-	return err
-}
-
-func (c *appServerClient) readLine(ctx context.Context) ([]byte, error) {
-	readTimeout := time.Duration(c.readTimeoutMs) * time.Millisecond
-	deadlineTimeout, hasDeadline := deadlineDuration(ctx)
-	if c.readTimeoutMs <= 0 || (hasDeadline && deadlineTimeout < readTimeout) {
-		return c.readLineOnce(ctx, nil)
-	}
-	return c.readLineOnce(ctx, time.After(readTimeout))
-}
-
-// readLineOnce waits for the next line from the long-lived reader, the
-// per-read timeout, or context cancellation — whichever fires first. A closed
-// readCh means the reader has exited; it surfaces the reader's sticky readErr
-// (io.EOF when it stopped cleanly). The DeadlineExceeded preference is retained
-// so a read that loses the race to an expiring context is classified as the
-// deadline, not as the EOF the dying process subsequently produced.
-func (c *appServerClient) readLineOnce(ctx context.Context, timeout <-chan time.Time) ([]byte, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-timeout:
-		return nil, &appServerReadTimeoutError{afterMs: c.readTimeoutMs}
-	case line, ok := <-c.readCh:
-		if !ok {
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				return nil, ctx.Err()
-			}
-			if c.readErr != nil {
-				return nil, c.readErr
-			}
-			return nil, io.EOF
-		}
-		return line, nil
-	}
-}
-func deadlineDuration(ctx context.Context) (time.Duration, bool) {
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		return 0, false
-	}
-	remaining := time.Until(deadline)
-	if remaining <= 0 {
-		return 0, true
-	}
-	return remaining, true
-}
-
-// appServerReadTimeoutError signals that a single stdio read exceeded the
-// configured codex read_timeout_ms budget. It is a typed error so the
-// classification paths detect it via errors.As rather than substring-matching
-// the message (AGENTS.md clean-code rule 8). The message is unchanged from the
-// original fmt.Errorf so existing logs and string-asserting tests still hold.
-type appServerReadTimeoutError struct {
-	afterMs int
-}
-
-func (e *appServerReadTimeoutError) Error() string {
-	return fmt.Sprintf("codex app-server read timeout after %dms", e.afterMs)
-}
-
-// isAppServerReadTimeout reports whether err is (or wraps) the read-timeout
-// signal. Both classifyAppServerOutcome and classifyTurnReadError consume it, so
-// the typed check lives here once rather than being inlined at each call site.
-func isAppServerReadTimeout(err error) bool {
-	var rt *appServerReadTimeoutError
-	return errors.As(err, &rt)
-}
-func protocolMessageCandidate(raw []byte) bool {
-	return strings.HasPrefix(strings.TrimLeft(string(raw), " \t\r\n"), "{")
-}
-func trimProtocolLine(raw []byte) string {
-	return strings.TrimRight(string(raw), "\r\n")
 }
 func (c *appServerClient) summary() string {
 	if strings.TrimSpace(c.lastMessage) != "" {

--- a/internal/runner/codex_app_server_approval.go
+++ b/internal/runner/codex_app_server_approval.go
@@ -2,8 +2,8 @@ package runner
 
 // codex_app_server_approval.go answers app-server server->client requests: the
 // approval-policy gate that auto-approves or declines exec/patch/tool requests,
-// and the dynamic (linear_graphql) tool-call bridge. The message loop that
-// dispatches these lives in codex_app_server.go.
+// and the dynamic (linear_graphql) tool-call bridge. The turn message loop
+// that dispatches these lives in codex_app_server_turn.go.
 
 import (
 	"context"

--- a/internal/runner/codex_app_server_events.go
+++ b/internal/runner/codex_app_server_events.go
@@ -2,8 +2,9 @@ package runner
 
 // codex_app_server_events.go records SPEC runtime events from the app-server
 // message stream onto the run's attempt log, including payload normalization
-// to snake_case. The message loop that calls these recorders lives in
-// codex_app_server.go.
+// to snake_case. The turn message loop that calls these recorders lives in
+// codex_app_server_turn.go; the session driver in codex_app_server.go records
+// the startup-failure and phase-transition events directly.
 
 import (
 	"encoding/json"

--- a/internal/runner/codex_app_server_transport.go
+++ b/internal/runner/codex_app_server_transport.go
@@ -1,0 +1,224 @@
+package runner
+
+// codex_app_server_transport.go is the JSON-RPC 2.0 stdio transport for the
+// `codex app-server` session: framing requests/notifications onto stdin, the
+// single long-lived stdout reader and its panic/terminal-error lifecycle, and
+// the per-read timeout machinery. The protocol client that drives sessions and
+// turns over this transport lives in codex_app_server.go.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+const (
+	// appServerScannerInitialBuf is the Scanner's starting buffer size; it grows
+	// as needed up to maxAppServerLineBytes.
+	appServerScannerInitialBuf = 64 << 10
+	// maxAppServerLineBytes caps each Codex app-server stdio line per SPEC §10.1
+	// ("Max line size: 10 MB"). Lines exceeding this surface as bufio.ErrTooLong
+	// instead of growing the buffer unbounded and OOMing the worker.
+	maxAppServerLineBytes = 10 * 1024 * 1024
+)
+
+func (c *appServerClient) request(ctx context.Context, method string, params any) (map[string]any, error) {
+	id := c.nextID
+	c.nextID++
+	if err := c.send(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params}); err != nil {
+		return nil, err
+	}
+	for {
+		msg, err := c.readMessage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if result, matched, rpcErr := responseForID(msg, id); matched {
+			return result, rpcErr
+		}
+		c.handleNotification(msg)
+	}
+}
+func (c *appServerClient) notify(method string, params map[string]any) error {
+	return c.send(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
+}
+func (c *appServerClient) send(msg map[string]any) error {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	_, err = c.stdin.Write(b)
+	return err
+}
+func (c *appServerClient) readMessage(ctx context.Context) (map[string]any, error) {
+	msg, raw, err := c.readProtocolMessage(ctx)
+	if err != nil {
+		if raw != nil {
+			return nil, fmt.Errorf("decode codex app-server message: %w", err)
+		}
+		return nil, err
+	}
+	return msg, nil
+}
+func (c *appServerClient) readProtocolMessage(ctx context.Context) (map[string]any, []byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	default:
+	}
+	line, err := c.readLine(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Scanner strips the line terminator; restore one in the transcript so
+	// successive JSON-RPC messages remain visually separated.
+	_, _ = c.out.Write(line)
+	_, _ = c.out.Write([]byte{'\n'})
+	var msg map[string]any
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return nil, line, NewError(CategoryResponseError, "decode codex app-server message", err)
+	}
+	return msg, line, nil
+}
+
+// startStdoutReader launches the single long-lived stdout reader. It is the
+// source stage of https://go.dev/blog/pipelines: one goroutine owns the
+// bufio.Scanner (which is not safe for concurrent use) and continuously scans
+// lines, handing each to the request/response consumer over readCh. Its lifetime
+// is the app-server process: it exits when scanner.Scan returns false (stdout
+// EOF or error — the process closed stdout on exit), recording a sticky readErr.
+//
+// The reader has no separate stop signal: the consumer never abandons readCh, it
+// drains to EOF at shutdown (RunCodexAppServer drains before cmd.Wait), so the
+// reader always keeps the pipe flowing and reaches EOF rather than parking on a
+// send forever (Go Code Review Comments, "Goroutine Lifetimes"). `defer
+// close(readCh)` runs on every exit path, so a consumer waiting on readCh is
+// always released and the close is the happens-before edge that publishes
+// readErr. readCh is created here so the goroutine and its channel have one owner.
+func (c *appServerClient) startStdoutReader() {
+	c.readCh = make(chan []byte)
+	go func() {
+		defer close(c.readCh)
+		defer c.recoverReaderPanic()
+		for c.scanner.Scan() {
+			// Scanner.Bytes() is invalidated by the next Scan (bufio docs); copy
+			// before handing the line across the goroutine boundary.
+			line := append([]byte(nil), c.scanner.Bytes()...)
+			c.readCh <- line
+		}
+		c.readErr = scanTerminalError(c.scanner)
+	}()
+}
+
+// recoverReaderPanic is the stdout reader's deferred recovery: a panic in the
+// scan loop is published as readErr (so the consumer sees an error rather than
+// hanging on a never-closed readCh) and logged with a stack, not swallowed —
+// matching the orchestrator's recoverPanicValue convention (recover.go).
+func (c *appServerClient) recoverReaderPanic() {
+	r := recover()
+	if r == nil {
+		return
+	}
+	if err, ok := r.(error); ok {
+		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %w", err)
+	} else {
+		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %v", r)
+	}
+	log.Printf("event=codex_app_server_reader_panic panic=%v stack=%q", r, debug.Stack())
+}
+
+// scanTerminalError maps a finished scanner to the terminal error the consumer
+// should observe once readCh closes. Scanner.Err is nil on io.EOF (bufio docs),
+// so a clean end-of-stream normalizes to io.EOF; an over-cap line keeps the
+// existing wrapped bufio.ErrTooLong contract.
+func scanTerminalError(sc *bufio.Scanner) error {
+	err := sc.Err()
+	if err == nil {
+		return io.EOF
+	}
+	if errors.Is(err, bufio.ErrTooLong) {
+		return fmt.Errorf("codex app-server line exceeded %d bytes: %w", maxAppServerLineBytes, err)
+	}
+	return err
+}
+
+func (c *appServerClient) readLine(ctx context.Context) ([]byte, error) {
+	readTimeout := time.Duration(c.readTimeoutMs) * time.Millisecond
+	deadlineTimeout, hasDeadline := deadlineDuration(ctx)
+	if c.readTimeoutMs <= 0 || (hasDeadline && deadlineTimeout < readTimeout) {
+		return c.readLineOnce(ctx, nil)
+	}
+	return c.readLineOnce(ctx, time.After(readTimeout))
+}
+
+// readLineOnce waits for the next line from the long-lived reader, the
+// per-read timeout, or context cancellation — whichever fires first. A closed
+// readCh means the reader has exited; it surfaces the reader's sticky readErr
+// (io.EOF when it stopped cleanly). The DeadlineExceeded preference is retained
+// so a read that loses the race to an expiring context is classified as the
+// deadline, not as the EOF the dying process subsequently produced.
+func (c *appServerClient) readLineOnce(ctx context.Context, timeout <-chan time.Time) ([]byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timeout:
+		return nil, &appServerReadTimeoutError{afterMs: c.readTimeoutMs}
+	case line, ok := <-c.readCh:
+		if !ok {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, ctx.Err()
+			}
+			if c.readErr != nil {
+				return nil, c.readErr
+			}
+			return nil, io.EOF
+		}
+		return line, nil
+	}
+}
+func deadlineDuration(ctx context.Context) (time.Duration, bool) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0, false
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0, true
+	}
+	return remaining, true
+}
+
+// appServerReadTimeoutError signals that a single stdio read exceeded the
+// configured codex read_timeout_ms budget. It is a typed error so the
+// classification paths detect it via errors.As rather than substring-matching
+// the message (AGENTS.md clean-code rule 8). The message is unchanged from the
+// original fmt.Errorf so existing logs and string-asserting tests still hold.
+type appServerReadTimeoutError struct {
+	afterMs int
+}
+
+func (e *appServerReadTimeoutError) Error() string {
+	return fmt.Sprintf("codex app-server read timeout after %dms", e.afterMs)
+}
+
+// isAppServerReadTimeout reports whether err is (or wraps) the read-timeout
+// signal. Both classifyAppServerOutcome and classifyTurnReadError consume it, so
+// the typed check lives here once rather than being inlined at each call site.
+func isAppServerReadTimeout(err error) bool {
+	var rt *appServerReadTimeoutError
+	return errors.As(err, &rt)
+}
+func protocolMessageCandidate(raw []byte) bool {
+	return strings.HasPrefix(strings.TrimLeft(string(raw), " \t\r\n"), "{")
+}
+func trimProtocolLine(raw []byte) string {
+	return strings.TrimRight(string(raw), "\r\n")
+}

--- a/internal/runner/codex_app_server_turn.go
+++ b/internal/runner/codex_app_server_turn.go
@@ -3,7 +3,7 @@ package runner
 // codex_app_server_turn.go handles a Codex turn's completion: awaiting the
 // terminal notification, classifying turn failures, and deriving quota-backoff
 // retry timing from a turn.failed payload. The transport that feeds these
-// notifications lives in codex_app_server.go.
+// notifications lives in codex_app_server_transport.go.
 
 import (
 	"context"

--- a/scripts/file_size_budget_test.go
+++ b/scripts/file_size_budget_test.go
@@ -24,15 +24,6 @@ var oversizedProductionGoFileBaseline = map[string]int{
 	// responsibility split), dropping the baseline from 1062 to 1002.
 	"internal/orchestrator/state.go": 1002,
 	"cmd/tui/main.go":                904,
-	// codex_app_server.go's baseline rose from 840 under #666, which replaces the
-	// per-read goroutine with a single long-lived stdout reader (the reader
-	// lifecycle the #661 burn-down comment flags as this file's priority split).
-	// #671 then extracts the JSON-RPC response-matching helpers (responseForID /
-	// numberID) into codex_app_server_response.go, dropping the baseline from 907
-	// to 877 — a first step toward the #661/#499 decomposition. #661 finishes the
-	// split by responsibility, dropping it under budget and removing this baseline;
-	// the #666 reader tests are that split's characterization harness.
-	"internal/runner/codex_app_server.go": 877,
 }
 
 func TestProductionGoFilesStayWithinSizeBudget(t *testing.T) {


### PR DESCRIPTION
Closes #722 (the `internal/runner/codex_app_server.go` entry of the #661 file-size baseline burn-down; the umbrella stays open for `state.go`, `doctor.go`, and `cmd/tui/main.go`)

## Summary

Burns down the risk-ranked first entry of the oversized-Go-file baseline from #661: extracts the JSON-RPC 2.0 stdio transport layer from `internal/runner/codex_app_server.go` (877 lines, over the machine-enforced 800-line production-file budget) into the new same-package file `codex_app_server_transport.go`. **Pure behavior-preserving move** — adversarially verified byte-identical and order-identical (sorted-multiset and ordered comparison vs `origin/main`; only `package`/`import`/blank lines differ). No signature, logic, or package-boundary changes; no new public API or indirection introduced to satisfy the budget.

`codex_app_server.go`: **877 → 672 lines.** New `codex_app_server_transport.go`: 224 lines.

| Moved to `codex_app_server_transport.go` | Responsibility |
|---|---|
| `request` / `notify` / `send` / `readMessage` / `readProtocolMessage` | JSON-RPC framing + request/response waiting |
| `startStdoutReader` / `recoverReaderPanic` / `scanTerminalError` | the #666 single long-lived stdout reader lifecycle |
| `readLine` / `readLineOnce` / `deadlineDuration` / `appServerReadTimeoutError` / `isAppServerReadTimeout` | per-read timeout machinery |
| `protocolMessageCandidate` / `trimProtocolLine`, scanner-size constants | protocol-line helpers + SPEC §10.1 line cap |

The protocol client (`appServerClient`, session/turn driving, payload builders) and the process lifecycle (`Run`, command setup, outcome classification) stay in `codex_app_server.go`, consistent with the existing `_cmd.go`/`_turn.go`/`_events.go`/`_response.go`/`_approval.go` decomposition. Three sibling file-header comments that named `codex_app_server.go` as the transport/message-loop home are corrected (`_turn.go`, `_events.go`, `_approval.go`); `_cmd.go`'s pointer was verified still accurate and left alone. Prerequisites #666 (reader lifecycle) and #671 (response matching) landed earlier, so this is the clean residual move the #661 ordering comment prescribed.

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Pure intra-package refactor; no schema/phase change. SPEC-sensitive paths: none.

## PR diff size budget (AGENTS.md)

- [ ] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [x] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Rationale (mirrors #686): the changed-line count is inflated by relocating ~205 lines out of a single file; **net production LOC ≈ +12** (the new file's header comment plus three corrected sibling headers). 5 production files (≤12). Splitting further would leave `codex_app_server.go` over budget mid-series, so the overage is atomic. Not auto-mergeable; needs human size-gate sign-off.

## Testing

- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'` — OK
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts` — PASS (codex_app_server.go baseline entry removed; no other baseline touched)
- [x] `go vet ./...` — clean
- [x] `go test -race -covermode=atomic ./...` — ALL PASS (the #666 reader tests are the characterization harness for the moved transport)
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused`) on touched packages — 0 issues
- [x] `go build ./cmd/worker ./cmd/tui` — ok

**Mutation verification** (against the committed artifact; tree restored clean after): padded `codex_app_server.go` past 800 lines → `TestProductionGoFilesStayWithinSizeBudget` **FAILS** ✓ — with the baseline entry gone, the generic gate now enforces the budget for this file (and the new transport file) directly. The move itself introduces no new behavior to mutation-test; behavior preservation is pinned by the byte-identity check above plus the full `-race` suite.

## Review disclosure

Pre-push dual review: Claude-family (`feature-dev:code-reviewer`, two rounds — round 1 NEEDS-CHANGES on the three stale sibling headers, fixed; round 2 MERGE-READY) plus an **independent adversarial reviewer substituting the Codex family**, which is externally unavailable (account usage limits; two `codex:codex-rescue` dispatches returned no verdict before the operator confirmed quota exhaustion). The substitute ran refute-framed checks (line-multiset + ordered identity, import-set union, init/order sensitivity, budget-gate regrowth, linter baselines, test anchoring) — MERGE-READY; its one LOW (missing file-purpose header on the new file) is fixed in this head. The post-push `@codex review` gate **is confirmed externally unavailable**: the trigger on this PR returned `Codex Review: Something went wrong … This workspace is deactivated` (no review, no threads, no reactions). Per the review protocol's external-unavailability clause, the compensating independent dual review above plus fully green CI stand in; the operator decides merge timing.

## Acceptance criteria (#722)

- [x] transport moved byte-identical into a cohesive same-package sibling file; no behavior change, no new public API.
- [x] `codex_app_server.go` now **672 ≤ 800** lines; baseline entry removed; gate still fails for any new unbaselined oversized production file.
- [x] #666 reader tests serve as the characterization harness; all runner tests pass unchanged under `-race`.
