### PR TITLE
test(e2e): cover the positive issue→PR loop with a scripted agent

### DIFF
--- a/test/e2e/fixtures/scripted-agent.md
+++ b/test/e2e/fixtures/scripted-agent.md
@@ -1,0 +1,27 @@
+---
+repo:
+  # clone_url is required by the schema validator when front matter is present.
+  # The test rewrites this placeholder to the live Gitea container clone URL
+  # before loading the service workflow (same pattern as mock-happy.md).
+  clone_url: http://localhost:3000/aiops-bot/demo-scripted-agent.git
+tracker:
+  kind: gitea
+  active_states:
+    - Todo
+  terminal_states:
+    - Done
+    - Canceled
+agent:
+  default: claude
+  timeout: 5m
+claude:
+  # The test rewrites this placeholder to the absolute path of the generated
+  # scripted-agent shell script (the script path is only known at test
+  # runtime, so it cannot be checked in).
+  command: __SCRIPTED_AGENT_COMMAND__
+policy:
+  mode: draft_pr
+verify:
+  commands: []
+---
+Scripted agent task {{ task.id }} for {{ repo.owner }}/{{ repo.name }}.

--- a/test/e2e/gitea.go
+++ b/test/e2e/gitea.go
@@ -297,6 +297,29 @@ func (g *giteaEnv) addIssueLabels(ctx context.Context, owner, repo string, issue
 	return nil
 }
 
