### PR TITLE
ci: enforce Conventional Commit PR titles + fix release-please changelog sections

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       - dependencies
       - area:foundation
     commit-message:
-      prefix: deps
+      prefix: "chore(deps)"
     groups:
       go-dependencies:
         patterns:
@@ -31,7 +31,7 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: deps
+      prefix: "chore(deps)"
 
   - package-ecosystem: npm
     directory: "/cmd/worker/dashboard"
@@ -45,7 +45,7 @@ updates:
       - dependencies
       - area:observability
     commit-message:
-      prefix: deps
+      prefix: "chore(deps)"
     groups:
       npm-dependencies:
         patterns:

--- a/.github/governance/README.md
+++ b/.github/governance/README.md
@@ -20,7 +20,7 @@ mismatched context blocks every PR forever waiting on a check that never reports
 - **`Validate PR title (Conventional Commits)`** is a required status check —
   squash-merge makes the PR title the commit subject release-please parses, so a
   non-Conventional-Commit title silently vanishes from the CHANGELOG and the
-  version bump (AGENTS.md → "Commit / PR-title convention",
+  version bump (AGENTS.md → Conventions,
   `.github/workflows/pr-title-lint.yml`).
 - Review-thread resolution required (the Codex-review protocol's unresolved
   threads block merge); stale reviews dismissed on push; squash-only; no branch

--- a/.github/governance/README.md
+++ b/.github/governance/README.md
@@ -53,8 +53,10 @@ SPEC-alignment checklist from `.github/pull_request_template.md` or it cannot
 merge — so land the template + gate first, then import the ruleset.
 
 The same ordering applies to `Validate PR title (Conventional Commits)`: its
-workflow runs on `pull_request_target` (base-branch config), so it does not
-report on any PR until `.github/workflows/pr-title-lint.yml` is on `main`.
-Importing the ruleset with that context **before** the workflow lands would
-deadlock every open PR (incl. the release-please PR) on a check that never runs.
-Land the workflow first, confirm it reports green on a PR, then re-import.
+workflow runs on `pull_request` (so the check attaches to the PR head SHA, like
+`pr-metadata.yml` — not `pull_request_target`, which would report on the base
+SHA and never satisfy the required context). A PR only gets the check once
+`.github/workflows/pr-title-lint.yml` is on `main`, so importing the ruleset
+with that context **before** the workflow lands would deadlock open PRs (and any
+branched from the pre-merge `main`) on a check that never reports. Land the
+workflow first, confirm it reports green on a PR, then re-import.

--- a/.github/governance/README.md
+++ b/.github/governance/README.md
@@ -17,6 +17,11 @@ mismatched context blocks every PR forever waiting on a check that never reports
   it adds no new key/phase; it must cite an upstream Elixir reference or track a
   `DEVIATIONS.md` row.
 - **`Go build and test`** and **`Security and supply-chain`** required.
+- **`Validate PR title (Conventional Commits)`** is a required status check —
+  squash-merge makes the PR title the commit subject release-please parses, so a
+  non-Conventional-Commit title silently vanishes from the CHANGELOG and the
+  version bump (AGENTS.md → "Commit / PR-title convention",
+  `.github/workflows/pr-title-lint.yml`).
 - Review-thread resolution required (the Codex-review protocol's unresolved
   threads block merge); stale reviews dismissed on push; squash-only; no branch
   deletion or force-push on `main`.
@@ -46,3 +51,10 @@ Apply the ruleset **after** this PR and any other open PRs merge. Once
 `PR Metadata / Validate PR metadata` is required, every open PR must carry the
 SPEC-alignment checklist from `.github/pull_request_template.md` or it cannot
 merge — so land the template + gate first, then import the ruleset.
+
+The same ordering applies to `Validate PR title (Conventional Commits)`: its
+workflow runs on `pull_request_target` (base-branch config), so it does not
+report on any PR until `.github/workflows/pr-title-lint.yml` is on `main`.
+Importing the ruleset with that context **before** the workflow lands would
+deadlock every open PR (incl. the release-please PR) on a check that never runs.
+Land the workflow first, confirm it reports green on a PR, then re-import.

--- a/.github/governance/main-ruleset.json
+++ b/.github/governance/main-ruleset.json
@@ -37,7 +37,8 @@
         "required_status_checks": [
           { "context": "Go build and test" },
           { "context": "Security and supply-chain" },
-          { "context": "Validate PR metadata" }
+          { "context": "Validate PR metadata" },
+          { "context": "Validate PR title (Conventional Commits)" }
         ]
       }
     }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 <!-- PR title MUST be a Conventional Commit: `type(scope): summary` — one of
 feat|fix|perf|refactor|docs|style|test|build|ci|chore|revert. Squash-merge uses
 it as the release-please-parsed commit subject; a non-conforming title is
