### PR TITLE
docs: drop chore/refactor noise from already-published CHANGELOG v0.1.1/v0.1.2 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@
 * **workspace:** bound every git subprocess with a per-operation timeout ([#764](https://github.com/xrf9268-hue/aiops-platform/issues/764)) ([4b0d276](https://github.com/xrf9268-hue/aiops-platform/commit/4b0d276ba3bf0a53dafcc94c09c8e30c59900ad5))
 * **workspace:** heal legacy partial mirrors and reap staging dirs on failed clones ([#774](https://github.com/xrf9268-hue/aiops-platform/issues/774)) ([c45b323](https://github.com/xrf9268-hue/aiops-platform/commit/c45b323ef503af67551baaa3909900281d193415)), closes [#765](https://github.com/xrf9268-hue/aiops-platform/issues/765)
 
-
-### Miscellaneous Chores
-
-* archive the issue-765 Trellis task and record the session journal ([#776](https://github.com/xrf9268-hue/aiops-platform/issues/776)) ([5df7640](https://github.com/xrf9268-hue/aiops-platform/commit/5df764074b80bc4e3c878715578c9d2fec265e0c)), closes [#775](https://github.com/xrf9268-hue/aiops-platform/issues/775)
-
 ## [0.1.1](https://github.com/xrf9268-hue/aiops-platform/compare/v0.1.0...v0.1.1) (2026-06-11)
 
 
@@ -26,13 +21,6 @@
 * post [@codex](https://github.com/codex) review triggers with a workspace-bound identity ([#747](https://github.com/xrf9268-hue/aiops-platform/issues/747)) ([a6f9e61](https://github.com/xrf9268-hue/aiops-platform/commit/a6f9e619cd76b21e590473364fcac9cdf1131d2b)), closes [#746](https://github.com/xrf9268-hue/aiops-platform/issues/746)
 * re-check Todo blockers in dispatch revalidation ([#750](https://github.com/xrf9268-hue/aiops-platform/issues/750)) ([#752](https://github.com/xrf9268-hue/aiops-platform/issues/752)) ([3c59890](https://github.com/xrf9268-hue/aiops-platform/commit/3c59890bf88d3ad690fb544664d3a03e5d4c25cf))
 * revalidate dispatch candidates against tracker state before spawning ([#749](https://github.com/xrf9268-hue/aiops-platform/issues/749)) ([e5c5e41](https://github.com/xrf9268-hue/aiops-platform/commit/e5c5e41e29ca066631a74f51bf9a4eaf7aa8ac7f)), closes [#740](https://github.com/xrf9268-hue/aiops-platform/issues/740)
-
-
-### Miscellaneous Chores
-
-* archive automated-release task and record session journal ([#737](https://github.com/xrf9268-hue/aiops-platform/issues/737)) ([ff1c4a8](https://github.com/xrf9268-hue/aiops-platform/commit/ff1c4a82a925c9455ccec0c02d4b0056bc5100fc))
-* archive Trellis task journals for the 2026-06-11 issue batch ([#758](https://github.com/xrf9268-hue/aiops-platform/issues/758)) ([58e7809](https://github.com/xrf9268-hue/aiops-platform/commit/58e780953ca5ca0f7b04d946614dd7495c2f2e73))
-* record v0.1.0 packaged-binary lifecycle test, archive task and journal ([#742](https://github.com/xrf9268-hue/aiops-platform/issues/742)) ([011341f](https://github.com/xrf9268-hue/aiops-platform/commit/011341fb896312db950fcc15e629f908e9d6f245))
 
 ## 0.1.0 (2026-06-10)
 


### PR DESCRIPTION
Closes #841

## Summary
- Strip the historical **Miscellaneous Chores** blocks from the published `CHANGELOG.md` sections for tags **v0.1.2** and **v0.1.1**, so those entries read as bug-fixes-only.
- Root cause: before #838, `release-please-config.json` rendered `chore`/`refactor` types **visible**, so the 0.1.1/0.1.2 sections carried Trellis-archive / dead-code-sweep bookkeeping. #838 hid those types **going forward**, but the release-please changelog updater is **prepend-only** and never rewrites past entries — hence this one-time manual reconciliation.
- No `### Code Refactoring` section existed in either release (only `### Miscellaneous Chores`), so the two chore blocks are the entire scope.
- **Cosmetic only:** published GitHub Release notes for the tags are unaffected (this edits the in-repo file, not the Release objects).

## Release-state safety
release-please is prepend-only and derives version state from git tags + `.release-please-manifest.json`, **not** a CHANGELOG content checksum, so editing a historical section below the prepend point cannot conflict with the next Release PR (v0.1.3). Confirmed no test/CI script parses `CHANGELOG.md` content — the only references (`pr-title-lint.yml`, `release-please.yml`, `validate-pr-metadata.mjs`) are code comments.

## Verification
- `git diff origin/main...HEAD` = exactly the two `### Miscellaneous Chores` block removals (12 deletions, 0 additions); no Bug Fixes / Features entry dropped.
- Resulting markdown matches release-please's native section output: one blank line between a release's last entry and the next `## [version]` header.
- No `.go` files touched ⇒ Go code gates (`gofmt`/`go vet`/`go test -race`) are not applicable to this change; a CHANGELOG edit has no regression/mutation seam (protocol §3 pure-documentation class).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded). _Docs-only: 1 file, 12 deletions, 0 production code._
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [ ] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [ ] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [ ] `go vet ./...`
- [ ] `go test -race -covermode=atomic ./...`
- [ ] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Docs-only change (`CHANGELOG.md`); no Go/Python sources touched, so the code/test gates above are N/A. Validation performed: exact-diff inspection + confirmation that no CI script parses CHANGELOG content.

## Review
- Pre-push dual diff-only reviewers (head `0a1b468`), both **MERGE-READY**, zero findings:
  - Claude-family (`pr-review-toolkit:code-reviewer`)
  - Codex-family (`codex:codex-rescue`)
- `@codex review` per-push gate (trigger comment `4701075009`, posted as `bytevane`, head `0a1b468` / base `1d07d5f`): **converged clean** — connector comment `4701077594` "Didn't find any major issues. Hooray!" for reviewed commit `0a1b468795`. 👀 appeared then cleared; no PR review threads opened.
- GraphQL `reviewThreads`: **0 total**, zero unresolved actionable threads (§5).
- CI on head `0a1b468`: **all 6 checks pass** (run `27492184427`) — Docker image build, E2E Gitea mock loop, Go build and test, Security and supply-chain, Validate PR metadata, Validate PR title.
- Merge method: squash into `main`. Awaiting explicit human merge permission (§8).
