### PR TITLE
docs: reword stale worker policy claims; link ADR 0002 and the Gitea bot runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,11 @@ polling and per-tick reconciliation. If a running issue is moved to `aiops/done`
 or `aiops/canceled`, the next poll refreshes that issue by ID and stops the
 in-flight run.
 
+For setting up a low-privilege bot account with the minimum token scopes
+(including the scopes the `gitea_issue_labels` state tool needs) and branch
+protection on a Gitea instance, follow the
+[Gitea bot and branch-protection runbook](docs/runbooks/gitea-bot-and-branch-protection.md).
+
 ## Continuous integration
 
 Every push to `main` and every pull request targeting `main` runs
@@ -446,12 +451,14 @@ add a bridge that imports `AGENTS.md` rather than duplicating content.
 - [Dashboard brand redesign & UX](docs/design/dashboard-brand-redesign.md)
 - [Research: Symphony-style personal productivity](docs/research/symphony-personal-productivity.md)
 - [ADR 0001: Adopt a Symphony-style personal orchestrator](docs/adr/0001-symphony-style-personal-orchestrator.md)
+- [ADR 0002: Ready-gated binary self-hosted development](docs/adr/0002-ready-gated-binary-self-hosting.md)
 - [Local development runbook](docs/runbooks/local-dev.md)
 - [Binary (non-Docker) deployment runbook](docs/runbooks/binary-deployment.md)
 - [CI/CD runbook](docs/runbooks/ci.md)
 - [Runtime debugging API](docs/runbooks/task-api.md)
 - [Workspace cache and cleanup](docs/runbooks/workspace-cache.md)
 - [GitHub local automation](docs/runbooks/github-local-automation.md)
+- [Gitea bot and branch protection](docs/runbooks/gitea-bot-and-branch-protection.md)
 
 ## Safety notes
 

--- a/docs/runbooks/binary-deployment.md
+++ b/docs/runbooks/binary-deployment.md
@@ -21,8 +21,10 @@ a service manager (systemd on Linux, launchd on macOS) instead of Compose.
   `claude`) launch local subprocesses via `os/exec`;
   none shell out to `docker`. `testcontainers-go` is test-only.
 - **No PR creation / tracker writes.** The worker prepares a git
-  workspace, runs the agent, enforces policy, and stops. Push and
-  draft-PR creation happen agent-side.
+  workspace, runs the agent, and stops. Push and draft-PR creation
+  happen agent-side; the worker enforces no post-run policy gate
+  (DEVIATIONS D33, #561 — `policy.mode` only selects the analysis-only
+  vs draft-PR prompt directive).
 
 ## 1. Host prerequisites
 

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -21,7 +21,9 @@ D8 (#76), it has stopped owning behaviors that earlier prototypes included:
   active issues on the next poll.
 - **No PR creation, no tracker writes.** The worker prepares a
   deterministic Git workspace, runs the configured agent (`mock`,
-  `codex-app-server`, or `claude`), enforces policy, and stops. Push, draft-PR
+  `codex-app-server`, or `claude`), and stops — it enforces no post-run
+  policy gate (DEVIATIONS D33, #561; `policy.mode` only selects the
+  analysis-only vs draft-PR prompt directive). Push, draft-PR
   creation, and tracker label transitions happen agent-side via the
   configured tool surface (`linear_graphql`, the workflow prompt's
   push step, etc.), not in `cmd/worker`.


### PR DESCRIPTION
Closes #784

## Summary
- Rewords the two runbook claims that the worker "enforces policy" (`docs/runbooks/binary-deployment.md`, `docs/runbooks/local-dev.md`) to the post-D33 reality: the worker-side policy gate was removed in #561/#574 (DEVIATIONS D33); `policy.mode` only selects the analysis-only vs draft-PR prompt directive.
- Links the two previously-orphaned current docs from their natural indexes: ADR 0002 and the Gitea bot/branch-protection runbook (the only Gitea token-scope documentation) join the README Architecture notes list, and the README Gitea issue-state labels section now points at the bot runbook for account/scope/branch-protection setup.

## Acceptance criteria (issue #784)
- [x] Both "enforces policy" phrases reworded to post-D33 reality (verified against DEVIATIONS D33 and `internal/worker/runtask.go` — `AppendAnalysisOnlyDirective` is the sole `policy.mode` consumer).
- [x] ADR 0002 and the Gitea bot runbook linked from their natural indexes (verdict: link, not delete — ADR 0002's `aiops:ready` convention is referenced by the batch runbook; the bot runbook is the only token-scope source).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 3 files, +14/−3, docs-only.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] Class sweep (`grep -rni 'enforces policy|enforce policy|policy enforcement'`): remaining hits are dated audit/plan snapshots and DEVIATIONS history, both exempt as historical records.

## Review ledger
- Head: 8a2a874.
- Pre-push dual diff-only review (protocol §3): Claude-family (`pr-review-toolkit:code-reviewer`) MERGE-READY, zero findings; Codex-family (`codex exec`, read-only) MERGE-READY, zero findings. Both verified D33/runtask.go consistency and link resolution independently.
- Serialized behind #809 (merged) per the batch runbook's soft-overlap rule (shared README.md).