### PR TITLE
orchestrator: pass the dispatcher into NewRuntimePollerWithTrackerFactory (#791)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -400,24 +400,16 @@ func run(ctx context.Context, args []string) error { //nolint:gocognit,funlen //
 		return err
 	}
 	readiness.MarkReady()
+	// SPEC §16.5 per-turn refresh wires through the dispatcher the actor
+	// actually spawns workers with — the same instance handed to Deps.Dispatcher
+	// above — so the tracker fan-in the poller rebuilds each tick lands where
+	// Spawn reads it and operator-cancel takes effect on the current poll tick.
 	poller, err := orchestrator.NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (orchestrator.IssueStateLister, error) {
 		return trackerClientForWorkflow(cfg)
-	}, orch, runtime, cfg, worker.LogEventEmitter{})
+	}, orch, runtime, dispatcher)
 	if err != nil {
 		return err
 	}
-	// SPEC §16.5 per-turn refresh wires through the dispatcher the actor
-	// actually spawns workers with (the line-298 instance), not the one
-	// NewRuntimePollerWithTrackerFactory creates internally. Without this
-	// the tracker fan-in built each tick would only update the poller's
-	// own (unused) dispatcher and operator-cancel would still wait for
-	// the next poll tick. Must precede RunPollLoopWithRuntime below so
-	// the first PollOnce sees the external dispatcher; this is safe today
-	// because OrchestratorState is freshly constructed with no claimed
-	// issues, so the actor cannot Spawn before the poll loop drives it.
-	// Any future persisted-state recovery added before this point must
-	// move AttachDispatcher above it.
-	poller.AttachDispatcher(dispatcher)
 	go func() {
 		if err := orchestrator.RunWorkflowReloadLoop(ctx, runtime, orchestrator.WorkflowReloadLoopOptions{}); err != nil && ctx.Err() == nil {
 			log.Printf("workflow reload loop exited: %v", err)

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -18,17 +18,21 @@ type RuntimePoller struct {
 	trackerFactory func(workflow.Config) (IssueStateLister, error)
 	orchestrator   *Orchestrator
 	runtime        *WorkflowRuntime
-	config         worker.Config
-	emitter        worker.EventEmitter
 
-	mu               sync.Mutex
-	poller           *Poller
-	dispatcher       *RuntimeDispatcher
-	lastSnapshotKey  string
-	currentRefresher IssueStateRefresher
+	mu              sync.Mutex
+	poller          *Poller
+	dispatcher      *RuntimeDispatcher
+	lastSnapshotKey string
 }
 
-func NewRuntimePollerWithTrackerFactory(trackerFactory func(workflow.Config) (IssueStateLister, error), orchestrator *Orchestrator, runtime *WorkflowRuntime, cfg worker.Config, emitter worker.EventEmitter) (*RuntimePoller, error) {
+// NewRuntimePollerWithTrackerFactory builds the runtime poll loop over the
+// dispatcher the actor spawns workers through. dispatcher must be the same
+// *RuntimeDispatcher handed to orchestrator.Deps.Dispatcher (the actor attaches
+// itself to it in New): the poller re-points the SPEC §16.5 per-turn refresh
+// hook at this dispatcher on every workflow-snapshot reload, so a separate
+// instance would leave the actor's dispatcher without a refresher and stall
+// operator-cancel until the next poll tick (#791).
+func NewRuntimePollerWithTrackerFactory(trackerFactory func(workflow.Config) (IssueStateLister, error), orchestrator *Orchestrator, runtime *WorkflowRuntime, dispatcher *RuntimeDispatcher) (*RuntimePoller, error) {
 	if trackerFactory == nil {
 		return nil, errors.New("runtime poller requires tracker factory")
 	}
@@ -38,42 +42,16 @@ func NewRuntimePollerWithTrackerFactory(trackerFactory func(workflow.Config) (Is
 	if runtime == nil {
 		return nil, errors.New("runtime poller requires workflow runtime")
 	}
-	dispatcher, err := NewRuntimeDispatcher(runtime, cfg, emitter)
-	if err != nil {
-		return nil, err
+	if dispatcher == nil {
+		return nil, errors.New("runtime poller requires dispatcher")
 	}
-	dispatcher.AttachOrchestrator(orchestrator)
-	rp := &RuntimePoller{trackerFactory: trackerFactory, orchestrator: orchestrator, runtime: runtime, config: cfg, emitter: emitter, dispatcher: dispatcher}
+	rp := &RuntimePoller{trackerFactory: trackerFactory, orchestrator: orchestrator, runtime: runtime, dispatcher: dispatcher}
 	initialPoller, err := rp.pollerForSnapshot(runtime.Current())
 	if err != nil {
 		return nil, err
 	}
 	rp.poller = initialPoller
 	return rp, nil
-}
-
-// AttachDispatcher rewires the dispatcher the RuntimePoller updates when
-// it builds a new tracker fan-in. Callers that construct their own
-// *RuntimeDispatcher externally (and pass it to orchestrator.Deps.Dispatcher
-// so the actor's Spawn uses it) must call this — otherwise the SPEC §16.5
-// refresher would land on the poller's internal dispatcher, which the
-// actor never sees. Passing nil is a no-op so tests that do not exercise
-// the refresher path can keep their existing construction.
-//
-// The poller copies its most recent tracker refresher onto the freshly
-// attached dispatcher so callers don't have to wait for the next workflow
-// snapshot change before the refresher hook activates.
-func (p *RuntimePoller) AttachDispatcher(d *RuntimeDispatcher) {
-	if p == nil || d == nil {
-		return
-	}
-	p.mu.Lock()
-	p.dispatcher = d
-	carry := p.currentRefresher
-	p.mu.Unlock()
-	if carry != nil {
-		d.SetIssueStateRefresher(carry)
-	}
 }
 
 func (p *RuntimePoller) PollOnce(ctx context.Context) error {
@@ -123,12 +101,11 @@ func (p *RuntimePoller) pollerForSnapshot(snap WorkflowSnapshot) (*Poller, error
 	p.lastSnapshotKey = key
 	// Concrete tracker clients (Linear/Gitea/GitHub) implement IssueStateRefresher;
 	// a bare lister (e.g. a test fake) does not, in which case the §11.2/§16.5
-	// refresh hooks no-op on a nil refresher.
+	// refresh hooks no-op on a nil refresher. dispatcher is the actor's own
+	// dispatcher (constructor invariant), so the refresher lands where Spawn
+	// reads it.
 	refresher, _ := trackerClient.(IssueStateRefresher)
-	p.currentRefresher = refresher
-	if p.dispatcher != nil {
-		p.dispatcher.SetIssueStateRefresher(refresher)
-	}
+	p.dispatcher.SetIssueStateRefresher(refresher)
 	poller := NewPollerWithReconciliation(trackerClient, p.orchestrator, snap.Reconciliation)
 	preflightCfg := snap.Workflow.Config
 	poller.preflight = &preflightCfg

--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
@@ -243,51 +244,67 @@ func TestRuntimeDispatcherConfigForSnapshotReturnsNilWithoutRefresher(t *testing
 	}
 }
 
-// TestRuntimePollerAttachDispatcherCarriesCurrentRefresher pins the
-// cmd/worker/main.go startup sequence: NewRuntimePollerWithTrackerFactory
-// builds the initial tracker fan-in (and SetIssueStateRefresher's it
-// onto its internal dispatcher) before the caller has a chance to
-// AttachDispatcher with the external dispatcher used by the actor. The
-// attach call must replay the current refresher so the first PollOnce
-// — which sees an unchanged snapshot key and short-circuits the
-// SetIssueStateRefresher path — does not leave the actor's dispatcher
-// without a refresher.
-func TestRuntimePollerAttachDispatcherCarriesCurrentRefresher(t *testing.T) {
-	stub := &stubRefresher{states: map[string]string{"issue-1": "In Progress"}}
-	internal := &RuntimeDispatcher{}
-	rp := &RuntimePoller{dispatcher: internal}
-	// Simulate pollerForSnapshot having stored the multiLister.
-	rp.mu.Lock()
-	rp.currentRefresher = stub
-	rp.mu.Unlock()
-	internal.SetIssueStateRefresher(stub)
+// TestRuntimePollerWiresRefresherOntoProvidedDispatcher pins #791: the
+// dispatcher the actor spawns workers through is passed into
+// NewRuntimePollerWithTrackerFactory, and the poller points the SPEC §16.5
+// per-turn refresh hook at *that* dispatcher (no separate internal instance,
+// no post-construction AttachDispatcher). Construction alone runs the initial
+// pollerForSnapshot, which must leave the provided dispatcher carrying the
+// factory's tracker as its refresher and producing a refresh that calls
+// through to it. A regression that built its own dispatcher would leave this
+// one's refresher nil.
+func TestRuntimePollerWiresRefresherOntoProvidedDispatcher(t *testing.T) {
+	ctx := context.Background()
+	path := writeWorkflowForReloadTest(t, "linear", 30000)
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load initial workflow: %v", err)
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeIssueStateTracker{}
+	trackerClient.setFetchIDStates(map[string]string{"issue-1": "In Progress"})
 
-	external := &RuntimeDispatcher{}
-	rp.AttachDispatcher(external)
-	if external.currentRefresher() == nil {
-		t.Fatal("AttachDispatcher did not carry the current refresher onto the external dispatcher")
+	dispatcher, err := NewRuntimeDispatcher(runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime dispatcher: %v", err)
+	}
+	// Same dispatcher to the actor (Deps.Dispatcher) and the poller, mirroring
+	// cmd/worker/main.go.
+	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+	if _, err := NewRuntimePollerWithTrackerFactory(func(workflow.Config) (IssueStateLister, error) {
+		return trackerClient, nil
+	}, orch, runtime, dispatcher); err != nil {
+		t.Fatalf("new runtime poller: %v", err)
+	}
+
+	if got := dispatcher.currentRefresher(); got != IssueStateRefresher(trackerClient) {
+		t.Fatalf("dispatcher.currentRefresher() = %v, want the factory's tracker %v; constructor must wire the refresher onto the provided dispatcher", got, trackerClient)
 	}
 
 	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
 		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress"}},
 	}}}
-	cfg := external.configForSnapshot(snap)
+	cfg := dispatcher.configForSnapshot(snap)
 	if cfg.IssueStateRefresher == nil {
-		t.Fatal("external dispatcher has no IssueStateRefresher factory after AttachDispatcher")
+		t.Fatal("provided dispatcher has no IssueStateRefresher factory after construction")
 	}
 	fn := cfg.IssueStateRefresher(task.Task{ID: "issue-1"}, snap.Workflow.Config)
 	if fn == nil {
-		t.Fatal("factory returned nil for valid task on external dispatcher")
+		t.Fatal("factory returned nil for valid task on provided dispatcher")
 	}
-	snapshot, err := fn(context.Background())
+	snapshot, err := fn(ctx)
 	if err != nil {
 		t.Fatalf("refresher err: %v", err)
 	}
 	if !snapshot.Active || !snapshot.Found || snapshot.State != "In Progress" {
-		t.Fatalf("snapshot = %+v, want found active In Progress; external dispatcher should call through to the stub refresher", snapshot)
+		t.Fatalf("snapshot = %+v, want found active In Progress; provided dispatcher should call through to the factory's tracker", snapshot)
 	}
-	if len(stub.calls) == 0 {
-		t.Fatal("stub refresher never invoked; external dispatcher is wired to a different tracker")
+	if len(trackerClient.fetchIssueStatesByRefsCalls()) == 0 {
+		t.Fatal("tracker refresher never invoked; provided dispatcher is wired to a different tracker")
 	}
 }
 

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -23,9 +23,18 @@ import (
 // to the test fake.
 func newRuntimePollerForTest(t *testing.T, lister IssueStateLister, orch *Orchestrator, runtime *WorkflowRuntime) *RuntimePoller {
 	t.Helper()
+	// These reload tests dispatch through the actor's own fakeDispatcher; the
+	// poller only needs a *RuntimeDispatcher to receive SetIssueStateRefresher,
+	// so a standalone instance is sufficient. The actor's-dispatcher-is-the-
+	// poller's-dispatcher invariant is pinned by
+	// TestRuntimePollerWiresRefresherOntoProvidedDispatcher.
+	dispatcher, err := NewRuntimeDispatcher(runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime dispatcher: %v", err)
+	}
 	poller, err := NewRuntimePollerWithTrackerFactory(func(workflow.Config) (IssueStateLister, error) {
 		return lister, nil
-	}, orch, runtime, worker.Config{}, nil)
+	}, orch, runtime, dispatcher)
 	if err != nil {
 		t.Fatalf("new runtime poller: %v", err)
 	}
@@ -368,10 +377,14 @@ func TestRuntimePollerRebuildsTrackerClientAfterTrackerConfigReload(t *testing.T
 	dispatcher := &fakeDispatcher{}
 	orch, cancel := startActor(t, Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	defer cancel()
+	runtimeDispatcher, err := NewRuntimeDispatcher(runtime, worker.Config{}, nil)
+	if err != nil {
+		t.Fatalf("new runtime dispatcher: %v", err)
+	}
 	poller, err := NewRuntimePollerWithTrackerFactory(func(cfg workflow.Config) (IssueStateLister, error) {
 		factoryCalls++
 		return trackersByKind[cfg.Tracker.Kind], nil
-	}, orch, runtime, worker.Config{}, nil)
+	}, orch, runtime, runtimeDispatcher)
 	if err != nil {
 		t.Fatalf("new runtime poller: %v", err)
 	}
@@ -382,6 +395,13 @@ func TestRuntimePollerRebuildsTrackerClientAfterTrackerConfigReload(t *testing.T
 	waitFor(t, func() bool { return dispatcher.count() == 1 }, time.Second)
 	if got := dispatcher.issueAt(0).ID; got != "linear-ready" {
 		t.Fatalf("first dispatched issue = %q, want linear-ready", got)
+	}
+	// The SPEC §16.5 refresher must track the rebuilt tracker client on the
+	// poller's dispatcher across reloads, not just at construction: pin it to
+	// the linear client now and the gitea client after reload so a regression
+	// that re-points the refresher only on first construction is caught.
+	if got := runtimeDispatcher.currentRefresher(); got != IssueStateRefresher(trackersByKind["linear"]) {
+		t.Fatalf("refresher after first poll = %v, want linear tracker client", got)
 	}
 
 	dispatcher.finishAt(0, WorkerResult{Elapsed: time.Millisecond})
@@ -395,6 +415,9 @@ func TestRuntimePollerRebuildsTrackerClientAfterTrackerConfigReload(t *testing.T
 	waitFor(t, func() bool { return dispatcher.count() == 2 }, time.Second)
 	if got := dispatcher.issueAt(1).ID; got != "gitea-rework" {
 		t.Fatalf("second dispatched issue after tracker config reload = %q, want gitea-rework", got)
+	}
+	if got := runtimeDispatcher.currentRefresher(); got != IssueStateRefresher(trackersByKind["gitea"]) {
+		t.Fatalf("refresher after tracker config reload = %v, want gitea tracker client; reload path must re-point the dispatcher refresher", got)
 	}
 	if factoryCalls < 2 {
 		t.Fatalf("tracker factory calls = %d, want at least 2 after tracker config reload", factoryCalls)


### PR DESCRIPTION
Closes #791

## Summary
- `NewRuntimePollerWithTrackerFactory` built its **own** `*RuntimeDispatcher` (and `AttachOrchestrator`'d it), which production immediately discarded: `cmd/worker/main.go` builds the real dispatcher the actor spawns through (and hands to `orchestrator.Deps.Dispatcher` + `WorkspaceCleaner`), then had to call `poller.AttachDispatcher(dispatcher)` to shadow the internal one. Omitting that rewire was a silent behavior bug — the SPEC §16.5 per-turn refresher would land on the unused internal dispatcher and operator-cancel would wait for the next poll tick. Classic footgun (clean-code rules 3/11).
- **Root cause / delta:** make `dispatcher *RuntimeDispatcher` a required constructor parameter; production passes the same instance it gives the actor. The actor `AttachOrchestrator`'s it synchronously in `New` (`actor.go:164`) before the poller is built, so the constructor no longer re-attaches.
- Deletes `AttachDispatcher` + its refresher-carry logic (the `currentRefresher` field), the now-dead `config`/`emitter` `RuntimePoller` fields, the always-true `dispatcher != nil` guard, and the `main.go` ordering comment that documented the footgun.

### Acceptance criteria
- [x] dispatcher is a parameter of `NewRuntimePollerWithTrackerFactory`; production passes the one dispatcher the actor uses.
- [x] `AttachDispatcher` and its refresher-carry logic deleted; the `main.go` ordering comment goes with it.
- [x] `NewRuntimePoller` test-wrapper situation resolved consistently with #787 — already merged via #815 (it deleted the wrapper), so no cross-PR coordination remains.

### Mutation verification
- `TestRuntimePollerWiresRefresherOntoProvidedDispatcher` (new) — drives the real param path; fails when the constructor wires the §16.5 refresher onto anything other than the **provided** dispatcher (verified by making the constructor build its own → `currentRefresher() = nil`).
- `TestRuntimePollerRebuildsTrackerClientAfterTrackerConfigReload` (augmented per pre-push Codex review) — now pins the **reload seam**: asserts the dispatcher's refresher tracks the rebuilt tracker client across a linear→gitea reload, not just at construction. Verified by guarding `SetIssueStateRefresher` behind first-construction-only → reload assertion fails.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Pure constructor-wiring simplification of an existing aiops-platform extension; the SPEC §16.5 refresh behavior is preserved (now wired directly instead of via a discard+rewire). All four files are modifications — the PR-metadata "newly-added orchestrator/worker file" trigger does not fire and `internal/workflow/config.go` is untouched.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 2 production files (`runtime_poller.go`, `main.go`), net negative LOC. The other two files are tests.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + golangci-lint (orchestrator+worker) 0 issues
- [x] pre-push dual review (Claude code-reviewer + Codex adversarial): both converged; Codex's one finding (untested reload seam) is folded in above.

## Notes
Adjacent-path check: the same dispatcher is still passed as `Deps.Dispatcher` and `WorkspaceCleaner` in `main.go` — unchanged; the poller is just a third consumer of the same object.