### PR TITLE
orchestrator: delete legacy shadow poll loop (NewPoller/RunPollLoop/NewRuntimePoller), retarget tests

### DIFF
--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1702,7 +1702,7 @@ func TestWorkerEntrypointDoesNotRequirePostgresQueue(t *testing.T) {
 			t.Fatalf("cmd/worker/main.go contains %q; worker startup must use tracker + orchestrator runtime state, not the Postgres queue", forbidden)
 		}
 	}
-	for _, required := range []string{"orchestrator.NewOrchestratorState", "orchestrator.NewWorkflowRuntime", "orchestrator.NewRuntimeDispatcher", "orchestrator.NewRuntimePoller", "orchestrator.RunPollLoopWithRuntime", "orchestrator.RunWorkflowReloadLoop"} {
+	for _, required := range []string{"orchestrator.NewOrchestratorState", "orchestrator.NewWorkflowRuntime", "orchestrator.NewRuntimeDispatcher", "orchestrator.NewRuntimePollerWithTrackerFactory", "orchestrator.RunPollLoopWithRuntime", "orchestrator.RunWorkflowReloadLoop"} {
 		if !strings.Contains(string(src), required) {
 			t.Fatalf("cmd/worker/main.go missing %q; worker startup must poll tracker issues through dynamically reloaded reconciled orchestrator runtime state", required)
 		}

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -102,22 +101,6 @@ type Poller struct {
 	// snapshot reload so `$VAR` resolution drift is detected on the
 	// next tick rather than at the next tracker call.
 	preflight *workflow.Config
-}
-
-// NewPoller returns a SPEC-aligned tracker poller backed by orchestrator-owned
-// runtime state instead of the legacy Postgres task queue.
-//
-// Callers that do not supply a ReconciliationConfig still get the SPEC §5.3.1
-// default terminal_states so the Todo blocker rule continues to honor
-// "Done"/"Canceled"/etc. without the hardcoded overlay #232 removed.
-// Operators who genuinely want to disable the blocker rule must construct via
-// NewPollerWithReconciliation with an explicit empty terminal_states slice.
-func NewPoller(tracker ActiveIssueLister, orchestrator *Orchestrator) *Poller {
-	return &Poller{
-		tracker:      tracker,
-		orchestrator: orchestrator,
-		reconcile:    ReconciliationConfig{TerminalStates: workflow.DefaultConfig().Tracker.TerminalStates},
-	}
 }
 
 // NewPollerWithReconciliation returns a poller that reconciles the
@@ -602,38 +585,5 @@ func IssueRenderVars(issue tracker.Issue) map[string]any {
 		"blocked_by":  blockedBy,
 		"created_at":  issue.CreatedAt,
 		"updated_at":  issue.UpdatedAt,
-	}
-}
-
-// RunPollLoop repeatedly polls the tracker until ctx is canceled.
-func RunPollLoop(ctx context.Context, poller *Poller, interval time.Duration) error { //nolint:gocognit // baseline (#521)
-	if poller == nil {
-		return errors.New("orchestrator poll loop requires poller")
-	}
-	if interval <= 0 {
-		interval = 30 * time.Second
-	}
-	intervalTimer := time.NewTimer(interval)
-	if !intervalTimer.Stop() {
-		<-intervalTimer.C
-	}
-	defer intervalTimer.Stop()
-	for {
-		if err := poller.PollOnce(ctx); err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			log.Printf("event=tracker_poll_error error=%q", err)
-		}
-		intervalTimer.Reset(interval)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-poller.orchestrator.retryWakeCh():
-			if !intervalTimer.Stop() {
-				<-intervalTimer.C
-			}
-		case <-intervalTimer.C:
-		}
 	}
 }

