### PR TITLE
fix: re-check Todo blockers in dispatch revalidation (#750)

### DIFF
--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -167,6 +167,10 @@ func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []
 	if len(issueRefs) == 0 {
 		return map[string]tracker.IssueState{}, nil
 	}
+	// Install a per-refresh blocker cache so buildBlockedBy fetches each
+	// `Depends on #N` blocker at most once across the batch, mirroring the
+	// listing path (#677).
+	ctx = withBlockerCache(ctx)
 	states := make(map[string]tracker.IssueState, len(issueRefs))
 	seen := map[string]struct{}{}
 	for _, issueRef := range issueRefs {
@@ -202,7 +206,17 @@ func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []
 		}
 		// Carry the full label set (SPEC §6.4 required_labels gate) alongside the
 		// derived state; extractGiteaLabels lowercases/trims to match the gate.
-		states[issueID] = tracker.IssueState{State: state, Labels: extractGiteaLabels(issue.Labels)}
+		// BlockedBy is re-derived from the refreshed body so dispatch-time
+		// revalidation can re-apply the SPEC §8.2 Todo blocker gate (#750);
+		// the body is authoritative for this adapter, so an absence of
+		// `Depends on #N` references is a positive non-nil "no blockers" and
+		// transiently-unresolvable references fail closed as open
+		// placeholders inside buildBlockedBy.
+		blockedBy := c.buildBlockedBy(ctx, issue.Body)
+		if blockedBy == nil {
+			blockedBy = []tracker.BlockerRef{}
+		}
+		states[issueID] = tracker.IssueState{State: state, Labels: extractGiteaLabels(issue.Labels), BlockedBy: blockedBy}
 	}
 	return states, nil
 }
@@ -583,33 +597,43 @@ func blockerCacheFrom(ctx context.Context) map[int]blockerCacheEntry {
 
 // cachedIssueByNumber fetches blocker issue n via getIssueByNumber at most once
 // per poll tick. A successful fetch and a definitive 404 are memoized; a
-// transient error returns a miss without caching so a later source issue can
-// retry. When no per-tick cache is installed (non-poll callers), it falls back
-// to a direct fetch.
-func (c *TrackerClient) cachedIssueByNumber(ctx context.Context, cache map[int]blockerCacheEntry, n int) (Issue, bool) {
+// transient error returns resolved=false without caching so a later source
+// issue can retry. resolved distinguishes "the lookup answered" (found tells
+// whether the issue exists) from "the lookup failed" — callers must not treat
+// a transient failure as a definitive absence. When no per-tick cache is
+// installed (non-poll callers), it falls back to a direct fetch.
+func (c *TrackerClient) cachedIssueByNumber(ctx context.Context, cache map[int]blockerCacheEntry, n int) (issue Issue, found, resolved bool) {
 	if cache != nil {
 		if entry, ok := cache[n]; ok {
-			return entry.issue, entry.found
+			return entry.issue, entry.found, true
 		}
 	}
-	issue, found, err := c.getIssueByNumber(ctx, n)
+	fetched, found, err := c.getIssueByNumber(ctx, n)
 	if err != nil {
-		return Issue{}, false
+		return Issue{}, false, false
 	}
 	if cache != nil {
-		cache[n] = blockerCacheEntry{issue: issue, found: found}
+		cache[n] = blockerCacheEntry{issue: fetched, found: found}
 	}
-	return issue, found
+	return fetched, found, true
 }
 
 // buildBlockedBy parses `Depends on #N` references from issue.Body and looks
 // up each blocker's current workflow state via a follow-up Gitea fetch so the
-// §8.2 Todo blocker rule can compare against the blocker's State. Lookup
-// failures are silently skipped (best-effort): a missing or deleted blocker
-// drops out of the list rather than aborting candidate enumeration. The
-// per-poll-tick blocker cache (installed by ListIssuesByStates) ensures each
-// distinct blocker is fetched at most once per tick across all source issues,
-// instead of O(distinct refs) per source issue (#677).
+// §8.2 Todo blocker rule can compare against the blocker's State. The
+// per-poll-tick blocker cache (installed by ListIssuesByStates and the narrow
+// refresh) ensures each distinct blocker is fetched at most once per tick
+// across all source issues, instead of O(distinct refs) per source issue
+// (#677).
+//
+// Reference resolution fails closed (#750 / PR #752 review): a transiently
+// unresolvable reference becomes a placeholder ref with an empty State, which
+// the shared tracker.BlockedByNonTerminal predicate treats as open — the Todo
+// gate then blocks the candidate for this tick instead of dispatching past a
+// blocker the lookup could not see; the next tick retries (the transient
+// failure is deliberately not cached). A definitive 404 is a DELETED blocker:
+// it can never become terminal, so blocking on it would starve the candidate
+// forever — it drops out of the list instead.
 func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string) []tracker.BlockerRef {
 	matches := dependsOnRegexp.FindAllStringSubmatch(body, -1)
 	if len(matches) == 0 {
@@ -617,7 +641,7 @@ func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string) []track
 	}
 	cache := blockerCacheFrom(ctx)
 	seen := map[int]struct{}{}
-	var out []tracker.BlockerRef
+	var refs []tracker.BlockerRef
 	for _, m := range matches {
 		n, err := strconv.Atoi(m[1])
 		if err != nil || n <= 0 {
@@ -627,18 +651,35 @@ func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string) []track
 			continue
 		}
 		seen[n] = struct{}{}
-		issue, found := c.cachedIssueByNumber(ctx, cache, n)
-		if !found {
-			continue
+		if ref, ok := c.blockerRefForNumber(ctx, cache, n); ok {
+			refs = append(refs, ref)
 		}
-		state, _ := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
-		out = append(out, tracker.BlockerRef{
-			ID:         giteaIssueID(issue),
-			Identifier: fmt.Sprintf("#%d", issue.Number),
-			State:      state,
-		})
 	}
-	return out
+	return refs
+}
+
+// blockerRefForNumber resolves one `Depends on #N` reference: a resolved
+// blocker carries its derived state, a transient lookup failure fails closed
+// as an empty-state placeholder (logged — without that a persistently failing
+// lookup would starve the candidate indistinguishably from a genuine open
+// blocker), and a definitively deleted blocker reports ok=false to drop out.
+func (c *TrackerClient) blockerRefForNumber(ctx context.Context, cache map[int]blockerCacheEntry, n int) (tracker.BlockerRef, bool) {
+	issue, found, resolved := c.cachedIssueByNumber(ctx, cache, n)
+	if !resolved {
+		if c.Logf != nil {
+			c.Logf("gitea blocker lookup failed transiently for #%d; failing closed as an open placeholder", n)
+		}
+		return tracker.BlockerRef{Identifier: fmt.Sprintf("#%d", n)}, true
+	}
+	if !found {
+		return tracker.BlockerRef{}, false
+	}
+	state, _ := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
+	return tracker.BlockerRef{
+		ID:         giteaIssueID(issue),
+		Identifier: fmt.Sprintf("#%d", issue.Number),
+		State:      state,
+	}, true
 }
 
 func giteaIssueID(issue Issue) string {

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -615,9 +615,12 @@ func TestTrackerClientListIssuesByStatesNormalizesLabelsAndBlockedBy(t *testing.
 	}
 }
 
-// TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure: a missing
-// blocker (404 or transient failure) silently drops out of BlockedBy rather
-// than aborting candidate enumeration. Best-effort semantics per #210.
+// TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure: a
+// definitively deleted blocker (404) silently drops out of BlockedBy rather
+// than aborting candidate enumeration — it can never become terminal, so
+// keeping it would starve the candidate forever. (A transient lookup failure
+// fails closed as an empty-state placeholder instead; see
+// TestTrackerClientFetchIssueStatesByRefsCarriesRefreshedBlockers.)
 func TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -885,11 +888,11 @@ func TestCachedIssueByNumberNilCacheFallsBackToDirectFetch(t *testing.T) {
 	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
-	issue, found := client.cachedIssueByNumber(context.Background(), nil, 3)
-	if !found || issue.Number != 3 {
-		t.Fatalf("cachedIssueByNumber(nil cache, 3) = (%#v, %v); want issue #3, true", issue, found)
+	issue, found, resolved := client.cachedIssueByNumber(context.Background(), nil, 3)
+	if !found || !resolved || issue.Number != 3 {
+		t.Fatalf("cachedIssueByNumber(nil cache, 3) = (%#v, %v, %v); want issue #3, true, true", issue, found, resolved)
 	}
-	if _, found = client.cachedIssueByNumber(context.Background(), nil, 3); !found {
+	if _, found, _ = client.cachedIssueByNumber(context.Background(), nil, 3); !found {
 		t.Fatalf("cachedIssueByNumber(nil cache, 3) second call found = false; want true")
 	}
 	if blockerFetches != 2 {
@@ -931,14 +934,158 @@ func TestTrackerClientListIssuesByStatesRetriesBlockerAfterTransientError(t *tes
 	if blockerFetches != 2 {
 		t.Fatalf("blocker #3 fetched %d times; want 2 (transient error not cached, retried for the second source issue)", blockerFetches)
 	}
-	withBlocker := 0
+	// The first source's transient failure fails closed as an empty-state
+	// placeholder (#750 / PR #752 review); the second source's retry resolves
+	// the real blocker state. Both carry #3 — the difference is the State.
+	resolved, placeholders := 0, 0
 	for _, iss := range issues {
-		if len(iss.BlockedBy) == 1 && iss.BlockedBy[0].Identifier == "#3" {
-			withBlocker++
+		if len(iss.BlockedBy) != 1 || iss.BlockedBy[0].Identifier != "#3" {
+			continue
+		}
+		if iss.BlockedBy[0].State == "" {
+			placeholders++
+		} else {
+			resolved++
 		}
 	}
-	if withBlocker != 1 {
-		t.Fatalf("issues carrying blocker #3 = %d; want 1 (first source errored+skipped, second retried+found)", withBlocker)
+	if placeholders != 1 || resolved != 1 {
+		t.Fatalf("blocker #3 carried as placeholder=%d resolved=%d; want 1 fail-closed placeholder (errored source) and 1 resolved (retried source)", placeholders, resolved)
+	}
+}
+
+// TestTrackerClientFetchIssueStatesByRefsCarriesRefreshedBlockers pins #750:
+// the narrow refresh re-derives `Depends on #N` blockers from the refreshed
+// body (with the blocker's current state) so dispatch revalidation can re-run
+// the SPEC §8.2 Todo blocker gate, and a dependency-free issue carries the
+// positive non-nil empty answer rather than nil ("no knowledge").
+func TestTrackerClientFetchIssueStatesByRefsCarriesRefreshedBlockers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/5":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 555, Number: 5, Title: "blocked todo", Body: "Depends on #9",
+				HTMLURL: "https://gitea.local/o/r/issues/5",
+				Labels:  []Label{{Name: "aiops/todo"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/9":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 999, Number: 9, Title: "reopened blocker",
+				HTMLURL: "https://gitea.local/o/r/issues/9",
+				Labels:  []Label{{Name: "aiops/in-progress"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/6":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 666, Number: 6, Title: "free todo", Body: "no dependencies here",
+				HTMLURL: "https://gitea.local/o/r/issues/6",
+				Labels:  []Label{{Name: "aiops/todo"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/7":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 777, Number: 7, Title: "todo with unresolvable dep", Body: "Depends on #99",
+				HTMLURL: "https://gitea.local/o/r/issues/7",
+				Labels:  []Label{{Name: "aiops/todo"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/99":
+			http.Error(w, "boom", http.StatusInternalServerError)
+		case "/api/v1/repos/owner/repo/issues/8":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 888, Number: 8, Title: "mixed deps, one reopened", Body: "Depends on #9\nDepends on #99",
+				HTMLURL: "https://gitea.local/o/r/issues/8",
+				Labels:  []Label{{Name: "aiops/todo"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/4":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 444, Number: 4, Title: "mixed deps, resolved one terminal", Body: "Depends on #10\nDepends on #99",
+				HTMLURL: "https://gitea.local/o/r/issues/4",
+				Labels:  []Label{{Name: "aiops/todo"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/10":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 1010, Number: 10, Title: "done blocker",
+				HTMLURL: "https://gitea.local/o/r/issues/10",
+				Labels:  []Label{{Name: "aiops/done"}},
+			})
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done", "Canceled"}}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{
+		{ID: "555", Identifier: "#5"},
+		{ID: "666", Identifier: "#6"},
+		{ID: "777", Identifier: "#7"},
+		{ID: "888", Identifier: "#8"},
+		{ID: "444", Identifier: "#4"},
+	})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs: %v", err)
+	}
+	blocked := states["555"].BlockedBy
+	if len(blocked) != 1 || blocked[0].ID != "999" || blocked[0].Identifier != "#9" || blocked[0].State != "In Progress" {
+		t.Fatalf("FetchIssueStatesByRefs(555).BlockedBy = %#v; want #9 in In Progress", blocked)
+	}
+	free := states["666"].BlockedBy
+	if free == nil || len(free) != 0 {
+		t.Fatalf("FetchIssueStatesByRefs(666).BlockedBy = %#v; want non-nil empty for a dependency-free body", free)
+	}
+	// A `Depends on #N` reference whose lookup transiently fails must fail
+	// closed: an empty-state placeholder the gate treats as open, never a
+	// positive "no blockers" — otherwise a transient blocker-lookup failure
+	// would let the candidate dispatch past a blocker the refresh could not
+	// see (PR #752 review).
+	failed := states["777"].BlockedBy
+	if len(failed) != 1 || failed[0].Identifier != "#99" || failed[0].State != "" {
+		t.Fatalf("FetchIssueStatesByRefs(777).BlockedBy = %#v; want one empty-state placeholder for the unresolvable #99", failed)
+	}
+	// Mixed resolution keeps the resolved reopened blocker AND the
+	// fail-closed placeholder; either alone blocks at the consumer's gate.
+	mixed := states["888"].BlockedBy
+	if len(mixed) != 2 || mixed[0].Identifier != "#9" || mixed[0].State != "In Progress" || mixed[1].Identifier != "#99" || mixed[1].State != "" {
+		t.Fatalf("FetchIssueStatesByRefs(888).BlockedBy = %#v; want resolved #9 (In Progress) plus the #99 placeholder", mixed)
+	}
+	// Resolved-terminal blockers do not unblock an unresolved sibling: the
+	// placeholder still fails the gate closed.
+	terminalMixed := states["444"].BlockedBy
+	if len(terminalMixed) != 2 || terminalMixed[0].Identifier != "#10" || terminalMixed[0].State != "Done" || terminalMixed[1].Identifier != "#99" || terminalMixed[1].State != "" {
+		t.Fatalf("FetchIssueStatesByRefs(444).BlockedBy = %#v; want resolved #10 (Done) plus the #99 placeholder", terminalMixed)
+	}
+}
+
+// A definitively deleted blocker (404) is skipped — it can never become
+// terminal, so blocking on it would starve the candidate forever; this
+// matches the listing path's handling of deleted references.
+func TestTrackerClientFetchIssueStatesByRefsSkipsDeletedBlockers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/5":
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID: 555, Number: 5, Title: "todo with deleted dep", Body: "Depends on #404",
+				HTMLURL: "https://gitea.local/o/r/issues/5",
+				Labels:  []Label{{Name: "aiops/todo"}},
+			})
+		case "/api/v1/repos/owner/repo/issues/404":
+			http.NotFound(w, r)
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"Todo"}}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "555", Identifier: "#5"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs: %v", err)
+	}
+	if got := states["555"].BlockedBy; got == nil || len(got) != 0 {
+		t.Fatalf("FetchIssueStatesByRefs(555).BlockedBy = %#v; want non-nil empty when the only dependency is deleted", got)
 	}
 }
 

--- a/internal/orchestrator/poller_candidates.go
+++ b/internal/orchestrator/poller_candidates.go
@@ -39,12 +39,13 @@ var dispatchRevalidationTimeout = 45 * time.Second
 // when the refresh omits it (upstream {:skip, :missing}; the Gitea adapter
 // also omits issues whose aiops/* state labels were stripped), when its
 // refreshed state left the configured active set, or when its refreshed
-// labels no longer satisfy the SPEC §6.4 required-labels gate — the same
-// gates the retry-fire path re-applies at fire time via
-// eligibleActiveIssueLister. Refreshed BlockedBy data is not available from
-// the narrow refresh, so the Todo-blocker gate keeps its listing-time result.
-// Survivors carry the refreshed state and labels so the per-state capacity
-// gate and the spawned worker see live tracker data, mirroring upstream's
+// labels no longer satisfy the SPEC §6.4 required-labels gate, or when it is
+// a Todo issue whose refreshed blockers are not all terminal (upstream
+// retry_candidate_issue?'s !todo_issue_blocked_by_non_terminal?,
+// orchestrator.ex:1602-1604, #750) — the same gates the retry-fire path
+// re-applies at fire time via eligibleActiveIssueLister. Survivors carry the
+// refreshed state, labels, and blocker data so the per-state capacity gate
+// and the spawned worker see live tracker data, mirroring upstream's
 // dispatch of the refreshed issue. On fetch failure the candidates the
 // refresh did return still dispatch and the rest are skipped (upstream skips
 // dispatch on refresh error); the next tick retries from a fresh listing.
@@ -100,12 +101,13 @@ func (p *Poller) claimableDispatchRefs(ctx context.Context, candidates []tracker
 // release stays single-sourced.
 func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimable map[IssueID]struct{}, statesByID map[string]tracker.IssueState) []tracker.Issue {
 	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
+	terminalStateKeys := normalizedStates(p.reconcile.TerminalStates)
 	kept := make([]tracker.Issue, 0, len(claimable))
 	for _, issue := range candidates {
 		if _, ok := claimable[IssueID(issue.ID)]; !ok {
 			continue
 		}
-		if revalidated, keep := revalidatedCandidate(issue, statesByID, activeStateKeys, p.reconcile.RequiredLabels); keep {
+		if revalidated, keep := revalidatedCandidate(issue, statesByID, activeStateKeys, terminalStateKeys, p.reconcile.RequiredLabels); keep {
 			kept = append(kept, revalidated)
 		}
 	}
@@ -114,9 +116,16 @@ func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimab
 
 // revalidatedCandidate applies the per-issue revalidation verdict: missing
 // from the refresh (upstream {:skip, :missing}), refreshed out of the active
-// set, or refreshed past the SPEC §6.4 required-labels gate all drop the
-// candidate; otherwise the refreshed state and labels are carried onto it.
-func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.IssueState, activeStateKeys map[string]struct{}, requiredLabels []string) (tracker.Issue, bool) {
+// set, refreshed past the SPEC §6.4 required-labels gate, or a refreshed Todo
+// issue whose blockers reopened all drop the candidate; otherwise the
+// refreshed state, labels, and blocker data are carried onto it. The blocker
+// recheck matches upstream retry_candidate_issue?'s
+// !todo_issue_blocked_by_non_terminal? on the refreshed issue
+// (orchestrator.ex:1602-1604, #750); when the refresh supplies no blocker
+// knowledge (nil BlockedBy — see tracker.IssueState), the gate re-runs on the
+// listing-time blockers, which the tick-start eligibility filter already
+// passed, so it cannot newly drop the candidate.
+func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.IssueState, activeStateKeys, terminalStateKeys map[string]struct{}, requiredLabels []string) (tracker.Issue, bool) {
 	refreshed, ok := statesByID[issue.ID]
 	if !ok || strings.TrimSpace(refreshed.State) == "" {
 		logStaleDispatchSkipped(issue, "", "missing_from_refresh")
@@ -124,12 +133,19 @@ func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.Iss
 	}
 	issue.State = refreshed.State
 	issue.Labels = refreshed.Labels
+	if refreshed.BlockedBy != nil {
+		issue.BlockedBy = refreshed.BlockedBy
+	}
 	if !isActiveTrackerState(issue.State, activeStateKeys) {
 		logStaleDispatchSkipped(issue, issue.State, "state_left_active_set")
 		return tracker.Issue{}, false
 	}
 	if !issueHasRequiredLabels(issue, requiredLabels) {
 		logStaleDispatchSkipped(issue, issue.State, "required_labels_missing")
+		return tracker.Issue{}, false
+	}
+	if todoIssueBlockedByOpenDependency(issue, terminalStateKeys) {
+		logStaleDispatchSkipped(issue, issue.State, "todo_blocker_not_terminal")
 		return tracker.Issue{}, false
 	}
 	return issue, true
@@ -217,16 +233,7 @@ func todoIssueBlockedByOpenDependency(issue tracker.Issue, terminalStates map[st
 	if !strings.EqualFold(strings.TrimSpace(issue.State), "Todo") {
 		return false
 	}
-	for _, blocker := range issue.BlockedBy {
-		state := strings.ToLower(strings.TrimSpace(blocker.State))
-		if state == "" {
-			return true
-		}
-		if _, terminal := terminalStates[state]; !terminal {
-			return true
-		}
-	}
-	return false
+	return tracker.BlockedByNonTerminal(issue.BlockedBy, terminalStates)
 }
 
 func sortCandidates(issues []tracker.Issue) {

--- a/internal/orchestrator/poller_candidates_test.go
+++ b/internal/orchestrator/poller_candidates_test.go
@@ -289,3 +289,111 @@ func TestPollOncePartialRevalidationErrorStillDispatchesFreshCandidates(t *testi
 		t.Fatalf("dispatched issues = %v; want [issue-1]", got)
 	}
 }
+
+// todoBlockerRevalidationConfig mirrors revalidationReconcileConfig but keeps
+// Todo active so the SPEC §8.2 blocker gate (Todo-only) is exercisable.
+func todoBlockerRevalidationConfig() ReconciliationConfig {
+	return ReconciliationConfig{
+		ActiveStates:      []string{"Todo", "In Progress"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	}
+}
+
+// TestPollOnceSkipsDispatchWhenRevalidationShowsReopenedBlocker pins #750: a
+// Todo candidate that passed the tick-start blocker gate (blocker terminal at
+// listing time) is dropped when the pre-dispatch refresh shows the blocker
+// back in a non-terminal state, matching upstream retry_candidate_issue?'s
+// !todo_issue_blocked_by_non_terminal? on the refreshed issue
+// (orchestrator.ex:1602-1604).
+func TestPollOnceSkipsDispatchWhenRevalidationShowsReopenedBlocker(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{
+		ID:         "issue-1",
+		Identifier: "GT-1",
+		State:      "Todo",
+		BlockedBy:  []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "Done"}},
+	}}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, todoBlockerRevalidationConfig())
+
+	trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
+		"issue-1": {State: "Todo", BlockedBy: []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "In Progress"}}},
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0 after the refreshed blocker reopened", got, dispatcher.issueIDs())
+	}
+}
+
+// A refresh that positively reports "no blockers" (non-nil empty) dispatches,
+// and a refresh without blocker knowledge (nil BlockedBy) keeps the
+// listing-time verdict instead of clearing it.
+func TestPollOnceBlockerRevalidationHonorsNilVersusEmptyContract(t *testing.T) {
+	t.Run("non-nil empty refreshed blockers dispatch", func(t *testing.T) {
+		trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{
+			ID:         "issue-1",
+			Identifier: "GT-1",
+			State:      "Todo",
+			BlockedBy:  []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "Done"}},
+		}}}
+		poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, todoBlockerRevalidationConfig())
+
+		trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
+			"issue-1": {State: "Todo", BlockedBy: []tracker.BlockerRef{}},
+		})
+		if err := poller.PollOnce(ctx); err != nil {
+			t.Fatalf("PollOnce() = %v; want nil", err)
+		}
+		if got := dispatcher.count(); got != 1 {
+			t.Fatalf("dispatched %d issues (%v); want 1 when the refresh positively reports no blockers", got, dispatcher.issueIDs())
+		}
+	})
+	t.Run("nil refreshed blockers keep the listing verdict", func(t *testing.T) {
+		// Listing blockers are all terminal (the candidate passed the
+		// tick-start gate); a nil-BlockedBy refresh must not clear them, and
+		// re-running the gate on them stays a pass — the candidate
+		// dispatches with its listing-time blocker data intact.
+		trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{
+			ID:         "issue-1",
+			Identifier: "GT-1",
+			State:      "Todo",
+			BlockedBy:  []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "Done"}},
+		}}}
+		poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, todoBlockerRevalidationConfig())
+
+		trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
+			"issue-1": {State: "Todo"},
+		})
+		if err := poller.PollOnce(ctx); err != nil {
+			t.Fatalf("PollOnce() = %v; want nil", err)
+		}
+		if got := dispatcher.count(); got != 1 {
+			t.Fatalf("dispatched %d issues (%v); want 1 when the refresh has no blocker knowledge", got, dispatcher.issueIDs())
+		}
+		if got := dispatcher.issueAt(0).BlockedBy; len(got) != 1 || got[0].ID != "blocker-1" {
+			t.Fatalf("dispatched issue BlockedBy = %#v; want listing-time blocker kept", got)
+		}
+	})
+}
+
+// A non-Todo refreshed state leaves the blocker gate inert (SPEC §8.2 gates
+// only Todo issues), even when the refresh carries non-terminal blockers.
+func TestPollOnceBlockerRevalidationGatesTodoOnly(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{
+		ID:         "issue-1",
+		Identifier: "GT-1",
+		State:      "Todo",
+	}}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, todoBlockerRevalidationConfig())
+
+	trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
+		"issue-1": {State: "In Progress", BlockedBy: []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "In Progress"}}},
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 1 {
+		t.Fatalf("dispatched %d issues (%v); want 1 — the blocker gate applies to Todo only", got, dispatcher.issueIDs())
+	}
+}

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -153,6 +153,9 @@ type fakeIssueStateTracker struct {
 	fetchIDErr    error
 	fetchRefCalls [][]tracker.IssueRef
 	fetchIDStates map[string]string
+	// fetchIDIssueStates, when set, takes precedence over fetchIDStates and
+	// returns full refresh facts (state + labels + blockers) per issue ID.
+	fetchIDIssueStates map[string]tracker.IssueState
 }
 
 type fakeIssueStateTrackerByCall struct {
@@ -198,6 +201,14 @@ func (f *fakeIssueStateTracker) FetchIssueStatesByRefs(_ context.Context, refs [
 		wanted[ref.ID] = struct{}{}
 	}
 	out := make(map[string]tracker.IssueState, len(refs))
+	if f.fetchIDIssueStates != nil {
+		for id, state := range f.fetchIDIssueStates {
+			if _, ok := wanted[id]; ok {
+				out[id] = state
+			}
+		}
+		return out, f.fetchIDErr
+	}
 	if f.fetchIDStates != nil {
 		for id, state := range f.fetchIDStates {
 			if _, ok := wanted[id]; ok {
@@ -230,6 +241,12 @@ func (f *fakeIssueStateTracker) setFetchIDStates(states map[string]string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.fetchIDStates = states
+}
+
+func (f *fakeIssueStateTracker) setFetchIDIssueStates(states map[string]tracker.IssueState) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fetchIDIssueStates = states
 }
 
 func (f *fakeIssueStateTracker) setFetchIDErr(err error) {

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -540,6 +540,11 @@ func (c *GitHubClient) recordPaginationCapHit(label string, maxPages int) {
 // matched label is returned (lowercased, matching mapGitHubIssue's
 // normalization). Otherwise the issue's open/closed state is returned. This
 // matches the GitHub convention where workflow position is encoded as labels.
+//
+// BlockedBy stays nil (#750 documented gap): this adapter models no issue
+// dependencies — its listing path never populates Issue.BlockedBy either —
+// so the refresh has no blocker knowledge to supply and consumers keep
+// their listing-time blocker verdict (which is likewise always empty here).
 func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]IssueState, error) {
 	return c.FetchIssueStatesByRefs(ctx, IssueRefsFromIDs(issueIDs))
 }

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -391,7 +392,74 @@ func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []str
 			states[n.ID] = IssueState{State: n.State.Name, Labels: labels}
 		}
 	}
+	if err := c.attachRefreshedTodoBlockers(ctx, states); err != nil {
+		// Blocker data is consumed only by dispatch-time revalidation; the
+		// reconcile and §16.5 per-turn refreshers share this method and must
+		// not fail on it — their state/label result is already complete, and
+		// an error here would short-circuit a healthy run's turn loop on a
+		// transient inverse-relations failure (PR #752 review). Instead,
+		// every refreshed Todo entry fails closed with an empty-state
+		// placeholder blocker — the same shape the Gitea adapter uses for an
+		// unresolvable reference — so the revalidation gate skips the
+		// candidate for this tick and the next tick retries, rather than
+		// dispatching past a blocker the failed query could not see (a
+		// listing-time "unblocked" verdict may predate a newly added
+		// relation). State-only consumers ignore BlockedBy and are
+		// unaffected.
+		log.Printf("event=linear_blocker_refresh_failed error=%q detail=\"refreshed Todo issues fail closed with a placeholder blocker this batch\"", err.Error())
+		failClosedTodoBlockers(states)
+	}
 	return states, nil
+}
+
+// failClosedTodoBlockers marks every Todo-state entry with one empty-state
+// placeholder blocker, which tracker.BlockedByNonTerminal treats as open.
+func failClosedTodoBlockers(states map[string]IssueState) {
+	for id, state := range states {
+		if !isTodoState(state.State) {
+			continue
+		}
+		state.BlockedBy = []BlockerRef{{}}
+		states[id] = state
+	}
+}
+
+// attachRefreshedTodoBlockers resolves blocker data for the refreshed issues
+// whose state is Todo — the only state the SPEC §8.2 blocker gate applies to,
+// mirroring the listing path's Todo-only resolution (#672) — so dispatch-time
+// revalidation can re-apply the gate on refreshed data like upstream
+// retry_candidate_issue? (orchestrator.ex:1602-1604) does (#750). Non-Todo
+// entries keep a nil BlockedBy ("no blocker knowledge supplied"); Todo
+// entries get the non-nil (possibly empty) result linearBlockersForIssues
+// guarantees for every requested id.
+//
+// Dispatch revalidation is the only consumer of the blocker data; the
+// reconcile and §16.5 per-turn refreshers share FetchIssueStatesByIDs and
+// inherit the extra Todo-only batched query as a side effect but ignore
+// BlockedBy (reconcile cancellation and the per-turn continue gate are
+// state/label-only by design). Upstream's fetch_issue_states_by_ids returns
+// fully normalized issues including blocked_by on every caller too, so the
+// cost profile matches the reference.
+func (c *LinearClient) attachRefreshedTodoBlockers(ctx context.Context, states map[string]IssueState) error {
+	ids := make([]string, 0, len(states))
+	for id, state := range states {
+		if isTodoState(state.State) {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	blockers, err := c.linearBlockersForIssues(ctx, ids)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		state := states[id]
+		state.BlockedBy = blockers[id]
+		states[id] = state
+	}
+	return nil
 }
 
 type linearRelationNode struct {

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -228,7 +228,9 @@ func TestListIssuesByStatesUsesDefaultPageSizeAndAggregatesMoreThanFiftyIssues(t
 }
 
 func TestFetchIssueStatesByIDsUsesIDListQuery(t *testing.T) {
+	var mu sync.Mutex
 	var recorded fakeLinearRequest
+	var blockerIDs []any
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var payload struct {
@@ -236,8 +238,19 @@ func TestFetchIssueStatesByIDsUsesIDListQuery(t *testing.T) {
 			Variables map[string]any `json:"variables"`
 		}
 		_ = json.Unmarshal(body, &payload)
-		recorded = fakeLinearRequest{OpName: opNameFromQuery(payload.Query), Query: payload.Query, Variables: payload.Variables}
 		w.Header().Set("Content-Type", "application/json")
+		// The refresh now resolves blockers for Todo-state issues (#750);
+		// answer that follow-up query while keeping the state query recorded.
+		if opNameFromQuery(payload.Query) == "ListIssuesInverseRelations" {
+			mu.Lock()
+			blockerIDs = payload.Variables["ids"].([]any)
+			mu.Unlock()
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","inverseRelations":{"nodes":[{"type":"blocks","issue":{"id":"blocker-1","identifier":"LIN-9","state":{"name":"In Progress"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}]}}}`)
+			return
+		}
+		mu.Lock()
+		recorded = fakeLinearRequest{OpName: opNameFromQuery(payload.Query), Query: payload.Query, Variables: payload.Variables}
+		mu.Unlock()
 		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Todo"},"labels":{"nodes":[{"name":"Aiops-Ready"}]}},{"id":"issue-2","state":{"name":"Done"}}]}}}`)
 	}))
 	defer httpSrv.Close()
@@ -263,6 +276,18 @@ func TestFetchIssueStatesByIDsUsesIDListQuery(t *testing.T) {
 	if !ok || len(ids) != 2 || ids[0] != "issue-1" || ids[1] != "issue-2" {
 		t.Fatalf("ids variable = %#v, want []string{issue-1, issue-2}", recorded.Variables["ids"])
 	}
+	// Blocker resolution is Todo-only: issue-1 carries the refreshed blocker,
+	// Done issue-2 keeps a nil BlockedBy ("no blocker knowledge supplied").
+	if len(blockerIDs) != 1 || blockerIDs[0] != "issue-1" {
+		t.Fatalf("blocker query ids = %#v, want [issue-1] (Todo issues only)", blockerIDs)
+	}
+	gotBlockers := states["issue-1"].BlockedBy
+	if len(gotBlockers) != 1 || gotBlockers[0].ID != "blocker-1" || gotBlockers[0].State != "In Progress" {
+		t.Fatalf("FetchIssueStatesByIDs(issue-1).BlockedBy = %#v; want blocker-1 in In Progress", gotBlockers)
+	}
+	if states["issue-2"].BlockedBy != nil {
+		t.Fatalf("FetchIssueStatesByIDs(issue-2).BlockedBy = %#v; want nil for non-Todo state", states["issue-2"].BlockedBy)
+	}
 }
 
 func TestFetchIssueStatesByIDsChunksLargeBatches(t *testing.T) {
@@ -275,11 +300,20 @@ func TestFetchIssueStatesByIDsChunksLargeBatches(t *testing.T) {
 			Variables map[string]any `json:"variables"`
 		}
 		_ = json.Unmarshal(body, &payload)
-		mu.Lock()
-		requests = append(requests, fakeLinearRequest{OpName: opNameFromQuery(payload.Query), Query: payload.Query, Variables: payload.Variables})
-		mu.Unlock()
+		op := opNameFromQuery(payload.Query)
 		ids := payload.Variables["ids"].([]any)
 		w.Header().Set("Content-Type", "application/json")
+		// All fixture issues refresh as Todo, so the blocker resolution
+		// (#750) follows up with chunked ListIssuesInverseRelations queries;
+		// answer them with empty relation pages and record only the state
+		// chunks for the chunking assertions below.
+		if op == "ListIssuesInverseRelations" {
+			_, _ = io.WriteString(w, linearEmptyInverseRelationsJSON(ids))
+			return
+		}
+		mu.Lock()
+		requests = append(requests, fakeLinearRequest{OpName: op, Query: payload.Query, Variables: payload.Variables})
+		mu.Unlock()
 		_, _ = io.WriteString(w, linearIssueStatesJSON(ids))
 	}))
 	defer httpSrv.Close()
