### PR TITLE
hardening: add panic recovery to the three unguarded goroutines; fix two letter-of-rule violations (#790)

### DIFF
--- a/internal/orchestrator/recover.go
+++ b/internal/orchestrator/recover.go
@@ -46,10 +46,11 @@ func recoverPanicValue(site string, r any) {
 // site updates do not have to repeat the `defer recoverPanic(...)`
 // boilerplate at every `go func()` call site.
 //
-// This is the narrow-scope close of #296 for the orchestrator package
-// only; the runner / worker / cmd-side `go func(` sites enumerated in
-// the issue are intentionally left for a follow-up. Inside the
-// orchestrator, every spawn now routes through here.
+// Inside the orchestrator, every spawn routes through here. Goroutines in
+// other packages (runner, workspace) install their own package-local
+// equivalent of recoverPanic — the orchestrator's is unexported — so the
+// recover-guard rule holds package by package; `cmd/*` goroutines are
+// exempt as package-main boot code.
 func safeGo(site string, fn func()) {
 	go func() {
 		defer recoverPanic(site)

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -57,6 +57,7 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 	stderrDone := make(chan struct{})
 	go func() {
 		defer close(stderrDone)
+		defer recoverPanic("runner.codex_app_server.stderr_drain")
 		_, _ = io.Copy(buf, stderr)
 	}()
 

--- a/internal/runner/recover.go
+++ b/internal/runner/recover.go
@@ -1,0 +1,27 @@
+package runner
+
+import (
+	"log"
+	"runtime/debug"
+)
+
+// recoverPanic is the runner package's process-survival guard for code on
+// goroutines the runner spawns directly (the SIGKILL backstop and the
+// app-server stderr drain). A panic that escaped one of those goroutines
+// would otherwise crash the whole worker process — taking every unrelated
+// in-flight run with it — instead of failing just the path that misbehaved
+// (AGENTS.md Conventions: every non-package-main `go func` installs a
+// recover guard).
+//
+// It is a package-local equivalent of the orchestrator's recoverPanic
+// (recover.go): that one is unexported, so the runner carries its own rather
+// than depending across the package boundary. The log shape matches so every
+// panic site emits the same SPEC §13.1-style structured line
+// (`event=panic site=<name>`) with an inline stack for diagnosis.
+//
+//	defer recoverPanic("runner.shell.sigkill_backstop")
+func recoverPanic(site string) {
+	if r := recover(); r != nil {
+		log.Printf("event=panic site=%s panic=%v stack=%q", site, r, string(debug.Stack()))
+	}
+}

--- a/internal/runner/recover_test.go
+++ b/internal/runner/recover_test.go
@@ -1,0 +1,48 @@
+package runner
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type syncLogBuffer struct {
+	buf *bytes.Buffer
+	mu  *sync.Mutex
+}
+
+func (w syncLogBuffer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+// TestRecoverPanicConfinesAndLogs asserts the package-local recoverPanic both
+// swallows a panic (the calling goroutine survives instead of crashing the
+// process) and emits the orchestrator-shaped structured line. If the
+// recover() inside recoverPanic is removed, the panic escapes this deferred
+// guard and crashes the test binary, so the test bites on the recover itself.
+func TestRecoverPanicConfinesAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	origOut, origFlags := log.Writer(), log.Flags()
+	log.SetOutput(syncLogBuffer{buf: &buf, mu: &mu})
+	log.SetFlags(0)
+	t.Cleanup(func() { log.SetOutput(origOut); log.SetFlags(origFlags) })
+
+	func() {
+		defer recoverPanic("runner.test_site")
+		panic("boom")
+	}()
+
+	mu.Lock()
+	got := buf.String()
+	mu.Unlock()
+	for _, want := range []string{"event=panic", "site=runner.test_site", "panic=boom", "stack="} {
+		if !strings.Contains(got, want) {
+			t.Errorf("recoverPanic log missing %q in:\n%s", want, got)
+		}
+	}
+}

--- a/internal/runner/shell_unix.go
+++ b/internal/runner/shell_unix.go
@@ -39,6 +39,7 @@ func terminateProcess(cmd *exec.Cmd) {
 	// SIGKILL to the whole group. cmd.WaitDelay only handles the
 	// direct child; grandchildren can survive otherwise.
 	go func(pid int) {
+		defer recoverPanic("runner.shell.sigkill_backstop")
 		time.Sleep(killGrace)
 		_ = syscall.Kill(-pid, syscall.SIGKILL)
 	}(cmd.Process.Pid)

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -98,7 +98,7 @@ func logWorkflowResolved(taskID, identifier string, res *workflow.Resolution) {
 	if len(res.ShadowedBy) > 0 {
 		parts = append(parts, "shadowed=["+strings.Join(res.ShadowedBy, ",")+"]")
 	}
-	LogTaskIDEventf(taskID, identifier, "workflow_resolved", "%s", strings.Join(parts, " "))
+	LogTaskIDEventf(taskID, identifier, task.EventWorkflowResolved, "%s", strings.Join(parts, " "))
 }
 
 func emitHookResults(ctx context.Context, ev EventEmitter, taskID, identifier string, results []workspace.HookResult) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -414,6 +414,7 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 	}
 	done := make(chan error, 1)
 	go func() {
+		defer recoverPanic("workspace.hook.cmd_wait")
 		done <- cmd.Wait()
 	}()
 
@@ -429,7 +430,7 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 		}
 	}
 	res := HookResult{Name: name, Command: command, ExitCode: exitCode(err), Output: out.String(), Truncated: out.Truncated(), Duration: time.Since(start), Err: err}
-	if runCtx.Err() == context.DeadlineExceeded {
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
 		res.Err = fmt.Errorf("hook timed out after %dms: %w", timeoutMs, runCtx.Err())
 		res.ExitCode = -1
 	}

--- a/internal/workspace/recover.go
+++ b/internal/workspace/recover.go
@@ -1,0 +1,24 @@
+package workspace
+
+import (
+	"log"
+	"runtime/debug"
+)
+
+// recoverPanic is the workspace package's process-survival guard for the
+// goroutine that drains a hook subprocess's exit via `done <- cmd.Wait()`.
+// A panic that escaped it would crash the whole worker process instead of
+// failing just the hook run (AGENTS.md Conventions: every non-package-main
+// `go func` installs a recover guard).
+//
+// It is a package-local equivalent of the orchestrator's recoverPanic
+// (orchestrator/recover.go), which is unexported; the log shape matches so
+// every panic site emits the same SPEC §13.1-style structured line
+// (`event=panic site=<name>`) with an inline stack for diagnosis.
+//
+//	defer recoverPanic("workspace.hook.cmd_wait")
+func recoverPanic(site string) {
+	if r := recover(); r != nil {
+		log.Printf("event=panic site=%s panic=%v stack=%q", site, r, string(debug.Stack()))
+	}
+}

--- a/internal/workspace/recover_test.go
+++ b/internal/workspace/recover_test.go
@@ -1,0 +1,48 @@
+package workspace
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type syncLogBuffer struct {
+	buf *bytes.Buffer
+	mu  *sync.Mutex
+}
+
+func (w syncLogBuffer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+// TestRecoverPanicConfinesAndLogs asserts the package-local recoverPanic both
+// swallows a panic (the calling goroutine survives instead of crashing the
+// process) and emits the orchestrator-shaped structured line. If the
+// recover() inside recoverPanic is removed, the panic escapes this deferred
+// guard and crashes the test binary, so the test bites on the recover itself.
+func TestRecoverPanicConfinesAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	origOut, origFlags := log.Writer(), log.Flags()
+	log.SetOutput(syncLogBuffer{buf: &buf, mu: &mu})
+	log.SetFlags(0)
+	t.Cleanup(func() { log.SetOutput(origOut); log.SetFlags(origFlags) })
+
+	func() {
+		defer recoverPanic("workspace.test_site")
+		panic("boom")
+	}()
+
+	mu.Lock()
+	got := buf.String()
+	mu.Unlock()
+	for _, want := range []string{"event=panic", "site=workspace.test_site", "panic=boom", "stack="} {
+		if !strings.Contains(got, want) {
+			t.Errorf("recoverPanic log missing %q in:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #790

## Summary
Consistency/hardening sweep (2026-06-12 release-readiness audit): bring the codebase into compliance with AGENTS.md's own stated rules. Three goroutines lacked the mandated panic recover guard and the deferral note pointed at a closed issue; plus two one-line letter-of-rule violations.

## Changes
- **Panic recovery for the three unguarded goroutines.** AGENTS.md requires every non-package-main `go func` to install a recover guard so a panic fails only its own path instead of crashing the whole worker. Added a **package-local `recoverPanic(site)`** to the runner and workspace packages — the orchestrator's `recoverPanic` is unexported, and this mirrors the existing in-tree precedent `recoverReaderPanic` (`runner/codex_app_server_transport.go`) — and installed `defer recoverPanic(...)` on:
  - `runner/shell_unix.go` SIGKILL backstop (`runner.shell.sigkill_backstop`)
  - `runner/codex_app_server.go` stderr drain (`runner.codex_app_server.stderr_drain`)
  - `workspace/manager.go` hook `cmd.Wait()` drain (`workspace.hook.cmd_wait`)

  After this, the only remaining unguarded `go func` sites are `cmd/*` package-main boot code (exempt by the rule).
- **`orchestrator/recover.go`**: rewrote the `safeGo` note so it no longer points at #296 (CLOSED 2026-05-23) and states the package-by-package guard model.
- **`runtask.go`**: use `task.EventWorkflowResolved` instead of the inline `"workflow_resolved"` literal.
- **`manager.go`**: classify the hook-timeout context error with `errors.Is` instead of `==` (clean-code rule 8; matches the shell runner path).

## Acceptance criteria (#790)
- [x] The three goroutines get a deferred recover (package-local equivalent of `recoverPanic`); `recover.go` no longer points at the closed #296.
- [x] `runtask.go` uses `task.EventWorkflowResolved`.
- [x] `manager.go` uses `errors.Is`.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Pure compliance hardening. No `internal/workflow/config.go` change; the two new files are in `internal/runner` and `internal/workspace` (the PR-metadata gate keys on new orchestrator/worker files, not these). The recover-guard pattern mirrors the orchestrator's existing `recoverPanic`/SPEC §7.4 survival model.

## PR diff size budget
- [x] `within budget` — 7 production Go files (2 new ~25-line recover helpers + 5 small edits), ~57 production LOC added. Test files excluded.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `go test -race -covermode=atomic ./...` — exit 0
- [x] `go vet ./...` — clean; `gofmt -l` clean; `go build ./cmd/worker ./cmd/tui` ok; `go mod tidy` clean
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' ./scripts` — ok
- [x] New `recover_test.go` in runner + workspace assert `recoverPanic` confines a panic AND logs the `event=panic site=… panic=… stack=…` line.

**Mutation verification:** with the fix committed, defeating `recover()` in each package's `recoverPanic` makes `TestRecoverPanicConfinesAndLogs` FAIL (`panic: boom [recovered, repanicked]` — the panic escapes the guard); `git checkout` restored, tree == HEAD. The two one-liners are behavior-preserving (`task.EventWorkflowResolved` == `"workflow_resolved"`; `errors.Is` equals `==` for the unwrapped context sentinel), so they carry no separate mutation target.

## Review
Pre-push dual diff-only reviewers on head `a541212`, both **MERGE-READY**. Verified: defer-LIFO order at the stderr drain is correct (`stderrDone` still closes), the `cmd.Wait()` goroutine cannot hang (buffered `done` + consumer's `runCtx.Done()` select), both one-liners behavior-preserving with imports present, the rewritten orchestrator note's claims all hold (class sweep found no other unguarded `go func` / stale literal), and the new tests bite on the recover (not the log). One LOW each: the test-only `syncLogBuffer` helper is duplicated across the two packages (acceptable — no shared test-support package warranted).

### Size gate
- [x] `within budget`
