### PR TITLE
test/e2e: clear the 5 pre-existing golangci e2e-tagged findings + lint e2e in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,17 @@ jobs:
           version: v2.12.2
           args: --config=.golangci.yml --enable-only=contextcheck,errcheck,errorlint,funlen,gocognit,gocritic,govet,ineffassign,revive,staticcheck,unparam,unused
 
+      # The e2e suite is build-tagged (`//go:build e2e`), so the default gate
+      # above never type-checks test/e2e/*.go and that class of lint finding
+      # silently accumulated (#802). Run the same blocking set a second time
+      # with the e2e tag, scoped to test/e2e, so build-tagged files can't
+      # escape lint.
+      - name: Run golangci-lint blocking gate (e2e build tag)
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          version: v2.12.2
+          args: --config=.golangci.yml --enable-only=contextcheck,errcheck,errorlint,funlen,gocognit,gocritic,govet,ineffassign,revive,staticcheck,unparam,unused --build-tags=e2e ./test/e2e/...
+
       - name: Verify Dockerfile Go version matches go.mod
         shell: bash
         run: |

--- a/test/e2e/gitea.go
+++ b/test/e2e/gitea.go
@@ -69,9 +69,13 @@ func startGitea(ctx context.Context) (*giteaEnv, error) {
 		"--email", "aiops-bot@example.invalid",
 		"-c", "/etc/gitea/app.ini",
 	})