--- a/internal/orchestrator/poller_candidates.go
+++ b/internal/orchestrator/poller_candidates.go
@@ -170,12 +170,10 @@ func filterIssuesNotInMap(issues []tracker.Issue, excluded map[string]tracker.Is
 }
 
 func filterEligibleCandidates(issues []tracker.Issue, terminalStates, requiredLabels []string) []tracker.Issue {
-	// Honor exactly what the caller supplied per SPEC §5.3.1. Callers that
-	// want the SPEC 5-state default get it from workflow.DefaultConfig at
-	// construction time (NewPoller seeds it; workflow.Load supplies it for
-	// omitted YAML). An explicit empty slice from
-	// NewPollerWithReconciliation disables the blocker rule entirely, which
-	// is the operator's call.
+	// Honor exactly what the caller supplied per SPEC §5.3.1. The SPEC 5-state
+	// default reaches NewPollerWithReconciliation through the workflow config
+	// (workflow.Load supplies it for omitted YAML). An explicit empty slice
+	// disables the blocker rule entirely, which is the operator's call.
 	terminal := normalizedStates(terminalStates)
 	out := make([]tracker.Issue, 0, len(issues))
 	for _, issue := range issues {

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -27,13 +27,38 @@ type fakeIssueTracker struct {
 }
 
 func (f *fakeIssueTracker) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
+	return f.list(nil, false)
+}
+
+// ListIssuesByStates lets fakeIssueTracker satisfy IssueStateLister so the
+// dispatch tests construct through the production NewPollerWithReconciliation
+// path (the deleted NewPoller used the bare ActiveIssueLister). It filters by
+// the requested states exactly like the real tracker and fakeIssueStateTracker,
+// so reconcileTick's terminal/inactive group listings only ever return
+// terminal-state issues — never an active dispatch candidate — and the run-less
+// dispatch behavior matches the old NewPoller construction verbatim.
+func (f *fakeIssueTracker) ListIssuesByStates(_ context.Context, states []string) ([]tracker.Issue, error) {
+	return f.list(states, true)
+}
+
+func (f *fakeIssueTracker) list(states []string, filterByState bool) ([]tracker.Issue, error) {
 	f.calls++
 	if f.err != nil && !f.partialSuccess {
 		return nil, f.err
 	}
 	issues := f.issues
+	if filterByState {
+		wanted := normalizedStates(states)
+		filtered := make([]tracker.Issue, 0, len(issues))
+		for _, issue := range issues {
+			if isActiveTrackerState(issue.State, wanted) {
+				filtered = append(filtered, issue)
+			}
+		}
+		issues = filtered
+	}
 	if !f.preserveMissingFields {
-		issues = defaultTrackerIssueTitles(f.issues)
+		issues = defaultTrackerIssueTitles(issues)
 	}
 	if f.err != nil {
 		return issues, f.err
@@ -882,10 +907,13 @@ func TestPollOnceFiltersTodoIssuesBlockedByNonTerminalBlockers(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	// NewPoller without a reconciliation config leaves reconcile.TerminalStates
-	// empty; filterEligibleCandidates falls back to workflow.DefaultConfig's
-	// SPEC §5.3.1 5-state set, so a Done blocker is still treated as terminal.
-	poller := NewPoller(trackerClient, orch)
+	// Construct through the production reconciliation path with the SPEC §5.3.1
+	// default terminal_states (workflow.DefaultConfig), so a Done blocker is
+	// still treated as terminal and only the unblocked Todo issue dispatches.
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:   []string{"Todo"},
+		TerminalStates: workflow.DefaultConfig().Tracker.TerminalStates,
+	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -916,7 +944,7 @@ func TestPollOnceSkipsMalformedTrackerCandidates(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -945,7 +973,7 @@ func TestPollOnceDispatchesMissingCreatedAtCandidateAfterDatedCandidates(t *test
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -973,7 +1001,7 @@ func TestPollOnceIgnoresBlockersForNonTodoStates(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"In Progress"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -1002,13 +1030,15 @@ func TestPollOnceTreatsDefaultSpecTerminalBlockersAsUnblocked(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
 	// Use workflow.DefaultConfig().Tracker.TerminalStates so the test actually
 	// exercises the SPEC §5.3.1 5-state default ("Done", "Canceled",
 	// "Cancelled", "Closed", "Duplicate"). Previously this was hard-coded to
 	// ["Done", "Canceled"] and relied on filterEligibleCandidates's now-removed
 	// hardcoded overlay (#232) to backfill the remaining three terminal states.
-	poller.reconcile.TerminalStates = workflow.DefaultConfig().Tracker.TerminalStates
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:   []string{"Todo"},
+		TerminalStates: workflow.DefaultConfig().Tracker.TerminalStates,
+	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -1042,10 +1072,12 @@ func TestPollOnceTodoBlockerHonorsOperatorConfiguredTerminalStates(t *testing.T)
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
 	// Operator subsets terminal_states to just ["Done"]. Closed and Duplicate
 	// must NOT be treated as terminal — both Todo issues stay blocked.
-	poller.reconcile.TerminalStates = []string{"Done"}
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:   []string{"Todo"},
+		TerminalStates: []string{"Done"},
+	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -1353,7 +1385,7 @@ func TestPollOnceSortsCandidatesByTrackerPriorityCreatedAtIdentifier(t *testing.
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -1384,13 +1416,17 @@ func TestPollOnceDispatchesTrackerCandidatesThroughRuntimeStateWithoutQueue(t *t
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
 
+	// The active listing flows through the production activeIssueListerFromStates
+	// wrapper into ListIssuesByStates. With no terminal/inactive reconcile groups
+	// configured and no run active yet, that single active query is the only
+	// tracker call this tick.
 	if trackerClient.calls != 1 {
-		t.Fatalf("ListActiveIssues calls = %d, want 1", trackerClient.calls)
+		t.Fatalf("ListIssuesByStates calls = %d, want 1", trackerClient.calls)
 	}
 	if got := dispatcher.count(); got != 1 {
 		t.Fatalf("dispatcher issues = %d, want 1", got)
@@ -1421,7 +1457,7 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("WaitStarted: %v", err)
 	}
-	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1", State: "Todo"}}}, orch)
+	poller := NewPollerWithReconciliation(&fakeIssueTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1", State: "Todo"}}}, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("initial poll once: %v", err)
@@ -1456,7 +1492,7 @@ func TestPollOnceKeepsDueContinuationRetryMissingFromActiveListing(t *testing.T)
 		t.Fatalf("WaitStarted: %v", err)
 	}
 	issue := tracker.Issue{ID: "issue-missing", Identifier: "ISSUE-MISSING", Title: "Issue missing from capped active listing", State: "Todo"}
-	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{issue}}, orch)
+	poller := NewPollerWithReconciliation(&fakeIssueTracker{issues: []tracker.Issue{issue}}, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("initial poll once: %v", err)
@@ -1481,7 +1517,7 @@ func TestPollOnceKeepsDueContinuationRetryMissingFromActiveListing(t *testing.T)
 	}
 }
 
-func TestRunPollLoopWakesWhenContinuationRetryTimerFires(t *testing.T) {
+func TestRunPollLoopWithRuntimeWakesWhenContinuationRetryTimerFires(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1494,22 +1530,49 @@ func TestRunPollLoopWakesWhenContinuationRetryTimerFires(t *testing.T) {
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("WaitStarted: %v", err)
 	}
-	issue := tracker.Issue{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1", State: "Todo"}
-	poller := NewPoller(&fakeIssueTracker{issues: []tracker.Issue{issue}}, orch)
+	// A 1-hour cadence means the only thing that can drive the second poll
+	// within the test window is the §8.5 retry-timer wake, not the interval
+	// timer — exercising sleepOrRetryWake on the production *RuntimePoller path
+	// (RunPollLoopWithRuntime only watches retryWakeCh for *RuntimePoller). A
+	// non-zero continuation budget is required because RuntimePoller.PollOnce
+	// pushes the snapshot's max_continuation_turns into the orchestrator, so a
+	// completed run only schedules the continuation whose timer does the waking.
+	path := writeWorkflowForReloadTest(t, "linear", 3600000, withReloadTestMaxContinuationTurns(5))
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load workflow: %v", err)
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "ISSUE-1", Title: "Issue 1", State: "Todo"}}}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
 
 	done := make(chan error, 1)
 	go func() {
-		done <- RunPollLoop(ctx, poller, time.Hour)
+		done <- RunPollLoopWithRuntime(ctx, poller, runtime, PollLoopRuntimeOptions{})
 	}()
-	waitForDispatcherCount(t, dispatcher, 2)
+	// The second dispatch can only come from the continuation retry timer waking
+	// the loop (the 1h cadence cannot fire in-window). That timer is the
+	// production RetryScheduler's fixed 1s continuationRetryDelay — RuntimePoller
+	// installs that scheduler from the workflow, overriding any injected one — so
+	// allow more than 1s and stop as soon as the wake-driven re-dispatch lands.
+	deadline := time.Now().Add(3 * time.Second)
+	for dispatcher.count() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := dispatcher.count(); got < 2 {
+		t.Fatalf("dispatcher issues = %d, want >=2 after the continuation retry timer woke the poll loop", got)
+	}
 	cancel()
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("RunPollLoop error = %v, want context canceled", err)
+			t.Fatalf("RunPollLoopWithRuntime error = %v, want context canceled", err)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("RunPollLoop did not exit after context cancel")
+		t.Fatal("RunPollLoopWithRuntime did not exit after context cancel")
 	}
 }
 
@@ -1539,7 +1602,7 @@ func TestPollOnceBuildTaskFailureSchedulesBackoffRetryNotPerTickSpin(t *testing.
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -1597,7 +1660,7 @@ func TestPollOnceDoesNotExceedMaxConcurrentAgents(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -1627,7 +1690,7 @@ func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("first poll once: %v", err)
 	}
@@ -1671,7 +1734,7 @@ func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("first poll once: %v", err)
 	}
@@ -1865,7 +1928,7 @@ func TestPollOnceDispatchesPartialIssuesWhenTrackerReturnsCategorizedError(t *te
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("WaitStarted: %v", err)
 	}
-	poller := NewPoller(trackerClient, orch)
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{ActiveStates: []string{"Todo"}})
 
 	pollErr := poller.PollOnce(ctx)
 	if pollErr == nil {

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -28,12 +28,6 @@ type RuntimePoller struct {
 	currentRefresher IssueStateRefresher
 }
 
-func NewRuntimePoller(tracker IssueStateLister, orchestrator *Orchestrator, runtime *WorkflowRuntime, cfg worker.Config, emitter worker.EventEmitter) (*RuntimePoller, error) {
-	return NewRuntimePollerWithTrackerFactory(func(workflow.Config) (IssueStateLister, error) {
-		return tracker, nil
-	}, orchestrator, runtime, cfg, emitter)
-}
-
 func NewRuntimePollerWithTrackerFactory(trackerFactory func(workflow.Config) (IssueStateLister, error), orchestrator *Orchestrator, runtime *WorkflowRuntime, cfg worker.Config, emitter worker.EventEmitter) (*RuntimePoller, error) {
 	if trackerFactory == nil {
 		return nil, errors.New("runtime poller requires tracker factory")

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -16,6 +16,22 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+// newRuntimePollerForTest builds a RuntimePoller through the production
+// NewRuntimePollerWithTrackerFactory constructor (the deleted NewRuntimePoller
+// wrapper used to wrap a single lister in this same closure). lister is served
+// for every workflow snapshot so reload-driven tracker selection still resolves
+// to the test fake.
+func newRuntimePollerForTest(t *testing.T, lister IssueStateLister, orch *Orchestrator, runtime *WorkflowRuntime) *RuntimePoller {
+	t.Helper()
+	poller, err := NewRuntimePollerWithTrackerFactory(func(workflow.Config) (IssueStateLister, error) {
+		return lister, nil
+	}, orch, runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+	return poller
+}
+
 type recordingWorkflowReloadEmitter struct {
 	mu     sync.Mutex
 	events []recordedWorkflowReloadEvent
@@ -138,10 +154,7 @@ func TestRuntimePollerUsesReloadedTrackerStatesFromSameWorkflowPath(t *testing.T
 	dispatcher := &fakeDispatcher{}
 	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
-	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
-	if err != nil {
-		t.Fatalf("new runtime poller: %v", err)
-	}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
 
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("first poll: %v", err)
@@ -189,10 +202,7 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsToDispatchCapacity(t *te
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
-	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
-	if err != nil {
-		t.Fatalf("new runtime poller: %v", err)
-	}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
 
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("first poll: %v", err)
@@ -234,10 +244,7 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsByStateToDispatchCapacit
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
-	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
-	if err != nil {
-		t.Fatalf("new runtime poller: %v", err)
-	}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
 
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("first poll: %v", err)
@@ -274,10 +281,7 @@ func TestRuntimePollerAppliesReloadedMaxRetryBackoffToFailureRetries(t *testing.
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
-	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
-	if err != nil {
-		t.Fatalf("new runtime poller: %v", err)
-	}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
 
 	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "Todo", withReloadTestMaxRetryBackoffMs(50))
 	if err := runtime.ReloadOnce(ctx); err != nil {
@@ -325,10 +329,7 @@ func TestRuntimePollerAppliesReloadedMaxContinuationTurnsToCleanContinuationBudg
 	if err := orch.WaitStarted(ctx); err != nil {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
-	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
-	if err != nil {
-		t.Fatalf("new runtime poller: %v", err)
-	}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
 
 	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "Todo", withReloadTestMaxContinuationTurns(1))
 	if err := runtime.ReloadOnce(ctx); err != nil {
@@ -422,10 +423,7 @@ func TestRuntimePollerRetryListerWrapsEligibilityFilter(t *testing.T) {
 	dispatcher := &recordingDispatcher{}
 	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
-	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
-	if err != nil {
-		t.Fatalf("new runtime poller: %v", err)
-	}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -487,10 +485,7 @@ func TestRuntimePollerRetryListerThreadsRequiredLabels(t *testing.T) {
 	dispatcher := &recordingDispatcher{}
 	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
-	poller, err := NewRuntimePoller(trackerClient, orch, runtime, worker.Config{}, nil)
-	if err != nil {
-		t.Fatalf("new runtime poller: %v", err)
-	}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll once: %v", err)
 	}
@@ -650,10 +645,7 @@ func TestRunPollLoopWithRuntimePollerHonorsInjectedSleep(t *testing.T) {
 	disp := &recordingDispatcher{releaseCh: make(chan struct{})}
 	orch, orchCancel := startActor(t, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Second}})
 	defer orchCancel()
-	poller, err := NewRuntimePoller(&fakeIssueStateTracker{}, orch, runtime, worker.Config{}, nil)
-	if err != nil {
-		t.Fatalf("new runtime poller: %v", err)
-	}
+	poller := newRuntimePollerForTest(t, &fakeIssueStateTracker{}, orch, runtime)
 	sleeper := &recordingPollSleeper{}
 
 	start := time.Now()

--- a/test/e2e/gitea_tracker_test.go
+++ b/test/e2e/gitea_tracker_test.go
@@ -54,7 +54,10 @@ func TestGiteaTrackerDispatchesLabeledIssueAndDedupesRepeatedPolls(t *testing.T)
 		t.Fatalf("start orchestrator: %v", err)
 	}
 
-	poller := orchestrator.NewPoller(client, orch)
+	poller := orchestrator.NewPollerWithReconciliation(client, orch, orchestrator.ReconciliationConfig{
+		ActiveStates:   []string{"Todo", "Rework"},
+		TerminalStates: []string{"Done", "Canceled"},
+	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("first poll: %v", err)
 	}
@@ -123,7 +126,11 @@ func TestGiteaTrackerIgnoresBacklogAndTerminalIssues(t *testing.T) {
 		t.Fatalf("start orchestrator: %v", err)
 	}
 
-	if err := orchestrator.NewPoller(client, orch).PollOnce(ctx); err != nil {
+	poller := orchestrator.NewPollerWithReconciliation(client, orch, orchestrator.ReconciliationConfig{
+		ActiveStates:   []string{"Todo", "Rework"},
+		TerminalStates: []string{"Done", "Canceled"},
+	})
+	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll: %v", err)
 	}
 	// No wait needed: PollOnce dispatches synchronously, so a zero spawn count

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -226,7 +226,12 @@ func runGiteaWorkerTask(t *testing.T, ctx context.Context, repo, title, body, fi
 		t.Fatalf("start orchestrator: %v", err)
 	}
 
-	if err := orchestrator.NewPoller(client, orch).PollOnce(ctx); err != nil {
+	poller := orchestrator.NewPollerWithReconciliation(client, orch, orchestrator.ReconciliationConfig{
+		ActiveStates:      cfg.Tracker.ActiveStates,
+		TerminalStates:    cfg.Tracker.TerminalStates,
+		WorkerExitTimeout: 10 * time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("poll: %v", err)
 	}
 


### PR DESCRIPTION
Closes #787

## Summary
Delete three dead production poll-loop symbols that `deadcode -test ./cmd/worker ./cmd/tui` flagged (only internal tests kept them alive) — a duplicate poll mechanism with one dead twin (clean-code rules 1/3/6) — and retarget their tests at the production entry points so coverage exercises the shipped loop.

Deleted (no non-test callers; grep-confirmed):
- `internal/orchestrator/poller.go` — `NewPoller` (a convenience ctor with `reconcileKnown=false`) and `RunPollLoop` (a complete second poll loop with its own interval timer + `retryWakeCh`). The shipped binary uses `NewPollerWithReconciliation` + `RunPollLoopWithRuntime`.
- `internal/orchestrator/runtime_poller.go` — `NewRuntimePoller` (thin single-lister wrapper). Production wires `NewRuntimePollerWithTrackerFactory` (`cmd/worker/main.go:403/426`).
- Removed the now-unused `"log"` import from `poller.go`; updated a stale comment in `poller_candidates.go` that named `NewPoller`.

## Test retargeting (production entry points)
- `poller_test.go`: `fakeIssueTracker` gains a state-filtering `ListIssuesByStates` (shared `list` helper) so it satisfies `IssueStateLister`. ~16 `NewPoller` sites now construct via `NewPollerWithReconciliation` with explicit `ActiveStates`/`TerminalStates`. Because `fakeIssueTracker` is **not** an `IssueStateRefresher`, the reconcile refresh/revalidate paths no-op and `appendInactiveFromStateGroups` only ever lists state-filtered terminal/inactive groups (never an active candidate), so run-less dispatch behavior matches the old `NewPoller` construction verbatim.
- `TestRunPollLoopWakes…` → `TestRunPollLoopWithRuntimeWakesWhenContinuationRetryTimerFires`: rebuilt as a `*RuntimePoller` test over `RunPollLoopWithRuntime` (its `sleepOrRetryWake` retry-wake branch only fires for `*RuntimePoller`). Asserts the production fixed `1s` `continuationRetryDelay` drives the wake.
- `workflow_reloader_test.go`: 8 `NewRuntimePoller` constructions → a `newRuntimePollerForTest` helper over `NewRuntimePollerWithTrackerFactory`.
- `cmd/worker/main_test.go`: the required-symbol assertion now matches the exact production symbol `NewRuntimePollerWithTrackerFactory` (not the `NewRuntimePoller` substring).
- e2e `gitea_tracker_test.go` + `happypath_test.go`: pollers construct via `NewPollerWithReconciliation` with the tracker's own `ActiveStates`/`TerminalStates`.

### Acceptance criteria (#787)
- [x] `NewPoller`, `RunPollLoop`, and the `NewRuntimePoller` wrapper deleted.
- [x] Their tests retargeted at `NewPollerWithReconciliation` / `NewRuntimePollerWithTrackerFactory` / `RunPollLoopWithRuntime`.
- [x] `deadcode -test ./cmd/worker ./cmd/tui` no longer reports these symbols (verified before/after).

### Note: e2e dispatch path tightened (not a bare rename)
The old `NewPoller(client, orch)` left `ReconciliationConfig` zero-valued, so the e2e dispatch flowed only through the Gitea client's own active filtering. The retarget supplies explicit states, so the e2e now runs through the same `reconcileTick`/revalidation path production uses — a strict fidelity improvement. `TestGiteaTrackerIgnoresBacklogAndTerminalIssues` still asserts zero spawns; `…DedupesRepeatedPolls` still asserts one.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Pure dead-code deletion + test retargeting onto the existing production poll loop; no SPEC concept added or removed.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff is 3 files, **+4 / −62 LOC** (test files excluded).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `gofmt -l` clean + golangci-lint gate clean on touched packages
- [x] `go vet -tags e2e ./test/e2e/...` (e2e compiles; Docker suite not run locally)
- [x] `deadcode -test ./cmd/worker ./cmd/tui` — the three symbols are gone

## Notes
Pre-push dual diff-only review (Claude-family + Codex-family) both returned **MERGE-READY**, no HIGH/MEDIUM; only LOW informational notes (e2e fidelity note above; the `list`/`newRuntimePollerForTest` test helpers route through the production constructors, not a convenience-ctor smell).