@@ -307,6 +341,26 @@ func TestFetchIssueStatesByIDsChunksLargeBatches(t *testing.T) {
 	if len(firstIDs) != linearIssuePageSize || len(secondIDs) != 5 {
 		t.Fatalf("chunk lengths = %d, %d; want %d, 5", len(firstIDs), len(secondIDs), linearIssuePageSize)
 	}
+	// A Todo issue with no inverse relations carries the positive non-nil
+	// empty answer, not nil ("no knowledge") — see tracker.IssueState.
+	if got := states["issue-1"].BlockedBy; got == nil || len(got) != 0 {
+		t.Fatalf("FetchIssueStatesByIDs(issue-1).BlockedBy = %#v; want non-nil empty for a blocker-free Todo issue", got)
+	}
+}
+
+func linearEmptyInverseRelationsJSON(ids []any) string {
+	var b strings.Builder
+	b.WriteString(`{"data":{"issues":{"nodes":[`)
+	for i, id := range ids {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"id":"`)
+		b.WriteString(id.(string))
+		b.WriteString(`","inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}`)
+	}
+	b.WriteString(`]}}}`)
+	return b.String()
 }
 
 func linearIssueStatesJSON(ids []any) string {
@@ -894,5 +948,43 @@ func TestListIssuesByStatesReturnsParseErrorForMalformedTimestamp(t *testing.T) 
 				t.Fatalf("ListIssuesByStates(%s) err = %q; want field %q and value %q", c.name, err.Error(), c.wantField, c.wantValue)
 			}
 		})
