### PR TITLE
release: publish prebuilt worker/codex-worker images to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,3 +243,121 @@ jobs:
           gh release upload "$RELEASE_TAG" dist/*.tar.gz dist/*_sbom.cdx.json dist/*_SHA256SUMS \
             --repo "$GITHUB_REPOSITORY" \
             --clobber
+
+  images:
+    name: Build and publish container images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - resolve
+      - ci
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ needs.resolve.outputs.commit_sha }}
+
+      - name: Verify tag matches resolved commit
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+          RELEASE_COMMIT_SHA: ${{ needs.resolve.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          resolved_sha="$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}")"
+          if [ "$resolved_sha" != "$RELEASE_COMMIT_SHA" ]; then
+            echo "Release tag $RELEASE_TAG moved from $RELEASE_COMMIT_SHA to $resolved_sha"
+            exit 1
+          fi
+
+      - name: Determine if this is the newest release
+        id: latest
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin >/dev/null 2>&1 || true
+          # Filter to strict vMAJOR.MINOR.PATCH releases (the same shape the
+          # resolve job validates) before taking the highest, so a stray or
+          # prerelease tag like v2.0.0-rc.1 — which the `v*.*.*` glob also
+          # matches — can't outrank a real release and strand `:latest`.
+          highest="$(git tag --list 'v*.*.*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"
+          # `:latest` (the Compose default) follows the newest release tag only.
+          # A real tag push (the new tag is highest) and a manual re-publish of
+          # the current release both qualify; a workflow_dispatch backfill of an
+          # OLDER tag does not, so `:latest` never moves backward (#795 review).
+          if [ "$RELEASE_TAG" = "$highest" ]; then
+            echo "is_newest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_newest=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "resolved=$RELEASE_TAG highest=$highest"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      # Publish the existing worker / codex-worker Dockerfile targets as-is
+      # (amd64, matching the CI `docker build`; multi-arch is a deliberate
+      # follow-up, not in #795's "publish as-is" scope). VERSION stamps the
+      # binary's main.version (#796) since .dockerignore drops .git in-image.
+      - name: Build and push worker image
+        id: worker
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          target: worker
+          push: true
+          provenance: false
+          build-args: |
+            VERSION=${{ needs.resolve.outputs.tag }}
+          # `:latest` only when this resolved tag is the newest release (see the
+          # Determine step); a backfill of an older tag emits an empty line,
+          # which build-push-action ignores, so the Compose default never moves
+          # backward — while manual recovery of the current release still works.
+          tags: |
+            ghcr.io/${{ github.repository }}-worker:${{ needs.resolve.outputs.tag }}
+            ${{ steps.latest.outputs.is_newest == 'true' && format('ghcr.io/{0}-worker:latest', github.repository) || '' }}
+
+      - name: Build and push codex-worker image
+        id: codex-worker
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          target: codex-worker
+          push: true
+          provenance: false
+          build-args: |
+            VERSION=${{ needs.resolve.outputs.tag }}
+          tags: |
+            ghcr.io/${{ github.repository }}-codex-worker:${{ needs.resolve.outputs.tag }}
+            ${{ steps.latest.outputs.is_newest == 'true' && format('ghcr.io/{0}-codex-worker:latest', github.repository) || '' }}
+
+      - name: Attest worker image
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}-worker
+          subject-digest: ${{ steps.worker.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest codex-worker image
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}-codex-worker
+          subject-digest: ${{ steps.codex-worker.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -145,10 +145,27 @@ aiops-platform_<tag>_SHA256SUMS` (plain checksums; `--ignore-missing` checks
 only the archives you downloaded, since the file lists every artifact) — both
 are published with the release.
 
-The default Compose service starts `worker`:
+Each tagged release publishes prebuilt **linux/amd64** images to GHCR, so you can
+run without a source checkout (arm64 hosts run them under emulation, or
+`--build` a native image):
 
 ```bash
-docker compose --env-file .env -f deploy/docker-compose.yml up --build worker
+docker pull ghcr.io/xrf9268-hue/aiops-platform-worker:latest
+# Codex-enabled agent runtime: ghcr.io/xrf9268-hue/aiops-platform-codex-worker:latest
+```
+
+Public packages pull without auth; if a package is still private, run
+`docker login ghcr.io` first (or `--build` from source instead). The published
+image runs as UID 1000 — if your host `id -u` differs and you use the Compose
+0600 SSH-key / Codex-home bind mounts, prefer `--build` (it aligns the container
+user via `AIOPS_UID`/`AIOPS_GID`), which the pulled image can't do.
+
+The default Compose service starts `worker` and references that image, falling
+back to a local build with `--build`:
+
+```bash
+docker compose --env-file .env -f deploy/docker-compose.yml pull worker        # use the published image
+docker compose --env-file .env -f deploy/docker-compose.yml up --build worker   # or build locally
 ```
 
 The image defaults to the worker (`CMD ["worker"]`), so a plain `docker run`

--- a/deploy/docker-compose.codex.yml
+++ b/deploy/docker-compose.codex.yml
@@ -13,6 +13,9 @@
 # configuration and refreshing auth state.
 services:
   worker:
+    # Override the base image with the published codex-worker image; the
+    # build.target below stays as the `--build` fallback (#795).
+    image: ghcr.io/xrf9268-hue/aiops-platform-codex-worker:${AIOPS_IMAGE_TAG:-latest}
     build:
       target: codex-worker
     environment:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,13 @@
 services:
   worker:
+    # Prefer the published image (`docker compose pull` / plain `up`); the
+    # build below stays as the `--build` fallback (#795). Override the tag with
+    # AIOPS_IMAGE_TAG (e.g. a pinned vX.Y.Z); `latest` tracks the newest release.
+    # NOTE: the published image is built as UID 1000. If your host `id -u`
+    # differs and you rely on the 0600 SSH-key bind mount below (or the Codex
+    # overlay's host-owned CODEX_HOME), run `--build` so the AIOPS_UID/AIOPS_GID
+    # args align the container user with the host — the pulled image cannot.
+    image: ghcr.io/xrf9268-hue/aiops-platform-worker:${AIOPS_IMAGE_TAG:-latest}
     build:
       context: ..
       # Align the in-container user with the host owner of the deploy key so

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -159,6 +159,21 @@ docker compose --env-file .env \
   up -d --build worker
 ```
 
+`--build` compiles the `codex-worker` target locally. To run a tagged release
+without building, pull the published image instead — drop `--build` and let
+Compose use `ghcr.io/xrf9268-hue/aiops-platform-codex-worker` (pin a version
+with `AIOPS_IMAGE_TAG=vX.Y.Z`, or take `:latest`):
+
+```bash
+docker pull ghcr.io/xrf9268-hue/aiops-platform-codex-worker:latest
+```
+
+Caveat: the published image is built as UID 1000. This runbook's mounts
+(host-owned `CODEX_HOME`, the 0600 SSH key, secret files) must be readable by
+that UID. If your host `id -u` is not 1000, keep `--build` (it sets
+`AIOPS_UID`/`AIOPS_GID` from your `.env` so the container user matches the
+mounts) rather than the pulled image.
+
 After the worker is healthy, smoke-check host reachability without printing the
 state API token:
 


### PR DESCRIPTION
## Summary

The release published only binary tarballs + SBOM (no image), `deploy/docker-compose.yml` used `build:` with no `image:`, and nothing mentioned `docker pull` — so the documented Docker onboarding path required a source checkout + local build (#795).

## Changes

- **release.yml `images` job** (on tag push, `needs: [resolve, ci]`): builds and pushes the existing **`worker`** and **`codex-worker`** Dockerfile targets to `ghcr.io/${owner}/aiops-platform-{worker,codex-worker}` via a SHA-pinned `docker/build-push-action`, tagged with the release version **and** `:latest`. Passes `--build-arg VERSION=<tag>` so the image reports its version (#796; `.dockerignore` drops `.git`, so the ARG is the only in-image stamp), and attests each pushed digest with the existing `attest-build-provenance` action. **amd64 only**, matching the current CI `docker build` — multi-arch is a deliberate follow-up, not in this "publish as-is" scope.
- **Compose**: `docker-compose.yml` (worker) and `docker-compose.codex.yml` (codex-worker) now reference the published `image:` (`AIOPS_IMAGE_TAG` pins a version; `:latest` default), keeping `build:` as the `--build` fallback. The dashboard overlay inherits the resolved image (no change).
- **README + first-run runbook**: `docker pull` + a note that private packages need `docker login ghcr.io`.

## Scope note

Distinct from deferred #464 (Codex skills / MCP toolchain Docker strategy): this only publishes the **existing** Dockerfile targets as-is.

## Acceptance criteria (issue #795)

- [x] `worker` + `codex-worker` targets pushed to GHCR from release.yml on tag push, via a SHA-pinned `docker/build-push-action`, tagged with the release version.
- [x] Deploy compose files reference `image: ghcr.io/...` with local `build:` retained as fallback.
- [x] README / first-run runbook mention `docker pull`.

## Verification

- **release.yml**: `actionlint` clean; YAML valid. All four action SHA pins verified accurate via `gh api` (login `c94ce9fb`#v3.7.0, buildx `8d2750c6`#v3.12.0, build-push `10e90e36`#v6.19.2, attest `a2bbfa25`#v4 — the latter matches the pin already in release.yml). `worker`/`codex-worker` targets confirmed present in the Dockerfile.
- **Compose**: `docker compose config` confirms the base resolves to `…-worker:${AIOPS_IMAGE_TAG:-latest}` with `build:` retained, and the codex overlay overrides to `…-codex-worker` while merging `build.target: codex-worker`. Image names are lowercase (GHCR-valid).
- **Cannot be locally build-validated**: Docker is unavailable here and the image job runs only on a release tag (not PR CI). CI's existing `docker build` (default target) still exercises the `worker` stage transitively; the `codex-worker` target is pre-existing and unchanged. Correctness rests on the actionlint/SHA/compose checks above + the first release run.
- **Post-publish step (disclosed, one-time)**: after the first release publishes the packages, set their GHCR visibility to public for unauthenticated `docker pull`.
- Pre-push dual review: `pr-review-toolkit:code-reviewer` **MERGE-READY** (independently re-verified the SHA pins via `gh api`, the compose merge via `docker compose config`, attestation usage, and VERSION stamping). `codex:codex-rescue` passed every statically-inspectable check but returned BLOCKED solely because its sandbox could not run `actionlint` or reach the network to spot-check SHAs — both of which I (and the Claude reviewer) ran locally with clean results. The Codex-family adversarial pass runs post-push via the GitHub `@codex review` gate (protocol §4).

## Size gate
- [x] `within budget` — release.yml job + 2 compose edits + README/runbook; no production Go code.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## SPEC alignment (AGENTS.md principle 6/7)

Release/distribution tooling; no SPEC-sensitive path, no new key/phase, no behavior change to the scheduler/runner. `internal/workflow/config.go` untouched; no new `internal/orchestrator`/`internal/worker` file.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Closes #795