+func (g *giteaEnv) getIssueLabels(ctx context.Context, owner, repo string, issue int) ([]string, error) {
+	resp, body, err := g.doJSON(ctx, "GET",
+		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/labels", url.PathEscape(owner), url.PathEscape(repo), issue),
+		nil, false)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("getIssueLabels: status %d body %s", resp.StatusCode, body)
+	}
+	var out []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, err
+	}
+	labels := make([]string, 0, len(out))
+	for _, label := range out {
+		labels = append(labels, label.Name)
+	}
+	return labels, nil
+}
+
 func (g *giteaEnv) replaceIssueLabels(ctx context.Context, owner, repo string, issue int, labels []string) error {
 	type req struct {
 		Labels []string `json:"labels"`

--- a/test/e2e/scripted_agent_test.go
+++ b/test/e2e/scripted_agent_test.go
@@ -1,0 +1,442 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
+	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// scriptedAgentTemplate is the shell script the test installs as the "coding
+// agent" (via `agent.default: claude` + `claude.command`). It performs the
+// agent-side half of the SPEC §1 loop from inside the workspace the worker
+// prepared: commit a change, push a branch, open a PR via the Gitea API, then
+// flip the issue's aiops/* state label. Credentials and coordinates must be
+// baked into the file by the test because the worker's agent env passthrough
+// deny list keeps GITEA_TOKEN out of the agent environment; the script's
+// first step asserts that absence, so a passthrough regression that leaked
+// the tracker token to agents fails this test. The fixture deliberately does
+// NOT cover the production agent's dynamic tool surface (gitea_issue_labels
+// needs a real coding agent): per issue #782 it plays the agent "via the
+// Gitea API" so the WORKER-side loop is exercised purely test-side. `set -eu`
+// makes any failed step surface as a runner error, which fails the
+// taskSucceeded wait.
+const scriptedAgentTemplate = `#!/bin/sh
+set -eu
+if [ -n "${GITEA_TOKEN:-}" ]; then
+  echo 'GITEA_TOKEN leaked into the agent environment' >&2
+  exit 1
+fi
+# Pin the label set BEFORE this agent touches it: in the claim->agent-start
+# window the worker must not have written tracker state, so the only aiops/*
+# label here is the seeded aiops/todo. This covers exactly that window — the
+# later replace-all PUT would mask a write landing between this snapshot and
+# the PUT, but in this harness the poller never ticks while the run is in
+# flight, so no worker code executes in that gap.
+labels=$(curl -sfS --max-time 30 -H 'Authorization: token {{TOKEN}}' \
+  '{{BASE_URL}}/api/v1/repos/{{OWNER}}/{{REPO}}/issues/{{ISSUE}}/labels')
+aiops_labels=$(printf '%s' "$labels" | grep -o '"name":"aiops/[^"]*"' | sed 's/^"name"://' | sort -u)
+if [ "$aiops_labels" != '"aiops/todo"' ]; then
+  echo "unexpected aiops/* labels before the agent ran: $aiops_labels" >&2
+  exit 1
+fi
+# The agent pushes its OWN agent/<n> branch instead of the worker-prepared
+# ai/<n> work branch on purpose: keeping the two actors' remote footprints
+# disjoint is what lets the retained negative assertion attribute any remote
+# ai/<n> appearance unambiguously to the worker. Which branch a real agent
+# pushes is prompt-level convention (SPEC §1 hands the whole handoff to the
+# agent); the worker-side contract under test does not depend on it.
+git checkout -b '{{BRANCH}}'
+printf 'scripted agent change for issue {{ISSUE}}\n' > AGENT_CHANGE.md
+git add AGENT_CHANGE.md
+git -c user.name=scripted-agent -c user.email=scripted-agent@example.invalid commit --quiet -m 'scripted agent change'
+# Push with the credential in an http.extraHeader instead of URL userinfo:
+# on failure git echoes the remote URL to stderr, which the runner streams
+# into test logs — the URL must therefore stay credential-free (the same
+# mask-before-log class the repo enforces for clone URLs).
+git -c http.extraHeader='Authorization: Basic {{AUTH_B64}}' push --quiet '{{PUSH_URL}}' 'HEAD:{{BRANCH}}'
+curl -sfS --max-time 30 -X POST \
+  -H 'Authorization: token {{TOKEN}}' \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"WIP: scripted agent PR for issue {{ISSUE}}","head":"{{BRANCH}}","base":"main"}' \
+  '{{BASE_URL}}/api/v1/repos/{{OWNER}}/{{REPO}}/pulls' > /dev/null
+# PUT /issues/{index}/labels replaces all labels; Gitea accepts label names
+# here (not only IDs) since 1.20, and the suite pins gitea/gitea:1.26.1 — the
+# same name-based contract giteaEnv.replaceIssueLabels relies on.
+curl -sfS --max-time 30 -X PUT \
+  -H 'Authorization: token {{TOKEN}}' \
+  -H 'Content-Type: application/json' \
+  -d '{"labels":["aiops/done"]}' \
+  '{{BASE_URL}}/api/v1/repos/{{OWNER}}/{{REPO}}/issues/{{ISSUE}}/labels' > /dev/null
+`
+
+// TestGiteaScriptedAgentLoop_PositiveHandoff covers the positive half of the
+// issue→PR loop that TestGiteaMockLoop_HappyPath only asserts negatively: a
+// scripted agent really commits, pushes a branch, opens a PR, and flips the
+// aiops/* label from inside the workspace, while the worker observes the
+// handoff, reconciles the now-terminal issue, and cleans the workspace —
+// without ever writing tracker state or PRs itself (#782).
+func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+
+	owner, repo := bed.gitea.botUser, "demo-scripted-agent"
+	cloneURL, err := bed.gitea.createRepo(ctx, repo)
+	if err != nil {
+		t.Fatalf("createRepo: %v", err)
+	}
+	if err := bed.gitea.putFile(ctx, owner, repo, "WORKFLOW.md", fixtureContent(t, "scripted-agent.md"), "seed workflow"); err != nil {
+		t.Fatalf("putFile workflow: %v", err)
+	}
+	issueNum, err := bed.gitea.createIssue(ctx, owner, repo, "scripted handoff", "agent pushes a branch, opens a PR, flips the label")
+	if err != nil {
+		t.Fatalf("createIssue: %v", err)
+	}
+	if err := bed.gitea.ensureLabels(ctx, owner, repo, []string{"aiops/todo", "aiops/done"}); err != nil {
+		t.Fatalf("ensure labels: %v", err)
+	}
+	if err := bed.gitea.addIssueLabels(ctx, owner, repo, issueNum, []string{"aiops/todo"}); err != nil {
+		t.Fatalf("add todo label: %v", err)
+	}
+
+	agentBranch := fmt.Sprintf("agent/%d", issueNum)
+	scriptPath := writeScriptedAgent(t, owner, repo, agentBranch, issueNum)
+	serviceWorkflow, err := workflow.Load(writeScriptedAgentServiceWorkflow(t, cloneURL, scriptPath))
+	if err != nil {
+		t.Fatalf("load service workflow: %v", err)
+	}
+
+	// Put the tracker credential into the WORKER process environment so the
+	// script's GITEA_TOKEN-absence guard pins something real: the runner
+	// builds the agent env from an allowlist (internal/runner/env.go), so a
+	// regression that inherits the worker env wholesale — or adds the token
+	// to the baseline allowlist — delivers the variable and fails the run.
+	// (Passthrough *requests* for GITEA_TOKEN are already rejected one layer
+	// earlier, at workflow load; see validateAgentEnvPassthrough.)
+	t.Setenv("GITEA_TOKEN", bed.gitea.botToken)
+
+	// The hand-set fields below deliberately mirror the fixture front matter
+	// (test/e2e/fixtures/scripted-agent.md) — the suite-wide assembly pattern
+	// shared with runGiteaWorkerTask. Tracker states are taken from the
+	// loaded workflow so the poller, reconciler, and dispatcher cannot drift
+	// from what the fixture declares.
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.Owner = owner
+	cfg.Repo.Name = repo
+	cfg.Repo.CloneURL = cloneURL
+	cfg.Repo.DefaultBranch = "main"
+	cfg.Tracker.Kind = "gitea"
+	cfg.Tracker.APIKey = bed.gitea.botToken
+	cfg.Tracker.ActiveStates = serviceWorkflow.Config.Tracker.ActiveStates
+	cfg.Tracker.TerminalStates = serviceWorkflow.Config.Tracker.TerminalStates
+	client := gitea.NewTrackerClient(cfg.Tracker, bed.gitea.baseURL, owner, repo)
+	client.HTTP = httpClientForE2E()
+
+	workspaceRoot := tmpDir()
+	events := &e2eEventRecorder{}
+	dispatcher := &scriptedAgentDispatcher{workspaceRoot: workspaceRoot}
+	dispatcher.WorkerTaskDispatcher = orchestrator.WorkerTaskDispatcher{
+		BuildTask: func(issue tracker.Issue) (task.Task, error) {
+			tk, err := orchestrator.TaskFromIssue(issue, cfg)
+			if err != nil {
+				return task.Task{}, err
+			}
+			events.recordTask(tk)
+			return tk, nil
+		},
+		Config: worker.Config{
+			WorkspaceRoot: workspaceRoot,
+			MirrorRoot:    tmpDir(),
+			Workflow:      serviceWorkflow,
+		},
+		Emitter:           events,
+		WorkspacePrepared: dispatcher.workspacePrepared,
+	}
+	orch := orchestrator.New(orchestrator.NewOrchestratorState(15000, 1), orchestrator.Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  orchestrator.RetryScheduler{MaxBackoff: time.Minute},
+		// Production wires the RuntimeDispatcher as the WorkspaceCleaner
+		// (cmd/worker/main.go); this cleaner delegates to the same shared
+		// worker.RemoveIssueWorkspace routine so the SPEC §18.1 terminal
+		// cleanup path under test matches the deployed seam.
+		WorkspaceCleaner: &scriptedAgentWorkspaceCleaner{
+			emitter:       events,
+			workspaceRoot: workspaceRoot,
+			hooks:         serviceWorkflow.Config.WorkspaceHooks(),
+		},
+	})
+	orchCtx, orchCancel := context.WithCancel(ctx)
+	t.Cleanup(orchCancel)
+	go orch.Run(orchCtx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("start orchestrator: %v", err)
+	}
+
+	poller := orchestrator.NewPollerWithReconciliation(client, orch, orchestrator.ReconciliationConfig{
+		ActiveStates:      cfg.Tracker.ActiveStates,
+		TerminalStates:    cfg.Tracker.TerminalStates,
+		WorkerExitTimeout: 10 * time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll: %v", err)
+	}
+
+	var taskID string
+	pollUntil(t, 90*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
+		tk, ok := events.taskBySource("gitea_issue", fmt.Sprintf("#%d", issueNum))
+		if !ok {
+			return false, nil
+		}
+		succeeded, err := events.taskSucceeded(tk.ID)
+		if err != nil || !succeeded {
+			return false, err
+		}
+		taskID = tk.ID
+		return true, nil
+	})
+	if taskID == "" {
+		t.Fatalf("scripted agent task did not complete")
+	}
+
+	workspacePath := dispatcher.preparedWorkspacePath()
+	if workspacePath == "" {
+		t.Fatalf("workspace path was not recorded by WorkspacePrepared")
+	}
+	// No race with the §16.6 continuation timer here: a fired continuation is
+	// a wake signal only (fireWakeSignal, internal/orchestrator/actor_retry.go)
+	// — never a timer-driven cleanup — and workspace prepare reuses the
+	// deterministic directory rather than delete/recreate, so the directory
+	// cannot vanish before the reconcile PollOnce below runs.
+	if info, err := os.Stat(workspacePath); err != nil || !info.IsDir() {
+		t.Fatalf("Stat(%q) = %v, %v; want existing workspace dir after the run", workspacePath, info, err)
+	}
+
+	assertScriptedAgentHandoff(t, ctx, owner, repo, issueNum, agentBranch, events.task(taskID).WorkBranch)
+
+	// The worker observes the handoff on the next reconciliation poll: the
+	// clean exit queued a SPEC §16.6 continuation retry (1s wake) carrying the
+	// run's workspace, and the reconcile pass — seeing the issue in a terminal
+	// state — releases the claim and routes the directory through the SPEC
+	// §18.1 WorkspaceCleaner seam. Both the continuation scheduling and the
+	// cleanup itself run on async followups, so poll until they settle instead
+	// of asserting after a single tick.
+	pollUntil(t, 60*time.Second, 500*time.Millisecond, func(ctx context.Context) (bool, error) {
+		// Treat transient poll/snapshot errors as not-yet-settled: the next
+		// tick retries and only the 60s timeout reports failure, so one API
+		// hiccup under CI load cannot fail the whole e2e run. The error is
+		// logged so a timeout still shows what kept the loop waiting.
+		if err := poller.PollOnce(ctx); err != nil {
+			t.Logf("reconcile PollOnce: %v (retrying)", err)
+			return false, nil
+		}
+		view, err := orch.Snapshot(ctx)
+		if err != nil {
+			t.Logf("orchestrator Snapshot: %v (retrying)", err)
+			return false, nil
+		}
+		if len(view.Running) != 0 || len(view.Retrying) != 0 {
+			return false, nil
+		}
+		if _, err := os.Stat(workspacePath); !os.IsNotExist(err) {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	// Re-check the tracker after reconciliation: the worker must not have
+	// rewritten the agent's label flip or opened a PR of its own.
+	assertScriptedAgentHandoff(t, ctx, owner, repo, issueNum, agentBranch, events.task(taskID).WorkBranch)
+}
+
+// assertScriptedAgentHandoff checks the agent-owned remote state (branch, PR,
+// label) and the worker-side negative boundary (no pushed work branch). It
+// runs both right after the task succeeds and again after reconciliation, so
+// a worker-side tracker/PR write at either stage fails the test.
+func assertScriptedAgentHandoff(t *testing.T, ctx context.Context, owner, repo string, issueNum int, agentBranch, workBranch string) {
+	t.Helper()
+
+	branchExists, err := bed.gitea.getBranch(ctx, owner, repo, agentBranch)
+	if err != nil {
+		t.Fatalf("getBranch(%q): %v", agentBranch, err)
+	}
+	if !branchExists {
+		t.Fatalf("getBranch(%q) = false; want agent branch pushed by the scripted agent", agentBranch)
+	}
+
+	prs, err := bed.gitea.listOpenPRs(ctx, owner, repo)
+	if err != nil {
+		t.Fatalf("listOpenPRs: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("listOpenPRs = %+v; want exactly 1 open PR (the scripted agent's)", prs)
+	}
+	if prs[0].Head.Ref != agentBranch {
+		t.Fatalf("open PR head = %q; want %q", prs[0].Head.Ref, agentBranch)
+	}
+	// What this pins is the fixture's INTERNAL consistency: the front matter
+	// declares policy.mode: draft_pr and the scripted agent honors it with
+	// the WIP title prefix Gitea maps to the draft flag. policy.mode is
+	// prompt-level convention (the worker-side gate was removed in #561), so
+	// no worker enforcement is claimed — editing the script to open a
+	// non-draft PR under the declared policy is what goes red here.
+	if !prs[0].Draft {
+		t.Fatalf("open PR draft = %v (title %q); want a draft PR per the fixture's policy.mode: draft_pr", prs[0].Draft, prs[0].Title)
+	}
+
+	labels, err := bed.gitea.getIssueLabels(ctx, owner, repo, issueNum)
+	if err != nil {
+		t.Fatalf("getIssueLabels: %v", err)
+	}
+	sort.Strings(labels)
+	if len(labels) != 1 || labels[0] != "aiops/done" {
+		t.Fatalf("getIssueLabels(#%d) = %v; want exactly [aiops/done] flipped by the agent", issueNum, labels)
+	}
+
+	if !regexp.MustCompile(`^ai/[0-9]+$`).MatchString(workBranch) {
+		t.Fatalf("unexpected worker task branch %q", workBranch)
+	}
+	workBranchExists, err := bed.gitea.getBranch(ctx, owner, repo, workBranch)
+	if err != nil {
+		t.Fatalf("getBranch(%q): %v", workBranch, err)
+	}
+	if workBranchExists {
+		t.Fatalf("worker must not push work branch %q", workBranch)
+	}
+}
+
+// writeScriptedAgent renders scriptedAgentTemplate with the live test-bed
+// coordinates baked in and installs it as an executable script.
+func writeScriptedAgent(t *testing.T, owner, repo, agentBranch string, issueNum int) string {
+	t.Helper()
+	pushURL := bed.gitea.baseURL + "/" + owner + "/" + repo + ".git"
+	authB64 := base64.StdEncoding.EncodeToString([]byte(bed.gitea.botUser + ":" + bed.gitea.botToken))
+	script := strings.NewReplacer(
+		"{{BRANCH}}", agentBranch,
+		"{{ISSUE}}", fmt.Sprintf("%d", issueNum),
+		"{{PUSH_URL}}", pushURL,
+		"{{AUTH_B64}}", authB64,
+		"{{TOKEN}}", bed.gitea.botToken,
+		"{{BASE_URL}}", bed.gitea.baseURL,
+		"{{OWNER}}", owner,
+		"{{REPO}}", repo,
+	).Replace(scriptedAgentTemplate)
+	path := filepath.Join(t.TempDir(), "scripted-agent.sh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write scripted agent: %v", err)
+	}
+	return path
+}
+
+// writeScriptedAgentServiceWorkflow rewrites the fixture's placeholders (the
+// validator-only clone_url and the runtime-generated agent script path) and
+// writes the result where workflow.Load can read it, mirroring
+// writeE2EServiceWorkflow.
+func writeScriptedAgentServiceWorkflow(t *testing.T, cloneURL, agentCommand string) string {
+	t.Helper()
+	body := string(fixtureContent(t, "scripted-agent.md"))
+	// Fail loud when the fixture and these literals drift: a silent no-op
+	// replacement would surface much later as an opaque clone/exec timeout.
+	for _, placeholder := range []string{
+		"http://localhost:3000/aiops-bot/demo-scripted-agent.git",
+		"__SCRIPTED_AGENT_COMMAND__",
+	} {
+		if !strings.Contains(body, placeholder) {
+			t.Fatalf("fixture scripted-agent.md does not contain placeholder %q; update writeScriptedAgentServiceWorkflow alongside the fixture", placeholder)
+		}
+	}
+	body = strings.ReplaceAll(body, "http://localhost:3000/aiops-bot/demo-scripted-agent.git", cloneURL)
+	body = strings.ReplaceAll(body, "__SCRIPTED_AGENT_COMMAND__", agentCommand)
+	path := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write service workflow: %v", err)
+	}
+	return path
+}
+
+// scriptedAgentDispatcher wraps WorkerTaskDispatcher to mirror the production
+// RuntimeDispatcher wiring this test depends on: AttachOrchestrator (called by
+// orchestrator.New) plus a WorkspacePrepared hook that records the workspace
+// path + root on the running entry so terminal reconciliation can clean it.
+type scriptedAgentDispatcher struct {
+	orchestrator.WorkerTaskDispatcher
+
+	workspaceRoot string
+
+	mu            sync.Mutex
+	orch          *orchestrator.Orchestrator
+	workspacePath string
+}
+
+func (d *scriptedAgentDispatcher) AttachOrchestrator(o *orchestrator.Orchestrator) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.orch = o
+}
+
+func (d *scriptedAgentDispatcher) workspacePrepared(ctx context.Context, issue tracker.Issue, _ task.Task, path string) {
+	d.mu.Lock()
+	d.workspacePath = path
+	orch := d.orch
+	d.mu.Unlock()
+	if orch == nil {
+		return
+	}
+	// Mirror RuntimeDispatcher.Spawn: capture the root the path was created
+	// under so SPEC §18.1 cleanup removes it against the same root.
+	_ = orch.RecordWorkspace(ctx, issue.ID, orchestrator.Workspace{Path: path, Root: d.workspaceRoot})
+}
+
+func (d *scriptedAgentDispatcher) preparedWorkspacePath() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.workspacePath
+}
+
+// scriptedAgentWorkspaceCleaner implements orchestrator.WorkspaceCleaner the
+// way production does (RuntimeDispatcher.CleanupReconciledWorkspace): it
+// delegates to worker.RemoveIssueWorkspace, the same routine the startup
+// sweep uses, so before_remove and the reconcile_workspace event contract
+// match the deployed worker.
+type scriptedAgentWorkspaceCleaner struct {
+	emitter       worker.EventEmitter
+	workspaceRoot string
+	hooks         workflow.WorkspaceHooks
+}
+
+func (c *scriptedAgentWorkspaceCleaner) CleanupReconciledWorkspace(ctx context.Context, w orchestrator.ReconciledWorkspace) {
+	root := strings.TrimSpace(w.Root)
+	if root == "" {
+		root = c.workspaceRoot
+	}
+	if _, err := worker.RemoveIssueWorkspace(ctx, c.emitter, worker.RemoveWorkspaceRequest{
+		WorkspaceRoot:      root,
+		TaskID:             "reconcile-active",
+		Path:               w.Path,
+		IssueID:            string(w.IssueID),
+		Identifier:         w.Identifier,
+		State:              w.State,
+		Reason:             w.Reason,
+		BeforeRemoveHook:   c.hooks.BeforeRemove,
+		HookTimeoutMillis:  c.hooks.TimeoutMs,
+		HookEnvPassthrough: c.hooks.EnvPassthrough,
+	}); err != nil {
+		log.Printf("e2e scripted-agent workspace cleanup failed: workspace=%q error=%q", w.Path, err)
+	}
+}


### PR DESCRIPTION
Closes #782

## Summary
- The Gitea e2e suite asserted only the negative boundary (worker pushes no branch, opens no PR); the mock runner never commits or writes the tracker, so no automated test exercised the positive half of the loop — an agent pushing a branch, opening a PR, flipping the `aiops/*` label, and the worker observing that handoff, reconciling, and cleaning the workspace. It had been validated exactly once, manually, in the v0.1.0 packaged-binary lifecycle test.
- New `TestGiteaScriptedAgentLoop_PositiveHandoff`: a test-generated `sh` script plays the agent through the claude `ShellRunner` seam (`agent.default: claude`, `claude.command: <script>`). The bot token, endpoints, and issue coordinates are baked into the script text because the agent env passthrough deny list blocks `GITEA_TOKEN` — the SPEC §1 token-isolation property this test demonstrates. The script commits, pushes `agent/<n>` via the authenticated clone URL, opens a PR over the Gitea API, and replaces `aiops/todo` with `aiops/done`.
- The test assembly mirrors two production wirings the plain e2e assembly lacked, verified line-by-line against `internal/orchestrator/runtime_poller.go`: `WorkspacePrepared → orch.RecordWorkspace` (as `RuntimeDispatcher.Spawn` wires it) and `Deps.WorkspaceCleaner → worker.RemoveIssueWorkspace` (as `CleanupReconciledWorkspace` does) — so the reconcile `PollOnce` exercises the production cleanup path.
- Assertions (positive + negative, re-checked after reconcile): task success; `agent/<n>` exists remotely; exactly 1 open PR with the agent head pinned; issue labels exactly `[aiops/done]`; the worker's own `ai/<n>` work branch never pushed; workspace dir present after the run and removed after the reconcile poll; `Snapshot().Running == 0`.
- One e2e test-bed helper added (`getIssueLabels` in `test/e2e/gitea.go`, build-tagged); new fixture `test/e2e/fixtures/scripted-agent.md`.

## Acceptance criteria (issue #782)
- [x] A scripted-agent e2e variant in the existing Gitea suite: a runner fixture whose "agent" actually commits, pushes a branch, and flips the `aiops/*` label via the Gitea API from inside the workspace.
- [x] Assertions: the worker observes the handoff, reconciles, cleans the workspace, and never itself writes tracker state or PRs (negative assertions kept).
- [x] Purely test-side (a fixture playing the agent role) — no SPEC §1 boundary change. Production diff: 0 files (only build-tagged e2e files + fixture).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff ~0 (test-tagged e2e files and fixtures only; `gitea.go` +24 lines is build-tagged test infrastructure counted at 380/800 of the file budget).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `gofmt -l` clean; `go vet -tags e2e ./test/e2e/...` clean
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] e2e (NOT in the CI gate — local evidence, Docker + gitea/gitea:1.26.1-rootless): `go test -tags e2e -race -timeout 15m -count=1 ./test/e2e/...` green on three separate runs, final tail:
  ```
  --- PASS: TestGiteaTrackerDispatchesLabeledIssueAndDedupesRepeatedPolls (0.39s)
  --- PASS: TestGiteaTrackerIgnoresBacklogAndTerminalIssues (0.37s)
  --- PASS: TestGiteaMockLoop_HappyPath (0.61s)
  --- PASS: TestGiteaWorkerReconciliationStopsRunMovedToDone (0.29s)
  --- PASS: TestGiteaScriptedAgentLoop_PositiveHandoff (1.97s)
  ok  	github.com/xrf9268-hue/aiops-platform/test/e2e	7.773s
  ```
