### PR TITLE
feat(doctor): preflight Gitea/GitHub tracker auth and label visibility; drop the stale services[] hint

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -496,26 +496,14 @@ func trackerClientForWorkflow(cfg workflow.Config) (trackerRuntimeClient, error)
 	case "linear":
 		return tracker.NewLinearClient(cfg.Tracker), nil
 	case "gitea":
-		baseURL := gitea.BaseURLFromTrackerConfig(cfg.Tracker, env("GITEA_BASE_URL", "http://localhost:3000"))
-		client := gitea.NewTrackerClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name)
+		client := gitea.NewTrackerClient(cfg.Tracker, gitea.BaseURLFromEnv(cfg.Tracker), cfg.Repo.Owner, cfg.Repo.Name)
 		client.Logf = log.Printf
 		return client, nil
 	case "github":
-		baseURL := cfg.Tracker.Endpoint
-		if baseURL == "" {
-			baseURL = env("GITHUB_API_BASE_URL", "https://api.github.com")
-		}
-		client := tracker.NewGitHubClient(cfg.Tracker, baseURL, cfg.Repo.Owner, cfg.Repo.Name)
+		client := tracker.NewGitHubClientFromEnv(cfg.Tracker, cfg.Repo.Owner, cfg.Repo.Name)
 		client.Logf = log.Printf
 		return client, nil
 	default:
 		return nil, tracker.NewError(tracker.CategoryUnsupportedTrackerKind, fmt.Sprintf("unsupported tracker.kind %q", cfg.Tracker.Kind), nil)
 	}
-}
-
-func env(k, d string) string {
-	if v := os.Getenv(k); v != "" {
-		return v
-	}
-	return d
 }

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -2059,6 +2059,55 @@ func TestWorkerReconciliationConfigIncludesInactiveStates(t *testing.T) {
 	}
 }
 
