### PR TITLE
cmd: version observability (--version, ldflags stamping, /api/v1/state field, --help subcommands)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,8 +160,10 @@ jobs:
             read -r goos goarch <<< "$target"
             out="dist/aiops-platform_${RELEASE_TAG}_${goos}_${goarch}"
             for binary in "${binaries[@]}"; do
+              # Stamp the release tag into each binary's main.version (#796);
+              # both cmd/worker and cmd/tui are package main with their own var.
               GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 \
-                go build -trimpath -ldflags="-s -w" -o "${out}/${binary}" "./cmd/${binary}"
+                go build -trimpath -ldflags="-s -w -X main.version=${RELEASE_TAG}" -o "${out}/${binary}" "./cmd/${binary}"
             done
           done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 COPY . .
 COPY --from=dashboard /src/cmd/worker/dashboard/dist ./cmd/worker/dashboard/dist
-RUN go build -o /out/worker ./cmd/worker
+# Stamp main.version from a build ARG (#796): .dockerignore drops .git, so the
+# Go toolchain's vcs.revision fallback is unavailable in the image. Pass
+# --build-arg VERSION=<tag> to stamp a real version; defaults to "devel" for a
+# plain `docker build`.
+ARG VERSION=devel
+RUN go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o /out/worker ./cmd/worker
 
 FROM debian:bookworm-slim AS worker
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ca-certificates git openssh-client ripgrep wget && rm -rf /var/lib/apt/lists/*

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -15,8 +15,17 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/buildinfo"
 	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
 )
+
+// version is the build stamp, set at link time via
+// -ldflags "-X main.version=<tag>" (release.yml, install.sh). It stays "devel"
+// for an un-stamped build; resolveVersion then falls back to the VCS revision
+// the Go toolchain records when built from a source tree (#796).
+var version = "devel"
+
+func resolveVersion() string { return buildinfo.Resolve(version) }
 
 // ANSI escape codes (mirrors Elixir @ansi_* module attributes)
 const (
@@ -47,7 +56,12 @@ func main() {
 	urlFlag := flag.String("url", "http://127.0.0.1:4000/", "worker HTTP API base URL")
 	intervalFlag := flag.Duration("interval", 5*time.Second, "poll interval")
 	rawFlag := flag.Bool("raw", false, "disable alt-screen/cursor management (upstream parity mode)")
+	versionFlag := flag.Bool("version", false, "print the build version and exit")
 	flag.Parse()
+	if *versionFlag {
+		fmt.Println(resolveVersion())
+		return
+	}
 
 	baseURL := strings.TrimSuffix(*urlFlag, "/")
 	// Allow env override when using the default flag value.

--- a/cmd/tui/version_test.go
+++ b/cmd/tui/version_test.go
@@ -1,0 +1,14 @@
+package main
+
+import "testing"
+
+// TestResolveVersionPrefersStamp pins the -ldflags -X path for the TUI: a
+// stamped main.version wins over the VCS fallback (#796).
+func TestResolveVersionPrefersStamp(t *testing.T) {
+	orig := version
+	t.Cleanup(func() { version = orig })
+	version = "v1.2.3"
+	if got := resolveVersion(); got != "v1.2.3" {
+		t.Fatalf("resolveVersion() = %q, want v1.2.3 (the -X stamp must win)", got)
+	}
+}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/buildinfo"
 	"github.com/xrf9268-hue/aiops-platform/internal/doctor"
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
@@ -21,7 +22,21 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+// version is the build stamp, set at link time via
+// -ldflags "-X main.version=<tag>" (release.yml, install.sh, Dockerfile).
+// It stays "devel" for an un-stamped `go build`/`go run`; resolveVersion then
+// falls back to the VCS revision the Go toolchain records when the binary was
+// built from a source tree (absent in Docker, where .dockerignore drops .git —
+// hence the explicit build ARG there).
+var version = "devel"
+
+func resolveVersion() string { return buildinfo.Resolve(version) }
+
 func main() { //nolint:gocognit // baseline (#521)
+	if len(os.Args) >= 2 && os.Args[1] == "--version" {
+		fmt.Println(resolveVersion())
+		os.Exit(0)
+	}
 	if len(os.Args) >= 2 && os.Args[1] == "--print-config" {
 		workdir, portOverride, err := parsePrintConfigArgs(os.Args[2:])
 		if err != nil {
@@ -126,6 +141,19 @@ func parseRunArgs(args []string) (string, *int, error) {
 	// and parse diagnostics reach the user. flag.ErrHelp is propagated
 	// to the caller, which treats it as a clean exit.
 	portFlag := fs.Int("port", 0, "override server.port from WORKFLOW.md: -1 disables the HTTP server, 0 binds an ephemeral port, 1..65535 binds explicitly. SPEC §13.7.")
+	// main() intercepts --print-config / --doctor / --version positionally
+	// before this flag set ever sees them, so the default `flag` usage hides
+	// them. Spell out every subcommand so `worker --help` is a complete map.
+	fs.Usage = func() {
+		out := fs.Output()
+		_, _ = fmt.Fprint(out, "Usage:\n"+
+			"  worker [--port=N] [path-to-WORKFLOW.md]            run the orchestrator loop (default)\n"+
+			"  worker --print-config [--port=N] <workdir>        print the resolved config and exit\n"+
+			"  worker --doctor [--mode=mock|real] [--deploy=binary|docker] [path]  run preflight checks and exit\n"+
+			"  worker --version                                  print the build version and exit\n\n"+
+			"Run-mode flags:\n")
+		fs.PrintDefaults()
+	}
 	if err := fs.Parse(reorderForFlagParse(args)); err != nil {
 		return "", nil, err
 	}
@@ -330,6 +358,7 @@ func run(ctx context.Context, args []string) error { //nolint:gocognit,funlen //
 	if err != nil {
 		return err
 	}
+	log.Printf("aiops worker starting version=%s", resolveVersion())
 	// Emit deprecated-alias warnings exactly once per startup; the env loaders
 	// below are pure and run more than once.
 	worker.WarnDeprecatedEnv()

--- a/cmd/worker/runbook_drift_test.go
+++ b/cmd/worker/runbook_drift_test.go
@@ -90,6 +90,7 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 	dueAt := time.Date(2026, 5, 21, 9, 11, 0, 0, time.UTC)
 	retryAttempt := 1
 	resp := stateapi.StateResponse{
+		Version:                    "v1.2.3",
 		GeneratedAt:                time.Date(2026, 5, 21, 9, 10, 0, 0, time.UTC),
 		PollIntervalMs:             15000,
 		MaxConcurrentAgents:        4,

--- a/cmd/worker/stateapi.go
+++ b/cmd/worker/stateapi.go
@@ -468,6 +468,7 @@ func apiStateFromView(view orchestrator.StateView) stateapi.StateResponse {
 	retrying := sortedAPIRetryRows(view.Retrying)
 	operatorStops := sortedAPIOperatorTerminalStops(view.OperatorTerminalStops)
 	return stateapi.StateResponse{
+		Version:                      resolveVersion(),
 		GeneratedAt:                  generatedAt,
 		PollIntervalMs:               view.PollIntervalMs,
 		MaxConcurrentAgents:          view.MaxConcurrentAgents,

--- a/cmd/worker/version_test.go
+++ b/cmd/worker/version_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
+)
+
+// TestResolveVersionPrefersStamp pins the -ldflags -X path: a stamped
+// main.version wins over the VCS fallback (#796).
+func TestResolveVersionPrefersStamp(t *testing.T) {
+	orig := version
+	t.Cleanup(func() { version = orig })
+	version = "v1.2.3"
+	if got := resolveVersion(); got != "v1.2.3" {
+		t.Fatalf("resolveVersion() = %q, want v1.2.3 (the -X stamp must win)", got)
+	}
+}
+
+// TestStateAPIStampsVersion mutation-verifies the wiring seam: the version
+// stamp must reach /api/v1/state. Dropping `Version: resolveVersion()` from
+// apiStateFromView omits the (omitempty) key and fails this test (#796).
+func TestStateAPIStampsVersion(t *testing.T) {
+	orig := version
+	t.Cleanup(func() { version = orig })
+	version = "v9.9.9-test"
+	raw, err := json.Marshal(apiStateFromView(orchestrator.StateView{}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["version"] != "v9.9.9-test" {
+		t.Fatalf("/api/v1/state version = %#v, want v9.9.9-test (mapper must stamp resolveVersion into the response)", got["version"])
+	}
+}

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -132,6 +132,7 @@ the shape here without updating the handler — or vice versa — fails the buil
 
 ```json
 {
+  "version": "v1.2.3",
   "generated_at": "2026-05-21T09:10:00Z",
   "poll_interval_ms": 15000,
   "max_concurrent_agents": 4,
@@ -273,6 +274,7 @@ Two consequences for dashboard authors:
 
 ### Top-level metadata fields
 
+- `version` — the worker build stamp (the `-ldflags -X main.version` value, or the VCS-revision fallback for a source build); omitted for an un-stamped/empty build. Lets a bug report name the exact build (also on `--version` and the startup log).
 - `generated_at` — RFC3339 timestamp the handler stamped when materializing the snapshot.
 - `poll_interval_ms` — current tracker poll interval (SPEC §13.7).
 - `max_concurrent_agents` — global concurrency cap.

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,60 @@
+// Package buildinfo resolves the version a binary reports (#796): the link-time
+// -ldflags "-X main.version=<tag>" stamp when set, else the VCS revision the Go
+// toolchain records for a source-tree build, else the stamp unchanged. It is
+// shared by cmd/worker and cmd/tui so the resolution rule has one definition;
+// each binary keeps its own main.version var because -X targets main.version.
+package buildinfo
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Resolve returns the human-facing version. stamped is the caller's
+// main.version var. A meaningful stamp wins; otherwise the VCS revision (short,
+// suffixed "-dirty" when the build tree was modified); otherwise the stamp
+// unchanged (typically "devel").
+func Resolve(stamped string) string {
+	if v := strings.TrimSpace(stamped); v != "" && v != "devel" {
+		return v
+	}
+	if rev := vcsRevision(); rev != "" {
+		return rev
+	}
+	return stamped
+}
+
+func vcsRevision() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	var revision string
+	var modified bool
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	return formatRevision(revision, modified)
+}
+
+// formatRevision shortens a VCS revision to 12 chars and appends "-dirty" when
+// the build tree was modified. An empty revision (no VCS info) stays empty so
+// Resolve can fall through to the stamp. Kept separate from ReadBuildInfo so
+// the formatting is unit-testable.
+func formatRevision(revision string, modified bool) string {
+	if revision == "" {
+		return ""
+	}
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+	if modified {
+		revision += "-dirty"
+	}
+	return revision
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,37 @@
+package buildinfo
+
+import "testing"
+
+// TestResolvePrefersStamp pins the load-bearing rule: a real -X stamp wins over
+// the VCS fallback, with surrounding whitespace trimmed (#796).
+func TestResolvePrefersStamp(t *testing.T) {
+	cases := map[string]string{"v1.2.3": "v1.2.3", "  v1.2.3  ": "v1.2.3"}
+	for in, want := range cases {
+		if got := Resolve(in); got != want {
+			t.Errorf("Resolve(%q) = %q, want %q (a real stamp must win over the VCS fallback)", in, got, want)
+		}
+	}
+}
+
+// TestFormatRevision pins the VCS-revision formatting deterministically (it is
+// the part of the fallback that does not depend on ReadBuildInfo): empty stays
+// empty, long revisions truncate to 12, and a modified tree gets "-dirty".
+func TestFormatRevision(t *testing.T) {
+	cases := []struct {
+		revision string
+		modified bool
+		want     string
+	}{
+		{"", false, ""},
+		{"", true, ""},
+		{"abc123", false, "abc123"},
+		{"0123456789abcdef0000", false, "0123456789ab"},
+		{"0123456789abcdef0000", true, "0123456789ab-dirty"},
+		{"abc123", true, "abc123-dirty"},
+	}
+	for _, c := range cases {
+		if got := formatRevision(c.revision, c.modified); got != c.want {
+			t.Errorf("formatRevision(%q, %v) = %q, want %q", c.revision, c.modified, got, c.want)
+		}
+	}
+}

--- a/internal/stateapi/types.go
+++ b/internal/stateapi/types.go
@@ -18,6 +18,11 @@ import "time"
 
 // StateResponse is the /api/v1/state body (SPEC §13.7.2).
 type StateResponse struct {
+	// Version is the worker build stamp (the -ldflags -X main.version value, the
+	// VCS-revision fallback, or "devel"), so a bug report can name the exact
+	// build. omitempty drops the key only when the resolved version is empty —
+	// which the "devel" default normally prevents (#796).
+	Version                    string         `json:"version,omitempty"`
 	GeneratedAt                time.Time      `json:"generated_at"`
 	PollIntervalMs             int64          `json:"poll_interval_ms"`
 	MaxConcurrentAgents        int            `json:"max_concurrent_agents"`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,9 +43,14 @@ command -v go >/dev/null 2>&1 || { echo "error: go toolchain not found on PATH (
 
 binaries=(worker tui)
 mkdir -p "$dist_dir"
+# Stamp main.version from the checkout's git description (nearest tag, else
+# short SHA, else devel) so a locally-installed binary reports a real version
+# via --version / the startup log / /api/v1/state (#796).
+version="$(cd "$repo_root" && git describe --tags --always --dirty 2>/dev/null || true)"
+[ -n "$version" ] || version="devel"
 for binary in "${binaries[@]}"; do
-  echo "building ${binary} -> dist/${binary}"
-  ( cd "$repo_root" && go build -trimpath -ldflags="-s -w" -o "dist/${binary}" "./cmd/${binary}" )
+  echo "building ${binary} (version=${version}) -> dist/${binary}"
+  ( cd "$repo_root" && go build -trimpath -ldflags="-s -w -X main.version=${version}" -o "dist/${binary}" "./cmd/${binary}" )
 done
 
 if [ -n "$prefix" ]; then

--- a/test/e2e/fixtures/dockerfile_buildlayer_test.go
+++ b/test/e2e/fixtures/dockerfile_buildlayer_test.go
@@ -56,7 +56,10 @@ func TestDockerfileBuildsDashboardBeforeWorker(t *testing.T) {
 	dashboardStage := strings.Index(df, "FROM node:22-bookworm AS dashboard")
 	buildStage := strings.Index(df, "FROM golang:${GO_VERSION}-bookworm AS build")
 	copyDashboard := strings.Index(df, "COPY --from=dashboard /src/cmd/worker/dashboard/dist ./cmd/worker/dashboard/dist")
-	buildWorker := strings.Index(df, "RUN go build -o /out/worker ./cmd/worker")
+	// Anchor on the output target, not the full command, so build-flag changes
+	// (e.g. the #796 -ldflags -X main.version stamp) don't break the
+	// layer-ordering assertion.
+	buildWorker := strings.Index(df, "-o /out/worker ./cmd/worker")
 	for name, idx := range map[string]int{
 		"dashboard stage": dashboardStage,
 		"go build stage":  buildStage,


### PR DESCRIPTION
## Summary

The worker/tui had **no version observability**: no `--version` flag; all three build paths (`release.yml`, `install.sh`, `Dockerfile`) stripped without stamping; `/api/v1/state` and the startup log carried no version — so a bug report couldn't name the build. `worker --help` also hid `--doctor`/`--print-config` (intercepted positionally before the flag set) (#796).

## Changes

- **`internal/buildinfo.Resolve(stamped)`** — one definition of the resolution rule shared by both binaries: the `-ldflags -X main.version` stamp when meaningful, else the Go toolchain's VCS revision (short 12 + `-dirty`), else the stamp. Each binary keeps its own `var version = "devel"` (because `-X` targets `main.version`); `formatRevision` is split out so the VCS formatting is unit-testable.
- **`--version`** on worker (positional intercept, like `--print-config`/`--doctor`) and tui (`--version` flag); the **startup log** now reports the resolved version.
- **`/api/v1/state`** gains a top-level `version` (omitempty) in `internal/stateapi`, stamped by the worker mapper; runbook example block + field list + drift fixture updated.
- **Stamping**: `-X main.version` in release.yml (per-binary, from the tag), `install.sh` (from `git describe --tags --always --dirty`), and the Dockerfile (`ARG VERSION=devel`; `.dockerignore` drops `.git`, so the VCS fallback is unavailable in-image).
- **`worker --help`** prints a custom usage listing the run / `--print-config` / `--doctor` / `--version` forms.

## Acceptance criteria (issue #796)

- [x] `var version = "devel"` stamped via `-ldflags -X` in release.yml, install.sh, Dockerfile (build ARG), with `debug.ReadBuildInfo` vcs.revision fallback.
- [x] Surfaced via `--version`, the startup log, and a `/api/v1/state` field (runbook drift fixture updated — non-zero omitempty value).
- [x] Custom `fs.Usage` on the main flag set lists the `--doctor`/`--print-config` forms.
- [x] cmd/tui gets the same stamping.

## Verification

- `gofmt`/`go vet ./...` clean · golangci blocking set 0 issues on changed pkgs · `go test -race ./...` green · size budget green · `go mod tidy` clean.
- `--version` smoke: un-stamped `go build` → `7608bf6d22ca-dirty` (VCS fallback); `-ldflags -X main.version=v0.0.9` → `v0.0.9` (stamp wins). Both worker + tui.
- **Seam mutation-verified**: deleting `Version: resolveVersion()` from the worker mapper fails `TestStateAPIStampsVersion`. The runbook drift test still passes (fixture `Version` non-zero + example/field-list gained `version`). `formatRevision` is deterministically unit-tested (12-char truncate, `-dirty`, empty).
- The `Dockerfile` build-layer test now anchors on the output target so the new `-ldflags` don't break it.
- Pre-push review: `pr-review-toolkit:code-reviewer` **MERGE-READY** (built both binaries, mutation-verified the seam, confirmed `-X main.version` targeting per binary). `codex:codex-rescue` could not execute `go` (sandbox `/tmp` read-only) so returned BLOCKED on environment grounds, not code; its static-inspection LOWs (Dockerfile comment referencing a not-yet-existing release image build → reworded; the `version` omitempty comment → corrected; weak fallback test → replaced with the deterministic `formatRevision` test) are all applied. The Codex-family adversarial pass runs post-push via the GitHub `@codex review` gate (protocol §4).

## Size gate
- [x] `within budget` — 122 changed production LOC across 9 files (incl. release.yml/install.sh/Dockerfile/runbook); tests excluded.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## SPEC alignment (AGENTS.md principle 6/7)

Observability surfacing on the existing SPEC §13.7 state API + build tooling; no new SPEC key/phase, no behavior change to the scheduler/runner boundary. `internal/workflow/config.go` untouched; no new `internal/orchestrator`/`internal/worker` file (new pkg is `internal/buildinfo`).

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Closes #796