- [x] Mutation-verified against the committed artifact: label-flip step deleted from the script → `getIssueLabels(#1) = [aiops/todo]; want exactly [aiops/done]` red, restored clean. Working-tree mutations during check: push+PR steps removed → branch assertion red; `WorkspaceCleaner` unwired → reconcile pollUntil times out red.
- [x] golangci blocking set with `--build-tags=e2e`: 0 findings in the new code; 5 pre-existing findings in untouched e2e files tracked as #802 (`area:tech-debt`).

## Review ledger
- Round 7 (head 302455b): follow-through round-6 (Codex clean) Claude left two LOWs — the draft assertion's comment overclaimed enforcement (policy.mode is prompt-level since #561; the comment now states it pins the fixture's internal consistency: an agent opening a non-draft PR under its declared draft_pr policy goes red) and the pre-agent label grep matched any quoted aiops/ string (now scoped to `"name":"aiops/..."`). Suite re-run green under `-race`.
- Round 6 (head 08d08a8): follow-through round-5 — (Codex MEDIUM + Claude LOW, same class) the bot token rode in the push URL's userinfo, and a failed `git push` echoes that URL into runner-streamed logs → push now uses a credential-free URL with the auth in `http.extraHeader` (Basic, b64 baked by the test) — the same mask-before-log class the repo enforces for clone URLs; (Codex MEDIUM) the fixture declares `policy.mode: draft_pr` but the agent opened a non-draft PR and nothing asserted draftness → the script now opens a `WIP:`-titled PR (Gitea maps the prefix to the `draft` flag) and the handoff assertion pins `prs[0].Draft == true`, so a non-draft handoff under a draft_pr workflow fails. Suite re-run green under `-race`.
- Round 5 (head 6bfa36c): follow-through round-4 — (Codex MEDIUM) "the agent should push the prepared `ai/<n>` work branch, the ad-hoc `agent/<n>` misses that path" → **refuted, recorded in a script comment**: disjoint actor footprints are load-bearing for the retained negative assertion (any remote `ai/<n>` appearance is then unambiguously the worker's doing); which branch a real agent pushes is prompt-level convention — SPEC §1 hands the whole handoff to the agent, and issue #782 prescribes only "pushes a branch" while explicitly requiring the negative assertions stay. (Claude LOW) the 180s parent ctx undershot the worst-case nested wait budgets (90s + 60s pollUntils + setup) → raised to 300s. Suite re-run green under `-race`.
- Round 4 (head 945f12a): follow-through round-3 (Codex clean) Claude left two LOWs — the pre-flip label-pin comment overclaimed its window (precise wording now states it covers claim→agent-start and why no worker code runs in the snapshot→PUT gap in this harness) and the script's curls had no `--max-time` while `agent.timeout` (5m) exceeds the test ctx (180s), turning a hung connection into an opaque pollUntil timeout (every curl now carries `--max-time 30` so failures route through `set -eu` loudly). Suite re-run green under `-race`.
- Round 3 (head 31e052d): the follow-through round-2 reviewers found — (Claude MEDIUM, **valid and sharp**) the GITEA_TOKEN-absence guard was a placebo: the test process never exported the variable, so nothing could deliver it regardless of env construction → fixed per the reviewer's prescription: `t.Setenv("GITEA_TOKEN", bed.gitea.botToken)` puts the credential into the worker process env, making the script guard pin the runner's allowlist construction; mutation-verified by switching `agentEnv` to wholesale `os.Environ()` inheritance — the guard tripped on every retry ("GITEA_TOKEN leaked into the agent environment") and the run goes red. Note the layered defenses confirmed along the way: adding GITEA_TOKEN to the baseline allowlist alone does NOT leak (the deny list vetoes inside `add()`), and passthrough requests are rejected at workflow load. (Claude LOW) silent-no-op placeholder replacement → fail-loud Contains guards added; (Claude LOW) hand-set tracker states duplicated the fixture → now derived from the loaded `serviceWorkflow.Config`; (Codex LOW) the replace-all label PUT could mask a hypothetical worker claim-write → the script now pins the pre-flip label set (exactly `aiops/todo`) before touching it. Full suite re-run green under `-race`.
- Round 2 (head 2c42d4c): the follow-through dual review on 253a462 found — (Claude MEDIUM) a claimed race between the §16.6 continuation timer and the workspace-present Stat → **refuted with evidence** (a fired continuation is a wake signal only, `actor_retry.go` `fireWakeSignal`; workspace prepare reuses the deterministic dir; verified line-by-line during trellis-check and by six green `-race` runs) and the refutation now lives in a comment at the assertion site; (Claude LOW + Codex MEDIUM, same root) the token-isolation comment overclaimed coverage and read as "bypasses the tool surface" → comment rewritten (the fixture deliberately does not cover the agent's dynamic tool surface — issue #782 prescribes playing the agent "via the Gitea API" so the worker-side loop is purely test-side) AND the script now actually asserts `GITEA_TOKEN` is absent from the agent env (a passthrough regression fails the run); (Claude LOW) the settle loop aborted on one transient poll error → softened to log-and-retry with the 60s timeout as the loud failure. Full suite re-run green under `-race` after the changes.
- Head after rebase onto main@072a8de: 253a462 (content identical to the reviewed 61db7b0→3efaf46 line; rebase over the merged #800/#801 was textual-only — disjoint paths; full e2e suite re-run green post-rebase).
- Pre-push dual diff-only reviews on 61db7b0: Codex `codex exec --output-schema` → `{"blocking_findings":[]}`; Claude `feature-dev:code-reviewer` → NEEDS-CHANGES with 2 findings, both triaged with evidence per protocol §3:
  - HIGH "PUT /issues/labels requires integer IDs, names will silently fail" — **refuted empirically**: the suite runs green against the pinned `gitea/gitea:1.26.1-rootless` container (label assertion `[aiops/done]` passes live), and the merged reconcile test's `replaceIssueLabels` helper uses the same name-based PUT. Gitea accepts label names here since 1.20. A contract comment was added to the script template so the next reader/reviewer sees the version dependency (the only code change from triage; suite re-run green after amend).
  - MEDIUM "continuation-retry followup may clean the workspace before the present-assert" — **refuted by production-code reading**: a fired continuation is a wake signal only (`fireWakeSignal`, `internal/orchestrator/actor_retry.go`); cleanup flows exclusively through reconcile `PollOnce` (`reconcileInactiveRetry` → `WorkspaceCleaner`), which the test itself drives. Verified against `actor_finalize.go`/`actor_retry.go`; documented in a test comment.
- trellis-check verified the production-mirror claims line-by-line against `runtime_poller.go` and ran two full Docker e2e rounds.

## Notes
- Trellis task: `.trellis/tasks/06-12-issue-782-e2e-scripted-agent-loop`.
- Follow-up filed during this PR's review: #802 (pre-existing e2e lint findings + whether CI should lint with `--build-tags=e2e`).