+// TestTrackerClientForWorkflowUsesGiteaLocalhostDefaultWhenNoEnvAndNoConfig
+// pins the all-empty arm of the shared gitea.BaseURLFromEnv resolution: with
+// no endpoint, no legacy project_slug, and no GITEA_BASE_URL, both the worker
+// and doctor must land on the local-dev default.
+func TestTrackerClientForWorkflowUsesGiteaLocalhostDefaultWhenNoEnvAndNoConfig(t *testing.T) {
+	t.Setenv("GITEA_BASE_URL", "")
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.Kind = "gitea"
+	cfg.Repo.Owner = "owner"
+	cfg.Repo.Name = "repo"
+
+	client, err := trackerClientForWorkflow(cfg)
+	if err != nil {
+		t.Fatalf("tracker client: %v", err)
+	}
+	giteaClient, ok := client.(*gitea.TrackerClient)
+	if !ok {
+		t.Fatalf("client type = %T, want *gitea.TrackerClient", client)
+	}
+	if giteaClient.BaseURL != "http://localhost:3000" {
+		t.Fatalf("base URL = %q, want the http://localhost:3000 default with no endpoint/env", giteaClient.BaseURL)
+	}
+}
+
+// TestTrackerClientForWorkflowUsesGitHubDefaultWhenNoEnvAndNoEndpoint pins
+// the all-empty arm of the shared tracker.NewGitHubClientFromEnv resolution:
+// with no endpoint and no GITHUB_API_BASE_URL, both the worker and doctor
+// must land on the constructor's api.github.com default.
+func TestTrackerClientForWorkflowUsesGitHubDefaultWhenNoEnvAndNoEndpoint(t *testing.T) {
+	t.Setenv("GITHUB_API_BASE_URL", "")
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.Owner = "owner"
+	cfg.Repo.Name = "repo"
+	cfg.Tracker.Kind = "github"
+	cfg.Tracker.APIKey = "github-token"
+
+	client, err := trackerClientForWorkflow(cfg)
+	if err != nil {
+		t.Fatalf("trackerClientForWorkflow: %v", err)
+	}
+	githubClient, ok := client.(*tracker.GitHubClient)
+	if !ok {
+		t.Fatalf("client type = %T, want *tracker.GitHubClient", client)
+	}
+	if githubClient.BaseURL != "https://api.github.com" {
+		t.Fatalf("github base URL = %q, want the https://api.github.com default with no endpoint/env", githubClient.BaseURL)
+	}
+}
+
 func TestTrackerClientForWorkflowBuildsGitHubClient(t *testing.T) {
 	cfg := workflow.DefaultConfig()
 	cfg.Repo.Owner = "xrf9268-hue"

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -76,7 +76,7 @@ func BuildReport(ctx context.Context, opts Options) Report {
 	r.checkProjectToolchain(ctx)
 	r.checkDockerCompose(ctx)
 	if wf != nil {
-		r.checkLinear(ctx, wf.Config)
+		r.checkTracker(ctx, wf.Config)
 		r.checkCodex(ctx, wf.Config)
 		r.checkGitHubAgent(ctx, wf.Config)
 		r.checkSandbox(ctx, wf.Config)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -483,7 +483,9 @@ func TestCheckProjectToolchainSkippedForBinaryDeploy(t *testing.T) {
 
 func TestBuildReportRealModeUsesCustomCodexCommandForAppServerProbe(t *testing.T) {
 	wrapper := installFakeCodexWrapper(t)
-	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server")
+	// The no-failure sweep below needs the real-mode Gitea tracker preflight
+	// (#781) to succeed, so supply an api_key and a stub endpoint.
+	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server", "\n  api_key: token\n  endpoint: "+trackerPreflightStubURL(t))
 	report := BuildReport(context.Background(), Options{
 		WorkflowPath: path,
 		Mode:         "real",
@@ -586,8 +588,10 @@ func TestBuildReportRealModeFailsWithoutGoModuleForTargetedTest(t *testing.T) {
 
 func TestBuildReportRealModeWarnsWithoutExplicitGoTestDir(t *testing.T) {
 	installFakeGitOnly(t)
+	// The HasFailures assertion below needs the real-mode Gitea tracker
+	// preflight (#781) to succeed, so point tracker.endpoint at a stub.
 	report := BuildReport(context.Background(), Options{
-		WorkflowPath: writeWorkflow(t, "gitea", "token"),
+		WorkflowPath: writeWorkflowBody(t, "gitea", "token", "mock", "\n  endpoint: "+trackerPreflightStubURL(t)),
 		Mode:         "real",
 		Runner:       fakeRealRunner,
 	})
@@ -760,7 +764,7 @@ if [ "$1" = "app-server" ]; then
 fi
 exit 1
 `)
-	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server")
+	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server", "")
 	report := BuildReport(context.Background(), Options{
 		WorkflowPath: path,
 		Mode:         "real",
@@ -792,7 +796,7 @@ if [ "$1" = "app-server" ]; then
 fi
 exit 1
 `)
-	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server")
+	path := writeWorkflowWithCodexCommand(t, wrapper+" app-server", "")
 	report := BuildReport(context.Background(), Options{
 		WorkflowPath: path,
 		Mode:         "real",
@@ -970,6 +974,18 @@ func writeWorkflow(t *testing.T, trackerKind, apiKey string) string {
 	return writeWorkflowBody(t, trackerKind, apiKey, "mock", "")
 }
 
+// trackerPreflightStubURL serves an empty JSON body for the real-mode tracker
+// preflight probes (#781) so fixtures whose reports must stay failure-free
+// never depend on a live tracker endpoint.
+func trackerPreflightStubURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
 func writeWorkflowWithEndpoint(t *testing.T, endpoint, agent string) string {
 	t.Helper()
 	body := "\n  endpoint: " + endpoint
@@ -1000,7 +1016,7 @@ prompt
 	return path
 }
 
-func writeWorkflowWithCodexCommand(t *testing.T, command string) string {
+func writeWorkflowWithCodexCommand(t *testing.T, command, extraTracker string) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
@@ -1010,7 +1026,7 @@ repo:
   name: r
   clone_url: https://example.invalid/o/r.git
 tracker:
-  kind: gitea
+  kind: gitea` + extraTracker + `
 agent:
   default: codex-app-server
 codex:

--- a/internal/doctor/doctor_tracker.go
+++ b/internal/doctor/doctor_tracker.go
@@ -1,32 +1,54 @@
 package doctor
 
-// doctor_tracker.go holds the tracker-facing checks: Linear API-key/GraphQL
-// auth and project visibility, and the GitHub agent-credential preflight
-// (gh auth + git push dry-run), plus the clone-URL/repo-selection helpers they
-// share. The report framework (reportBuilder, run helpers, shared output
-// formatting) lives in doctor.go.
+// doctor_tracker.go holds the tracker-facing checks: the per-kind tracker
+// credential preflight (Linear API-key/GraphQL auth and project visibility;
+// Gitea/GitHub auth by driving the worker's own tracker clients through
+// their real poll query), and the GitHub agent-credential preflight (gh auth
+// + git push dry-run), plus the clone-URL/repo-selection helpers they share.
+// The report framework (reportBuilder, run helpers, shared output formatting)
+// lives in doctor.go.
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
-func (r *reportBuilder) checkLinear(ctx context.Context, cfg workflow.Config) {
-	if strings.TrimSpace(cfg.Tracker.Kind) != "linear" {
-		r.warn("Linear", "tracker.kind is not linear; Linear smoke checks skipped", "Use a Linear workflow for the documented first-run path.")
-		return
+// checkTracker dispatches the tracker credential preflight on tracker.kind so
+// a Gitea or GitHub operator with a missing or bad token fails at doctor time
+// instead of at the first poll (#781). The switch matches on the raw kind,
+// exactly like the worker's trackerClientForWorkflow dispatch
+// (cmd/worker/main.go): the loader's allowed-kinds validation compares raw
+// values too (internal/workflow/validate.go), so a whitespace-bearing kind
+// never loads and cannot reach this switch. The default branch is a
+// defensive fallback.
+func (r *reportBuilder) checkTracker(ctx context.Context, cfg workflow.Config) {
+	switch cfg.Tracker.Kind {
+	case "linear":
+		r.checkLinear(ctx, cfg)
+	case "gitea":
+		r.checkGiteaTracker(ctx, cfg)
+	case "github":
+		r.checkGitHubTracker(ctx, cfg)
+	default:
+		r.warn("Tracker", fmt.Sprintf("tracker.kind %q has no doctor preflight", cfg.Tracker.Kind), "Set tracker.kind to gitea, github, or linear in WORKFLOW.md.")
 	}
+}
+
+func (r *reportBuilder) checkLinear(ctx context.Context, cfg workflow.Config) {
 	if strings.TrimSpace(cfg.Tracker.APIKey) == "" {
 		r.fail("Linear API key", "tracker.api_key resolved empty", "Provide LINEAR_API_KEY via the worker environment (a systemd EnvironmentFile, a Docker secret, or a shell export).")
 		return
@@ -40,6 +62,115 @@ func (r *reportBuilder) checkLinear(ctx context.Context, cfg workflow.Config) {
 		return
 	}
 	r.pass("Linear auth", "API key authenticated and configured projects are visible")
+}
+
+// checkGiteaTracker preflights the Gitea tracker credentials by driving the
+// worker's own tracker client through its real poll query. Every hand-built
+// mirror of the worker's tracker access drifted in review (PR #801: base-URL
+// duplication, endpoint divergence, /user false-negatives, and an
+// unconditional /pulls probe the production client gates on the configured
+// states), so the construction below calls the same shared constructors
+// trackerClientForWorkflow (cmd/worker/main.go) calls
+// (gitea.BaseURLFromEnv + gitea.NewTrackerClient) and ListActiveIssues
+// inherits whatever the poll loop does — fidelity by shared construction,
+// not by mirroring.
+func (r *reportBuilder) checkGiteaTracker(ctx context.Context, cfg workflow.Config) {
+	if !r.trackerPreflightStages(cfg, "Gitea API key", "Set tracker.api_key: $GITEA_TOKEN in WORKFLOW.md and provide GITEA_TOKEN via the worker environment.", "Gitea auth") {
+		return
+	}
+	base := gitea.BaseURLFromEnv(cfg.Tracker)
+	client := gitea.NewTrackerClient(cfg.Tracker, base, cfg.Repo.Owner, cfg.Repo.Name)
+	client.HTTP = r.opts.HTTPClient
+	listCtx, cancel := context.WithTimeout(ctx, trackerListingTimeout)
+	defer cancel()
+	_, err := client.ListActiveIssues(listCtx)
+	r.reportTrackerListing("Gitea auth", base, "tracker.endpoint or GITEA_BASE_URL", cfg, err)
+}
+
+// checkGitHubTracker preflights the GitHub tracker credentials by driving the
+// worker's own GitHub client through the shared constructor
+// (tracker.NewGitHubClientFromEnv — the same call trackerClientForWorkflow
+// makes in cmd/worker/main.go; same drift rationale as checkGiteaTracker).
+// ListActiveIssues inherits the client's per-request deadlines (#295), the
+// Bearer header, the githubStatesMayIncludeOpenIssues pulls gating,
+// pagination, and JSON decoding — so a closed-only active_states workflow
+// with an Issues-only token passes doctor exactly as it polls. Check names
+// carry the "tracker" qualifier to stay distinct from the agent-side
+// "GitHub agent …" checks.
+func (r *reportBuilder) checkGitHubTracker(ctx context.Context, cfg workflow.Config) {
+	if !r.trackerPreflightStages(cfg, "GitHub tracker API key", "Set tracker.api_key: $GITHUB_TOKEN in WORKFLOW.md and provide GITHUB_TOKEN via the worker environment.", "GitHub tracker auth") {
+		return
+	}
+	client := tracker.NewGitHubClientFromEnv(cfg.Tracker, cfg.Repo.Owner, cfg.Repo.Name)
+	client.HTTP = r.opts.HTTPClient
+	listCtx, cancel := context.WithTimeout(ctx, trackerListingTimeout)
+	defer cancel()
+	_, err := client.ListActiveIssues(listCtx)
+	r.reportTrackerListing("GitHub tracker auth", client.BaseURL, "tracker.endpoint or GITHUB_API_BASE_URL", cfg, err)
+}
+
+// trackerPreflightStages runs the doctor-side stages shared by the Gitea and
+// GitHub tracker checks before any live traffic, mirroring checkLinear's
+// branch order: an empty resolved api_key FAILs in both modes, mock mode
+// passes without network access, and a missing repo.owner/repo.name FAILs
+// because the production listing call needs the repository coordinates. It
+// returns false when the live listing must not run.
+func (r *reportBuilder) trackerPreflightStages(cfg workflow.Config, keyCheckName, keyFix, authCheckName string) bool {
+	if strings.TrimSpace(cfg.Tracker.APIKey) == "" {
+		r.fail(keyCheckName, "tracker.api_key resolved empty", keyFix)
+		return false
+	}
+	if !r.realMode() {
+		r.pass(keyCheckName, "present; live auth skipped in mock mode")
+		return false
+	}
+	if strings.TrimSpace(cfg.Repo.Owner) == "" || strings.TrimSpace(cfg.Repo.Name) == "" {
+		r.fail(authCheckName, "repo.owner and repo.name are required for the repository visibility probe", "Set repo.owner and repo.name to the repository the worker polls.")
+		return false
+	}
+	return true
+}
+
+// reportTrackerListing turns the production client's ListActiveIssues result
+// into the auth check verdict. Failures are rebuilt around the masked base
+// URL (maskedProbeError) because tracker.endpoint may carry basic-auth
+// userinfo that *url.Error embeds; the PASS detail masks it for the same
+// reason.
+func (r *reportBuilder) reportTrackerListing(authCheckName, base, baseHint string, cfg workflow.Config, err error) {
+	repoFullName := strings.TrimSpace(cfg.Repo.Owner) + "/" + strings.TrimSpace(cfg.Repo.Name)
+	if err != nil {
+		r.fail(authCheckName, maskedProbeError(base, err).Error(), "Verify tracker.api_key, the tracker base URL ("+baseHint+"), and that the token can run the worker's issue listing for "+repoFullName+".")
+		return
+	}
+	r.pass(authCheckName, "the worker's own issue listing for "+repoFullName+" succeeded against "+workflow.MaskCloneURL(base))
+}
+
+// trackerProbeTimeout bounds each live Linear GraphQL probe request. The
+// default HTTPClient carries its own 10s timeout, but Options.HTTPClient is
+// injectable, so per the repo convention the probe enforces its own deadline
+// instead of trusting the client.
+const trackerProbeTimeout = 10 * time.Second
+
+// trackerListingTimeout bounds the whole Gitea/GitHub preflight listing call.
+// The production clients already wrap every individual request in
+// context.WithTimeout (internal/gitea requestTimeout; github.go
+// RequestTimeout, #295) — injection of Options.HTTPClient cannot strip that —
+// but ListActiveIssues spans multiple requests (states × pagination), so the
+// call site adds an overall budget per the convention that external I/O is
+// deadline-bounded at the caller even when the client honors ctx.
+const trackerListingTimeout = time.Minute
+
+// maskedProbeError rebuilds a tracker client or probe error around the masked
+// endpoint: *url.Error embeds the request URL (parse errors verbatim,
+// transport errors with only the password redacted by net/http), so a
+// tracker.endpoint carrying basic-auth userinfo would otherwise leak into the
+// doctor report through the FAIL detail.
+func maskedProbeError(endpoint string, err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		err = urlErr.Err
+	}
+	return fmt.Errorf("probe %s: %w", workflow.MaskCloneURL(endpoint), err)
 }
 
 func (r *reportBuilder) checkGitHubAgent(ctx context.Context, cfg workflow.Config) {
@@ -95,47 +226,61 @@ func (r *reportBuilder) prepareGitPushProbe(ctx context.Context, env []string) (
 	return dir, cleanup, nil
 }
 
-func (r *reportBuilder) checkLinearGraphQL(ctx context.Context, cfg workflow.Config) error { //nolint:gocognit // baseline (#521)
+func (r *reportBuilder) checkLinearGraphQL(ctx context.Context, cfg workflow.Config) error {
 	query := `query Doctor($projectSlug: String!) { viewer { id name } projects(filter: { slugId: { eq: $projectSlug } }, first: 1) { nodes { id slugId name } } }`
 	projectSlugs := linearProjectSlugs(cfg)
 	if len(projectSlugs) == 0 {
-		return fmt.Errorf("linear project_slug is required at tracker.project_slug or services[].tracker.project_slug")
+		return fmt.Errorf("linear project_slug is required at tracker.project_slug")
 	}
 	endpoint := strings.TrimSpace(cfg.Tracker.Endpoint)
 	if endpoint == "" {
 		endpoint = tracker.DefaultLinearEndpoint
 	}
 	for _, projectSlug := range projectSlugs {
-		var out struct {
-			Data struct {
-				Projects struct {
-					Nodes []struct {
-						ID string `json:"id"`
-					} `json:"nodes"`
-				} `json:"projects"`
-			} `json:"data"`
-			Errors []map[string]any `json:"errors"`
-		}
-		body, _ := json.Marshal(map[string]any{"query": query, "variables": map[string]any{"projectSlug": projectSlug}})
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
-		if err != nil {
+		if err := r.probeLinearProjectSlug(ctx, endpoint, cfg.Tracker.APIKey, query, projectSlug); err != nil {
 			return err
 		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", cfg.Tracker.APIKey)
-		resp, err := r.opts.HTTPClient.Do(req)
-		if err != nil {
-			return err
-		}
-		if err := decodeLinearProjectProbe(resp, &out); err != nil {
-			return err
-		}
-		if len(out.Errors) > 0 {
-			return fmt.Errorf("linear GraphQL errors for project_slug %q: %v", projectSlug, out.Errors)
-		}
-		if len(out.Data.Projects.Nodes) == 0 {
-			return fmt.Errorf("project_slug %q is not visible to the token", projectSlug)
-		}
+	}
+	return nil
+}
+
+// probeLinearProjectSlug runs one auth+visibility probe with its own request
+// deadline: Options.HTTPClient is injectable, so the request must not trust
+// the client's timeout (trackerProbeTimeout).
+func (r *reportBuilder) probeLinearProjectSlug(ctx context.Context, endpoint, apiKey, query, projectSlug string) error {
+	var out struct {
+		Data struct {
+			Projects struct {
+				Nodes []struct {
+					ID string `json:"id"`
+				} `json:"nodes"`
+			} `json:"projects"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, trackerProbeTimeout)
+	defer cancel()
+	body, _ := json.Marshal(map[string]any{"query": query, "variables": map[string]any{"projectSlug": projectSlug}})
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		// Same leak class as the Gitea/GitHub probes: *url.Error embeds the
+		// endpoint, which may carry userinfo credentials.
+		return maskedProbeError(endpoint, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", apiKey)
+	resp, err := r.opts.HTTPClient.Do(req)
+	if err != nil {
+		return maskedProbeError(endpoint, err)
+	}
+	if err := decodeLinearProjectProbe(resp, &out); err != nil {
+		return err
+	}
+	if len(out.Errors) > 0 {
+		return fmt.Errorf("linear GraphQL errors for project_slug %q: %v", projectSlug, out.Errors)
+	}
+	if len(out.Data.Projects.Nodes) == 0 {
+		return fmt.Errorf("project_slug %q is not visible to the token", projectSlug)
 	}
 	return nil
 }
@@ -149,7 +294,13 @@ func decodeLinearProjectProbe(resp *http.Response, out any) error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("linear returned %s", resp.Status)
 	}
-	return json.NewDecoder(resp.Body).Decode(out)
+	// Preflight mirrors the consumer: the poller decodes this response
+	// immediately, so name the non-JSON body (a login proxy answering 200
+	// HTML) instead of surfacing a bare json.SyntaxError.
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("linear returned %s with a body that is not JSON: %w", resp.Status, err)
+	}
+	return nil
 }
 
 func linearProjectSlugs(cfg workflow.Config) []string {

--- a/internal/doctor/doctor_tracker_drain_test.go
+++ b/internal/doctor/doctor_tracker_drain_test.go
@@ -88,3 +88,9 @@ func TestDecodeLinearProjectProbeDrainsResponseBodies(t *testing.T) {
 		})
 	}
 }
+
+// The Gitea/GitHub tracker preflight has no doctor-side drain tests anymore:
+// it drives the worker's own tracker clients, whose poll paths own the
+// response-body lifecycle (tracker.DrainAndClose in internal/gitea
+// tracker_client.go and internal/tracker github.go, pinned by those
+// packages' drain tests — #762/#771).

--- a/internal/doctor/doctor_tracker_preflight_test.go
+++ b/internal/doctor/doctor_tracker_preflight_test.go
@@ -1,0 +1,685 @@
+package doctor
+
+// Tests for the Gitea/GitHub tracker credential preflight (#781): the
+// empty-key FAIL, the mock-mode skip, and the real-mode listing that drives
+// the worker's own tracker clients — so the requests asserted here are the
+// production poll queries themselves, not hand-built doctor probes (the
+// PR #801 drift class).
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// writeTrackerPreflightWorkflow writes a minimal non-Linear workflow whose
+// tracker section is fully caller-controlled (no implicit project_slug, so
+// the env-fallback base-URL tests can exercise the worker's resolution chain).
+func writeTrackerPreflightWorkflow(t *testing.T, kind, extraTracker string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: https://example.invalid/o/r.git
+tracker:
+  kind: ` + kind + extraTracker + `
+agent:
+  default: mock
+---
+prompt
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	return path
+}
+
+// newTrackerStub serves status for every request, asserts the exact
+// Authorization header the worker's client sends, and records each request's
+// path+query for endpoint-shape assertions.
+func newTrackerStub(t *testing.T, wantAuth string, status int) (*httptest.Server, func() []string) {
+	t.Helper()
+	var mu sync.Mutex
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != wantAuth {
+			t.Errorf("Authorization = %q; want %q", got, wantAuth)
+		}
+		mu.Lock()
+		requests = append(requests, r.URL.RequestURI())
+		mu.Unlock()
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(requests)
+	}
+}
+
+// newPullsRejectingStub serves 200 `[]` for every request except paths
+// containing /pulls, which get 403 — modeling a token that can read issues
+// but not pull requests (a fine-grained PAT with Issues:read only).
+func newPullsRejectingStub(t *testing.T) (*httptest.Server, func() []string) {
+	t.Helper()
+	var mu sync.Mutex
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.URL.RequestURI())
+		mu.Unlock()
+		if strings.Contains(r.URL.Path, "/pulls") {
+			w.WriteHeader(http.StatusForbidden)
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(requests)
+	}
+}
+
+// assertRequestsHitWorkerListingSurface asserts every recorded request stays
+// on the worker's repo listing surface and no path carries a doubled slash
+// (the trailing-slash base-URL regression). The exact query shape belongs to
+// the production clients, so this deliberately pins only the prefix.
+func assertRequestsHitWorkerListingSurface(t *testing.T, requests []string, wantPrefix string) {
+	t.Helper()
+	if len(requests) == 0 {
+		t.Fatalf("recorded requests = %v; want at least one request on the worker's listing surface %q", requests, wantPrefix)
+	}
+	for _, request := range requests {
+		if !strings.HasPrefix(request, wantPrefix) {
+			t.Errorf("recorded request = %q; want prefix %q (the worker's listing surface)", request, wantPrefix)
+		}
+		if strings.Contains(request, "//") {
+			t.Errorf("recorded request = %q; want no %q from base-URL joining", request, "//")
+		}
+	}
+}
+
+func countRequestsContaining(requests []string, fragment string) int {
+	count := 0
+	for _, request := range requests {
+		if strings.Contains(request, fragment) {
+			count++
+		}
+	}
+	return count
+}
+
+func TestBuildReportFailsWhenGiteaTrackerAPIKeyMissing(t *testing.T) {
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "gitea", ""),
+		Mode:         "mock",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "Gitea API key")
+	if check.Status != Fail {
+		t.Fatalf("Gitea API key status = %s; want %s", check.Status, Fail)
+	}
+	if !strings.Contains(check.Fix, "tracker.api_key: $GITEA_TOKEN") {
+		t.Fatalf("Gitea API key fix = %q; want the tracker.api_key: $GITEA_TOKEN remediation", check.Fix)
+	}
+}
+
+func TestBuildReportMockModeSkipsGiteaTrackerLiveAuth(t *testing.T) {
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "gitea", "\n  api_key: gitea-key"),
+		Mode:         "mock",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "Gitea API key")
+	if check.Status != Pass || !strings.Contains(check.Detail, "live auth skipped in mock mode") {
+		t.Fatalf("Gitea API key check = %+v; want PASS with the mock-mode skip detail", check)
+	}
+	if checkExists(report, "Gitea auth") {
+		t.Fatalf("Gitea auth check present in mock mode; want the live listing skipped in %+v", report.Checks)
+	}
+}
+
+func TestBuildReportRealModeAuthenticatesGiteaTracker(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, requests := newTrackerStub(t, "token gitea-key", http.StatusOK)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "gitea", "\n  api_key: gitea-key\n  endpoint: "+srv.URL),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	if check := findCheck(t, report, "Gitea auth"); check.Status != Pass {
+		t.Fatalf("Gitea auth check = %+v; want PASS", check)
+	}
+	assertRequestsHitWorkerListingSurface(t, requests(), "/api/v1/repos/o/r/")
+}
+
+func TestBuildReportRealModeGiteaTrackerUsesGiteaBaseURLFallback(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, requests := newTrackerStub(t, "token gitea-key", http.StatusOK)
+	t.Setenv("GITEA_BASE_URL", srv.URL)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "gitea", "\n  api_key: gitea-key"),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	if check := findCheck(t, report, "Gitea auth"); check.Status != Pass {
+		t.Fatalf("Gitea auth check with GITEA_BASE_URL fallback = %+v; want PASS", check)
+	}
+	assertRequestsHitWorkerListingSurface(t, requests(), "/api/v1/repos/o/r/")
+}
+
+func TestBuildReportRealModeFailsGiteaTrackerOnUnauthorized(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, _ := newTrackerStub(t, "token bad-key", http.StatusUnauthorized)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "gitea", "\n  api_key: bad-key\n  endpoint: "+srv.URL),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "Gitea auth")
+	if check.Status != Fail {
+		t.Fatalf("Gitea auth status on 401 = %s; want %s", check.Status, Fail)
+	}
+	if !strings.Contains(check.Detail, "401") {
+		t.Fatalf("Gitea auth detail = %q; want the client's 401 status surfaced", check.Detail)
+	}
+}
+
+func TestBuildReportFailsWhenGitHubTrackerAPIKeyMissing(t *testing.T) {
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", ""),
+		Mode:         "mock",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "GitHub tracker API key")
+	if check.Status != Fail {
+		t.Fatalf("GitHub tracker API key status = %s; want %s", check.Status, Fail)
+	}
+	if !strings.Contains(check.Fix, "tracker.api_key: $GITHUB_TOKEN") {
+		t.Fatalf("GitHub tracker API key fix = %q; want the tracker.api_key: $GITHUB_TOKEN remediation", check.Fix)
+	}
+}
+
+func TestBuildReportMockModeSkipsGitHubTrackerLiveAuth(t *testing.T) {
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", "\n  api_key: gh-key"),
+		Mode:         "mock",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "GitHub tracker API key")
+	if check.Status != Pass || !strings.Contains(check.Detail, "live auth skipped in mock mode") {
+		t.Fatalf("GitHub tracker API key check = %+v; want PASS with the mock-mode skip detail", check)
+	}
+	if checkExists(report, "GitHub tracker auth") {
+		t.Fatalf("GitHub tracker auth check present in mock mode; want the live listing skipped in %+v", report.Checks)
+	}
+}
+
+func TestBuildReportRealModeAuthenticatesGitHubTracker(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, requests := newTrackerStub(t, "Bearer gh-key", http.StatusOK)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", "\n  api_key: gh-key\n  endpoint: "+srv.URL),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	if check := findCheck(t, report, "GitHub tracker auth"); check.Status != Pass {
+		t.Fatalf("GitHub tracker auth check = %+v; want PASS", check)
+	}
+	got := requests()
+	assertRequestsHitWorkerListingSurface(t, got, "/repos/o/r/")
+	// The default active states include open issues, so the client's
+	// claimed-issue detection lists open pulls exactly once.
+	if pulls := countRequestsContaining(got, "/pulls"); pulls != 1 {
+		t.Fatalf("GitHub /pulls requests = %d in %v; want exactly 1 (the client's claimed-issue listing)", pulls, got)
+	}
+}
+
+func TestBuildReportRealModeGitHubTrackerUsesEnvBaseURLFallback(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, requests := newTrackerStub(t, "Bearer gh-key", http.StatusOK)
+	t.Setenv("GITHUB_API_BASE_URL", srv.URL)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", "\n  api_key: gh-key"),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	if check := findCheck(t, report, "GitHub tracker auth"); check.Status != Pass {
+		t.Fatalf("GitHub tracker auth check with GITHUB_API_BASE_URL fallback = %+v; want PASS", check)
+	}
+	assertRequestsHitWorkerListingSurface(t, requests(), "/repos/o/r/")
+}
+
+func TestBuildReportRealModeFailsGitHubTrackerOnUnauthorized(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, _ := newTrackerStub(t, "Bearer bad-key", http.StatusUnauthorized)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", "\n  api_key: bad-key\n  endpoint: "+srv.URL),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "GitHub tracker auth")
+	if check.Status != Fail {
+		t.Fatalf("GitHub tracker auth status on 401 = %s; want %s", check.Status, Fail)
+	}
+	if !strings.Contains(check.Detail, "401") {
+		t.Fatalf("GitHub tracker auth detail = %q; want the client's 401 status surfaced", check.Detail)
+	}
+}
+
+func TestCheckGiteaTrackerFailsWithoutRepoOwnerAndName(t *testing.T) {
+	r := &reportBuilder{opts: Options{Mode: "real"}}
+	r.normalize()
+	cfg := workflow.Config{Tracker: workflow.TrackerConfig{Kind: "gitea", APIKey: "gitea-key"}}
+	r.checkGiteaTracker(context.Background(), cfg)
+
+	check := findCheck(t, Report{Checks: r.checks}, "Gitea auth")
+	if check.Status != Fail {
+		t.Fatalf("checkGiteaTracker(no repo.owner/name) Gitea auth status = %s; want %s", check.Status, Fail)
+	}
+	if !strings.Contains(check.Fix, "repo.owner and repo.name") {
+		t.Fatalf("Gitea auth fix = %q; want the repo.owner/repo.name remediation", check.Fix)
+	}
+}
+
+// roundTripFunc adapts a function to http.RoundTripper so a test can inject a
+// transport failure without opening a socket.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// TestCheckGiteaTrackerMasksEndpointUserinfoInErrors pins the masking
+// guarantee at the client-error wrap point: the production client's transport
+// errors are *url.Error values embedding the request URL (only the password
+// is redacted by net/http — a token in the username position survives), so
+// the FAIL detail must rebuild around the masked base URL before the text
+// reaches the report. The sentinel error text also pins the HTTPClient
+// injection seam: only the injected transport can produce it, so dropping
+// `client.HTTP = r.opts.HTTPClient` makes the real dial error surface
+// instead.
+func TestCheckGiteaTrackerMasksEndpointUserinfoInErrors(t *testing.T) {
+	const secret = "tracker-userinfo-secret"
+	r := &reportBuilder{opts: Options{
+		Mode: "real",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("injected sentinel transport failure: connection refused")
+		})},
+	}}
+	r.normalize()
+	cfg := workflow.Config{}
+	cfg.Tracker.Kind = "gitea"
+	cfg.Tracker.APIKey = "gitea-key"
+	cfg.Tracker.Endpoint = "https://" + secret + "@127.0.0.1:1"
+	// A hand-built config carries no loader defaults, so name the active
+	// states explicitly; an empty set would short-circuit the listing without
+	// any request reaching the failing transport.
+	cfg.Tracker.ActiveStates = []string{"Todo"}
+	cfg.Repo.Owner = "o"
+	cfg.Repo.Name = "r"
+
+	r.checkGiteaTracker(context.Background(), cfg)
+
+	check := findCheck(t, Report{Checks: r.checks}, "Gitea auth")
+	if check.Status != Fail {
+		t.Fatalf("checkGiteaTracker(unreachable endpoint) Gitea auth status = %s; want %s", check.Status, Fail)
+	}
+	if strings.Contains(check.Detail, secret) {
+		t.Fatalf("Gitea auth detail = %q; must not leak endpoint userinfo credentials", check.Detail)
+	}
+	if !strings.Contains(check.Detail, "injected sentinel transport failure") {
+		t.Fatalf("Gitea auth detail = %q; want the injected transport's cause %q (pins both the error pass-through and the HTTPClient injection)", check.Detail, "injected sentinel transport failure")
+	}
+	if !strings.Contains(check.Detail, "127.0.0.1:1") {
+		t.Fatalf("Gitea auth detail = %q; want the masked endpoint host %q kept for diagnosis", check.Detail, "127.0.0.1:1")
+	}
+}
+
+// TestCheckTrackerWarnsOnUnknownKind pins the defensive default branch of the
+// kind dispatch: the loader rejects unsupported kinds, but a direct caller
+// must still get a visible WARN rather than a silent skip.
+func TestCheckTrackerWarnsOnUnknownKind(t *testing.T) {
+	r := &reportBuilder{opts: Options{Mode: "mock"}}
+	r.normalize()
+	r.checkTracker(context.Background(), workflow.Config{Tracker: workflow.TrackerConfig{Kind: "jira"}})
+
+	check := findCheck(t, Report{Checks: r.checks}, "Tracker")
+	if check.Status != Warn {
+		t.Fatalf("checkTracker(kind=jira) Tracker status = %s; want %s", check.Status, Warn)
+	}
+}
+
+// TestCheckLinearGraphQLProjectSlugErrorNamesOnlyTrackerProjectSlug pins the
+// removal of the services[].tracker.project_slug clause: that schema was
+// deleted in #573 (DEVIATIONS D25), so a remediation citing it steers
+// operators into a config the loader rejects.
+func TestCheckLinearGraphQLProjectSlugErrorNamesOnlyTrackerProjectSlug(t *testing.T) {
+	r := &reportBuilder{opts: Options{Mode: "real"}}
+	r.normalize()
+
+	err := r.checkLinearGraphQL(context.Background(), workflow.Config{})
+	if err == nil {
+		t.Fatalf("checkLinearGraphQL(no project_slug) error = nil; want missing-slug error")
+	}
+	if got, want := err.Error(), "linear project_slug is required at tracker.project_slug"; got != want {
+		t.Fatalf("checkLinearGraphQL(no project_slug) error = %q; want %q", got, want)
+	}
+}
+
+// TestLinearProbeCarriesPerRequestDeadline pins the repo convention that the
+// doctor's Linear GraphQL probe enforces its own context deadline instead of
+// trusting the injectable HTTPClient's timeout: with a zero-timeout client, a
+// stalled tracker would otherwise hang doctor forever. The Gitea/GitHub
+// preflights need no doctor-side pin anymore: they drive the production
+// clients, whose per-request deadlines are owned and tested by their own
+// packages (internal/gitea requestTimeout; internal/tracker github.go
+// RequestTimeout, #295).
+func TestLinearProbeCarriesPerRequestDeadline(t *testing.T) {
+	var sawDeadline []bool
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		_, ok := req.Context().Deadline()
+		sawDeadline = append(sawDeadline, ok)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"projects":{"nodes":[{"id":"p"}]}}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})}
+	r := &reportBuilder{opts: Options{Mode: "real", HTTPClient: client}}
+	r.normalize()
+
+	cfg := workflow.Config{}
+	cfg.Tracker.Kind = "linear"
+	cfg.Tracker.APIKey = "lin-k"
+	cfg.Tracker.ProjectSlug = "platform"
+	if err := r.checkLinearGraphQL(context.Background(), cfg); err != nil {
+		t.Fatalf("checkLinearGraphQL() = %v; want nil from the stub transport", err)
+	}
+
+	if len(sawDeadline) != 1 {
+		t.Fatalf("probe request count = %d; want 1 (the Linear GraphQL probe)", len(sawDeadline))
+	}
+	if !sawDeadline[0] {
+		t.Errorf("Linear probe request carried no context deadline; want trackerProbeTimeout-bounded context")
+	}
+}
+
+// TestBuildReportRealModeGitHubTrackerNormalizesTrailingSlashEndpoint pins
+// NewGitHubClient's trailing-slash normalization on the doctor path: a
+// trailing-slash tracker.endpoint must still produce clean listing paths, not
+// "//repos/...", or doctor would query a different URL than the poll loop.
+func TestBuildReportRealModeGitHubTrackerNormalizesTrailingSlashEndpoint(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, requests := newTrackerStub(t, "Bearer gh-key", http.StatusOK)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", "\n  api_key: gh-key\n  endpoint: "+srv.URL+"/"),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	if check := findCheck(t, report, "GitHub tracker auth"); check.Status != Pass {
+		t.Fatalf("GitHub tracker auth check with trailing-slash endpoint = %+v; want PASS", check)
+	}
+	assertRequestsHitWorkerListingSurface(t, requests(), "/repos/o/r/")
+}
+
+// TestBuildReportRealModeGiteaTrackerNormalizesTrailingSlashEndpoint mirrors
+// the GitHub trailing-slash pin on the Gitea side: BaseURLFromTrackerConfig
+// owns the TrimRight there, and this test fails if that normalization (or the
+// doctor's reliance on it) regresses into "//api/v1/..." listing paths.
+func TestBuildReportRealModeGiteaTrackerNormalizesTrailingSlashEndpoint(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, requests := newTrackerStub(t, "token gitea-key", http.StatusOK)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "gitea", "\n  api_key: gitea-key\n  endpoint: "+srv.URL+"/"),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	if check := findCheck(t, report, "Gitea auth"); check.Status != Pass {
+		t.Fatalf("Gitea auth check with trailing-slash endpoint = %+v; want PASS", check)
+	}
+	assertRequestsHitWorkerListingSurface(t, requests(), "/api/v1/repos/o/r/")
+}
+
+// TestBuildReportRealModeGitHubTrackerClosedOnlyStatesSkipPullsListing pins
+// the PR #801 round-4 finding as a regression: ListIssuesByStates gates the
+// open-pulls claimed-issue listing on githubStatesMayIncludeOpenIssues, so a
+// closed-only active_states workflow polled with an Issues-only token never
+// touches /pulls — and doctor, driving the same client, must inherit that
+// gating instead of false-FAILing on a hand-built unconditional /pulls probe.
+func TestBuildReportRealModeGitHubTrackerClosedOnlyStatesSkipPullsListing(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, requests := newPullsRejectingStub(t)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", "\n  api_key: gh-key\n  endpoint: "+srv.URL+"\n  active_states: [\"closed\"]"),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	if check := findCheck(t, report, "GitHub tracker auth"); check.Status != Pass {
+		t.Fatalf("GitHub tracker auth with closed-only active_states and a pulls-403 stub = %+v; want PASS (the client never lists pulls for closed-only states)", check)
+	}
+	got := requests()
+	assertRequestsHitWorkerListingSurface(t, got, "/repos/o/r/")
+	if pulls := countRequestsContaining(got, "/pulls"); pulls != 0 {
+		t.Fatalf("GitHub /pulls requests = %d in %v; want 0 (doctor must inherit the client's githubStatesMayIncludeOpenIssues gating)", pulls, got)
+	}
+}
+
+// TestBuildReportRealModeFailsGitHubTrackerWhenPullsForbidden is the inverse
+// of the closed-only pin: with the default open-inclusive active states the
+// client's claimed-issue detection does list open pulls, so a token that can
+// read issues but not pull requests must FAIL doctor exactly as it would fail
+// the first poll.
+func TestBuildReportRealModeFailsGitHubTrackerWhenPullsForbidden(t *testing.T) {
+	installFakeGitOnly(t)
+	srv, requests := newPullsRejectingStub(t)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", "\n  api_key: gh-key\n  endpoint: "+srv.URL),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "GitHub tracker auth")
+	if check.Status != Fail {
+		t.Fatalf("GitHub tracker auth with pulls 403 and open-inclusive states = %+v; want FAIL", check)
+	}
+	if !strings.Contains(check.Detail, "403") {
+		t.Fatalf("GitHub tracker auth detail = %q; want the client's 403 status surfaced", check.Detail)
+	}
+	got := requests()
+	if pulls := countRequestsContaining(got, "/pulls"); pulls == 0 {
+		t.Fatalf("GitHub /pulls requests = 0 in %v; want at least 1 (open-inclusive states list pulls first)", got)
+	}
+}
+
+// TestBuildReportRealModeFailsGiteaTrackerOnNonJSONBody pins the consumer-
+// fidelity rule for 2xx responses: the production client decodes the listing
+// immediately, so a login proxy or misrouted base URL answering 200 with HTML
+// fails preflight with the client's own decode error, not pass on status
+// alone.
+func TestBuildReportRealModeFailsGiteaTrackerOnNonJSONBody(t *testing.T) {
+	installFakeGitOnly(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>login</body></html>"))
+	}))
+	t.Cleanup(srv.Close)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "gitea", "\n  api_key: gitea-key\n  endpoint: "+srv.URL),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "Gitea auth")
+	if check.Status != Fail {
+		t.Fatalf("Gitea auth with 200 HTML body = %+v; want FAIL on the client's decode error", check)
+	}
+	if !strings.Contains(check.Detail, "invalid character") {
+		t.Fatalf("Gitea auth detail = %q; want the client's JSON decode error fragment %q", check.Detail, "invalid character")
+	}
+}
+
+// TestProbeLinearProjectSlugMasksEndpointUserinfoInErrors mirrors the
+// Gitea/GitHub masking pin on the Linear path: request/transport errors must
+// rebuild around the masked endpoint before the text reaches the Linear auth
+// FAIL detail.
+func TestProbeLinearProjectSlugMasksEndpointUserinfoInErrors(t *testing.T) {
+	const secret = "linear-userinfo-secret"
+	r := &reportBuilder{opts: Options{
+		Mode: "real",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("dial tcp 127.0.0.1:443: connection refused")
+		})},
+	}}
+	r.normalize()
+
+	cases := []struct {
+		name     string
+		endpoint string
+		wantPart string
+	}{
+		{
+			name:     "transport error keeps the inner cause",
+			endpoint: "https://" + secret + "@linear.example/graphql",
+			wantPart: "connection refused",
+		},
+		{
+			name:     "request parse error drops the raw URL",
+			endpoint: "https://bot:" + secret + "@linear.example/graphql\n",
+			wantPart: "linear.example",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := r.probeLinearProjectSlug(context.Background(), tc.endpoint, "lin-key", "query {}", "platform")
+			if err == nil {
+				t.Fatalf("probeLinearProjectSlug(%q) = nil; want masked error", tc.endpoint)
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Fatalf("probeLinearProjectSlug(%q) error %q leaks the userinfo secret", tc.endpoint, err)
+			}
+			if !strings.Contains(err.Error(), tc.wantPart) {
+				t.Fatalf("probeLinearProjectSlug(%q) error %q; want it to keep %q", tc.endpoint, err, tc.wantPart)
+			}
+		})
+	}
+}
+
+// TestBuildReportRealModeFailsLinearOnNonJSONBody mirrors the Gitea non-JSON
+// pin on the Linear path: a login proxy answering the GraphQL probe with 200
+// HTML must FAIL with a detail naming the non-JSON body, not a bare
+// json.SyntaxError.
+func TestBuildReportRealModeFailsLinearOnNonJSONBody(t *testing.T) {
+	installFakeCodex(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>login</body></html>"))
+	}))
+	t.Cleanup(srv.Close)
+	path := writeWorkflowWithEndpoint(t, srv.URL, "codex-app-server")
+	t.Setenv("AIOPS_TEST_LINEAR_KEY", "lin-test")
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Runner:       fakeRealRunner,
+	})
+
+	check := findCheck(t, report, "Linear auth")
+	if check.Status != Fail {
+		t.Fatalf("Linear auth with 200 HTML body = %+v; want FAIL on the non-JSON body", check)
+	}
+	if !strings.Contains(check.Detail, "not JSON") {
+		t.Fatalf("Linear auth detail = %q; want it to name the non-JSON body", check.Detail)
+	}
+}
+
+// TestGiteaTrackerStatusErrorWithUserinfoEndpointStaysMasked pins that the
+// production client's non-transport error texts (HTTP status, decode) stay
+// credential-free when tracker.endpoint carries basic-auth userinfo: the
+// client error reaches the FAIL detail through maskedProbeError, and nothing
+// in the status path interpolates the raw URL.
+func TestGiteaTrackerStatusErrorWithUserinfoEndpointStaysMasked(t *testing.T) {
+	installFakeGitOnly(t)
+	const secret = "status-userinfo-secret"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"unauthorized"}`))
+	}))
+	t.Cleanup(srv.Close)
+	endpoint := strings.Replace(srv.URL, "http://", "http://bot:"+secret+"@", 1)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "gitea", "\n  api_key: gitea-key\n  endpoint: "+endpoint),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "Gitea auth")
+	if check.Status != Fail {
+		t.Fatalf("Gitea auth with userinfo endpoint and 401 = %+v; want FAIL", check)
+	}
+	if strings.Contains(check.Detail, secret) || strings.Contains(check.Fix, secret) {
+		t.Fatalf("Gitea auth FAIL output leaks the userinfo secret: detail=%q fix=%q", check.Detail, check.Fix)
+	}
+	if !strings.Contains(check.Detail, "401") {
+		t.Fatalf("Gitea auth detail = %q; want the 401 status surfaced", check.Detail)
+	}
+}
+
+// TestGitHubTrackerStatusErrorWithUserinfoEndpointStaysMasked is the GitHub
+// twin of the Gitea status-error masking pin: a userinfo-bearing
+// tracker.endpoint plus a non-transport client failure (HTTP 401) must reach
+// the FAIL detail with the credential masked.
+func TestGitHubTrackerStatusErrorWithUserinfoEndpointStaysMasked(t *testing.T) {
+	installFakeGitOnly(t)
+	const secret = "gh-status-userinfo-secret"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	t.Cleanup(srv.Close)
+	endpoint := strings.Replace(srv.URL, "http://", "http://bot:"+secret+"@", 1)
+	report := BuildReport(context.Background(), Options{
+		WorkflowPath: writeTrackerPreflightWorkflow(t, "github", "\n  api_key: gh-key\n  endpoint: "+endpoint),
+		Mode:         "real",
+		Runner:       passingRunner,
+	})
+
+	check := findCheck(t, report, "GitHub tracker auth")
+	if check.Status != Fail {
+		t.Fatalf("GitHub tracker auth with userinfo endpoint and 401 = %+v; want FAIL", check)
+	}
+	if strings.Contains(check.Detail, secret) || strings.Contains(check.Fix, secret) {
+		t.Fatalf("GitHub tracker auth FAIL output leaks the userinfo secret: detail=%q fix=%q", check.Detail, check.Fix)
+	}
+	if !strings.Contains(check.Detail, "401") {
+		t.Fatalf("GitHub tracker auth detail = %q; want the 401 status surfaced", check.Detail)
+	}
+}

--- a/internal/gitea/config.go
+++ b/internal/gitea/config.go
@@ -1,6 +1,7 @@
 package gitea
 
 import (
+	"os"
 	"strings"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
@@ -16,4 +17,18 @@ func BaseURLFromTrackerConfig(cfg workflow.TrackerConfig, fallback string) strin
 		return strings.TrimRight(legacy, "/")
 	}
 	return strings.TrimRight(strings.TrimSpace(fallback), "/")
+}
+
+// BaseURLFromEnv resolves the Gitea tracker base URL exactly as the worker
+// dispatch does: tracker config first (endpoint, then the legacy
+// project_slug), then the GITEA_BASE_URL environment variable, then the
+// local-dev default. Shared by cmd/worker and internal/doctor so the doctor
+// preflight can never drift from the poll loop's resolution (PR #801 drift
+// class).
+func BaseURLFromEnv(cfg workflow.TrackerConfig) string {
+	fallback := os.Getenv("GITEA_BASE_URL")
+	if fallback == "" {
+		fallback = "http://localhost:3000"
+	}
+	return BaseURLFromTrackerConfig(cfg, fallback)
 }

--- a/internal/tracker/github.go
+++ b/internal/tracker/github.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -84,6 +85,20 @@ type githubPullRequestSummary struct {
 	Body    string `json:"body"`
 	State   string `json:"state"`
 	HTMLURL string `json:"html_url"`
+}
+
+// NewGitHubClientFromEnv builds the GitHub tracker client with the base URL
+// resolved exactly as the worker dispatch does: tracker.endpoint first, then
+// the GITHUB_API_BASE_URL environment variable, then the constructor's
+// api.github.com default. Shared by cmd/worker and internal/doctor so the
+// doctor preflight can never drift from the poll loop's resolution (PR #801
+// drift class).
+func NewGitHubClientFromEnv(cfg workflow.TrackerConfig, owner, repo string) *GitHubClient {
+	baseURL := cfg.Endpoint
+	if baseURL == "" {
+		baseURL = os.Getenv("GITHUB_API_BASE_URL")
+	}
+	return NewGitHubClient(cfg, baseURL, owner, repo)
 }
 
 func NewGitHubClient(cfg workflow.TrackerConfig, baseURL, owner, repo string) *GitHubClient {


### PR DESCRIPTION
Closes #781

## Summary
- **Round-9 structural close-out**: the base-URL env resolution was extracted to shared constructors — `gitea.BaseURLFromEnv` and `tracker.NewGitHubClientFromEnv` — and both `trackerClientForWorkflow` (cmd/worker) and the doctor preflight now call the same functions; the duplicated inline resolution (flagged four times across review rounds) and the worker's dead `env()` helper are gone. Behavioral equivalence of old-vs-new worker resolution was verified case-by-case (endpoint set / env set / both empty / whitespace edges) by the round-9 reviewer; the all-empty default arms got worker-side pins (`TestTrackerClientForWorkflowUsesGiteaLocalhostDefaultWhenNoEnvAndNoConfig`, `…GitHubDefaultWhenNoEnvAndNoEndpoint`). Seam mutation (rule 11): breaking the env name inside the shared `BaseURLFromEnv` turns the doctor fallback test red — one source of truth, drift impossible.
- `worker --doctor` short-circuited every non-linear `tracker.kind` to a WARN ("Linear smoke checks skipped"), so a Gitea/GitHub operator with a bad or missing token passed preflight and only discovered the problem as per-poll log errors.
- `BuildReport` now dispatches the tracker check on `tracker.kind`: linear keeps the existing check; gitea/github get a three-stage preflight mirroring it — empty resolved `tracker.api_key` → FAIL in both modes (remediation names the exact `tracker.api_key: $GITEA_TOKEN` / `$GITHUB_TOKEN` line); mock mode → PASS with "live auth skipped"; `--mode=real` → live auth + repo-label visibility probes.
- Probe resolution mirrors the worker's own `trackerClientForWorkflow` chain exactly: Gitea base via `gitea.BaseURLFromTrackerConfig` + `GITEA_BASE_URL` fallback, `Authorization: token`; GitHub base `tracker.endpoint` → `GITHUB_API_BASE_URL` → `https://api.github.com`, `Bearer`. Check names carry the "tracker" qualifier to stay distinct from the agent-side "GitHub agent …" checks.
- The visibility probe targets the worker's **actual poll endpoints** (not a `/labels` proxy): Gitea `GET /api/v1/repos/{o}/{r}/issues?limit=1` (`tracker_client.go:502`); GitHub `GET .../issues?per_page=1` **and** `GET .../pulls?state=open&per_page=1` — the GitHub poll path lists open pulls for claimed-issue detection (`openPullRequestClaimedIssueNumbers`) before issues, and a fine-grained PAT can hold Issues:read without Pull requests:read, so a labels-only probe could pass doctor while the first poll fails. This is the faithful mirror of the Linear check, which probes the very project the poller reads.
- Probe responses drain before close (the #771/#762 class); probe errors are rebuilt around the masked endpoint (`*url.Error` embeds the probe URL and net/http redacts only the password, so a token in userinfo position would otherwise reach FAIL details); every probe carries its own `context.WithTimeout` (`trackerProbeTimeout`) — the same-class Linear per-slug probe was brought under the same deadline (extracted as `probeLinearProjectSlug`, stale gocognit nolint dropped).
- The Linear project_slug error no longer points at the `services[]` schema removed in #573 (DEVIATIONS D25) — config written per the old hint was silently rejected by the loader.

## Acceptance criteria (issue #781)
- [x] Doctor validates gitea/github tracker kinds: FAIL on empty resolved `tracker.api_key`; in `--mode=real`, probes the tracker API with the token plus repo/label visibility, mirroring the Linear auth+project check. **Deliberate deviation from the issue's suggested mechanism**: the parenthetical `/user` endpoints were dropped after review evidence showed they create false-NEGATIVE preflights for exactly the least-privilege tokens the repo recommends (Gitea `read:issue`-scoped tokens and GitHub App installation tokens 403 on `/user` while polling fine; the poll loop never calls `/user`). Auth+visibility ride on the worker's actual poll-listing endpoints instead — the faithful mirror of the Linear check, which folds both into the poller's own query. Substance of the criterion (real-mode token probe + repo/label visibility) is met.
- [x] The `services[].tracker.project_slug` clause is removed from the error message (exact-equality pin test added).
- [x] Boundary note: doctor is operator preflight (the accepted preventive layer per D31's #542 note), not an agent-output gate — no SPEC §1 concern, no new DEVIATIONS row needed.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff: 4 files (`internal/doctor/doctor_tracker.go`, `internal/gitea/config.go`, `internal/tracker/github.go`, `cmd/worker/main.go`), well under the 12-file/300-LOC guideline; test files excluded.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./internal/doctor/... ./cmd/worker/...` (post-rebase; full `./...` suite runs in the follow-through Docker quality gate on this head)
- [x] `gofmt -l` clean; `go mod tidy` clean; golangci blocking set on `internal/doctor/` → 0 issues, no new nolint
- [x] Mutation-verified against the committed artifact: (a) gitea dispatch case no-op'd → 4 tests red on the missing checks; (b) per-request deadline unwrapped → `TestTrackerProbesCarryPerRequestDeadline` red; working-tree spot mutations during check: drain→Close red, auth headers swapped red, mask removed red. Tree restored clean each time.

## Review ledger
- Round 11 (head b2d5dd3): script-stage Claude flagged (MEDIUM) the missing GitHub twin of the userinfo status-error masking pin (Linear and Gitea both had one) → added `TestGitHubTrackerStatusErrorWithUserinfoEndpointStaysMasked`. Script-stage Codex for 5f78e84: clean.
- Round 10 (head 5f78e84): script-stage Claude flagged (LOW) the listing call carrying no doctor-side deadline; the hazard premise (HTTP injection strips client timeouts) is false — both clients wrap every request in `context.WithTimeout` (gitea `requestTimeout`; github `RequestTimeout` #295) — but the call-site convention ("deadline-bounded at the caller even when the client honors ctx") and consistency with the Linear probe argue for an overall budget: `trackerListingTimeout` (1m) now wraps `ListActiveIssues` (multi-request: states × pagination). Script-stage Codex for 62312ed: clean (its only round-9 finding, a gofmt blank line from the env() deletion, was fixed in the same head).
- Round 8 (head 06e511d, comment/test-only delta): PR-stage round-5 Claude flagged (MEDIUM) "client status/decode error texts might embed the unmasked URL, and no test pins it" — the leak claim was already refuted by the round-7 line-by-line grep (no URL interpolation in the clients' listing error paths; live fragments are `list Gitea issues failed: status 401`), but the missing pin was real → added `TestGiteaTrackerStatusErrorWithUserinfoEndpointStaysMasked` (userinfo-bearing endpoint + 401 stub → FAIL detail/fix carry no secret, status surfaced); (LOW, repeat of round 3) raw-Kind TrimSpace → permanently answered in code per the reviewer's own alternative: the checkTracker comment now records the loader's raw allowed-kinds guarantee; (LOW) two comments left dangling references to the deleted hand-probe helpers → restated inline. The script-stage Codex review for 8c6a08e was clean.
- Round 7 — structural convergence (head 8c6a08e): the PR-stage round-4 reviewer found the fourth hand-mirror drift (doctor probed /pulls unconditionally while `ListIssuesByStates` gates it on `githubStatesMayIncludeOpenIssues` — a closed-only `active_states` workflow with an Issues-only token would false-FAIL). Per the reviewer's own alternative ("or drive the actual client path") and the sweep-the-class rule, real-mode preflight now **drives the worker's own tracker clients**: it constructs exactly what `trackerClientForWorkflow` builds (`gitea.NewTrackerClient` / `tracker.NewGitHubClient`, `HTTP` injected) and calls `ListActiveIssues` — inheriting headers, per-request deadlines (#295), pulls gating, pagination, and JSON decoding, so the whole mirror-drift class is structurally dead. Hand-built probe machinery deleted (net −67 production LOC vs round 6). New pins: closed-only states → zero `/pulls` with a pulls-403 stub (mutation-verified against the committed artifact by forcing open states — red); default states + pulls-403 → FAIL; HTTP-injection seam via sentinel transport (red when injection removed); masked client errors. Round-7 re-review: Claude MERGE-READY (construction parity line-by-line, `Logf` nil-guards on all 4 reachable sites, no URL interpolation in client error texts), Codex `{"blocking_findings":[]}`.
- Rounds 5–6 (head 661fc31): PR-stage round-3 reviewers found (Codex MEDIUM + Claude MEDIUM, converging) the Linear probe this PR refactored still returned raw `*url.Error`s (userinfo-leak class fixed on the sibling probes) → **fixed**: `probeLinearProjectSlug` routes request/transport errors through `maskedProbeError` (text now verb-neutral "probe %s" since Linear POSTs), with a Linear masked-error pin test; (Codex MEDIUM) a 2xx non-JSON body (login proxy HTML) passed preflight while the pollers decode immediately → **fixed**: `checkTrackerProbeResponse` decodes the body as a JSON list and FAILs naming the non-JSON body (test added), and the Linear 2xx decode path got the matching named error + test (round-5 Claude finding); (Claude LOW) `checkTracker` switches on raw `Kind` without TrimSpace → **recorded, no change**: the loader's allowed-kinds validation compares raw values, so a whitespace-bearing kind never loads (doctor's tracker check is unreachable), and the raw switch exactly mirrors `trackerClientForWorkflow`. Round-6 re-review on 661fc31: Claude MERGE-READY (wrap + test placebo-check explicit), Codex clean. Mutation-verified on the committed artifact: JSON-list decode removed → non-JSON test red; Linear mask removed → mask test red showing the exact leaked secret.
- Round 4 (head e6a53b8): PR-stage round-2 reviewers found the `/user` probe class (Codex MEDIUM: Gitea least-privilege `read:issue` tokens fail `/user`; Claude LOW: GitHub App installation tokens 403 `/user`) → **fixed** by removing the `/user` stage (see deviation note above); Claude LOW (Gitea trailing-slash untested — note its no-TrimRight claim was wrong, `BaseURLFromTrackerConfig` strips, but the pin test was missing) → Gitea trailing-slash test added; Claude LOW (repo-probe failure branch untested) → mid-loop failure test added (issues 200 → pulls 403 → FAIL, both URIs asserted); Claude LOW (GitHub base/default re-hardcoded, 2nd occurrence) → **fixed** by deriving the base from `tracker.NewGitHubClient(...).BaseURL` (default + TrimRight from the one production constructor; precedence verified byte-identical incl. empty-endpoint-empty-env). Round-4 re-review on e6a53b8: Claude MERGE-READY (explicitly concurs the `/user` removal is sound; constructor side-effect-free), Codex `{"blocking_findings":[]}`.
- Round 3 (post-rebase head d36de1a): the follow-through PR-stage dual review on 1c7b71c returned 1 Codex MEDIUM (probes checked /user+labels but the poll loop lists issues/pulls — a labels-readable token could still fail the first poll) → **fixed** by probing the actual poll endpoints (above), verified against `tracker_client.go:502` / `github.go:136,316`; 1 Claude LOW (no test pinned the TrimRight trailing-slash normalization) → **fixed** with `TestBuildReportRealModeGitHubTrackerNormalizesTrailingSlashEndpoint`; 1 Claude LOW (envDefault re-states the worker's env names/defaults with no parity test) → **recorded, no change**: the fallback tests pin doctor's own env-var names and defaults via t.Setenv; a shared package for two constants judged over-design. Round-3 re-review on d36de1a: Claude MERGE-READY (scope-equivalence of every probe URL verified), Codex `{"blocking_findings":[]}`. Mutation-verified on the committed artifact: TrimRight removed → trailing-slash test red with `//user` evidence; pulls probe dropped → endpoint-shape tests red.
- Head after rebase onto main@09001fb: (see PR commits; pre-rebase reviewed head d5a6827 → amended 7347e1e, rebase was textual-only over disjoint files).
- Pre-push dual diff-only reviews, round 1 (d5a6827): Claude `feature-dev:code-reviewer` MERGE-READY with 1 MEDIUM (GitHub TrimRight comment claimed a structural mirror the worker defers to `NewGitHubClient`) → comment corrected; Codex `codex exec --output-schema` 1 MEDIUM (probes lacked per-request `context.WithTimeout`) → fixed for the new probes AND the same-class Linear probe, deadline guard test added.
- Round 2 (7347e1e): Claude MERGE-READY (cancel/drain ordering and Linear behavior-preservation explicitly verified); Codex `{"blocking_findings":[]}`.
- Recorded, no code change: Claude round-1 awareness note (authHeader literal built before the empty-key guard — value unused on that path) and LOW (mock-mode tests don't assert zero HTTP traffic; the checkExists assertions are the guard).

## Notes
- Trellis task: `.trellis/tasks/06-12-issue-781-doctor-tracker-preflight` (PRD + verified resolution-chain research).