+	}
+}
+
+// A failed blocker resolution must not fail the state refresh: reconcile and
+// the §16.5 per-turn hook share FetchIssueStatesByIDs and ignore BlockedBy,
+// so an inverse-relations failure would otherwise short-circuit a healthy
+// run's turn loop (PR #752 review). The refreshed Todo entry instead fails
+// closed with an empty-state placeholder blocker so dispatch revalidation
+// skips it for the tick — a listing-time "unblocked" verdict may predate a
+// newly added relation the failed query could not see. State and labels
+// survive.
+func TestFetchIssueStatesByIDsSurvivesBlockerResolutionFailure(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		if opNameFromQuery(payload.Query) == "ListIssuesInverseRelations" {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Todo"},"labels":{"nodes":[{"name":"Ready"}]}}]}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"issue-1"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs = error %v; want success despite blocker resolution failure", err)
+	}
+	got := states["issue-1"]
+	if got.State != "Todo" || len(got.Labels) != 1 {
+		t.Fatalf("states[issue-1] = %+v; want Todo state and labels preserved", got)
+	}
+	if len(got.BlockedBy) != 1 || got.BlockedBy[0].State != "" {
+		t.Fatalf("states[issue-1].BlockedBy = %#v; want one empty-state placeholder (fail closed) after blocker resolution failure", got.BlockedBy)
 	}
 }

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -29,6 +29,22 @@ type Issue struct {
 type IssueState struct {
 	State  string
 	Labels []string
+	// BlockedBy carries the refreshed blocker dependencies so dispatch-time
+	// revalidation can re-apply the SPEC §8.2 Todo blocker gate, matching
+	// upstream retry_candidate_issue? (orchestrator.ex:1602-1604), which
+	// re-checks todo_issue_blocked_by_non_terminal? on the refreshed issue
+	// (#750). nil means the adapter supplied no blocker knowledge for this
+	// issue and the consumer must keep its listing-time verdict; a non-nil
+	// empty slice is a positive "no blockers" answer. Unresolvable blocker
+	// knowledge fails closed as an empty-state placeholder the gate treats
+	// as open — never as nil, which would read as "safe". Linear resolves
+	// blockers only for refreshed Todo-state issues (the only state the gate
+	// applies to), placeholding the whole Todo batch when the
+	// inverse-relations query fails; Gitea derives them from the issue
+	// body's `Depends on #N` references, placeholding
+	// transiently-unresolvable references and skipping definitively-deleted
+	// blockers; GitHub has no blocker concept and always leaves this nil.
+	BlockedBy []BlockerRef
 }
 
 // IssueRef carries the stable tracker ID plus the human identifier captured at
@@ -57,6 +73,25 @@ type BlockerRef struct {
 	ID         string
 	Identifier string
 	State      string
+}
+
+// BlockedByNonTerminal reports whether any blocker in blockedBy is still open
+// per the SPEC §8.2 rule: an empty/unknown blocker state blocks, and a state
+// outside terminalStates (lowercased, trimmed keys) blocks. It is the single
+// source of truth for the "is this blocker open" judgment (#750). The
+// empty-state branch is what makes the Gitea adapter's fail-closed
+// placeholder refs (unresolvable `Depends on #N` lookups) block at the gate.
+func BlockedByNonTerminal(blockedBy []BlockerRef, terminalStates map[string]struct{}) bool {
+	for _, blocker := range blockedBy {
+		state := strings.ToLower(strings.TrimSpace(blocker.State))
+		if state == "" {
+			return true
+		}
+		if _, terminal := terminalStates[state]; !terminal {
+			return true
+		}
+	}
+	return false
 }
 
 // TimeString returns the canonical string form used by workspace keys for a

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -29,3 +29,27 @@ func TestTimeStringNormalizesOffsetsToUTC(t *testing.T) {
 		t.Fatalf("TimeString(offset time) = %q, want UTC RFC3339Nano", got)
 	}
 }
+
+// TestBlockedByNonTerminal pins the shared SPEC §8.2 "is this blocker open"
+// predicate's three edges (#750): empty/unknown state blocks, a non-terminal
+// state blocks, and an all-terminal set does not.
+func TestBlockedByNonTerminal(t *testing.T) {
+	terminal := map[string]struct{}{"done": {}, "canceled": {}}
+	cases := []struct {
+		name      string
+		blockedBy []BlockerRef
+		want      bool
+	}{
+		{name: "nil blockers do not block", blockedBy: nil, want: false},
+		{name: "empty blockers do not block", blockedBy: []BlockerRef{}, want: false},
+		{name: "all terminal does not block", blockedBy: []BlockerRef{{State: "Done"}, {State: " canceled "}}, want: false},
+		{name: "non-terminal blocks", blockedBy: []BlockerRef{{State: "Done"}, {State: "In Progress"}}, want: true},
+		{name: "empty state blocks", blockedBy: []BlockerRef{{State: ""}}, want: true},
+		{name: "whitespace state blocks", blockedBy: []BlockerRef{{State: "   "}}, want: true},
+	}
+	for _, tc := range cases {
+		if got := BlockedByNonTerminal(tc.blockedBy, terminal); got != tc.want {
+			t.Fatalf("BlockedByNonTerminal(%+v) = %t; want %t (%s)", tc.blockedBy, got, tc.want, tc.name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #750

## Problem (deferred from #749)

PR #749 ported upstream's dispatch-time candidate revalidation, but the narrow refresh contract (`tracker.IssueState`) carried only `State`+`Labels`, so `revalidatedCandidate` kept the **listing-time** blocker verdict. Upstream's acceptance predicate `retry_candidate_issue?` = `candidate_issue?` **AND** `!todo_issue_blocked_by_non_terminal?` re-checks the Todo blocker gate against the **refreshed** issue (`elixir/lib/symphony_elixir/orchestrator.ex:1602-1604`). A Todo issue whose blocker flipped from terminal to non-terminal inside the tick's staleness window still dispatched.

## Change

- **`internal/tracker/tracker.go`** — `IssueState` gains `BlockedBy []BlockerRef` under an explicit contract: **nil = adapter supplied no blocker knowledge** (consumer keeps its listing-time verdict); **non-nil empty = positive "no blockers"**. New shared predicate `BlockedByNonTerminal` is the single source of truth for the SPEC §8.2 "is this blocker open" judgment (empty/unknown state blocks; non-terminal blocks), used by the orchestrator gate and the Gitea adapter alike (clean-code rule 3).
- **`internal/tracker/linear.go`** — `FetchIssueStatesByIDs` attaches blockers for refreshed **Todo-state** issues only (the only state the gate applies to, mirroring the listing path's #672 Todo-only batched resolution) via the existing `linearBlockersForIssues` (guarantees non-nil for every requested id). Doc comment scopes the side-effect cost on the reconcile/§16.5 per-turn refresher callers (they ignore `BlockedBy`). A blocker-resolution failure fails closed: the refreshed Todo batch carries an empty-state placeholder blocker (logged) instead of failing the shared refresh — state-only consumers stay healthy and revalidation skips the candidates for one tick rather than trusting a listing-time verdict the failed query could not confirm.
- **`internal/gitea/tracker_client.go`** — blocker derivation from `Depends on #N` now fails closed: a transiently-unresolvable reference becomes an empty-state placeholder `BlockerRef` (open per the shared predicate → the Todo gate blocks for the tick; uncached, so the next tick retries; `Logf`-surfaced so persistent starvation is operator-visible). A definitive 404 (deleted blocker) is skipped — it can never become terminal, so blocking would starve the candidate forever. Applies to the refresh AND the listing path (same defect class). The refresh reports non-nil always (body is authoritative; nil→empty coercion).
- **`internal/tracker/github.go`** — documented gap: GitHub models no issue dependencies (listing never populates `BlockedBy` either); the refresh stays nil.
- **`internal/orchestrator/poller_candidates.go`** — `revalidatedCandidate` carries refreshed blocker data when non-nil and re-applies `todoIssueBlockedByOpenDependency`, dropping with reason `todo_blocker_not_terminal`. `todoIssueBlockedByOpenDependency` delegates its loop to the shared predicate.

## Acceptance criteria

- [x] Narrow refresh exposes blocker data for Linear (Todo-state issues, batched); Gitea re-derives from the refreshed body; GitHub documents the gap
- [x] `revalidatedCandidate` re-applies `todoIssueBlockedByOpenDependency` on refreshed blocker data, matching upstream `retry_candidate_issue?` (`orchestrator.ex:1602-1604`)
- [x] Regression: a Todo candidate whose blocker reopens between listing and dispatch is not dispatched — `TestPollOnceSkipsDispatchWhenRevalidationShowsReopenedBlocker`; mutation-verified (below)

## Verification

```
gofmt -l $(git ls-files '*.go')                      # empty
go mod tidy && git diff --exit-code -- go.mod go.sum
go vet ./...
go test -race -covermode=atomic ./...                # all green
go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts
go build ./cmd/worker ./cmd/tui
golangci-lint --enable-only=staticcheck,unparam,unused (changed pkgs)  # 0 issues
```

Mutation verification (committed artifact, each restored after FAIL):
- M1 drop the blocker recheck in `revalidatedCandidate` → reopened-blocker test FAILs
- M2 nil refresh overwrites listing blockers → nil-vs-empty contract test FAILs
- M3 Linear stops attaching refreshed blockers → Linear adapter test FAILs
- M4 Gitea refresh drops `BlockedBy` → Gitea adapter test FAILs
- M5 completeness verdict dropped → unresolved-dep test FAILs
- M6 mixed-resolution decisive branch dropped → mixed-deps test FAILs
- M7 shared predicate ignores empty-state blockers → boundary unit test FAILs
- M8 transient failure stops producing the fail-closed placeholder → refresh/listing placeholder tests FAIL
- M9 deleted blocker treated like transient (would starve forever) → deleted-blocker tests FAIL
- M10 Linear blocker-resolution failure fails the whole state refresh again → degradation test FAILs
- M11 Linear blocker failure degrades to nil instead of the fail-closed placeholder → degradation test FAILs

## Reviews

Pre-push dual diff-only review, 3 rounds: Claude (`feature-dev:code-reviewer`) round 1 MERGE-READY with 2 doc/cost notes (addressed); Codex (`codex exec --output-schema`) round 1 found the Gitea nil→empty coercion upgrading unresolved deps into "no blockers" (fixed: completeness verdict), round 2 found mixed resolution losing a known reopened blocker (fixed: decisive-keep via the shared predicate), round 3 clean. GitHub `@codex review` on 3c79323 raised 1 P2 (incomplete Gitea blocker refresh published nil, so a blocker added/reopened after listing whose lookup failed could still dispatch): fixed in the bot-suggested fail-closed direction, generalized — a transiently-unresolvable `Depends on #N` becomes an empty-state placeholder the shared predicate treats as open (gate blocks one tick, retried next tick, transient failures uncached, `Logf` surfaced); a definitive 404 (deleted blocker) is skipped (blocking would starve forever; matches listing). This replaced the completeness/decisive machinery and also fixed the same class on the listing path. Round 4: Claude MERGE-READY after one logging finding (fixed), Codex clean. GitHub `@codex review` round 2 raised 1 P2 (Linear blocker-resolution failure failed the whole FetchIssueStatesByIDs, short-circuiting the reconcile/§16.5 per-turn refreshers that ignore BlockedBy): fixed by degrading to nil BlockedBy for the batch with an event=linear_blocker_refresh_failed log — revalidation keeps the listing verdict for exactly the failed query. A CI gocognit failure on buildBlockedBy was fixed by decomposition (blockerRefForNumber). Round 5: Claude MERGE-READY, Codex clean. GitHub `@codex review` round 3 raised 1 P2 (Linear nil degradation kept a listing-time "unblocked" verdict that may predate a newly added relation): fixed fail-closed — the whole refreshed Todo batch gets an empty-state placeholder blocker (same shape as Gitea), revalidation skips one tick and retries. Round 6: Claude MERGE-READY, Codex `{"blocking_findings":[]}`. Branch then rebased onto main after #751 merged (sibling regression suites re-run green).

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Note: this closes a gap against an existing upstream behavior — `revalidate_issue_for_dispatch` → `retry_candidate_issue?` (`elixir/lib/symphony_elixir/orchestrator.ex:909-924`, `:995-1013`, `:1602-1604`). No new key/phase.

### Size gate
- [x] `within budget` — 5 production files, ~150 changed production LOC; test files excluded
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Umbrella: #67.
