### PR TITLE
fix: post @codex review triggers with a workspace-bound identity

### DIFF
--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -121,8 +121,34 @@ Triage:
 
 Run it **on every pushed head**, not once per PR.
 
-1. `gh pr comment <pr> --body "@codex review"`; record that trigger
-   comment's id plus the head SHA, base SHA, and base branch at trigger time.
+1. Post the trigger with a workspace-bound identity, resolving the token
+   first so a missing token fails loud instead of silently falling back to the
+   default account:
+
+   ```bash
+   trigger_token="$(gh auth token --user bytevane)" \
+     && GH_TOKEN="$trigger_token" gh pr comment <pr> --body "@codex review"
+   ```
+
+   The `&&` chain is what makes it fail-closed in an interactive shell: `gh`
+   treats an empty `GH_TOKEN` as unset and silently falls back to the default
+   (deactivated-workspace) identity.
+
+   Record that trigger comment's id plus the head SHA, base SHA, and base
+   branch at trigger time. **The trigger comment's GitHub identity selects the
+   Codex workspace** — the bot resolves the ChatGPT workspace from whoever
+   posts the comment, not from the repo or the App installation. On this
+   machine only `bytevane` is bound to an active workspace; a trigger from
+   `xrf9268-hue` or `YYvanYang` fails with
+   `This workspace is deactivated. Select an active workspace and try again.`
+   (proven 2026-06-11 on bytevane/aiops-platform#17: the same head got two
+   deactivated errors and then a clean review, with the commenter as the only
+   variable). If that error appears, re-trigger as `bytevane` — do not fall
+   back, do not mirror the PR to a fork (earlier "fork doesn't bypass it"
+   evidence was confounded by always commenting as `xrf9268-hue`). Keep
+   `xrf9268-hue` as the active `gh` account; pass the bytevane token per
+   command via `GH_TOKEN`. `scripts/local-pr-follow-through.sh` applies the
+   same rule via `AIOPS_CODEX_TRIGGER_USER` (default `bytevane`).
 2. **Poll** its reactions summary —
    `gh api repos/<owner>/<repo>/issues/comments/<id> --jq '.reactions.eyes'`
    (the issue-comment object carries the `.reactions` counts; no separate

--- a/scripts/local-pr-follow-through.sh
+++ b/scripts/local-pr-follow-through.sh
@@ -429,6 +429,12 @@ gh_cmd() {
   "$timeout_bin" "$gh_timeout" gh "$@"
 }
 
+# Portable lowercasing: ${var,,} needs Bash 4+, but macOS /bin/bash is 3.2 and
+# this script only requires `env bash`.
+to_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 run_with_timeout() {
   local duration="$1"
   shift
@@ -460,7 +466,7 @@ if [[ -n "$codex_trigger_user" ]]; then
   # wrong-identity trigger fails only later as "workspace is deactivated",
   # so pin the token to the expected account up front.
   codex_trigger_login="$(GH_TOKEN="$codex_trigger_token" gh_cmd api user --jq '.login')"
-  if [[ "${codex_trigger_login,,}" != "${codex_trigger_user,,}" ]]; then
+  if [[ "$(to_lower "$codex_trigger_login")" != "$(to_lower "$codex_trigger_user")" ]]; then
     echo "gh token for AIOPS_CODEX_TRIGGER_USER=$codex_trigger_user authenticates as '$codex_trigger_login'; refresh it with 'gh auth login'" >&2
     exit 1
   fi
@@ -872,7 +878,7 @@ wait_for_github_codex_review() {
   # before the trigger-identity requirement) may be bound to a deactivated
   # Codex workspace, and waiting on it burns the full poll timeout. Like the
   # Python filter, an empty author (deleted user) is rejected, not skipped.
-  if [[ -n "$codex_trigger_user" && "${cached_user,,}" != "${codex_trigger_user,,}" ]]; then
+  if [[ -n "$codex_trigger_user" && "$(to_lower "$cached_user")" != "$(to_lower "$codex_trigger_user")" ]]; then
     cached_body=""
   fi
   if [[ -n "$trigger_id" && -n "$started_at" && "$cached_body" == *"$head_oid"* && "$cached_body" == *"$base_oid"* && "$cached_body" == *"$base_ref"* ]]; then

--- a/scripts/local-pr-follow-through.sh
+++ b/scripts/local-pr-follow-through.sh
@@ -442,6 +442,30 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
   export GITHUB_TOKEN
 fi
 
+# The @codex review bot resolves the ChatGPT workspace from the GitHub identity
+# that posts the trigger comment, not from the repo (protocol §4). The default
+# gh identity on this machine is bound to a deactivated workspace, so triggers
+# must be posted as AIOPS_CODEX_TRIGGER_USER (default bytevane). Set it to the
+# empty string to post with the default credentials instead. Fail loud when the
+# named account has no stored gh token: a wrong-identity trigger always fails
+# with "This workspace is deactivated" and the poll would burn its full timeout.
+codex_trigger_user="${AIOPS_CODEX_TRIGGER_USER-bytevane}"
+codex_trigger_token=""
+if [[ -n "$codex_trigger_user" ]]; then
+  if ! codex_trigger_token="$(gh_cmd auth token -h github.com --user "$codex_trigger_user")" || [[ -z "$codex_trigger_token" ]]; then
+    echo "cannot resolve a gh token for AIOPS_CODEX_TRIGGER_USER=$codex_trigger_user (gh error above); run 'gh auth login' for that account or set AIOPS_CODEX_TRIGGER_USER= to use default credentials" >&2
+    exit 1
+  fi
+  # A stale keyring entry can hold a token for a different login; a
+  # wrong-identity trigger fails only later as "workspace is deactivated",
+  # so pin the token to the expected account up front.
+  codex_trigger_login="$(GH_TOKEN="$codex_trigger_token" gh_cmd api user --jq '.login')"
+  if [[ "${codex_trigger_login,,}" != "${codex_trigger_user,,}" ]]; then
+    echo "gh token for AIOPS_CODEX_TRIGGER_USER=$codex_trigger_user authenticates as '$codex_trigger_login'; refresh it with 'gh auth login'" >&2
+    exit 1
+  fi
+fi
+
 acquire_follow_through_lock
 
 prepare_pr_worktree() {
@@ -790,7 +814,7 @@ find_existing_github_codex_review_trigger() {
   local head_commit_at comments_json
   head_commit_at="$(gh_cmd api "repos/${repo_owner}/${repo_name}/commits/${head_oid}" --jq '.commit.committer.date // .commit.author.date')"
   comments_json="$(gh_cmd api --paginate --slurp "repos/${repo_owner}/${repo_name}/issues/${pr}/comments?per_page=100")"
-  COMMENTS_JSON="$comments_json" python3 - "$head_commit_at" "$head_oid" "$base_oid" "$base_ref" <<'PY'
+  COMMENTS_JSON="$comments_json" TRIGGER_USER="$codex_trigger_user" python3 - "$head_commit_at" "$head_oid" "$base_oid" "$base_ref" <<'PY'
 import json
 import os
 import sys
@@ -805,6 +829,7 @@ if raw_comments and isinstance(raw_comments[0], list):
 else:
     comments = raw_comments
 matches = []
+trigger_user = os.environ.get("TRIGGER_USER") or ""
 for comment in comments:
     body = (comment.get("body") or "").strip()
     created_at = comment.get("created_at") or ""
@@ -813,6 +838,12 @@ for comment in comments:
     if head_oid not in body or base_oid not in body or base_ref not in body:
         continue
     if created_at < head_commit_at:
+        continue
+    # A trigger posted by a different identity may be bound to a deactivated
+    # Codex workspace; reusing it would wait on a review that never starts.
+    # GitHub logins are case-insensitive, so compare casefolded.
+    login = ((comment.get("user") or {}).get("login") or "").casefold()
+    if trigger_user and login != trigger_user.casefold():
         continue
     matches.append(comment)
 if not matches:
@@ -831,8 +862,18 @@ wait_for_github_codex_review() {
   state_file="$(github_codex_review_state_file "$pr" "$head_oid" "$base_oid" "$base_ref")"
   trigger_id="$(jq -r '.trigger_id // empty' "$state_file" 2>/dev/null || true)"
   started_at="$(jq -r '.started_at // empty' "$state_file" 2>/dev/null || true)"
+  local cached_user=""
   if [[ -n "$trigger_id" && -n "$started_at" ]] && cached_comment_json="$(gh_cmd api "repos/${repo_owner}/${repo_name}/issues/comments/${trigger_id}" 2>/dev/null)"; then
     cached_body="$(jq -r '.body // ""' <<<"$cached_comment_json")"
+    cached_user="$(jq -r '.user.login // ""' <<<"$cached_comment_json")"
+  fi
+  # The author check mirrors find_existing_github_codex_review_trigger: a
+  # cached trigger posted by a different identity (e.g. a state file written
+  # before the trigger-identity requirement) may be bound to a deactivated
+  # Codex workspace, and waiting on it burns the full poll timeout. Like the
+  # Python filter, an empty author (deleted user) is rejected, not skipped.
+  if [[ -n "$codex_trigger_user" && "${cached_user,,}" != "${codex_trigger_user,,}" ]]; then
+    cached_body=""
   fi
   if [[ -n "$trigger_id" && -n "$started_at" && "$cached_body" == *"$head_oid"* && "$cached_body" == *"$base_oid"* && "$cached_body" == *"$base_ref"* ]]; then
     audit_log "github_codex_review_reused" "pr=$pr head=$head_oid base=$base_oid base_ref=$base_ref trigger_id=$trigger_id state_file=$state_file"
@@ -853,7 +894,7 @@ wait_for_github_codex_review() {
     audit_log "github_codex_review_existing_trigger_found" "pr=$pr head=$head_oid base=$base_oid base_ref=$base_ref trigger_id=$trigger_id state_file=$state_file"
     echo "Using existing GitHub Codex review trigger for PR #$pr at $head_oid against $base_ref@$base_oid (comment $trigger_id)"
   else
-    trigger_json="$(gh_cmd api \
+    trigger_json="$(GH_TOKEN="${codex_trigger_token:-$GITHUB_TOKEN}" gh_cmd api \
       -X POST \
       "repos/${repo_owner}/${repo_name}/issues/${pr}/comments" \
       -f body="@codex review


### PR DESCRIPTION
Closes #746

## Summary
- The GitHub Codex bot resolves the ChatGPT workspace from the **GitHub identity that posts the `@codex review` trigger comment**, not from the repo or App installation. Proven 2026-06-11 on bytevane/aiops-platform#17: identical head, three triggers — `xrf9268-hue` and `YYvanYang` both got "This workspace is deactivated", `bytevane` reviewed clean. Earlier "fork mirror doesn't bypass deactivation" conclusions were confounded (every trigger had been posted as `xrf9268-hue`).
- `docs/runbooks/pr-review-merge-protocol.md` §4 now documents the trigger-identity requirement with a fail-closed two-step command (`&&`-chained so an empty token cannot silently fall back to the default identity).
- `scripts/local-pr-follow-through.sh` now posts triggers as `AIOPS_CODEX_TRIGGER_USER` (default `bytevane`): resolves the token fail-loud, verifies the token's actual login via `gh api user` (stale keyring entries surface immediately instead of as a later workspace error), and refuses to reuse trigger comments — cached state file or discovered on the PR — posted by a different or deleted identity, which would otherwise burn the full poll timeout waiting on a review that never starts. Comparisons are casefolded (GitHub logins are case-insensitive).
- `bytevane` was granted Write on this repo (2026-06-11), so triggers work directly on upstream PRs — no fork mirror needed. **This PR is itself the first live upstream validation of a bytevane-posted trigger.**

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Operator tooling + runbook only; no SPEC-sensitive path touched.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

2 files, +71/−4 (one runbook, one operator script).

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...` (no Go changes; gate unaffected)
- [x] `go test -race -covermode=atomic ./...` covered by CI (no Go production changes)
- [x] `gofmt -l` clean (no Go changes)
- [x] additional validation noted below when needed

Additional validation:
- `bash -n scripts/local-pr-follow-through.sh` clean; `go test ./scripts` (docs/skill consistency pins) green on every round.
- Empirical check that a bash env-prefix assignment on a shell function does **not** persist after the call (`V=1 f; echo ${V-unset}` → unset), so `GH_TOKEN=… gh_cmd …` cannot leak the trigger token into later gh calls; `gh_cmd` is a one-line timeout wrapper that does not touch auth.
- The `@codex review` run on this very PR validates the bytevane-trigger path on upstream.

## Notes
**Pre-push dual review (protocol §3), two rounds (63192b3 → c378748):**
- Round 1 — Codex CLI: cached-trigger reuse bypassed the author check (fixed: cached path now mirrors the Python filter, rejecting different/empty authors); runbook one-liner not fail-closed (fixed: `&&`-chained two-step). Claude: token-resolution error hidden by `2>/dev/null` + no token-ownership check (fixed: stderr surfaces, login pinned via `gh api user`); case-sensitive login compare (fixed: casefold both sides).
- Round 2 — both reviewers re-flagged the runbook snippet's fail-open assignment in interactive shells (fixed with the `&&` chain + rationale); Claude caught the cached path being fail-open for deleted-user (empty) authors where the Python path was fail-closed (fixed, paths now aligned).
- **Recorded, no change:** with the documented `AIOPS_CODEX_TRIGGER_USER=` (empty) override, trigger reuse accepts any author — that override is an explicit operator opt-out asserting the default identity's workspace works, under which a prior default-identity trigger is a valid trigger; filtering it would force duplicate trigger comments in the opt-out mode.
- **Refuted with evidence:** "GH_TOKEN prefix on a shell function may persist after the call" — empirically false on this bash (see Testing), and `gh_cmd` performs no auth handling.
- **Deferred (recorded):** no regression-test harness exists for the embedded Python filter / bash token-resolution paths in this operator script; the repo has no bash-script test infrastructure and the script fails loud at runtime. Will revisit if the script's logic keeps growing.