### PR TITLE
docs: add unattended maker+reviewer CI-gated auto-merge guide + example WORKFLOWs

### DIFF
--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -1,0 +1,204 @@
+# Unattended maker + reviewer + CI-gated auto-merge
+
+A deployment for running **multiple incremental tasks unattended**: a *maker*
+worker implements each issue and opens a PR, an independent *reviewer* worker
+judges it in a fresh context, and clean PRs land on `main` via **CI-gated
+auto-merge** — no human in the merge path, while keeping a maker/checker quality
+gate.
+
+This builds on the maker/checker split in
+[`reviewer-worker.md`](reviewer-worker.md) (read that first) and the bot/branch
+posture in
+[`gitea-bot-and-branch-protection.md`](gitea-bot-and-branch-protection.md). It
+adds the *landing* step those leave to a human.
+
+Example WORKFLOWs (validated through `worker --print-config`):
+[`examples/maker-WORKFLOW.md`](../../examples/maker-WORKFLOW.md) and
+[`examples/reviewer-automerge-WORKFLOW.md`](../../examples/reviewer-automerge-WORKFLOW.md)
+— the latter is the auto-merge variant of the verdict-only
+[`examples/reviewer-WORKFLOW.md`](../../examples/reviewer-WORKFLOW.md).
+
+## Why this shape (boundaries you can't design around)
+
+- **The orchestrator never merges, pushes, or opens PRs** — SPEC §1 / #76. The
+  worker is a scheduler/runner + tracker *reader*. "Auto-merge" is therefore
+  **not** an aiops-platform feature; it is performed by the *agent* + the
+  *forge*, never the worker. Upstream Symphony is explicit: *"Symphony is a
+  scheduler/runner and tracker reader … Ticket writes … are typically performed
+  by the coding agent"*
+  ([blog](../research/2026-04-27-openai-symphony-blog.md)).
+- **A run may end at a handoff state, not `Done`.** The maker stops at
+  `Human Review`; the reviewer issues the `Done`/`Rework` verdict — the
+  maker/checker split (a fresh model decides "done", not the one that wrote it).
+- **The agent shepherds the merge, gated by CI.** Upstream: *"By the time a
+  ticket reaches Merging, … the change will make it into the main branch without
+  human babysitting. The system watches CI, rebases when needed, … retries flaky
+  checks."* Here the reviewer approves + enables forge auto-merge; the forge
+  lands it only when required checks pass.
+- **Safety baseline** (gitea-bot-and-branch-protection.md): *"Reviewers must
+  remain the only path that lands code on `main`"* and any auto-merge *"must be
+  opt-in per repository, must require all status checks green, and must still
+  require at least one … review."* The review requirement is satisfied by the
+  **reviewer bot's** approval (a distinct account from the maker). Keep a periodic
+  human audit of merged work as defense in depth.
+
+## Topology
+
+Two worker processes, one Gitea repo/project, **two bot accounts**:
+
+| | maker worker | reviewer worker |
+|---|---|---|
+| `WORKFLOW.md` | `examples/maker-WORKFLOW.md` | `examples/reviewer-automerge-WORKFLOW.md` |
+| Bot account | `maker-bot` (Write) | `review-bot` (Write) — **must differ** |
+| `tracker.active_states` | `[Todo, Rework]` | `[Human Review]` |
+| `tracker.inactive_states` | `[Human Review, In Progress]` | `[Todo, In Progress, Rework]` |
+| `workspace.root` | `~/aiops-workspaces/maker` | `~/aiops-workspaces/reviewer` — **must differ (hard)** |
+| `AIOPS_MIRROR_ROOT` | `~/aiops-mirrors/maker` | `~/aiops-mirrors/reviewer` — **must differ (hard)** |
+| agent state writes | flips → `aiops/human-review`; opens PR; comments PR URL | approves + enables auto-merge; flips → `aiops/done` / `aiops/rework` |
+
+```
+Todo ──maker──▶ Human Review ──reviewer(pass)──▶ Done   ──CI green──▶ auto-merge → main
+  ▲                              └──reviewer(fail)──▶ Rework
+  └──────────────── maker re-dispatch on Rework ◀───────────────┘
+```
+
+The two hard isolation requirements (separate `workspace.root` **and** separate
+`AIOPS_MIRROR_ROOT` per worker — same issue resolves to the same `PathFor`
+directory and the same `ai/<id>` work-branch, so a shared root or mirror is
+deterministically broken) are documented in [`reviewer-worker.md`](reviewer-worker.md);
+they apply unchanged here.
+
+## 1. Bots and credentials
+
+Create **two** dedicated low-privilege Gitea users, `maker-bot` and `review-bot`,
+each a repo collaborator with **Write** (not Admin), 2FA on. Three secrets,
+isolated on purpose:
+
+- `GITEA_TOKEN` — worker-held tracker/API token for polling + the
+  `gitea_issue_labels` proxy. Never enters the agent process (denied by
+  `internal/workflow/agent_env_policy.go`). Scope it to read issues + write issue
+  labels/comments.
+- `MAKER_CLONE_URL` = `http://maker-bot:<maker-token>@gitea.local/<owner>/<repo>.git`
+  — the maker agent's push + PR credential.
+- `REVIEWER_CLONE_URL` = `http://review-bot:<review-token>@gitea.local/<owner>/<repo>.git`
+  — the reviewer agent's fetch + approve + auto-merge credential.
+
+Clone-URL userinfo is masked in logs / `--print-config` (`workflow.MaskCloneURL`).
+
+## 2. CI that gates the merge
+
+Auto-merge is only as safe as the checks it waits on. Add a PR-triggered CI
+workflow whose **job/status name matches the required check** in branch
+protection (step 3), kept in lockstep with the maker's `verify.commands`:
+
+```yaml
+# .gitea/workflows/ci.yml  (Gitea Actions)
+name: ci
+on: { pull_request: { branches: [main] } }
+jobs:
+  build-test:                 # <-- this name is the required status check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.25' }
+      - run: go build ./...
+      - run: go test ./...
+```
+
+## 3. Branch protection on `main` (opt-in, per repo)
+
+Gitea → repo **Settings → Branches → Protect `main`**:
+
+- **Enable status check** and require `build-test`. Auto-merge waits on it.
+- **Require approvals: 1.** The reviewer bot's `APPROVED` review satisfies it; a
+  PR author cannot approve their own PR — which is why maker and reviewer are
+  different accounts.
+- **Dismiss stale approvals on push** / block merge without all checks green.
+- **Restrict direct pushes to `main`** (merge only via PR) — reviewers stay the
+  only path to `main`.
+- Allow the **squash** merge style and enable the repo's **auto-merge** option.
+- Bots stay **Write** — none can edit branch protection.
+
+## 4. Run the two workers
+
+Each process gets its own `AIOPS_WORKFLOW_PATH`, `workspace.root` (in the file),
+`AIOPS_MIRROR_ROOT` (env), and clone-URL secret. Validate before launching:
+
+```bash
+# --- maker ---
+export GITEA_TOKEN=...           AIOPS_MIRROR_ROOT=~/aiops-mirrors/maker
+export MAKER_CLONE_URL='http://maker-bot:<tok>@gitea.local/<owner>/<repo>.git'
+mkdir -p ~/aiops/maker && cp examples/maker-WORKFLOW.md ~/aiops/maker/WORKFLOW.md
+worker --print-config ~/aiops/maker            # confirm: source=file, api_key=***, networkAccess=true
+AIOPS_WORKFLOW_PATH=~/aiops/maker/WORKFLOW.md worker --port 4000 &
+
+# --- reviewer (separate shell / unit; distinct roots + bot) ---
+export GITEA_TOKEN=...           AIOPS_MIRROR_ROOT=~/aiops-mirrors/reviewer
+export REVIEWER_CLONE_URL='http://review-bot:<tok>@gitea.local/<owner>/<repo>.git'
+mkdir -p ~/aiops/reviewer && cp examples/reviewer-automerge-WORKFLOW.md ~/aiops/reviewer/WORKFLOW.md
+worker --print-config ~/aiops/reviewer
+AIOPS_WORKFLOW_PATH=~/aiops/reviewer/WORKFLOW.md worker --port 4001 &
+```
+
+Production: run each as its own systemd unit
+([`binary-deployment.md`](binary-deployment.md)) with its own `EnvironmentFile`.
+Keep `agent.default: mock` until the loop is trusted, then switch to
+`codex-app-server`. On a userns-restricted host the `workspace-write` bwrap
+sandbox fails `--doctor`; run the worker in a container / AppArmor-allowed env
+(binary-deployment.md §1).
+
+## 5. Multiple incremental (dependent) tasks
+
+To make increment N+1 build on N's merged code, encode the order in the tracker
+so the orchestrator only dispatches unblocked work (blog: *"Agents only start
+working on tasks that aren't blocked … execution unfolds … optimally in parallel
+for this DAG"*):
+
+- Put `Depends on #N` in issue N+1's body. The Gitea adapter parses it; the
+  Todo-blocker gate (SPEC §8.2) holds N+1 until #N reaches a **terminal** aiops
+  state (`Done`/`Canceled`).
+- On a clean run, N's PR auto-merges → #N closes/`Done` → next poll dispatches
+  N+1, whose maker branches from the now-updated `main`. Fully unattended.
+- Independent issues fan out in parallel up to `max_concurrent_agents`.
+
+## End-to-end flow (one issue, unattended)
+
+1. Maker claims `Todo` → implements → `go build/test` green → pushes `ai/<id>` →
+   opens PR (`Closes #N`) → comments PR URL → flips `Human Review`. Its run stops
+   on the next reconcile (issue left the maker's active set).
+2. Reviewer claims `Human Review` → fetches head → runs the rubric incl.
+   `build/test`. **PASS**: approves (review-bot), enables
+   `merge_when_checks_succeed`, flips `Done`. **FAIL**: posts findings, flips
+   `Rework` (maker re-dispatches and addresses them).
+3. CI runs on the PR; when `build-test` is green and the approval is present,
+   Gitea auto-merges (squash) and deletes the branch. `Closes #N` resolves the
+   issue.
+
+## Best-practice checklist
+
+- [ ] Distinct `workspace.root` **and** distinct `AIOPS_MIRROR_ROOT` per worker (both hard).
+- [ ] Distinct bot accounts (`maker-bot` ≠ `review-bot`) so the reviewer's approval is valid.
+- [ ] `networkAccess: true` in both `turn_sandbox_policy` blocks (push/fetch/API need it).
+- [ ] `GITEA_TOKEN` never in agent env; label writes only via `gitea_issue_labels`.
+- [ ] Maker `verify.commands` == the required CI checks (a green local run predicts a green merge).
+- [ ] Maker never sets `aiops/done`; reviewer is the only Done/auto-merge path.
+- [ ] Branch protection: required checks + 1 approval + no direct push to `main` + squash + auto-merge enabled.
+- [ ] One-issue-per-PR; agents file follow-up issues for out-of-scope finds.
+- [ ] Periodic human audit of auto-merged work (the bot review is the gate, not a human).
+
+## Optional: a "Merging" shepherd for flaky CI / monorepos
+
+The blog's **Merging** state has an agent *"watch CI, rebase when needed, resolve
+conflicts, retry flaky checks."* If CI is flaky or your base moves fast, add a
+`Merging` state and either extend the reviewer prompt to poll CI and rebase/re-run
+before flipping `Done`, or run a third worker that claims `Merging` and shepherds
+the PR to a green merge. With stable CI, the reviewer's local `build/test` gate
+plus `merge_when_checks_succeed` is enough and you can skip this.
+
+## What this is NOT
+
+- Not a worker-side merge step — that would violate #76 and race reconcile-cancel
+  (#557). The merge is forge-native + agent-triggered.
+- Not blind self-merge — the maker cannot approve or land its own PR; a distinct
+  reviewer + CI gate it.

--- a/examples/maker-WORKFLOW.md
+++ b/examples/maker-WORKFLOW.md
@@ -1,0 +1,117 @@
+---
+# MAKER worker — implements a Todo/Rework issue, opens a PR, and hands off to
+# the reviewer by moving the issue no further than "Human Review".
+# Deploy alongside examples/reviewer-automerge-WORKFLOW.md; see docs/runbooks/unattended-maker-reviewer-automerge.md.
+repo:
+  owner: your-gitea-user
+  name: your-repo
+  default_branch: main
+  # The maker's push + PR credential: a low-privilege MAKER bot token embedded
+  # as HTTP basic-auth. The tracker api_key below never reaches the agent
+  # (env-passthrough deny list), so this remote credential is what the agent
+  # uses to push and open the PR. Whole-value $VAR only (embedded ${VAR} stays
+  # literal), so reference a full URL env var:
+  clone_url: $MAKER_CLONE_URL  # e.g. http://maker-bot:<token>@gitea.local/your-gitea-user/your-repo.git
+
+tracker:
+  kind: gitea
+  endpoint: http://gitea.local
+  # Worker-held token for polling + the gitea_issue_labels handoff proxy;
+  # expanded from the worker env, never exposed to the agent.
+  api_key: $GITEA_TOKEN
+  # The maker owns implementation states; "Human Review" is the handoff state
+  # it never crosses (the reviewer issues Done/Rework).
+  active_states:
+    - Todo
+    - Rework
+  terminal_states:
+    - Done
+    - Canceled
+  # Once handed off, the in-flight maker run becomes ineligible and stops on the
+  # next poll (reconcile-cancel) — the reviewer takes over.
+  inactive_states:
+    - Human Review
+    - In Progress
+
+polling:
+  interval_ms: 30000
+
+workspace:
+  # HARD REQUIREMENT: must differ from the reviewer worker's workspace.root
+  # (same root + same issue = same PathFor dir; worktree reuse force-resets it
+  # while the other process may still be streaming). See the unattended-auto-merge runbook.
+  root: ~/aiops-workspaces/maker
+
+agent:
+  default: codex-app-server
+  max_concurrent_agents: 3   # bounded fan-out across independent Todo issues
+  max_turns: 30
+
+codex:
+  command: codex app-server
+  # workspace-write lets the agent build/test before pushing. networkAccess:true
+  # is required for `git push` and the Gitea PR API (typed policies default to
+  # networkAccess:false, which would block both).
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    writableRoots: []
+    networkAccess: true
+    excludeTmpdirEnvVar: false
+    excludeSlashTmp: false
+
+policy:
+  mode: draft_pr
+
+verify:
+  # Surfaced to the prompt; the agent runs these before pushing. Keep in lockstep
+  # with the CI checks branch protection requires (see the unattended-auto-merge runbook), so a green local
+  # run predicts a green PR.
+  commands:
+    - go build ./...
+    - go test ./...
+---
+You are an autonomous MAKER agent. You implement the issue in a fresh git
+worktree, open a pull request, and hand the work to an independent reviewer.
+You do NOT review or merge your own work.
+
+Issue:
+- Identifier: {{ issue.identifier }}   (the human #N; use its digits for Gitea API + gitea_issue_labels)
+- URL: {{ issue.url }}
+- Title: {{ task.title }}
+
+Repository: {{ repo.owner }}/{{ repo.name }} (base branch: {{ repo.branch }}).
+Your Gitea push + API credential is the basic-auth token already embedded in the
+`origin` remote URL — read it with `git remote get-url origin`.
+
+Description:
+{{ task.description }}
+
+Do all of the following end to end, without asking for confirmation:
+
+1. Implement the change in this worktree. If the issue body says `Depends on #M`,
+   the orchestrator only dispatches you once #M is in a terminal state, so the
+   base branch already contains #M's merged work — build on it.
+2. Run the verify commands until green: `go build ./...` and `go test ./...`.
+   Add tests that would fail if your change were reverted (no placebo tests).
+3. Commit, then push the work branch:
+   `git push -u origin "$(git rev-parse --abbrev-ref HEAD)"`.
+4. Open a pull request against `{{ repo.branch }}` via the Gitea API, with a
+   closing keyword so the merge resolves the issue:
+   `POST /repos/{{ repo.owner }}/{{ repo.name }}/pulls`
+   body `{"head":"<branch>","base":"{{ repo.branch }}","title":"<type(scope): summary>","body":"Closes #{{ issue.identifier }}\n\n<what + how tested>"}`.
+   Use the basic-auth credential from `origin` for the call.
+5. Comment the PR URL on this issue (the reviewer reads the newest PR-URL comment
+   to find your change):
+   `POST /repos/{{ repo.owner }}/{{ repo.name }}/issues/{{ issue.identifier }}/comments`.
+6. Hand off for review: set this issue to the "Human Review" state via the
+   `gitea_issue_labels` tool (do NOT use a raw token; the orchestrator proxies it).
+   Do this exactly once, as your LAST action.
+
+Hard constraints:
+- Do NOT set `aiops/done` — `Done` is the reviewer's verdict, not yours. Moving
+  past `Human Review` would bypass the checker (maker/checker split).
+- Do NOT merge any PR. Landing code on `main` is the reviewer + CI-gated
+  auto-merge path, never the maker.
+- Keep the PR scoped to this issue; file a separate issue for unrelated
+  improvements you notice.

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -1,0 +1,114 @@
+---
+# REVIEWER worker — a fresh-context checker that claims "Human Review", judges
+# the maker's PR against a rubric, and on PASS approves + enables CI-gated
+# auto-merge, then issues the Done verdict. On FAIL it sends the PR back via
+# Rework. Deploy alongside examples/maker-WORKFLOW.md; see docs/runbooks/unattended-maker-reviewer-automerge.md.
+repo:
+  owner: your-gitea-user
+  name: your-repo
+  default_branch: main
+  # DISTINCT bot from the maker. Branch protection requires an approving review,
+  # and an author cannot approve their own PR — so the reviewer must be a second
+  # low-privilege bot account. Its token is what the reviewer uses to fetch the
+  # head, read/post comments, approve, and enable auto-merge.
+  clone_url: $REVIEWER_CLONE_URL  # e.g. http://review-bot:<token>@gitea.local/your-gitea-user/your-repo.git
+
+tracker:
+  kind: gitea
+  endpoint: http://gitea.local
+  api_key: $GITEA_TOKEN          # worker-held; powers polling + gitea_issue_labels verdict proxy
+  active_states:
+    - Human Review               # the reviewer claims exactly the maker's handoff state
+  terminal_states:
+    - Done
+    - Canceled
+  inactive_states:               # maker-owned states cancel an in-flight review (Rework pull-back)
+    - Todo
+    - In Progress
+    - Rework
+
+polling:
+  interval_ms: 30000
+
+workspace:
+  # HARD REQUIREMENT: must differ from the maker worker's workspace.root.
+  root: ~/aiops-workspaces/reviewer
+
+agent:
+  default: codex-app-server
+  max_concurrent_agents: 2
+  max_turns: 12
+
+codex:
+  command: codex app-server
+  # workspace-write so the reviewer can fetch the head branch and run build/test.
+  # networkAccess:true is REQUIRED — git fetch + Gitea API + the auto-merge call
+  # all need network; typed policies default it to false.
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    writableRoots: []
+    networkAccess: true
+    excludeTmpdirEnvVar: false
+    excludeSlashTmp: false
+
+policy:
+  mode: draft_pr
+  # Do NOT use analysis_only — that is the PLAN.md contract and forbids tracker
+  # comments, the opposite of a reviewer whose deliverables are a findings
+  # comment + an approval + the verdict label flip. Review-only lives in the body.
+---
+You are an independent REVIEWER. You did not write the change under review.
+You review, decide a verdict, and (on pass) land it via CI-gated auto-merge.
+You do NOT write or push code.
+
+Issue under review:
+- Identifier: {{ issue.identifier }}   (the human #N; use its digits for every Gitea API call + gitea_issue_labels — never task.id)
+- URL: {{ issue.url }}
+- Title: {{ task.title }}
+
+Repository: {{ repo.owner }}/{{ repo.name }} (base branch: {{ repo.branch }}).
+Your Gitea credential is the basic-auth token in `git remote get-url origin`;
+use it for every API call below.
+
+## Step 1 — find the change under review
+Read this issue's comments via the API and take the newest PR-URL the maker
+commented. Obtain the diff either way:
+- `git fetch origin <head-branch>` and diff against `{{ repo.branch }}`, or
+- `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>.diff`.
+If you cannot identify the PR, comment what you looked for and flip to
+`aiops/rework` so the maker re-hands-off.
+
+## Step 2 — review against the rubric (every item must pass)
+1. The diff implements what the issue asked; each acceptance criterion is met or
+   explicitly addressed in the PR body.
+2. Tests cover the changed behavior and would fail if the change were reverted
+   (no placebo tests).
+3. The diff is scoped to this issue — no unrelated changes ride along.
+4. No correctness/safety problems (races, unchecked errors, secrets in code/logs).
+5. Executable gate: on the fetched head, `go build ./...` and `go test ./...` pass.
+   (This mirrors the required CI checks, so your approval predicts a green merge.)
+
+## Step 3 — verdict
+PASS (every item passes):
+  a. Comment a short per-item review summary on the issue.
+  b. Approve the PR:
+     `POST /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>/reviews`
+     body `{"event":"APPROVED","body":"Rubric passed: <1-line>"}`.
+  c. Enable CI-gated auto-merge (the forge merges only when all required status
+     checks are green — you do NOT merge directly):
+     `POST /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>/merge`
+     body `{"Do":"squash","merge_when_checks_succeed":true,"delete_branch_after_merge":true}`.
+  d. Set the label to `aiops/done` via the gitea_issue_labels tool — your LAST action.
+
+FAIL (any item fails):
+  - Comment the failing items with concrete, actionable findings (file, line,
+    what to change), then set the label to `aiops/rework` via gitea_issue_labels.
+    The maker re-runs from your findings. This is your LAST action.
+
+## Hard constraints (review-only)
+- Do NOT modify, commit, or push code. Your only writes are: the review comment,
+  the approval, the auto-merge enablement, and the one verdict label flip.
+- Judge only what the diff and its tests prove; unverified PR-description claims
+  count for nothing.
+- Do the verdict label flip exactly once, as the final action.


### PR DESCRIPTION
Closes #857

## Summary
- Adds a deployment guide `docs/runbooks/unattended-maker-reviewer-automerge.md` plus two example WORKFLOWs (`examples/maker-WORKFLOW.md`, `examples/reviewer-automerge-WORKFLOW.md`) for running **multiple incremental tasks unattended**.
- A *maker* worker implements each issue and opens a PR (stops at `Human Review`); an independent *reviewer* worker judges it in a fresh context and, on pass, **approves + enables forge-native CI-gated auto-merge** (`merge_when_checks_succeed`), then flips `Done`; on fail it sends `Rework`.
- The merge is performed by the **agent + the forge, never the worker** — consistent with the scheduler/runner-and-tracker-reader boundary (SPEC §1 / #76). Builds directly on `docs/runbooks/reviewer-worker.md` (maker/checker split, the two hard isolation requirements) and `docs/runbooks/gitea-bot-and-branch-protection.md` (two bots, branch protection, opt-in auto-merge requiring all checks green + a review).
- The `reviewer-automerge` example is the auto-merge variant of the existing verdict-only `examples/reviewer-WORKFLOW.md`. Both new example WORKFLOWs were validated through `worker --print-config`.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Docs + examples only: touches `docs/runbooks/` and `examples/` exclusively; no SPEC-sensitive path, no code, and the example WORKFLOWs reuse existing config keys (repo/tracker/polling/workspace/agent/codex/policy/verify).

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff is 0 files / 0 LOC (documentation + example config only).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- N/A — docs/examples-only PR; no Go/production code changed. Both example WORKFLOWs pass `worker --print-config` (front matter loads, dispatchable, secrets masked).

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked.