### PR TITLE
docs: reviewer-worker pattern — fresh-context checker on Human Review (#753)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,10 @@ specific observed failure per the "Earned rules" principle.
 1. **Audit adjacent paths for aiops-platform extensions before
    touching a SPEC code path.** Upstream Symphony is single-project;
    this port layers extensions on top of the SPEC algorithm
-   (service routing via `selectRoutedCandidates`, multi-tracker
-   fan-out, per-state capacity caps, reconciliation hooks).
+   (per-state capacity caps via `UpdateMaxConcurrentAgentsByState`,
+   the eligibility/required-labels gates in `filterEligibleCandidates`,
+   dispatch revalidation via `revalidateDispatchCandidates`,
+   reconciliation hooks).
    When you touch a path that consumes a SPEC concept (candidates,
    retries, dispatch, reconcile), `grep` the symbol and list the
    other consumers. Every aiops-platform-specific filter they apply

--- a/docs/runbooks/reviewer-worker.md
+++ b/docs/runbooks/reviewer-worker.md
@@ -1,0 +1,245 @@
+# Reviewer worker — a fresh-context checker on `Human Review`
+
+How to run a second worker process whose agent reviews handed-off work
+against a rubric and issues the terminal verdict, so the model that wrote
+the code is not the one that declares it done.
+
+This is the deployment pattern behind the maker/checker split that already
+exists in the tracker state machine: under this pattern's prompt contract
+the maker agent moves an issue no further than `Human Review` (a
+*pending-verification* state), and `Done` is issued by the checker — a
+human today, a fresh-context reviewer agent with this runbook. (The split
+is a prompt contract, not a platform enforcement: `gitea_issue_labels`
+accepts any `aiops/*` state label, so a maker prompt that allowed
+`aiops/done` would bypass the checker.) It is pure configuration + prompt: **zero platform code**, no
+new config keys, consistent with D25's "one process per service" stance
+(service routing was removed in #573) and the single-workflow-source rule
+(#72). The rejected alternative — a worker-side verifier gate at the
+`Finishing` phase — is documented in #744's closing verdict (worker does not
+own PR handoff per #76; post-turn gates race reconcile-cancel per #557/D33;
+upstream has no verifier equivalent).
+
+Advisory background (per the AGENTS.md practitioner-accounts clause): both
+loop-engineering articles this pattern answers gate the *stop condition*
+with an independent-context grader — "a fresh model decides if the loop is
+done instead of the one that did the work" (Osmani), "grading is done in an
+independent context window" (Martin). The reviewer worker is that shape
+expressed inside the SPEC state machine.
+
+## Topology
+
+Two worker processes, one tracker project:
+
+| | maker worker | reviewer worker |
+|---|---|---|
+| `WORKFLOW.md` | implementation prompt | rubric/review prompt ([example](../../examples/reviewer-WORKFLOW.md)) |
+| `tracker.active_states` | `[Todo, Rework]` | `[Human Review]` |
+| `tracker.inactive_states` | `[Human Review]` | `[Todo, In Progress, Rework]` |
+| `workspace.root` | e.g. `~/aiops-workspaces/maker` | **a different root — hard requirement, see below** |
+| `AIOPS_MIRROR_ROOT` env | e.g. `~/aiops-mirrors/maker` | **a different mirror root — hard requirement, see below** |
+| state writes (agent-side) | flips to `aiops/human-review` | flips to `aiops/done` / `aiops/rework` |
+
+Both point at the same Gitea repo/project. Optionally narrow the reviewer
+further with `tracker.required_labels`.
+
+State flow:
+
+```
+Todo ──maker──▶ Human Review ──reviewer──▶ Done        (rubric passed)
+  ▲                                  └────▶ Rework      (rubric failed)
+  └──────────── maker re-dispatch on Rework ◀──────────┘
+```
+
+The `Rework` return path is the platform's existing re-dispatch cycle — no
+new mechanics. (Exercised live in the v0.1.0 lifecycle test: 12/12 issues
+merged, with three `Rework` round-trips.)
+
+## Hard requirement: separate `workspace.root` per worker
+
+The two workers MUST NOT share a workspace root. The collision is
+deterministic, not theoretical:
+
+- `PathFor` is `Root/<owner>/<repo>/<sourceType>/<sourceEventID>` (falling
+  back to `Root/<owner>/<repo>/<task.ID>` when source type/event id are
+  unset; `internal/workspace/manager.go`) — either way the *same issue*
+  resolves to the *same directory* in both processes when the roots match.
+- Workspace reuse is destructive: `reuseWorktree` runs
+  `git reset --quiet HEAD -- .` followed by
+  `git checkout --force --no-track -B <branch> <startRef>`, force-discarding
+  tracked modifications.
+- The processes overlap in time. After the maker flips the handoff label,
+  the maker's run keeps streaming until its reconcile pass observes the
+  inactive state — up to one full poll interval (the tail window measured in
+  #557). The reviewer can dispatch inside that window and force-reset a
+  worktree the maker's agent is still using. There is no cross-process lock
+  to save you.
+
+Give each worker its own `workspace.root` and the collision is impossible
+(different path prefixes).
+
+### Bare mirror cache: also a hard requirement — set `AIOPS_MIRROR_ROOT` per worker
+
+`workspace.root` isolation does NOT isolate the bare mirror cache. Each
+worker's mirror root resolves (in order) from the `AIOPS_MIRROR_ROOT` env
+var, else `<user-cache-dir>/aiops-platform/mirrors`, else
+`<tmp>/aiops-platform/mirrors` (`internal/workspace/mirror.go`). Two workers
+on the same host and user therefore share one bare mirror per clone URL —
+and in THIS pattern that is not merely a contention risk, it is broken by
+design:
+
+- Both workers dispatch the *same issue* on the *same work branch* name,
+  `ai/<issue.ID>` (`internal/orchestrator/poller.go`).
+- Worktrees attach to the shared bare mirror
+  (`git worktree add --no-track -B <branch>`), and git refuses to check out
+  a branch that another worktree of the same repository already has checked
+  out. While the maker's worktree holds `ai/<issue.ID>`, the reviewer's
+  workspace preparation for that issue fails outright.
+
+Set a distinct `AIOPS_MIRROR_ROOT` for each worker process. It costs one
+extra bare clone on disk and removes both the branch-namespace collision
+and the flock/fetch contention class (mirror preparation is serialized
+across processes by the per-mirror OS-level advisory flock in
+`acquireMirrorLock`; an acquisition error fails closed and retries on the
+normal backoff).
+
+## Reviewer `WORKFLOW.md`
+
+Start from [`examples/reviewer-WORKFLOW.md`](../../examples/reviewer-WORKFLOW.md).
+Verify any edited front matter against the real loader before deploying —
+the snippet must pass, with the same environment the reviewer process will
+launch under (the mirror root comes from the environment, not the front
+matter — omitting it falls back to the shared per-user cache and hits the
+branch collision documented above):
+
+```bash
+export AIOPS_MIRROR_ROOT=~/aiops-mirrors/reviewer   # hard requirement, see above
+export GITEA_TOKEN=...           # worker-held tracker token
+export REVIEWER_CLONE_URL=...    # bot basic-auth clone URL
+cp examples/reviewer-WORKFLOW.md /path/to/reviewer-workdir/WORKFLOW.md
+go run ./cmd/worker --print-config /path/to/reviewer-workdir
+```
+
+Launch the reviewer worker with those same exports in place.
+
+Two properties of the example are load-bearing:
+
+1. **"Review only, do not write code" lives in the prompt body.** Do not
+   reach for `policy.mode: analysis_only` to enforce it: that directive is
+   the plan-artifact contract (`internal/worker/runtask.go`,
+   `AppendAnalysisOnlyDirective`) — it asks the agent to produce
+   `.aiops/PLAN.md` and to refrain from posting tracker comments, which is
+   the wrong job description for a reviewer whose deliverables are exactly
+   a findings comment plus a verdict label flip. (It is a prompt directive,
+   not a worker-enforced gate — the post-turn analysis gate class was
+   removed in #561/D33 — but pointing it at a reviewer buys you nothing
+   and contradicts the prompt you actually want.)
+2. **The verdict path does not depend on the sandbox.** The label flip goes
+   through `gitea_issue_labels`, an orchestrator-proxied dynamic tool: the
+   request is executed by the worker process holding the token, not by the
+   agent's sandboxed filesystem/network. Even the strictest sandbox tier
+   still delivers verdicts.
+
+### Sandbox: two tiers (both need explicit network access)
+
+The typed sandbox policies derive `networkAccess: false` by default
+(`internal/workflow/codex_schema.go`), and everything in "finding the diff"
+below — `git fetch`, Gitea API calls — needs the network. Set
+`codex.turn_sandbox_policy` explicitly in either tier (the v0.1.0 lifecycle
+test hit exactly this: the maker could not push or open PRs until
+`networkAccess: true` was set):
+
+- **Default — review can run build/test:**
+  `thread_sandbox: workspace-write` plus an explicit `workspaceWrite` turn
+  policy (the same shape the maker runs; note the loader requires the full
+  field set for this type — `writableRoots`, `networkAccess`,
+  `excludeTmpdirEnvVar`, `excludeSlashTmp` — see the example for the exact
+  YAML). The reviewer can
+  `git fetch` the head branch, diff locally, and run `go build` /
+  `go test`. Keep the "do not commit, do not push" constraint in the
+  prompt.
+- **Strict — judge the diff text only:**
+  `thread_sandbox: read-only` +
+  `turn_sandbox_policy: {type: readOnly, networkAccess: true}`. The
+  read-only filesystem blocks `git fetch` too (fetch writes `.git`), so the
+  diff must come from the Gitea API as text
+  (`GET /repos/{owner}/{repo}/pulls/{number}.diff`) and build/test rubric
+  items are off the table. Strongest containment.
+
+## Finding the diff under review
+
+Nothing hands the reviewer a PR link: the rendered prompt contains only the
+SPEC §4.1.1 issue snapshot (`internal/worker/runtask.go`,
+`issueRenderVarsForTask`), and the reviewer's worktree is freshly created
+from the base ref — **the maker's changes are not in the reviewer's local
+checkout**.
+
+**Credentials reality check.** The tracker API token never reaches the
+agent: `GITEA_TOKEN` and friends are on the env-passthrough deny list
+(`internal/workflow/agent_env_policy.go`), and the only Gitea dynamic tool
+is the label flip. What the agent CAN use is the same surface the maker
+uses to push and open PRs: the workspace's git remote. Give `repo.clone_url`
+an HTTP(S) basic-auth token (`http://<bot>:<token>@gitea.local/...`) — the
+agent reads it from `git remote get-url origin` and uses it both for
+`git fetch` and for Gitea API calls (read issue comments, fetch the PR
+diff, post the review-findings comment). Use a low-privilege bot account
+for that token per the repo safety posture; with an SSH `clone_url` the
+agent can fetch but has no API credential, which limits the reviewer to
+fetch-and-diff plus the label flip (no comments).
+
+Adopt one of these two discovery conventions and write it into BOTH prompts
+(the example uses the first):
+
+1. **PR URL in an issue comment (default).** The maker's prompt requires it
+   to comment the PR URL on the issue immediately after opening the PR. The
+   reviewer reads the issue comments, takes the newest PR URL, and obtains
+   the diff via `git fetch origin <head-branch>` or the API.
+2. **Head-branch lookup.** The platform dispatches every run on work branch
+   `ai/<issue.ID>` (`internal/orchestrator/poller.go`). Note that for the
+   Gitea tracker `issue.ID` is Gitea's *internal* issue id, not the
+   human-visible issue number — discover the actual branch/PR by listing
+   open PRs whose head matches `ai/*` and whose body/title references the
+   issue, rather than reconstructing the name from the issue number.
+
+## Single-process alternative: in-run grader sub-agent (verified)
+
+If you cannot run a second worker, the maker's own `WORKFLOW.md` can demand
+an independent-context grade *before* the handoff label flip — the
+preventive placement both articles actually describe.
+
+Verified live (codex CLI 0.137.0, `codex app-server`, experimental API on —
+the platform's standard session shape):
+
+- The session exposes a multi-agent tool family —
+  `multi_agent_v1.spawn_agent` / `send_input` / `wait_agent` /
+  `resume_agent` / `close_agent` — discoverable through the session's
+  `tool_search` tool (it is not in the initially visible tool list). An
+  end-to-end probe (spawn a grader with inline instructions, wait, read its
+  verdict) succeeded; the wire stream reports it as `collabAgentToolCall`
+  items.
+- **Named `.codex/agents/*.toml` definitions are NOT exposed** in this mode
+  (probed: a `.codex/agents/grader.toml` in the workspace was not available
+  as a named agent). Define the grader inline in the `spawn_agent`
+  instructions instead of relying on repo-level agent files.
+
+Prompt shape that works:
+
+```
+Before flipping the handoff label: use tool_search to find your
+multi-agent tools, spawn one sub-agent whose instructions are the rubric
+below plus the diff you produced, wait for its verdict, and only proceed
+to the handoff if it answers PASS. On FAIL, fix the findings and re-grade.
+```
+
+Caveats: the grader burns extra tokens per run (spend it where a second
+opinion pays — Osmani's caveat); the tool family is experimental surface
+and should be re-verified after a codex CLI upgrade
+(`CodexProtocolVersion` bumps, see `internal/runner/codex_version.go`).
+
+## Alignment statement
+
+- Zero platform changes: two processes, two `WORKFLOW.md` files, one
+  tracker. Matches D25 ("Replaceable by running one process per service")
+  and #72 (one workflow source *per process*).
+- The reviewer is an ordinary SPEC worker; its "verdict" is an agent-side
+  tracker write through the existing tool surface (SPEC §1, #76).
+- No `DEVIATIONS.md` entry needed; no SPEC-sensitive paths touched.

--- a/examples/reviewer-WORKFLOW.md
+++ b/examples/reviewer-WORKFLOW.md
@@ -1,0 +1,158 @@
+---
+# Reviewer worker: a fresh-context checker that reviews handed-off work on
+# "Human Review" and issues the verdict (Done / Rework) as an agent-side
+# label flip. Deployment guide: docs/runbooks/reviewer-worker.md
+repo:
+  owner: your-gitea-user
+  name: your-repo
+  # Use an HTTP(S) basic-auth clone URL with a low-privilege bot token: the
+  # tracker api_key below never reaches the agent (env-passthrough deny
+  # list), so this remote credential is what the reviewer uses to fetch the
+  # head branch and call the Gitea API (read comments, fetch the PR diff,
+  # post the review-findings comment) — the same surface the maker uses to
+  # push and open PRs. The loader expands an env reference only when it is
+  # the ENTIRE field value ($VAR / ${VAR}); embedded ${VAR} stays literal,
+  # so reference a full URL env var like this:
+  clone_url: $REVIEWER_CLONE_URL  # e.g. http://review-bot:<token>@gitea.local/your-gitea-user/your-repo.git
+  default_branch: main
+
+tracker:
+  kind: gitea
+  endpoint: http://gitea.local
+  # Worker-held token for polling and the gitea_issue_labels verdict proxy;
+  # expanded from the worker's environment, never exposed to the agent.
+  api_key: $GITEA_TOKEN
+  # The reviewer claims exactly the maker's handoff state.
+  active_states:
+    - Human Review
+  terminal_states:
+    - Done
+    - Canceled
+  # Maker-owned states make a running review ineligible: a Rework verdict
+  # (or an operator pulling the issue back) cancels the in-flight reviewer
+  # run on the next poll.
+  inactive_states:
+    - Todo
+    - In Progress
+    - Rework
+
+polling:
+  interval_ms: 30000
+
+workspace:
+  # HARD REQUIREMENT: must differ from the maker worker's workspace.root.
+  # Same root + same issue = same PathFor directory, and worktree reuse
+  # force-resets it while the maker may still be streaming (see runbook).
+  root: ~/aiops-workspaces/reviewer
+
+agent:
+  default: codex-app-server
+  max_concurrent_agents: 1
+  max_turns: 8
+
+codex:
+  command: codex app-server
+  # Two tiers (pick one); BOTH need networkAccess: true — the typed sandbox
+  # policies derive networkAccess: false by default, which blocks the
+  # git fetch / Gitea API calls the review depends on. The verdict label
+  # flip works in either tier: gitea_issue_labels is executed by the
+  # orchestrator-side proxy, not the sandboxed agent.
+  #
+  # Default tier — review can fetch the head branch, diff locally, and run
+  # build/test (toolchains write caches and temp files):
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    writableRoots: []
+    networkAccess: true
+    excludeTmpdirEnvVar: false
+    excludeSlashTmp: false
+  # Strict tier — judge the diff text only. The read-only filesystem blocks
+  # `git fetch` too (it writes .git), so the diff must come from the Gitea
+  # API as text, and build/test rubric items are off the table:
+  #   thread_sandbox: read-only
+  #   turn_sandbox_policy:
+  #     type: readOnly
+  #     networkAccess: true
+
+policy:
+  mode: draft_pr
+  # NOTE: do NOT set `mode: analysis_only` to enforce "review only" — that
+  # directive is the plan-artifact contract (produce .aiops/PLAN.md, refrain
+  # from tracker comments), which is the wrong job description for a
+  # reviewer whose deliverables are a findings comment plus the verdict
+  # label flip. The review-only constraint belongs in the prompt body below.
+---
+You are an independent REVIEWER. You did not write the change under review;
+judge it strictly against the rubric. You review and issue a verdict — you
+do NOT write code.
+
+Issue under review:
+- Identifier: {{ issue.identifier }}
+- URL: {{ issue.url }}
+- Title: {{ task.title }}
+
+IMPORTANT — issue numbering: every Gitea API call and the
+gitea_issue_labels tool take the human issue NUMBER (the digits of the
+`#N` identifier above). Do not use the tracker-internal id from
+`task.id` for those calls — on Gitea it is a different number and would
+read, comment on, or re-label the wrong issue.
+
+Repository: {{ repo.owner }}/{{ repo.name }} (base branch: {{ repo.branch }})
+
+Description:
+{{ task.description }}
+
+## Hard constraints (review-only)
+
+- Do not modify, commit, or push any code. Your only writes are tracker
+  writes: issue comments and the verdict label flip.
+- Your local worktree starts at the base branch and does NOT contain the
+  change under review. Obtain the diff first (next section).
+- Judge only what the diff and its tests prove. Unverified claims in the PR
+  description count for nothing.
+
+## Step 1 — find the change under review
+
+Your Gitea credential is the basic-auth token in the workspace's git
+remote (`git remote get-url origin`); use it for every API call below.
+
+The maker's workflow comments the PR URL on this issue right after opening
+the PR. Read this issue's comments via the API, take the newest PR URL,
+then obtain the diff either way:
+
+- `git fetch origin <head-branch>` and diff against the base branch, or
+- fetch the unified diff from the Gitea API
+  (`GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>.diff`).
+
+If no PR URL comment exists, fall back to listing open PRs whose head branch
+matches `ai/*` and whose title/body references this issue. If you still
+cannot identify the PR, comment what you looked for on the issue and flip
+the label to `aiops/rework` so the maker re-runs with a proper handoff.
+
+## Step 2 — review against the rubric
+
+Rubric (every item must pass):
+
+1. The diff implements what the issue asked — each acceptance criterion is
+   met or explicitly addressed in the PR body.
+2. Tests cover the changed behavior, and the tests would fail if the change
+   were reverted (no placebo tests).
+3. No unrelated changes ride along; the diff is scoped to this issue.
+4. No obvious correctness or safety problems (races, unchecked errors,
+   secrets in code or logs).
+
+<!-- With thread_sandbox: workspace-write you may extend the rubric with
+     executable checks, e.g.: 5. `go build ./...` and `go test ./...` pass
+     on the fetched head. Keep the no-commit/no-push constraint above. -->
+
+## Step 3 — verdict
+
+- Every rubric item passes → comment a short review summary (what you
+  checked, per-item result) on the issue, then set the label to
+  `aiops/done` via the gitea_issue_labels tool.
+- Any item fails → comment the failing items with concrete, actionable
+  findings (file, line, what to change), then set the label to
+  `aiops/rework`. The maker re-runs from your findings.
+
+The label flip is your handoff: do it exactly once, as the last action.


### PR DESCRIPTION
Closes #753

Documents the reviewer-worker deployment pattern — the behavior follow-up to #744's closing verdict: a second worker process claiming `active_states: [Human Review]` whose fresh-context agent reviews the maker's PR against a rubric and issues the verdict as the agent-side `aiops/done` / `aiops/rework` label flip. Zero platform code.

## Deliverables

- **`docs/runbooks/reviewer-worker.md`** — topology + state flow (reuses the existing Rework re-dispatch path, exercised 3× in the v0.1.0 lifecycle test); **two hard isolation requirements** with mechanisms: separate `workspace.root` (PathFor same-path + `reuseWorktree` force-reset + the #557 handoff tail window) AND separate `AIOPS_MIRROR_ROOT` (both workers dispatch the same issue on the same `ai/<issue.ID>` work branch; git refuses a branch checked out by another worktree of a shared bare mirror — reviewer workspace prep fails outright); credential reality (tracker token is env-deny-listed, the agent's only Gitea surface is the `clone_url` basic-auth remote, same as the maker's push/PR path); executable diff-discovery convention (PR-URL issue comment default / head-branch API lookup fallback, with the Gitea internal-id caveat for `ai/<issue.ID>`); two sandbox tiers, both requiring explicit `networkAccess: true` (typed policies derive false — the lifecycle test hit exactly this), with read-only's git-fetch limitation (fetch writes `.git`) documented.
- **`examples/reviewer-WORKFLOW.md`** — rubric-driven review-only prompt; review-only constraint in the prompt body (NOT `policy.mode: analysis_only`, whose plan-artifact contract is the wrong job description for a reviewer); whole-field env references only (`$GITEA_TOKEN`, `$REVIEWER_CLONE_URL` — the loader expands env refs only when they are the entire field value).
- **Single-process grader option — verified live** (codex CLI 0.137.0 `codex app-server`, experimental API, the platform's standard session shape): `multi_agent_v1.spawn_agent` / `send_input` / `wait_agent` / `resume_agent` / `close_agent` are discoverable via the session's `tool_search` tool; an end-to-end probe (spawn grader with inline instructions → wait → read verdict) succeeded, reported as `collabAgentToolCall` items. **Named `.codex/agents/*.toml` definitions are NOT exposed in this mode** (probed) — documented inline-instructions shape + re-verify-on-codex-upgrade caveat.
- **AGENTS.md** — replaced the stale `selectRoutedCandidates` reference (removed with service routing + multi-tracker fan-out in #573/D25) with current extension symbols (`UpdateMaxConcurrentAgentsByState`, `filterEligibleCandidates`, `revalidateDispatchCandidates`).

## Acceptance criteria

- [x] Runbook exists; every config snippet validated through the real loader (`go run ./cmd/worker --print-config`) — both sandbox tiers, env-expanded `api_key`/`clone_url` (masked in output)
- [x] Separate `workspace.root` as hard requirement with the collision mechanism; bare-mirror-cache stance explicit (hard requirement, with the branch-namespace collision rationale)
- [x] Executable diff-discovery convention (two options), incl. the reviewer-worktree-lacks-the-diff fact and fetch/API paths + credential surface
- [x] Example reviewer `WORKFLOW.md` with rubric + review-only constraint; sandbox in two tiers with the proxy-tool verdict note
- [x] Single-process grader option: verified and documented (incl. the `.codex/agents` negative result)
- [x] AGENTS.md stale reference fixed
- [x] Zero platform code changes (docs + example only; no DEVIATIONS row; no SPEC-sensitive paths)

## Reviews

Pre-push dual diff-only review, 3 rounds (docs fact-checked against code each round): round 1 — mirror-lock misattribution fixed (Claude), shared-mirror branch collision + missing `api_key` + network/credential reality for diff access + `analysis_only` overstatement + prompt-contract framing (Codex, all validated and fixed); round 2 — `workspaceWrite` required-field list completed (Claude), embedded-`${VAR}`-not-expanded + multi-tracker fan-out staleness + example NOTE alignment (Codex, fixed); round 3 — PathFor fallback branch noted (Claude, fixed), Codex clean `{"blocking_findings":[]}`. One round-1 Claude finding (topology table missing maker `active_states`) refuted — present at line 33.

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

### Size gate
- [x] `within budget` — docs + example only; production Go diff is zero
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
