### PR TITLE
docs: backfill v0.1.3 CHANGELOG with 3 changes dropped by pre-#838 commit types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@
 
 ### Features
 
+* **dashboard:** worker-status version chip + favicon (Symphony #90) ([#834](https://github.com/xrf9268-hue/aiops-platform/issues/834)) ([661cf47](https://github.com/xrf9268-hue/aiops-platform/commit/661cf4714ef223fbdbf2366176b905d829e8bc69)), closes [#833](https://github.com/xrf9268-hue/aiops-platform/issues/833)
+* **cmd:** version observability (--version, ldflags stamping, /api/v1/state field, --help subcommands) ([#828](https://github.com/xrf9268-hue/aiops-platform/issues/828)) ([19e3c8f](https://github.com/xrf9268-hue/aiops-platform/commit/19e3c8fbe9752cbd477d8961fd12912670f87b9c)), closes [#796](https://github.com/xrf9268-hue/aiops-platform/issues/796)
 * **doctor:** preflight Gitea/GitHub trackers by driving the worker's own clients ([#801](https://github.com/xrf9268-hue/aiops-platform/issues/801)) ([072a8de](https://github.com/xrf9268-hue/aiops-platform/commit/072a8deafdbed96e6a31d87340fec5e0920ba245)), closes [#781](https://github.com/xrf9268-hue/aiops-platform/issues/781)
+
+
+### Bug Fixes
+
+* add panic recovery to the three unguarded goroutines; fix two letter-of-rule violations ([#818](https://github.com/xrf9268-hue/aiops-platform/issues/818)) ([28a69ee](https://github.com/xrf9268-hue/aiops-platform/commit/28a69eecaf44f4e249b96e3e2ba898c56e6f6d47)), closes [#790](https://github.com/xrf9268-hue/aiops-platform/issues/790)
 
 ## [0.1.2](https://github.com/xrf9268-hue/aiops-platform/compare/v0.1.1...v0.1.2) (2026-06-12)
 


### PR DESCRIPTION
Closes #850

## Summary

The v0.1.3 release (#803) credited only #801 under Features. Auditing every commit since v0.1.2, **three genuinely user-facing changes** were missing from the generated changelog because their squash-merge subjects (= PR titles) used non-Conventional commit types, which release-please silently drops. All three merged **before** #838 added the `Validate PR title (Conventional Commits)` required check (03b51d3); their subjects are now immutable, so release-please cannot retroactively include them.

This backfills the three entries by hand, in release-please's exact format, into the (now-released, frozen) v0.1.3 `CHANGELOG.md` section — mirroring #849's post-publish CHANGELOG-accuracy edit.

| PR | merged subject (type used) | correct type | section |
|----|----|----|----|
| #834 | `dashboard:` worker-status version chip + favicon | `feat(dashboard)` | Features |
| #828 | `cmd:` version observability | `feat(cmd)` | Features |
| #818 | `hardening:` panic recovery for 3 unguarded goroutines (closes #790) | `fix` | Bug Fixes |

**Correctly omitted:** #827 (`release:` tarball packaging + SHA256SUMS) and #829 (`release:` GHCR prebuilt images) are **build**-class = hidden by design; backfilling them would re-add the release-eng noise #849 just removed. **Version 0.1.3 is unchanged** — the patch bump was correctly driven by the one valid `feat` (#801); only the changelog narrative was incomplete.

Each entry's PR number, commit short-SHA, and closing issue were verified against `git show` + `gh pr view` (#834→661cf47 closes #833; #828→19e3c8f closes #796; #818→28a69ee closes #790). Ordering is release-please's newest-commit-first within each section. The released v0.1.3 section is frozen for release-please (it only prepends the next unreleased version), so the manual edit is durable — same mechanism #849 relied on.

**Follow-up:** the GitHub Release v0.1.3 body still shows only #801; will sync it via `gh release edit v0.1.3` once this lands.

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing

- [x] `go vet ./...` — N/A to changed file; no `.go` touched (`git diff --name-only -- '*.go'` empty).
- [x] `gofmt -l` clean — no Go files changed.
- [x] Docs-only diff: `CHANGELOG.md` backfill verified against `git show`/`gh pr view` and release-please format.