### PR TITLE
workspace: delete the zero-caller age-based Cleanup subsystem and its impossible runbook path (#789)

### DIFF
--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -372,9 +372,8 @@ the worker falls back to `AIOPS_WORKSPACE_ROOT` (legacy alias
 every retry and lets two tasks run concurrently without sharing a
 working tree. See the dedicated
 [workspace cache runbook](workspace-cache.md) for the on-disk layout,
-configuration knobs, and recommended cleanup cadence (the
-`(*workspace.Manager).Cleanup` API or removal of the effective
-workspace root once old tasks no longer matter).
+configuration knobs, and the recommended manual cleanup cadence
+(removing the effective workspace root once old tasks no longer matter).
 
 ## Running e2e tests locally
 

--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -240,26 +240,34 @@ recommended strategy is age-based pruning, gated on operator preference:
   rebuilt. `mod/` is intentionally shared and is not managed by workspace
   cleanup.
 
-The Go API for cleanup is `(*workspace.Manager).Cleanup(ctx, maxAge)`.
-It walks `$AIOPS_WORKSPACE_ROOT`, deletes each task directory whose mtime
-predates `now - maxAge`, and returns a `CleanupReport` with counts of
-removed/skipped/failed entries. It never touches the mirror cache.
+The worker exposes no in-process cleanup API and no scheduler; pruning is
+an out-of-band operator task.
 
 ### How to trigger cleanup
 
-There is no built-in scheduler. Pick one of the following based on how
-the worker is deployed:
+Delete stale per-task worktrees directly on disk between runs. The next
+task re-creates its worktree from the bare mirror (fast), so this is safe
+to run during any pause.
 
-1. **Cron / launchd**: schedule a tiny wrapper binary that calls
-   `workspace.New(root).Cleanup(ctx, 48*time.Hour)`. Suitable for the
-   personal daily workflow described in
-   [personal-daily-workflow.md](personal-daily-workflow.md).
-2. **Manual**: `rm -rf $AIOPS_WORKSPACE_ROOT/*` between long pauses works in
-   a pinch. The next task simply re-creates its worktree from the bare
-   mirror, which is fast.
-3. **Future hook**: a follow-up issue may wire `Cleanup` into the
-   worker's main loop (e.g. once per N completed tasks). Until that
-   lands, treat cleanup as an out-of-band concern.
+First confirm your **effective** workspace root: it is `workspace.root`
+from `WORKFLOW.md` when set, otherwise `$AIOPS_WORKSPACE_ROOT` (legacy
+`$WORKSPACE_ROOT`), otherwise the SPEC temp default. `go run ./cmd/worker
+--print-config <repo-clone>` prints the resolved value. Then prune that
+exact path — never an unset variable, or the glob below expands to `/*`
+and recurses into host directories:
+
+```sh
+# The :? guard makes the shell refuse to run rm when the root is unset or
+# empty, so the glob can never become "/*". Replace the env var with your
+# resolved workspace.root path if you do not deploy via AIOPS_WORKSPACE_ROOT.
+rm -rf "${AIOPS_WORKSPACE_ROOT:?set the workspace root before pruning}"/*
+```
+
+For age-based pruning, delete only the individual task directories under
+that root whose corresponding task is already `succeeded` or `failed` and
+that fall outside your chosen window (24h–72h for personal use; see the
+policy above). Never delete the bare mirrors under `$AIOPS_MIRROR_ROOT`:
+they are the long-lived cache that keeps worktree re-creation cheap.
 
 ## Cleanup containment invariant
 

--- a/internal/workspace/mirror.go
+++ b/internal/workspace/mirror.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -295,97 +294,4 @@ func cloneMirrorLocked(ctx context.Context, cloneURL, mirror string) (string, er
 	}
 	moved = true
 	return mirror, nil
-}
-
-// Cleanup removes per-task worktrees whose directory mtime is older than
-// maxAge. For each stale worktree we first try `git worktree remove --force`
-// against the owning mirror so the bare repo's administrative state is
-// cleaned up, then fall back to plain os.RemoveAll if git refuses (for
-// example when the mirror has been deleted out from under us).
-//
-// The function never returns an error for a single failed entry; it logs
-// the count of removed and failed entries via the returned CleanupReport so
-// callers can decide whether to surface a warning. Errors are only returned
-// for catastrophic conditions (root unreadable).
-//
-// maxAge <= 0 is treated as "remove everything", which is occasionally
-// useful from an operator CLI; callers that want a no-op should skip the
-// call entirely.
-func (m *Manager) Cleanup(ctx context.Context, maxAge time.Duration) (CleanupReport, error) {
-	report := CleanupReport{Threshold: maxAge}
-	cutoff := time.Now().Add(-maxAge)
-	entries, err := os.ReadDir(m.Root)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return report, nil
-		}
-		return report, fmt.Errorf("read workspace root: %w", err)
-	}
-	for _, repoEntry := range entries {
-		if !repoEntry.IsDir() {
-			continue
-		}
-		cleanupWorktreeDirs(ctx, filepath.Join(m.Root, repoEntry.Name()), cutoff, maxAge, &report)
-	}
-	return report, nil
-}
-
-func cleanupWorktreeDirs(ctx context.Context, dir string, cutoff time.Time, maxAge time.Duration, report *CleanupReport) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		report.Failed++
-		return
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		path := filepath.Join(dir, entry.Name())
-		if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
-			cleanupWorktree(ctx, path, cutoff, maxAge, report)
-			continue
-		}
-		cleanupWorktreeDirs(ctx, path, cutoff, maxAge, report)
-	}
-}
-
-func cleanupWorktree(ctx context.Context, taskDir string, cutoff time.Time, maxAge time.Duration, report *CleanupReport) {
-	info, err := os.Stat(taskDir)
-	if err != nil {
-		report.Failed++
-		return
-	}
-	if maxAge > 0 && info.ModTime().After(cutoff) {
-		report.Skipped++
-		return
-	}
-	if removeWorktree(ctx, taskDir) {
-		report.Removed++
-	} else {
-		report.Failed++
-	}
-}
-
-// removeWorktree best-effort detaches a task directory from its owning bare
-// mirror and deletes the on-disk path. It returns true when the directory
-// is gone after the call.
-func removeWorktree(ctx context.Context, taskDir string) bool {
-	// The worktree's gitdir file points at <mirror>/worktrees/<id>; we ask
-	// git itself to clean both sides via the worktree itself.
-	_ = runGit(ctx, taskDir, "worktree", "remove", "--force", ".")
-	if _, err := os.Stat(taskDir); err == nil {
-		if err := os.RemoveAll(taskDir); err != nil {
-			return false
-		}
-	}
-	return true
-}
-
-// CleanupReport summarises a Cleanup pass. It is intentionally tiny and
-// JSON-friendly so it can be logged or surfaced in a future ops CLI.
-type CleanupReport struct {
-	Threshold time.Duration `json:"threshold"`
-	Removed   int           `json:"removed"`
-	Skipped   int           `json:"skipped"`
-	Failed    int           `json:"failed"`
 }

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 	"unicode/utf8"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
@@ -1298,62 +1297,6 @@ type gitCmdError struct {
 
 func (e *gitCmdError) Error() string {
 	return strings.Join(e.Args, " ") + ": " + e.Err.Error() + "\n" + e.Out
-}
-
-func TestCleanup_RemovesOldWorktreesKeepsRecent(t *testing.T) {
-	upstream := initBareUpstream(t)
-	mgr := newTestManager(t)
-	ctx := context.Background()
-
-	old := makeTask("old", upstream)
-	recent := makeTask("recent", upstream)
-
-	oldDir, _, err := mgr.PrepareGitWorkspace(ctx, old)
-	if err != nil {
-		t.Fatalf("prepare old: %v", err)
-	}
-	recentDir, _, err := mgr.PrepareGitWorkspace(ctx, recent)
-	if err != nil {
-		t.Fatalf("prepare recent: %v", err)
-	}
-
-	// Backdate the "old" worktree so it sits well outside the cleanup
-	// threshold while "recent" stays inside it.
-	past := time.Now().Add(-48 * time.Hour)
-	if err := os.Chtimes(oldDir, past, past); err != nil {
-		t.Fatal(err)
-	}
-
-	report, err := mgr.Cleanup(ctx, 24*time.Hour)
-	if err != nil {
-		t.Fatalf("cleanup: %v", err)
-	}
-	if report.Removed != 1 {
-		t.Fatalf("expected 1 removal, got %+v", report)
-	}
-	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
-		t.Fatalf("old worktree still present at %s", oldDir)
-	}
-	if _, err := os.Stat(recentDir); err != nil {
-		t.Fatalf("recent worktree should still exist: %v", err)
-	}
-
-	// The mirror itself must survive cleanup so subsequent tasks reuse it.
-	mirror := mirrorPathFor(MirrorRoot(mgr.MirrorRoot), upstream)
-	if _, err := os.Stat(filepath.Join(mirror, "HEAD")); err != nil {
-		t.Fatalf("mirror lost during cleanup: %v", err)
-	}
-}
-
-func TestCleanup_MissingRootIsNotAnError(t *testing.T) {
-	mgr := &Manager{Root: filepath.Join(t.TempDir(), "does-not-exist")}
-	report, err := mgr.Cleanup(context.Background(), time.Hour)
-	if err != nil {
-		t.Fatalf("expected nil error for missing root, got %v", err)
-	}
-	if report.Removed != 0 || report.Failed != 0 {
-		t.Fatalf("expected empty report, got %+v", report)
-	}
 }
 
 func TestMirrorRoot_OverrideWins(t *testing.T) {


### PR DESCRIPTION
Closes #789

## Summary
Deletions-only sweep (2026-06-12 release-readiness audit). The age-based worktree **`Cleanup` subsystem** in `internal/workspace/mirror.go` had **zero non-test callers** and **no equivalent in the Symphony Elixir reference**, and its runbook documented an **impossible invocation path**: it told operators to schedule an external binary calling `workspace.New(root).Cleanup(...)`, but `internal/workspace` is a Go `internal` package no external binary can import. Per harness principles 1/6/7 the verdict is **delete, not wire up**.

## Changes
- **`mirror.go`** — delete `Manager.Cleanup`, `cleanupWorktreeDirs`, `cleanupWorktree`, `removeWorktree`, and the `CleanupReport` they populate (+ the now-unused `time` import). `runGit` stays (6+ other call sites).
- **`mirror_test.go`** — delete the two tests that were the subsystem's only consumers (`TestCleanup_RemovesOldWorktreesKeepsRecent`, `TestCleanup_MissingRootIsNotAnError`) and the now-unused `time` import.
- **`docs/runbooks/workspace-cache.md`** — rewrite "How to trigger cleanup" around the manual on-disk path (`rm -rf "$AIOPS_WORKSPACE_ROOT"/*` + age-based selective deletion). Remove the impossible wrapper-binary instructions and the "future hook" item.
- **`docs/runbooks/local-dev.md`** — reword the stale `(*workspace.Manager).Cleanup` API pointer to the manual cadence.
- **No replacement worker-loop cleanup hook is added** — intentional; that machinery is exactly the over-design upstream lacks (acceptance criterion 3).

Side benefit: the deleted `removeWorktree` was the one path that called `os.RemoveAll` on a per-task worktree **bypassing `workspace.SafeRemove`**; removing it makes the runbook's "Cleanup containment invariant" (all per-task deletions go through `SafeRemove`) strictly more accurate. The surviving production cleanup sites (`runtask.go::removeWorkdirAfterHookFailure`, `reconcile.go::removeWorkspace`) both use `SafeRemove`.

## Acceptance criteria (#789)
- [x] `Manager.Cleanup` + the three helpers and their tests deleted (and `CleanupReport`, orphaned by the deletion).
- [x] `workspace-cache.md` "How to trigger cleanup" rewritten around the manual path; impossible wrapper-binary instructions removed.
- [x] No replacement worker-loop hook added.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Pure deletions/doc-rewrites. No `internal/workflow/config.go` change and no newly-added orchestrator/worker file. Upstream Elixir has a `workspace.before_remove` lifecycle hook but **no age-based sweep** — confirming "delete, don't wire up".

## PR diff size budget
- [x] `within budget` — 1 production Go file (`mirror.go`) + 2 docs; net **−153 LOC** (18 insertions / 171 deletions). Test file excluded.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `go vet ./...` — clean
- [x] `go test -race -covermode=atomic ./...` — exit 0
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' ./scripts` — ok
- [x] `gofmt -l` clean; `go build ./cmd/worker ./cmd/tui` ok; `go mod tidy` clean
- [x] `deadcode -test ./...` reports no `Cleanup`/`removeWorktree` symbols

No mutation verification: this PR adds no production behavior (deletions only); the surviving worktree-prep/SafeRemove paths keep their existing coverage.

## Review
Pre-push dual diff-only reviewers on head `6aa4da2`, both **MERGE-READY** (no HIGH/MEDIUM): zero-caller/no-dangling-ref confirmed, imports correctly dropped, the `SafeRemove` containment invariant is *more* accurate after deletion, docs accurate (`rm -rf` idiom already used elsewhere in the runbook), and "delete, don't wire up" aligns with principles 1/6/7.

### Size gate
- [x] `within budget`

---
**Update — head `9b5624f`:** `@codex review` round 1 (on `6aa4da2`) flagged one P2: the `rm -rf "$AIOPS_WORKSPACE_ROOT"/*` snippet could expand to `rm -rf /*` when the root is unset (the worker may resolve `workspace.root`/a temp default instead of the env var; GNU `--preserve-root` only blocks the literal `/`). **Fixed**: the snippet now uses a `${ROOT:?}` guard (verified: unset/empty aborts `rm` with exit 127) and documents resolving the effective root via `--print-config`. Thread replied + resolved. Re-triggered `@codex review` on `9b5624f`.
