### PR TITLE
stateapi: extract /api/v1/state wire DTOs into a shared internal/stateapi (worker + TUI)

### DIFF
--- a/cmd/tui/layout_test.go
+++ b/cmd/tui/layout_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 )
 
 // visibleString strips ANSI escape sequences so tests can reason about the
@@ -96,14 +98,14 @@ func TestFormatRunningRow_TokensDoNotCorruptAlignment(t *testing.T) {
 	const eventWidth = 44
 	wantWidth := fixedRunningWidth() + chromeWidth + eventWidth // 66 + 10 + 44 = 120
 
-	r := runningEntry{
+	r := stateapi.Running{
 		Identifier:        "ENG-1234",
 		State:             "running",
 		SessionID:         "sess-1", // short → no "..." from the session cell
 		TurnCount:         7,
 		LastEvent:         "codex/event/token_count",
 		StartedAt:         &started,
-		Tokens:            tokenInfo{TotalTokens: 1_000_000_000}, // "1,000,000,000" = 13 runes
+		Tokens:            stateapi.RunningTokens{TotalTokens: 1_000_000_000}, // "1,000,000,000" = 13 runes
 		CodexAppServerPID: 12345,
 	}
 
@@ -118,18 +120,18 @@ func TestFormatRunningRow_TokensDoNotCorruptAlignment(t *testing.T) {
 
 // ── acceptance criteria: readable at 80 / 100 / 120 columns ─────────────────
 
-func representativeState(now time.Time) *stateResponse {
+func representativeState(now time.Time) *stateapi.StateResponse {
 	started := now.Add(-3600 * time.Second)
 	due := now.Add(30 * time.Second)
-	return &stateResponse{
+	return &stateapi.StateResponse{
 		MaxConcurrentAgents: 10,
-		Counts: stateCounts{
-			CompletedTotal:                     12,
-			AgentHandoffReconcileStoppedTotal:  3,
-			AgentHandoffReconcileStoppedRecent: 2,
+		Counts: stateapi.Counts{
+			CompletedTotal:                    12,
+			AgentHandoffReconcileStoppedTotal: 3,
+			AgentHandoffReconcileStopped:      2,
 		},
-		CodexTotals: codexTotals{InputTokens: 123456, OutputTokens: 654321, TotalTokens: 1_000_000_000, SecondsRunning: 3600},
-		Running: []runningEntry{{
+		CodexTotals: stateapi.CodexTotals{InputTokens: 123456, OutputTokens: 654321, TotalTokens: 1_000_000_000, SecondsRunning: 3600},
+		Running: []stateapi.Running{{
 			Identifier:        "ENG-1234",
 			State:             "running",
 			SessionID:         "01HXAYZ-very-long-session-identifier-0001",
@@ -138,10 +140,10 @@ func representativeState(now time.Time) *stateResponse {
 			LastMessage:       "notification", // the word that wrapped (noti / fication) in #466
 			StartedAt:         &started,
 			LastEventAt:       &now,
-			Tokens:            tokenInfo{TotalTokens: 1_000_000_000},
+			Tokens:            stateapi.RunningTokens{TotalTokens: 1_000_000_000},
 			CodexAppServerPID: 12345,
 		}},
-		Retrying: []retryEntry{{
+		Retrying: []stateapi.Retry{{
 			Identifier: "ENG-9999",
 			Attempt:    2,
 			DueAt:      &due,
@@ -178,7 +180,7 @@ func TestRenderFrame_StaysWithinTerminalWidth(t *testing.T) {
 // assertFrameWithinWidth renders the frame and checks that no line exceeds the
 // terminal width and that the (over-long) rate-limits line was clipped to fill
 // it — proving the policy engaged at this width and the line did not wrap.
-func assertFrameWithinWidth(t *testing.T, state *stateResponse, now time.Time, width int) {
+func assertFrameWithinWidth(t *testing.T, state *stateapi.StateResponse, now time.Time, width int) {
 	t.Helper()
 	lines := strings.Split(renderFrame(state, nil, now, 100, "http://127.0.0.1:4001", 5*time.Second), "\n")
 	for _, line := range lines {

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 )
 
 // ANSI escape codes (mirrors Elixir @ansi_* module attributes)
@@ -93,7 +95,7 @@ func main() {
 		}
 	}()
 
-	fetch := func(ctx context.Context) (*stateResponse, error) {
+	fetch := func(ctx context.Context) (*stateapi.StateResponse, error) {
 		return fetchStateWithAuth(ctx, client, stateURL, authToken)
 	}
 
@@ -128,7 +130,7 @@ func raiseAfterSignal(sig os.Signal) {
 // run drives the poll/render loop until ctx is cancelled (signal or otherwise),
 // restoring terminal state on the way out so an interrupted dashboard never
 // leaves the real terminal in alt-screen / cursor-hidden state.
-func run(ctx context.Context, scr *screen, fetch func(context.Context) (*stateResponse, error), interval time.Duration, baseURL string) { //nolint:gocognit // baseline (#521)
+func run(ctx context.Context, scr *screen, fetch func(context.Context) (*stateapi.StateResponse, error), interval time.Duration, baseURL string) { //nolint:gocognit // baseline (#521)
 	scr.enter()
 	defer scr.restore()
 
@@ -140,7 +142,7 @@ func run(ctx context.Context, scr *screen, fetch func(context.Context) (*stateRe
 	// at the new width without issuing another fetch.
 	var (
 		haveSnapshot bool
-		lastState    *stateResponse
+		lastState    *stateapi.StateResponse
 		lastErr      error
 		lastNow      time.Time
 	)

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 )
 
 // ── formatCount / groupThousands ──────────────────────────────────────────────
@@ -155,7 +157,7 @@ func TestCell_PadsShortStrings(t *testing.T) {
 }
 
 func TestFormatRetryRowIncludesQuotaBackoffKind(t *testing.T) {
-	got := formatRetryRow(retryEntry{
+	got := formatRetryRow(stateapi.Retry{
 		IssueID:    "issue-1",
 		Identifier: "ENG-1",
 		Attempt:    1,
@@ -171,7 +173,7 @@ func TestFormatRetryRowIncludesQuotaBackoffKind(t *testing.T) {
 }
 
 func TestFormatRetryRowDefaultsKindToFailure(t *testing.T) {
-	got := formatRetryRow(retryEntry{IssueID: "issue-1", Identifier: "ENG-1", Attempt: 1})
+	got := formatRetryRow(stateapi.Retry{IssueID: "issue-1", Identifier: "ENG-1", Attempt: 1})
 	if !strings.Contains(got, "kind=failure") {
 		t.Fatalf("formatRetryRow missing default failure kind: %q", got)
 	}
@@ -233,6 +235,73 @@ func TestFetchState_ParsesValidResponse(t *testing.T) {
 	}
 	if state.PollIntervalMs != 5000 {
 		t.Errorf("PollIntervalMs = %d, want 5000", state.PollIntervalMs)
+	}
+}
+
+// TestFetchState_DecodesSharedContractFields is the consumer half of the #793
+// anti-drift guard: the TUI now decodes /api/v1/state into the same
+// stateapi types the worker marshals, so a JSON-tag change is observable here
+// as a dropped value rather than a silently blank dashboard. It pins every
+// field the dashboard renders — handoff counts, per-row token totals, retry
+// kind, codex totals, and the nested rate-limit bucket — so a tag typo on any
+// of them fails this test (and the worker-side runbook drift test), not the
+// rendered UI.
+func TestFetchState_DecodesSharedContractFields(t *testing.T) {
+	body := `{
+	  "poll_interval_ms": 5000,
+	  "max_concurrent_agents": 4,
+	  "counts": {"completed_total": 12, "agent_handoff_reconcile_stopped_total": 3, "agent_handoff_reconcile_stopped": 2},
+	  "running": [{"issue_id": "i1", "issue_identifier": "ENG-1", "state": "In Progress", "session_id": "sess-1", "turn_count": 7, "last_event": "turn_completed", "last_message": "working", "started_at": "2026-05-21T09:09:55Z", "codex_app_server_pid": 12345, "tokens": {"total_tokens": 2000}}],
+	  "retrying": [{"issue_id": "i2", "attempt": 2, "due_at": "2026-05-21T09:11:00Z", "error": "retry soon", "kind": "quota_backoff"}],
+	  "codex_totals": {"total_tokens": 300, "seconds_running": 1.5},
+	  "rate_limits": {"limit_id": "lim", "primary": {"remaining": 42, "limit": 100}}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	state, err := fetchState(context.Background(), &http.Client{}, srv.URL)
+	if err != nil {
+		t.Fatalf("fetchState() error = %v", err)
+	}
+	if got := state.Counts.AgentHandoffReconcileStopped; got != 2 {
+		t.Errorf("Counts.AgentHandoffReconcileStopped = %d, want 2 (agent_handoff_reconcile_stopped tag)", got)
+	}
+	if got := state.Counts.CompletedTotal; got != 12 {
+		t.Errorf("Counts.CompletedTotal = %d, want 12 (completed_total tag)", got)
+	}
+	// Pin every running-row field the dashboard renders (render.go formatRunningRow)
+	// so a tag typo on any of them fails here rather than blanking a column.
+	if len(state.Running) != 1 {
+		t.Fatalf("Running = %+v, want one row", state.Running)
+	}
+	r := state.Running[0]
+	if r.IssueID != "i1" || r.Identifier != "ENG-1" || r.State != "In Progress" || r.SessionID != "sess-1" ||
+		r.TurnCount != 7 || r.LastEvent != "turn_completed" || r.LastMessage != "working" ||
+		r.CodexAppServerPID != 12345 || r.Tokens.TotalTokens != 2000 {
+		t.Errorf("Running[0] = %+v, want every rendered field decoded (issue_id/identifier/state/session_id/turn_count/last_event/last_message/codex_app_server_pid/tokens.total_tokens tags)", r)
+	}
+	if r.StartedAt == nil || !r.StartedAt.Equal(time.Date(2026, 5, 21, 9, 9, 55, 0, time.UTC)) {
+		t.Errorf("Running[0].StartedAt = %v, want decoded started_at", r.StartedAt)
+	}
+	// Pin every retry-row field the dashboard renders (render.go formatRetryRow).
+	if len(state.Retrying) != 1 {
+		t.Fatalf("Retrying = %+v, want one row", state.Retrying)
+	}
+	rt := state.Retrying[0]
+	if rt.Attempt != 2 || rt.Error != "retry soon" || rt.Kind != "quota_backoff" || rt.DueAt == nil {
+		t.Errorf("Retrying[0] = %+v, want attempt/error/kind/due_at decoded", rt)
+	}
+	if state.CodexTotals.TotalTokens != 300 || state.CodexTotals.SecondsRunning != 1.5 {
+		t.Errorf("CodexTotals = %+v, want total_tokens=300 seconds_running=1.5", state.CodexTotals)
+	}
+	// The dashboard renders the bucket via formatRateLimits, which reads the
+	// decoded map; assert the nested object survived decoding into map[string]any.
+	primary, ok := state.RateLimits["primary"].(map[string]any)
+	if !ok || primary["remaining"] != float64(42) {
+		t.Errorf("RateLimits[\"primary\"] = %#v, want decoded bucket with remaining=42", state.RateLimits["primary"])
 	}
 }
 
@@ -387,8 +456,8 @@ func TestRun_RestoresTerminalOnSignal(t *testing.T) {
 	var buf bytes.Buffer
 	scr := newScreen(&buf, true /* isTTY */, false /* raw */)
 
-	fetch := func(ctx context.Context) (*stateResponse, error) {
-		return &stateResponse{MaxConcurrentAgents: 3}, nil
+	fetch := func(ctx context.Context) (*stateapi.StateResponse, error) {
+		return &stateapi.StateResponse{MaxConcurrentAgents: 3}, nil
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -438,7 +507,9 @@ func TestRun_CancelDuringFetchAbortsAndRestores(t *testing.T) {
 		<-fctx.Done()
 		return fctx.Err()
 	}
-	fetchState := func(fctx context.Context) (*stateResponse, error) { return &stateResponse{}, fetch(fctx) }
+	fetchState := func(fctx context.Context) (*stateapi.StateResponse, error) {
+		return &stateapi.StateResponse{}, fetch(fctx)
+	}
 
 	done := make(chan struct{})
 	go func() {

--- a/cmd/tui/render.go
+++ b/cmd/tui/render.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 )
 
 // Column widths (mirrors Elixir @running_*_width constants)
@@ -33,7 +35,7 @@ const (
 
 // safeRenderFrame wraps renderFrame with panic recovery, mirroring the
 // `rescue` blocks in status_dashboard.ex (maybe_render/1, render_content/3).
-func safeRenderFrame(state *stateResponse, fetchErr error, now time.Time, tps float64, baseURL string, interval time.Duration) (out string) {
+func safeRenderFrame(state *stateapi.StateResponse, fetchErr error, now time.Time, tps float64, baseURL string, interval time.Duration) (out string) {
 	defer func() {
 		if r := recover(); r != nil {
 			out = clipFrame([]string{
@@ -49,7 +51,7 @@ func safeRenderFrame(state *stateResponse, fetchErr error, now time.Time, tps fl
 // ── Rendering ────────────────────────────────────────────────────────────────
 // Mirrors format_snapshot_content/2 in status_dashboard.ex.
 
-func renderFrame(state *stateResponse, fetchErr error, now time.Time, tps float64, baseURL string, interval time.Duration) string { //nolint:gocognit,funlen // baseline (#521)
+func renderFrame(state *stateapi.StateResponse, fetchErr error, now time.Time, tps float64, baseURL string, interval time.Duration) string { //nolint:gocognit,funlen // baseline (#521)
 	if fetchErr != nil {
 		return clipFrame([]string{
 			colorize("╭─ AIOPS STATUS", ansiBold),
@@ -77,7 +79,7 @@ func renderFrame(state *stateResponse, fetchErr error, now time.Time, tps float6
 			colorize("completed "+formatCount(state.Counts.CompletedTotal), ansiGreen) +
 			colorize(" | ", ansiGray) +
 			colorize("agent "+formatCount(state.Counts.AgentHandoffReconcileStoppedTotal), ansiGreen) +
-			colorize(" (recent "+formatCount(int64(state.Counts.AgentHandoffReconcileStoppedRecent))+")", ansiGray),
+			colorize(" (recent "+formatCount(int64(state.Counts.AgentHandoffReconcileStopped))+")", ansiGray),
 		colorize("│ Throughput: ", ansiBold) + colorize(formatTPS(tps)+" tps", ansiCyan),
 		colorize("│ Runtime:    ", ansiBold) + colorize(formatRuntimeSecs(state.CodexTotals.SecondsRunning), ansiMagenta),
 		colorize("│ Tokens:     ", ansiBold) +
@@ -165,7 +167,7 @@ func fixedRunningWidth() int {
 }
 
 // formatRunningRow mirrors format_running_summary/2.
-func formatRunningRow(r runningEntry, now time.Time, eventWidth int) string {
+func formatRunningRow(r stateapi.Running, now time.Time, eventWidth int) string {
 	id := cell(issueLabel(r.Identifier, r.IssueID), colID)
 	stage := cell(r.State, colStage)
 
@@ -208,7 +210,7 @@ func formatRunningRow(r runningEntry, now time.Time, eventWidth int) string {
 }
 
 // formatRetryRow mirrors format_retry_summary/1.
-func formatRetryRow(r retryEntry) string {
+func formatRetryRow(r stateapi.Retry) string {
 	id := issueLabel(r.Identifier, r.IssueID)
 	attempt := strconv.Itoa(r.Attempt)
 	kind := r.Kind

--- a/cmd/tui/resize_unix_test.go
+++ b/cmd/tui/resize_unix_test.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 )
 
 // lockedBuffer is a goroutine-safe io.Writer so the test can read frames while
@@ -39,11 +41,11 @@ func TestRun_RedrawsOnSIGWINCH(t *testing.T) {
 	scr := newScreen(lb, true /* isTTY */, false /* raw */)
 
 	var fetches int32
-	fetch := func(context.Context) *stateResponse {
+	fetch := func(context.Context) *stateapi.StateResponse {
 		atomic.AddInt32(&fetches, 1)
-		return &stateResponse{MaxConcurrentAgents: 3}
+		return &stateapi.StateResponse{MaxConcurrentAgents: 3}
 	}
-	fetchState := func(ctx context.Context) (*stateResponse, error) { return fetch(ctx), ctx.Err() }
+	fetchState := func(ctx context.Context) (*stateapi.StateResponse, error) { return fetch(ctx), ctx.Err() }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})

--- a/cmd/tui/state_client.go
+++ b/cmd/tui/state_client.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 )
 
 const stateAPIAuthTokenEnv = "AIOPS_STATE_API_TOKEN"
@@ -20,64 +22,10 @@ const stateAPIAuthTokenEnv = "AIOPS_STATE_API_TOKEN"
 // throughputWindowMs is the rolling window for TPS calculation (5 s).
 const throughputWindowMs = 5_000
 
-// ── API response types ────────────────────────────────────────────────────────
-// Field names match the /api/v1/state JSON contract (SPEC §13.7.2).
-
-type stateResponse struct {
-	GeneratedAt         time.Time              `json:"generated_at"`
-	PollIntervalMs      int64                  `json:"poll_interval_ms"`
-	MaxConcurrentAgents int                    `json:"max_concurrent_agents"`
-	Counts              stateCounts            `json:"counts"`
-	Running             []runningEntry         `json:"running"`
-	Retrying            []retryEntry           `json:"retrying"`
-	CodexTotals         codexTotals            `json:"codex_totals"`
-	RateLimits          map[string]interface{} `json:"rate_limits"`
-}
-
-type stateCounts struct {
-	Running                            int   `json:"running"`
-	Blocked                            int   `json:"blocked"`
-	Retrying                           int   `json:"retrying"`
-	CompletedTotal                     int64 `json:"completed_total"`
-	AgentHandoffReconcileStoppedTotal  int64 `json:"agent_handoff_reconcile_stopped_total"`
-	AgentHandoffReconcileStoppedRecent int   `json:"agent_handoff_reconcile_stopped"`
-}
-
-type runningEntry struct {
-	IssueID           string     `json:"issue_id"`
-	Identifier        string     `json:"issue_identifier"`
-	State             string     `json:"state"`
-	SessionID         string     `json:"session_id"`
-	TurnCount         int        `json:"turn_count"`
-	LastEvent         string     `json:"last_event"`
-	LastMessage       string     `json:"last_message"`
-	StartedAt         *time.Time `json:"started_at"`
-	LastEventAt       *time.Time `json:"last_event_at"`
-	Tokens            tokenInfo  `json:"tokens"`
-	CodexAppServerPID int        `json:"codex_app_server_pid"`
-}
-
-type tokenInfo struct {
-	InputTokens  int64 `json:"input_tokens"`
-	OutputTokens int64 `json:"output_tokens"`
-	TotalTokens  int64 `json:"total_tokens"`
-}
-
-type retryEntry struct {
-	IssueID    string     `json:"issue_id"`
-	Identifier string     `json:"issue_identifier"`
-	Attempt    int        `json:"attempt"`
-	DueAt      *time.Time `json:"due_at"`
-	Error      string     `json:"error"`
-	Kind       string     `json:"kind"`
-}
-
-type codexTotals struct {
-	InputTokens    int64   `json:"input_tokens"`
-	OutputTokens   int64   `json:"output_tokens"`
-	TotalTokens    int64   `json:"total_tokens"`
-	SecondsRunning float64 `json:"seconds_running"`
-}
+// The /api/v1/state response DTOs live in internal/stateapi, shared verbatim
+// with the worker (producer) so the JSON contract has one definition (#793).
+// This file keeps only the TUI-side fetch and the rolling token-throughput
+// sampling.
 
 // ── TPS tracking ──────────────────────────────────────────────────────────────
 
@@ -115,11 +63,11 @@ func rollingTPS(samples []tokenSample, now time.Time, currentTokens int64) float
 	return float64(delta) / elapsed
 }
 
-func fetchState(ctx context.Context, client *http.Client, url string) (*stateResponse, error) {
+func fetchState(ctx context.Context, client *http.Client, url string) (*stateapi.StateResponse, error) {
 	return fetchStateWithAuth(ctx, client, url, "")
 }
 
-func fetchStateWithAuth(ctx context.Context, client *http.Client, url string, authToken string) (*stateResponse, error) {
+func fetchStateWithAuth(ctx context.Context, client *http.Client, url string, authToken string) (*stateapi.StateResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -136,7 +84,7 @@ func fetchStateWithAuth(ctx context.Context, client *http.Client, url string, au
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	var s stateResponse
+	var s stateapi.StateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
 		return nil, err
 	}

--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 // Ported pixel-for-pixel from the Claude Design "lean/Worker Status v2.html"
 // handoff; the styling lives in styles.css. The mock data the prototype
 // shipped with is replaced here by the real /api/v1/state contract
-// (cmd/worker/stateapi.go · apiStateResponse), which it mirrors field-for-field.
+// (internal/stateapi · StateResponse), which it mirrors field-for-field.
 
 const REFRESH_MS = 5000;
 

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -5,7 +5,7 @@ import App, { stateAPIURL } from './App';
 const iso = (msAgo) => new Date(Date.now() - msAgo).toISOString();
 const unixIn = (s) => Math.floor(Date.now() / 1000) + s;
 
-// Shaped exactly like GET /api/v1/state (cmd/worker/stateapi.go · apiStateResponse).
+// Shaped exactly like GET /api/v1/state (internal/stateapi · StateResponse).
 function busyState(overrides = {}) {
   return {
     generated_at: iso(0),

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -49,7 +49,7 @@ func TestApiRunningRowAlwaysEmitsSpec13_7_2StatusKeys(t *testing.T) {
 	}
 	for _, key := range []string{"state", "session_id", "turn_count", "last_event", "last_message", "tokens"} {
 		if _, ok := got[key]; !ok {
-			t.Errorf("apiStateRunning JSON missing %q for a freshly-dispatched run: %s", key, raw)
+			t.Errorf("stateapi.Running JSON missing %q for a freshly-dispatched run: %s", key, raw)
 		}
 	}
 }

--- a/cmd/worker/runbook_drift_test.go
+++ b/cmd/worker/runbook_drift_test.go
@@ -10,18 +10,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
+	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 )
 
 // TestRuntimeStatusRunbookExampleMatchesHandler asserts bi-directional schema
-// parity between docs/runbooks/runtime-status.md and apiStateResponse:
+// parity between docs/runbooks/runtime-status.md and stateapi.StateResponse:
 //
 //  1. doc → handler: every ```json fenced block tagged as the /api/v1/state
 //     example (identified by the `counts` key) strict-decodes into
-//     apiStateResponse with json.DisallowUnknownFields. Catches drift where
+//     stateapi.StateResponse with json.DisallowUnknownFields. Catches drift where
 //     the doc references a field that does not exist in the wire format.
 //
-//  2. handler → doc: marshal a fully-populated apiStateResponse (every
+//  2. handler → doc: marshal a fully-populated stateapi.StateResponse (every
 //     omitempty field set), then walk the resulting key tree and assert each
 //     key path exists in the runbook example. Catches drift where the
 //     handler grows a new JSON field that the runbook forgets to mention.
@@ -53,9 +53,9 @@ func TestRuntimeStatusRunbookExampleMatchesHandler(t *testing.T) {
 
 		dec := json.NewDecoder(bytes.NewReader([]byte(block)))
 		dec.DisallowUnknownFields()
-		var into apiStateResponse
+		var into stateapi.StateResponse
 		if err := dec.Decode(&into); err != nil {
-			t.Fatalf("runbook block %d failed strict decode into apiStateResponse: %v\n%s", i, err, block)
+			t.Fatalf("runbook block %d failed strict decode into stateapi.StateResponse: %v\n%s", i, err, block)
 		}
 		stateExample = probe
 		break
@@ -74,12 +74,12 @@ func TestRuntimeStatusRunbookExampleMatchesHandler(t *testing.T) {
 	}
 	if len(missing) > 0 {
 		sort.Strings(missing)
-		t.Fatalf("apiStateResponse fields not documented in docs/runbooks/runtime-status.md /api/v1/state example:\n  %s\nUpdate the runbook to mention these keys, or remove the field from apiStateResponse if intentional.", strings.Join(missing, "\n  "))
+		t.Fatalf("stateapi.StateResponse fields not documented in docs/runbooks/runtime-status.md /api/v1/state example:\n  %s\nUpdate the runbook to mention these keys, or remove the field from stateapi.StateResponse if intentional.", strings.Join(missing, "\n  "))
 	}
 }
 
 // fullyPopulatedAPIStateResponseJSON returns the JSON encoding of an
-// apiStateResponse with every field — including every `omitempty` field —
+// stateapi.StateResponse with every field — including every `omitempty` field —
 // populated, so json.Marshal cannot omit anything. Used to enumerate the
 // complete handler-side schema for drift detection.
 func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
@@ -89,12 +89,12 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 	lastEventAt := time.Date(2026, 5, 21, 9, 10, 0, 0, time.UTC)
 	dueAt := time.Date(2026, 5, 21, 9, 11, 0, 0, time.UTC)
 	retryAttempt := 1
-	resp := apiStateResponse{
+	resp := stateapi.StateResponse{
 		GeneratedAt:                time.Date(2026, 5, 21, 9, 10, 0, 0, time.UTC),
 		PollIntervalMs:             15000,
 		MaxConcurrentAgents:        4,
 		MaxConcurrentAgentsByState: map[string]int{"In Progress": 2},
-		Counts: apiStateCounts{
+		Counts: stateapi.Counts{
 			Running:                           1,
 			Blocked:                           1,
 			Retrying:                          1,
@@ -105,7 +105,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 			AgentHandoffReconcileStopped:      3,
 			AgentHandoffReconcileStoppedTotal: 4,
 		},
-		Running: []apiStateRunning{{
+		Running: []stateapi.Running{{
 			IssueID:       "issue-1",
 			Identifier:    "ENG-1",
 			IssueURL:      "https://tracker.example/issues/ENG-1",
@@ -118,14 +118,14 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 			LastEventAt:   &lastEventAt,
 			RetryAttempt:  &retryAttempt,
 			WorkspacePath: "/var/aiops/workspaces/acme/repo/issue-1",
-			Tokens: apiRunningTokens{
+			Tokens: stateapi.RunningTokens{
 				InputTokens:  1200,
 				OutputTokens: 800,
 				TotalTokens:  2000,
 			},
 			CodexAppServerPID: 12345,
 		}},
-		Blocked: []apiStateBlocked{{
+		Blocked: []stateapi.Blocked{{
 			IssueID:           "issue-2",
 			Identifier:        "ENG-2",
 			IssueURL:          "https://tracker.example/issues/ENG-2",
@@ -138,7 +138,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 			Error:             "input required: mcpServer/elicitation/request",
 			CodexAppServerPID: 67890,
 		}},
-		Retrying: []apiStateRetry{{
+		Retrying: []stateapi.Retry{{
 			IssueID:    "issue-3",
 			Identifier: "ENG-3",
 			IssueURL:   "https://tracker.example/issues/ENG-3",
@@ -146,15 +146,15 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 			DueAt:      &dueAt,
 			Error:      "retry soon",
 		}},
-		Completed:                    []orchestrator.IssueID{"issue-4"},
-		ReconcileStoppedWithProgress: []orchestrator.IssueID{"issue-6"},
-		CodexTotals: apiCodexTotals{
+		Completed:                    []string{"issue-4"},
+		ReconcileStoppedWithProgress: []string{"issue-6"},
+		CodexTotals: stateapi.CodexTotals{
 			InputTokens:    100,
 			OutputTokens:   200,
 			TotalTokens:    300,
 			SecondsRunning: 1.5,
 		},
-		RateLimits: &orchestrator.RateLimitSnapshot{},
+		RateLimits: map[string]any{},
 	}
 	return mustMarshal(t, resp)
 }

--- a/cmd/worker/stateapi.go
+++ b/cmd/worker/stateapi.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
+	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -31,135 +32,12 @@ const (
 
 var errRefreshBodyTooLarge = errors.New("refresh request body exceeds 1 MiB")
 
-type apiStateResponse struct {
-	GeneratedAt                time.Time              `json:"generated_at"`
-	PollIntervalMs             int64                  `json:"poll_interval_ms"`
-	MaxConcurrentAgents        int                    `json:"max_concurrent_agents"`
-	MaxConcurrentAgentsByState map[string]int         `json:"max_concurrent_agents_by_state,omitempty"`
-	Counts                     apiStateCounts         `json:"counts"`
-	Running                    []apiStateRunning      `json:"running"`
-	Blocked                    []apiStateBlocked      `json:"blocked"`
-	Retrying                   []apiStateRetry        `json:"retrying"`
-	Completed                  []orchestrator.IssueID `json:"completed"`
-	// ReconcileStoppedWithProgress lists reconcile-stopped runs that had completed ≥1
-	// agent turn (made progress — usually the agent's handoff, but turn_completed
-	// fires after every turn, so it can also be a run stopped after an intermediate
-	// turn; inspect to confirm, it is not a guaranteed success) before the per-tick
-	// reconcile reaped them — surfaced so a progressed-but-reaped run is visible
-	// rather than absent from completed (#557). It does not overlap
-	// completed: a reconcile-stopped run is not a clean §16.5 exit, matching
-	// upstream's accounting, so completed stays unchanged.
-	ReconcileStoppedWithProgress []orchestrator.IssueID    `json:"reconcile_stopped_with_progress"`
-	AgentHandoffReconcileStopped []orchestrator.IssueID    `json:"agent_handoff_reconcile_stopped"`
-	OperatorTerminalStops        []apiOperatorTerminalStop `json:"operator_terminal_stops"`
-	CodexTotals                  apiCodexTotals            `json:"codex_totals"`
-	// RateLimits is the latest Codex rate-limit payload (SPEC §13.7.2). It
-	// is emitted unconditionally — `null` until a `rate_limit_updated`
-	// notification is observed — so operators can rely on the key always
-	// being present (upstream parity, #328). A nil snapshot marshals to
-	// JSON null, not an omitted key.
-	RateLimits *orchestrator.RateLimitSnapshot `json:"rate_limits"`
-}
-type apiCodexTotals struct {
-	InputTokens    int64   `json:"input_tokens"`
-	OutputTokens   int64   `json:"output_tokens"`
-	TotalTokens    int64   `json:"total_tokens"`
-	SecondsRunning float64 `json:"seconds_running"`
-}
-type apiStateCounts struct {
-	Running int `json:"running"`
-	Blocked int `json:"blocked"`
-	// Retrying is the current retry-backoff queue depth.
-	Retrying int `json:"retrying"`
-	// Completed is the size of the FIFO-bounded recent-completed set
-	// (the same set published as `state.completed`). For lifetime
-	// totals across worker restarts and FIFO evictions, use
-	// completed_total. SPEC §13.7 §4.1.8.
-	Completed int `json:"completed"`
-	// CompletedTotal is a monotonic counter of every observed Succeeded
-	// transition since process start, independent of FIFO eviction. Added
-	// for #234 so long-running deployments still expose a true lifetime
-	// number when the bounded set has rotated.
-	CompletedTotal int64 `json:"completed_total"`
-	// ReconcileStoppedWithProgress is the size of the FIFO-bounded recent set of
-	// reconcile-stopped runs that had made progress (≥1 completed turn; the same set
-	// published as `state.reconcile_stopped_with_progress`);
-	// ReconcileStoppedWithProgressTotal is the lifetime monotonic counter that
-	// survives FIFO eviction (#557).
-	ReconcileStoppedWithProgress      int   `json:"reconcile_stopped_with_progress"`
-	ReconcileStoppedWithProgressTotal int64 `json:"reconcile_stopped_with_progress_total"`
-	AgentHandoffReconcileStopped      int   `json:"agent_handoff_reconcile_stopped"`
-	AgentHandoffReconcileStoppedTotal int64 `json:"agent_handoff_reconcile_stopped_total"`
-	// OperatorTerminalStops is the size of the FIFO-bounded recent D35 latch set
-	// (the same set published as `state.operator_terminal_stops`).
-	// OperatorTerminalStopsTotal is the lifetime monotonic counter that survives
-	// the #667 cap eviction, so a long-running worker that has rotated past the
-	// bound still exposes the true number of distinct operator-terminal-stops.
-	OperatorTerminalStops      int   `json:"operator_terminal_stops"`
-	OperatorTerminalStopsTotal int64 `json:"operator_terminal_stops_total"`
-}
-type apiStateRunning struct {
-	IssueID    orchestrator.IssueID `json:"issue_id"`
-	Identifier string               `json:"issue_identifier,omitempty"`
-	// IssueURL is the tracker-provided issue URL, emitted only when available
-	// (SPEC §13.7 SHOULD). omitempty keeps URL-less rows (mock tracker) clean.
-	IssueURL string `json:"issue_url,omitempty"`
-	// State / SessionID / TurnCount / LastEvent / LastMessage are part of
-	// the SPEC §13.7.2 running-row contract — the sample literally shows
-	// `"last_message": ""` and `"turn_count": 7`, so a freshly-dispatched
-	// run with zero/empty values must still emit the keys. omitempty would
-	// let consumers confuse "known zero/empty" with "field missing".
-	State             string           `json:"state"`
-	SessionID         string           `json:"session_id"`
-	TurnCount         int              `json:"turn_count"`
-	LastEvent         string           `json:"last_event"`
-	LastMessage       string           `json:"last_message"`
-	StartedAt         *time.Time       `json:"started_at,omitempty"`
-	LastEventAt       *time.Time       `json:"last_event_at,omitempty"`
-	RetryAttempt      *int             `json:"retry_attempt,omitempty"`
-	WorkspacePath     string           `json:"workspace_path,omitempty"`
-	Tokens            apiRunningTokens `json:"tokens"`
-	CodexAppServerPID int              `json:"codex_app_server_pid,omitempty"`
-}
-
-// apiRunningTokens mirrors SPEC §13.7.2's per-running-row `tokens` object.
-type apiRunningTokens struct {
-	InputTokens  int64 `json:"input_tokens"`
-	OutputTokens int64 `json:"output_tokens"`
-	TotalTokens  int64 `json:"total_tokens"`
-}
-type apiStateBlocked struct {
-	IssueID           orchestrator.IssueID `json:"issue_id"`
-	Identifier        string               `json:"issue_identifier,omitempty"`
-	IssueURL          string               `json:"issue_url,omitempty"`
-	State             string               `json:"state,omitempty"`
-	BlockedAt         *time.Time           `json:"blocked_at,omitempty"`
-	WorkspacePath     string               `json:"workspace_path,omitempty"`
-	SessionID         string               `json:"session_id,omitempty"`
-	LastEventAt       *time.Time           `json:"last_event_at,omitempty"`
-	Method            string               `json:"method,omitempty"`
-	Error             string               `json:"error,omitempty"`
-	CodexAppServerPID int                  `json:"codex_app_server_pid,omitempty"`
-}
-type apiStateRetry struct {
-	IssueID    orchestrator.IssueID   `json:"issue_id"`
-	Identifier string                 `json:"issue_identifier,omitempty"`
-	IssueURL   string                 `json:"issue_url,omitempty"`
-	Attempt    int                    `json:"attempt"`
-	DueAt      *time.Time             `json:"due_at,omitempty"`
-	Error      string                 `json:"error,omitempty"`
-	Kind       orchestrator.RetryKind `json:"kind"`
-}
-type apiOperatorTerminalStop struct {
-	IssueID               orchestrator.IssueID `json:"issue_id"`
-	Identifier            string               `json:"issue_identifier,omitempty"`
-	State                 string               `json:"state,omitempty"`
-	StoppedAt             *time.Time           `json:"stopped_at,omitempty"`
-	SuppressedDispatches  int                  `json:"suppressed_dispatches"`
-	FirstSuppressedAt     *time.Time           `json:"first_suppressed_at,omitempty"`
-	FirstSuppressedState  string               `json:"first_suppressed_state,omitempty"`
-	FirstSuppressedReason string               `json:"first_suppressed_reason,omitempty"`
-}
+// The /api/v1/state wire DTOs live in internal/stateapi so cmd/worker
+// (producer) and cmd/tui (consumer) share one definition (#793). The
+// orchestrator.StateView -> wire mappers below stay here: they are
+// single-consumer projection, not part of the shared contract. The
+// /api/v1/<issue> and error DTOs below stay here for the same reason —
+// nothing else consumes them.
 type apiIssueResponse struct {
 	IssueIdentifier string               `json:"issue_identifier"`
 	IssueID         orchestrator.IssueID `json:"issue_id"`
@@ -171,11 +49,11 @@ type apiIssueResponse struct {
 		RestartCount        int  `json:"restart_count"`
 		CurrentRetryAttempt *int `json:"current_retry_attempt"`
 	} `json:"attempts"`
-	Running      *apiStateRunning `json:"running"`
-	Retry        *apiStateRetry   `json:"retry"`
-	RecentEvents []map[string]any `json:"recent_events"`
-	LastError    *string          `json:"last_error"`
-	Tracked      map[string]any   `json:"tracked"`
+	Running      *stateapi.Running `json:"running"`
+	Retry        *stateapi.Retry   `json:"retry"`
+	RecentEvents []map[string]any  `json:"recent_events"`
+	LastError    *string           `json:"last_error"`
+	Tracked      map[string]any    `json:"tracked"`
 }
 type apiErrorResponse struct {
 	Error apiError `json:"error"`
@@ -476,7 +354,7 @@ func matchesIssueLookup(issueID orchestrator.IssueID, identifier, normalizedWant
 func normalizeIssueLookup(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
-func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
+func apiRunningFromView(row orchestrator.RunningView) stateapi.Running {
 	var startedAt *time.Time
 	if !row.StartedAt.IsZero() {
 		v := row.StartedAt
@@ -487,8 +365,8 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 		v := row.LastEventAt
 		lastEventAt = &v
 	}
-	return apiStateRunning{
-		IssueID:       row.IssueID,
+	return stateapi.Running{
+		IssueID:       string(row.IssueID),
 		Identifier:    row.Identifier,
 		IssueURL:      row.IssueURL,
 		State:         row.State,
@@ -500,7 +378,7 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 		LastEventAt:   lastEventAt,
 		RetryAttempt:  copyIntPointer(row.RetryAttempt),
 		WorkspacePath: row.WorkspacePath,
-		Tokens: apiRunningTokens{
+		Tokens: stateapi.RunningTokens{
 			InputTokens:  row.Tokens.InputTokens,
 			OutputTokens: row.Tokens.OutputTokens,
 			TotalTokens:  row.Tokens.TotalTokens,
@@ -508,20 +386,20 @@ func apiRunningFromView(row orchestrator.RunningView) apiStateRunning {
 		CodexAppServerPID: row.CodexAppServerPID,
 	}
 }
-func apiRetryFromView(row orchestrator.RetryView) apiStateRetry {
+func apiRetryFromView(row orchestrator.RetryView) stateapi.Retry {
 	var dueAt *time.Time
 	if !row.DueAt.IsZero() {
 		v := row.DueAt
 		dueAt = &v
 	}
-	return apiStateRetry{
-		IssueID:    row.IssueID,
+	return stateapi.Retry{
+		IssueID:    string(row.IssueID),
 		Identifier: row.Identifier,
 		IssueURL:   row.IssueURL,
 		Attempt:    row.Attempt,
 		DueAt:      dueAt,
 		Error:      row.Error,
-		Kind:       retryKindOrFailure(row.Kind),
+		Kind:       string(retryKindOrFailure(row.Kind)),
 	}
 }
 func retryKindOrFailure(kind orchestrator.RetryKind) orchestrator.RetryKind {
@@ -552,13 +430,13 @@ func apiErrorCode(err error) string {
 	}
 	return "internal_error"
 }
-func apiStateFromView(view orchestrator.StateView) apiStateResponse {
+func apiStateFromView(view orchestrator.StateView) stateapi.StateResponse {
 	generatedAt := view.GeneratedAt
 	if generatedAt.IsZero() {
 		generatedAt = time.Now().UTC()
 	}
 	running := sortedAPIRunningRows(view.Running)
-	blocked := make([]apiStateBlocked, 0, len(view.Blocked))
+	blocked := make([]stateapi.Blocked, 0, len(view.Blocked))
 	for _, row := range view.Blocked {
 		var blockedAt *time.Time
 		if !row.BlockedAt.IsZero() {
@@ -570,8 +448,8 @@ func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 			v := row.LastEventAt
 			lastEventAt = &v
 		}
-		blocked = append(blocked, apiStateBlocked{
-			IssueID:           row.IssueID,
+		blocked = append(blocked, stateapi.Blocked{
+			IssueID:           string(row.IssueID),
 			Identifier:        row.Identifier,
 			IssueURL:          row.IssueURL,
 			State:             row.State,
@@ -588,20 +466,8 @@ func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 		return blocked[i].IssueID < blocked[j].IssueID
 	})
 	retrying := sortedAPIRetryRows(view.Retrying)
-	completed := append([]orchestrator.IssueID(nil), view.Completed...)
-	sort.Slice(completed, func(i, j int) bool {
-		return completed[i] < completed[j]
-	})
-	reconcileFinished := append([]orchestrator.IssueID(nil), view.ReconcileStoppedWithProgress...)
-	sort.Slice(reconcileFinished, func(i, j int) bool {
-		return reconcileFinished[i] < reconcileFinished[j]
-	})
-	agentHandoffFinished := append([]orchestrator.IssueID(nil), view.AgentHandoffReconcileStopped...)
-	sort.Slice(agentHandoffFinished, func(i, j int) bool {
-		return agentHandoffFinished[i] < agentHandoffFinished[j]
-	})
 	operatorStops := sortedAPIOperatorTerminalStops(view.OperatorTerminalStops)
-	return apiStateResponse{
+	return stateapi.StateResponse{
 		GeneratedAt:                  generatedAt,
 		PollIntervalMs:               view.PollIntervalMs,
 		MaxConcurrentAgents:          view.MaxConcurrentAgents,
@@ -610,21 +476,37 @@ func apiStateFromView(view orchestrator.StateView) apiStateResponse {
 		Running:                      running,
 		Blocked:                      blocked,
 		Retrying:                     retrying,
-		Completed:                    completed,
-		ReconcileStoppedWithProgress: reconcileFinished,
-		AgentHandoffReconcileStopped: agentHandoffFinished,
+		Completed:                    sortedIssueIDStrings(view.Completed),
+		ReconcileStoppedWithProgress: sortedIssueIDStrings(view.ReconcileStoppedWithProgress),
+		AgentHandoffReconcileStopped: sortedIssueIDStrings(view.AgentHandoffReconcileStopped),
 		OperatorTerminalStops:        operatorStops,
-		CodexTotals: apiCodexTotals{
+		CodexTotals: stateapi.CodexTotals{
 			InputTokens:    view.CodexTotals.InputTokens,
 			OutputTokens:   view.CodexTotals.OutputTokens,
 			TotalTokens:    view.CodexTotals.TotalTokens,
 			SecondsRunning: view.CodexTotals.SecondsRunning,
 		},
-		RateLimits: copyRateLimitsForAPI(view.CodexRateLimits),
+		RateLimits: rateLimitsForAPI(view.CodexRateLimits),
 	}
 }
-func sortedAPIRunningRows(rows []orchestrator.RunningView) []apiStateRunning {
-	running := make([]apiStateRunning, 0, len(rows))
+
+// sortedIssueIDStrings converts an orchestrator IssueID slice to the wire
+// []string and sorts it. It returns nil (not an empty slice) for empty input
+// so the JSON key marshals to `null`, preserving the wire shape these ID
+// lists have always emitted (the row lists below emit `[]` via make(.., 0)).
+func sortedIssueIDStrings(ids []orchestrator.IssueID) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = string(id)
+	}
+	sort.Strings(out)
+	return out
+}
+func sortedAPIRunningRows(rows []orchestrator.RunningView) []stateapi.Running {
+	running := make([]stateapi.Running, 0, len(rows))
 	for _, row := range rows {
 		running = append(running, apiRunningFromView(row))
 	}
@@ -633,8 +515,8 @@ func sortedAPIRunningRows(rows []orchestrator.RunningView) []apiStateRunning {
 	})
 	return running
 }
-func sortedAPIRetryRows(rows []orchestrator.RetryView) []apiStateRetry {
-	retrying := make([]apiStateRetry, 0, len(rows))
+func sortedAPIRetryRows(rows []orchestrator.RetryView) []stateapi.Retry {
+	retrying := make([]stateapi.Retry, 0, len(rows))
 	for _, row := range rows {
 		retrying = append(retrying, apiRetryFromView(row))
 	}
@@ -643,8 +525,8 @@ func sortedAPIRetryRows(rows []orchestrator.RetryView) []apiStateRetry {
 	})
 	return retrying
 }
-func apiCountsFromView(view orchestrator.StateView) apiStateCounts {
-	return apiStateCounts{
+func apiCountsFromView(view orchestrator.StateView) stateapi.Counts {
+	return stateapi.Counts{
 		Running:                           len(view.Running),
 		Blocked:                           len(view.Blocked),
 		Retrying:                          len(view.Retrying),
@@ -659,8 +541,8 @@ func apiCountsFromView(view orchestrator.StateView) apiStateCounts {
 	}
 }
 
-func sortedAPIOperatorTerminalStops(rows []orchestrator.OperatorTerminalStopView) []apiOperatorTerminalStop {
-	out := make([]apiOperatorTerminalStop, 0, len(rows))
+func sortedAPIOperatorTerminalStops(rows []orchestrator.OperatorTerminalStopView) []stateapi.OperatorTerminalStop {
+	out := make([]stateapi.OperatorTerminalStop, 0, len(rows))
 	for _, row := range rows {
 		var stoppedAt *time.Time
 		if !row.StoppedAt.IsZero() {
@@ -672,8 +554,8 @@ func sortedAPIOperatorTerminalStops(rows []orchestrator.OperatorTerminalStopView
 			v := row.FirstSuppressedAt
 			firstSuppressedAt = &v
 		}
-		out = append(out, apiOperatorTerminalStop{
-			IssueID:               row.IssueID,
+		out = append(out, stateapi.OperatorTerminalStop{
+			IssueID:               string(row.IssueID),
 			Identifier:            row.Identifier,
 			State:                 row.State,
 			StoppedAt:             stoppedAt,
@@ -688,12 +570,18 @@ func sortedAPIOperatorTerminalStops(rows []orchestrator.OperatorTerminalStopView
 	})
 	return out
 }
-func copyRateLimitsForAPI(src *orchestrator.RateLimitSnapshot) *orchestrator.RateLimitSnapshot {
+
+// rateLimitsForAPI projects the orchestrator rate-limit snapshot to the wire
+// map. A nil snapshot yields a nil map so `rate_limits` marshals to JSON null
+// (the always-present key contract, #328). The returned map aliases the
+// snapshot's backing store, matching the prior shallow copy — safe because the
+// view is itself a point-in-time snapshot that the response is marshaled from
+// immediately.
+func rateLimitsForAPI(src *orchestrator.RateLimitSnapshot) map[string]any {
 	if src == nil {
 		return nil
 	}
-	copied := *src
-	return &copied
+	return map[string]any(*src)
 }
 func copyConcurrencyLimits(src map[string]int) map[string]int {
 	if len(src) == 0 {

--- a/internal/stateapi/types.go
+++ b/internal/stateapi/types.go
@@ -1,0 +1,161 @@
+// Package stateapi defines the /api/v1/state response wire DTOs (SPEC §13.7.2).
+//
+// It is the single source of truth for the JSON contract shared by the worker
+// (producer, cmd/worker) and the TUI (consumer, cmd/tui): a field added here
+// surfaces in both binaries from one definition, so a new field can no longer
+// be added to the producer while the consumer silently never renders it, and a
+// JSON-tag typo can no longer drop data on only one side (#793).
+//
+// It deliberately holds only the wire shape — plain string / map[string]any /
+// time.Time, no internal/orchestrator import — so the thin TUI binary need not
+// pull in the scheduler core to decode a status snapshot. The worker's
+// orchestrator.StateView -> wire mappers stay in cmd/worker (single-consumer
+// projection); the /api/v1/<issue> and error DTOs stay there too for the same
+// reason.
+package stateapi
+
+import "time"
+
+// StateResponse is the /api/v1/state body (SPEC §13.7.2).
+type StateResponse struct {
+	GeneratedAt                time.Time      `json:"generated_at"`
+	PollIntervalMs             int64          `json:"poll_interval_ms"`
+	MaxConcurrentAgents        int            `json:"max_concurrent_agents"`
+	MaxConcurrentAgentsByState map[string]int `json:"max_concurrent_agents_by_state,omitempty"`
+	Counts                     Counts         `json:"counts"`
+	Running                    []Running      `json:"running"`
+	Blocked                    []Blocked      `json:"blocked"`
+	Retrying                   []Retry        `json:"retrying"`
+	Completed                  []string       `json:"completed"`
+	// ReconcileStoppedWithProgress lists reconcile-stopped runs that had completed ≥1
+	// agent turn (made progress — usually the agent's handoff, but turn_completed
+	// fires after every turn, so it can also be a run stopped after an intermediate
+	// turn; inspect to confirm, it is not a guaranteed success) before the per-tick
+	// reconcile reaped them — surfaced so a progressed-but-reaped run is visible
+	// rather than absent from completed (#557). It does not overlap
+	// completed: a reconcile-stopped run is not a clean §16.5 exit, matching
+	// upstream's accounting, so completed stays unchanged.
+	ReconcileStoppedWithProgress []string               `json:"reconcile_stopped_with_progress"`
+	AgentHandoffReconcileStopped []string               `json:"agent_handoff_reconcile_stopped"`
+	OperatorTerminalStops        []OperatorTerminalStop `json:"operator_terminal_stops"`
+	CodexTotals                  CodexTotals            `json:"codex_totals"`
+	// RateLimits is the latest Codex rate-limit payload (SPEC §13.7.2). It
+	// is emitted unconditionally — `null` until a `rate_limit_updated`
+	// notification is observed — so operators can rely on the key always
+	// being present (upstream parity, #328). A nil map marshals to JSON
+	// null, not an omitted key.
+	RateLimits map[string]any `json:"rate_limits"`
+}
+
+// CodexTotals mirrors SPEC §13.7.2's aggregate `codex_totals` object.
+type CodexTotals struct {
+	InputTokens    int64   `json:"input_tokens"`
+	OutputTokens   int64   `json:"output_tokens"`
+	TotalTokens    int64   `json:"total_tokens"`
+	SecondsRunning float64 `json:"seconds_running"`
+}
+
+// Counts mirrors SPEC §13.7.2's `counts` object.
+type Counts struct {
+	Running int `json:"running"`
+	Blocked int `json:"blocked"`
+	// Retrying is the current retry-backoff queue depth.
+	Retrying int `json:"retrying"`
+	// Completed is the size of the FIFO-bounded recent-completed set
+	// (the same set published as `state.completed`). For lifetime
+	// totals across worker restarts and FIFO evictions, use
+	// completed_total. SPEC §13.7 §4.1.8.
+	Completed int `json:"completed"`
+	// CompletedTotal is a monotonic counter of every observed Succeeded
+	// transition since process start, independent of FIFO eviction. Added
+	// for #234 so long-running deployments still expose a true lifetime
+	// number when the bounded set has rotated.
+	CompletedTotal int64 `json:"completed_total"`
+	// ReconcileStoppedWithProgress is the size of the FIFO-bounded recent set of
+	// reconcile-stopped runs that had made progress (≥1 completed turn; the same set
+	// published as `state.reconcile_stopped_with_progress`);
+	// ReconcileStoppedWithProgressTotal is the lifetime monotonic counter that
+	// survives FIFO eviction (#557).
+	ReconcileStoppedWithProgress      int   `json:"reconcile_stopped_with_progress"`
+	ReconcileStoppedWithProgressTotal int64 `json:"reconcile_stopped_with_progress_total"`
+	AgentHandoffReconcileStopped      int   `json:"agent_handoff_reconcile_stopped"`
+	AgentHandoffReconcileStoppedTotal int64 `json:"agent_handoff_reconcile_stopped_total"`
+	// OperatorTerminalStops is the size of the FIFO-bounded recent D35 latch set
+	// (the same set published as `state.operator_terminal_stops`).
+	// OperatorTerminalStopsTotal is the lifetime monotonic counter that survives
+	// the #667 cap eviction, so a long-running worker that has rotated past the
+	// bound still exposes the true number of distinct operator-terminal-stops.
+	OperatorTerminalStops      int   `json:"operator_terminal_stops"`
+	OperatorTerminalStopsTotal int64 `json:"operator_terminal_stops_total"`
+}
+
+// Running mirrors SPEC §13.7.2's per-running-row object.
+type Running struct {
+	IssueID    string `json:"issue_id"`
+	Identifier string `json:"issue_identifier,omitempty"`
+	// IssueURL is the tracker-provided issue URL, emitted only when available
+	// (SPEC §13.7 SHOULD). omitempty keeps URL-less rows (mock tracker) clean.
+	IssueURL string `json:"issue_url,omitempty"`
+	// State / SessionID / TurnCount / LastEvent / LastMessage are part of
+	// the SPEC §13.7.2 running-row contract — the sample literally shows
+	// `"last_message": ""` and `"turn_count": 7`, so a freshly-dispatched
+	// run with zero/empty values must still emit the keys. omitempty would
+	// let consumers confuse "known zero/empty" with "field missing".
+	State             string        `json:"state"`
+	SessionID         string        `json:"session_id"`
+	TurnCount         int           `json:"turn_count"`
+	LastEvent         string        `json:"last_event"`
+	LastMessage       string        `json:"last_message"`
+	StartedAt         *time.Time    `json:"started_at,omitempty"`
+	LastEventAt       *time.Time    `json:"last_event_at,omitempty"`
+	RetryAttempt      *int          `json:"retry_attempt,omitempty"`
+	WorkspacePath     string        `json:"workspace_path,omitempty"`
+	Tokens            RunningTokens `json:"tokens"`
+	CodexAppServerPID int           `json:"codex_app_server_pid,omitempty"`
+}
+
+// RunningTokens mirrors SPEC §13.7.2's per-running-row `tokens` object.
+type RunningTokens struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	TotalTokens  int64 `json:"total_tokens"`
+}
+
+// Blocked mirrors SPEC §13.7.2's per-blocked-row object.
+type Blocked struct {
+	IssueID           string     `json:"issue_id"`
+	Identifier        string     `json:"issue_identifier,omitempty"`
+	IssueURL          string     `json:"issue_url,omitempty"`
+	State             string     `json:"state,omitempty"`
+	BlockedAt         *time.Time `json:"blocked_at,omitempty"`
+	WorkspacePath     string     `json:"workspace_path,omitempty"`
+	SessionID         string     `json:"session_id,omitempty"`
+	LastEventAt       *time.Time `json:"last_event_at,omitempty"`
+	Method            string     `json:"method,omitempty"`
+	Error             string     `json:"error,omitempty"`
+	CodexAppServerPID int        `json:"codex_app_server_pid,omitempty"`
+}
+
+// Retry mirrors SPEC §13.7.2's per-retry-row object. Kind is the wire form of
+// orchestrator.RetryKind (a string enum).
+type Retry struct {
+	IssueID    string     `json:"issue_id"`
+	Identifier string     `json:"issue_identifier,omitempty"`
+	IssueURL   string     `json:"issue_url,omitempty"`
+	Attempt    int        `json:"attempt"`
+	DueAt      *time.Time `json:"due_at,omitempty"`
+	Error      string     `json:"error,omitempty"`
+	Kind       string     `json:"kind"`
+}
+
+// OperatorTerminalStop mirrors SPEC §13.7.2's per-operator-terminal-stop row.
+type OperatorTerminalStop struct {
+	IssueID               string     `json:"issue_id"`
+	Identifier            string     `json:"issue_identifier,omitempty"`
+	State                 string     `json:"state,omitempty"`
+	StoppedAt             *time.Time `json:"stopped_at,omitempty"`
+	SuppressedDispatches  int        `json:"suppressed_dispatches"`
+	FirstSuppressedAt     *time.Time `json:"first_suppressed_at,omitempty"`
+	FirstSuppressedState  string     `json:"first_suppressed_state,omitempty"`
+	FirstSuppressedReason string     `json:"first_suppressed_reason,omitempty"`
+}


### PR DESCRIPTION
## Summary

The `/api/v1/state` JSON response shape was defined **three times** — the worker producer (`cmd/worker/stateapi.go`), a hand-copied consumer struct in `cmd/tui/state_client.go`, and the dashboard JSX — with **no parity guard** between the two Go copies (clean-code rule 3). A field added to the worker could silently never render in the TUI, and a JSON-tag typo could drop data on one side only.

This extracts the shared `/api/v1/state` wire DTOs into a new **leaf package `internal/stateapi`**, imported verbatim by both binaries, so the contract has one definition.

## Design

- `internal/stateapi` holds only the wire shape — `StateResponse` + nested `Counts`/`Running`/`RunningTokens`/`Blocked`/`Retry`/`OperatorTerminalStop`/`CodexTotals` — using plain `string` / `map[string]any` / `time.Time` and **no `internal/orchestrator` import**, so the thin TUI binary need not pull in the scheduler core to decode a status snapshot.
- The `orchestrator.StateView` → wire **mappers stay in `cmd/worker`** (single-consumer projection). The single-consumer `/api/v1/<issue>` and error DTOs also stay in `cmd/worker`, now referencing the shared types (acceptance criterion 2).
- `cmd/tui/state_client.go`'s hand-copied DTOs are **deleted**; the TUI decodes the shared `StateResponse` directly.
- Dashboard JSX is out of scope (can't import a Go type); the runbook drift test keeps covering docs (acceptance criterion 3).

## Wire compatibility (byte-for-byte preserved)

- ID-lists (`completed` / `reconcile_stopped_with_progress` / `agent_handoff_reconcile_stopped`) became `[]string`; `sortedIssueIDStrings` returns **nil for empty** so they still marshal `null` when empty (matching the old `append([]orchestrator.IssueID(nil), …)`), while row-lists keep emitting `[]`.
- `rate_limits` became `map[string]any` (`rateLimitsForAPI`); nil → `null`, key always present (no omitempty), populated payload identical. Aliasing is safe — `StateView.CodexRateLimits` is already a fresh deep copy per snapshot, marshaled immediately.
- `kind` via `string(retryKindOrFailure(...))`; tag set verified **72/72 identical** to the pre-change structs (incl. every `omitempty`).

## Acceptance criteria (issue #793)

- [x] Wire DTO structs extracted to `internal/stateapi`, imported by both `cmd/worker` and `cmd/tui`; `cmd/tui/state_client.go`'s copy deleted.
- [x] HTTP handlers + server loop stay in `cmd/worker` (single consumer, well-tested in-package).
- [x] Dashboard JSX out of scope; runbook drift test keeps covering docs.
- [x] Drift-test rule honored: every `omitempty` field in the synthetic fixture stays non-zero.

## Verification

- `gofmt -l` clean · `go vet ./...` clean · `go mod tidy` clean · golangci-lint: no findings in changed files
- `go build ./cmd/worker ./cmd/tui` · `go test -race -covermode=atomic ./...` green · `TestProductionGoFilesStayWithinSizeBudget` green
- **Regression tests are the anti-drift guards**, mutation-verified against the committed artifact (head `de8a5f7`): typo the shared `agent_handoff_reconcile_stopped` tag in `internal/stateapi/types.go` →
  - consumer `cmd/tui` `TestFetchState_DecodesSharedContractFields` **FAILS** (`= 0, want 2`)
  - producer `cmd/worker` `TestRuntimeStatusRunbookExampleMatchesHandler` **FAILS**
  - restored, tree == HEAD, both green.
- Pre-push review: **3× MERGE-READY** — Claude-family `pr-review-toolkit:code-reviewer`, an independent adversarial reviewer, and (after the local Codex sandbox was fixed) the Codex-family `codex:codex-rescue`, all empirically verifying wire parity, deep-copy safety, omitempty fidelity, and non-placebo tests. The two **LOW** findings were fixed in head `de8a5f7`: (1) stale `apiStateResponse` doc-comment pointers in `cmd/worker/dashboard/src/App.{jsx,test.jsx}` repointed to `internal/stateapi · StateResponse`; (2) `TestFetchState_DecodesSharedContractFields` hardened to pin every running/retry row field the dashboard renders. The GitHub `@codex review` gate also returned a clean result.
- (superseded) earlier note: 2× local review (Claude-family `pr-review-toolkit:code-reviewer` + an independent adversarial reviewer, both empirically verified wire parity, deep-copy safety, omitempty fidelity, and non-placebo tests). The Codex-family `codex:codex-rescue` local pass was **blocked by a sandbox network-isolation error (not an approval)**; the adversarial Codex pass runs post-push via the GitHub `@codex review` gate (protocol §4), as in #820.

## Known pre-existing (out of scope)

- `docs/runbooks/runtime-status.md` shows `"completed": []` for empty lists, but the wire emits `null` (true before this PR too). Filed as a follow-up; the drift test isn't sensitive to it.

## SPEC alignment (AGENTS.md principle 6/7)

Pure refactor of the SPEC §13.7.2 state-API representation: no new key/phase, no behavior change, no SPEC deviation. `internal/workflow/config.go` is untouched and the only new file is `internal/stateapi/types.go` (not a SPEC-sensitive `internal/orchestrator/`/`internal/worker/` path), so the gate's SPEC-sensitive trigger does not fire.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

### Size gate
- [ ] `within budget`
- [x] `size-gated: justified overage` — 5 production files, ~493 changed production LOC by raw diff count, but it is a single **verified-lossless extraction/move** (moved bodies diff to the same tag set; net production LOC ≈ flat) that cannot be split without reintroducing the duplicate the issue exists to remove. Near-zero review burden. **Needs human size-gate sign-off** (per #820 precedent; not auto-merged).
- [ ] `size-gated: split recommended`

Closes #793
