### PR TITLE
security: add a minimal SECURITY.md vulnerability-disclosure channel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported versions
+
+`aiops-platform` is pre-release and ships from a single line of development.
+Only the **latest published release** (see
+[Releases](https://github.com/xrf9268-hue/aiops-platform/releases)) receives
+security fixes. There are no maintained back-release branches.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report privately through GitHub's
+[Private vulnerability reporting](https://github.com/xrf9268-hue/aiops-platform/security/advisories/new):
+on the repository's **Security** tab, choose **Report a vulnerability**. This
+opens a private advisory visible only to the maintainers, so the fix can land
+before any public disclosure.
+
+Please include enough to reproduce: affected version/commit, configuration
+(redact tokens and secrets), and the impact you observed. You will get an
+acknowledgement of the report; the maintainers will coordinate a fix and a
+coordinated-disclosure timeline with you.
+
+## Scope
+
+This tool runs coding agents against real repositories with real tracker and
+git credentials, so its threat model — sandboxing, token isolation, the
+scheduler/runner boundary, and the controls operators should apply before
+connecting it to live repositories or trackers — is documented in
+[`docs/security-posture.md`](docs/security-posture.md). Read it before a
+first real run.


### PR DESCRIPTION
## Summary

The repo had **no vulnerability-disclosure channel** — no `SECURITY.md` (root or `.github/`), and `docs/security-posture.md` documents the threat model but not how to report a finding privately. For a self-hostable tool that runs coding agents against real repos with real tokens, a private reporting path is the one piece of OSS security ceremony that earns its keep (#798).

## Changes

- Add a minimal **`SECURITY.md`**:
  - **Supported version** = the latest published release (no maintained back-release branches, matching the pre-release single line of development).
  - **Report privately** via GitHub Private vulnerability reporting (Security tab → *Report a vulnerability*), linking the advisory-new URL.
  - Links **`docs/security-posture.md`** for the threat model (sandboxing, token isolation, scheduler/runner boundary, operator controls).
- Enabled GitHub **"Private vulnerability reporting"** on the repo (verified `{"enabled":true}`), so the advisory flow the file points at is live.

Out of scope per the audit's strictness bar (and the issue): CONTRIBUTING.md / CODE_OF_CONDUCT.

## Acceptance criteria (issue #798)

- [x] Minimal `SECURITY.md`: supported version = latest release; report via GitHub Security Advisories; link `docs/security-posture.md`.
- [x] GitHub "Private vulnerability reporting" enabled in repo settings.

## Verification

- Docs-only change (one new markdown file); no Go code path, so no unit/mutation test applies.
- Dual pre-push review: **2× MERGE-READY** (`pr-review-toolkit:code-reviewer` + `codex:codex-rescue`). Both verified the advisory URL (`.../security/advisories/new`) and releases URL return HTTP 200, `docs/security-posture.md` exists and genuinely covers the named topics, no SLA overreach, no secret leakage, valid markdown.
- `gofmt`/`go vet`/tests unaffected (no Go changes).

## SPEC alignment (AGENTS.md principle 6/7)

Docs/security-policy addition; no SPEC-sensitive path, no new key/phase, no behavior change. `internal/workflow/config.go` untouched; no new `internal/orchestrator`/`internal/worker` file.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

### Size gate
- [x] `within budget` — 1 new file, docs-only (~30 LOC), well within the ~12-file / ~300-LOC guideline.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Closes #798
