### PR TITLE
feat: regroup dashboard live work per Worker Status v2 design

### DIFF
--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 // Lean Worker-status dashboard — a read-only view of GET /api/v1/state.
-// Ported pixel-for-pixel from the Claude Design "lean/Worker Status.html"
+// Ported pixel-for-pixel from the Claude Design "lean/Worker Status v2.html"
 // handoff; the styling lives in styles.css. The mock data the prototype
 // shipped with is replaced here by the real /api/v1/state contract
 // (cmd/worker/stateapi.go · apiStateResponse), which it mirrors field-for-field.
@@ -301,7 +301,7 @@ function RunningTable({ rows }) {
         <caption className="sr-only">Running sessions</caption>
         <thead><tr>
           <th scope="col">Issue</th><th scope="col">State</th><th scope="col">Runtime</th>
-          <th scope="col">Latest activity</th><th scope="col" className="r">Tokens (in / out)</th>
+          <th scope="col">Latest activity</th><th scope="col" className="r tok-h">Tokens<span className="th-sub"> in / out</span></th>
         </tr></thead>
         <tbody>
           {rows.map((r) => (
@@ -555,11 +555,13 @@ export default function App() {
         <div className="meta-cell"><div className="meta-k">Runtime total</div><div className="meta-v tnum">{dur(ct.seconds_running)}</div><div className="meta-sub">cumulative agent time</div></div>
       </div>
 
-      {/* Live work (Running) in the wider left column; system context (Rate
-          limits + the conditional Reconcile roll-up) stacks in the narrower
-          right column. Splitting the lower half into two columns roughly halves
-          its height so the dashboard fits one screen without clipping or inner
-          scrollbars; collapses to one column ≤980px (see styles.css). */}
+      {/* Live work (Running → Retrying → Blocked, matching the KPI order) in
+          the wider left column; system context (Rate limits + the conditional
+          Reconcile roll-up) stacks in the narrower right column. Grouping all
+          three in-flight buckets in one column keeps attention items together
+          and directly under the matching KPIs, instead of scattering them
+          above and below the reference data; collapses to one column ≤980px
+          (see styles.css). */}
       <div className="body-grid">
         <div className="body-main">
           {/* running */}
@@ -569,6 +571,24 @@ export default function App() {
               <div className="panel-meta"><b>{c.running || 0}</b> / {maxConc} concurrent</div>
             </div>
             <RunningTable rows={s.running || []} />
+          </div>
+
+          {/* retrying */}
+          <div className="panel">
+            <div className="panel-head">
+              <div className="panel-title"><span className="accent-stroke" />Retrying<Badge kind="retry">{c.retrying || 0}</Badge></div>
+              <div className="panel-meta">backoff queue</div>
+            </div>
+            <RetryTable rows={s.retrying || []} />
+          </div>
+
+          {/* blocked */}
+          <div className="panel">
+            <div className="panel-head">
+              <div className="panel-title"><span className="accent-stroke" />Blocked<Badge kind="blocked">{c.blocked || 0}</Badge></div>
+              <div className="panel-meta">needs attention</div>
+            </div>
+            <BlockedTable rows={s.blocked || []} />
           </div>
         </div>
 
@@ -597,7 +617,7 @@ export default function App() {
                 {stopped.length > 0 ? (
                   <div className="rollup-cell" title={STOPPED_DESC}>
                     <span className="rollup-k"><span className="kpi-dot retry" />Stopped w/ progress</span>
-                    <span className="rollup-v">{c.reconcile_stopped_with_progress}<small> this window · {c.reconcile_stopped_with_progress_total} total</small></span>
+                    <span className="rollup-v"><b>{c.reconcile_stopped_with_progress}</b> this window<span className="tot">· {c.reconcile_stopped_with_progress_total} total</span></span>
                     <span className="rollup-ids">{stopped.map((id) => <span key={id} className="tier-badge">{id}</span>)}</span>
                     <span className="sr-only">{STOPPED_DESC}</span>
                   </div>
@@ -605,7 +625,7 @@ export default function App() {
                 {handoff.length > 0 ? (
                   <div className="rollup-cell" title={HANDOFF_DESC}>
                     <span className="rollup-k"><span className="kpi-dot done" />Agent handoff</span>
-                    <span className="rollup-v">{c.agent_handoff_reconcile_stopped}<small> this window · {c.agent_handoff_reconcile_stopped_total} total</small></span>
+                    <span className="rollup-v"><b>{c.agent_handoff_reconcile_stopped}</b> this window<span className="tot">· {c.agent_handoff_reconcile_stopped_total} total</span></span>
                     <span className="rollup-ids">{handoff.map((id) => <span key={id} className="tier-badge">{id}</span>)}</span>
                     <span className="sr-only">{HANDOFF_DESC}</span>
                   </div>
@@ -613,24 +633,6 @@ export default function App() {
               </div>
             </div>
           ) : null}
-        </div>
-      </div>
-
-      {/* retrying + blocked — full-width row spanning the page below the two columns */}
-      <div className="grid-2">
-        <div className="panel">
-          <div className="panel-head">
-            <div className="panel-title"><span className="accent-stroke" />Retrying<Badge kind="retry">{c.retrying || 0}</Badge></div>
-            <div className="panel-meta">backoff queue</div>
-          </div>
-          <RetryTable rows={s.retrying || []} />
-        </div>
-        <div className="panel">
-          <div className="panel-head">
-            <div className="panel-title"><span className="accent-stroke" />Blocked<Badge kind="blocked">{c.blocked || 0}</Badge></div>
-            <div className="panel-meta">needs attention</div>
-          </div>
-          <BlockedTable rows={s.blocked || []} />
         </div>
       </div>
     </div>

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -210,6 +210,26 @@ describe('Worker status dashboard', () => {
     expect(container.querySelector('pre.rate-raw')).toBeNull();
   });
 
+  it('groups all live-work panels in the main column in KPI order (Worker Status v2)', async () => {
+    const { container } = render(<App />);
+    await screen.findByRole('heading', { name: /Worker status/i });
+
+    // v1 scattered the buckets: Retrying + Blocked sat in a full-width .grid-2
+    // row at the very bottom, below the reference gauges. v2 groups all three
+    // in-flight buckets in the main column, directly under the matching KPIs.
+    const mainTitles = [...container.querySelectorAll('.body-main .panel-title')].map((el) => el.textContent);
+    expect(mainTitles).toEqual(['Running2', 'Retrying1', 'Blocked1']); // count badge renders inline
+    const sideTitles = [...container.querySelectorAll('.body-side .panel-title')].map((el) => el.textContent);
+    expect(sideTitles).toEqual(['Rate limits', 'Reconcile roll-up']);
+    expect(container.querySelector('.grid-2')).toBeNull(); // the bottom row is gone
+
+    // tokens header renders as one line: bold "Tokens" + dim "in / out" suffix
+    const tokHeader = container.querySelector('th.tok-h');
+    expect(tokHeader).not.toBeNull();
+    expect(tokHeader.textContent).toBe('Tokens in / out');
+    expect(tokHeader.querySelector('.th-sub').textContent).toBe(' in / out');
+  });
+
   it('keeps reconcile-stopped details in the roll-up under the delivered KPI', async () => {
     render(<App />);
     const rollup = (await screen.findByText('Reconcile roll-up')).closest('.panel');
@@ -217,7 +237,10 @@ describe('Worker status dashboard', () => {
     // both buckets render as compact rows inside the single roll-up panel
     const stoppedCell = within(rollup).getByText('Stopped w/ progress').closest('.rollup-cell');
     expect(within(stoppedCell).getByText('bb0190')).toBeTruthy();
-    expect(stoppedCell.textContent).toContain('4 total'); // lifetime total
+    // v2: the window count is the serif-numeric anchor (<b>), the lifetime
+    // total is the dimmed .tot suffix — not one undifferentiated mono run.
+    expect(stoppedCell.querySelector('.rollup-v b').textContent).toBe('1');
+    expect(stoppedCell.querySelector('.rollup-v .tot').textContent).toBe('· 4 total');
     // sr-only explanation present (the prose lives in textContent, not just title)
     expect(stoppedCell.textContent).toContain('worth inspecting');
 

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -217,9 +217,13 @@ describe('Worker status dashboard', () => {
     // v1 scattered the buckets: Retrying + Blocked sat in a full-width .grid-2
     // row at the very bottom, below the reference gauges. v2 groups all three
     // in-flight buckets in the main column, directly under the matching KPIs.
-    const mainTitles = [...container.querySelectorAll('.body-main .panel-title')].map((el) => el.textContent);
-    expect(mainTitles).toEqual(['Running2', 'Retrying1', 'Blocked1']); // count badge renders inline
-    const sideTitles = [...container.querySelectorAll('.body-side .panel-title')].map((el) => el.textContent);
+    // Read only the title's own text nodes so the structural assertion is not
+    // coupled to the fixture's count-badge values.
+    const titleText = (el) => [...el.childNodes]
+      .filter((n) => n.nodeType === Node.TEXT_NODE).map((n) => n.textContent).join('');
+    const mainTitles = [...container.querySelectorAll('.body-main .panel-title')].map(titleText);
+    expect(mainTitles).toEqual(['Running', 'Retrying', 'Blocked']);
+    const sideTitles = [...container.querySelectorAll('.body-side .panel-title')].map(titleText);
     expect(sideTitles).toEqual(['Rate limits', 'Reconcile roll-up']);
     expect(container.querySelector('.grid-2')).toBeNull(); // the bottom row is gone
 

--- a/cmd/worker/dashboard/src/styles.css
+++ b/cmd/worker/dashboard/src/styles.css
@@ -304,7 +304,6 @@ a { color:inherit; text-decoration:none; }
 .accent-stroke { width:13px; height:2px; border-radius:2px; background:var(--accent); flex-shrink:0; }
 .panel-meta { color:var(--ink-mute); font-family:var(--font-mono); font-size:11.5px; white-space:nowrap; }
 .panel-meta b { color:var(--ink-soft); font-weight:500; }
-.grid-2 { display:grid; grid-template-columns:1fr 1fr; gap:var(--gap); align-items:start; }
 
 /* ─── Rate limits ──────────────────────────────────────────── */
 .rate-tier { display:flex; align-items:center; gap:8px; margin-bottom:10px; font-size:12px; color:var(--ink-mute); flex-wrap:wrap; }
@@ -328,10 +327,6 @@ a { color:inherit; text-decoration:none; }
 /* ─── Tables ───────────────────────────────────────────────── */
 .table-wrap { overflow-x:auto; margin:0 calc(var(--gap) * -1) calc(var(--gap) * -1); padding:0 var(--gap) 0; }
 table.sessions { width:100%; border-collapse:collapse; font-size:12.5px; min-width:560px; }
-/* narrow tables (Retrying / Blocked) sit two-up in .grid-2 — don't force the
-   wide min-width that the full-bleed Running table needs, or they overflow
-   their half-column and clip the last cell. */
-.table-wrap.narrow table.sessions { min-width:360px; }
 table.sessions th {
   text-align:left; font-size:10px; font-weight:600; letter-spacing:.06em; text-transform:uppercase;
   color:var(--ink-mute); padding:0 12px 8px 0; border-bottom:1px solid var(--hairline);
@@ -349,6 +344,10 @@ table.sessions tr:last-child td { border-bottom:0; }
 .upd { color:var(--ink); max-width:34ch; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
 .upd.err { color:var(--danger); }
 .tok { font-family:var(--font-mono); font-size:11.5px; text-align:right; font-variant-numeric:tabular-nums; }
+/* single-line "TOKENS in / out" header — the bold-first cell values carry the
+   in/out meaning, so the suffix stays dim and the header never wraps. */
+table.sessions th.tok-h { white-space:nowrap; }
+table.sessions th.tok-h .th-sub { font-weight:400; color:var(--ink-faint); letter-spacing:.04em; }
 .tok b { font-weight:600; }
 
 /* ─── Badges (domain-state axis) ───────────────────────────── */
@@ -391,44 +390,59 @@ table.sessions tr:last-child td { border-bottom:0; }
    explanatory prose the old panels carried is now exposed via a hover
    `title` plus an sr-only span (App.jsx) so no visible vertical budget is
    spent on it. ───────────────────────────────────────────────────── */
-.rollup-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:var(--gap); }
+/* Both buckets share a 3-track grid (label · metric · ids) via subgrid, so the
+   count column and the id column line up across rows no matter how wide each
+   label or the active font is — no fixed widths to drift. Each row keeps its
+   inset card. The window count carries the serif-numeric treatment used by the
+   KPIs/meta so it reads as the value; the lifetime total stays dim. Collapses
+   to flex-wrap on phones so nothing overflows the narrow viewport. */
+.rollup-grid { display:grid; grid-template-columns:auto auto 1fr; gap:8px var(--gap); }
 .rollup-cell {
-  display:flex; align-items:center; gap:9px; flex-wrap:wrap;
+  display:grid; grid-template-columns:subgrid; grid-column:1 / -1; align-items:center;
   background:var(--inset); border:1px solid var(--hairline-2);
-  border-radius:var(--radius-md); padding:9px 12px;
+  border-radius:var(--radius-md); padding:8px 12px;
 }
-.rollup-k { display:flex; align-items:center; gap:6px; font-size:11px; font-weight:600; letter-spacing:.01em; color:var(--ink-soft); white-space:nowrap; }
-.rollup-v { font-family:var(--font-mono); font-size:13px; font-weight:600; color:var(--ink); white-space:nowrap; }
-.rollup-v small { font-family:var(--font-ui); font-weight:400; font-size:10.5px; color:var(--ink-mute); }
-.rollup-ids { display:flex; gap:5px; flex-wrap:wrap; margin-left:auto; }
+.rollup-k { display:flex; align-items:center; gap:7px; font-size:11.5px; font-weight:600; letter-spacing:.01em; color:var(--ink-soft); white-space:nowrap; }
+.rollup-v { font-family:var(--font-mono); font-size:11px; color:var(--ink-mute); white-space:nowrap; }
+.rollup-v b { font-family:var(--font-num); font-size:17px; font-weight:600; color:var(--ink); margin-right:2px; font-variant-numeric:tabular-nums; }
+.rollup-v .tot { color:var(--ink-faint); margin-left:5px; }
+.rollup-ids { display:flex; gap:5px; flex-wrap:wrap; justify-content:flex-end; }
+@media (max-width:640px) {
+  .rollup-grid { display:flex; flex-direction:column; }
+  .rollup-cell { display:flex; flex-wrap:wrap; gap:6px 9px; grid-column:auto; }
+  .rollup-ids { margin-left:auto; }
+}
 
 /* ─── Two-column body — the real compaction that gets the dashboard onto
-   one screen WITHOUT clipping or inner scrollbars. The live focus (Running)
-   takes the wider left column; system context (Rate limits + the conditional
-   Reconcile roll-up) stacks in the narrower right column. Retrying + Blocked
-   sit in a full-width row below (see .grid-2). Splitting the lower half this
-   way roughly halves its height, so the whole page falls under a normal
-   display height naturally — content is never cut off, and short screens just
-   scroll. Collapses to one column ≤980px (the ≤820px rules below take over). */
+   one screen WITHOUT clipping or inner scrollbars. The live focus (Running,
+   then Retrying + Blocked, in KPI order) takes the wider left column; system
+   context (Rate limits + the conditional Reconcile roll-up) stacks in the
+   narrower right column. Grouping all three in-flight buckets in one column
+   keeps attention items together and directly under the matching KPIs, and
+   splitting the lower half into two columns roughly halves its height, so the
+   whole page falls under a normal display height naturally — content is never
+   cut off, and short screens just scroll. Collapses to one column ≤980px
+   (the ≤820px rules below take over). */
 .body-grid { display:grid; grid-template-columns:minmax(0,1.5fr) minmax(330px,1fr); gap:var(--gap); align-items:start; margin-bottom:var(--gap); }
 .body-main, .body-side { display:flex; flex-direction:column; gap:var(--gap); min-width:0; }
-.body-grid .panel, .body-grid .grid-2 { margin-bottom:0; }
+.body-grid .panel { margin-bottom:0; }
 /* Tables were tuned for the old full-width stack — full-bleed negative margins
    and wide min-widths overflow a column. Inside the two-column body, drop the
    bleed and let each table fit its (narrower) panel. */
 .body-grid .table-wrap { margin:0; padding:0; }
-.body-grid table.sessions, .body-grid .table-wrap.narrow table.sessions { min-width:0; }
+.body-grid table.sessions { min-width:0; }
 @media (max-width:980px) { .body-grid { grid-template-columns:1fr; } }
 
-/* Full-width Retrying/Blocked row: each table fits its half comfortably. Clip
-   the wrap so the per-second countdown re-render can't flash a transient
-   horizontal scrollbar. To keep that clip from hiding real data, force the
-   long free-text cells (workspace paths, error/detail strings) to break rather
-   than overflow — an unbreakable token (URL, hash) would otherwise be clipped
-   instead of scrolled. (≤640px the global card rule restores stacked layout.) */
+/* Retrying/Blocked tables in the main column: each fits its panel comfortably
+   (the long error/detail cells wrap). Clip the wrap so the per-second retry
+   countdown re-render can't flash a transient horizontal scrollbar. To keep
+   that clip from hiding real data, force the long free-text cells (workspace
+   paths, error/detail strings) to break rather than overflow — an unbreakable
+   token (URL, hash) would otherwise be clipped instead of scrolled.
+   (≤640px the global card rule restores stacked layout.) */
 @media (min-width:641px) {
-  .app > .grid-2 .table-wrap { overflow:hidden; }
-  .app > .grid-2 .wp, .app > .grid-2 .upd { overflow-wrap:anywhere; }
+  .body-main .table-wrap.narrow { overflow:hidden; }
+  .body-main .table-wrap.narrow .wp, .body-main .table-wrap.narrow .upd { overflow-wrap:anywhere; }
 }
 
 /* ─── Responsive ───────────────────────────────────────────── */
@@ -437,7 +451,6 @@ table.sessions tr:last-child td { border-bottom:0; }
   .meta-strip { grid-template-columns:repeat(2,1fr); }
   .meta-cell:nth-child(3) { border-left:0; }
   .meta-cell:nth-child(n+3) { border-top:1px solid var(--hairline-2); }
-  .grid-2 { grid-template-columns:1fr; }
   .rate-grid { grid-template-columns:1fr; }
   .title-meta { text-align:left; }
   .title-meta .row { justify-content:flex-start; }
@@ -458,11 +471,7 @@ table.sessions tr:last-child td { border-bottom:0; }
 
   /* table → cards */
   .table-wrap { overflow-x:visible; margin:0; padding:0; }
-  /* the .narrow tables (Retrying / Blocked) carry a 360px min-width for their
-     two-up desktop layout via a 2-class selector — which out-specifies a plain
-     `table.sessions` reset and would keep them 360px wide in card mode, blowing
-     past the phone viewport. Match that specificity here so they collapse too. */
-  table.sessions, .table-wrap.narrow table.sessions { min-width:0; display:block; }
+  table.sessions { min-width:0; display:block; }
   table.sessions thead { display:none; }
   table.sessions tbody { display:block; }
   table.sessions tr {

--- a/cmd/worker/dashboard/src/styles.css
+++ b/cmd/worker/dashboard/src/styles.css
@@ -401,6 +401,7 @@ table.sessions th.tok-h .th-sub { font-weight:400; color:var(--ink-faint); lette
   display:grid; grid-template-columns:subgrid; grid-column:1 / -1; align-items:center;
   background:var(--inset); border:1px solid var(--hairline-2);
   border-radius:var(--radius-md); padding:8px 12px;
+  position:relative; /* containing block for the absolutely-positioned sr-only span */
 }
 .rollup-k { display:flex; align-items:center; gap:7px; font-size:11.5px; font-weight:600; letter-spacing:.01em; color:var(--ink-soft); white-space:nowrap; }
 .rollup-v { font-family:var(--font-mono); font-size:11px; color:var(--ink-mute); white-space:nowrap; }


### PR DESCRIPTION
Closes #730

## Summary
- Port the `lean/Worker Status v2.html` Claude Design handoff to `cmd/worker/dashboard`: move the Retrying and Blocked panels out of the bottom full-width row into the main column directly under Running, matching the KPI order — attention items no longer sit below the fold under the rate-limit reference gauges.
- Reconcile roll-up: both bucket rows now share a 3-track CSS subgrid (label · metric · ids) so counts and issue-id chips align across rows regardless of label width/font; the window count gets the serif-numeric treatment with the lifetime total dimmed; ≤640px falls back to flex-wrap.
- Running table tokens header tightened to a single line (bold `TOKENS` + dim `in / out` suffix) so it stops wrapping in the narrower column.
- The ≥641px scrollbar-flash guard (clip + `overflow-wrap:anywhere` hardening) is retargeted to the narrow tables' new home in `.body-main`; the now-dead `.grid-2` rules are removed.

Pure presentation change — no new data fields, no API change. All repo production adaptations over the v1 port are preserved (fetch loop, settings popover, raw-JSON rate-limit fallback, issue links, sr-only roll-up descriptions, Delivered KPI wording).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded). 2 production files (`App.jsx`, `styles.css`), ~60 production LOC changed.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [ ] `go test -race -covermode=atomic ./...` (no Go files changed; deferred to CI)
- [x] `gofmt -l` clean (no Go files changed)
- [x] additional validation: `npm test` (vitest, 17/17) + `npm run build` in `cmd/worker/dashboard`; new layout/roll-up/header assertions mutation-verified against the committed artifact (each of the three v2 changes reverted in turn → its test fails, tree restored to HEAD).

## Notes
- Design source: Claude Design handoff bundle, primary file `lean/Worker Status v2.html`; design intent recorded in the bundle's chat26 transcript (2026-06-10 session).