-dropped from the CHANGELOG and the version bump (AGENTS.md → "Commit / PR-title
-convention"). Enforced by the `Validate PR title (Conventional Commits)` check. -->
+dropped from the CHANGELOG and the version bump (AGENTS.md → Conventions).
+Enforced by the `Validate PR title (Conventional Commits)` check. -->
 Closes #<issue>
 
 ## Summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+<!-- PR title MUST be a Conventional Commit: `type(scope): summary` — one of
+feat|fix|perf|refactor|docs|style|test|build|ci|chore|revert. Squash-merge uses
+it as the release-please-parsed commit subject; a non-conforming title is
+dropped from the CHANGELOG and the version bump (AGENTS.md → "Commit / PR-title
+convention"). Enforced by the `Validate PR title (Conventional Commits)` check. -->
 Closes #<issue>
 
 ## Summary

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -5,8 +5,7 @@ name: PR Title Lint
 # `main` to build the CHANGELOG and decide the version bump, so a PR title that
 # is not a Conventional Commit is dropped silently — no changelog entry, no
 # bump. This gate validates the one string release-please will consume. See
-# docs/runbooks/ci.md (Conventional Commits) and AGENTS.md (Commit / PR-title
-# convention).
+# docs/runbooks/ci.md (Conventional Commits) and AGENTS.md (Conventions).
 #
 # Uses `pull_request` (not `pull_request_target`) so the check run attaches to
 # the PR head SHA. A required status check is matched against the head commit; a

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,19 +1,26 @@
 name: PR Title Lint
 
 # Squash-merge makes the PR title the squash commit subject (repo setting
-# "Default to PR title for squash merge commits" → squash_merge_commit_title:
-# PR_TITLE). release-please parses that subject on `main` to build the
-# CHANGELOG and decide the version bump, so a PR title that is not a
-# Conventional Commit is dropped silently — no changelog entry, no bump. This
-# gate validates the one string release-please will consume. See
+# squash_merge_commit_title: PR_TITLE). release-please parses that subject on
+# `main` to build the CHANGELOG and decide the version bump, so a PR title that
+# is not a Conventional Commit is dropped silently — no changelog entry, no
+# bump. This gate validates the one string release-please will consume. See
 # docs/runbooks/ci.md (Conventional Commits) and AGENTS.md (Commit / PR-title
 # convention).
+#
+# Uses `pull_request` (not `pull_request_target`) so the check run attaches to
+# the PR head SHA. A required status check is matched against the head commit; a
+# `pull_request_target` run reports against the base SHA, which would leave this
+# required context stuck "pending" forever. This mirrors
+# .github/workflows/pr-metadata.yml and the "no pull_request_target" invariant
+# in docs/runbooks/ci.md. The action only reads the PR title from the event
+# payload (no checkout, no secrets), so the read-only fork token is sufficient.
 
 on:
-  pull_request_target:
-    # `synchronize` is required because this is a required status check: the
-    # check must re-run on the head SHA of every push, not just title edits.
-    types: [opened, reopened, edited, synchronize]
+  pull_request:
+    # `synchronize` re-runs the required check on every head push; `edited`
+    # re-validates when the title changes.
+    types: [opened, edited, reopened, synchronize, ready_for_review, converted_to_draft]
 
 permissions:
   pull-requests: read

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,58 @@
+name: PR Title Lint
+
+# Squash-merge makes the PR title the squash commit subject (repo setting
+# "Default to PR title for squash merge commits" → squash_merge_commit_title:
+# PR_TITLE). release-please parses that subject on `main` to build the
+# CHANGELOG and decide the version bump, so a PR title that is not a
+# Conventional Commit is dropped silently — no changelog entry, no bump. This
+# gate validates the one string release-please will consume. See
+# docs/runbooks/ci.md (Conventional Commits) and AGENTS.md (Commit / PR-title
+# convention).
+
+on:
+  pull_request_target:
+    # `synchronize` is required because this is a required status check: the
+    # check must re-run on the head SHA of every push, not just title edits.
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    # Don't run on forks of this repo (the action only needs read scope, but a
+    # fork has no reason to gate its own PR titles).
+    if: github.repository == 'xrf9268-hue/aiops-platform'
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # The canonical Conventional Commits type set (AGENTS.md). Kept in
+          # lockstep with the type table there and with release-please's
+          # recognized types. `chore` covers the release bot's own
+          # `chore(main): release X.Y.Z` PR title.
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            style
+            test
+            build
+            ci
+            chore
+            revert
+          # Scope is optional and free-form (e.g. `fix(runner,doctor):`).
+          requireScope: false
+          # PR subjects are free-form sentences rendered verbatim into the
+          # CHANGELOG; don't impose a leading-lowercase rule.
+          subjectPattern: '.+'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,6 +431,39 @@ These rules apply to every PR. Each is earned by a specific observed failure —
   checklist and never author SPEC deviations); the exemption list lives in
   `validate-pr-metadata.mjs`.
   ([provenance](docs/engineering-rules-rationale.md#conventions))
+- **PR titles are Conventional Commits — release-please parses them.** `main`
+  merges squash-only (`.github/governance/main-ruleset.json`) with the squash
+  subject set to the PR title (`squash_merge_commit_title: PR_TITLE`), and
+  release-please reads that subject to build `CHANGELOG.md` and pick the version
+  bump. A title whose type is not a recognized Conventional Commit type is
+  **dropped silently** — no changelog line, no bump — so mistyped work vanishes
+  from releases (it is why the pending v0.1.3 Release PR #803 would omit
+  #828/#829/#834 while listing four chores, mostly Trellis archival). Title every
+  PR `type(optional-scope): summary` using
+  exactly these types; the `Validate PR title (Conventional Commits)` required
+  check (`.github/workflows/pr-title-lint.yml`) enforces it:
+
+  | Type | Use for | CHANGELOG |
+  |------|---------|-----------|
+  | `feat` | a new user-facing capability | ✅ Features (bumps) |
+  | `fix` | a bug fix | ✅ Bug Fixes (bumps) |
+  | `perf` | a performance change with no behavior change | ✅ Performance Improvements |
+  | `revert` | revert of a prior commit | ✅ Reverts |
+  | `refactor` | code change, no behavior change (e.g. file decomposition) | hidden |
+  | `docs` | docs only (README, runbooks, this file) | hidden |
+  | `style` | formatting / non-semantic code style | hidden |
+  | `test` | tests only | hidden |
+  | `build` | build system / release packaging / build deps | hidden |
+  | `ci` | CI, workflows, governance rulesets | hidden |
+  | `chore` | housekeeping (Trellis task archival, version bumps) | hidden |
+
+  Only `feat`/`fix`/breaking move the version (`feat`→minor, `fix`→patch,
+  breaking→major; pre-1.0 the `bump-*-pre-major` flags downshift these to
+  patch/patch/minor). A `type!:` or `BREAKING CHANGE:` footer marks a breaking
+  change and surfaces even for an otherwise-hidden type. Don't invent types
+  (`maintainability:`, `cmd:`, `deps:` are all dropped) — a refactor is
+  `refactor:`, a dependency bump is `chore(deps):`/`build(deps):`.
+  ([provenance](docs/engineering-rules-rationale.md#conventions))
 
 ## WORKFLOW.md discovery (worker side)
 

--- a/dependabot_test.go
+++ b/dependabot_test.go
@@ -3,10 +3,36 @@ package aiopsplatform_test
 import (
 	"os"
 	"slices"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
+
+// conventionalCommitTypes mirrors the allow-list in
+// .github/workflows/pr-title-lint.yml and AGENTS.md → "Commit / PR-title
+// convention". Dependabot turns commit-message.prefix into the PR-title prefix
+// ("<prefix>: …"), and the required `Validate PR title (Conventional Commits)`
+// check rejects any non-conventional type — so a prefix outside this set would
+// silently brick every Dependabot PR.
+var conventionalCommitTypes = []string{
+	"feat", "fix", "perf", "refactor", "docs", "style",
+	"test", "build", "ci", "chore", "revert",
+}
+
+// isConventionalCommitPrefix reports whether a Dependabot commit-message prefix
+// is a Conventional Commit type with an optional (scope) — e.g. "chore(deps)" or
+// "build".
+func isConventionalCommitPrefix(prefix string) bool {
+	typePart := prefix
+	if i := strings.IndexByte(prefix, '('); i >= 0 {
+		if !strings.HasSuffix(prefix, ")") {
+			return false
+		}
+		typePart = prefix[:i]
+	}
+	return slices.Contains(conventionalCommitTypes, typePart)
+}
 
 type dependabotConfig struct {
 	Updates []dependabotUpdate `yaml:"updates"`
@@ -74,8 +100,8 @@ func TestDependabotCoversDashboardNPMDependencies(t *testing.T) {
 			t.Fatalf("dashboard npm config missing label %q in %v", label, dashboardNPM.Labels)
 		}
 	}
-	if dashboardNPM.CommitMessage.Prefix != "deps" {
-		t.Fatalf("unexpected dashboard npm commit prefix: %q", dashboardNPM.CommitMessage.Prefix)
+	if !isConventionalCommitPrefix(dashboardNPM.CommitMessage.Prefix) {
+		t.Fatalf("dashboard npm commit prefix %q is not a Conventional Commit type (Dependabot titles would fail the PR-title lint)", dashboardNPM.CommitMessage.Prefix)
 	}
 	group, ok := dashboardNPM.Groups["npm-dependencies"]
 	if !ok {
@@ -83,5 +109,31 @@ func TestDependabotCoversDashboardNPMDependencies(t *testing.T) {
 	}
 	if !slices.Contains(group.Patterns, "*") {
 		t.Fatalf("dashboard npm group must cover all packages, got %v", group.Patterns)
+	}
+}
+
+// TestDependabotPrefixesAreConventionalCommitTypes guards the coupling codex
+// flagged on #838: every Dependabot ecosystem's commit-message.prefix must be a
+// Conventional Commit type so its generated PR titles pass the required
+// `Validate PR title (Conventional Commits)` check. A bare `deps:` (the prior
+// value) would leave every dependency/security-update PR stuck on that gate.
+func TestDependabotPrefixesAreConventionalCommitTypes(t *testing.T) {
+	body, err := os.ReadFile(".github/dependabot.yml")
+	if err != nil {
+		t.Fatalf("read dependabot config: %v", err)
+	}
+	var config dependabotConfig
+	if err := yaml.Unmarshal(body, &config); err != nil {
+		t.Fatalf("parse dependabot config: %v", err)
+	}
+	if len(config.Updates) == 0 {
+		t.Fatal("dependabot config declares no updates")
+	}
+	for _, update := range config.Updates {
+		prefix := update.CommitMessage.Prefix
+		if !isConventionalCommitPrefix(prefix) {
+			t.Errorf("%s (%s): commit-message.prefix %q is not a Conventional Commit type; Dependabot PR titles would fail the required PR-title lint — use e.g. chore(deps) or build(deps)",
+				update.PackageEcosystem, update.Directory, prefix)
+		}
 	}
 }

--- a/dependabot_test.go
+++ b/dependabot_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // conventionalCommitTypes mirrors the allow-list in
-// .github/workflows/pr-title-lint.yml and AGENTS.md → "Commit / PR-title
-// convention". Dependabot turns commit-message.prefix into the PR-title prefix
+// .github/workflows/pr-title-lint.yml and AGENTS.md → Conventions. Dependabot
+// turns commit-message.prefix into the PR-title prefix
 // ("<prefix>: …"), and the required `Validate PR title (Conventional Commits)`
 // check rejects any non-conventional type — so a prefix outside this set would
 // silently brick every Dependabot PR.

--- a/dependabot_test.go
+++ b/dependabot_test.go
@@ -2,8 +2,8 @@ package aiopsplatform_test
 
 import (
 	"os"
+	"regexp"
 	"slices"
-	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -20,18 +20,21 @@ var conventionalCommitTypes = []string{
 	"test", "build", "ci", "chore", "revert",
 }
 
+// conventionalCommitPrefixRE matches a Conventional Commit type (captured) with
+// an optional single, non-empty, non-nested (scope): "chore", "chore(deps)",
+// "fix(runner,doctor)". It rejects malformed forms like "chore()", "chore(a)(b)",
+// and "chore(foo(bar)".
+var conventionalCommitPrefixRE = regexp.MustCompile(`^([a-z]+)(?:\([^()]+\))?$`)
+
 // isConventionalCommitPrefix reports whether a Dependabot commit-message prefix
-// is a Conventional Commit type with an optional (scope) — e.g. "chore(deps)" or
-// "build".
+// is an allowed Conventional Commit type with an optional (scope) — e.g.
+// "chore(deps)" or "build".
 func isConventionalCommitPrefix(prefix string) bool {
-	typePart := prefix
-	if i := strings.IndexByte(prefix, '('); i >= 0 {
-		if !strings.HasSuffix(prefix, ")") {
-			return false
-		}
-		typePart = prefix[:i]
+	m := conventionalCommitPrefixRE.FindStringSubmatch(prefix)
+	if m == nil {
+		return false
 	}
-	return slices.Contains(conventionalCommitTypes, typePart)
+	return slices.Contains(conventionalCommitTypes, m[1])
 }
 
 type dependabotConfig struct {
@@ -109,6 +112,31 @@ func TestDependabotCoversDashboardNPMDependencies(t *testing.T) {
 	}
 	if !slices.Contains(group.Patterns, "*") {
 		t.Fatalf("dashboard npm group must cover all packages, got %v", group.Patterns)
+	}
+}
+
+func TestIsConventionalCommitPrefix(t *testing.T) {
+	cases := []struct {
+		prefix string
+		want   bool
+	}{
+		{"chore(deps)", true},
+		{"build(deps)", true},
+		{"fix(runner,doctor)", true},
+		{"build", true},
+		{"chore", true},
+		{"deps", false},           // not an allowed type
+		{"", false},               // empty
+		{"chore()", false},        // empty scope
+		{"chore(a)(b)", false},    // trailing extra scope
+		{"chore(foo(bar)", false}, // nested/unbalanced parens
+		{"Chore(deps)", false},    // uppercase type
+		{"chore: x", false},       // includes the colon/subject, not a bare prefix
+	}
+	for _, c := range cases {
+		if got := isConventionalCommitPrefix(c.prefix); got != c.want {
+			t.Errorf("isConventionalCommitPrefix(%q) = %v; want %v", c.prefix, got, c.want)
+		}
 	}
 }
 

--- a/docs/engineering-rules-rationale.md
+++ b/docs/engineering-rules-rationale.md
@@ -260,11 +260,13 @@ shipped.
   by release-please — no changelog entry, no version bump — while `chore` was
   configured visible, flooding the changelog with Trellis bookkeeping. The fix
   removes the `changelog-sections` override (chore/refactor inherit the
-  upstream-default hidden state), sets `squash_merge_commit_title: PR_TITLE` so
-  the parsed subject is the linted title, and adds the
+  upstream-default hidden state) and adds the
   `Validate PR title (Conventional Commits)` required check
   (`.github/workflows/pr-title-lint.yml`, pinned
-  `amannn/action-semantic-pull-request`). **Earned by:** the pending v0.1.3
+  `amannn/action-semantic-pull-request`); separately, the repo setting
+  `squash_merge_commit_title` is set to `PR_TITLE` (a GitHub repo setting applied
+  out-of-band, not a committed file) so the parsed subject is the linted title.
+  **Earned by:** the pending v0.1.3
   Release PR (#803) lists one `feat` and four chores (three Trellis-archive —
   #836/#807/#813 — plus the #788 dead-code sweep) while omitting every other
   change shipped since v0.1.2 — `cmd:` version observability (#828), `release:`

--- a/docs/engineering-rules-rationale.md
+++ b/docs/engineering-rules-rationale.md
@@ -254,3 +254,20 @@ shipped.
   required-check wiring lives in `.github/governance/main-ruleset.json`. **Earned
   by:** #588 — those removals all shipped despite the rules existing, because the
   checks were judgment at audit time rather than mechanical at author time.
+- **PR titles are Conventional Commits.** Squash-merge makes the PR title the
+  commit subject release-please parses; titles using freeform `area:` prefixes
+  (`maintainability:`, `cmd:`, `stateapi:`, `dashboard:`, …) are dropped silently
+  by release-please — no changelog entry, no version bump — while `chore` was
+  configured visible, flooding the changelog with Trellis bookkeeping. The fix
+  removes the `changelog-sections` override (chore/refactor inherit the
+  upstream-default hidden state), sets `squash_merge_commit_title: PR_TITLE` so
+  the parsed subject is the linted title, and adds the
+  `Validate PR title (Conventional Commits)` required check
+  (`.github/workflows/pr-title-lint.yml`, pinned
+  `amannn/action-semantic-pull-request`). **Earned by:** the pending v0.1.3
+  Release PR (#803) lists one `feat` and four chores (three Trellis-archive —
+  #836/#807/#813 — plus the #788 dead-code sweep) while omitting every other
+  change shipped since v0.1.2 — `cmd:` version observability (#828), `release:`
+  GHCR images (#829), `dashboard:` version chip + favicon (#834), the #831
+  `maintainability:` decomposition — because their types were not Conventional
+  Commits, so release-please neither listed nor counted them.

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -118,6 +118,19 @@ features bump patch). Merging the Release PR creates the `vX.Y.Z` tag and the
 GitHub Release with changelog notes; the tag push triggers the Release
 workflow below, which attaches binaries and the SBOM.
 
+Because `main` merges squash-only with `squash_merge_commit_title: PR_TITLE`,
+the squash commit subject is the PR title, and release-please parses that
+subject. A PR title that is not a Conventional Commit (any of the canonical
+types in AGENTS.md → "Commit / PR-title convention") is dropped silently — no
+changelog entry, no version bump — so the `Validate PR title (Conventional
+Commits)` required check (`.github/workflows/pr-title-lint.yml`, a SHA-pinned
+`amannn/action-semantic-pull-request`) gates every PR title. `release-please-config.json`
+deliberately carries **no** `changelog-sections` override: it inherits
+release-please's default, which hides `chore`/`refactor`/`docs`/`style`/`test`/
+`build`/`ci` so the CHANGELOG stays a user-facing "what changed for an operator"
+document (breaking changes of any type still surface). If you add a new required
+CI job, register its check name in `.github/governance/main-ruleset.json`.
+
 The workflow authenticates with a short-lived GitHub App installation token,
 not `GITHUB_TOKEN`: GitHub suppresses workflow runs for events created by
 `GITHUB_TOKEN`, so a `GITHUB_TOKEN`-cut tag would never trigger

--- a/docs/runbooks/ci.md
+++ b/docs/runbooks/ci.md
@@ -121,7 +121,7 @@ workflow below, which attaches binaries and the SBOM.
 Because `main` merges squash-only with `squash_merge_commit_title: PR_TITLE`,
 the squash commit subject is the PR title, and release-please parses that
 subject. A PR title that is not a Conventional Commit (any of the canonical
-types in AGENTS.md → "Commit / PR-title convention") is dropped silently — no
+types in AGENTS.md → Conventions) is dropped silently — no
 changelog entry, no version bump — so the `Validate PR title (Conventional
 Commits)` required check (`.github/workflows/pr-title-lint.yml`, a SHA-pinned
 `amannn/action-semantic-pull-request`) gates every PR title. `release-please-config.json`

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,19 +5,6 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "initial-version": "0.1.0",
-  "bootstrap-sha": "0cc8cc4b7a5d9bb6cf8cd80a27e5002f33b9b624",
-  "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance Improvements" },
-    { "type": "refactor", "section": "Code Refactoring" },
-    { "type": "chore", "section": "Miscellaneous Chores" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Documentation", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "build", "section": "Build System", "hidden": true },
-    { "type": "ci", "section": "Continuous Integration", "hidden": true }
-  ],
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
Closes #837

## Summary
- **Root cause:** release-please (`release-type: go`) only lists/bumps on recognized Conventional Commit types, but the repo squash-merges freeform `area:` PR titles (`maintainability:`, `cmd:`, `stateapi:`, `dashboard:`, …) that it **drops entirely** — no CHANGELOG entry, no version bump — while `chore`/`refactor` were configured visible and flooded the user-facing notes with Trellis bookkeeping. The pending v0.1.3 Release PR (#803) lists one `feat` + four mostly-Trellis chores while omitting #828/#829/#834/#831.
- **`release-please-config.json`:** drop the `changelog-sections` override (inherit release-please's default → hides chore/refactor/docs/style/test/build/ci) and the now-inert `bootstrap-sha`.
- **`.github/workflows/pr-title-lint.yml` (new):** SHA-pinned `amannn/action-semantic-pull-request@…48f2562 # v6.1.1` on `pull_request_target` validates every PR title against the canonical 11 types. The squash subject == PR title (repo setting `squash_merge_commit_title=PR_TITLE`, set out-of-band) == what release-please parses.
- **`main-ruleset.json` + `governance/README.md`:** make `Validate PR title (Conventional Commits)` a required check; document the land-workflow-then-import sequencing (the check only reports once the workflow is on `main`, so importing earlier would deadlock open PRs).
- **`AGENTS.md` + rationale + `ci.md` + PR template:** the type table, why the PR title is the parsed subject, and provenance.

Source-verified in the task research: only `feat`/`fix`/breaking bump; unknown types are dropped (not bucketed); the changelog updater is prepend-only → past releases untouched, the open 0.1.3 PR re-renders on the next `push:main`. A read-only ruleset drift-check is deliberately deferred to a separate follow-up.

**Operator follow-ups (post-merge, documented in `governance/README.md`):** re-import the ruleset (`gh api PUT …/rulesets/<id> --input main-ruleset.json`) so the new required check binds — only after this workflow lands on `main`. The `squash_merge_commit_title=PR_TITLE` repo setting is already applied.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

CI/release tooling + docs only; no SPEC-sensitive path (`internal/workflow/config.go`, new `internal/orchestrator/`/`internal/worker/` file) touched. `/api/v1/state` and the orchestrator are unchanged.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 8 files (4 CI/config: `release-please-config.json`, `pr-title-lint.yml`, `main-ruleset.json`, PR template; 4 docs), ~140 insertions, no Go/production code.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `gofmt -l` clean (no Go changes); `go vet ./...` unaffected
- [x] `actionlint .github/workflows/pr-title-lint.yml` → exit 0
- [x] `release-please-config.json` + `main-ruleset.json` parse as valid JSON; `pr-title-lint.yml` parses as valid YAML
- [x] action SHA `48f256284bd46cdaab1048c3721360e808335d50` verified == `amannn/action-semantic-pull-request` v6.1.1 (GitHub API); ruleset `context` == workflow job `name:` exactly
- [x] No test/script asserts on the changed config (grep) — no breakage
- [x] No Go/production-code changes → `go test -race` surface unaffected (CI re-runs the full gate on this PR)

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
- This PR's own title is a Conventional Commit (`ci: …`), dogfooding the new rule. The PR-title lint does **not** gate this PR (its workflow isn't on `main` yet — `pull_request_target` uses base-branch config).
- Local review: Claude code-reviewer pass = 0 blocking (2 nits fixed). A local Codex review stalled on this sandbox's unavailable network SHA-verification tools without surfacing a blocking finding; the authoritative `@codex review` will run on this PR.