### PR TITLE
release: ship examples/WORKFLOW.md + .env.example inside tarballs + emit a SHA256SUMS file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,9 +181,33 @@ jobs:
           set -euo pipefail
           for out in dist/aiops-platform_${RELEASE_TAG}_*; do
             [ -d "$out" ] || continue
+            # Ship a runnable starting point alongside the binaries so a
+            # binary-download user has a config template without cloning (#797).
+            # Keep WORKFLOW.md under examples/ so the bundled .env.example's
+            # AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md resolves from the
+            # extracted directory.
+            mkdir -p "$out/examples"
+            cp examples/WORKFLOW.md "$out/examples/"
+            cp .env.example "$out/"
             tar -C dist -czf "${out}.tar.gz" "$(basename "$out")"
             rm -rf "$out"
           done
+
+      - name: Generate SHA256SUMS
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Plain checksums file so operators without the gh CLI / attestation
+          # flow can still verify archive integrity (#797). Computed over the
+          # archives + SBOM (basenames only, so `sha256sum -c` works from the
+          # download dir); emitted before attestation so the existing
+          # subject-path: dist/* step signs it too.
+          ( cd dist && sha256sum \
+              "aiops-platform_${RELEASE_TAG}"_*.tar.gz \
+              "aiops-platform_${RELEASE_TAG}_sbom.cdx.json" \
+              > "aiops-platform_${RELEASE_TAG}_SHA256SUMS" )
 
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
@@ -214,6 +238,6 @@ jobs:
               --notes "Automated aiops-platform release for $RELEASE_TAG" \
               --verify-tag
           fi
-          gh release upload "$RELEASE_TAG" dist/*.tar.gz dist/*_sbom.cdx.json \
+          gh release upload "$RELEASE_TAG" dist/*.tar.gz dist/*_sbom.cdx.json dist/*_SHA256SUMS \
             --repo "$GITHUB_REPOSITORY" \
             --clobber

--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ To run it directly under a service manager instead of Compose — build/install,
 `worker --doctor` preflight, and Linux (systemd) / macOS (launchd) samples —
 see the [binary deployment runbook](docs/runbooks/binary-deployment.md).
 
+Prebuilt Linux/macOS (amd64/arm64) archives are attached to each
+[GitHub Release](https://github.com/xrf9268-hue/aiops-platform/releases) as
+`aiops-platform_<tag>_<os>_<arch>.tar.gz`, bundling the `worker` and `tui`
+binaries plus `examples/WORKFLOW.md` and `.env.example`. Verify a download with
+either `gh attestation verify <archive> --repo xrf9268-hue/aiops-platform`
+(build provenance) or `sha256sum --ignore-missing -c
+aiops-platform_<tag>_SHA256SUMS` (plain checksums; `--ignore-missing` checks
+only the archives you downloaded, since the file lists every artifact) — both
+are published with the release.
+
 The default Compose service starts `worker`:
 
 ```bash


### PR DESCRIPTION
## Summary

Release archives shipped **binaries only** — no config template and no plain checksums file (verified against the live v0.1.1/v0.1.2 assets). A binary-download user had to clone for a starting config, and integrity verification required the `gh` CLI attestation flow, which not every operator has (#797).

## Changes

- **Bundle a starting config into each tarball**: the package step copies `examples/WORKFLOW.md` and `.env.example` into each per-platform archive alongside the `worker`/`tui` binaries (they land at the archive root).
- **Emit `aiops-platform_<tag>_SHA256SUMS`** over the archives + SBOM (basenames, so `sha256sum -c` works from the download dir), generated **before** the attestation step so the existing `subject-path: dist/*` signs it too, and added to the release upload.
- **README** points at [GitHub Releases](https://github.com/xrf9268-hue/aiops-platform/releases) and both verification paths (`gh attestation verify` for provenance, `sha256sum --ignore-missing -c` for plain checksums).

## Acceptance criteria (issue #797)

- [x] Tarballs include `examples/WORKFLOW.md` and `.env.example` (a few lines in the package step).
- [x] The package step emits `aiops-platform_<tag>_SHA256SUMS` over `dist/*`, uploaded with the release and covered by the existing attestation step.
- [x] One README sentence pointing at GitHub Releases + both verification paths.

## Verification

- **Simulated the package + SHA256SUMS steps end-to-end**: tarballs contain `WORKFLOW.md` + `.env.example` + `worker`/`tui`; `SHA256SUMS` lists the 4 archives + SBOM by basename; `sha256sum -c` verifies OK. YAML valid.
- The `[ -d "$out" ]` guard correctly leaves the SBOM file standalone (not tarred); SHA256SUMS references the exact SBOM filename the SBOM step emits; the file excludes itself.
- Pre-push dual review: `pr-review-toolkit:code-reviewer` **MERGE-READY** (simulated and verified ordering/attestation/basenames). `codex:codex-rescue` flagged a **MEDIUM** — `sha256sum -c` warns/fails when a user downloaded only one archive — fixed by documenting `--ignore-missing` (verifies only the present files). Re-verified.
- Docs/CI-config only — no Go changes (`gofmt`/`go vet`/tests unaffected).

## SPEC alignment (AGENTS.md principle 6/7)

Release-artifact packaging + docs; no SPEC-sensitive path, no new key/phase, no behavior change. `internal/workflow/config.go` untouched; no new `internal/orchestrator`/`internal/worker` file.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

### Size gate
- [x] `within budget` — `release.yml` (~21 lines) + a README paragraph; no production code.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Closes #797
