### PR TITLE
fix: mirror agent-handoff mutation audit onto gitea_issue_labels (#748)

### DIFF
--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -239,11 +239,20 @@ func (c *TrackerClient) issueNumberForStateRefresh(ref tracker.IssueRef) (int, b
 	if issueNumber, ok := c.cachedIssueNumber(ref.ID); ok {
 		return issueNumber, true
 	}
-	if issueNumber, ok := giteaIssueNumberFromIdentifier(ref.Identifier); ok {
+	return IssueNumberFromRef(ref.ID, ref.Identifier)
+}
+
+// IssueNumberFromRef derives a Gitea issue number from a tracker issue
+// reference without network access. Only "#N"-shaped values are trusted: a
+// bare numeric ID is the Gitea-internal int64 id (giteaIssueID prefers it
+// over the issue number), so parsing it as an issue number could silently
+// target a different issue.
+func IssueNumberFromRef(id, identifier string) (int, bool) {
+	if issueNumber, ok := giteaIssueNumberFromIdentifier(identifier); ok {
 		return issueNumber, true
 	}
-	if strings.HasPrefix(strings.TrimSpace(ref.ID), "#") {
-		return giteaIssueNumberFromIdentifier(ref.ID)
+	if strings.HasPrefix(strings.TrimSpace(id), "#") {
+		return giteaIssueNumberFromIdentifier(id)
 	}
 	return 0, false
 }

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -941,3 +941,27 @@ func TestTrackerClientListIssuesByStatesRetriesBlockerAfterTransientError(t *tes
 		t.Fatalf("issues carrying blocker #3 = %d; want 1 (first source errored+skipped, second retried+found)", withBlocker)
 	}
 }
+
+// TestIssueNumberFromRef pins the "#N"-only contract (#748): a bare numeric ID
+// is the Gitea-internal int64 id, not the issue number, and must not parse.
+func TestIssueNumberFromRef(t *testing.T) {
+	cases := []struct {
+		id, identifier string
+		want           int
+		ok             bool
+	}{
+		{id: "8842", identifier: "#12", want: 12, ok: true},
+		{id: "#12", identifier: "", want: 12, ok: true},
+		{id: "8842", identifier: "", want: 0, ok: false},
+		{id: "", identifier: "", want: 0, ok: false},
+		{id: "#0", identifier: "", want: 0, ok: false},
+		{id: "#x", identifier: "", want: 0, ok: false},
+		{id: "8842", identifier: " #12 ", want: 12, ok: true},
+	}
+	for _, tc := range cases {
+		got, ok := IssueNumberFromRef(tc.id, tc.identifier)
+		if got != tc.want || ok != tc.ok {
+			t.Fatalf("IssueNumberFromRef(%q, %q) = (%d, %t); want (%d, %t)", tc.id, tc.identifier, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/internal/orchestrator/actor_reconcile_stopped_with_progress_test.go
+++ b/internal/orchestrator/actor_reconcile_stopped_with_progress_test.go
@@ -479,3 +479,99 @@ func TestRecordReconcileStoppedWithProgressCapsAndDedup(t *testing.T) {
 		t.Fatalf("CumulativeReconcileStoppedWithProgressTotal = %d; want 4 (a,b,c,c)", got)
 	}
 }
+
+func recordGiteaMutation(t *testing.T, o *Orchestrator, issueID string, classified bool) {
+	t.Helper()
+	payload := map[string]any{"tool": "gitea_issue_labels"}
+	if classified {
+		payload["current_issue_non_active_state_update"] = true
+	}
+	err := o.RecordRuntimeEvent(context.Background(), issueID, task.RuntimeEvent{
+		Event:   task.EventToolCallMutation,
+		Payload: payload,
+	})
+	if err != nil {
+		t.Fatalf("RecordRuntimeEvent(gitea_issue_labels mutation): %v", err)
+	}
+}
+
+// TestReconcileCancelAfterGiteaCurrentIssueHandoffRecordsAgentHandoff pins #748:
+// a Gitea run whose agent flipped the current issue's aiops/* label out of the
+// active states (classified tool_call_mutation from gitea_issue_labels) and was
+// then reconcile-stopped must increment the agent-handoff counter, exactly like
+// the Linear tool path.
+func TestReconcileCancelAfterGiteaCurrentIssueHandoffRecordsAgentHandoff(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "8842", Identifier: "#12", State: "In Progress"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+	recordGiteaMutation(t, o, iss.ID, true)
+	if err := o.RecordRuntimeEvent(context.Background(), iss.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+		t.Fatalf("RecordRuntimeEvent(turn_completed): %v", err)
+	}
+
+	inactive := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "Human Review"}}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), inactive, normalizedStates([]string{"done"}), 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+	disp.finishAt(0, WorkerResult{Err: context.Canceled, Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0
+	}, time.Second)
+
+	v, _ := o.Snapshot(context.Background())
+	if len(v.AgentHandoffReconcileStopped) != 1 || v.AgentHandoffReconcileStopped[0] != IssueID(iss.ID) {
+		t.Fatalf("AgentHandoffReconcileStopped = %v; want [%s]", v.AgentHandoffReconcileStopped, iss.ID)
+	}
+	if v.CumulativeAgentHandoffReconcileStoppedTotal != 1 {
+		t.Fatalf("CumulativeAgentHandoffReconcileStoppedTotal = %d; want 1", v.CumulativeAgentHandoffReconcileStoppedTotal)
+	}
+	if len(v.Completed) != 0 {
+		t.Fatalf("Completed = %v; want empty (agent handoff reconcile stop is not a clean §16.5 exit)", v.Completed)
+	}
+}
+
+// An unclassified gitea_issue_labels mutation (e.g. a flip to another active
+// state) must not count as a handoff even when the run made progress.
+func TestReconcileCancelAfterUnclassifiedGiteaMutationDoesNotRecordAgentHandoff(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "8843", Identifier: "#13", State: "In Progress"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+	recordGiteaMutation(t, o, iss.ID, false)
+	if err := o.RecordRuntimeEvent(context.Background(), iss.ID, task.RuntimeEvent{Event: task.EventTurnCompleted}); err != nil {
+		t.Fatalf("RecordRuntimeEvent(turn_completed): %v", err)
+	}
+
+	inactive := map[string]tracker.Issue{iss.ID: {ID: iss.ID, Identifier: iss.Identifier, State: "Human Review"}}
+	if err := o.ReconcileInactiveTrackerIssuesAndWait(context.Background(), inactive, normalizedStates([]string{"done"}), 0); err != nil {
+		t.Fatalf("ReconcileInactiveTrackerIssuesAndWait: %v", err)
+	}
+	disp.finishAt(0, WorkerResult{Err: context.Canceled, Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0
+	}, time.Second)
+
+	v, _ := o.Snapshot(context.Background())
+	if len(v.AgentHandoffReconcileStopped) != 0 {
+		t.Fatalf("AgentHandoffReconcileStopped = %v; want empty for unclassified gitea mutation", v.AgentHandoffReconcileStopped)
+	}
+	if v.CumulativeAgentHandoffReconcileStoppedTotal != 0 {
+		t.Fatalf("CumulativeAgentHandoffReconcileStoppedTotal = %d; want 0", v.CumulativeAgentHandoffReconcileStoppedTotal)
+	}
+	if len(v.ReconcileStoppedWithProgress) != 1 || v.ReconcileStoppedWithProgress[0] != IssueID(iss.ID) {
+		t.Fatalf("ReconcileStoppedWithProgress = %v; want [%s] (progress is still recorded)", v.ReconcileStoppedWithProgress, iss.ID)
+	}
+}

--- a/internal/orchestrator/runtime_events.go
+++ b/internal/orchestrator/runtime_events.go
@@ -88,7 +88,7 @@ func (s *OrchestratorState) recordAgentHandoffFields(run *RunningEntry, event ta
 		return
 	}
 	payload, _ := asStringMap(event.Payload)
-	if !linearMutationPayload(payload) {
+	if !agentHandoffMutationPayload(payload) {
 		return
 	}
 	if handoffBool(payload, "current_issue_non_active_state_update") {
@@ -99,13 +99,22 @@ func (s *OrchestratorState) recordAgentHandoffFields(run *RunningEntry, event ta
 	}
 }
 
-func isLinearMutationTool(tool string) bool {
-	return tool == "linear_graphql" || tool == "linear_ai_workpad"
+// isAgentHandoffMutationTool names the agent-visible tracker mutation tools
+// whose tool_call_mutation events can carry a current-issue handoff
+// classification. The Gitea label tool joined the taxonomy in #748 so a Gitea
+// run's handoff label flip is counted like a Linear state update.
+func isAgentHandoffMutationTool(tool string) bool {
+	switch tool {
+	case "linear_graphql", "linear_ai_workpad", "gitea_issue_labels":
+		return true
+	default:
+		return false
+	}
 }
 
-func linearMutationPayload(payload map[string]any) bool {
+func agentHandoffMutationPayload(payload map[string]any) bool {
 	tool, ok := stringField(payload, "tool")
-	return ok && isLinearMutationTool(tool)
+	return ok && isAgentHandoffMutationTool(tool)
 }
 
 func handoffBool(payload map[string]any, key string) bool {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -146,7 +146,8 @@ type RunningEntry struct {
 	InputRequiredMethod string
 
 	// AgentCurrentIssueHandoff is set only when the agent successfully updates
-	// this run's issue into a non-active state through the guarded Linear tool.
+	// this run's issue into a non-active state through an agent-visible tracker
+	// mutation tool (linear_graphql, linear_ai_workpad, gitea_issue_labels).
 	// It is the delivery signal when reconcile stops the worker before clean
 	// exit, and it avoids latching agent-owned terminal handoffs as operator
 	// stops.

--- a/internal/orchestrator/status.go
+++ b/internal/orchestrator/status.go
@@ -28,10 +28,12 @@ const (
 	// /api/v1 status so string(kind) maps straight through.
 	RuntimeEventReconcileStopped RuntimeEventKind = "reconcile_stopped_with_progress"
 	// RuntimeEventAgentHandoffReconcileStopped marks a reconcile-stopped run
-	// that observed a guarded current-issue Linear state handoff before the
-	// tracker made the issue inactive. This is a scheduler/reader observability
-	// signal only: completed accounting stays limited to clean worker exits, and
-	// Linear writes remain agent-owned.
+	// that observed a current-issue state handoff through an agent-visible
+	// tracker mutation tool (linear_graphql, linear_ai_workpad,
+	// gitea_issue_labels — #748) before the tracker made the issue inactive.
+	// This is a scheduler/reader observability signal only: completed
+	// accounting stays limited to clean worker exits, and tracker writes
+	// remain agent-owned.
 	RuntimeEventAgentHandoffReconcileStopped RuntimeEventKind = "agent_handoff_reconcile_stopped"
 	// RuntimeEventDispatchPreflightFailed flags SPEC §8.1 step 2 failures:
 	// the per-tick dispatch preflight could not validate the workflow's

--- a/internal/runner/codex_app_server_approval.go
+++ b/internal/runner/codex_app_server_approval.go
@@ -282,14 +282,15 @@ func (c *appServerClient) resolveDynamicToolResult(ctx context.Context, name str
 }
 
 // withMutationAuditSink derives the tool-execution context carrying the audit
-// sink that fires for any tool routing through the Linear GraphQL proxy.
+// sink that fires for any tool routing through a tracker mutation proxy —
+// the Linear GraphQL proxy and the Gitea issue-labels proxy alike (#748).
 // linear_ai_workpad composes deterministic commentCreate/commentUpdate
 // mutations through the same token-isolated callRaw transport, so operators
 // need the tool_call_mutation runtime event for those harness-attributable
-// writes too. Only the proxy itself fires the sink, so installing it on
+// writes too. Only the proxies themselves fire the sink, so installing it on
 // unrelated tools is a no-op.
 func (c *appServerClient) withMutationAuditSink(ctx context.Context, name string) context.Context {
-	ctx = WithLinearGraphQLMutationSink(ctx, func(audit LinearGraphQLMutationAudit) {
+	ctx = WithToolMutationSink(ctx, func(audit ToolMutationAudit) {
 		c.recordRuntimeEvent(task.EventToolCallMutation, c.withRuntimeContext(mutationAuditPayload(name, audit)))
 	})
 	ctx = WithLinearGraphQLMutationRejectedSink(ctx, func(rejection linearGraphQLMutationRejected) {
@@ -300,7 +301,7 @@ func (c *appServerClient) withMutationAuditSink(ctx context.Context, name string
 	})
 }
 
-func mutationAuditPayload(tool string, audit LinearGraphQLMutationAudit) map[string]any {
+func mutationAuditPayload(tool string, audit ToolMutationAudit) map[string]any {
 	payload := map[string]any{"tool": tool}
 	if audit.OperationField != "" {
 		payload["operation_field"] = audit.OperationField

--- a/internal/runner/codex_app_server_approval_test.go
+++ b/internal/runner/codex_app_server_approval_test.go
@@ -221,8 +221,8 @@ func TestHandleDynamicToolCall_MutationSinkRecordsToolCallMutationEvent(t *testi
 		"linear_graphql": {Name: "linear_graphql", Call: func(ctx context.Context, _ ToolCall) (string, error) {
 			// A real proxy fires the sink installed on the tool context when it
 			// dispatches a mutation; emulate that here.
-			if sink := linearGraphQLMutationSinkFrom(ctx); sink != nil {
-				sink(LinearGraphQLMutationAudit{OperationField: "issueUpdate"})
+			if sink := toolMutationSinkFrom(ctx); sink != nil {
+				sink(ToolMutationAudit{OperationField: "issueUpdate"})
 			}
 			return `{"success":true}`, nil
 		}},

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -79,60 +79,123 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 	if failure != "" {
 		return failure, nil
 	}
-	if failure := p.deleteStaleStateLabels(ctx, client, endpoint, staleStateLabels); failure != "" {
+	deletedStaleLabels, failure := p.deleteStaleStateLabels(ctx, client, endpoint, staleStateLabels)
+	p.fireMutationAudit(ctx, mutationAuditFacts{
+		issueNumber:   call.IssueNumber,
+		desiredLabel:  desiredStateLabels[0],
+		currentLabels: currentLabels,
+		deletedLabels: deletedStaleLabels,
+		wroteAdd:      len(labelsToAdd) > 0,
+		fullSuccess:   failure == "",
+	})
+	if failure != "" {
 		return failure, nil
-	}
-	if len(labelsToAdd) > 0 || len(staleStateLabels) > 0 {
-		p.fireMutationAudit(ctx, call.IssueNumber, desiredStateLabels[0], currentLabels)
 	}
 	return result, nil
 }
 
+// mutationAuditFacts carries what actually happened during one label replace
+// so the audit decision can reason about the writes that landed, not the
+// writes that were intended.
+type mutationAuditFacts struct {
+	issueNumber   int
+	desiredLabel  string
+	currentLabels []giteaIssueLabel
+	deletedLabels []giteaIssueLabel
+	wroteAdd      bool
+	fullSuccess   bool
+}
+
 // fireMutationAudit mirrors the Linear proxy's success-audit contract (#748):
-// the shared mutation sink fires only after the full replace (desired-label
-// add plus stale-label delete) succeeded AND at least one HTTP write actually
-// ran. A partial failure must not fire — a surviving stale active label keeps
-// the derived state active (IssueStateFromLabels active-first priority), so
-// the issue never left the active set. The success path includes the retry
-// that only deletes a stale label left by an earlier partial replace: that
-// delete is the write that completes the handoff. A zero-write no-op (label
-// already in the desired shape) must not fire: the flip happened elsewhere —
+// on a fully successful replace with at least one HTTP write, the shared sink
+// always fires (classification keys only for an active→non-active current-
+// issue flip). A zero-write no-op must not fire: the flip happened elsewhere —
 // an earlier audited call, or an operator's manual label edit, which must not
 // be attributed to the agent as a handoff.
-func (p giteaIssueLabelsProxy) fireMutationAudit(ctx context.Context, issueNumber int, desiredLabel string, preWriteLabels []giteaIssueLabel) {
-	if sink := toolMutationSinkFrom(ctx); sink != nil {
-		sink(p.classifyLabelMutation(issueNumber, desiredLabel, preWriteLabels))
+//
+// A partial failure fires only when the writes that DID land already moved the
+// derived state out of the active set (Codex P2 on #751): the aiops/* mapping
+// priority is not strictly active-first — aiops/human-review outranks
+// aiops/todo — so a successful add of the desired non-active label with a
+// failed stale aiops/todo delete still flips the derived state, reconcile
+// stops the run, and skipping the audit would lose the handoff exactly like
+// the bug this change fixes. When the surviving stale label outranks the
+// desired one (aiops/in-progress, aiops/rework) the derived state stays
+// active, nothing fires, and the agent's retry carries the signal instead.
+func (p giteaIssueLabelsProxy) fireMutationAudit(ctx context.Context, facts mutationAuditFacts) {
+	sink := toolMutationSinkFrom(ctx)
+	if sink == nil {
+		return
+	}
+	if !facts.wroteAdd && len(facts.deletedLabels) == 0 {
+		return
+	}
+	audit := p.classifyLabelMutation(facts)
+	if facts.fullSuccess || audit.CurrentIssueNonActiveStateUpdate {
+		sink(audit)
 	}
 }
 
 // classifyLabelMutation marks the audit as a current-issue handoff only when
-// the replace moved the issue FROM a configured active state TO a non-active
-// one. The pre-write gate matters: the Linear path's guard rejects current-
-// issue mutations whose refreshed state is not active, so its classification
-// implicitly proves the issue left the active set. The Gitea tool has no such
-// guard, so without checking the pre-write labels a flip between two
-// non-active states (e.g. an operator's manual aiops/done later relabeled
-// aiops/human-review by the agent) would be misattributed as an agent handoff
-// and mask the operator-owned stop.
-func (p giteaIssueLabelsProxy) classifyLabelMutation(issueNumber int, desiredLabel string, preWriteLabels []giteaIssueLabel) ToolMutationAudit {
+// the landed writes moved the issue FROM a configured active state TO a
+// non-active one. The pre-write gate matters: the Linear path's guard rejects
+// current-issue mutations whose refreshed state is not active, so its
+// classification implicitly proves the issue left the active set. The Gitea
+// tool has no such guard, so without checking the pre-write labels a flip
+// between two non-active states (e.g. an operator's manual aiops/done later
+// relabeled aiops/human-review by the agent) would be misattributed as an
+// agent handoff and mask the operator-owned stop.
+//
+// The post state derives from the label set the writes actually produced:
+// current labels minus the stale labels confirmed deleted, plus the desired
+// label (added by this call or already present). On full success that reduces
+// to the desired label alone; after a partial delete failure it is the
+// most-active possible surviving set, so a non-active verdict is safe.
+func (p giteaIssueLabelsProxy) classifyLabelMutation(facts mutationAuditFacts) ToolMutationAudit {
 	audit := ToolMutationAudit{}
-	if p.currentIssueNumber <= 0 || issueNumber != p.currentIssueNumber {
+	if p.currentIssueNumber <= 0 || facts.issueNumber != p.currentIssueNumber {
 		return audit
 	}
-	preState, _ := gitea.IssueStateFromLabels(stateLabelsForClassification(preWriteLabels), nil)
+	preState, _ := gitea.IssueStateFromLabels(stateLabelsForClassification(facts.currentLabels), nil)
 	if preState == "" || matchStateFold(p.activeStates, preState) == "" {
 		return audit
 	}
-	state, _ := gitea.IssueStateFromLabels([]gitea.Label{{Name: desiredLabel}}, nil)
-	if state == "" || matchStateFold(p.activeStates, state) != "" {
+	postState, _ := gitea.IssueStateFromLabels(postWriteStateLabels(facts), nil)
+	if postState == "" || matchStateFold(p.activeStates, postState) != "" {
 		return audit
 	}
 	audit.CurrentIssueNonActiveStateUpdate = true
-	if terminal := matchStateFold(p.terminalStates, state); terminal != "" {
+	if terminal := matchStateFold(p.terminalStates, postState); terminal != "" {
 		audit.CurrentIssueTerminalStateUpdate = true
 		audit.CurrentIssueTerminalState = terminal
 	}
 	return audit
+}
+
+// postWriteStateLabels reconstructs the issue's label set after the landed
+// writes: current labels minus confirmed deletions, plus the desired label.
+func postWriteStateLabels(facts mutationAuditFacts) []gitea.Label {
+	out := make([]gitea.Label, 0, len(facts.currentLabels)+1)
+	for _, label := range facts.currentLabels {
+		if containsIssueLabelFold(facts.deletedLabels, label.Name) {
+			continue
+		}
+		out = append(out, gitea.Label{Name: label.Name})
+	}
+	if !containsLabelFoldGitea(out, facts.desiredLabel) {
+		out = append(out, gitea.Label{Name: facts.desiredLabel})
+	}
+	return out
+}
+
+func containsLabelFoldGitea(labels []gitea.Label, label string) bool {
+	want := strings.ToLower(strings.TrimSpace(label))
+	for _, candidate := range labels {
+		if strings.ToLower(strings.TrimSpace(candidate.Name)) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func stateLabelsForClassification(labels []giteaIssueLabel) []gitea.Label {
@@ -237,20 +300,23 @@ func (p giteaIssueLabelsProxy) addAndConfirmDesiredLabels(ctx context.Context, c
 }
 
 // deleteStaleStateLabels removes each stale aiops/* label, failing if Gitea
-// omitted a label's id. failure is "" on success.
-func (p giteaIssueLabelsProxy) deleteStaleStateLabels(ctx context.Context, client *http.Client, endpoint string, staleStateLabels []giteaIssueLabel) string {
+// omitted a label's id. failure is "" on success. deleted reports the labels
+// confirmed removed before any failure, so the mutation audit can reason
+// about the writes that actually landed.
+func (p giteaIssueLabelsProxy) deleteStaleStateLabels(ctx context.Context, client *http.Client, endpoint string, staleStateLabels []giteaIssueLabel) (deleted []giteaIssueLabel, failure string) {
 	for _, label := range staleStateLabels {
 		if label.ID == 0 {
 			failure, _ := dynamicToolFailure(map[string]any{
 				"error": map[string]any{"message": "Gitea label response omitted id for stale aiops label", "label": label.Name},
 			})
-			return failure
+			return deleted, failure
 		}
 		if failure := p.deleteIssueLabel(ctx, client, endpoint, label.ID); failure != "" {
-			return failure
+			return deleted, failure
 		}
+		deleted = append(deleted, label)
 	}
-	return ""
+	return deleted, ""
 }
 
 func (p giteaIssueLabelsProxy) addIssueLabels(ctx context.Context, client *http.Client, endpoint string, labels []string) (string, string) {

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -27,6 +27,30 @@ type giteaIssueLabelsProxy struct {
 	// round trip. Zero uses defaultDynamicToolHTTPTimeout; tests set a tiny
 	// value to exercise the timeout path.
 	httpTimeout time.Duration
+	// currentIssueNumber, activeStates, and terminalStates power the
+	// agent-handoff classification mirrored from the Linear tool path (#748):
+	// a successful label replace that moves the current issue out of the
+	// configured active states is the agent's handoff signal. A zero
+	// currentIssueNumber disables classification; the audit still fires.
+	currentIssueNumber int
+	activeStates       []string
+	terminalStates     []string
+}
+
+// withCurrentIssueClassification copies the dispatched issue's number and the
+// tracker's configured state sets onto the proxy so a successful label replace
+// can be classified as a current-issue handoff. Only "#N"-shaped refs are
+// trusted (see gitea.IssueNumberFromRef); without one, classification stays
+// disabled and the proxy behaves as before.
+func (p giteaIssueLabelsProxy) withCurrentIssueClassification(cfg workflow.TrackerConfig, opts dynamicToolOptions) giteaIssueLabelsProxy {
+	number, ok := gitea.IssueNumberFromRef(opts.currentIssueID, opts.currentIssueIdentifier)
+	if !ok {
+		return p
+	}
+	p.currentIssueNumber = number
+	p.activeStates = append([]string(nil), cfg.ActiveStates...)
+	p.terminalStates = append([]string(nil), cfg.TerminalStates...)
+	return p
 }
 
 type giteaIssueLabel struct {
@@ -58,7 +82,82 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 	if failure := p.deleteStaleStateLabels(ctx, client, endpoint, staleStateLabels); failure != "" {
 		return failure, nil
 	}
+	if len(labelsToAdd) > 0 || len(staleStateLabels) > 0 {
+		p.fireMutationAudit(ctx, call.IssueNumber, desiredStateLabels[0], currentLabels)
+	}
 	return result, nil
+}
+
+// fireMutationAudit mirrors the Linear proxy's success-audit contract (#748):
+// the shared mutation sink fires only after the full replace (desired-label
+// add plus stale-label delete) succeeded AND at least one HTTP write actually
+// ran. A partial failure must not fire — a surviving stale active label keeps
+// the derived state active (IssueStateFromLabels active-first priority), so
+// the issue never left the active set. The success path includes the retry
+// that only deletes a stale label left by an earlier partial replace: that
+// delete is the write that completes the handoff. A zero-write no-op (label
+// already in the desired shape) must not fire: the flip happened elsewhere —
+// an earlier audited call, or an operator's manual label edit, which must not
+// be attributed to the agent as a handoff.
+func (p giteaIssueLabelsProxy) fireMutationAudit(ctx context.Context, issueNumber int, desiredLabel string, preWriteLabels []giteaIssueLabel) {
+	if sink := toolMutationSinkFrom(ctx); sink != nil {
+		sink(p.classifyLabelMutation(issueNumber, desiredLabel, preWriteLabels))
+	}
+}
+
+// classifyLabelMutation marks the audit as a current-issue handoff only when
+// the replace moved the issue FROM a configured active state TO a non-active
+// one. The pre-write gate matters: the Linear path's guard rejects current-
+// issue mutations whose refreshed state is not active, so its classification
+// implicitly proves the issue left the active set. The Gitea tool has no such
+// guard, so without checking the pre-write labels a flip between two
+// non-active states (e.g. an operator's manual aiops/done later relabeled
+// aiops/human-review by the agent) would be misattributed as an agent handoff
+// and mask the operator-owned stop.
+func (p giteaIssueLabelsProxy) classifyLabelMutation(issueNumber int, desiredLabel string, preWriteLabels []giteaIssueLabel) ToolMutationAudit {
+	audit := ToolMutationAudit{}
+	if p.currentIssueNumber <= 0 || issueNumber != p.currentIssueNumber {
+		return audit
+	}
+	preState, _ := gitea.IssueStateFromLabels(stateLabelsForClassification(preWriteLabels), nil)
+	if preState == "" || matchStateFold(p.activeStates, preState) == "" {
+		return audit
+	}
+	state, _ := gitea.IssueStateFromLabels([]gitea.Label{{Name: desiredLabel}}, nil)
+	if state == "" || matchStateFold(p.activeStates, state) != "" {
+		return audit
+	}
+	audit.CurrentIssueNonActiveStateUpdate = true
+	if terminal := matchStateFold(p.terminalStates, state); terminal != "" {
+		audit.CurrentIssueTerminalStateUpdate = true
+		audit.CurrentIssueTerminalState = terminal
+	}
+	return audit
+}
+
+func stateLabelsForClassification(labels []giteaIssueLabel) []gitea.Label {
+	out := make([]gitea.Label, 0, len(labels))
+	for _, label := range labels {
+		out = append(out, gitea.Label{Name: label.Name})
+	}
+	return out
+}
+
+// matchStateFold returns the configured state entry equal to state
+// (case-insensitive, trimmed), or "" when absent. Returning the configured
+// entry keeps the audit's terminal-state value sourced from the workflow
+// config, matching the Linear guard's resolved-state semantics.
+func matchStateFold(states []string, state string) string {
+	state = strings.TrimSpace(state)
+	if state == "" {
+		return ""
+	}
+	for _, candidate := range states {
+		if strings.EqualFold(strings.TrimSpace(candidate), state) {
+			return strings.TrimSpace(candidate)
+		}
+	}
+	return ""
 }
 
 // validateDesiredStateLabels enforces the tool's input contract: exactly one

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -651,3 +651,261 @@ func TestGiteaIssueLabelsNoOpWhenDesiredAlreadyPresentAndNoStale(t *testing.T) {
 		t.Fatalf("methods = %#v; want GET only for an already-satisfied issue", methods)
 	}
 }
+
+// giteaEchoLabelServer serves the labels endpoint for handoff-classification
+// tests: GET returns currentLabels JSON, POST echoes the requested labels with
+// synthetic ids, DELETE succeeds unless failDelete is set.
+func giteaEchoLabelServer(currentLabels string, failDelete bool) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, currentLabels)
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var payload struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.Unmarshal(body, &payload)
+			echoed := make([]map[string]any, 0, len(payload.Labels))
+			for i, name := range payload.Labels {
+				echoed = append(echoed, map[string]any{"id": 900 + i, "name": name})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"labels": echoed})
+		case http.MethodDelete:
+			if failDelete {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return
+			}
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+func giteaClassificationProxy(serverURL string) giteaIssueLabelsProxy {
+	return giteaIssueLabelsProxy{
+		token:              "token",
+		baseURL:            serverURL,
+		owner:              "owner",
+		repo:               "repo",
+		currentIssueNumber: 7,
+		activeStates:       []string{"Todo", "In Progress"},
+		terminalStates:     []string{"Done", "Canceled"},
+	}
+}
+
+func TestGiteaIssueLabelsClassifiesCurrentIssueHandoffMutation(t *testing.T) {
+	cases := []struct {
+		name          string
+		issueNumber   int
+		label         string
+		currentLabels string
+		want          ToolMutationAudit
+	}{
+		{
+			name:        "non-active flip on current issue classifies handoff",
+			issueNumber: 7,
+			label:       "aiops/human-review",
+			want:        ToolMutationAudit{CurrentIssueNonActiveStateUpdate: true},
+		},
+		{
+			name:        "terminal flip on current issue classifies terminal handoff",
+			issueNumber: 7,
+			label:       "aiops/done",
+			want: ToolMutationAudit{
+				CurrentIssueNonActiveStateUpdate: true,
+				CurrentIssueTerminalStateUpdate:  true,
+				CurrentIssueTerminalState:        "Done",
+			},
+		},
+		{
+			name:        "active flip on current issue does not classify",
+			issueNumber: 7,
+			label:       "aiops/todo",
+			want:        ToolMutationAudit{},
+		},
+		{
+			name:        "non-active flip on another issue does not classify",
+			issueNumber: 8,
+			label:       "aiops/human-review",
+			want:        ToolMutationAudit{},
+		},
+		{
+			// The issue was already terminal before the write (e.g. an
+			// operator's manual aiops/done); relabeling it must not be
+			// misattributed as an agent handoff out of the active set.
+			name:          "terminal pre-state does not classify",
+			issueNumber:   7,
+			label:         "aiops/human-review",
+			currentLabels: `[{"id":101,"name":"aiops/done"}]`,
+			want:          ToolMutationAudit{},
+		},
+		{
+			// Pre-state derives to Human Review (non-active wins over the
+			// stale terminal label by mapping priority): cleaning up the
+			// stale label is a write but not a flip out of the active set.
+			name:          "non-active pre-state stale cleanup does not classify",
+			issueNumber:   7,
+			label:         "aiops/human-review",
+			currentLabels: `[{"id":102,"name":"aiops/human-review"},{"id":103,"name":"aiops/canceled"}]`,
+			want:          ToolMutationAudit{},
+		},
+		{
+			// No aiops/* state label at all before the write: the pre-state
+			// is unknown, so the conservative verdict is "not a handoff".
+			name:          "missing pre-state does not classify",
+			issueNumber:   7,
+			label:         "aiops/human-review",
+			currentLabels: `[{"id":202,"name":"bug"}]`,
+			want:          ToolMutationAudit{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			currentLabels := tc.currentLabels
+			if currentLabels == "" {
+				currentLabels = `[{"id":101,"name":"aiops/in-progress"}]`
+			}
+			server := giteaEchoLabelServer(currentLabels, false)
+			defer server.Close()
+			proxy := giteaClassificationProxy(server.URL)
+			proxy.http = server.Client()
+
+			var audits []ToolMutationAudit
+			ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+				audits = append(audits, audit)
+			})
+			result, err := proxy.call(ctx, ToolCall{IssueNumber: tc.issueNumber, Labels: []string{tc.label}})
+			if err != nil {
+				t.Fatalf("call(%d, %q) error = %v; want nil", tc.issueNumber, tc.label, err)
+			}
+			if !toolResultSucceeded(result) {
+				t.Fatalf("call(%d, %q) result = %s; want success", tc.issueNumber, tc.label, result)
+			}
+			if len(audits) != 1 {
+				t.Fatalf("mutation sink fired %d times for (%d, %q); want 1", len(audits), tc.issueNumber, tc.label)
+			}
+			if audits[0] != tc.want {
+				t.Fatalf("classifyLabelMutation(%d, %q) audit = %+v; want %+v", tc.issueNumber, tc.label, audits[0], tc.want)
+			}
+		})
+	}
+}
+
+// The retry that only deletes a stale active label (the desired label landed in
+// an earlier partial replace) is the write completing the handoff and must
+// classify; a replace whose stale-label delete fails must fire no audit at all,
+// because the surviving active label keeps the derived state active.
+func TestGiteaIssueLabelsStaleDeleteRetryAndPartialFailureAuditContract(t *testing.T) {
+	t.Run("stale-delete-only retry classifies handoff", func(t *testing.T) {
+		server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"},{"id":102,"name":"aiops/human-review"}]`, false)
+		defer server.Close()
+		proxy := giteaClassificationProxy(server.URL)
+		proxy.http = server.Client()
+
+		var audits []ToolMutationAudit
+		ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+			audits = append(audits, audit)
+		})
+		result, err := proxy.call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/human-review"}})
+		if err != nil {
+			t.Fatalf("call error = %v; want nil", err)
+		}
+		if !toolResultSucceeded(result) {
+			t.Fatalf("call result = %s; want success", result)
+		}
+		want := ToolMutationAudit{CurrentIssueNonActiveStateUpdate: true}
+		if len(audits) != 1 || audits[0] != want {
+			t.Fatalf("audits = %+v; want exactly [%+v]", audits, want)
+		}
+	})
+	t.Run("zero-write no-op fires no audit", func(t *testing.T) {
+		// The label is already in the desired shape, so the call makes no HTTP
+		// write. The flip happened elsewhere (an earlier audited call or an
+		// operator's manual edit) and must not be attributed to the agent.
+		server := giteaEchoLabelServer(`[{"id":102,"name":"aiops/human-review"}]`, false)
+		defer server.Close()
+		proxy := giteaClassificationProxy(server.URL)
+		proxy.http = server.Client()
+
+		var audits []ToolMutationAudit
+		ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+			audits = append(audits, audit)
+		})
+		result, err := proxy.call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/human-review"}})
+		if err != nil {
+			t.Fatalf("call error = %v; want nil", err)
+		}
+		if !toolResultSucceeded(result) {
+			t.Fatalf("call result = %s; want success", result)
+		}
+		if len(audits) != 0 {
+			t.Fatalf("audits = %+v; want none for a zero-write no-op", audits)
+		}
+	})
+	t.Run("failed stale delete fires no audit", func(t *testing.T) {
+		server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"}]`, true)
+		defer server.Close()
+		proxy := giteaClassificationProxy(server.URL)
+		proxy.http = server.Client()
+
+		var audits []ToolMutationAudit
+		ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+			audits = append(audits, audit)
+		})
+		result, err := proxy.call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/human-review"}})
+		if err != nil {
+			t.Fatalf("call error = %v; want nil (structured failure result)", err)
+		}
+		if toolResultSucceeded(result) {
+			t.Fatalf("call result = %s; want failure when stale delete fails", result)
+		}
+		if len(audits) != 0 {
+			t.Fatalf("audits = %+v; want none for a partial replace", audits)
+		}
+	})
+}
+
+// TestDynamicToolsWireGiteaCurrentIssueClassification drives the production
+// construction seam (#748, clean-code rule 11): DynamicToolsForWorkflow +
+// WithCurrentIssueToolGuard must thread the "#N" identifier and the tracker
+// state sets into the Gitea proxy. The bare-numeric task ID is deliberately a
+// different number than the issue, pinning that classification keys on the
+// "#N" identifier, never on the Gitea-internal id.
+func TestDynamicToolsWireGiteaCurrentIssueClassification(t *testing.T) {
+	server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"}]`, false)
+	defer server.Close()
+
+	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{
+		Repo: workflow.RepoConfig{Owner: "owner", Name: "repo"},
+		Tracker: workflow.TrackerConfig{
+			Kind:           "gitea",
+			APIKey:         "token",
+			Endpoint:       server.URL,
+			ActiveStates:   []string{"Todo", "In Progress"},
+			TerminalStates: []string{"Done", "Canceled"},
+		},
+	}}, WithCurrentIssueToolGuard("99999", "#7", nil))
+	tool, ok := tools.Lookup("gitea_issue_labels")
+	if !ok {
+		t.Fatalf("gitea_issue_labels tool not advertised; tools=%#v", tools.Names())
+	}
+
+	var audits []ToolMutationAudit
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+		audits = append(audits, audit)
+	})
+	result, err := tool.Call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/human-review"}})
+	if err != nil {
+		t.Fatalf("tool.Call error = %v; want nil", err)
+	}
+	if !toolResultSucceeded(result) {
+		t.Fatalf("tool.Call result = %s; want success", result)
+	}
+	want := ToolMutationAudit{CurrentIssueNonActiveStateUpdate: true}
+	if len(audits) != 1 || audits[0] != want {
+		t.Fatalf("audits = %+v; want exactly [%+v]", audits, want)
+	}
+}

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -654,8 +654,9 @@ func TestGiteaIssueLabelsNoOpWhenDesiredAlreadyPresentAndNoStale(t *testing.T) {
 
 // giteaEchoLabelServer serves the labels endpoint for handoff-classification
 // tests: GET returns currentLabels JSON, POST echoes the requested labels with
-// synthetic ids, DELETE succeeds unless failDelete is set.
-func giteaEchoLabelServer(currentLabels string, failDelete bool) *httptest.Server {
+// synthetic ids, DELETE succeeds unless the trailing label id is listed in
+// failDeleteIDs.
+func giteaEchoLabelServer(currentLabels string, failDeleteIDs ...string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method {
@@ -673,9 +674,13 @@ func giteaEchoLabelServer(currentLabels string, failDelete bool) *httptest.Serve
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"labels": echoed})
 		case http.MethodDelete:
-			if failDelete {
-				http.Error(w, "boom", http.StatusInternalServerError)
-				return
+			parts := strings.Split(strings.TrimRight(r.URL.Path, "/"), "/")
+			deleteID := parts[len(parts)-1]
+			for _, failID := range failDeleteIDs {
+				if deleteID == failID {
+					http.Error(w, "boom", http.StatusInternalServerError)
+					return
+				}
 			}
 			_, _ = io.WriteString(w, `{}`)
 		default:
@@ -768,7 +773,7 @@ func TestGiteaIssueLabelsClassifiesCurrentIssueHandoffMutation(t *testing.T) {
 			if currentLabels == "" {
 				currentLabels = `[{"id":101,"name":"aiops/in-progress"}]`
 			}
-			server := giteaEchoLabelServer(currentLabels, false)
+			server := giteaEchoLabelServer(currentLabels)
 			defer server.Close()
 			proxy := giteaClassificationProxy(server.URL)
 			proxy.http = server.Client()
@@ -800,7 +805,7 @@ func TestGiteaIssueLabelsClassifiesCurrentIssueHandoffMutation(t *testing.T) {
 // because the surviving active label keeps the derived state active.
 func TestGiteaIssueLabelsStaleDeleteRetryAndPartialFailureAuditContract(t *testing.T) {
 	t.Run("stale-delete-only retry classifies handoff", func(t *testing.T) {
-		server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"},{"id":102,"name":"aiops/human-review"}]`, false)
+		server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"},{"id":102,"name":"aiops/human-review"}]`)
 		defer server.Close()
 		proxy := giteaClassificationProxy(server.URL)
 		proxy.http = server.Client()
@@ -825,7 +830,7 @@ func TestGiteaIssueLabelsStaleDeleteRetryAndPartialFailureAuditContract(t *testi
 		// The label is already in the desired shape, so the call makes no HTTP
 		// write. The flip happened elsewhere (an earlier audited call or an
 		// operator's manual edit) and must not be attributed to the agent.
-		server := giteaEchoLabelServer(`[{"id":102,"name":"aiops/human-review"}]`, false)
+		server := giteaEchoLabelServer(`[{"id":102,"name":"aiops/human-review"}]`)
 		defer server.Close()
 		proxy := giteaClassificationProxy(server.URL)
 		proxy.http = server.Client()
@@ -845,8 +850,12 @@ func TestGiteaIssueLabelsStaleDeleteRetryAndPartialFailureAuditContract(t *testi
 			t.Fatalf("audits = %+v; want none for a zero-write no-op", audits)
 		}
 	})
-	t.Run("failed stale delete fires no audit", func(t *testing.T) {
-		server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"}]`, true)
+	t.Run("failed stale delete with surviving higher-priority active label fires no audit", func(t *testing.T) {
+		// aiops/in-progress outranks aiops/human-review in the mapping
+		// priority, so the surviving stale label keeps the derived state
+		// active: the issue never left the active set and the agent's retry
+		// will carry the signal.
+		server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"}]`, "101")
 		defer server.Close()
 		proxy := giteaClassificationProxy(server.URL)
 		proxy.http = server.Client()
@@ -863,7 +872,61 @@ func TestGiteaIssueLabelsStaleDeleteRetryAndPartialFailureAuditContract(t *testi
 			t.Fatalf("call result = %s; want failure when stale delete fails", result)
 		}
 		if len(audits) != 0 {
-			t.Fatalf("audits = %+v; want none for a partial replace", audits)
+			t.Fatalf("audits = %+v; want none for a partial replace that stays active", audits)
+		}
+	})
+	t.Run("failed aiops/todo delete after successful add still fires handoff", func(t *testing.T) {
+		// Codex P2 on #751: aiops/human-review outranks aiops/todo, so the
+		// successful add alone flips the derived state to Human Review —
+		// reconcile will stop the run on the next poll even though the
+		// stale delete failed. Skipping the audit here would lose the
+		// handoff exactly like the bug #748 fixes.
+		server := giteaEchoLabelServer(`[{"id":103,"name":"aiops/todo"}]`, "103")
+		defer server.Close()
+		proxy := giteaClassificationProxy(server.URL)
+		proxy.http = server.Client()
+
+		var audits []ToolMutationAudit
+		ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+			audits = append(audits, audit)
+		})
+		result, err := proxy.call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/human-review"}})
+		if err != nil {
+			t.Fatalf("call error = %v; want nil (structured failure result)", err)
+		}
+		if toolResultSucceeded(result) {
+			t.Fatalf("call result = %s; want failure when stale delete fails", result)
+		}
+		want := ToolMutationAudit{CurrentIssueNonActiveStateUpdate: true}
+		if len(audits) != 1 || audits[0] != want {
+			t.Fatalf("audits = %+v; want exactly [%+v] (landed add already left the active set)", audits, want)
+		}
+	})
+	t.Run("partial delete accounting derives post state from landed writes", func(t *testing.T) {
+		// Two stale active labels; the in-progress delete lands, the todo
+		// delete fails. The landed writes leave {todo, human-review}, which
+		// derives Human Review (non-active) → handoff fires. If the audit
+		// ignored which deletes landed and used the full pre-write set, the
+		// surviving in-progress would wrongly keep the verdict active.
+		server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"},{"id":103,"name":"aiops/todo"}]`, "103")
+		defer server.Close()
+		proxy := giteaClassificationProxy(server.URL)
+		proxy.http = server.Client()
+
+		var audits []ToolMutationAudit
+		ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+			audits = append(audits, audit)
+		})
+		result, err := proxy.call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/human-review"}})
+		if err != nil {
+			t.Fatalf("call error = %v; want nil (structured failure result)", err)
+		}
+		if toolResultSucceeded(result) {
+			t.Fatalf("call result = %s; want failure when a stale delete fails", result)
+		}
+		want := ToolMutationAudit{CurrentIssueNonActiveStateUpdate: true}
+		if len(audits) != 1 || audits[0] != want {
+			t.Fatalf("audits = %+v; want exactly [%+v] (post state from landed writes)", audits, want)
 		}
 	})
 }
@@ -875,7 +938,7 @@ func TestGiteaIssueLabelsStaleDeleteRetryAndPartialFailureAuditContract(t *testi
 // different number than the issue, pinning that classification keys on the
 // "#N" identifier, never on the Gitea-internal id.
 func TestDynamicToolsWireGiteaCurrentIssueClassification(t *testing.T) {
-	server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"}]`, false)
+	server := giteaEchoLabelServer(`[{"id":101,"name":"aiops/in-progress"}]`)
 	defer server.Close()
 
 	tools := DynamicToolsForWorkflow(workflow.Workflow{Config: workflow.Config{

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -16,37 +16,41 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
-// linearGraphQLMutationSinkKey carries the audit-event callback through the
-// linear_graphql tool call. handleDynamicToolCall installs the sink before
-// invoking the tool; the proxy fires it once a mutation HTTP round-trip
-// returns a non-error response. The key is unexported so only runner code
-// can write or read it — agent-controlled paths cannot forge a bypass.
-type linearGraphQLContextKey int
+// toolMutationSinkKey carries the audit-event callback through tracker
+// mutation tool calls (linear_graphql, linear_ai_workpad, gitea_issue_labels).
+// handleDynamicToolCall installs the sink before invoking the tool; the proxy
+// fires it once a mutation round-trip succeeds. The key is unexported so only
+// runner code can write or read it — agent-controlled paths cannot forge a
+// bypass.
+type dynamicToolContextKey int
 
 const (
-	linearGraphQLMutationSinkKey linearGraphQLContextKey = iota + 1
+	toolMutationSinkKey dynamicToolContextKey = iota + 1
 	linearGraphQLMutationRejectedSinkKey
 	linearGraphQLPostStopMutationSinkKey
 	linearGraphQLCurrentIssueHandoffKey
 	linearGraphQLCurrentIssueTerminalHandoffKey
 )
 
-// LinearGraphQLMutationAudit is the non-secret audit fact emitted once a
-// mutation succeeds. It deliberately excludes query text, variables, and state
-// IDs; current-issue handoff fields are parsed classifications only.
-type LinearGraphQLMutationAudit struct {
+// ToolMutationAudit is the non-secret audit fact emitted once a tracker
+// mutation succeeds — by the linear_graphql/linear_ai_workpad proxy and the
+// gitea_issue_labels proxy alike, so both trackers share one handoff
+// classification taxonomy (#748). It deliberately excludes query text,
+// variables, and state IDs; current-issue handoff fields are parsed
+// classifications only.
+type ToolMutationAudit struct {
 	OperationField                   string
 	CurrentIssueNonActiveStateUpdate bool
 	CurrentIssueTerminalStateUpdate  bool
 	CurrentIssueTerminalState        string
 }
 
-// LinearGraphQLMutationSink is the audit callback invoked once per
-// successful mutation dispatched through the agent-visible linear_graphql
-// tool. Implementations must NOT echo the query body or variables — the
-// design intent is operator visibility of WHICH mutation ran, not WHAT
-// values were attached.
-type LinearGraphQLMutationSink func(LinearGraphQLMutationAudit)
+// ToolMutationSink is the audit callback invoked once per successful
+// mutation dispatched through an agent-visible tracker mutation tool
+// (linear_graphql, linear_ai_workpad, gitea_issue_labels). Implementations
+// must NOT echo the query body or variables — the design intent is operator
+// visibility of WHICH mutation ran, not WHAT values were attached.
+type ToolMutationSink func(ToolMutationAudit)
 
 type linearGraphQLMutationFieldSink func(operationName string)
 
@@ -60,19 +64,20 @@ type linearGraphQLMutationRejected struct {
 
 type linearGraphQLMutationRejectedSink func(linearGraphQLMutationRejected)
 
-// WithLinearGraphQLMutationSink returns a context that the linear_graphql
-// tool consults to surface successful mutations as audit events. The sink
-// is invoked only after the HTTP response status is 2xx; transport failures
-// and Linear-reported GraphQL errors do not fire the audit.
-func WithLinearGraphQLMutationSink(ctx context.Context, sink LinearGraphQLMutationSink) context.Context {
+// WithToolMutationSink returns a context that the tracker mutation proxies
+// consult to surface successful mutations as audit events. The sink is
+// invoked only after the mutation actually succeeded; transport failures,
+// Linear-reported GraphQL errors, and partial Gitea label replaces do not
+// fire the audit.
+func WithToolMutationSink(ctx context.Context, sink ToolMutationSink) context.Context {
 	if sink == nil {
 		return ctx
 	}
-	return context.WithValue(ctx, linearGraphQLMutationSinkKey, sink)
+	return context.WithValue(ctx, toolMutationSinkKey, sink)
 }
 
-func linearGraphQLMutationSinkFrom(ctx context.Context) LinearGraphQLMutationSink {
-	sink, _ := ctx.Value(linearGraphQLMutationSinkKey).(LinearGraphQLMutationSink)
+func toolMutationSinkFrom(ctx context.Context) ToolMutationSink {
+	sink, _ := ctx.Value(toolMutationSinkKey).(ToolMutationSink)
 	return sink
 }
 
@@ -247,7 +252,7 @@ func DynamicToolsForWorkflow(wf workflow.Workflow, toolOptions ...DynamicToolOpt
 			owner:   wf.Config.Repo.Owner,
 			repo:    wf.Config.Repo.Name,
 			http:    http.DefaultClient,
-		}
+		}.withCurrentIssueClassification(trackerCfg, opts)
 		tools.tools["gitea_issue_labels"] = DynamicTool{
 			Name:        "gitea_issue_labels",
 			Description: "Replace the aiops/* state label on one Gitea issue using orchestrator-configured Gitea auth. Input: {issue_number:number, labels:string[]} with exactly one aiops/* label. The Gitea API token is never exposed to the agent process.",
@@ -595,8 +600,8 @@ func (p linearGraphQLProxy) dispatch(ctx context.Context, query string, op linea
 			if sink := linearGraphQLPostStopMutationSinkFrom(ctx); sink != nil {
 				sink(op.FieldName)
 			}
-		} else if sink := linearGraphQLMutationSinkFrom(ctx); sink != nil {
-			sink(LinearGraphQLMutationAudit{
+		} else if sink := toolMutationSinkFrom(ctx); sink != nil {
+			sink(ToolMutationAudit{
 				OperationField:                   op.FieldName,
 				CurrentIssueNonActiveStateUpdate: linearGraphQLCurrentIssueHandoffFrom(ctx),
 				CurrentIssueTerminalStateUpdate:  linearGraphQLCurrentIssueTerminalHandoffFrom(ctx),

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -586,11 +586,11 @@ func TestLinearGraphQLEmitsAuditEventForSuccessfulMutation(t *testing.T) {
 
 	proxy := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client(), allowMutations: true}
 
-	var sinkCalls []LinearGraphQLMutationAudit
-	sink := func(audit LinearGraphQLMutationAudit) {
+	var sinkCalls []ToolMutationAudit
+	sink := func(audit ToolMutationAudit) {
 		sinkCalls = append(sinkCalls, audit)
 	}
-	ctx := WithLinearGraphQLMutationSink(context.Background(), sink)
+	ctx := WithToolMutationSink(context.Background(), sink)
 
 	if _, err := proxy.call(ctx, ToolCall{Query: `mutation { issueUpdate(id: "1", input: {}) { success } }`}); err != nil {
 		t.Fatalf("mutation: %v", err)
@@ -619,8 +619,8 @@ func TestLinearGraphQLDoesNotEmitAuditOnGraphQLErrors(t *testing.T) {
 	defer httpServer.Close()
 
 	proxy := linearGraphQLProxy{apiKey: "token", baseURL: httpServer.URL, http: httpServer.Client(), allowMutations: true}
-	var sinkCalls []LinearGraphQLMutationAudit
-	ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+	var sinkCalls []ToolMutationAudit
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 		sinkCalls = append(sinkCalls, audit)
 	})
 
@@ -851,7 +851,7 @@ func TestLinearGraphQLWorkpadEmitsAuditEvent(t *testing.T) {
 			workpad := NewLinearWorkpadTool(harnessTool)
 
 			var sinkCalls []string
-			ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+			ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 				sinkCalls = append(sinkCalls, audit.OperationField)
 			})
 
@@ -1117,7 +1117,7 @@ func TestLinearGraphQLIgnoresUnusedMutationFragmentDefinition(t *testing.T) {
 
 	proxy := guardedLinearProxy(httpServer, IssueStateSnapshot{Found: true, State: "In Progress", Active: true})
 	var mutationFields []string
-	ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 		mutationFields = append(mutationFields, audit.OperationField)
 	})
 	var rejections []linearGraphQLMutationRejected
@@ -1222,8 +1222,8 @@ func TestLinearGraphQLAllowsCurrentIssueNonActiveHandoffState(t *testing.T) {
 	defer httpServer.Close()
 
 	proxy := guardedLinearProxy(httpServer, IssueStateSnapshot{Found: true, State: "In Progress", Active: true})
-	var mutationAudits []LinearGraphQLMutationAudit
-	ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+	var mutationAudits []ToolMutationAudit
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 		mutationAudits = append(mutationAudits, audit)
 	})
 
@@ -1262,8 +1262,8 @@ func TestLinearGraphQLMarksCurrentIssueTerminalHandoffState(t *testing.T) {
 
 	proxy := guardedLinearProxy(httpServer, IssueStateSnapshot{Found: true, State: "In Progress", Active: true})
 	proxy.currentIssueGuard.terminalStates = []string{"Done"}
-	var mutationAudits []LinearGraphQLMutationAudit
-	ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+	var mutationAudits []ToolMutationAudit
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 		mutationAudits = append(mutationAudits, audit)
 	})
 
@@ -1299,8 +1299,8 @@ func TestLinearGraphQLMarksTerminalHandoffWhenOtherConfiguredTerminalStatesAreMi
 
 	proxy := guardedLinearProxy(httpServer, IssueStateSnapshot{Found: true, State: "In Progress", Active: true})
 	proxy.currentIssueGuard.terminalStates = []string{"Done", "Closed", "Duplicate"}
-	var mutationAudits []LinearGraphQLMutationAudit
-	ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+	var mutationAudits []ToolMutationAudit
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 		mutationAudits = append(mutationAudits, audit)
 	})
 
@@ -1333,9 +1333,9 @@ func TestLinearGraphQLAllowsCurrentIssueHandoffWhenTerminalStateLookupFails(t *t
 
 	proxy := guardedLinearProxy(httpServer, IssueStateSnapshot{Found: true, State: "In Progress", Active: true})
 	proxy.currentIssueGuard.terminalStates = []string{"Done"}
-	var mutationAudits []LinearGraphQLMutationAudit
+	var mutationAudits []ToolMutationAudit
 	var rejections []linearGraphQLMutationRejected
-	ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 		mutationAudits = append(mutationAudits, audit)
 	})
 	ctx = WithLinearGraphQLMutationRejectedSink(ctx, func(rejection linearGraphQLMutationRejected) {
@@ -1379,7 +1379,7 @@ func TestLinearGraphQLNormalMutationAuditDoesNotRefreshCurrentIssueState(t *test
 		return IssueStateSnapshot{Found: true, State: "In Progress", Active: true}, nil
 	}
 	var normal, postStop []string
-	ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 		normal = append(normal, audit.OperationField)
 	})
 	ctx = WithLinearGraphQLPostStopMutationSink(ctx, func(field string) {
@@ -1492,7 +1492,7 @@ func TestLinearGraphQLPostStopCommentsUseDistinctAudit(t *testing.T) {
 		OperatorTerminalStop: true,
 	})
 	var normal, postStop []string
-	ctx := WithLinearGraphQLMutationSink(context.Background(), func(audit LinearGraphQLMutationAudit) {
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
 		normal = append(normal, audit.OperationField)
 	})
 	ctx = WithLinearGraphQLPostStopMutationSink(ctx, func(field string) {


### PR DESCRIPTION
Closes #748

## Problem

The v0.1.0 lifecycle test (#740 F7) ran 12 fully successful Gitea agent handoffs (PR opened + `aiops/human-review` label flip each) yet the state API reported `completed_total=0` and `agent_handoff_reconcile_stopped_total=0` — every run was classified as a plain `reconcile_stopped_with_progress`. The agent-handoff classification pipeline existed only for the Linear tools (`linear_graphql` / `linear_ai_workpad`); `gitea_issue_labels` fired no mutation-audit sink at all. This is AGENTS.md cross-cutting checklist item 1: an aiops extension applied on one tool path but not its sibling.

## Change

- **`internal/runner/gitea_tools.go`** — the proxy now fires the shared mutation-audit sink after a label replace fully succeeds (desired add + stale delete) **and** at least one HTTP write ran. It classifies a current-issue flip **from a configured active pre-write state** out of the active set as the handoff (`current_issue_non_active_state_update`), adding the terminal keys (`current_issue_terminal_state_update`, `current_issue_terminal_state`) when the target state is in the configured terminal states. The payload is built by the single existing `mutationAuditPayload` (clean-code rule 3).
  - Partial failure fires nothing: a surviving stale active label keeps the derived state active (`IssueStateFromLabels` active-first priority), so the issue never left the active set.
  - The stale-delete-only retry (desired label landed in an earlier partial replace) does classify — that delete completes the handoff.
  - A zero-write no-op fires nothing: the flip happened elsewhere (an earlier audited call or an operator's manual edit) and must not be attributed to the agent.
- **`internal/runner/tools.go`** — sink family renamed tracker-neutral in one atomic change (clean-code rule 4): `LinearGraphQLMutationAudit`→`ToolMutationAudit`, `WithLinearGraphQLMutationSink`→`WithToolMutationSink`, `linearGraphQLContextKey`→`dynamicToolContextKey`. The Gitea proxy is wired through `withCurrentIssueClassification(trackerCfg, opts)` from the same `WithCurrentIssueToolGuard` options the Linear guard uses.
- **`internal/gitea/tracker_client.go`** — exported `IssueNumberFromRef`: only `"#N"`-shaped refs parse; a bare numeric ID is the Gitea-internal int64 id (`giteaIssueID` prefers it over the issue number) and parsing it as an issue number could silently target a different issue. `issueNumberForStateRefresh` now delegates to it (one source of truth).
- **`internal/orchestrator/runtime_events.go`** — `isLinearMutationTool`→`isAgentHandoffMutationTool`, accepting `gitea_issue_labels`, so `RunningEntry.AgentCurrentIssueHandoff` is set and `finalizeRunOp` records `agent_handoff_reconcile_stopped`. Stale Linear-only comments in `state.go`/`status.go` updated.

## Acceptance criteria

- [x] Successful `gitea_issue_labels` mutation moving the current issue out of active states emits `task.EventToolCallMutation` with the same classification payload keys as the Linear path (single `mutationAuditPayload` source of truth) — `TestGiteaIssueLabelsClassifiesCurrentIssueHandoffMutation`
- [x] `recordAgentHandoffFields` recognizes the Gitea tool's mutation events — `TestReconcileCancelAfterGiteaCurrentIssueHandoffRecordsAgentHandoff`
- [x] A Gitea run reconcile-stopped after the handoff label flip increments `agent_handoff_reconcile_stopped_total` (regression test drives RequestDispatch → RecordRuntimeEvent → reconcile → finalize)
- [x] Non-handoff label mutations (flip to another active state; other issue; zero-write no-op) do not set the classification

## Verification

```
gofmt -l $(git ls-files '*.go')                      # empty
go mod tidy && git diff --exit-code -- go.mod go.sum
go vet ./...
go test -race -covermode=atomic ./...                # all green
go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts
go build ./cmd/worker ./cmd/tui
golangci-lint run --enable-only=staticcheck,unparam,unused (changed pkgs)  # 0 issues
```

Mutation verification (committed artifact, each restored after FAIL):
- M1 drop `gitea_issue_labels` from `isAgentHandoffMutationTool` → orchestrator finalize test FAILs
- M2 drop the `fireMutationAudit` call → classification test FAILs
- M3 drop the `withCurrentIssueClassification` wiring seam (rule 11) → seam test FAILs
- M4 drop the active-state membership gate → classification test FAILs
- M5 drop the zero-write gate → no-op audit test FAILs
- M6 drop the pre-state active gate → pre-state classification cases FAIL
- M7 drop the landed-delete accounting → partial-delete test FAILs
- M8 drop the partial-failure handoff fire → Codex-P2 regression test FAILs

## Reviews

- Pre-push dual diff-only review: Claude-family (`feature-dev:code-reviewer`) round 1 found 2 MEDIUM (stale `linearGraphQLContextKey` name; zero-write no-op misattribution) — both fixed + regression subtest; round 2 found 1 comment-staleness defect (`status.go` Linear-pinned doc) — fixed; Codex-family (`codex exec --output-schema`, diff-only) round 2 found 1 MEDIUM (classification did not prove the pre-write state was active, so a non-active→non-active relabel could be misattributed as an agent handoff and mask an operator-owned stop) — fixed with a pre-state gate derived from the labels fetched before the write, plus 3 regression cases. Round 3: Claude MERGE-READY, Codex clean. GitHub `@codex review` on bcf80a9 raised 1 P2 (a successful add with a failed stale `aiops/todo` delete still flips the derived state — human-review outranks todo in mapping priority — and the audit was skipped, losing the handoff): fixed by classifying from the post-write label set reconstructed from the writes that actually landed; partial failure now fires only the handoff fact. Round 4 on the fixed head: Claude MERGE-READY, Codex `{"blocking_findings":[]}`.

## Scope notes

- The Linear guard's *rejection* surface (active-state flip rejection, operator-stop gate, rejected/post-stop sinks) is deliberately **not** mirrored here: #748 scopes to the audit/classification taxonomy. The Gitea tool's input contract is already narrow (exactly one `aiops/*` label). If guard parity is wanted it is a separate decision.

### Size gate
- [x] `within budget` — 6 production files, ~190 changed production LOC (incl. rename churn); test files excluded
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Note: no new config keys, phases, or worker-side gates. The handoff classification is a pre-existing aiops extension; this PR only mirrors it onto the sibling Gitea tool path per cross-cutting checklist item 1.
