### PR TITLE
tests: httptest-backed loop-level integration coverage for the github and linear tracker kinds

### DIFF
--- a/internal/orchestrator/poller_github_loop_test.go
+++ b/internal/orchestrator/poller_github_loop_test.go
@@ -1,0 +1,170 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// These tests drive a real tracker.GitHubClient — not an in-memory fake —
+// through the full poll -> dispatch -> reconcile loop against canned-response
+// httptest servers (no containers), mirroring the Gitea e2e loop shape. They
+// close the gap the unit tests leave: github_test.go exercises the client in
+// isolation and poller_test.go exercises the loop with fakeIssueStateTracker,
+// but nothing composes the real client with NewPollerWithReconciliation (#794).
+
+// githubLoopServer serves the GitHub REST endpoints the poll loop touches:
+// the open-PR claim scan (/pulls), the active-issue listing (/issues), and the
+// per-issue narrow state refresh (/issues/{number}). list/refresh return the
+// JSON the caller supplies for the current phase so a test can flip an issue
+// from active to terminal between ticks.
+func githubLoopServer(t *testing.T, listBody, refreshBody func() any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case "/repos/acme/api/issues":
+			_ = json.NewEncoder(w).Encode(listBody())
+		case "/repos/acme/api/issues/159":
+			_ = json.NewEncoder(w).Encode(refreshBody())
+		default:
+			t.Errorf("unexpected GitHub request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func githubIssueJSON(label string) map[string]any {
+	return map[string]any{
+		"id": 159, "number": 159, "title": "loop integration", "state": "open",
+		"created_at": "2026-05-20T01:02:03Z", "updated_at": "2026-05-20T02:03:04Z",
+		"labels": []map[string]any{{"name": label}},
+	}
+}
+
+// waitForIssueNotRunningOrRetrying waits until the specific issue id leaves the
+// running/retrying sets. The package's waitForNoRunningOrRetrying hard-codes
+// "issue-1", so it can't be used for these tests' real issue ids (#794).
+func waitForIssueNotRunningOrRetrying(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		view, err := orch.Snapshot(ctx)
+		if err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+		if !hasRunningOrRetrying(view, id) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	view, err := orch.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	t.Fatalf("issue %s still running/retrying after reconcile cancel: running=%v retrying=%v", id, view.Running, view.Retrying)
+}
+
+func TestPollerLoopGitHubClientDispatchesActiveIssue(t *testing.T) {
+	srv := githubLoopServer(t,
+		func() any { return []map[string]any{githubIssueJSON("Todo")} },
+		func() any { return githubIssueJSON("Todo") },
+	)
+	defer srv.Close()
+	client := tracker.NewGitHubClient(workflow.TrackerConfig{
+		APIKey: "test-token", ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"},
+	}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(client, orch, ReconciliationConfig{
+		ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"}, WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 1)
+
+	got := dispatcher.issueAt(0)
+	if got.ID != "159" || got.Identifier != "#159" || got.State != "todo" {
+		t.Fatalf("dispatched issue = %+v; want ID 159 identifier #159 state todo (mapped from the active label)", got)
+	}
+}
+
+func TestPollerLoopGitHubClientReconcileCancelsIssueLeavingActive(t *testing.T) {
+	// phase 0: the issue carries the active Todo label; phase 1: it has moved to
+	// the terminal Done label and dropped out of the active listing, so the
+	// reconcile pass must cancel the in-flight run on the next tick.
+	// The dispatch path revalidates each candidate via the narrow state refresh
+	// (/issues/{number}) before dispatching, so both the listing and the refresh
+	// must report the active Todo label in phase 0 for the run to start; phase 1
+	// flips both to the terminal Done label so the reconcile pass cancels it.
+	var phase atomic.Int32
+	label := func() string {
+		if phase.Load() == 0 {
+			return "Todo"
+		}
+		return "Done"
+	}
+	srv := githubLoopServer(t,
+		func() any {
+			if phase.Load() == 0 {
+				return []map[string]any{githubIssueJSON("Todo")}
+			}
+			return []map[string]any{}
+		},
+		func() any { return githubIssueJSON(label()) },
+	)
+	defer srv.Close()
+	client := tracker.NewGitHubClient(workflow.TrackerConfig{
+		APIKey: "test-token", ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"},
+	}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(client, orch, ReconciliationConfig{
+		ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"}, WorkerExitTimeout: time.Second,
+	})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher)
+
+	phase.Store(1)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("reconcile poll once: %v", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForIssueNotRunningOrRetrying(t, ctx, orch, "159")
+}

--- a/internal/orchestrator/poller_linear_loop_test.go
+++ b/internal/orchestrator/poller_linear_loop_test.go
@@ -1,0 +1,228 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// These tests drive a real tracker.LinearClient through the full
+// poll -> dispatch -> reconcile loop against a canned GraphQL httptest server
+// (no containers), the Linear counterpart to poller_github_loop_test.go (#794).
+// Linear, unlike the GitHub adapter, resolves blocker relations for Todo
+// issues, so the SPEC §8.2 blocker gate is exercised here end-to-end.
+
+// linearLoopServer routes the three GraphQL operations the loop issues — the
+// ListIssues active listing, the IssueStatesByIDs narrow refresh, and the
+// Todo-only ListIssuesInverseRelations blocker query — to per-operation
+// response builders so a test can vary them by phase. IssueStatesByIDs is
+// matched before the broader ListIssues check because both contain "Issue".
+func linearLoopServer(t *testing.T, listNodes, refreshNodes, blockerNodes func() []any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		var nodes []any
+		switch {
+		case strings.Contains(req.Query, "IssueStatesByIDs"):
+			nodes = refreshNodes()
+		case strings.Contains(req.Query, "InverseRelations"):
+			nodes = blockerNodes()
+		case strings.Contains(req.Query, "ListIssues"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"issues": map[string]any{
+				"nodes":    listNodes(),
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+			}}})
+			return
+		default:
+			t.Errorf("unexpected Linear GraphQL query: %s", req.Query)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"issues": map[string]any{"nodes": nodes}}})
+	}))
+}
+
+func linearListNode(id, identifier, state string) any {
+	return map[string]any{
+		"id": id, "identifier": identifier, "title": "loop integration",
+		"description": "", "url": "https://linear.app/x/issue/" + identifier,
+		"priority": 2, "branchName": "", "createdAt": "2026-05-20T01:02:03.000Z",
+		"updatedAt": "2026-05-20T02:03:04.000Z",
+		"labels":    map[string]any{"nodes": []any{}},
+		"state":     map[string]any{"name": state},
+	}
+}
+
+func linearRefreshNode(id, state string) any {
+	return map[string]any{
+		"id": id, "state": map[string]any{"name": state},
+		"labels": map[string]any{"nodes": []any{}},
+	}
+}
+
+// linearBlockerNode is one ListIssuesInverseRelations node: issueID is blocked
+// by blockerID (a "blocks" relation) which sits in blockerState.
+func linearBlockerNode(issueID, blockerID, blockerState string) any {
+	return map[string]any{
+		"id": issueID,
+		"inverseRelations": map[string]any{
+			"nodes": []any{map[string]any{
+				"type":  "blocks",
+				"issue": map[string]any{"id": blockerID, "identifier": blockerID, "state": map[string]any{"name": blockerState}},
+			}},
+			"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+		},
+	}
+}
+
+func newLinearLoopClient(t *testing.T, srv *httptest.Server) *tracker.LinearClient {
+	t.Helper()
+	client := tracker.NewLinearClient(workflow.TrackerConfig{
+		APIKey:         "test-key",
+		ProjectSlug:    "aiops-loop",
+		ActiveStates:   []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done", "Canceled"},
+	})
+	client.BaseURL = srv.URL
+	client.HTTP = srv.Client()
+	return client
+}
+
+func linearLoopReconcileConfig() ReconciliationConfig {
+	return ReconciliationConfig{
+		ActiveStates:      []string{"Todo", "In Progress"},
+		TerminalStates:    []string{"Done", "Canceled"},
+		WorkerExitTimeout: time.Second,
+	}
+}
+
+func TestPollerLoopLinearClientDispatchesActiveIssue(t *testing.T) {
+	noNodes := func() []any { return nil }
+	srv := linearLoopServer(t,
+		func() []any { return []any{linearListNode("lin-1", "AIS-1", "In Progress")} },
+		func() []any { return []any{linearRefreshNode("lin-1", "In Progress")} },
+		noNodes,
+	)
+	defer srv.Close()
+	client := newLinearLoopClient(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(client, orch, linearLoopReconcileConfig())
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	waitForDispatcherCount(t, dispatcher, 1)
+	if got := dispatcher.issueAt(0); got.ID != "lin-1" || got.Identifier != "AIS-1" || got.State != "In Progress" {
+		t.Fatalf("dispatched issue = %+v; want lin-1 AIS-1 In Progress", got)
+	}
+}
+
+func TestPollerLoopLinearClientBlockerGateSuppressesTodoDispatch(t *testing.T) {
+	// A Todo issue blocked by a non-terminal dependency must not dispatch. The
+	// Linear listing resolves Todo blockers inline (fetchLinearIssuesPage ->
+	// attachLinearBlockers), so the open "blocks" relation the inverse-relations
+	// query reports lands on the candidate and the SPEC §8.2 eligibility gate
+	// drops it before dispatch. (Dispatch-time revalidation re-applies the same
+	// gate on refreshed data; that path is covered by the client unit tests.)
+	srv := linearLoopServer(t,
+		func() []any { return []any{linearListNode("lin-1", "AIS-1", "Todo")} },
+		func() []any { return []any{linearRefreshNode("lin-1", "Todo")} },
+		func() []any { return []any{linearBlockerNode("lin-1", "AIS-2", "In Progress")} },
+	)
+	defer srv.Close()
+	client := newLinearLoopClient(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatcher := &recordingDispatcher{releaseCh: make(chan struct{})}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(client, orch, linearLoopReconcileConfig())
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("poll once: %v", err)
+	}
+	// Give any erroneous dispatch a chance to register before asserting absence.
+	time.Sleep(100 * time.Millisecond)
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues; want 0 (Todo blocked by a non-terminal dependency must be gated)", got)
+	}
+}
+
+func TestPollerLoopLinearClientReconcileCancelsIssueLeavingActive(t *testing.T) {
+	var phase atomic.Int32
+	state := func() string {
+		if phase.Load() == 0 {
+			return "In Progress"
+		}
+		return "Done"
+	}
+	srv := linearLoopServer(t,
+		func() []any {
+			if phase.Load() == 0 {
+				return []any{linearListNode("lin-1", "AIS-1", "In Progress")}
+			}
+			return nil
+		},
+		func() []any { return []any{linearRefreshNode("lin-1", state())} },
+		func() []any { return nil },
+	)
+	defer srv.Close()
+	client := newLinearLoopClient(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(client, orch, linearLoopReconcileConfig())
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher)
+
+	phase.Store(1)
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("reconcile poll once: %v", err)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForIssueNotRunningOrRetrying(t, ctx, orch, "lin-1")
+}


### PR DESCRIPTION
## Summary

Only the **Gitea** tracker kind was driven through the full poll→dispatch→reconcile loop (via the container-backed `test/e2e` suite). `GitHubClient` / `LinearClient` were exercised only in isolation (`github_test.go` 18 tests, `linear_test.go` 26 tests), and the loop was only ever tested with the in-memory `fakeIssueStateTracker` — **no test composed a real client with `NewPollerWithReconciliation`** (#794). The newest kind (github) had the least field mileage.

This adds **httptest-backed loop tests (no containers)** that wire a real `GitHubClient` and `LinearClient` — against canned REST / GraphQL servers — into `NewPollerWithReconciliation` and assert the loop end-to-end, mirroring the Gitea e2e shape.

## Coverage (github first, linear second)

- **github** — `poller_github_loop_test.go`:
  - dispatch of an active issue (asserts the client's id/identifier/state label-mapping: `159` / `#159` / `todo`);
  - reconcile-cancel when the issue leaves the active set (the `/issues` listing drops it and the narrow `/issues/{number}` refresh reports the terminal `Done` label).
  - The GitHub adapter models no dependencies (`BlockedBy` always nil), so the blocker gate is covered on the linear side.
- **linear** — `poller_linear_loop_test.go`:
  - dispatch of an active issue;
  - **SPEC §8.2 blocker gate** suppressing a `Todo` issue whose Todo-only inverse-relations resolution reports an open `blocks` relation (the Linear listing resolves Todo blockers inline, so the eligibility filter drops it);
  - reconcile-cancel on transition to a terminal state.

## These genuinely drive the real clients (not placebos)

- Dispatch assertions pin the real client's id/identifier/state mapping; a wrong canned response fails them.
- The reconcile-cancel proof is `waitForContextCanceled(dispatcher.contextAt(0))` **plus** a per-id `waitForIssueNotRunningOrRetrying(…, "159"/"lin-1")`. Mutation-verified: forcing the phase-1 refresh to stay active makes `waitForContextCanceled` fail (`context was not canceled`).
- The blocker-gate negative assertion is mutation-verified: removing the blocker makes the same Todo issue dispatch (`count 1`).
- The dispatch loop revalidates each candidate via the narrow refresh before dispatching — surfaced and accounted for while writing these (the refresh must agree with the listing for the run to start).

## Verification

- `gofmt`/`go vet ./...` clean · `go test -race ./internal/orchestrator/` green (87.3% pkg coverage) · full `go test -race ./...` green · size budget green · `go mod tidy` clean.
- Pre-push dual review: Claude-family `pr-review-toolkit:code-reviewer` **MERGE-READY** (20× `-race`, contract-faithful, mutation-verified). Codex-family `codex:codex-rescue` initially **NEEDS-CHANGES** on two MEDIUMs — (1) the reconcile assertion used the package's `waitForNoRunningOrRetrying`, which hard-codes `"issue-1"` and was a no-op for these tests' ids; (2) the blocker-gate comment misattributed the gate to dispatch-time revalidation when the Linear listing resolves blockers inline. Both fixed (per-id wait helper; corrected comment) and **re-verified MERGE-READY**.
- Two **LOW**s left as decided (disclosed): the reused `recordingDispatcher`'s never-closed `releaseCh` goroutine (pre-existing helper pattern, reaped at process exit, intentionally keeps the run "running"); the canned servers don't assert request params (the dispatch/cancel/suppress outcomes already prove the client issued the right requests).

No production code changes.

## SPEC alignment (AGENTS.md principle 6/7)

Test-only addition exercising existing SPEC behavior (poll→dispatch→reconcile, §8.2 blocker gate, §11.2/§16.3 reconcile). No new key/phase, no SPEC-sensitive path, no behavior change. `internal/workflow/config.go` untouched; the new files are tests, not new `internal/orchestrator`/`internal/worker` production files.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

### Size gate
- [x] `within budget` — 2 new test files, zero production diff.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Closes #794
