### PR TITLE
docs: document the GitHub tracker state model, token scopes, and example templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ brand/UX rationale.
 
 ## Quick start: worker-owned tracker polling path
 
-Edit `examples/WORKFLOW.md` with your repository and tracker settings, then run
+Start from the example workflow for your tracker —
+[`examples/WORKFLOW.md`](examples/WORKFLOW.md) (Linear),
+[`examples/gitea-WORKFLOW.md`](examples/gitea-WORKFLOW.md) (Gitea), or
+[`examples/github-local-WORKFLOW.md`](examples/github-local-WORKFLOW.md)
+(GitHub) — edit your repository and tracker settings, then run
 the worker. It reconciles workspaces on startup before the first poll tick, then
 repeatedly fetches active issues and dispatches them through the in-memory
 orchestrator state:
@@ -402,6 +406,46 @@ For setting up a low-privilege bot account with the minimum token scopes
 (including the scopes the `gitea_issue_labels` state tool needs) and branch
 protection on a Gitea instance, follow the
 [Gitea bot and branch-protection runbook](docs/runbooks/gitea-bot-and-branch-protection.md).
+
+## GitHub issue-state labels
+
+For `tracker.kind: github`, a configured state named `open`, `closed`, or
+`all` (case-insensitive) maps directly to the GitHub issue-state filter with
+no label involved. **Any other state name is treated as an issue label**: the
+worker polls open issues carrying that label, so a workflow state such as
+`aiops:ready` means "open and labeled `aiops:ready`".
+
+| Configured state | What the worker polls |
+| --- | --- |
+| `open` / `closed` / `all` | GitHub issue state, no label filter |
+| anything else (e.g. `aiops:ready`) | open issues carrying that label |
+
+The dogfood convention ([ADR 0002](docs/adr/0002-ready-gated-binary-self-hosting.md)):
+use a dedicated `aiops:ready` label as the unattended queue entry and do
+**not** include `open` in `active_states`, so the worker never sweeps
+arbitrary open issues into execution. Priority labels are triage metadata,
+not permission to run. (The colon form `aiops:ready` is just this repo's
+GitHub-side naming, distinct from the Gitea path's `aiops/*` labels above —
+any label name works as long as the configured state matches it exactly.)
+
+Two behaviors keep the label-as-state loop safe:
+
+- **Open-PR claim skip.** Whenever an active state can include open issues,
+  the worker lists open pull requests and parses closing keywords
+  (`Closes #N`, `Fixes #N`, …) from each PR's title and body; an issue
+  claimed by an open PR is skipped while both stay open, so a poll never
+  double-dispatches an issue whose agent PR is already in flight.
+- **Reconciliation.** Removing the state label or closing the issue takes it
+  out of the active set; per-tick reconciliation then stops an in-flight run
+  on a following poll.
+
+`tracker.api_key` needs only read access — a fine-grained PAT with read-only
+**Issues**, **Pull requests**, and **Metadata** permissions on the target
+repository (classic-PAT equivalent: `public_repo`, or `repo` for private
+repositories).
+
+[`examples/github-local-WORKFLOW.md`](examples/github-local-WORKFLOW.md) is a
+working template wiring all of the above.
 
 ## Continuous integration
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ repeatedly fetches active issues and dispatches them through the in-memory
 orchestrator state:
 
 ```bash
-export AIOPS_WORKFLOW_PATH=$PWD/examples/WORKFLOW.md
+# Point AIOPS_WORKFLOW_PATH at the template you picked above:
+export AIOPS_WORKFLOW_PATH=$PWD/examples/WORKFLOW.md                 # Linear
+# export AIOPS_WORKFLOW_PATH=$PWD/examples/gitea-WORKFLOW.md         # Gitea
+# export AIOPS_WORKFLOW_PATH=$PWD/examples/github-local-WORKFLOW.md  # GitHub
 export AIOPS_WORKSPACE_ROOT=$PWD/.aiops/workspaces
 
 # For tracker.kind: linear  (consumed via WORKFLOW.md "api_key: $LINEAR_API_KEY")
@@ -435,9 +438,12 @@ Two behaviors keep the label-as-state loop safe:
   (`Closes #N`, `Fixes #N`, …) from each PR's title and body; an issue
   claimed by an open PR is skipped while both stay open, so a poll never
   double-dispatches an issue whose agent PR is already in flight.
