### PR TITLE
fix: revalidate dispatch candidates against tracker state before spawning

### DIFF
--- a/internal/orchestrator/actor_dispatch.go
+++ b/internal/orchestrator/actor_dispatch.go
@@ -248,6 +248,45 @@ func (d *dispatchClaimableIssueIDsOp) apply(st *OrchestratorState) func() {
 	return nil
 }
 
+// ReleaseMissingContinuation drops the queued continuation entry of an issue
+// the dispatch revalidation could not observe at all (missing from the narrow
+// refresh: deleted, or a Gitea issue whose aiops/* state labels were
+// stripped). Such an issue is invisible to every reconcile listing and
+// refresh — the no-information-on-absence invariant means nothing else ever
+// releases it, so without this the continuation would sit in
+// RetryAttempts/Claimed forever (#740 review). Release-only, mirroring
+// retryFireAfterFetchOp's absence branch (#341): absence is not a terminal
+// observation, so no workspace action is taken. Candidates whose refresh DID
+// return a row are not routed here — the reconcile pass observes the same
+// refreshed state on its own narrow refresh and owns that cleanup (including
+// terminal workspace removal).
+func (o *Orchestrator) ReleaseMissingContinuation(ctx context.Context, id IssueID, identifier string) error {
+	return o.submit(ctx, &releaseMissingContinuationOp{id: id, identifier: identifier})
+}
+
+type releaseMissingContinuationOp struct {
+	id         IssueID
+	identifier string
+}
+
+func (r *releaseMissingContinuationOp) apply(st *OrchestratorState) func() {
+	entry, allow := dispatchClaimGateAllows(st, r.id, time.Now())
+	if !allow || entry == nil {
+		// The claim state moved on since the revalidation read (entry consumed,
+		// replaced by another retry kind, or the issue was never claimed) —
+		// nothing of ours to release.
+		return nil
+	}
+	st.ReleaseClaim(r.id)
+	st.RecordEvent(RuntimeEvent{
+		Kind:       RuntimeEventFailed,
+		IssueID:    r.id,
+		Identifier: r.identifier,
+		Message:    "continuation released: issue missing from dispatch revalidation",
+	})
+	return nil
+}
+
 func cleanTurnBudgetForContinuationBudget(maxContinuationTurns, continuationTurnCount int) int {
 	remaining := maxContinuationTurns - continuationTurnCount
 	if remaining < 0 {

--- a/internal/orchestrator/actor_dispatch.go
+++ b/internal/orchestrator/actor_dispatch.go
@@ -183,17 +183,69 @@ func resolveDispatchClaim(st *OrchestratorState, id IssueID, trackerRechecked bo
 	if !trackerRechecked {
 		return nil, 0, 0, st.IsClaimed(id)
 	}
-	entry, ok := st.RetryAttempts[id]
-	if !ok {
-		return nil, 0, 0, st.IsClaimed(id)
-	}
-	if entry.Kind != RetryKindContinuation {
+	entry, allow := dispatchClaimGateAllows(st, id, time.Now())
+	if !allow {
 		return nil, 0, 0, true
 	}
-	if !entry.IsDue(time.Now()) {
-		return nil, 0, 0, true
+	if entry == nil {
+		return nil, 0, 0, false
 	}
 	return entry, entry.Attempt, entry.ContinuationTurnCount, false
+}
+
+// dispatchClaimGateAllows reports whether a tracker-rechecked dispatch for id
+// would pass the claim gate right now: the issue is entirely unclaimed
+// (entry nil), or its queued retry entry is a DUE continuation (entry
+// returned for the caller to consume). Shared by resolveDispatchClaim and
+// dispatchClaimableIssueIDsOp so the dispatch gate and the poller's
+// pre-dispatch revalidation subset cannot drift (#740).
+func dispatchClaimGateAllows(st *OrchestratorState, id IssueID, now time.Time) (entry *RetryEntry, allow bool) {
+	queued, ok := st.RetryAttempts[id]
+	if !ok {
+		return nil, !st.IsClaimed(id)
+	}
+	if queued.Kind != RetryKindContinuation || !queued.IsDue(now) {
+		return nil, false
+	}
+	return queued, true
+}
+
+// DispatchClaimableIssueIDs returns the subset of ids a tracker-rechecked
+// dispatch would currently pass the claim gate for. The poller uses it to
+// revalidate (and dispatch) only candidates that can actually spawn this
+// tick — the same trim upstream gets from should_dispatch_issue? running
+// before revalidate_issue_for_dispatch (orchestrator.ex:776-777, 909-910) —
+// instead of re-fetching tracker state for already-running issues every tick.
+// The dispatch op re-resolves the claim authoritatively, so a claim taken
+// between this read and the dispatch is still denied there.
+func (o *Orchestrator) DispatchClaimableIssueIDs(ctx context.Context, ids []IssueID) (map[IssueID]struct{}, error) {
+	reply := make(chan map[IssueID]struct{}, 1)
+	if err := o.submit(ctx, &dispatchClaimableIssueIDsOp{ids: ids, result: reply}); err != nil {
+		return nil, err
+	}
+	select {
+	case claimable := <-reply:
+		return claimable, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+type dispatchClaimableIssueIDsOp struct {
+	ids    []IssueID
+	result chan<- map[IssueID]struct{}
+}
+
+func (d *dispatchClaimableIssueIDsOp) apply(st *OrchestratorState) func() {
+	now := time.Now()
+	claimable := make(map[IssueID]struct{}, len(d.ids))
+	for _, id := range d.ids {
+		if _, allow := dispatchClaimGateAllows(st, id, now); allow {
+			claimable[id] = struct{}{}
+		}
+	}
+	d.result <- claimable
+	return nil
 }
 
 func cleanTurnBudgetForContinuationBudget(maxContinuationTurns, continuationTurnCount int) int {

--- a/internal/orchestrator/actor_dispatch.go
+++ b/internal/orchestrator/actor_dispatch.go
@@ -248,45 +248,6 @@ func (d *dispatchClaimableIssueIDsOp) apply(st *OrchestratorState) func() {
 	return nil
 }
 
-// ReleaseMissingContinuation drops the queued continuation entry of an issue
-// the dispatch revalidation could not observe at all (missing from the narrow
-// refresh: deleted, or a Gitea issue whose aiops/* state labels were
-// stripped). Such an issue is invisible to every reconcile listing and
-// refresh — the no-information-on-absence invariant means nothing else ever
-// releases it, so without this the continuation would sit in
-// RetryAttempts/Claimed forever (#740 review). Release-only, mirroring
-// retryFireAfterFetchOp's absence branch (#341): absence is not a terminal
-// observation, so no workspace action is taken. Candidates whose refresh DID
-// return a row are not routed here — the reconcile pass observes the same
-// refreshed state on its own narrow refresh and owns that cleanup (including
-// terminal workspace removal).
-func (o *Orchestrator) ReleaseMissingContinuation(ctx context.Context, id IssueID, identifier string) error {
-	return o.submit(ctx, &releaseMissingContinuationOp{id: id, identifier: identifier})
-}
-
-type releaseMissingContinuationOp struct {
-	id         IssueID
-	identifier string
-}
-
-func (r *releaseMissingContinuationOp) apply(st *OrchestratorState) func() {
-	entry, allow := dispatchClaimGateAllows(st, r.id, time.Now())
-	if !allow || entry == nil {
-		// The claim state moved on since the revalidation read (entry consumed,
-		// replaced by another retry kind, or the issue was never claimed) —
-		// nothing of ours to release.
-		return nil
-	}
-	st.ReleaseClaim(r.id)
-	st.RecordEvent(RuntimeEvent{
-		Kind:       RuntimeEventFailed,
-		IssueID:    r.id,
-		Identifier: r.identifier,
-		Message:    "continuation released: issue missing from dispatch revalidation",
-	})
-	return nil
-}
-
 func cleanTurnBudgetForContinuationBudget(maxContinuationTurns, continuationTurnCount int) int {
 	remaining := maxContinuationTurns - continuationTurnCount
 	if remaining < 0 {

--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -466,3 +466,46 @@ func refreshRunningIssue(run *RunningEntry, issue tracker.Issue) {
 	run.AgentCurrentIssueHandoff = false
 	clearAgentCurrentIssueTerminalHandoff(run)
 }
+
+// ReleaseVanishedContinuations drops queued continuation retries whose issue a
+// clean narrow refresh was asked about but did not return (deleted, or a Gitea
+// issue whose aiops/* state labels were stripped so no state can be derived).
+// Such an issue is invisible to every listing and refresh from then on — the
+// no-information-on-absence invariant keeps the reconcile cancel paths away
+// from it by design — so without this release the continuation sits in
+// RetryAttempts/Claimed forever and the issue wedges in retrying (#740
+// review). Release-only, mirroring retryFireAfterFetchOp's absence branch
+// (#341): absence is not a terminal observation, so no workspace action.
+// Failure/quota retries are deliberately not touched — their fire path runs
+// its own candidate fetch and releases on absence — and running/blocked
+// issues are not in RetryAttempts, so a vanished ref for them is a no-op
+// here; the destructive paths keep requiring positive observations.
+func (o *Orchestrator) ReleaseVanishedContinuations(ctx context.Context, refs []tracker.IssueRef) error {
+	return o.submit(ctx, &releaseVanishedContinuationsOp{refs: refs})
+}
+
+type releaseVanishedContinuationsOp struct {
+	refs []tracker.IssueRef
+}
+
+func (r *releaseVanishedContinuationsOp) apply(st *OrchestratorState) func() {
+	for _, ref := range r.refs {
+		id := IssueID(ref.ID)
+		entry, ok := st.RetryAttempts[id]
+		if !ok || entry.Kind != RetryKindContinuation {
+			continue
+		}
+		identifier := entry.Identifier
+		if identifier == "" {
+			identifier = ref.Identifier
+		}
+		st.ReleaseClaim(id)
+		st.RecordEvent(RuntimeEvent{
+			Kind:       RuntimeEventFailed,
+			IssueID:    id,
+			Identifier: identifier,
+			Message:    "continuation released: issue vanished from tracker refresh",
+		})
+	}
+	return nil
+}

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -363,7 +363,33 @@ func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID
 		issue.Labels = st.Labels
 		refreshed[id] = issue
 	}
+	if err == nil {
+		err = p.releaseVanishedContinuations(ctx, issueRefs, statesByID)
+	}
 	return refreshed, err
+}
+
+// releaseVanishedContinuations releases queued continuation entries whose
+// issue a CLEAN narrow refresh was asked about but did not return with a
+// usable state (deleted, or a Gitea issue whose aiops/* state labels were
+// stripped). Reconcile's cancel paths deliberately treat absence as
+// no-information, so without this sweep such a continuation wedges in
+// RetryAttempts/Claimed forever — the poll loop never lists the issue again
+// and nothing else releases it (#740 review). Gated on err == nil: with a
+// failed fetch a missing row is indistinguishable from tracker downtime.
+// Kind filtering (continuations only, release-only) happens actor-side in
+// ReleaseVanishedContinuations.
+func (p *Poller) releaseVanishedContinuations(ctx context.Context, queried []tracker.IssueRef, statesByID map[string]tracker.IssueState) error {
+	vanished := make([]tracker.IssueRef, 0, len(queried))
+	for _, ref := range queried {
+		if st, ok := statesByID[ref.ID]; !ok || strings.TrimSpace(st.State) == "" {
+			vanished = append(vanished, ref)
+		}
+	}
+	if len(vanished) == 0 {
+		return nil
+	}
+	return p.orchestrator.ReleaseVanishedContinuations(ctx, vanished)
 }
 
 func (p *Poller) reconcileInactiveStateGroups() [][]string {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sort"
 	"strings"
 	"time"
 
@@ -172,6 +171,10 @@ func (p *Poller) PollOnce(ctx context.Context) error { //nolint:gocognit // base
 	}
 	sortCandidates(candidates)
 	p.overflow = nil
+	candidates, revalidateErr := p.revalidateDispatchCandidates(ctx, candidates)
+	if revalidateErr != nil {
+		pollErr = errors.Join(pollErr, revalidateErr)
+	}
 	var dispatchErr error
 	for _, issue := range candidates {
 		if issue.ID == "" {
@@ -410,138 +413,6 @@ func issueMap(issues []tracker.Issue) map[string]tracker.Issue {
 	return out
 }
 
-func filterIssuesNotInMap(issues []tracker.Issue, excluded map[string]tracker.Issue) []tracker.Issue {
-	if len(excluded) == 0 {
-		return issues
-	}
-	out := make([]tracker.Issue, 0, len(issues))
-	for _, issue := range issues {
-		if _, ok := excluded[issue.ID]; ok {
-			continue
-		}
-		out = append(out, issue)
-	}
-	return out
-}
-
-func filterEligibleCandidates(issues []tracker.Issue, terminalStates, requiredLabels []string) []tracker.Issue {
-	// Honor exactly what the caller supplied per SPEC §5.3.1. Callers that
-	// want the SPEC 5-state default get it from workflow.DefaultConfig at
-	// construction time (NewPoller seeds it; workflow.Load supplies it for
-	// omitted YAML). An explicit empty slice from
-	// NewPollerWithReconciliation disables the blocker rule entirely, which
-	// is the operator's call.
-	terminal := normalizedStates(terminalStates)
-	out := make([]tracker.Issue, 0, len(issues))
-	for _, issue := range issues {
-		if !issueHasRequiredCandidateFields(issue) {
-			continue
-		}
-		if todoIssueBlockedByOpenDependency(issue, terminal) {
-			continue
-		}
-		if !issueHasRequiredLabels(issue, requiredLabels) {
-			continue
-		}
-		out = append(out, issue)
-	}
-	return out
-}
-
-// issueHasRequiredLabels reports whether issue carries every label in required
-// (SPEC §4.1.1 / §6.4). See labelsSatisfyRequired for the matching semantics.
-func issueHasRequiredLabels(issue tracker.Issue, required []string) bool {
-	return labelsSatisfyRequired(issue.Labels, required)
-}
-
-// labelsSatisfyRequired reports whether labels contains every entry in required
-// (SPEC §4.1.1 / §6.4). Both sides are trimmed and lowercased so matching is
-// case-insensitive regardless of tracker label casing. Empty required disables
-// the gate (returns true); a blank required entry ("") can never match a
-// tracker's non-empty labels, so it blocks every issue as SPEC mandates. Shared
-// by the dispatch/reconcile predicate and the §16.5 per-turn continue gate so
-// they cannot diverge.
-func labelsSatisfyRequired(labels, required []string) bool {
-	if len(required) == 0 {
-		return true
-	}
-	have := make(map[string]struct{}, len(labels))
-	for _, label := range labels {
-		have[strings.ToLower(strings.TrimSpace(label))] = struct{}{}
-	}
-	for _, label := range required {
-		if _, ok := have[strings.ToLower(strings.TrimSpace(label))]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-func issueHasRequiredCandidateFields(issue tracker.Issue) bool {
-	return strings.TrimSpace(issue.ID) != "" &&
-		strings.TrimSpace(issue.Identifier) != "" &&
-		strings.TrimSpace(issue.Title) != "" &&
-		strings.TrimSpace(issue.State) != ""
-}
-
-func todoIssueBlockedByOpenDependency(issue tracker.Issue, terminalStates map[string]struct{}) bool {
-	if !strings.EqualFold(strings.TrimSpace(issue.State), "Todo") {
-		return false
-	}
-	for _, blocker := range issue.BlockedBy {
-		state := strings.ToLower(strings.TrimSpace(blocker.State))
-		if state == "" {
-			return true
-		}
-		if _, terminal := terminalStates[state]; !terminal {
-			return true
-		}
-	}
-	return false
-}
-
-func sortCandidates(issues []tracker.Issue) {
-	sort.SliceStable(issues, func(i, j int) bool {
-		left, right := issues[i], issues[j]
-		leftPriority := linearPrioritySortKey(left.Priority)
-		rightPriority := linearPrioritySortKey(right.Priority)
-		if leftPriority != rightPriority {
-			return leftPriority < rightPriority
-		}
-		if compareCreatedAt(left.CreatedAt, right.CreatedAt) < 0 {
-			return true
-		}
-		if compareCreatedAt(left.CreatedAt, right.CreatedAt) > 0 {
-			return false
-		}
-		return left.Identifier < right.Identifier
-	})
-}
-
-func compareCreatedAt(left, right time.Time) int {
-	switch {
-	case left.IsZero() && right.IsZero():
-		return 0
-	case left.IsZero():
-		return 1
-	case right.IsZero():
-		return -1
-	case left.Before(right):
-		return -1
-	case left.After(right):
-		return 1
-	default:
-		return 0
-	}
-}
-
-func linearPrioritySortKey(priority int) int {
-	if priority == 0 {
-		return 1 << 30
-	}
-	return priority
-}
-
 func normalizedStates(states []string) map[string]struct{} {
 	out := make(map[string]struct{}, len(states))
 	for _, state := range states {
@@ -551,36 +422,6 @@ func normalizedStates(states []string) map[string]struct{} {
 		}
 	}
 	return out
-}
-
-func mergeOverflowCandidates(overflow, fresh []tracker.Issue) []tracker.Issue {
-	if len(overflow) == 0 {
-		return fresh
-	}
-	candidates := make([]tracker.Issue, 0, len(overflow)+len(fresh))
-	freshByID := make(map[string]tracker.Issue, len(fresh))
-	seen := make(map[string]struct{}, len(overflow)+len(fresh))
-	for _, issue := range fresh {
-		if issue.ID == "" {
-			continue
-		}
-		freshByID[issue.ID] = issue
-	}
-	for _, issue := range overflow {
-		freshIssue, ok := freshByID[issue.ID]
-		if !ok {
-			continue
-		}
-		seen[issue.ID] = struct{}{}
-		candidates = append(candidates, freshIssue)
-	}
-	for _, issue := range fresh {
-		if _, ok := seen[issue.ID]; ok {
-			continue
-		}
-		candidates = append(candidates, issue)
-	}
-	return candidates
 }
 
 // TaskBuilder converts a tracker candidate into the task shape consumed by the

--- a/internal/orchestrator/poller_candidates.go
+++ b/internal/orchestrator/poller_candidates.go
@@ -1,0 +1,298 @@
+package orchestrator
+
+// poller_candidates.go holds the poll tick's candidate-selection pipeline:
+// eligibility filtering, ordering, overflow carry-over, and the pre-dispatch
+// tracker revalidation that keeps a long tick from dispatching stale
+// candidates (#740). PollOnce itself lives in poller.go.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// dispatchRevalidationTimeout caps the pre-dispatch candidate revalidation
+// fetch. PollOnce's ctx carries no deadline of its own, so an unresponsive
+// tracker would otherwise pin the poll loop inside the revalidation call
+// indefinitely.
+var dispatchRevalidationTimeout = 45 * time.Second
+
+// revalidateDispatchCandidates refreshes the tracker state of every candidate
+// the dispatch loop could actually spawn this tick and drops candidates that
+// are no longer dispatchable, porting upstream revalidate_issue_for_dispatch
+// (orchestrator.ex:909-924, 995-1013). The candidate listing is read at tick
+// start, and the reconcile pass between that read and the dispatch loop can
+// block on worker-exit waits long enough for the listing to go stale — a
+// freed slot then burns a full agent run on an ineligible issue until the
+// next reconcile pass corrects it (#740).
+//
+// Candidates the claim gate would deny anyway (running, blocked, queued
+// failure retries, not-yet-due continuations) are dropped without a refresh —
+// the same trim upstream gets from should_dispatch_issue? running before
+// revalidate_issue_for_dispatch — so the refresh cost stays proportional to
+// what can spawn, not to the active listing. A refreshed candidate is dropped
+// when the refresh omits it (upstream {:skip, :missing}; the Gitea adapter
+// also omits issues whose aiops/* state labels were stripped), when its
+// refreshed state left the configured active set, or when its refreshed
+// labels no longer satisfy the SPEC §6.4 required-labels gate — the same
+// gates the retry-fire path re-applies at fire time via
+// eligibleActiveIssueLister. Refreshed BlockedBy data is not available from
+// the narrow refresh, so the Todo-blocker gate keeps its listing-time result.
+// Survivors carry the refreshed state and labels so the per-state capacity
+// gate and the spawned worker see live tracker data, mirroring upstream's
+// dispatch of the refreshed issue. On fetch failure the candidates the
+// refresh did return still dispatch and the rest are skipped (upstream skips
+// dispatch on refresh error); the next tick retries from a fresh listing.
+// Pollers without a narrow-refresh state tracker skip revalidation.
+func (p *Poller) revalidateDispatchCandidates(ctx context.Context, candidates []tracker.Issue) ([]tracker.Issue, error) {
+	refresher, ok := p.stateTracker.(IssueStateRefresher)
+	if !ok || len(candidates) == 0 {
+		return candidates, nil
+	}
+	claimable, refs, err := p.claimableDispatchRefs(ctx, candidates)
+	if err != nil {
+		return nil, err
+	}
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	fetchCtx, cancel := context.WithTimeout(ctx, dispatchRevalidationTimeout)
+	defer cancel()
+	statesByID, fetchErr := fetchIssueStates(fetchCtx, refresher, refs)
+	if fetchErr != nil {
+		fetchErr = fmt.Errorf("revalidate dispatch candidates: %w", fetchErr)
+	}
+	return p.filterRevalidatedCandidates(candidates, claimable, statesByID), fetchErr
+}
+
+// claimableDispatchRefs asks the orchestrator which candidates the dispatch
+// claim gate would currently allow and returns the narrow-refresh refs for
+// exactly that subset.
+func (p *Poller) claimableDispatchRefs(ctx context.Context, candidates []tracker.Issue) (map[IssueID]struct{}, []tracker.IssueRef, error) {
+	ids := make([]IssueID, 0, len(candidates))
+	for _, issue := range candidates {
+		ids = append(ids, IssueID(issue.ID))
+	}
+	claimable, err := p.orchestrator.DispatchClaimableIssueIDs(ctx, ids)
+	if err != nil {
+		return nil, nil, fmt.Errorf("revalidate dispatch candidates: %w", err)
+	}
+	refs := make([]tracker.IssueRef, 0, len(claimable))
+	for _, issue := range candidates {
+		if _, ok := claimable[IssueID(issue.ID)]; ok {
+			refs = append(refs, tracker.IssueRef{ID: issue.ID, Identifier: issue.Identifier})
+		}
+	}
+	return claimable, refs, nil
+}
+
+// filterRevalidatedCandidates keeps the claimable candidates whose refreshed
+// tracker row still passes the dispatch gates, carrying the refreshed state
+// and labels onto each survivor.
+func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimable map[IssueID]struct{}, statesByID map[string]tracker.IssueState) []tracker.Issue {
+	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
+	out := make([]tracker.Issue, 0, len(claimable))
+	for _, issue := range candidates {
+		if _, ok := claimable[IssueID(issue.ID)]; !ok {
+			continue
+		}
+		if revalidated, keep := revalidatedCandidate(issue, statesByID, activeStateKeys, p.reconcile.RequiredLabels); keep {
+			out = append(out, revalidated)
+		}
+	}
+	return out
+}
+
+// revalidatedCandidate applies the per-issue revalidation verdict: missing
+// from the refresh (upstream {:skip, :missing}), refreshed out of the active
+// set, or refreshed past the SPEC §6.4 required-labels gate all drop the
+// candidate; otherwise the refreshed state and labels are carried onto it.
+func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.IssueState, activeStateKeys map[string]struct{}, requiredLabels []string) (tracker.Issue, bool) {
+	refreshed, ok := statesByID[issue.ID]
+	if !ok || strings.TrimSpace(refreshed.State) == "" {
+		logStaleDispatchSkipped(issue, "", "missing_from_refresh")
+		return tracker.Issue{}, false
+	}
+	issue.State = refreshed.State
+	issue.Labels = refreshed.Labels
+	if !isActiveTrackerState(issue.State, activeStateKeys) {
+		logStaleDispatchSkipped(issue, issue.State, "state_left_active_set")
+		return tracker.Issue{}, false
+	}
+	if !issueHasRequiredLabels(issue, requiredLabels) {
+		logStaleDispatchSkipped(issue, issue.State, "required_labels_missing")
+		return tracker.Issue{}, false
+	}
+	return issue, true
+}
+
+func logStaleDispatchSkipped(issue tracker.Issue, state, reason string) {
+	log.Printf("event=stale_dispatch_skipped issue=%q state=%q reason=%s", issue.Identifier, state, reason)
+}
+
+func filterIssuesNotInMap(issues []tracker.Issue, excluded map[string]tracker.Issue) []tracker.Issue {
+	if len(excluded) == 0 {
+		return issues
+	}
+	out := make([]tracker.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if _, ok := excluded[issue.ID]; ok {
+			continue
+		}
+		out = append(out, issue)
+	}
+	return out
+}
+
+func filterEligibleCandidates(issues []tracker.Issue, terminalStates, requiredLabels []string) []tracker.Issue {
+	// Honor exactly what the caller supplied per SPEC §5.3.1. Callers that
+	// want the SPEC 5-state default get it from workflow.DefaultConfig at
+	// construction time (NewPoller seeds it; workflow.Load supplies it for
+	// omitted YAML). An explicit empty slice from
+	// NewPollerWithReconciliation disables the blocker rule entirely, which
+	// is the operator's call.
+	terminal := normalizedStates(terminalStates)
+	out := make([]tracker.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if !issueHasRequiredCandidateFields(issue) {
+			continue
+		}
+		if todoIssueBlockedByOpenDependency(issue, terminal) {
+			continue
+		}
+		if !issueHasRequiredLabels(issue, requiredLabels) {
+			continue
+		}
+		out = append(out, issue)
+	}
+	return out
+}
+
+// issueHasRequiredLabels reports whether issue carries every label in required
+// (SPEC §4.1.1 / §6.4). See labelsSatisfyRequired for the matching semantics.
+func issueHasRequiredLabels(issue tracker.Issue, required []string) bool {
+	return labelsSatisfyRequired(issue.Labels, required)
+}
+
+// labelsSatisfyRequired reports whether labels contains every entry in required
+// (SPEC §4.1.1 / §6.4). Both sides are trimmed and lowercased so matching is
+// case-insensitive regardless of tracker label casing. Empty required disables
+// the gate (returns true); a blank required entry ("") can never match a
+// tracker's non-empty labels, so it blocks every issue as SPEC mandates. Shared
+// by the dispatch/reconcile predicate and the §16.5 per-turn continue gate so
+// they cannot diverge.
+func labelsSatisfyRequired(labels, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	have := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		have[strings.ToLower(strings.TrimSpace(label))] = struct{}{}
+	}
+	for _, label := range required {
+		if _, ok := have[strings.ToLower(strings.TrimSpace(label))]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func issueHasRequiredCandidateFields(issue tracker.Issue) bool {
+	return strings.TrimSpace(issue.ID) != "" &&
+		strings.TrimSpace(issue.Identifier) != "" &&
+		strings.TrimSpace(issue.Title) != "" &&
+		strings.TrimSpace(issue.State) != ""
+}
+
+func todoIssueBlockedByOpenDependency(issue tracker.Issue, terminalStates map[string]struct{}) bool {
+	if !strings.EqualFold(strings.TrimSpace(issue.State), "Todo") {
+		return false
+	}
+	for _, blocker := range issue.BlockedBy {
+		state := strings.ToLower(strings.TrimSpace(blocker.State))
+		if state == "" {
+			return true
+		}
+		if _, terminal := terminalStates[state]; !terminal {
+			return true
+		}
+	}
+	return false
+}
+
+func sortCandidates(issues []tracker.Issue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		left, right := issues[i], issues[j]
+		leftPriority := linearPrioritySortKey(left.Priority)
+		rightPriority := linearPrioritySortKey(right.Priority)
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+		if compareCreatedAt(left.CreatedAt, right.CreatedAt) < 0 {
+			return true
+		}
+		if compareCreatedAt(left.CreatedAt, right.CreatedAt) > 0 {
+			return false
+		}
+		return left.Identifier < right.Identifier
+	})
+}
+
+func compareCreatedAt(left, right time.Time) int {
+	switch {
+	case left.IsZero() && right.IsZero():
+		return 0
+	case left.IsZero():
+		return 1
+	case right.IsZero():
+		return -1
+	case left.Before(right):
+		return -1
+	case left.After(right):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func linearPrioritySortKey(priority int) int {
+	if priority == 0 {
+		return 1 << 30
+	}
+	return priority
+}
+
+func mergeOverflowCandidates(overflow, fresh []tracker.Issue) []tracker.Issue {
+	if len(overflow) == 0 {
+		return fresh
+	}
+	candidates := make([]tracker.Issue, 0, len(overflow)+len(fresh))
+	freshByID := make(map[string]tracker.Issue, len(fresh))
+	seen := make(map[string]struct{}, len(overflow)+len(fresh))
+	for _, issue := range fresh {
+		if issue.ID == "" {
+			continue
+		}
+		freshByID[issue.ID] = issue
+	}
+	for _, issue := range overflow {
+		freshIssue, ok := freshByID[issue.ID]
+		if !ok {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		candidates = append(candidates, freshIssue)
+	}
+	for _, issue := range fresh {
+		if _, ok := seen[issue.ID]; ok {
+			continue
+		}
+		candidates = append(candidates, issue)
+	}
+	return candidates
+}

--- a/internal/orchestrator/poller_candidates.go
+++ b/internal/orchestrator/poller_candidates.go
@@ -7,7 +7,6 @@ package orchestrator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -68,30 +67,7 @@ func (p *Poller) revalidateDispatchCandidates(ctx context.Context, candidates []
 	if fetchErr != nil {
 		fetchErr = fmt.Errorf("revalidate dispatch candidates: %w", fetchErr)
 	}
-	kept, missing := p.filterRevalidatedCandidates(candidates, claimable, statesByID)
-	// Release queued continuations only on a clean fetch: with fetchErr set, a
-	// row may be missing because the fetch failed, not because the issue is
-	// gone (upstream {:error} leaves state untouched). Candidates dropped with
-	// a PRESENT-but-ineligible row are deliberately not released — the
-	// reconcile pass observes the same refreshed state on its own narrow
-	// refresh of retrying refs and owns that cleanup, including terminal
-	// workspace removal. A missing row is the one observation reconcile can
-	// never act on (absence is "no information" there), so the wedged
-	// continuation is released here (#740 review).
-	if fetchErr == nil {
-		fetchErr = p.releaseMissingContinuations(ctx, missing)
-	}
-	return kept, fetchErr
-}
-
-func (p *Poller) releaseMissingContinuations(ctx context.Context, missing []tracker.Issue) error {
-	var err error
-	for _, issue := range missing {
-		if releaseErr := p.orchestrator.ReleaseMissingContinuation(ctx, IssueID(issue.ID), issue.Identifier); releaseErr != nil {
-			err = errors.Join(err, fmt.Errorf("release missing continuation %s: %w", issue.ID, releaseErr))
-		}
-	}
-	return err
+	return p.filterRevalidatedCandidates(candidates, claimable, statesByID), fetchErr
 }
 
 // claimableDispatchRefs asks the orchestrator which candidates the dispatch
@@ -115,62 +91,48 @@ func (p *Poller) claimableDispatchRefs(ctx context.Context, candidates []tracker
 	return claimable, refs, nil
 }
 
-// revalidationVerdict classifies one candidate's revalidation outcome. The
-// missing case is split out because the caller routes it to a continuation
-// release (a missing issue is invisible to the reconcile pass), while
-// present-but-ineligible drops are left to reconcile's own narrow refresh.
-type revalidationVerdict int
-
-const (
-	revalidationKeep revalidationVerdict = iota
-	revalidationStale
-	revalidationMissing
-)
-
 // filterRevalidatedCandidates keeps the claimable candidates whose refreshed
 // tracker row still passes the dispatch gates, carrying the refreshed state
-// and labels onto each survivor. Candidates whose refresh row is missing
-// entirely are returned separately for the continuation-release pass.
-func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimable map[IssueID]struct{}, statesByID map[string]tracker.IssueState) (kept, missing []tracker.Issue) {
+// and labels onto each survivor. Dropping is skip-only: a dropped candidate's
+// queued continuation (if any) is released by the reconcile pass's
+// vanished-continuation sweep when the row is missing, or by the inactive
+// reconcile when the row is present but ineligible — never here, so the
+// release stays single-sourced.
+func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimable map[IssueID]struct{}, statesByID map[string]tracker.IssueState) []tracker.Issue {
 	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
-	kept = make([]tracker.Issue, 0, len(claimable))
+	kept := make([]tracker.Issue, 0, len(claimable))
 	for _, issue := range candidates {
 		if _, ok := claimable[IssueID(issue.ID)]; !ok {
 			continue
 		}
-		revalidated, verdict := revalidatedCandidate(issue, statesByID, activeStateKeys, p.reconcile.RequiredLabels)
-		switch verdict {
-		case revalidationKeep:
+		if revalidated, keep := revalidatedCandidate(issue, statesByID, activeStateKeys, p.reconcile.RequiredLabels); keep {
 			kept = append(kept, revalidated)
-		case revalidationMissing:
-			missing = append(missing, issue)
-		case revalidationStale:
 		}
 	}
-	return kept, missing
+	return kept
 }
 
 // revalidatedCandidate applies the per-issue revalidation verdict: missing
 // from the refresh (upstream {:skip, :missing}), refreshed out of the active
 // set, or refreshed past the SPEC §6.4 required-labels gate all drop the
 // candidate; otherwise the refreshed state and labels are carried onto it.
-func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.IssueState, activeStateKeys map[string]struct{}, requiredLabels []string) (tracker.Issue, revalidationVerdict) {
+func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.IssueState, activeStateKeys map[string]struct{}, requiredLabels []string) (tracker.Issue, bool) {
 	refreshed, ok := statesByID[issue.ID]
 	if !ok || strings.TrimSpace(refreshed.State) == "" {
 		logStaleDispatchSkipped(issue, "", "missing_from_refresh")
-		return tracker.Issue{}, revalidationMissing
+		return tracker.Issue{}, false
 	}
 	issue.State = refreshed.State
 	issue.Labels = refreshed.Labels
 	if !isActiveTrackerState(issue.State, activeStateKeys) {
 		logStaleDispatchSkipped(issue, issue.State, "state_left_active_set")
-		return tracker.Issue{}, revalidationStale
+		return tracker.Issue{}, false
 	}
 	if !issueHasRequiredLabels(issue, requiredLabels) {
 		logStaleDispatchSkipped(issue, issue.State, "required_labels_missing")
-		return tracker.Issue{}, revalidationStale
+		return tracker.Issue{}, false
 	}
-	return issue, revalidationKeep
+	return issue, true
 }
 
 func logStaleDispatchSkipped(issue tracker.Issue, state, reason string) {

--- a/internal/orchestrator/poller_candidates.go
+++ b/internal/orchestrator/poller_candidates.go
@@ -7,6 +7,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -67,7 +68,30 @@ func (p *Poller) revalidateDispatchCandidates(ctx context.Context, candidates []
 	if fetchErr != nil {
 		fetchErr = fmt.Errorf("revalidate dispatch candidates: %w", fetchErr)
 	}
-	return p.filterRevalidatedCandidates(candidates, claimable, statesByID), fetchErr
+	kept, missing := p.filterRevalidatedCandidates(candidates, claimable, statesByID)
+	// Release queued continuations only on a clean fetch: with fetchErr set, a
+	// row may be missing because the fetch failed, not because the issue is
+	// gone (upstream {:error} leaves state untouched). Candidates dropped with
+	// a PRESENT-but-ineligible row are deliberately not released — the
+	// reconcile pass observes the same refreshed state on its own narrow
+	// refresh of retrying refs and owns that cleanup, including terminal
+	// workspace removal. A missing row is the one observation reconcile can
+	// never act on (absence is "no information" there), so the wedged
+	// continuation is released here (#740 review).
+	if fetchErr == nil {
+		fetchErr = p.releaseMissingContinuations(ctx, missing)
+	}
+	return kept, fetchErr
+}
+
+func (p *Poller) releaseMissingContinuations(ctx context.Context, missing []tracker.Issue) error {
+	var err error
+	for _, issue := range missing {
+		if releaseErr := p.orchestrator.ReleaseMissingContinuation(ctx, IssueID(issue.ID), issue.Identifier); releaseErr != nil {
+			err = errors.Join(err, fmt.Errorf("release missing continuation %s: %w", issue.ID, releaseErr))
+		}
+	}
+	return err
 }
 
 // claimableDispatchRefs asks the orchestrator which candidates the dispatch
@@ -91,44 +115,62 @@ func (p *Poller) claimableDispatchRefs(ctx context.Context, candidates []tracker
 	return claimable, refs, nil
 }
 
+// revalidationVerdict classifies one candidate's revalidation outcome. The
+// missing case is split out because the caller routes it to a continuation
+// release (a missing issue is invisible to the reconcile pass), while
+// present-but-ineligible drops are left to reconcile's own narrow refresh.
+type revalidationVerdict int
+
+const (
+	revalidationKeep revalidationVerdict = iota
+	revalidationStale
+	revalidationMissing
+)
+
 // filterRevalidatedCandidates keeps the claimable candidates whose refreshed
 // tracker row still passes the dispatch gates, carrying the refreshed state
-// and labels onto each survivor.
-func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimable map[IssueID]struct{}, statesByID map[string]tracker.IssueState) []tracker.Issue {
+// and labels onto each survivor. Candidates whose refresh row is missing
+// entirely are returned separately for the continuation-release pass.
+func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimable map[IssueID]struct{}, statesByID map[string]tracker.IssueState) (kept, missing []tracker.Issue) {
 	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
-	out := make([]tracker.Issue, 0, len(claimable))
+	kept = make([]tracker.Issue, 0, len(claimable))
 	for _, issue := range candidates {
 		if _, ok := claimable[IssueID(issue.ID)]; !ok {
 			continue
 		}
-		if revalidated, keep := revalidatedCandidate(issue, statesByID, activeStateKeys, p.reconcile.RequiredLabels); keep {
-			out = append(out, revalidated)
+		revalidated, verdict := revalidatedCandidate(issue, statesByID, activeStateKeys, p.reconcile.RequiredLabels)
+		switch verdict {
+		case revalidationKeep:
+			kept = append(kept, revalidated)
+		case revalidationMissing:
+			missing = append(missing, issue)
+		case revalidationStale:
 		}
 	}
-	return out
+	return kept, missing
 }
 
 // revalidatedCandidate applies the per-issue revalidation verdict: missing
 // from the refresh (upstream {:skip, :missing}), refreshed out of the active
 // set, or refreshed past the SPEC §6.4 required-labels gate all drop the
 // candidate; otherwise the refreshed state and labels are carried onto it.
-func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.IssueState, activeStateKeys map[string]struct{}, requiredLabels []string) (tracker.Issue, bool) {
+func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.IssueState, activeStateKeys map[string]struct{}, requiredLabels []string) (tracker.Issue, revalidationVerdict) {
 	refreshed, ok := statesByID[issue.ID]
 	if !ok || strings.TrimSpace(refreshed.State) == "" {
 		logStaleDispatchSkipped(issue, "", "missing_from_refresh")
-		return tracker.Issue{}, false
+		return tracker.Issue{}, revalidationMissing
 	}
 	issue.State = refreshed.State
 	issue.Labels = refreshed.Labels
 	if !isActiveTrackerState(issue.State, activeStateKeys) {
 		logStaleDispatchSkipped(issue, issue.State, "state_left_active_set")
-		return tracker.Issue{}, false
+		return tracker.Issue{}, revalidationStale
 	}
 	if !issueHasRequiredLabels(issue, requiredLabels) {
 		logStaleDispatchSkipped(issue, issue.State, "required_labels_missing")
-		return tracker.Issue{}, false
+		return tracker.Issue{}, revalidationStale
 	}
-	return issue, true
+	return issue, revalidationKeep
 }
 
 func logStaleDispatchSkipped(issue tracker.Issue, state, reason string) {

--- a/internal/orchestrator/poller_candidates_test.go
+++ b/internal/orchestrator/poller_candidates_test.go
@@ -110,6 +110,101 @@ func TestPollOnceSkipsDispatchWhenRevalidationDropsRequiredLabels(t *testing.T) 
 	}
 }
 
+// seedDueContinuation installs a due continuation retry entry (with its claim)
+// through the actor, the state a clean worker exit leaves behind while the
+// next dispatch is pending.
+func seedDueContinuation(t *testing.T, ctx context.Context, poller *Poller, issue tracker.Issue) {
+	t.Helper()
+	id := IssueID(issue.ID)
+	done := make(chan struct{})
+	if err := poller.orchestrator.submit(ctx, opFunc(func(st *OrchestratorState) func() {
+		st.Claimed[id] = struct{}{}
+		st.ClaimedIssues[id] = issue
+		st.RetryAttempts[id] = &RetryEntry{
+			IssueID:               id,
+			Identifier:            issue.Identifier,
+			Kind:                  RetryKindContinuation,
+			Attempt:               1,
+			DueAt:                 time.Now().Add(-time.Minute),
+			ContinuationTurnCount: 2,
+		}
+		close(done)
+		return nil
+	})); err != nil {
+		t.Fatalf("seed continuation: %v", err)
+	}
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("seed continuation: %v", ctx.Err())
+	}
+}
+
+// continuationClaimState reads whether the issue still holds a retry entry and
+// a claim, serialized through the actor.
+func continuationClaimState(t *testing.T, ctx context.Context, poller *Poller, id IssueID) (retained, claimed bool) {
+	t.Helper()
+	done := make(chan struct{})
+	if err := poller.orchestrator.submit(ctx, opFunc(func(st *OrchestratorState) func() {
+		_, retained = st.RetryAttempts[id]
+		_, claimed = st.Claimed[id]
+		close(done)
+		return nil
+	})); err != nil {
+		t.Fatalf("read claim state: %v", err)
+	}
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("read claim state: %v", ctx.Err())
+	}
+	return retained, claimed
+}
+
+func TestPollOnceReleasesDueContinuationWhenRevalidationOmitsIssue(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
+
+	// The refresh omits the issue entirely (deleted / Gitea aiops/* labels
+	// stripped). Reconcile treats absence as no-information forever, so the
+	// revalidation pass must release the queued continuation or the issue
+	// wedges in retrying (#740 review P2).
+	trackerClient.setFetchIDStates(map[string]string{})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0", got, dispatcher.issueIDs())
+	}
+	retained, claimed := continuationClaimState(t, ctx, poller, "issue-1")
+	if retained || claimed {
+		t.Fatalf("continuation after missing revalidation: retained=%v claimed=%v; want released", retained, claimed)
+	}
+}
+
+func TestPollOnceRetainsDueContinuationWhenRevalidationFetchFails(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
+
+	// With the fetch failing, a missing row is indistinguishable from tracker
+	// downtime — the continuation must survive (upstream {:error} leaves state
+	// untouched).
+	trackerClient.setFetchIDStates(map[string]string{})
+	trackerClient.setFetchIDErr(errors.New("tracker briefly down"))
+	if err := poller.PollOnce(ctx); err == nil || !strings.Contains(err.Error(), "revalidate dispatch candidates") {
+		t.Fatalf("PollOnce() = %v; want wrapped revalidation fetch error", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0", got, dispatcher.issueIDs())
+	}
+	retained, claimed := continuationClaimState(t, ctx, poller, "issue-1")
+	if !retained || !claimed {
+		t.Fatalf("continuation after failed revalidation fetch: retained=%v claimed=%v; want retained", retained, claimed)
+	}
+}
+
 func TestPollOncePartialRevalidationErrorStillDispatchesFreshCandidates(t *testing.T) {
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{
 		{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"},

--- a/internal/orchestrator/poller_candidates_test.go
+++ b/internal/orchestrator/poller_candidates_test.go
@@ -1,0 +1,131 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+)
+
+// startRevalidationHarness builds the PollOnce fixture the #740 dispatch
+// revalidation tests share: a reconciling poller over a narrow-refresh-capable
+// tracker fake and a recording dispatcher, with the orchestrator actor running.
+func startRevalidationHarness(t *testing.T, trackerClient *fakeIssueStateTracker, cfg ReconciliationConfig) (*Poller, *recordingDispatcher, context.Context) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	dispatcher := &recordingDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+	return NewPollerWithReconciliation(trackerClient, orch, cfg), dispatcher, ctx
+}
+
+func revalidationReconcileConfig() ReconciliationConfig {
+	return ReconciliationConfig{
+		ActiveStates:      []string{"In Progress", "Rework"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	}
+}
+
+func TestPollOnceSkipsDispatchWhenRevalidationShowsInactiveState(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+
+	// The listing (tick start) still shows the issue active; the pre-dispatch
+	// revalidation observes it already moved to a terminal state (#740).
+	trackerClient.setFetchIDStates(map[string]string{"issue-1": "Done"})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0 after stale revalidation", got, dispatcher.issueIDs())
+	}
+}
+
+func TestPollOnceSkipsDispatchWhenRevalidationOmitsIssue(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+
+	// An empty refresh result is upstream's {:skip, :missing}: the issue was
+	// deleted, or (Gitea) its aiops/* state labels were stripped so no state
+	// can be derived.
+	trackerClient.setFetchIDStates(map[string]string{})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0 when refresh omits the candidate", got, dispatcher.issueIDs())
+	}
+}
+
+func TestPollOnceDispatchesRevalidatedCandidateWithRefreshedState(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+
+	// Still active, but in a different active state than the listing showed:
+	// the dispatch must carry the refreshed state (per-state capacity gates and
+	// the spawned worker read it), mirroring upstream's refreshed_issue dispatch.
+	trackerClient.setFetchIDStates(map[string]string{"issue-1": "Rework"})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 1 {
+		t.Fatalf("dispatched %d issues (%v); want 1", got, dispatcher.issueIDs())
+	}
+	if got := dispatcher.issueAt(0).State; got != "Rework" {
+		t.Fatalf("dispatched issue state = %q; want refreshed state %q", got, "Rework")
+	}
+}
+
+func TestPollOnceSkipsDispatchWhenRevalidationDropsRequiredLabels(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{
+		ID:         "issue-1",
+		Identifier: "LIN-1",
+		State:      "In Progress",
+		Labels:     []string{"aiops"},
+	}}}
+	cfg := revalidationReconcileConfig()
+	cfg.RequiredLabels = []string{"aiops"}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, cfg)
+
+	// The listing carries the required label; the revalidation refresh returns
+	// the issue still active but without it (SPEC §6.4 gate re-applied on
+	// refreshed labels).
+	trackerClient.setFetchIDStates(map[string]string{"issue-1": "In Progress"})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0 after required label removal", got, dispatcher.issueIDs())
+	}
+}
+
+func TestPollOncePartialRevalidationErrorStillDispatchesFreshCandidates(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{
+		{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"},
+		{ID: "issue-2", Identifier: "LIN-2", State: "In Progress"},
+	}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+
+	// A partial refresh (one row plus an error) dispatches the row it did
+	// confirm and skips the rest; the error surfaces as a non-fatal poll error.
+	trackerClient.setFetchIDStates(map[string]string{"issue-1": "In Progress"})
+	trackerClient.setFetchIDErr(errors.New("revalidation fetch interrupted"))
+	err := poller.PollOnce(ctx)
+	if err == nil || !strings.Contains(err.Error(), "revalidate dispatch candidates") || !strings.Contains(err.Error(), "revalidation fetch interrupted") {
+		t.Fatalf("PollOnce() = %v; want wrapped revalidation fetch error", err)
+	}
+	if got := dispatcher.issueIDs(); len(got) != 1 || got[0] != "issue-1" {
+		t.Fatalf("dispatched issues = %v; want [issue-1]", got)
+	}
+}

--- a/internal/orchestrator/poller_candidates_test.go
+++ b/internal/orchestrator/poller_candidates_test.go
@@ -167,9 +167,9 @@ func TestPollOnceReleasesDueContinuationWhenRevalidationOmitsIssue(t *testing.T)
 	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
 
 	// The refresh omits the issue entirely (deleted / Gitea aiops/* labels
-	// stripped). Reconcile treats absence as no-information forever, so the
-	// revalidation pass must release the queued continuation or the issue
-	// wedges in retrying (#740 review P2).
+	// stripped). Reconcile's cancel paths treat absence as no-information
+	// forever, so the vanished-continuation sweep must release the queued
+	// continuation or the issue wedges in retrying (#740 review P2).
 	trackerClient.setFetchIDStates(map[string]string{})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce() = %v; want nil", err)
@@ -183,14 +183,79 @@ func TestPollOnceReleasesDueContinuationWhenRevalidationOmitsIssue(t *testing.T)
 	}
 }
 
+func TestPollOnceReleasesDueContinuationAbsentFromActiveListing(t *testing.T) {
+	// The between-tick variant: the issue vanished BEFORE this tick's listing,
+	// so it is never a dispatch candidate at all. The reconcile pass still
+	// narrow-refreshes it as a claimed (retrying) ref; a clean refresh that
+	// does not return it must release the continuation (#740 review HIGH).
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
+
+	trackerClient.setFetchIDStates(map[string]string{})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0", got, dispatcher.issueIDs())
+	}
+	retained, claimed := continuationClaimState(t, ctx, poller, "issue-1")
+	if retained || claimed {
+		t.Fatalf("continuation absent from listing: retained=%v claimed=%v; want released", retained, claimed)
+	}
+}
+
+func TestPollOnceRetainsVanishedFailureRetry(t *testing.T) {
+	// A failure retry whose issue vanished is NOT released by the sweep: its
+	// own fire path runs the SPEC §16.6 candidate fetch and releases on
+	// absence with terminal-state resolution (#341). Releasing it here would
+	// double-own that contract.
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+	id := IssueID("issue-1")
+	done := make(chan struct{})
+	if err := poller.orchestrator.submit(ctx, opFunc(func(st *OrchestratorState) func() {
+		st.Claimed[id] = struct{}{}
+		st.ClaimedIssues[id] = tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}
+		st.RetryAttempts[id] = &RetryEntry{
+			IssueID:    id,
+			Identifier: "LIN-1",
+			Kind:       RetryKindFailure,
+			Attempt:    1,
+			DueAt:      time.Now().Add(time.Hour),
+		}
+		close(done)
+		return nil
+	})); err != nil {
+		t.Fatalf("seed failure retry: %v", err)
+	}
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("seed failure retry: %v", ctx.Err())
+	}
+
+	trackerClient.setFetchIDStates(map[string]string{})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0", got, dispatcher.issueIDs())
+	}
+	retained, claimed := continuationClaimState(t, ctx, poller, id)
+	if !retained || !claimed {
+		t.Fatalf("failure retry after vanished refresh: retained=%v claimed=%v; want retained", retained, claimed)
+	}
+}
+
 func TestPollOnceRetainsDueContinuationWhenRevalidationFetchFails(t *testing.T) {
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
 	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
 	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
 
 	// With the fetch failing, a missing row is indistinguishable from tracker
-	// downtime — the continuation must survive (upstream {:error} leaves state
-	// untouched).
+	// downtime — the vanished-continuation sweep must not run and the
+	// continuation must survive (upstream {:error} leaves state untouched).
 	trackerClient.setFetchIDStates(map[string]string{})
 	trackerClient.setFetchIDErr(errors.New("tracker briefly down"))
 	if err := poller.PollOnce(ctx); err == nil || !strings.Contains(err.Error(), "revalidate dispatch candidates") {


### PR DESCRIPTION
Closes #740

## Summary
- **Root cause**: `PollOnce` reads the candidate listing at tick start, but the reconcile pass between that read and the dispatch loop can block on worker-exit waits for minutes. A slot freed by a reconcile cancel then dispatched candidates from the stale listing — in the v0.1.0 lifecycle test, an issue whose `aiops/*` labels were stripped ~1 minute earlier got a full codex run (~2.5 min) before the next reconcile pass corrected it; 2 of 18 dispatches (~11%) were wasted this way.
- **Verdict on the issue's question**: the Elixir reference **does revalidate at dispatch time** — `dispatch_issue` calls `revalidate_issue_for_dispatch` with a narrow `fetch_issue_states_by_ids` read immediately before every spawn and skips on `{:skip, :missing}` / stale / error (`elixir/lib/symphony_elixir/orchestrator.ex:909-924`, `:995-1013`). Reconcile-as-safety-net is not the designed behavior, so this PR aligns.
- **Fix 1 — dispatch revalidation (72b6cce)**: immediately before the dispatch loop, ask the orchestrator actor which candidates the claim gate would currently allow (`DispatchClaimableIssueIDs`, sharing the `dispatchClaimGateAllows` predicate with `resolveDispatchClaim` so gate and trim cannot drift), narrow-refresh exactly that subset (45s-bounded), and drop candidates the refresh omits, that left the active set, or that lost a SPEC §6.4 required label. Survivors dispatch with refreshed state+labels. Cost matches upstream's `should_dispatch_issue?`-before-revalidate trim: running/blocked/queued-retry issues are not re-fetched every tick (pinned by `TestPollOnceAppliesPartialRunningIDRefreshWhenRefreshReturnsError`).
- **Fix 2 — vanished-continuation sweep (e220d37, from review)**: Codex review P2 found a dropped-but-claimable due continuation wedges forever when its issue is missing from the refresh; the dual reviewers then surfaced the wider class — an issue vanishing *between* ticks never becomes a candidate at all. The release now lives in the one place that observes every claimed issue each tick: the reconcile narrow refresh. A **clean** fetch that does not return a queried claimed ref releases that issue's queued `RetryKindContinuation` entry (`ReleaseVanishedContinuations`, release-only, mirroring the failure-retry absence branch from #341). Failure/quota retries keep their own fire-time absence handling; running/blocked issues stay untouched (destructive paths still require positive observations). An intermediate seam-side release (6051497) was removed in favor of this single source.
- **File move only**: candidate-selection helpers moved verbatim from `poller.go` to the new `poller_candidates.go` for the 800-line file budget.

## Adjacent-path audit (AGENTS.md cross-cutting item 1)
- Retry-fire path: already refreshes at fire time via `eligibleActiveIssueLister` (same gates) — unchanged; its absence-release contract is deliberately not duplicated by the sweep (kind filter, pinned by `TestPollOnceRetainsVanishedFailureRetry`).
- Continuation re-dispatch: flows through the poll loop, so it gets revalidated data; vanished issues are released by the sweep.
- Reconcile cancel paths keep "absence = no information" (never mass-cancel); the sweep releases bookkeeping only (no worker cancel, no workspace removal), and dispatch treats absence as skip — matching upstream `{:skip, :missing}`.

## Deferred gaps (tracked per AGENTS rule 2)
- **#750** (`area:spec-alignment`): revalidation does not re-check Todo blockers — upstream `retry_candidate_issue?` does (`orchestrator.ex:1602-1604`), but the narrow-refresh contract lacks `BlockedBy`; closing it touches all three adapters. Window is one tick; listing-time and retry-fire gates still apply.
- **#748**: counter-taxonomy observation from #740 (F7) root-caused — `gitea_issue_labels` fires no mutation audit and `recordAgentHandoffFields` only accepts Linear tools; separate runner-side mechanism.

## SPEC alignment (AGENTS.md principle 6/7)
- [ ] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [x] Adds one, justified by an upstream **Elixir reference** — dispatch-time candidate revalidation ports `revalidate_issue_for_dispatch` / `dispatch_issue`, `elixir/lib/symphony_elixir/orchestrator.ex:909-924` and `elixir/lib/symphony_elixir/orchestrator.ex:995-1013`; the claim-gate trim mirrors `should_dispatch_issue?` before the revalidate (`elixir/lib/symphony_elixir/orchestrator.ex:776-777`); the vanished-continuation sweep extends the absence-release behavior aiops ported from upstream `handle_retry_issue_lookup` (`elixir/lib/symphony_elixir/orchestrator.ex:1082-1090`, see #341) to the aiops-local continuation entries (D34) that upstream does not have. No new config key.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [ ] `within budget` — ≤12 production files / ≤300 production LOC.
- [x] `size-gated: justified overage` — 5 production files; gross production diff ~590 changed LOC, of which ~440 is the verbatim helper move out of `poller.go` forced by the repo's own 800-line file budget; net new production logic ~150 LOC across the revalidation + sweep, which form one atomic correctness change (the sweep exists because the revalidation's skip-only drop would otherwise wedge continuations). **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended`.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`) — 0 issues
- [x] additional validation noted below

### Regression tests (new, `poller_candidates_test.go`)
- listing-active → refresh-terminal ⇒ no dispatch (the F3 scenario)
- refresh omits the issue (deleted / Gitea label-strip) ⇒ no dispatch + queued continuation released
- between-tick vanish (absent from listing entirely) ⇒ continuation released (review HIGH)
- fetch error ⇒ no release (downtime ≠ gone), confirmed rows still dispatch, wrapped error surfaces
- refresh shows a different **active** state ⇒ dispatched with the refreshed state
- refresh drops a required label ⇒ no dispatch (SPEC §6.4 re-applied)
- vanished **failure** retry ⇒ retained (fire-path owns absence, #341)

### Mutation verification (against committed HEAD, tree restored clean each round)
Head 72b6cce: drop revalidation call / drop refreshed-state carry / drop labels recheck / refresh-ignores-claim-gate — all FAIL.
Head e220d37: drop sweep call / sweep despite fetch error / drop continuation-kind filter — all FAIL.

### Review rounds (protocol §3–§5)
- 72b6cce: Claude subagent MERGE-READY; Codex CLI contract `{"blocking_findings":[]}` (codex-rescue subagent returned a bare verdict, CLI fallback re-run per protocol).
- @codex review on 72b6cce: 1 P2 (wedged continuation) — fixed in 6051497, thread replied + resolved.
- 6051497: Claude subagent MERGE-READY; Codex CLI surfaced the between-tick HIGH + the Todo-blocker MEDIUM → HIGH fixed by e220d37 (class fix), MEDIUM tracked as #750.
- e220d37: Claude subagent MERGE-READY; Codex CLI `{"blocking_findings":[]}`. **Process note**: this head was pushed before its dual review ran (protocol §3 ordering slip); both reviews completed clean immediately after push.