### PR TITLE
fix(workspace): heal legacy partial mirrors and reap staging dirs on failed clones

### DIFF
--- a/internal/workspace/mirror.go
+++ b/internal/workspace/mirror.go
@@ -218,8 +218,11 @@ func (m *Manager) ensureMirrorLocked(ctx context.Context, cloneURL, mirror strin
 		// mid-clone, #765) has HEAD + remote.origin.url but the bare-clone
 		// "do nothing" refspec, so without this line every refresh fetch
 		// updates only FETCH_HEAD and `worktree add` wedges on each §8.4
-		// retry until an operator deletes the directory.
-		if err := runGit(ctx, mirror, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+		// retry until an operator deletes the directory. --replace-all keeps
+		// the write valid when the key holds multiple values (e.g. an
+		// operator-added extra refspec): plain `git config <key> <value>`
+		// refuses multi-valued keys and would wedge the mirror instead.
+		if err := runGit(ctx, mirror, "config", "--replace-all", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
 			return "", fmt.Errorf("reassert fetch refspec: %w", err)
 		}
 		// Existing mirror: refresh remote-tracking refs only. `fetch origin`

--- a/internal/workspace/mirror.go
+++ b/internal/workspace/mirror.go
@@ -213,6 +213,15 @@ func (m *Manager) ensureMirrorLocked(ctx context.Context, cloneURL, mirror strin
 		return "", fmt.Errorf("mkdir mirror parent: %w", err)
 	}
 	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err == nil {
+		// Re-assert the remote-tracking refspec before refreshing: a partial
+		// clone left at the final path by a pre-staging binary (worker killed
+		// mid-clone, #765) has HEAD + remote.origin.url but the bare-clone
+		// "do nothing" refspec, so without this line every refresh fetch
+		// updates only FETCH_HEAD and `worktree add` wedges on each §8.4
+		// retry until an operator deletes the directory.
+		if err := runGit(ctx, mirror, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+			return "", fmt.Errorf("reassert fetch refspec: %w", err)
+		}
 		// Existing mirror: refresh remote-tracking refs only. `fetch origin`
 		// resolves the stored credentialed remote.origin.url, so its forwarded
 		// stderr is redacted (#595).
@@ -245,9 +254,21 @@ func cloneMirrorLocked(ctx context.Context, cloneURL, mirror string) (string, er
 	// Clear leftovers from prior interrupted attempts so `git clone` does
 	// not refuse the staging path; the final path is normally created only
 	// by the rename below, but an older worker version may have left a
-	// HEAD-less partial mirror there.
+	// HEAD-less partial mirror there. The deferred cleanup below cannot
+	// replace this sweep: a SIGKILLed worker never runs its deferred
+	// functions, so the next attempt must still clear the debris.
 	_ = os.RemoveAll(staging)
 	_ = os.RemoveAll(mirror)
+	// A failed attempt must not leak the staging directory: a repo removed
+	// from config after one failed first clone would otherwise keep its
+	// `.git.staging` debris until an operator deletes it by hand (#765).
+	// The success path renames staging into place before returning.
+	moved := false
+	defer func() {
+		if !moved {
+			_ = os.RemoveAll(staging)
+		}
+	}()
 	// The clone URL carries the agent's `user:token@` push credential on the
 	// command line, so both the forwarded git stderr (runGitRedacted) and the
 	// wrapped error string (MaskCloneURL) must mask it (#595).
@@ -269,6 +290,7 @@ func cloneMirrorLocked(ctx context.Context, cloneURL, mirror string) (string, er
 	if err := os.Rename(staging, mirror); err != nil {
 		return "", fmt.Errorf("move mirror into place: %w", err)
 	}
+	moved = true
 	return mirror, nil
 }
 

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -90,6 +91,11 @@ func TestEnsureMirror_FirstCallClonesSecondCallReuses(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err != nil {
 		t.Fatalf("expected bare repo HEAD at %s: %v", mirror, err)
 	}
+	// The staging build directory is renamed into place on success; a
+	// leftover would mean the deferred failure-path cleanup misfired (#765).
+	if _, err := os.Stat(mirror + mirrorStagingSuffix); !os.IsNotExist(err) {
+		t.Fatalf("staging dir survived a successful clone: stat err=%v", err)
+	}
 	// A bare clone has no working tree; assert that absence to confirm
 	// we used --mirror rather than a regular clone.
 	if _, err := os.Stat(filepath.Join(mirror, ".git")); err == nil {
@@ -159,6 +165,111 @@ func TestEnsureMirror_ConcurrentFirstUseSerializesClone(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(want, "HEAD")); err != nil {
 		t.Fatalf("expected bare repo HEAD at %s: %v", want, err)
+	}
+}
+
+// TestEnsureMirror_HealsLegacyPartialMirrorMissingRefspec is the #765
+// legacy-wedge regression: a pre-#764 binary killed mid-clone could leave a
+// partial bare repo at the FINAL mirror path — HEAD plus a config carrying
+// remote.origin.url, but the bare-clone "do nothing" fetch refspec and no
+// refs. The existing-mirror branch must re-assert the remote-tracking
+// refspec before its refresh fetch so the mirror heals into a
+// worktree-able state instead of wedging every retry until an operator
+// deletes the directory.
+func TestEnsureMirror_HealsLegacyPartialMirrorMissingRefspec(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	mirror := mirrorPathFor(MirrorRoot(mgr.MirrorRoot), upstream)
+	if err := os.MkdirAll(filepath.Dir(mirror), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "init", "--bare", "-q", "-b", "main", mirror},
+		// `git config remote.origin.url` (not `git remote add`) reproduces
+		// the killed-clone config shape: a URL with no fetch refspec.
+		{"git", "--git-dir", mirror, "config", "remote.origin.url", upstream},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	// Sanity: the constructed legacy state matches the wedge precondition —
+	// HEAD present, no fetch refspec, no refs at all.
+	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err != nil {
+		t.Fatalf("precondition broken: legacy mirror missing HEAD: %v", err)
+	}
+	if err := exec.Command("git", "--git-dir", mirror, "config", "--get", "remote.origin.fetch").Run(); err == nil {
+		t.Fatal("precondition broken: legacy mirror already has a fetch refspec")
+	}
+	if err := exec.Command("git", "--git-dir", mirror, "rev-parse", "--verify", "refs/heads/main").Run(); err == nil {
+		t.Fatal("precondition broken: legacy mirror already has refs/heads/main")
+	}
+
+	tk := makeTask("task-legacy-heal", upstream)
+	dir, createdNow, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("PrepareGitWorkspace over legacy partial mirror: %v", err)
+	}
+	if !createdNow {
+		t.Fatal("prepare over legacy partial mirror reported createdNow=false")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "README.md")); err != nil {
+		t.Fatalf("expected README.md inside healed worktree %s: %v", dir, err)
+	}
+	// The heal is the re-asserted refspec letting the refresh fetch populate
+	// the remote-tracking ref the worktree start ref resolves through.
+	if err := exec.Command("git", "--git-dir", mirror, "rev-parse", "--verify", "refs/remotes/origin/main").Run(); err != nil {
+		t.Fatalf("legacy mirror not healed: refs/remotes/origin/main still missing: %v", err)
+	}
+}
+
+// TestEnsureMirror_FailedCloneRemovesStagingDir is the #765 staging-leak
+// regression: a failed first clone — the on-disk shape of a #759 per-op
+// timeout killing `git clone --bare` mid-transfer — must not leave the
+// `<mirror>.git.staging` build directory behind. Before the deferred
+// cleanup, a repo removed from config after one failed first clone leaked
+// its staging dir until an operator deleted it by hand.
+func TestEnsureMirror_FailedCloneRemovesStagingDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH git shim requires a POSIX shell")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	// A git shim whose `clone` leaves a partial staging directory and exits
+	// non-zero, mimicking a clone killed before it could clean up. Non-clone
+	// invocations must not happen on this path; fail loudly if they do.
+	shimDir := t.TempDir()
+	shim := `#!/bin/sh
+if [ "$1" = "clone" ]; then
+  for last; do :; done
+  mkdir -p "$last"
+  printf 'ref: refs/heads/main\n' > "$last/HEAD"
+  exit 128
+fi
+echo "unexpected git invocation: $*" >&2
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cloneURL := "file:///nonexistent/aiops-765-staging.git"
+	if _, err := mgr.EnsureMirror(ctx, cloneURL); err == nil {
+		t.Fatal("EnsureMirror succeeded under a failing clone shim; want error")
+	}
+	mirror := mirrorPathFor(MirrorRoot(mgr.MirrorRoot), cloneURL)
+	if _, err := os.Stat(mirror + mirrorStagingSuffix); !os.IsNotExist(err) {
+		t.Fatalf("staging dir left behind after failed clone: stat err=%v", err)
+	}
+	if _, err := os.Stat(mirror); !os.IsNotExist(err) {
+		t.Fatalf("final mirror path materialized despite failed clone: stat err=%v", err)
 	}
 }
 
@@ -939,12 +1050,15 @@ func TestWriteSensitiveArtifactReplacesHardLinkedArtifact(t *testing.T) {
 // `refs/remotes/origin/<base>` through the post-clone fetch refspec
 // rewrite, so `git rev-parse --verify origin/<base>` succeeds and the
 // fallback never fires in production. This test drives the fallback
-// explicitly by deleting `refs/remotes/origin/main` from a freshly
-// prepared mirror and emptying the fetch refspec so the next
-// `ensureMirrorLocked`'s fetch does not repopulate it — guarding the
-// fallback against a future refactor of EnsureMirror's refspec layout
-// (and ensuring `file://` test fixtures continue to work even when the
-// mirror only carries `refs/heads/<base>`).
+// explicitly by deleting the base branch on the UPSTREAM so the next
+// `ensureMirrorLocked`'s `fetch --prune` removes `refs/remotes/origin/main`
+// from the mirror while the mirror keeps its bare `refs/heads/main` from
+// the original `git clone --bare`. (The earlier construction — unsetting
+// `remote.origin.fetch` on the mirror — stopped driving the fallback when
+// the existing-mirror branch began re-asserting the refspec before every
+// refresh fetch, #765.) This guards the fallback against a future refactor
+// of EnsureMirror's refspec layout and ensures `file://` test fixtures
+// continue to work even when the mirror only carries `refs/heads/<base>`.
 func TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName(t *testing.T) {
 	upstream := initBareUpstream(t)
 	mgr := newTestManager(t)
@@ -965,31 +1079,28 @@ func TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName(t *testing.T)
 	if err != nil {
 		t.Fatalf("mirror rev-parse refs/heads/main: %v", err)
 	}
-	// Strip `refs/remotes/origin/*` and empty the fetch refspec so the
-	// next prepare's `git fetch --prune --tags origin` does not bring
-	// `origin/main` back. With no refspec, the fetch is effectively a
-	// no-op for ref tracking; the mirror keeps its `refs/heads/main` from
-	// the original `git clone --bare`.
-	if out, err := exec.Command("git", "--git-dir", mirror, "update-ref", "-d", "refs/remotes/origin/main").CombinedOutput(); err != nil {
-		t.Fatalf("delete refs/remotes/origin/main: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "--git-dir", mirror, "config", "--unset-all", "remote.origin.fetch").CombinedOutput(); err != nil {
-		t.Fatalf("unset remote.origin.fetch: %v\n%s", err, out)
+	// Delete the base branch on the upstream so the next prepare's
+	// `git fetch --prune --tags origin` prunes `refs/remotes/origin/main`
+	// from the mirror; the mirror keeps its bare `refs/heads/main` from the
+	// original `git clone --bare` because fetch never touches local heads.
+	upstreamPath := strings.TrimPrefix(upstream, "file://")
+	if out, err := exec.Command("git", "--git-dir", upstreamPath, "update-ref", "-d", "refs/heads/main").CombinedOutput(); err != nil {
+		t.Fatalf("delete upstream refs/heads/main: %v\n%s", err, out)
 	}
 	// Sanity: confirm the precondition the fallback branch needs — the
-	// remote-tracking ref is gone but the bare head ref survives.
-	if err := exec.Command("git", "--git-dir", mirror, "rev-parse", "--verify", "refs/remotes/origin/main").Run(); err == nil {
-		t.Fatal("precondition broken: refs/remotes/origin/main still resolves on the mirror")
+	// upstream branch is gone but the mirror's bare head ref survives.
+	if err := exec.Command("git", "--git-dir", upstreamPath, "rev-parse", "--verify", "refs/heads/main").Run(); err == nil {
+		t.Fatal("precondition broken: refs/heads/main still resolves on the upstream")
 	}
 	if err := exec.Command("git", "--git-dir", mirror, "rev-parse", "--verify", "refs/heads/main").Run(); err != nil {
 		t.Fatalf("precondition broken: refs/heads/main missing on mirror: %v", err)
 	}
 
 	// New task → first-touch path runs through the startRef resolution.
-	// With `origin/main` deleted, the `git rev-parse --verify origin/main`
-	// gate fails and startRef falls back to bare `main`; the subsequent
-	// `git worktree add ... main` must succeed against the mirror's
-	// `refs/heads/main`.
+	// The refresh fetch prunes `origin/main`, the `git rev-parse --verify
+	// origin/main` gate fails, and startRef falls back to bare `main`; the
+	// subsequent `git worktree add ... main` must succeed against the
+	// mirror's `refs/heads/main`.
 	tk := makeTask("task-fallback", upstream)
 	dir, createdNow, err := mgr.PrepareGitWorkspace(ctx, tk)
 	if err != nil {
@@ -997,6 +1108,12 @@ func TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName(t *testing.T)
 	}
 	if !createdNow {
 		t.Fatal("first prepare for new task reported createdNow=false")
+	}
+	// Post-condition: the prune actually removed the remote-tracking ref,
+	// so the prepare above really exercised the fallback rather than
+	// resolving `origin/main`.
+	if err := exec.Command("git", "--git-dir", mirror, "rev-parse", "--verify", "refs/remotes/origin/main").Run(); err == nil {
+		t.Fatal("fetch --prune kept refs/remotes/origin/main; the fallback was not driven")
 	}
 	headOut, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
 	if err != nil {

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -225,6 +225,37 @@ func TestEnsureMirror_HealsLegacyPartialMirrorMissingRefspec(t *testing.T) {
 	}
 }
 
+// TestEnsureMirror_ReplacesMultiValuedFetchRefspec pins the --replace-all on
+// the refresh-path refspec re-assert (#765, PR #774 codex P2): when an
+// operator has added a second `remote.origin.fetch` value to a healthy
+// mirror, plain `git config <key> <value>` refuses multi-valued keys
+// ("cannot overwrite multiple values with a single value") and would turn a
+// previously fetchable mirror into a permanent EnsureMirror failure.
+func TestEnsureMirror_ReplacesMultiValuedFetchRefspec(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	mirror, err := mgr.EnsureMirror(ctx, upstream)
+	if err != nil {
+		t.Fatalf("first EnsureMirror: %v", err)
+	}
+	if out, err := exec.Command("git", "--git-dir", mirror, "config", "--add", "remote.origin.fetch", "+refs/tags/*:refs/tags/*").CombinedOutput(); err != nil {
+		t.Fatalf("add second fetch refspec: %v\n%s", err, out)
+	}
+
+	if _, err := mgr.EnsureMirror(ctx, upstream); err != nil {
+		t.Fatalf("EnsureMirror over multi-valued fetch refspec: %v", err)
+	}
+	out, err := exec.Command("git", "--git-dir", mirror, "config", "--get-all", "remote.origin.fetch").Output()
+	if err != nil {
+		t.Fatalf("read fetch refspecs after refresh: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(out)), "+refs/heads/*:refs/remotes/origin/*"; got != want {
+		t.Fatalf("fetch refspecs after refresh = %q, want exactly %q", got, want)
+	}
+}
+
 // TestEnsureMirror_FailedCloneRemovesStagingDir is the #765 staging-leak
 // regression: a failed first clone — the on-disk shape of a #759 per-op
 // timeout killing `git clone --bare` mid-transfer — must not leave the


### PR DESCRIPTION
Closes #765

## Summary
- `ensureMirrorLocked` now re-asserts `remote.origin.fetch` (`--replace-all`, `+refs/heads/*:refs/remotes/origin/*`) before the refresh fetch, mirroring what the clone path already does. A partial clone left at the **final** mirror path by a pre-#764 binary (worker SIGKILLed mid-clone: `HEAD` + `remote.origin.url`, no fetch refspec, no refs) previously sent every refresh down the existing-mirror branch with the bare-clone "do nothing" refspec — fetch updated only `FETCH_HEAD`, `resolveStartRef` fell back to a branch that does not exist, and `worktree add` wedged on every §8.4 retry until an operator deleted the directory. The re-assert is idempotent for healthy mirrors and heals the legacy state in place; `--replace-all` (round-2 codex P2) keeps the write valid when the key holds operator-added multiple values, converging them onto the canonical refspec instead of failing.
- `cloneMirrorLocked` now reaps `<mirror>.git.staging` on its error paths via a deferred cleanup gated on a `moved` sentinel (the success path renames staging into place). Previously a repo removed from config after one failed first clone leaked its staging dir indefinitely. The head-of-function `RemoveAll` sweep stays: a SIGKILLed worker never runs deferred functions, so the next attempt must still clear that debris.
- Adjacent-path repair: `TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName` drove the startRef fallback by unsetting the mirror's refspec — a construction the re-assert turns into a placebo. It now drives the fallback by deleting the upstream branch (`fetch --prune` drops `origin/main`; the mirror keeps bare `refs/heads/main`), with a post-condition assert that the prune actually fired.

## Acceptance criteria (issue #765)
- [x] Existing-mirror branch re-asserts the remote-tracking refspec before fetch; `TestEnsureMirror_HealsLegacyPartialMirrorMissingRefspec` constructs the legacy state (final-path dir with `HEAD` + origin URL, no refspec, no refs) and proves `PrepareGitWorkspace` yields a worktree-able mirror.
- [x] A failed `cloneMirrorLocked` leaves no `.git.staging` directory behind; `TestEnsureMirror_FailedCloneRemovesStagingDir` pins it via a PATH git-shim whose `clone` leaves a partial staging dir and exits non-zero (the #759 timeout-kill shape). The success path is pinned unchanged by a new staging-gone assert in `TestEnsureMirror_FirstCallClonesSecondCallReuses`.
- [x] Mutation-verified all three production changes per AGENTS.md clean-code rule 6 (see Testing).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Upstream check: the Elixir reference has no mirror/bare-clone equivalent (grep of `/tmp/symphony-upstream/elixir/lib` shows no mirror machinery); the mirror cache is an established aiops workspace mechanism (#228, #764) and this PR is same-file hardening of it, not a new phase/gate.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file, +26/-1 production LOC (`internal/workspace/mirror.go`; `mirror_test.go` is test code and excluded).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
Head `c98b85f`.
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...` (full sweep on 03e6a12; `./internal/workspace/` re-run on c98b85f — the increment touches only that package)
- [x] `gofmt -l` clean + blocking golangci gate (`./internal/workspace/...` with `--issues-exit-code=1`: 0 issues)
- [x] Mutation verification against committed heads:
  - reverted the refspec re-assert → `TestEnsureMirror_HealsLegacyPartialMirrorMissingRefspec` FAILS with `worktree add: exit status 128` (the exact wedge from the issue); restored, tree clean.
  - neutered the deferred cleanup (`_ = os.RemoveAll(staging)` → `_ = staging`, compiling mutation per rule 11) → `TestEnsureMirror_FailedCloneRemovesStagingDir` FAILS with `staging dir left behind after failed clone`; restored, tree clean.
  - dropped `--replace-all` from the re-assert → `TestEnsureMirror_ReplacesMultiValuedFetchRefspec` FAILS with `reassert fetch refspec: exit status 5`; restored, tree clean.

## Review ledger
- Round 1 (head `03e6a12`): pre-push dual review — Codex family (`codex exec --output-schema`, read-only sandbox) `{"blocking_findings":[]}`; Claude family (`feature-dev:code-reviewer`) MERGE-READY, no HIGH findings. `@codex review` trigger comment 4688438124 (bytevane): review submitted for 03e6a12 with one P2 — plain `git config` refuses multi-valued `remote.origin.fetch` and would wedge a healthy mirror carrying an operator-added extra refspec. Validated as a real regression; fixed in `c98b85f` (`--replace-all` + regression test); thread replied and resolved.
- Round 2 (head `c98b85f`): pre-push dual review — Codex family `{"blocking_findings":[]}`; Claude family MERGE-READY (no findings ≥80 confidence; its <80 observation — operator-added refspecs are silently converged — is the intended canonical-refspec semantics, matching the clone path). Its one LOW from round 1 — the re-assert is an extra idempotent `git config` write per refresh — matches the pre-existing `extensions.worktreeConfig` refresh-path pattern, accepted by design.
