### PR TITLE
fix: map Gitea aiops/todo to SPEC state "Todo" so the blocker gate fires

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,9 @@ label:
 
 | Workflow state | Gitea label |
 | --- | --- |
-| `AI Ready` | `aiops/todo` |
+| `Todo` | `aiops/todo` |
 | `In Progress` | `aiops/in-progress` |
+| `Human Review` | `aiops/human-review` |
 | `Rework` | `aiops/rework` |
 | `Done` | `aiops/done` |
 | `Canceled` | `aiops/canceled` |

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1712,7 +1712,7 @@ func TestWorkerEntrypointDoesNotRequirePostgresQueue(t *testing.T) {
 func TestLoadWorkflowForStartupReconcileUsesConfiguredWorkflowPath(t *testing.T) {
 	dir := t.TempDir()
 	workflowPath := filepath.Join(dir, "linear-workflow.md")
-	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n  active_states: [\"AI Ready\"]\n  terminal_states: [\"Done\"]\n---\nprompt\n"
+	body := "---\nrepo:\n  owner: o\n  name: r\n  clone_url: git@example.com:o/r.git\ntracker:\n  kind: linear\n  project_slug: platform\n  active_states: [\"Todo\"]\n  terminal_states: [\"Done\"]\n---\nprompt\n"
 	if err := os.WriteFile(workflowPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write workflow: %v", err)
 	}
@@ -2041,14 +2041,14 @@ func TestWorkerReconciliationConfigIncludesInactiveStates(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Repo.CloneURL = "git@example.com:o/r.git"
 	cfg.Tracker.Kind = "linear"
-	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress", "Rework"}
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress", "Rework"}
 	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
 
 	reconcile := reconciliationConfigForWorkflow(cfg)
 	if len(reconcile.InactiveStates) == 0 {
 		t.Fatalf("inactive reconciliation states = %v, want non-empty states for explicit inactive tracker observations", reconcile.InactiveStates)
 	}
-	if containsState(reconcile.InactiveStates, "AI Ready") || containsState(reconcile.InactiveStates, "In Progress") || containsState(reconcile.InactiveStates, "Rework") {
+	if containsState(reconcile.InactiveStates, "Todo") || containsState(reconcile.InactiveStates, "In Progress") || containsState(reconcile.InactiveStates, "Rework") {
 		t.Fatalf("inactive reconciliation states = %v, must not include configured active states", reconcile.InactiveStates)
 	}
 	if containsState(reconcile.InactiveStates, "Done") || containsState(reconcile.InactiveStates, "Canceled") {
@@ -2087,7 +2087,7 @@ func TestWorkerReconciliationConfigDoesNotProbeUnmappedGiteaInactiveStates(t *te
 	cfg := workflow.DefaultConfig()
 	cfg.Repo.CloneURL = "git@example.com:o/r.git"
 	cfg.Tracker.Kind = "gitea"
-	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress", "Rework"}
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress", "Rework"}
 	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
 
 	reconcile := reconciliationConfigForWorkflow(cfg)
@@ -2102,15 +2102,15 @@ func TestWorkerReconciliationConfigDoesNotProbeUnmappedGiteaInactiveStates(t *te
 func TestWorkerReconciliationConfigUsesWorkflowInactiveStates(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Repo.CloneURL = "git@example.com:o/r.git"
-	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress"}
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress"}
 	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
-	cfg.Tracker.InactiveStates = []string{"Paused", "Blocked", "Done", "AI Ready"}
+	cfg.Tracker.InactiveStates = []string{"Paused", "Blocked", "Done", "Todo"}
 
 	reconcile := reconciliationConfigForWorkflow(cfg)
 	if !containsState(reconcile.InactiveStates, "Paused") || !containsState(reconcile.InactiveStates, "Blocked") {
 		t.Fatalf("inactive reconciliation states = %v, want workflow-configured inactive states", reconcile.InactiveStates)
 	}
-	if containsState(reconcile.InactiveStates, "Done") || containsState(reconcile.InactiveStates, "AI Ready") {
+	if containsState(reconcile.InactiveStates, "Done") || containsState(reconcile.InactiveStates, "Todo") {
 		t.Fatalf("inactive reconciliation states = %v, must exclude configured active/terminal states", reconcile.InactiveStates)
 	}
 }
@@ -2118,7 +2118,7 @@ func TestWorkerReconciliationConfigUsesWorkflowInactiveStates(t *testing.T) {
 func TestWorkerReconciliationConfigThreadsRequiredLabels(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Repo.CloneURL = "git@example.com:o/r.git"
-	cfg.Tracker.ActiveStates = []string{"AI Ready", "In Progress"}
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress"}
 	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
 	cfg.Tracker.RequiredLabels = []string{"aiops-ready", "triaged"}
 

--- a/cmd/worker/runbook_drift_test.go
+++ b/cmd/worker/runbook_drift_test.go
@@ -129,7 +129,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 			IssueID:           "issue-2",
 			Identifier:        "ENG-2",
 			IssueURL:          "https://tracker.example/issues/ENG-2",
-			State:             "AI Ready",
+			State:             "Todo",
 			BlockedAt:         &blockedAt,
 			WorkspacePath:     "/var/aiops/workspaces/acme/repo/issue-2",
 			SessionID:         "thread-1-turn-1",

--- a/docs/day1-runbook.md
+++ b/docs/day1-runbook.md
@@ -34,7 +34,7 @@ tracker:
   kind: gitea
   endpoint: http://your-gitea-host
   active_states:
-    - AI Ready
+    - Todo
     - Rework
   terminal_states:
     - Done
@@ -42,7 +42,7 @@ tracker:
 ```
 
 Gitea issue state is encoded by `aiops/*` labels. For example, `aiops/todo`
-maps to `AI Ready`.
+maps to `Todo`.
 
 ## 3. Start Worker
 

--- a/docs/runbooks/agentic-project-template.md
+++ b/docs/runbooks/agentic-project-template.md
@@ -39,8 +39,8 @@ Use one clear ready signal per tracker:
 
 | Tracker | Recommended ready gate |
 | --- | --- |
-| Linear | A dedicated active state such as `AI Ready`, with native blocked-by relations for dependencies |
-| Gitea | A dedicated ready label/state for unblocked work; keep dependent issues in `Todo` or out of active labels until `Depends on #N` blockers are terminal |
+| Linear | The `Todo` state as the ready gate, with native blocked-by relations for dependencies — SPEC §8.2 only blocker-gates issues whose state is literally `Todo`, so a renamed ready state (e.g. `AI Ready`) silently disables dependency blocking |
+| Gitea | The `aiops/todo` label (state `Todo`); `Depends on #N` blockers in non-terminal states keep the issue undispatched via the same `Todo` blocker rule |
 | GitHub | A dedicated `aiops:ready` label; do not use `open` as an unattended active state |
 
 Priority is not readiness. Treat priority as human triage metadata unless the

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -249,8 +249,9 @@ tool surface, not the worker. Default state labels:
 
 | Workflow state | Gitea label |
 | --- | --- |
-| `AI Ready` | `aiops/todo` |
+| `Todo` | `aiops/todo` |
 | `In Progress` | `aiops/in-progress` |
+| `Human Review` | `aiops/human-review` |
 | `Rework` | `aiops/rework` |
 | `Done` | `aiops/done` |
 | `Canceled` | `aiops/canceled` |

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -25,40 +25,40 @@ only sees the configured tracker states or labels in `WORKFLOW.md`.
 The worker poll tick reads issues whose state name appears in `tracker.active_states` of your `WORKFLOW.md`. Use a simple lifecycle:
 
 ```text
-Backlog -> AI Ready -> In Progress -> Human Review -> Rework -> Done
+Backlog -> Todo -> In Progress -> Human Review -> Rework -> Done
                                                   \-> Canceled
 ```
 
 Per-state rules:
 
 - `Backlog`: not picked up. Use this for anything you have not refined yet.
-- `AI Ready`: refined and small enough that an agent can attempt it. The worker poll tick picks these up.
+- `Todo`: refined and small enough that an agent can attempt it. The worker poll tick picks these up. Name this state exactly `Todo`: the SPEC §8.2 blocker rule only gates issues whose state is literally `Todo`, so a renamed ready state silently disables dependency blocking (#739).
 - `In Progress`: the agent has claimed an issue or you are iterating on it. Stays in `active_states` so re-runs after a push are allowed.
 - `Human Review`: agent finished and opened a draft PR. Not in `active_states`. Read the diff yourself. Per SPEC §1, tracker updates belong on the agent/tool side, not in the worker scheduler.
 - `Rework`: review found issues and you want another attempt. Keep `Rework` in `active_states` so the worker can pick the issue up again after the tracker state changes. The in-memory orchestrator state, not Postgres queue rows, is the scheduling authority for the running worker process.
 - `Done` / `Canceled`: terminal. Listed under `tracker.terminal_states`.
 
-Default `active_states` in code:
+Recommended `active_states` for this lifecycle (the code default is `[Todo, In Progress]`; `Rework` is an opt-in override):
 
 ```yaml
 tracker:
   active_states:
-    - AI Ready
+    - Todo
     - In Progress
     - Rework
 ```
 
-Rule of thumb: if you do not feel comfortable letting an agent open a draft PR for an issue right now, do not move it to `AI Ready`.
+Rule of thumb: if you do not feel comfortable letting an agent open a draft PR for an issue right now, do not move it to `Todo`.
 
 For GitHub dogfood, use the dedicated `aiops:ready` label as the ready gate
-instead of an `AI Ready` state. Do not treat `open` or `priority:pN` labels as
+instead of a `Todo` state. Do not treat `open` or `priority:pN` labels as
 readiness.
 
 ## Writing good issues
 
 The issue title and description are passed to the runner via the `PROMPT.md` template (see `examples/WORKFLOW.md`). Vague issues produce vague diffs.
 
-Checklist before moving an issue to `AI Ready`:
+Checklist before moving an issue to `Todo`:
 
 - One clear outcome. Not "improve logging" but "log tracker issue id in worker poll dispatch output".
 - Concrete file or package hints. Mention paths like `internal/runner/shell.go` so the agent does not wander.
@@ -155,13 +155,13 @@ Skip automation entirely when:
 
 - the task touches sensitive areas (infra, deploy, migrations, secrets).
 - it is a security-sensitive change or a data migration.
-- requirements are still ambiguous. Use a planning issue instead and only move to `AI Ready` once the design is settled.
+- requirements are still ambiguous. Use a planning issue instead and only move to `Todo` once the design is settled.
 - the change is large enough that a draft PR would blow well past the ~12-file / ~300-LOC review guideline.
 
 Decision shortcut:
 
 ```text
-unsure or risky                       -> manual review, keep issue out of AI Ready
+unsure or risky                       -> manual review, keep issue out of Todo
 plumbing or smoke test                -> mock
 real code change (SPEC default)       -> codex-app-server
 prefer Claude / want a second opinion -> claude

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -176,7 +176,7 @@ the shape here without updating the handler — or vice versa — fails the buil
       "issue_id": "issue-2",
       "issue_identifier": "ENG-2",
       "issue_url": "https://tracker.example/issues/ENG-2",
-      "state": "AI Ready",
+      "state": "Todo",
       "blocked_at": "2026-05-20T06:05:38Z",
       "workspace_path": "/var/aiops/workspaces/acme/repo/issue-2",
       "session_id": "thread-1-turn-1",

--- a/docs/workflows/company-cautious-WORKFLOW.md
+++ b/docs/workflows/company-cautious-WORKFLOW.md
@@ -11,7 +11,7 @@ tracker:
   project_slug: your-linear-project-slug
   api_key: $LINEAR_API_KEY
   active_states:
-    - AI Ready
+    - Todo
     - In Progress
     - Rework
   terminal_states:

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -18,7 +18,7 @@ tracker:
   # uses project_slug: aiops-platform-abc123
   project_slug: your-linear-project-slug
   active_states:
-    - AI Ready
+    - Todo
     - In Progress
     - Rework
   terminal_states:

--- a/examples/gitea-WORKFLOW.md
+++ b/examples/gitea-WORKFLOW.md
@@ -12,7 +12,7 @@ tracker:
   # overflowing aiops/* state label and logs the diagnostic.
   # pagination_max_pages: 25
   active_states:
-    - AI Ready
+    - Todo
     - Rework
   terminal_states:
     - Done

--- a/internal/gitea/label_state.go
+++ b/internal/gitea/label_state.go
@@ -35,12 +35,16 @@ type StateDiagnostic struct {
 // The order is also the deterministic conflict priority: active/rework labels
 // win over terminal labels so an issue is not silently dropped when a stale
 // terminal label remains alongside a label that requests work.
+//
+// aiops/todo MUST map to the SPEC state name "Todo": the §8.2 blocker rule
+// only gates issues whose state is literally Todo, so a renamed pre-dispatch
+// state silently disables dependency blocking for this tracker (#739).
 func DefaultStateLabelMappings() []StateLabelMapping {
 	return []StateLabelMapping{
 		{Label: "aiops/rework", State: "Rework"},
 		{Label: "aiops/in-progress", State: "In Progress"},
 		{Label: "aiops/human-review", State: "Human Review"},
-		{Label: "aiops/todo", State: "AI Ready"},
+		{Label: "aiops/todo", State: "Todo"},
 		{Label: "aiops/done", State: "Done"},
 		{Label: "aiops/canceled", State: "Canceled"},
 	}

--- a/internal/gitea/label_state_test.go
+++ b/internal/gitea/label_state_test.go
@@ -45,8 +45,8 @@ func TestIssueStateFromLabelsUsesDeterministicPriorityForConflicts(t *testing.T)
 func TestIssueStateFromLabelsIgnoresUnknownAIOpsLabels(t *testing.T) {
 	state, diagnostics := IssueStateFromLabels([]Label{{Name: "aiops/backlog"}, {Name: "aiops/todo"}}, DefaultStateLabelMappings())
 
-	if state != "AI Ready" {
-		t.Fatalf("state = %q, want AI Ready", state)
+	if state != "Todo" {
+		t.Fatalf("state = %q, want Todo", state)
 	}
 	if !hasDiagnostic(diagnostics, "unknown_aiops_label") {
 		t.Fatalf("diagnostics = %#v, want unknown_aiops_label", diagnostics)
@@ -54,7 +54,7 @@ func TestIssueStateFromLabelsIgnoresUnknownAIOpsLabels(t *testing.T) {
 }
 
 func TestStateLabelNamesForStatesFiltersConfiguredStates(t *testing.T) {
-	got := StateLabelNamesForStates([]string{"AI Ready", "Rework", "Done", "Not Configured"}, DefaultStateLabelMappings())
+	got := StateLabelNamesForStates([]string{"Todo", "Rework", "Done", "Not Configured"}, DefaultStateLabelMappings())
 	want := []string{"aiops/todo", "aiops/rework", "aiops/done"}
 
 	if !slices.Equal(got, want) {

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -76,7 +76,7 @@ func TestTrackerClientListIssuesByStatesMapsAIOpsLabels(t *testing.T) {
 
 	client := NewTrackerClient(workflow.TrackerConfig{
 		APIKey:       "secret",
-		ActiveStates: []string{"AI Ready", "Rework"},
+		ActiveStates: []string{"Todo", "Rework"},
 	}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
@@ -90,8 +90,8 @@ func TestTrackerClientListIssuesByStatesMapsAIOpsLabels(t *testing.T) {
 	if len(issues) != 2 {
 		t.Fatalf("issues len = %d, want 2", len(issues))
 	}
-	if issues[0].ID != "101" || issues[0].Identifier != "#1" || issues[0].State != "AI Ready" {
-		t.Fatalf("first issue = %#v, want mapped AI Ready state", issues[0])
+	if issues[0].ID != "101" || issues[0].Identifier != "#1" || issues[0].State != "Todo" {
+		t.Fatalf("first issue = %#v, want mapped Todo state", issues[0])
 	}
 	if issues[1].State != "Rework" {
 		t.Fatalf("second issue state = %q, want Rework", issues[1].State)
@@ -132,7 +132,7 @@ func TestTrackerClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) 
 
 	client := NewTrackerClient(workflow.TrackerConfig{
 		APIKey:       "secret",
-		ActiveStates: []string{"AI Ready"},
+		ActiveStates: []string{"Todo"},
 	}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
@@ -290,7 +290,7 @@ func TestTrackerClientListIssuesByStatesDeduplicatesIssuesReturnedForMultipleLab
 
 	client := NewTrackerClient(workflow.TrackerConfig{
 		APIKey:       "secret",
-		ActiveStates: []string{"AI Ready", "Rework"},
+		ActiveStates: []string{"Todo", "Rework"},
 	}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
@@ -321,12 +321,12 @@ func TestTrackerClientListIssuesByStatesFiltersTerminalAndMissingStates(t *testi
 
 	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
-	if len(issues) != 1 || issues[0].Identifier != "#3" || issues[0].State != "AI Ready" {
-		t.Fatalf("issues = %#v, want only AI Ready issue", issues)
+	if len(issues) != 1 || issues[0].Identifier != "#3" || issues[0].State != "Todo" {
+		t.Fatalf("issues = %#v, want only Todo issue", issues)
 	}
 	if requestedState != "open" {
 		t.Fatalf("state query = %q, want open for active states", requestedState)
@@ -428,7 +428,7 @@ func TestTrackerClientListIssuesByStatesAllowsExactlyFullMaxPages(t *testing.T) 
 
 	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates returned error for exactly full max pages: %v", err)
 	}
@@ -476,7 +476,7 @@ func TestTrackerClientListIssuesByStatesErrorsWhenLabelOverflows(t *testing.T) {
 	if got := client.PaginationCapHits(); got != 0 {
 		t.Fatalf("initial PaginationCapHits = %d, want 0", got)
 	}
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready", "Rework"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo", "Rework"})
 	if !errors.Is(err, tracker.ErrIssueListingCapped) {
 		t.Fatalf("ListIssuesByStates err = %v, want tracker.ErrIssueListingCapped", err)
 	}
@@ -517,7 +517,7 @@ func TestTrackerClientListIssuesByStatesContinuesWhenServerCapsPageBelowRequeste
 
 	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
@@ -578,11 +578,11 @@ func TestTrackerClientListIssuesByStatesNormalizesLabelsAndBlockedBy(t *testing.
 
 	client := NewTrackerClient(workflow.TrackerConfig{
 		APIKey:       "secret",
-		ActiveStates: []string{"AI Ready"},
+		ActiveStates: []string{"Todo"},
 	}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
@@ -651,11 +651,11 @@ func TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure(t *testin
 
 	client := NewTrackerClient(workflow.TrackerConfig{
 		APIKey:       "secret",
-		ActiveStates: []string{"AI Ready"},
+		ActiveStates: []string{"Todo"},
 	}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
@@ -683,7 +683,7 @@ func TestTrackerClientListIssuesByStatesSurfacesMalformedTimestamp(t *testing.T)
 
 	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err == nil {
 		t.Fatalf("ListIssuesByStates(malformed created_at) = %#v, nil; want parse error", issues)
 	}
@@ -721,7 +721,7 @@ func TestTrackerClientListIssuesByStatesDeduplicatesWithinSingleLabelScope(t *te
 
 	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
@@ -760,7 +760,7 @@ func TestTrackerClientListIssuesByStateLabelSkipsEmptyStateWithoutWantedStatesFi
 	if capped {
 		t.Fatalf("listIssuesByStateLabel capped = true; want false")
 	}
-	if len(issues) != 1 || issues[0].ID != "602" || issues[0].State != "AI Ready" {
+	if len(issues) != 1 || issues[0].ID != "602" || issues[0].State != "Todo" {
 		t.Fatalf("listIssuesByStateLabel(empty wantedStates) = %#v; want only issue 602 (unlabelled issue 601 dropped by state==\"\" guard, not wantedStates)", issues)
 	}
 }
@@ -779,7 +779,7 @@ func mustTime(value string) time.Time {
 
 // newSharedBlockerTrackerClient builds a Gitea mock whose issue-list endpoint
 // returns the given source issues and whose per-issue endpoint serves a single
-// shared blocker (#3, "AI Ready"), counting how many times the blocker is
+// shared blocker (#3, "Todo"), counting how many times the blocker is
 // fetched. It is the harness for the #677 per-poll-tick blocker-cache tests.
 func newSharedBlockerTrackerClient(t *testing.T, sources []Issue, blockerFetches *int) *TrackerClient {
 	t.Helper()
@@ -796,7 +796,7 @@ func newSharedBlockerTrackerClient(t *testing.T, sources []Issue, blockerFetches
 		}
 	}))
 	t.Cleanup(server.Close)
-	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"AI Ready"}}, server.URL, "owner", "repo")
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"Todo"}}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 	return client
 }
@@ -808,7 +808,7 @@ func TestTrackerClientListIssuesByStatesFetchesSharedBlockerOncePerTick(t *testi
 		{ID: 102, Number: 2, Title: "b", Body: "Depends on #3", HTMLURL: "https://gitea.local/o/r/issues/2", Labels: []Label{{Name: "aiops/todo"}}},
 	}, &blockerFetches)
 
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
@@ -819,15 +819,15 @@ func TestTrackerClientListIssuesByStatesFetchesSharedBlockerOncePerTick(t *testi
 		t.Fatalf("shared blocker #3 fetched %d times; want 1 (cached across both source issues in one tick)", blockerFetches)
 	}
 	for _, iss := range issues {
-		if len(iss.BlockedBy) != 1 || iss.BlockedBy[0].Identifier != "#3" || iss.BlockedBy[0].State != "AI Ready" {
-			t.Fatalf("issue %s BlockedBy = %#v; want one blocker #3 in state AI Ready", iss.Identifier, iss.BlockedBy)
+		if len(iss.BlockedBy) != 1 || iss.BlockedBy[0].Identifier != "#3" || iss.BlockedBy[0].State != "Todo" {
+			t.Fatalf("issue %s BlockedBy = %#v; want one blocker #3 in state Todo", iss.Identifier, iss.BlockedBy)
 		}
 	}
 }
 
 func TestTrackerClientListIssuesByStatesRereadsBlockerOnNextTick(t *testing.T) {
 	var blockerFetches int
-	blockerLabel := "aiops/todo" // "AI Ready" on tick 1
+	blockerLabel := "aiops/todo" // "Todo" on tick 1
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
@@ -843,15 +843,15 @@ func TestTrackerClientListIssuesByStatesRereadsBlockerOnNextTick(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"AI Ready"}}, server.URL, "owner", "repo")
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"Todo"}}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
-	tick1, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	tick1, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates tick 1: %v", err)
 	}
 	blockerLabel = "aiops/done" // blocker transitions to "Done" between ticks
-	tick2, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	tick2, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates tick 2: %v", err)
 	}
@@ -859,8 +859,8 @@ func TestTrackerClientListIssuesByStatesRereadsBlockerOnNextTick(t *testing.T) {
 	if blockerFetches != 2 {
 		t.Fatalf("blocker #3 fetched %d times across two ticks; want 2 (once per tick, no cross-tick cache leak)", blockerFetches)
 	}
-	if len(tick1) != 1 || len(tick1[0].BlockedBy) != 1 || tick1[0].BlockedBy[0].State != "AI Ready" {
-		t.Fatalf("tick 1 BlockedBy = %#v; want blocker #3 in state AI Ready", tick1)
+	if len(tick1) != 1 || len(tick1[0].BlockedBy) != 1 || tick1[0].BlockedBy[0].State != "Todo" {
+		t.Fatalf("tick 1 BlockedBy = %#v; want blocker #3 in state Todo", tick1)
 	}
 	if len(tick2) != 1 || len(tick2[0].BlockedBy) != 1 || tick2[0].BlockedBy[0].State != "Done" {
 		t.Fatalf("tick 2 BlockedBy = %#v; want blocker #3 re-read in state Done", tick2)
@@ -921,10 +921,10 @@ func TestTrackerClientListIssuesByStatesRetriesBlockerAfterTransientError(t *tes
 		}
 	}))
 	defer server.Close()
-	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"AI Ready"}}, server.URL, "owner", "repo")
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"Todo"}}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v; a best-effort blocker error must not abort listing", err)
 	}

--- a/internal/gitea/tracker_client_timeout_test.go
+++ b/internal/gitea/tracker_client_timeout_test.go
@@ -42,7 +42,7 @@ func TestTrackerClientListIssuesAbortsHungServer(t *testing.T) {
 	srv := hungGiteaServer(t)
 	client := NewTrackerClient(workflow.TrackerConfig{
 		APIKey:       "secret",
-		ActiveStates: []string{"AI Ready"},
+		ActiveStates: []string{"Todo"},
 	}, srv.URL, "owner", "repo")
 	client.HTTP = srv.Client()
 	client.RequestTimeout = 100 * time.Millisecond

--- a/internal/orchestrator/actor_reconcile_inactive_test.go
+++ b/internal/orchestrator/actor_reconcile_inactive_test.go
@@ -104,7 +104,7 @@ func TestReconcileInactiveLeavesUnlistedBlockedClaimed(t *testing.T) {
 	})
 	defer cancel()
 
-	issue := tracker.Issue{ID: "ENG-PB1", Identifier: "ENG-PB1", State: "AI Ready"}
+	issue := tracker.Issue{ID: "ENG-PB1", Identifier: "ENG-PB1", State: "Todo"}
 	blockIssue(t, o, disp, issue, 0, 1)
 
 	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(),
@@ -141,7 +141,7 @@ func TestReconcileInactiveNonTerminalBlockedReleasesWithoutCleanup(t *testing.T)
 	})
 	defer cancel()
 
-	issue := tracker.Issue{ID: "ENG-NB1", Identifier: "ENG-NB1", State: "AI Ready"}
+	issue := tracker.Issue{ID: "ENG-NB1", Identifier: "ENG-NB1", State: "Todo"}
 	blockIssue(t, o, disp, issue, 0, 1)
 
 	// Listed, but in a configured-inactive non-terminal state (Backlog, with

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -377,7 +377,7 @@ func TestReconcileStalledRunsCancelsWorkerPastTimeout(t *testing.T) {
 	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "STALL-1", Identifier: "STALL-1", Title: "stuck", State: "AI Ready"}
+	iss := tracker.Issue{ID: "STALL-1", Identifier: "STALL-1", Title: "stuck", State: "Todo"}
 	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
 		t.Fatalf("RequestDispatch: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestReconcileStalledRunsLeavesActiveRunsAlone(t *testing.T) {
 	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "ACTIVE-1", Identifier: "ACTIVE-1", State: "AI Ready"}
+	iss := tracker.Issue{ID: "ACTIVE-1", Identifier: "ACTIVE-1", State: "Todo"}
 	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
 		t.Fatalf("RequestDispatch: %v", err)
 	}
@@ -437,7 +437,7 @@ func TestReconcileStalledRunsSkipsWhenTimeoutDisabled(t *testing.T) {
 	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "OFF-1", Identifier: "OFF-1", State: "AI Ready"}
+	iss := tracker.Issue{ID: "OFF-1", Identifier: "OFF-1", State: "Todo"}
 	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
 		t.Fatalf("RequestDispatch: %v", err)
 	}
@@ -616,7 +616,7 @@ func TestRetryFireUsesRefreshedIssueWhenReconciledMidQueue(t *testing.T) {
 
 func TestTrackerRecheckedDispatchDoesNotConsumeFailureRetry(t *testing.T) {
 	st := NewOrchestratorState(30000, 1)
-	iss := tracker.Issue{ID: "ENG-FAIL-RETRY", Identifier: "ENG-FAIL-RETRY", Title: "failure retry", State: "AI Ready"}
+	iss := tracker.Issue{ID: "ENG-FAIL-RETRY", Identifier: "ENG-FAIL-RETRY", Title: "failure retry", State: "Todo"}
 	id := IssueID(iss.ID)
 	st.ScheduleRetry(&RetryEntry{
 		IssueID:    id,
@@ -1748,7 +1748,7 @@ func TestFinalize_InputRequiredExitBlocksIssueWithoutRetry(t *testing.T) {
 	})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "ENG-INPUT", Identifier: "ENG-INPUT", State: "AI Ready", Title: "needs input"}
+	iss := tracker.Issue{ID: "ENG-INPUT", Identifier: "ENG-INPUT", State: "Todo", Title: "needs input"}
 	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
 		t.Fatalf("RequestDispatch: %v", err)
 	}
@@ -1789,7 +1789,7 @@ func TestFinalize_NormalExitAfterInputRequiredBlocksInsteadOfContinuationRetry(t
 	})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "ENG-NORMAL-BLOCK", Identifier: "ENG-NORMAL-BLOCK", State: "AI Ready", Title: "needs input"}
+	iss := tracker.Issue{ID: "ENG-NORMAL-BLOCK", Identifier: "ENG-NORMAL-BLOCK", State: "Todo", Title: "needs input"}
 	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
 		t.Fatalf("RequestDispatch: %v", err)
 	}
@@ -1819,7 +1819,7 @@ func TestReconcileBlockedIssuesRefreshesActiveAndReleasesInactive(t *testing.T) 
 	})
 	defer cancel()
 
-	blocked := tracker.Issue{ID: "ENG-BLOCK-A", Identifier: "ENG-BLOCK-A", State: "AI Ready", Title: "active block"}
+	blocked := tracker.Issue{ID: "ENG-BLOCK-A", Identifier: "ENG-BLOCK-A", State: "Todo", Title: "active block"}
 	terminalWorkspace := t.TempDir()
 	if err := o.RequestDispatch(context.Background(), blocked, nil); err != nil {
 		t.Fatalf("RequestDispatch %s: %v", blocked.ID, err)
@@ -1842,7 +1842,7 @@ func TestReconcileBlockedIssuesRefreshesActiveAndReleasesInactive(t *testing.T) 
 
 	// Active pass: the blocked entry is still in an active state (moved to
 	// Rework), so it is refreshed in place rather than released.
-	activeStates := map[string]struct{}{"ai ready": {}, "rework": {}}
+	activeStates := map[string]struct{}{"todo": {}, "rework": {}}
 	if err := o.RefreshActiveTrackerIssues(context.Background(), map[string]tracker.Issue{
 		blocked.ID: {ID: blocked.ID, Identifier: blocked.Identifier, State: "Rework", Title: blocked.Title},
 	}, activeStates); err != nil {
@@ -2992,7 +2992,7 @@ func TestRetryFire_DropsStaleContinuationFireAfterFailureReplacement(t *testing.
 	o := New(st, Deps{Dispatcher: disp})
 
 	issueID := IssueID("ENG-KIND")
-	continuationIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "AI Ready", Title: "old continuation"}
+	continuationIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "Todo", Title: "old continuation"}
 	failureIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "Needs Fix", Title: "new failure"}
 	st.ScheduleRetry(&RetryEntry{
 		Issue:      failureIssue,
@@ -3038,7 +3038,7 @@ func TestRetryFire_DropsStaleFailureFireAfterContinuationReplacement(t *testing.
 
 	issueID := IssueID("ENG-KIND")
 	failureIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "Needs Fix", Title: "old failure"}
-	continuationIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "AI Ready", Title: "new continuation"}
+	continuationIssue := tracker.Issue{ID: string(issueID), Identifier: "ENG-KIND", State: "Todo", Title: "new continuation"}
 	timer := time.AfterFunc(time.Hour, func() {})
 	defer timer.Stop()
 	st.ScheduleRetry(&RetryEntry{
@@ -3739,7 +3739,7 @@ func TestRetryFire_ReleasesClaimWhenIssueAbsentFromCandidates(t *testing.T) {
 	})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "ENG-GONE", Identifier: "ENG-GONE", Title: "absent", State: "AI Ready"}
+	iss := tracker.Issue{ID: "ENG-GONE", Identifier: "ENG-GONE", Title: "absent", State: "Todo"}
 	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 2, "transient"); err != nil {
 		t.Fatalf("ScheduleRetry: %v", err)
 	}
@@ -3974,7 +3974,7 @@ func TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError(t *testing.T) {
 	})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "ENG-FETCH-FAIL", Identifier: "ENG-FETCH-FAIL", Title: "fetch err", State: "AI Ready"}
+	iss := tracker.Issue{ID: "ENG-FETCH-FAIL", Identifier: "ENG-FETCH-FAIL", Title: "fetch err", State: "Todo"}
 	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
 		t.Fatalf("ScheduleRetry: %v", err)
 	}
@@ -4032,7 +4032,7 @@ func TestRetryFire_DispatchesWhenCandidateFetchReturnsIssue(t *testing.T) {
 	defer cancel()
 
 	stale := freshState
-	stale.State = "AI Ready"
+	stale.State = "Todo"
 	if err := o.ScheduleRetry(context.Background(), stale, stale.Identifier, 1, "transient"); err != nil {
 		t.Fatalf("ScheduleRetry: %v", err)
 	}
@@ -4092,7 +4092,7 @@ func TestRetryFire_FetchTimeoutReschedulesAsRetryPollFailed(t *testing.T) {
 	})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "ENG-TIMEOUT", Identifier: "ENG-TIMEOUT", Title: "hang", State: "AI Ready"}
+	iss := tracker.Issue{ID: "ENG-TIMEOUT", Identifier: "ENG-TIMEOUT", Title: "hang", State: "Todo"}
 	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
 		t.Fatalf("ScheduleRetry: %v", err)
 	}
@@ -4144,7 +4144,7 @@ func TestRetryFire_QuotaBackoffFetchFailureReschedulesWithoutOrphaningClaim(t *t
 	})
 	defer cancel()
 
-	iss := tracker.Issue{ID: "ENG-QUOTA-POLL", Identifier: "ENG-QUOTA-POLL", Title: "quota poll", State: "AI Ready"}
+	iss := tracker.Issue{ID: "ENG-QUOTA-POLL", Identifier: "ENG-QUOTA-POLL", Title: "quota poll", State: "Todo"}
 	if err := o.scheduleQuotaBackoffRetry(context.Background(), iss, iss.Identifier, 0, "quota backoff", 0, Workspace{}); err != nil {
 		t.Fatalf("scheduleQuotaBackoffRetry: %v", err)
 	}
@@ -4324,7 +4324,7 @@ func TestRetryFireAfterFetch_RefreshedIdentifierSurfacesInSnapshot(t *testing.T)
 	}
 	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
 
-	stale := tracker.Issue{ID: "ID-STABLE", Identifier: "OLD-1", Title: "renamed", State: "AI Ready"}
+	stale := tracker.Issue{ID: "ID-STABLE", Identifier: "OLD-1", Title: "renamed", State: "Todo"}
 	if err := o.ScheduleRetry(context.Background(), stale, stale.Identifier, 1, "transient"); err != nil {
 		t.Fatalf("ScheduleRetry: %v", err)
 	}

--- a/internal/orchestrator/poller_gitea_seam_test.go
+++ b/internal/orchestrator/poller_gitea_seam_test.go
@@ -1,0 +1,46 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// TestGiteaPreDispatchStateIsBlockerGated pins the producer/consumer seam
+// behind #739: the Gitea adapter's pre-dispatch state (derived from the
+// aiops/todo label) must be the literal "Todo" state the SPEC §8.2 blocker
+// rule keys on. If the adapter ever renames that state again (it shipped as
+// "AI Ready"), blocked Gitea issues dispatch while their dependencies are
+// still open and this test fails.
+func TestGiteaPreDispatchStateIsBlockerGated(t *testing.T) {
+	mappings := gitea.DefaultStateLabelMappings()
+	preDispatch, diags := gitea.IssueStateFromLabels([]gitea.Label{{Name: "aiops/todo"}}, mappings)
+	if len(diags) != 0 {
+		t.Fatalf("IssueStateFromLabels(aiops/todo) diagnostics = %v, want none", diags)
+	}
+	terminal, diags := gitea.IssueStateFromLabels([]gitea.Label{{Name: "aiops/done"}}, mappings)
+	if len(diags) != 0 {
+		t.Fatalf("IssueStateFromLabels(aiops/done) diagnostics = %v, want none", diags)
+	}
+	terminalStates := []string{terminal}
+
+	// Field repro from the v0.1.0 lifecycle test: issue #10 (aiops/todo)
+	// declared "Depends on #4" while #4 was still aiops/todo.
+	blocked := tracker.Issue{
+		ID:         "10",
+		Identifier: "#10",
+		Title:      "blocked by open dependency",
+		State:      preDispatch,
+		BlockedBy:  []tracker.BlockerRef{{ID: "4", Identifier: "#4", State: preDispatch}},
+	}
+	if out := filterEligibleCandidates([]tracker.Issue{blocked}, terminalStates, nil); len(out) != 0 {
+		t.Fatalf("filterEligibleCandidates(issue in %q blocked by non-terminal %q) = %d issues, want 0", preDispatch, preDispatch, len(out))
+	}
+
+	released := blocked
+	released.BlockedBy = []tracker.BlockerRef{{ID: "4", Identifier: "#4", State: terminal}}
+	if out := filterEligibleCandidates([]tracker.Issue{released}, terminalStates, nil); len(out) != 1 {
+		t.Fatalf("filterEligibleCandidates(issue in %q blocked by terminal %q) = %d issues, want 1", preDispatch, terminal, len(out))
+	}
+}

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -884,10 +884,10 @@ func TestPollOnceSkipsMalformedTrackerCandidates(t *testing.T) {
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{preserveMissingFields: true, issues: []tracker.Issue{
-		{ID: "missing-identifier", Title: "Missing identifier", State: "AI Ready"},
-		{ID: "missing-title", Identifier: "LIN-2", State: "AI Ready"},
+		{ID: "missing-identifier", Title: "Missing identifier", State: "Todo"},
+		{ID: "missing-title", Identifier: "LIN-2", State: "Todo"},
 		{ID: "missing-state", Identifier: "LIN-3", Title: "Missing state"},
-		{ID: "valid", Identifier: "LIN-4", Title: "Ready work", State: "AI Ready", CreatedAt: mustTime("2026-05-15T00:00:00Z")},
+		{ID: "valid", Identifier: "LIN-4", Title: "Ready work", State: "Todo", CreatedAt: mustTime("2026-05-15T00:00:00Z")},
 	}}
 	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
 	orch := New(NewOrchestratorState(30000, 4), Deps{
@@ -915,8 +915,8 @@ func TestPollOnceDispatchesMissingCreatedAtCandidateAfterDatedCandidates(t *test
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{preserveMissingFields: true, issues: []tracker.Issue{
-		{ID: "missing-created-at", Identifier: "LIN-2", Title: "Missing created timestamp", State: "AI Ready", Priority: 1},
-		{ID: "dated", Identifier: "LIN-1", Title: "Dated", State: "AI Ready", Priority: 1, CreatedAt: mustTime("2026-05-15T00:00:00Z")},
+		{ID: "missing-created-at", Identifier: "LIN-2", Title: "Missing created timestamp", State: "Todo", Priority: 1},
+		{ID: "dated", Identifier: "LIN-1", Title: "Dated", State: "Todo", Priority: 1, CreatedAt: mustTime("2026-05-15T00:00:00Z")},
 	}}
 	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
 	orch := New(NewOrchestratorState(30000, 2), Deps{
@@ -944,7 +944,7 @@ func TestPollOnceIgnoresBlockersForNonTodoStates(t *testing.T) {
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{
-		{ID: "ready-blocked", Identifier: "LIN-1", State: "AI Ready", BlockedBy: []tracker.BlockerRef{{ID: "open-blocker", Identifier: "LIN-0", State: "In Progress"}}},
+		{ID: "in-progress-blocked", Identifier: "LIN-1", State: "In Progress", BlockedBy: []tracker.BlockerRef{{ID: "open-blocker", Identifier: "LIN-0", State: "In Progress"}}},
 	}}
 	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
@@ -961,7 +961,7 @@ func TestPollOnceIgnoresBlockersForNonTodoStates(t *testing.T) {
 		t.Fatalf("poll once: %v", err)
 	}
 	waitForDispatcherCount(t, dispatcher, 1)
-	if got := dispatcher.issueAt(0).ID; got != "ready-blocked" {
+	if got := dispatcher.issueAt(0).ID; got != "in-progress-blocked" {
 		t.Fatalf("dispatched issue ID = %q, want non-Todo issue dispatched despite blockers", got)
 	}
 	close(dispatcher.releaseCh)
@@ -1318,12 +1318,12 @@ func TestPollOnceSortsCandidatesByTrackerPriorityCreatedAtIdentifier(t *testing.
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{
-		{ID: "unprioritized", Identifier: "LIN-0", State: "AI Ready", Priority: 0, CreatedAt: mustTime("2026-05-14T00:00:00Z")},
-		{ID: "later-high", Identifier: "LIN-9", State: "AI Ready", Priority: 2, CreatedAt: mustTime("2026-05-17T00:00:00Z")},
-		{ID: "middle-tie-b", Identifier: "LIN-B", State: "AI Ready", Priority: 1, CreatedAt: mustTime("2026-05-16T00:00:00Z")},
-		{ID: "oldest", Identifier: "LIN-1", State: "AI Ready", Priority: 1, CreatedAt: mustTime("2026-05-15T00:00:00Z")},
-		{ID: "offset-newer", Identifier: "LIN-O", State: "AI Ready", Priority: 1, CreatedAt: mustTime("2026-05-15T01:00:00+02:00")},
-		{ID: "middle-tie-a", Identifier: "LIN-A", State: "AI Ready", Priority: 1, CreatedAt: mustTime("2026-05-16T00:00:00Z")},
+		{ID: "unprioritized", Identifier: "LIN-0", State: "Todo", Priority: 0, CreatedAt: mustTime("2026-05-14T00:00:00Z")},
+		{ID: "later-high", Identifier: "LIN-9", State: "Todo", Priority: 2, CreatedAt: mustTime("2026-05-17T00:00:00Z")},
+		{ID: "middle-tie-b", Identifier: "LIN-B", State: "Todo", Priority: 1, CreatedAt: mustTime("2026-05-16T00:00:00Z")},
+		{ID: "oldest", Identifier: "LIN-1", State: "Todo", Priority: 1, CreatedAt: mustTime("2026-05-15T00:00:00Z")},
+		{ID: "offset-newer", Identifier: "LIN-O", State: "Todo", Priority: 1, CreatedAt: mustTime("2026-05-15T01:00:00+02:00")},
+		{ID: "middle-tie-a", Identifier: "LIN-A", State: "Todo", Priority: 1, CreatedAt: mustTime("2026-05-16T00:00:00Z")},
 	}}
 	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
 	orch := New(NewOrchestratorState(30000, 6), Deps{
@@ -1354,7 +1354,7 @@ func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *t
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}}
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Todo"}}}
 	releaseCh := make(chan struct{})
 	dispatcher := &recordingDispatcher{releaseCh: releaseCh}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
@@ -1403,7 +1403,7 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("WaitStarted: %v", err)
 	}
-	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1", State: "AI Ready"}}}, orch)
+	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1", State: "Todo"}}}, orch)
 
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("initial poll once: %v", err)
@@ -1437,7 +1437,7 @@ func TestPollOnceKeepsDueContinuationRetryMissingFromActiveListing(t *testing.T)
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("WaitStarted: %v", err)
 	}
-	issue := tracker.Issue{ID: "issue-missing", Identifier: "ISSUE-MISSING", Title: "Issue missing from capped active listing", State: "AI Ready"}
+	issue := tracker.Issue{ID: "issue-missing", Identifier: "ISSUE-MISSING", Title: "Issue missing from capped active listing", State: "Todo"}
 	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{issue}}, orch)
 
 	if err := poller.PollOnce(ctx); err != nil {
@@ -1476,7 +1476,7 @@ func TestRunPollLoopWakesWhenContinuationRetryTimerFires(t *testing.T) {
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("WaitStarted: %v", err)
 	}
-	issue := tracker.Issue{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1", State: "AI Ready"}
+	issue := tracker.Issue{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1", State: "Todo"}
 	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{issue}}, orch)
 
 	done := make(chan error, 1)
@@ -1508,7 +1508,7 @@ func TestPollOnceBuildTaskFailureSchedulesBackoffRetryNotPerTickSpin(t *testing.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready", UpdatedAt: mustTime("2026-05-17T00:00:00Z")}}}
+	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Todo", UpdatedAt: mustTime("2026-05-17T00:00:00Z")}}}
 	dispatcher := &erroringTaskDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
@@ -1565,9 +1565,9 @@ func TestPollOnceDoesNotExceedMaxConcurrentAgents(t *testing.T) {
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{
-		{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"},
-		{ID: "issue-2", Identifier: "LIN-2", State: "AI Ready"},
-		{ID: "issue-3", Identifier: "LIN-3", State: "AI Ready"},
+		{ID: "issue-1", Identifier: "LIN-1", State: "Todo"},
+		{ID: "issue-2", Identifier: "LIN-2", State: "Todo"},
+		{ID: "issue-3", Identifier: "LIN-3", State: "Todo"},
 	}}
 	dispatcher := &blockingDispatcher{}
 	orch := New(NewOrchestratorState(30000, 2), Deps{
@@ -1595,8 +1595,8 @@ func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{
-		{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"},
-		{ID: "issue-2", Identifier: "LIN-2", State: "AI Ready"},
+		{ID: "issue-1", Identifier: "LIN-1", State: "Todo"},
+		{ID: "issue-2", Identifier: "LIN-2", State: "Todo"},
 	}}
 	firstRunBlocked := make(chan struct{})
 	dispatcher := &recordingDispatcher{releaseCh: firstRunBlocked}
@@ -1640,8 +1640,8 @@ func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
 	defer cancel()
 
 	trackerClient := &fakeIssueTracker{issues: []tracker.Issue{
-		{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"},
-		{ID: "issue-2", Identifier: "LIN-2", State: "AI Ready"},
+		{ID: "issue-1", Identifier: "LIN-1", State: "Todo"},
+		{ID: "issue-2", Identifier: "LIN-2", State: "Todo"},
 	}}
 	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
@@ -1662,7 +1662,7 @@ func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
 	close(dispatcher.releaseCh)
 	waitForCompleted(t, ctx, orch, "issue-1")
 	dispatcher.releaseCh = nil
-	trackerClient.issues = []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}}
+	trackerClient.issues = []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Todo"}}
 	waitForRetryDue(t, ctx, orch, "issue-1")
 
 	if err := poller.PollOnce(ctx); err != nil {
@@ -1832,8 +1832,8 @@ func TestPollOnceDispatchesPartialIssuesWhenTrackerReturnsCategorizedError(t *te
 	)
 	trackerClient := &fakeIssueTracker{
 		issues: []tracker.Issue{
-			{ID: "issue-1", Identifier: "GH-1", State: "AI Ready"},
-			{ID: "issue-2", Identifier: "GH-2", State: "AI Ready"},
+			{ID: "issue-1", Identifier: "GH-1", State: "Todo"},
+			{ID: "issue-2", Identifier: "GH-2", State: "Todo"},
 		},
 		err:            categorizedErr,
 		partialSuccess: true,

--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -67,7 +67,7 @@ func TestRuntimeDispatcherConfigForSnapshotBuildsRefresherClosure(t *testing.T) 
 	d.SetIssueStateRefresher(stub)
 
 	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
-		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress", "AI Ready"}},
+		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress", "Todo"}},
 	}}}
 	cfg := d.configForSnapshot(snap)
 	if cfg.IssueStateRefresher == nil {

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -132,7 +132,7 @@ func TestRuntimePollerUsesReloadedTrackerStatesFromSameWorkflowPath(t *testing.T
 		t.Fatalf("new runtime: %v", err)
 	}
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{
-		{ID: "issue-ready", Identifier: "ISSUE-1", Title: "ready", State: "AI Ready"},
+		{ID: "issue-ready", Identifier: "ISSUE-1", Title: "ready", State: "Todo"},
 		{ID: "issue-rework", Identifier: "ISSUE-2", Title: "rework", State: "Rework"},
 	}}
 	dispatcher := &fakeDispatcher{}
@@ -180,8 +180,8 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsToDispatchCapacity(t *te
 		t.Fatalf("new runtime: %v", err)
 	}
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{
-		{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "AI Ready"},
-		{ID: "issue-2", Identifier: "ISSUE-2", Title: "two", State: "AI Ready"},
+		{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "Todo"},
+		{ID: "issue-2", Identifier: "ISSUE-2", Title: "two", State: "Todo"},
 	}}
 	dispatcher := &blockingDispatcher{}
 	orch := New(NewOrchestratorState(30000, initial.Config.Agent.MaxConcurrentAgents), Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
@@ -199,7 +199,7 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsToDispatchCapacity(t *te
 	}
 	waitForBlockingDispatcherCount(t, dispatcher, 1)
 
-	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "AI Ready", withReloadTestMaxConcurrentAgents(2))
+	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "Todo", withReloadTestMaxConcurrentAgents(2))
 	if err := runtime.ReloadOnce(ctx); err != nil {
 		t.Fatalf("reload workflow: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsByStateToDispatchCapacit
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	path := writeWorkflowForReloadTest(t, "linear", 30000, withReloadTestMaxConcurrentAgents(10), withReloadTestMaxConcurrentAgentsByState(map[string]int{"AI Ready": 1}))
+	path := writeWorkflowForReloadTest(t, "linear", 30000, withReloadTestMaxConcurrentAgents(10), withReloadTestMaxConcurrentAgentsByState(map[string]int{"Todo": 1}))
 	initial, err := workflow.Load(path)
 	if err != nil {
 		t.Fatalf("load initial workflow: %v", err)
@@ -223,8 +223,8 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsByStateToDispatchCapacit
 		t.Fatalf("new runtime: %v", err)
 	}
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{
-		{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "AI Ready"},
-		{ID: "issue-2", Identifier: "ISSUE-2", Title: "two", State: "AI Ready"},
+		{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "Todo"},
+		{ID: "issue-2", Identifier: "ISSUE-2", Title: "two", State: "Todo"},
 	}}
 	dispatcher := &blockingDispatcher{}
 	st := NewOrchestratorState(30000, initial.Config.Agent.MaxConcurrentAgents)
@@ -244,7 +244,7 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsByStateToDispatchCapacit
 	}
 	waitForBlockingDispatcherCount(t, dispatcher, 1)
 
-	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "AI Ready", withReloadTestMaxConcurrentAgents(10), withReloadTestMaxConcurrentAgentsByState(map[string]int{"ai_ready": 2}))
+	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "Todo", withReloadTestMaxConcurrentAgents(10), withReloadTestMaxConcurrentAgentsByState(map[string]int{"todo": 2}))
 	if err := runtime.ReloadOnce(ctx); err != nil {
 		t.Fatalf("reload workflow: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestRuntimePollerAppliesReloadedMaxRetryBackoffToFailureRetries(t *testing.
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)
 	}
-	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "AI Ready"}}}
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "Todo"}}}
 	dispatcher := &fakeDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Second}})
 	go orch.Run(ctx)
@@ -279,7 +279,7 @@ func TestRuntimePollerAppliesReloadedMaxRetryBackoffToFailureRetries(t *testing.
 		t.Fatalf("new runtime poller: %v", err)
 	}
 
-	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "AI Ready", withReloadTestMaxRetryBackoffMs(50))
+	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "Todo", withReloadTestMaxRetryBackoffMs(50))
 	if err := runtime.ReloadOnce(ctx); err != nil {
 		t.Fatalf("reload workflow: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestRuntimePollerAppliesReloadedMaxContinuationTurnsToCleanContinuationBudg
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)
 	}
-	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "AI Ready"}}}
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "one", State: "Todo"}}}
 	dispatcher := &fakeDispatcher{}
 	st := NewOrchestratorState(30000, 1)
 	st.MaxContinuationTurns = initial.Config.Agent.MaxContinuationTurns
@@ -330,7 +330,7 @@ func TestRuntimePollerAppliesReloadedMaxContinuationTurnsToCleanContinuationBudg
 		t.Fatalf("new runtime poller: %v", err)
 	}
 
-	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "AI Ready", withReloadTestMaxContinuationTurns(1))
+	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "Todo", withReloadTestMaxContinuationTurns(1))
 	if err := runtime.ReloadOnce(ctx); err != nil {
 		t.Fatalf("reload workflow: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestRuntimePollerRebuildsTrackerClientAfterTrackerConfigReload(t *testing.T
 		t.Fatalf("new runtime: %v", err)
 	}
 	trackersByKind := map[string]*fakeIssueStateTracker{
-		"linear": {issues: []tracker.Issue{{ID: "linear-ready", Identifier: "ISSUE-1", Title: "ready", State: "AI Ready"}}},
+		"linear": {issues: []tracker.Issue{{ID: "linear-ready", Identifier: "ISSUE-1", Title: "ready", State: "Todo"}}},
 		"gitea":  {issues: []tracker.Issue{{ID: "gitea-rework", Identifier: "ISSUE-2", Title: "rework", State: "Rework"}}},
 	}
 	factoryCalls := 0
@@ -451,7 +451,7 @@ func TestRuntimePollerRetryListerWrapsEligibilityFilter(t *testing.T) {
 	}
 
 	// Positive control: a clean issue passes the wrap.
-	trackerClient.issues = []tracker.Issue{{ID: "gitea-ready", Identifier: "READY-1", Title: "ready", State: "AI Ready"}}
+	trackerClient.issues = []tracker.Issue{{ID: "gitea-ready", Identifier: "READY-1", Title: "ready", State: "Todo"}}
 	got, err = lister.ListActiveIssues(ctx)
 	if err != nil {
 		t.Fatalf("ListActiveIssues (positive control): %v", err)
@@ -503,7 +503,7 @@ func TestRuntimePollerRetryListerThreadsRequiredLabels(t *testing.T) {
 	// An active-state issue missing the required label must be dropped on the
 	// retry-fire seam: a queued retry whose issue lost the label is ineligible.
 	trackerClient.issues = []tracker.Issue{{
-		ID: "gitea-unlabeled", Identifier: "UNLABELED-1", Title: "missing required label", State: "AI Ready",
+		ID: "gitea-unlabeled", Identifier: "UNLABELED-1", Title: "missing required label", State: "Todo",
 	}}
 	got, err := lister.ListActiveIssues(ctx)
 	if err != nil {
@@ -515,7 +515,7 @@ func TestRuntimePollerRetryListerThreadsRequiredLabels(t *testing.T) {
 
 	// Positive control: the same active issue carrying the required label passes.
 	trackerClient.issues = []tracker.Issue{{
-		ID: "gitea-labeled", Identifier: "LABELED-1", Title: "has required label", State: "AI Ready",
+		ID: "gitea-labeled", Identifier: "LABELED-1", Title: "has required label", State: "Todo",
 		Labels: []string{"aiops-ready"},
 	}}
 	got, err = lister.ListActiveIssues(ctx)
@@ -555,8 +555,8 @@ func TestWorkflowRuntimeReloadFailureKeepsPreviousConfigAndEmitsFailureEvent(t *
 	if got := snap.Workflow.Config.Tracker.PollIntervalMs; got != 30000 {
 		t.Fatalf("poll interval after failed reload = %d, want previous 30000", got)
 	}
-	if got := snap.Workflow.Config.Tracker.ActiveStates; len(got) != 1 || got[0] != "AI Ready" {
-		t.Fatalf("active states after failed reload = %#v, want previous [AI Ready]", got)
+	if got := snap.Workflow.Config.Tracker.ActiveStates; len(got) != 1 || got[0] != "Todo" {
+		t.Fatalf("active states after failed reload = %#v, want previous [Todo]", got)
 	}
 	if got := emitter.count(task.EventWorkflowReloadFailed); got != 1 {
 		t.Fatalf("workflow_reload_failed event count = %d, want 1", got)
@@ -621,7 +621,7 @@ func TestRunPollLoopWithRuntimeUsesReloadedPollingCadence(t *testing.T) {
 		t.Fatalf("new runtime: %v", err)
 	}
 	poller := &countingPollOnce{afterFirst: func() {
-		writeWorkflowForReloadTestAt(t, path, "linear", 75, "AI Ready")
+		writeWorkflowForReloadTestAt(t, path, "linear", 75, "Todo")
 		_ = runtime.ReloadOnce(context.Background())
 	}}
 	sleeper := &recordingPollSleeper{}
@@ -707,7 +707,7 @@ func (s *reloadLoopTestSleeper) sleep(_ context.Context, _ time.Duration) error 
 func writeWorkflowForReloadTest(t *testing.T, trackerKind string, pollIntervalMs int, opts ...reloadWorkflowTestOption) string {
 	t.Helper()
 	path := t.TempDir() + "/WORKFLOW.md"
-	writeWorkflowForReloadTestAt(t, path, trackerKind, pollIntervalMs, "AI Ready", opts...)
+	writeWorkflowForReloadTestAt(t, path, trackerKind, pollIntervalMs, "Todo", opts...)
 	return path
 }
 

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -383,7 +383,7 @@ func TestListIssuesByStatesPaginates(t *testing.T) {
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
 
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready", "In Progress"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo", "In Progress"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
@@ -460,7 +460,7 @@ func TestListIssuesByStatesPaginatesLinearInverseRelationsBeforeMappingBlockers(
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
 
-	issues, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
@@ -624,7 +624,7 @@ func TestListIssuesByStatesErrorsWhenNextPageCursorMissing(t *testing.T) {
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
 
-	_, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err == nil || !strings.Contains(err.Error(), "linear pagination missing endCursor") {
 		t.Fatalf("ListIssuesByStates error = %v, want missing cursor error", err)
 	}
@@ -638,7 +638,7 @@ func TestListIssuesByStatesErrorsWhenMaxPagesExceeded(t *testing.T) {
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
 
-	_, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"})
+	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
 	if err == nil || !strings.Contains(err.Error(), "linear pagination exceeded") {
 		t.Fatalf("ListIssuesByStates error = %v, want max pages error", err)
 	}
@@ -740,9 +740,9 @@ func TestNewLinearClientEndpointActuallyUsedForRequests(t *testing.T) {
 	defer srv.Close()
 
 	endpoint := srv.URL + "/custom-graphql"
-	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k", ProjectSlug: "aiops", Endpoint: endpoint, ActiveStates: []string{"AI Ready"}})
+	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k", ProjectSlug: "aiops", Endpoint: endpoint, ActiveStates: []string{"Todo"}})
 	client.HTTP = srv.Client()
-	if _, err := client.ListIssuesByStates(context.Background(), []string{"AI Ready"}); err != nil {
+	if _, err := client.ListIssuesByStates(context.Background(), []string{"Todo"}); err != nil {
 		t.Fatalf("ListIssuesByStates: %v", err)
 	}
 	if observed != "/custom-graphql" {

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -70,7 +70,7 @@ func TestReconcileStartupRemovesTerminalWorkspaces(t *testing.T) {
 	emitter := &fakeEmitter{}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready", "In Progress", "Rework"},
+		ActiveStates:    []string{"Todo", "In Progress", "Rework"},
 		TerminalStates:  []string{"Done", "Canceled"},
 		Tracker:         fakeReconcileTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}, {ID: "issue-2", Identifier: "LIN-2", State: "Done"}}},
 		Emitter:         emitter,
@@ -139,7 +139,7 @@ func TestReconcileStartupIsIdempotent(t *testing.T) {
 	}
 	cfg := ReconcileConfig{
 		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready"},
+		ActiveStates:    []string{"Todo"},
 		TerminalStates:  []string{"Done"},
 		Tracker:         fakeReconcileTracker{issues: []tracker.Issue{{Identifier: "LIN-2", State: "Done"}}},
 		Emitter:         &fakeEmitter{},
@@ -164,12 +164,12 @@ func TestReconcileStartupRemovesUnknownWorkspacesWhenTerminalIssuesObserved(t *t
 	}
 
 	fake := &fakeReconcileTrackerByCall{issuesByCall: [][]tracker.Issue{
-		{{ID: "issue-1", Identifier: "LIN-1", State: "AI Ready"}},
+		{{ID: "issue-1", Identifier: "LIN-1", State: "Todo"}},
 		{{ID: "issue-2", Identifier: "LIN-2", State: "Done"}},
 	}}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready"},
+		ActiveStates:    []string{"Todo"},
 		TerminalStates:  []string{"Done"},
 		Tracker:         fake,
 		Emitter:         &fakeEmitter{},
@@ -192,7 +192,7 @@ func TestReconcileStartupRefusesToRemoveWhenTrackerReturnsNoIssues(t *testing.T)
 
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready"},
+		ActiveStates:    []string{"Todo"},
 		TerminalStates:  []string{"Done"},
 		Tracker:         fakeReconcileTracker{},
 		Emitter:         &fakeEmitter{},
@@ -224,7 +224,7 @@ func TestReconcileStartupTolerantOfActiveFetchFailure(t *testing.T) {
 	emitter := &fakeEmitter{}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready"},
+		ActiveStates:    []string{"Todo"},
 		TerminalStates:  []string{"Done"},
 		Tracker:         &fakeReconcileTrackerByCall{errByCall: []error{errors.New("tracker outage"), nil}},
 		Emitter:         emitter,
@@ -273,7 +273,7 @@ func TestReconcileStartupSafeWhenActiveListingCapped(t *testing.T) {
 	emitter := &fakeEmitter{}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:  root,
-		ActiveStates:   []string{"AI Ready"},
+		ActiveStates:   []string{"Todo"},
 		TerminalStates: []string{"Done"},
 		Tracker: &fakeReconcileTrackerByCall{
 			// Active fetch returns capped error; terminal fetch would have
@@ -437,11 +437,11 @@ func TestReconcileStartupMatchesGiteaWorkspaceLayout(t *testing.T) {
 
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:  root,
-		ActiveStates:   []string{"AI Ready"},
+		ActiveStates:   []string{"Todo"},
 		TerminalStates: []string{"Done"},
 		TrackerKind:    "gitea",
 		Tracker: fakeReconcileTracker{issues: []tracker.Issue{
-			{ID: "issue-1", Identifier: "GIT-1", State: "AI Ready"},
+			{ID: "issue-1", Identifier: "GIT-1", State: "Todo"},
 			{ID: "issue-2", Identifier: "GIT-2", State: "Done"},
 		}},
 		Emitter:         &fakeEmitter{},
@@ -673,7 +673,7 @@ func TestReconcileStartupRunsBeforeRemoveHookAndStillRemovesOnFailure(t *testing
 	emitter := &fakeEmitter{}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:  root,
-		ActiveStates:   []string{"AI Ready"},
+		ActiveStates:   []string{"Todo"},
 		TerminalStates: []string{"Done"},
 		TrackerKind:    "linear",
 		Tracker:        fakeReconcileTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Done"}}},
@@ -738,7 +738,7 @@ func TestReconcileStartupRejectsEmptyTerminalStatesBeforeCleanup(t *testing.T) {
 
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready"},
+		ActiveStates:    []string{"Todo"},
 		Tracker:         fakeReconcileTracker{},
 		Emitter:         &fakeEmitter{},
 		ReconcileTaskID: "reconcile-startup",
@@ -763,7 +763,7 @@ func TestReconcileStartupHandlesSourceEventIDAndTaskIDWorkspaceLayouts(t *testin
 
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:   root,
-		ActiveStates:    []string{"AI Ready"},
+		ActiveStates:    []string{"Todo"},
 		TerminalStates:  []string{"Done"},
 		Tracker:         fakeReconcileTracker{issues: []tracker.Issue{{ID: "issue-uuid", Identifier: "LIN-123", State: "Done"}}},
 		Emitter:         &fakeEmitter{},

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -443,9 +443,9 @@ func DefaultConfig() Config {
 		// Tracker.ActiveStates / TerminalStates mirror SPEC §6.4's
 		// cheat-sheet defaults (Todo/In Progress active; Closed,
 		// Cancelled, Canceled, Duplicate, Done terminal). Workflows that
-		// run on a non-SPEC vocabulary (e.g. the personal profile's
-		// "AI Ready"/"Rework") declare the override in WORKFLOW.md front
-		// matter — see examples/WORKFLOW.md.
+		// run on extra states (e.g. the personal profile's "Rework")
+		// declare the override in WORKFLOW.md front matter — see
+		// examples/WORKFLOW.md.
 		// Tracker.Kind is intentionally left empty: SPEC §6.4 marks it
 		// REQUIRED, so DefaultConfig must not silently default it. A
 		// WORKFLOW.md that declares front matter must set `tracker.kind`

--- a/internal/workflow/normalize_test.go
+++ b/internal/workflow/normalize_test.go
@@ -80,7 +80,7 @@ func TestNormalizeStateConcurrencyKey_Shape(t *testing.T) {
 		{"REWORK", "rework"},
 		{"", ""},
 		{"   ", ""},
-		{"AI Ready", "ai_ready"},
+		{"Human Review", "human_review"},
 	}
 	for _, tc := range cases {
 		if got := NormalizeStateConcurrencyKey(tc.in); got != tc.want {

--- a/test/e2e/fixtures/gitea-worker.md
+++ b/test/e2e/fixtures/gitea-worker.md
@@ -11,7 +11,7 @@ verify:
 tracker:
   kind: gitea
   active_states:
-    - AI Ready
+    - Todo
     - Rework
   terminal_states:
     - Done

--- a/test/e2e/gitea_tracker_test.go
+++ b/test/e2e/gitea_tracker_test.go
@@ -37,7 +37,7 @@ func TestGiteaTrackerDispatchesLabeledIssueAndDedupesRepeatedPolls(t *testing.T)
 
 	client := gitea.NewTrackerClient(workflow.TrackerConfig{
 		APIKey:         bed.gitea.botToken,
-		ActiveStates:   []string{"AI Ready", "Rework"},
+		ActiveStates:   []string{"Todo", "Rework"},
 		TerminalStates: []string{"Done", "Canceled"},
 	}, bed.gitea.baseURL, owner, repo)
 	client.HTTP = httpClientForE2E()
@@ -60,7 +60,7 @@ func TestGiteaTrackerDispatchesLabeledIssueAndDedupesRepeatedPolls(t *testing.T)
 	}
 	waitForE2E(t, func() bool { return disp.count() == 1 }, time.Second)
 	got := disp.issueAt(0)
-	if got.Identifier != "#1" || got.Title != "poll me" || got.State != "AI Ready" {
+	if got.Identifier != "#1" || got.Title != "poll me" || got.State != "Todo" {
 		t.Fatalf("unexpected dispatched issue: %+v", got)
 	}
 	if cloneURL == "" {
@@ -104,7 +104,7 @@ func TestGiteaTrackerIgnoresBacklogAndTerminalIssues(t *testing.T) {
 
 	client := gitea.NewTrackerClient(workflow.TrackerConfig{
 		APIKey:         bed.gitea.botToken,
-		ActiveStates:   []string{"AI Ready", "Rework"},
+		ActiveStates:   []string{"Todo", "Rework"},
 		TerminalStates: []string{"Done", "Canceled"},
 	}, bed.gitea.baseURL, owner, repo)
 	client.HTTP = httpClientForE2E()

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -82,7 +82,7 @@ func TestGiteaWorkerReconciliationStopsRunMovedToDone(t *testing.T) {
 	cfg.Repo.DefaultBranch = "main"
 	cfg.Tracker.Kind = "gitea"
 	cfg.Tracker.APIKey = bed.gitea.botToken
-	cfg.Tracker.ActiveStates = []string{"AI Ready"}
+	cfg.Tracker.ActiveStates = []string{"Todo"}
 	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
 	client := gitea.NewTrackerClient(cfg.Tracker, bed.gitea.baseURL, owner, repo)
 	client.HTTP = httpClientForE2E()
@@ -112,8 +112,8 @@ func TestGiteaWorkerReconciliationStopsRunMovedToDone(t *testing.T) {
 	}
 	select {
 	case issue := <-dispatcher.started:
-		if issue.Identifier != fmt.Sprintf("#%d", issueNum) || issue.State != "AI Ready" {
-			t.Fatalf("started issue = %#v, want Gitea issue #%d in AI Ready", issue, issueNum)
+		if issue.Identifier != fmt.Sprintf("#%d", issueNum) || issue.State != "Todo" {
+			t.Fatalf("started issue = %#v, want Gitea issue #%d in Todo", issue, issueNum)
 		}
 	case <-ctx.Done():
 		t.Fatalf("worker did not start: %v", ctx.Err())
@@ -189,7 +189,7 @@ func runGiteaWorkerTask(t *testing.T, ctx context.Context, repo, title, body, fi
 	cfg.Repo.DefaultBranch = "main"
 	cfg.Tracker.Kind = "gitea"
 	cfg.Tracker.APIKey = bed.gitea.botToken
-	cfg.Tracker.ActiveStates = []string{"AI Ready"}
+	cfg.Tracker.ActiveStates = []string{"Todo"}
 	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
 	serviceWorkflow, err := workflow.Load(writeE2EServiceWorkflow(t, string(fixtureContent(t, fixture)), cloneURL))
 	if err != nil {


### PR DESCRIPTION
Closes #739

## Summary
- On Gitea trackers the SPEC §8.2 blocker rule ("If the issue state is `Todo`, do not dispatch when any blocker is non-terminal") was structurally dead: the Gitea adapter mapped its pre-dispatch label `aiops/todo` to the invented state name **"AI Ready"**, while the poller gate `todoIssueBlockedByOpenDependency` (`internal/orchestrator/poller.go:487`) keys on the literal `"Todo"` — a faithful port of upstream `elixir/lib/symphony_elixir/orchestrator.ex:864` (`todo_issue_blocked_by_non_terminal?`, which compares `normalize_issue_state(issue_state) == "todo"`). Field repro: v0.1.0 lifecycle test dispatched issue #10 (`Depends on #4`) while blocker #4 was non-terminal.
- Root-cause fix is producer-side, one line: `DefaultStateLabelMappings()` now maps `aiops/todo → "Todo"` (SPEC vocabulary, clean-code rule 4), with the constraint documented at the mapping. The gate is untouched — it already matches SPEC §8.2 and upstream. No new "adapter initial state" concept was added (upstream has no equivalent; principle 6).
- `buildBlockedBy` (§11.3) keeps its live consumer instead of being deleted; one source of truth restored across producer/consumer (cross-cutting checklist item 1).
- Atomic rename swept across tests, e2e fixtures, examples, README/runbook tables, per clean-code rule 3/10. Historical records (`DECISION.md` "Was" column, `docs/research/`, `docs/superpowers/plans/`, Trellis archives) intentionally untouched.
- Side benefit: Gitea now works under the SPEC §6.4 default `active_states: [Todo, In Progress]` without an operator override.
- New seam regression test `internal/orchestrator/poller_gitea_seam_test.go` pins the producer/consumer vocabulary: states derived from `gitea.DefaultStateLabelMappings()` are fed through `filterEligibleCandidates`, reproducing the field scenario (#10 blocked by #4). Mutation-verified: reverting the mapping to "AI Ready" fails this test and the gitea package tests.

## SPEC alignment (AGENTS.md principle 6/7)
- [ ] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [x] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

No new key/phase/gate is added; `internal/workflow/config.go` is touched only to update a stale comment that still named "AI Ready" as example vocabulary. The change itself is dictated by the upstream reference: `elixir/lib/symphony_elixir/orchestrator.ex:864` (`todo_issue_blocked_by_non_terminal?` keys on the literal normalized `"todo"` state), which is why the Gitea pre-dispatch state must be named `Todo`, and by SPEC §8.2 / §6.4 (default `active_states` `["Todo", "In Progress"]`).

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: `internal/gitea/label_state.go` (1 mapping line + why-comment) and `internal/workflow/config.go` (comment only). Everything else is tests, e2e fixtures, examples, and docs.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused`) on changed packages: 0 issues
- [x] additional validation noted below when needed

Additional validation:
- Mutation verification: with the mapping reverted to "AI Ready", `TestGiteaPreDispatchStateIsBlockerGated` fails (`want 0, got 1 dispatched`) and `internal/gitea` package tests fail; restored fix is green.
- `go vet -tags e2e ./test/e2e/...` compiles; the Docker-backed e2e suite is validated by the CI `e2e` job (mechanical state-string updates only).
- `go build ./cmd/worker ./cmd/tui` clean; `go mod tidy` no-op.

## Notes
**Pre-push dual review (protocol §3), head `eacf6d3`:**
- Claude family (`feature-dev:code-reviewer` on b7791fc, then hardened `claude -p` diff-only on eacf6d3): the one MEDIUM (README/local-dev Gitea label tables missing the live `Human Review` / `aiops/human-review` row) was validated and fixed in the amended head. Remaining finding is one LOW, recorded below.
- Codex family: the `codex:codex-rescue` subagent run died mid-flight (rollout stalled, process gone, no job record) — fell back per protocol to `codex exec --sandbox read-only --ephemeral --output-schema` with the diff on stdin; result `{"blocking_findings":[]}` on both b7791fc and the amended head eacf6d3.

**Recorded LOW (no change, rationale):**
- *Claude LOW:* deployments with a stale `active_states: ["AI Ready"]` override now silently match no Gitea label (zero dispatch) and there is no startup diagnostic for unmappable active states. Accepted: pre-release (no users to migrate; the only field deployment is our own lifecycle test), upstream/SPEC have no active_states validation equivalent (principle 6 — upstream absence is an over-design signal), and `go run ./cmd/worker --print-config` already surfaces the effective states for self-diagnosis.
- *Claude LOW (seam test breadth):* the seam test pins vocabulary with a single `Done` terminal state; gate interaction with the SPEC default 5-state terminal set is already covered by `TestPollOnceTreatsDefaultSpecTerminalBlockersAsUnblocked` and `TestPollOnceTodoBlockerHonorsOperatorConfiguredTerminalStates`.

**Acceptance vs issue #739 suggested direction:** SPEC §8.2 keys the rule on the literal `Todo` state name (not "not-yet-started" semantics) — confirmed against upstream; therefore the fix aligns the tracker adapter's pre-dispatch state name instead of changing the gate, and the `buildBlockedBy` producer stays (no dead path remains).