-	if execErr != nil || code != 0 {
+	if execErr != nil {
 		_ = c.Terminate(ctx)
-		return nil, fmt.Errorf("create gitea admin user: exit %d err %v", code, execErr)
+		return nil, fmt.Errorf("create gitea admin user (exit %d): %w", code, execErr)
+	}
+	if code != 0 {
+		_ = c.Terminate(ctx)
+		return nil, fmt.Errorf("create gitea admin user: unexpected exit code %d", code)
 	}
 
 	host, err := c.Host(ctx)
@@ -145,7 +149,7 @@ func (g *giteaEnv) doJSON(ctx context.Context, method, path string, body any, ba
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody, _ := io.ReadAll(resp.Body)
 	return resp, respBody, nil
 }
@@ -202,20 +206,22 @@ func (g *giteaEnv) createRepo(ctx context.Context, name string) (cloneURL string
 	return out.CloneURL, nil
 }
 
-func (g *giteaEnv) putFile(ctx context.Context, owner, repo, path string, content []byte, msg string) error {
+// putWorkflowFile seeds the repo's canonical WORKFLOW.md (the only file the
+// e2e suite ever writes through the contents API).
+func (g *giteaEnv) putWorkflowFile(ctx context.Context, owner, repo string, content []byte, msg string) error {
 	type req struct {
 		Message string `json:"message"`
 		Content string `json:"content"`
 	}
 	resp, body, err := g.doJSON(ctx, "POST",
-		fmt.Sprintf("/api/v1/repos/%s/%s/contents/%s", url.PathEscape(owner), url.PathEscape(repo), path),
+		fmt.Sprintf("/api/v1/repos/%s/%s/contents/WORKFLOW.md", url.PathEscape(owner), url.PathEscape(repo)),
 		req{Message: msg, Content: encodeBase64(content)},
 		false)
 	if err != nil {
 		return err
 	}
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("putFile: status %d body %s", resp.StatusCode, body)
+		return fmt.Errorf("putWorkflowFile: status %d body %s", resp.StatusCode, body)
 	}
 	return nil
 }
@@ -241,22 +247,6 @@ func (g *giteaEnv) createIssue(ctx context.Context, owner, repo, title, body str
 		return 0, err
 	}
 	return out.Number, nil
-}
-
-func (g *giteaEnv) commentIssue(ctx context.Context, owner, repo string, issue int, body string) error {
-	type req struct {
-		Body string `json:"body"`
-	}
-	resp, respBody, err := g.doJSON(ctx, "POST",
-		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments", url.PathEscape(owner), url.PathEscape(repo), issue),
-		req{Body: body}, false)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("commentIssue: status %d body %s", resp.StatusCode, respBody)
-	}
-	return nil
 }
 
 func (g *giteaEnv) ensureLabels(ctx context.Context, owner, repo string, labels []string) error {

--- a/test/e2e/gitea_tracker_test.go
+++ b/test/e2e/gitea_tracker_test.go
@@ -21,7 +21,7 @@ func TestGiteaTrackerDispatchesLabeledIssueAndDedupesRepeatedPolls(t *testing.T)
 	if err != nil {
 		t.Fatalf("create repo: %v", err)
 	}
-	if err := bed.gitea.putFile(context.Background(), owner, repo, "WORKFLOW.md", fixtureContent(t, "gitea-worker.md"), "add workflow"); err != nil {
+	if err := bed.gitea.putWorkflowFile(context.Background(), owner, repo, fixtureContent(t, "gitea-worker.md"), "add workflow"); err != nil {
 		t.Fatalf("put workflow: %v", err)
 	}
 	issueNumber, err := bed.gitea.createIssue(context.Background(), owner, repo, "poll me", "dispatch through polling")
@@ -86,7 +86,7 @@ func TestGiteaTrackerIgnoresBacklogAndTerminalIssues(t *testing.T) {
 	if _, err := bed.gitea.createRepo(context.Background(), repo); err != nil {
 		t.Fatalf("create repo: %v", err)
 	}
-	if err := bed.gitea.putFile(context.Background(), owner, repo, "WORKFLOW.md", fixtureContent(t, "gitea-worker.md"), "add workflow"); err != nil {
+	if err := bed.gitea.putWorkflowFile(context.Background(), owner, repo, fixtureContent(t, "gitea-worker.md"), "add workflow"); err != nil {
 		t.Fatalf("put workflow: %v", err)
 	}
 	backlogIssue, err := bed.gitea.createIssue(context.Background(), owner, repo, "backlog", "must not dispatch")

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -130,7 +130,7 @@ func TestGiteaWorkerReconciliationStopsRunMovedToDone(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatalf("worker was not canceled after moving issue to Done: %v", ctx.Err())
 	}
-	pollUntil(t, 10*time.Second, 100*time.Millisecond, func(ctx context.Context) (bool, error) {
+	pollUntil(ctx, t, 10*time.Second, 100*time.Millisecond, func(ctx context.Context) (bool, error) {
 		view, err := orch.Snapshot(ctx)
 		if err != nil {
 			return false, err
@@ -168,8 +168,8 @@ func runGiteaWorkerTask(t *testing.T, ctx context.Context, repo, title, body, fi
 	if err != nil {
 		t.Fatalf("createRepo: %v", err)
 	}
-	if err := bed.gitea.putFile(ctx, owner, repo, "WORKFLOW.md", fixtureContent(t, fixture), "seed workflow"); err != nil {
-		t.Fatalf("putFile workflow: %v", err)
+	if err := bed.gitea.putWorkflowFile(ctx, owner, repo, fixtureContent(t, fixture), "seed workflow"); err != nil {
+		t.Fatalf("putWorkflowFile: %v", err)
 	}
 	issueNum, err := bed.gitea.createIssue(ctx, owner, repo, title, body)
 	if err != nil {
@@ -235,7 +235,7 @@ func runGiteaWorkerTask(t *testing.T, ctx context.Context, repo, title, body, fi
 		t.Fatalf("poll: %v", err)
 	}
 
-	pollUntil(t, 90*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
+	pollUntil(ctx, t, 90*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
 		tk, ok := events.taskBySource("gitea_issue", fmt.Sprintf("#%d", issueNum))
 		if !ok {
 			return false, nil

--- a/test/e2e/poll.go
+++ b/test/e2e/poll.go
@@ -9,11 +9,13 @@ import (
 )
 
 // pollUntil retries fn every interval until it returns (true, nil) or
-// fails the test on timeout.
-func pollUntil(t *testing.T, timeout, interval time.Duration, fn func(context.Context) (bool, error)) {
+// fails the test on timeout. The poll context derives from the caller's ctx
+// so a cancelled/expired parent (e.g. the test's deadline) stops the poll
+// instead of being ignored.
+func pollUntil(ctx context.Context, t *testing.T, timeout, interval time.Duration, fn func(context.Context) (bool, error)) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	var lastErr error
 	for time.Now().Before(deadline) {

--- a/test/e2e/scripted_agent_test.go
+++ b/test/e2e/scripted_agent_test.go
@@ -102,8 +102,8 @@ func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createRepo: %v", err)
 	}
-	if err := bed.gitea.putFile(ctx, owner, repo, "WORKFLOW.md", fixtureContent(t, "scripted-agent.md"), "seed workflow"); err != nil {
-		t.Fatalf("putFile workflow: %v", err)
+	if err := bed.gitea.putWorkflowFile(ctx, owner, repo, fixtureContent(t, "scripted-agent.md"), "seed workflow"); err != nil {
+		t.Fatalf("putWorkflowFile: %v", err)
 	}
 	issueNum, err := bed.gitea.createIssue(ctx, owner, repo, "scripted handoff", "agent pushes a branch, opens a PR, flips the label")
 	if err != nil {
@@ -199,7 +199,7 @@ func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
 	}
 
 	var taskID string
-	pollUntil(t, 90*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
+	pollUntil(ctx, t, 90*time.Second, 250*time.Millisecond, func(ctx context.Context) (bool, error) {
 		tk, ok := events.taskBySource("gitea_issue", fmt.Sprintf("#%d", issueNum))
 		if !ok {
 			return false, nil
@@ -237,7 +237,7 @@ func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
 	// §18.1 WorkspaceCleaner seam. Both the continuation scheduling and the
 	// cleanup itself run on async followups, so poll until they settle instead
 	// of asserting after a single tick.
-	pollUntil(t, 60*time.Second, 500*time.Millisecond, func(ctx context.Context) (bool, error) {
+	pollUntil(ctx, t, 60*time.Second, 500*time.Millisecond, func(ctx context.Context) (bool, error) {
 		// Treat transient poll/snapshot errors as not-yet-settled: the next
 		// tick retries and only the 60s timeout reports failure, so one API
 		// hiccup under CI load cannot fail the whole e2e run. The error is


### PR DESCRIPTION
## Summary

CI's golangci-lint gate runs **without** the `e2e` build tag, so `test/e2e/*.go` (`//go:build e2e`) is never type-checked and that class of lint finding silently accumulates. The 2026-06-12 release-readiness batch surfaced **5 findings** under the blocking set with `--build-tags=e2e` (#802). This fixes all 5 and adds a CI pass so they can't recur.

## The 5 findings (all fixed)

| Linter | Location | Fix |
|---|---|---|
| contextcheck | `poll.go` `pollUntil` | Thread the caller's `ctx` through `pollUntil` and derive the poll deadline from it (`WithTimeout(ctx, …)`), so a cancelled/expired parent stops the poll instead of being ignored (was `context.Background()`). 4 call sites updated. |
| errorlint | `gitea.go:74` | Split admin-user-create into a wrapped exec error (`%w`, now also carrying the exit code) and a separate non-zero-exit message — no `%v` on an error. |
| errcheck | `gitea.go` `doJSON` | Explicitly ignore `resp.Body.Close()` in the defer. |
| unparam | `gitea.go` `putFile` | Every caller passed the constant `"WORKFLOW.md"`; drop the always-constant `path` param and rename to `putWorkflowFile`. |
| unused | `gitea.go` `commentIssue` | Delete the dead helper. |

**Timing safety of the contextcheck change:** deriving from the parent bounds each poll by `min(parent remaining, timeout)`. Headroom is ample at every call site — HappyPath 90s parent with a mock agent that completes in seconds; reconcile 90s parent / 10s poll; scripted-agent 300s parent / 90s+60s polls. No timeout regression; it is a strict correctness improvement (the poll now honors the test deadline).

## Acceptance criterion 2 — CI decision (implemented)

Per harness principle 3 (tighten the harness on an observed failure), CI now runs the **same blocking set a second time with `--build-tags=e2e` scoped to `./test/e2e/...`**, so build-tagged files can no longer escape lint.

## Verification

- `gofmt -l` clean · `go vet ./...` and `go vet -tags e2e ./test/e2e/...` clean · `go build ./cmd/...` · `go test -race ./...` green · size budget green.
- `go build -tags e2e ./test/e2e/...` compiles.
- **The CI guard is real and analyzes e2e files** (a Codex-family reviewer's degraded sandbox reported "no go files to analyze" — refuted by direct evidence): the exact CI command reports `0 issues` on this head; on `origin/main` it reproduces the 5 findings; and a mutation re-introducing the errcheck finding is **caught** (`gitea.go errcheck, 1 issues`). So the new step both fails on the class and passes once fixed.
- No standalone regression test per fix — these are lint cleanups; the new CI e2e-lint step is the class-level recurrence guard (clean-code rule 10), empirically shown to catch all 5 on the pre-fix tree.
- The full e2e suite runs in CI's required **E2E Gitea mock loop** job (Docker not available locally).
- Pre-push dual review: Claude-family `pr-review-toolkit:code-reviewer` **MERGE-READY** (independently reproduced base=5 / HEAD=0 and verified each fix); Codex-family `codex:codex-rescue` cleared every fix but returned BLOCKED solely on a "no go files to analyze" result from its sandbox — refuted above with a reproduced mutation. The one shared **LOW** (preserve the exit code when there's also an exec error) is applied.

## SPEC alignment (AGENTS.md principle 6/7)

Test-only + CI config; no SPEC-sensitive path, no new key/phase, no behavior change to the orchestrator. `internal/workflow/config.go` untouched; no new `internal/orchestrator`/`internal/worker` file.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

### Size gate
- [x] `within budget` — 5 build-tagged test/e2e files + one CI workflow step; no production Go code changed.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Closes #802
