### PR TITLE
docs(protocol): poll loops keep predicates in --jq, carry JSON via printf, fail loud

### DIFF
--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -164,6 +164,20 @@ Run it **on every pushed head**, not once per PR.
      and base still match the recorded trigger refs.
    Do not automate the last case by parsing Codex natural-language output; an
    unattended gate that lacks a structured clean signal should fail closed.
+
+   **Poll-loop implementation constraints** (earned: the PR #774 second-round
+   watch stalled silently for 16+ rounds, 2026-06-12). The interactive shell
+   on this machine is zsh, whose builtin `echo` interprets backslash escapes
+   by default (`man zshbuiltins`) — piping rich-text JSON through
+   `echo "$var"` turns the `\n` escapes inside review/comment `body` fields
+   into real control characters and breaks every JSON parser downstream,
+   while small scalar JSON survives, making the breakage look intermittent.
+   Therefore: keep the predicate inside `--jq` and emit only small
+   scalars/flags (as the commands above already do); use `printf '%s' "$var"`
+   when a variable must carry JSON; and never silence the producer's stderr
+   inside a poll loop — print an `ERR:` line on fetch/parse failure, because
+   a watcher whose failure mode is silence is indistinguishable from "still
+   waiting".
 3. **CI green** uses native `gh pr checks <pr> --watch --fail-fast` (blocks to
    completion) — never `sleep`-poll.
 4. Local review **does not replace** this gate: the GitHub Codex bot and the


### PR DESCRIPTION
Closes #777

## Summary
- Adds one earned rule to [`pr-review-merge-protocol.md`](../blob/main/docs/runbooks/pr-review-merge-protocol.md) §4 (the shared single source of truth that `handle-issue`, `handle-pr`, and `batch-issue-processing.md` reference): poll loops keep predicates inside `--jq` emitting only scalars/flags; variables that must carry JSON go through `printf '%s'`, never `echo`; and poll loops fail loud (an `ERR:` line on fetch/parse failure instead of swallowed stderr).
- Earned by an observed failure (PR #774 second-round codex watch, 2026-06-12): the interactive shell is zsh, whose builtin `echo` interprets backslash escapes by default (`man zshbuiltins`), so rich-text JSON (comment `body` `\n` escapes) piped through `echo "$var"` gained real control characters → `JSONDecodeError` → swallowed by `2>/dev/null` → the watcher spun silently for 16+ rounds. Root cause A/B-reproduced (`echo` fails at char 221, `printf '%s'` parses clean; `od` shows the injected newline); the corrected pattern was field-tested on the PR #776 watch (signal hit in 4 rounds).
- Verified non-targets before writing: repo scripts are unaffected (`local-pr-follow-through.sh` / `refresh-codex-schema.sh` are bash-shebang and echo only escape-free scalars); §4's own commands were already scalar-only `--jq`; the consuming skills/runbooks reference the protocol and deliberately get no duplicated copy (one source of truth, clean-code rule 3).

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)

- [x] `within budget` — one runbook file, +16 LOC of documentation; zero production code.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing

- [x] Documentation-only change; no Go paths touched. Root-cause evidence and the corrected pattern's field test are linked in the Summary.