-- **Reconciliation.** Removing the state label or closing the issue takes it
-  out of the active set; per-tick reconciliation then stops an in-flight run
-  on a following poll.
+- **Reconciliation.** Closing the issue (a configured terminal state) stops
+  an in-flight run on a following poll. Removing the state label keeps the
+  issue out of *future* dispatch but does **not** cancel an already-running
+  agent under this configuration: the refreshed issue falls back to plain
+  `open`, which is neither active nor a configured inactive/terminal state.
+  Close the issue to stop work that is already running.
 
 `tracker.api_key` needs only read access — a fine-grained PAT with read-only
 **Issues**, **Pull requests**, and **Metadata** permissions on the target


### PR DESCRIPTION
Closes #785

## Summary
- Adds a "GitHub issue-state labels" README section parallel to the Gitea one: `open`/`closed`/`all` special states, label-as-state semantics (any other configured state polls open issues carrying that label), the `aiops:ready` convention per ADR 0002, the open-PR claim skip (closing-keyword parsing over open PR title/body), and per-tick reconciliation. Previously all of this existed only as YAML comments in `examples/github-local-WORKFLOW.md`.
- One sentence on minimum GitHub token scopes: `tracker.api_key` is read-only for GitHub — fine-grained PAT with read-only Issues / Pull requests / Metadata (classic `public_repo`/`repo`).
- Quick start now links the per-tracker example templates (`examples/WORKFLOW.md`, `examples/gitea-WORKFLOW.md`, `examples/github-local-WORKFLOW.md`) so non-Linear users start from the right file.

## Acceptance criteria (issue #785)
- [x] A "GitHub issue-state labels" README section parallel to the Gitea one (open/closed/all special states, label-as-state semantics, the open-PR claim skip).
- [x] One sentence on minimum GitHub token scopes.
- [x] Quick start links `examples/github-local-WORKFLOW.md` and `examples/gitea-WORKFLOW.md`.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 file, +45/−1, docs-only.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] Every factual claim validated against `internal/tracker/github.go` (`githubIssueQueryForState`, `githubStatesMayIncludeOpenIssues`, `openPullRequestClaimedIssueNumbers`, `githubClaimedIssueRE`) and `internal/runner/tools.go` (the only tracker write tool is Gitea-gated, so the GitHub token is read-only).

## Review ledger
- Head: 6a6e1da (d7a0b2d + one LOW clarification).
- Pre-push dual diff-only review (protocol §3): Claude-family (`pr-review-toolkit:code-reviewer`) MERGE-READY with 1 optional LOW (Gitea `aiops/*` slash vs GitHub `aiops:ready` colon could read as inconsistent — fixed with a clarifying parenthetical); Codex-family (`codex exec`, read-only) MERGE-READY, zero findings (noted the closing-keyword examples are a subset of the regex, covered by the ellipsis).
- Serialized behind #809/#810 (both merged) per the batch runbook's soft-overlap rule (shared README.md).

## Codex bot status (final)
- Trigger 1 (comment 4696855046, bytevane, 00:59:50Z) → `usage limits` reply in 2s (comment at 00:59:52Z).
- Trigger 2 (comment 4696951982, bytevane, ~01:17Z) → no bot response after 12+ minutes; quota exhausted, awaiting reset.
- Protocol §4.4 compensation (disclosed per "If Codex is externally unavailable… compensate with an equivalent independent dual review"): full dual diff-only review on d7a0b2d (Claude family + Codex CLI family, both MERGE-READY) **plus** dual delta review of d7a0b2d→6a6e1da (both MERGE-READY) — the pushed head is fully covered by two independent families.
- Merge is intentionally held until a fresh `@codex review` converges clean on 6a6e1da (operator preference: the GitHub bot gate is not substitutable by local review). Re-trigger cycle in progress.


### Final state (head ad64c0f)
- The earlier "quota exhausted" reading was wrong: triggers 1–2 DID produce PR reviews on 6a6e1da (review ids 4490161512/4490276655, both "Reviewed commit 6a6e1da" with two P2 findings) — my watcher was only polling issue comments and missed them.
- Both P2 findings validated and fixed in ad64c0f (per-tracker `AIOPS_WORKFLOW_PATH` exports; corrected label-removal reconciliation claim verified against `githubResolveState` + `refreshedIssueIsInactive`). Both threads replied to and resolved.
- Dual delta review on 6a6e1da→ad64c0f: Claude family + Codex CLI family, both MERGE-READY.
- Fresh `@codex review` (trigger 4697042182, bytevane) on ad64c0f: 👀 appeared and cleared, completion comment "Didn't find any major issues — Reviewed commit `ad64c0f599`".
- CI green on ad64c0f (run 27452888356, all jobs SUCCESS); warning audit clean; zero unresolved non-outdated threads.
