### PR TITLE
docs: address @codex review on #858 (Done only post-merge; maker uses numeric issue number)

### DIFF
--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -51,26 +51,30 @@ Two worker processes, one Gitea repo/project, **two bot accounts**:
 | `WORKFLOW.md` | `examples/maker-WORKFLOW.md` | `examples/reviewer-automerge-WORKFLOW.md` |
 | Bot account | `maker-bot` (Write) | `review-bot` (Write) — **must differ** |
 | `tracker.active_states` | `[Todo, Rework]` | `[Human Review]` |
-| `tracker.inactive_states` | `[Human Review, In Progress, Merging]` | `[Todo, In Progress, Rework, Merging]` |
+| `tracker.inactive_states` | `[Human Review, In Progress]` | `[Todo, In Progress, Rework]` |
 | `workspace.root` | `~/aiops-workspaces/maker` | `~/aiops-workspaces/reviewer` — **must differ (hard)** |
 | `AIOPS_MIRROR_ROOT` | `~/aiops-mirrors/maker` | `~/aiops-mirrors/reviewer` — **must differ (hard)** |
-| agent state writes | flips → `aiops/human-review`; opens PR; comments PR URL | approves + enables auto-merge; **confirms the merge, then** flips → `aiops/done` (or `aiops/merging` if CI is slow); `aiops/rework` on fail |
+| agent state writes | flips → `aiops/human-review`; opens PR; comments PR URL | approves + enables auto-merge; **confirms the merge, then** flips → `aiops/done`; stays in `Human Review` (re-checks next poll) if CI is still landing; `aiops/rework` on fail |
 
 ```
 Todo ──maker──▶ Human Review ──reviewer──▶ approve + enable CI-gated auto-merge
-                   │                               │
-                   ├─(rubric fail)─▶ Rework        forge merges when required CI is green
-                   │                               │
-                   │                        reviewer confirms merge ─▶ Done ─▶ (main)
-                   └─(slow/flaky CI)─▶ Merging ──(Merging worker: merged?)─▶ Done
-  ▲
-  └──────── maker re-dispatch on Rework ────────┘
+                  ▲   │                              │
+                  │   └─(rubric fail)─▶ Rework       forge merges when required CI is green
+                  │                       │                 │
+   reviewer re-polls Human Review         │        reviewer confirms merge ─▶ Done ─▶ (main)
+   until the forge confirms merge         │
+   (no terminal flip meanwhile)           │
+  ▲                                       │
+  └────────── maker re-dispatch on Rework ┘
 ```
 
 **`Done` is issued only AFTER the forge reports the PR merged** — never on the
 reviewer's verdict alone. Otherwise a `Depends on #N` dependent (whose gate keys
 off the terminal `aiops/*` label, not the forge merge) could unblock and start
-N+1 from a stale `main` while CI is still running or later fails.
+N+1 from a stale `main` while CI is still running or later fails. When CI has not
+landed within the reviewer's turn budget, it makes **no** terminal flip and leaves
+the issue in `Human Review`; the next poll re-claims it and re-checks (see
+[Slow or flaky CI](#slow-or-flaky-ci)) — there is no separate holding state.
 
 The two hard isolation requirements (separate `workspace.root` **and** separate
 `AIOPS_MIRROR_ROOT` per worker — same issue resolves to the same `PathFor`
@@ -183,13 +187,14 @@ for this DAG"*):
    `build/test`. **PASS**: approves (review-bot), enables `merge_when_checks_succeed`,
    then — while still `Human Review` (so it is not reconcile-cancelled) — confirms
    the merge via `GET …/pulls/<number>` → `merged:true` and flips `Done`. If CI is
-   slow/flaky and the merge has not landed within its budget, it flips the
-   non-terminal `Merging` and stops; a Merging worker finalizes `Done` post-merge.
+   slow/flaky and the merge has not landed within its budget, it makes **no**
+   terminal flip and leaves the issue in `Human Review`; the next poll re-claims it
+   and re-checks until the forge confirms the merge.
    **FAIL**: posts findings, flips `Rework` (maker re-dispatches).
 3. CI runs on the PR; when `build-test` is green and the approval is present,
    Gitea auto-merges (squash) and deletes the branch. `Closes #<N>` also resolves
-   the Gitea issue. `Done` is set by the reviewer/Merging worker after that merge,
-   never before.
+   the Gitea issue. `Done` is set by the reviewer only after that merge, never
+   before.
 
 ## Best-practice checklist
 
@@ -205,19 +210,33 @@ for this DAG"*):
 - [ ] One-issue-per-PR; agents file follow-up issues for out-of-scope finds.
 - [ ] Periodic human audit of auto-merged work (the bot review is the gate, not a human).
 
-## Optional: a "Merging" worker for slow/flaky CI or monorepos
+## Slow or flaky CI
 
 For fast, stable CI the reviewer confirms the merge inline (poll → `Done`), so you
-need nothing more. When CI is slow or flaky — or your base moves fast and PRs need
-rebasing — the reviewer instead parks the issue at the non-terminal `Merging` state
-and a dedicated **Merging worker** finalizes it. This is the blog's **Merging**
-state: an agent that *"watches CI, rebases when needed, resolves conflicts, retries
-flaky checks,"* then flips `aiops/done` once the forge reports the PR merged. Run it
-as a third worker (`active_states: [Merging]`, its own distinct `workspace.root` +
-`AIOPS_MIRROR_ROOT`, the same two-hard-isolation rules), with a prompt that: reads
-the PR for this issue, confirms `merged:true` (rebasing / re-running CI as needed),
-and on success flips `aiops/done` via `gitea_issue_labels`. Keeping `Done` strictly
-post-merge is what makes dependent (`Depends on #N`) chains safe.
+need nothing more. When CI is slow or flaky, the merge may not land within the
+reviewer's turn budget. The reviewer then makes **no terminal flip** and leaves the
+issue in `Human Review`; because that is the reviewer's active state, the next poll
+re-claims the issue and re-checks the PR — flipping `Done` only once the forge
+reports `merged:true`. Dependents stay gated throughout, since the issue never
+reaches a terminal state before the merge. (On re-claim the reviewer detects its own
+prior approval and skips straight to the merge re-check, so it does not re-run the
+full rubric every poll.) If CI stays red **after** approval — a local-pass /
+CI-fail mismatch the reviewer's own `build/test` did not catch — the issue parks in
+`Human Review` indefinitely and its dependents stay gated; that is a signal for a
+human to investigate the mismatch, not to force `Done`/`Canceled` (either would
+unblock dependents from a `main` that never received the change).
+
+Upstream Symphony models this landing phase as a dedicated **Merging** state with an
+agent that *"watches CI, rebases when needed, resolves conflicts, retries flaky
+checks"* ([blog](../research/2026-04-27-openai-symphony-blog.md); upstream
+`elixir/WORKFLOW.md`). The Gitea adapter's state set is currently fixed to the six
+`aiops/*` labels in the topology table — `validGiteaStateLabels`
+(`internal/runner/gitea_tools.go`) rejects any other label, and
+`DefaultStateLabelMappings` (`internal/gitea/label_state.go`) has no `Merging` — so a
+native `Merging` state is a tracked **code** enhancement
+([#863](https://github.com/xrf9268-hue/aiops-platform/issues/863)), not something you
+can configure today. Until it lands, the `Human Review` re-poll above is the slow-CI
+path.
 
 ## What this is NOT
 

--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -228,7 +228,7 @@ reports `merged:true`. This re-poll only works because the maker used a non-clos
 `Refs #<N>`: an issue auto-closed at merge would drop out of the poller's
 `state=open` listing for `Human Review` before `Done` is set. Dependents stay gated
 throughout, since the issue never reaches a terminal state before the merge. (On re-claim the reviewer detects its own
-prior approval and skips straight to the merge re-check, so it does not re-run the
+**current (non-stale)** prior approval and skips straight to the merge re-check, so it does not re-run the
 full rubric every poll.) This re-poll is **bounded**, not infinite: each clean
 exit consumes from `agent.max_continuation_turns` (D34; it defaults to `max_turns`,
 so the reviewer WORKFLOW sets it explicitly higher). When the budget is exhausted —

--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -181,20 +181,26 @@ for this DAG"*):
 ## End-to-end flow (one issue, unattended)
 
 1. Maker claims `Todo` → implements → `go build/test` green → pushes `ai/<id>` →
-   opens PR (`Closes #<N>`) → comments PR URL → flips `Human Review`. Its run stops
+   opens PR referencing the issue with a **non-closing** `Refs #<N>` (NOT
+   `Closes` — see below) → comments PR URL → flips `Human Review`. Its run stops
    on the next reconcile (issue left the maker's active set).
 2. Reviewer claims `Human Review` → fetches head → runs the rubric incl.
    `build/test`. **PASS**: approves (review-bot), enables `merge_when_checks_succeed`,
    then — while still `Human Review` (so it is not reconcile-cancelled) — confirms
-   the merge via `GET …/pulls/<number>` → `merged:true` and flips `Done`. If CI is
-   slow/flaky and the merge has not landed within its budget, it makes **no**
-   terminal flip and leaves the issue in `Human Review`; the next poll re-claims it
-   and re-checks until the forge confirms the merge.
+   the merge via `GET …/pulls/<number>` → `merged:true`, flips `Done`, and closes
+   the issue (it owns closure, since the maker left it open). If CI is slow/flaky
+   and the merge has not landed within its budget, it makes **no** terminal flip
+   and leaves the issue in `Human Review`; the next poll re-claims it and re-checks
+   until the forge confirms the merge.
    **FAIL**: posts findings, flips `Rework` (maker re-dispatches).
 3. CI runs on the PR; when `build-test` is green and the approval is present,
-   Gitea auto-merges (squash) and deletes the branch. `Closes #<N>` also resolves
-   the Gitea issue. `Done` is set by the reviewer only after that merge, never
-   before.
+   Gitea auto-merges (squash) and deletes the branch. The merge does **not** close
+   the issue (the maker used `Refs #<N>`, not a closing keyword); the reviewer
+   flips `Done` and closes it only after confirming the merge, never before.
+   **Why not `Closes #<N>`:** the poller lists `Human Review` (a non-terminal
+   active state) with `state=open`, so an issue auto-closed at merge-time would
+   drop out of the reviewer's poll *before* it could set `Done` — stranding it
+   (closed + still `Human Review`) and blocking every `Depends on #N` dependent.
 
 ## Best-practice checklist
 
@@ -205,7 +211,8 @@ for this DAG"*):
 - [ ] Maker `verify.commands` == the required CI checks (a green local run predicts a green merge).
 - [ ] Maker never sets `aiops/done`; reviewer is the only Done/auto-merge path.
 - [ ] Reviewer issues `aiops/done` **only after the forge confirms the merge** — never on the verdict alone (else `Depends on #N` dependents unblock from stale `main`).
-- [ ] Maker uses the numeric issue number (digits of `{{ issue.identifier }}`, no leading `#`) in every API path / `Closes` keyword — `{{ issue.identifier }}` renders as `#N` on Gitea.
+- [ ] Maker references the issue with a **non-closing** `Refs #<N>` (not `Closes`); the reviewer flips `Done` and closes the issue post-merge. A closing keyword auto-closes the issue at merge, dropping it from the reviewer's `state=open` poll before `Done` is set — stranding it and its dependents.
+- [ ] Maker uses the numeric issue number (digits of `{{ issue.identifier }}`, no leading `#`) in every API path / issue reference — `{{ issue.identifier }}` renders as `#N` on Gitea.
 - [ ] Branch protection: required checks + 1 approval + no direct push to `main` + squash + auto-merge enabled.
 - [ ] One-issue-per-PR; agents file follow-up issues for out-of-scope finds.
 - [ ] Periodic human audit of auto-merged work (the bot review is the gate, not a human).
@@ -217,8 +224,10 @@ need nothing more. When CI is slow or flaky, the merge may not land within the
 reviewer's turn budget. The reviewer then makes **no terminal flip** and leaves the
 issue in `Human Review`; because that is the reviewer's active state, the next poll
 re-claims the issue and re-checks the PR — flipping `Done` only once the forge
-reports `merged:true`. Dependents stay gated throughout, since the issue never
-reaches a terminal state before the merge. (On re-claim the reviewer detects its own
+reports `merged:true`. This re-poll only works because the maker used a non-closing
+`Refs #<N>`: an issue auto-closed at merge would drop out of the poller's
+`state=open` listing for `Human Review` before `Done` is set. Dependents stay gated
+throughout, since the issue never reaches a terminal state before the merge. (On re-claim the reviewer detects its own
 prior approval and skips straight to the merge re-check, so it does not re-run the
 full rubric every poll.) If CI stays red **after** approval — a local-pass /
 CI-fail mismatch the reviewer's own `build/test` did not catch — the issue parks in

--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -51,16 +51,26 @@ Two worker processes, one Gitea repo/project, **two bot accounts**:
 | `WORKFLOW.md` | `examples/maker-WORKFLOW.md` | `examples/reviewer-automerge-WORKFLOW.md` |
 | Bot account | `maker-bot` (Write) | `review-bot` (Write) — **must differ** |
 | `tracker.active_states` | `[Todo, Rework]` | `[Human Review]` |
-| `tracker.inactive_states` | `[Human Review, In Progress]` | `[Todo, In Progress, Rework]` |
+| `tracker.inactive_states` | `[Human Review, In Progress, Merging]` | `[Todo, In Progress, Rework, Merging]` |
 | `workspace.root` | `~/aiops-workspaces/maker` | `~/aiops-workspaces/reviewer` — **must differ (hard)** |
 | `AIOPS_MIRROR_ROOT` | `~/aiops-mirrors/maker` | `~/aiops-mirrors/reviewer` — **must differ (hard)** |
-| agent state writes | flips → `aiops/human-review`; opens PR; comments PR URL | approves + enables auto-merge; flips → `aiops/done` / `aiops/rework` |
+| agent state writes | flips → `aiops/human-review`; opens PR; comments PR URL | approves + enables auto-merge; **confirms the merge, then** flips → `aiops/done` (or `aiops/merging` if CI is slow); `aiops/rework` on fail |
 
 ```
-Todo ──maker──▶ Human Review ──reviewer(pass)──▶ Done   ──CI green──▶ auto-merge → main
-  ▲                              └──reviewer(fail)──▶ Rework
-  └──────────────── maker re-dispatch on Rework ◀───────────────┘
+Todo ──maker──▶ Human Review ──reviewer──▶ approve + enable CI-gated auto-merge
+                   │                               │
+                   ├─(rubric fail)─▶ Rework        forge merges when required CI is green
+                   │                               │
+                   │                        reviewer confirms merge ─▶ Done ─▶ (main)
+                   └─(slow/flaky CI)─▶ Merging ──(Merging worker: merged?)─▶ Done
+  ▲
+  └──────── maker re-dispatch on Rework ────────┘
 ```
+
+**`Done` is issued only AFTER the forge reports the PR merged** — never on the
+reviewer's verdict alone. Otherwise a `Depends on #N` dependent (whose gate keys
+off the terminal `aiops/*` label, not the forge merge) could unblock and start
+N+1 from a stale `main` while CI is still running or later fails.
 
 The two hard isolation requirements (separate `workspace.root` **and** separate
 `AIOPS_MIRROR_ROOT` per worker — same issue resolves to the same `PathFor`
@@ -158,22 +168,28 @@ for this DAG"*):
 - Put `Depends on #N` in issue N+1's body. The Gitea adapter parses it; the
   Todo-blocker gate (SPEC §8.2) holds N+1 until #N reaches a **terminal** aiops
   state (`Done`/`Canceled`).
-- On a clean run, N's PR auto-merges → #N closes/`Done` → next poll dispatches
-  N+1, whose maker branches from the now-updated `main`. Fully unattended.
+- Because the reviewer issues `Done` **only after the forge confirms the merge**,
+  N+1 unblocks only once N is actually on `main`, so its maker branches from the
+  updated tree. (If `Done` were issued on the verdict alone, N+1 could start from a
+  stale `main` while N's CI was still running — this is the bug this guide avoids.)
 - Independent issues fan out in parallel up to `max_concurrent_agents`.
 
 ## End-to-end flow (one issue, unattended)
 
 1. Maker claims `Todo` → implements → `go build/test` green → pushes `ai/<id>` →
-   opens PR (`Closes #N`) → comments PR URL → flips `Human Review`. Its run stops
+   opens PR (`Closes #<N>`) → comments PR URL → flips `Human Review`. Its run stops
    on the next reconcile (issue left the maker's active set).
 2. Reviewer claims `Human Review` → fetches head → runs the rubric incl.
-   `build/test`. **PASS**: approves (review-bot), enables
-   `merge_when_checks_succeed`, flips `Done`. **FAIL**: posts findings, flips
-   `Rework` (maker re-dispatches and addresses them).
+   `build/test`. **PASS**: approves (review-bot), enables `merge_when_checks_succeed`,
+   then — while still `Human Review` (so it is not reconcile-cancelled) — confirms
+   the merge via `GET …/pulls/<number>` → `merged:true` and flips `Done`. If CI is
+   slow/flaky and the merge has not landed within its budget, it flips the
+   non-terminal `Merging` and stops; a Merging worker finalizes `Done` post-merge.
+   **FAIL**: posts findings, flips `Rework` (maker re-dispatches).
 3. CI runs on the PR; when `build-test` is green and the approval is present,
-   Gitea auto-merges (squash) and deletes the branch. `Closes #N` resolves the
-   issue.
+   Gitea auto-merges (squash) and deletes the branch. `Closes #<N>` also resolves
+   the Gitea issue. `Done` is set by the reviewer/Merging worker after that merge,
+   never before.
 
 ## Best-practice checklist
 
@@ -183,18 +199,25 @@ for this DAG"*):
 - [ ] `GITEA_TOKEN` never in agent env; label writes only via `gitea_issue_labels`.
 - [ ] Maker `verify.commands` == the required CI checks (a green local run predicts a green merge).
 - [ ] Maker never sets `aiops/done`; reviewer is the only Done/auto-merge path.
+- [ ] Reviewer issues `aiops/done` **only after the forge confirms the merge** — never on the verdict alone (else `Depends on #N` dependents unblock from stale `main`).
+- [ ] Maker uses the numeric issue number (digits of `{{ issue.identifier }}`, no leading `#`) in every API path / `Closes` keyword — `{{ issue.identifier }}` renders as `#N` on Gitea.
 - [ ] Branch protection: required checks + 1 approval + no direct push to `main` + squash + auto-merge enabled.
 - [ ] One-issue-per-PR; agents file follow-up issues for out-of-scope finds.
 - [ ] Periodic human audit of auto-merged work (the bot review is the gate, not a human).
 
-## Optional: a "Merging" shepherd for flaky CI / monorepos
+## Optional: a "Merging" worker for slow/flaky CI or monorepos
 
-The blog's **Merging** state has an agent *"watch CI, rebase when needed, resolve
-conflicts, retry flaky checks."* If CI is flaky or your base moves fast, add a
-`Merging` state and either extend the reviewer prompt to poll CI and rebase/re-run
-before flipping `Done`, or run a third worker that claims `Merging` and shepherds
-the PR to a green merge. With stable CI, the reviewer's local `build/test` gate
-plus `merge_when_checks_succeed` is enough and you can skip this.
+For fast, stable CI the reviewer confirms the merge inline (poll → `Done`), so you
+need nothing more. When CI is slow or flaky — or your base moves fast and PRs need
+rebasing — the reviewer instead parks the issue at the non-terminal `Merging` state
+and a dedicated **Merging worker** finalizes it. This is the blog's **Merging**
+state: an agent that *"watches CI, rebases when needed, resolves conflicts, retries
+flaky checks,"* then flips `aiops/done` once the forge reports the PR merged. Run it
+as a third worker (`active_states: [Merging]`, its own distinct `workspace.root` +
+`AIOPS_MIRROR_ROOT`, the same two-hard-isolation rules), with a prompt that: reads
+the PR for this issue, confirms `merged:true` (rebasing / re-running CI as needed),
+and on success flips `aiops/done` via `gitea_issue_labels`. Keeping `Done` strictly
+post-merge is what makes dependent (`Depends on #N`) chains safe.
 
 ## What this is NOT
 

--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -229,11 +229,17 @@ reports `merged:true`. This re-poll only works because the maker used a non-clos
 `state=open` listing for `Human Review` before `Done` is set. Dependents stay gated
 throughout, since the issue never reaches a terminal state before the merge. (On re-claim the reviewer detects its own
 prior approval and skips straight to the merge re-check, so it does not re-run the
-full rubric every poll.) If CI stays red **after** approval — a local-pass /
-CI-fail mismatch the reviewer's own `build/test` did not catch — the issue parks in
-`Human Review` indefinitely and its dependents stay gated; that is a signal for a
-human to investigate the mismatch, not to force `Done`/`Canceled` (either would
-unblock dependents from a `main` that never received the change).
+full rubric every poll.) This re-poll is **bounded**, not infinite: each clean
+exit consumes from `agent.max_continuation_turns` (D34; it defaults to `max_turns`,
+so the reviewer WORKFLOW sets it explicitly higher). When the budget is exhausted —
+e.g. CI stays red after approval (a local-pass / CI-fail mismatch the reviewer's own
+`build/test` did not catch) — the orchestrator parks the issue in local `blocked`
+(`continuation_budget`); its dependents stay gated, and an operator must investigate
+the mismatch and redrive it (raising the budget does not auto-redrive a blocked
+claim) — not force `Done`/`Canceled`, either of which would unblock dependents from a
+`main` that never received the change. For CI that is *routinely* slower than the
+budget, the dedicated Merging worker (#863) is the right tool, not an ever-larger
+number.
 
 Upstream Symphony models this landing phase as a dedicated **Merging** state with an
 agent that *"watches CI, rebases when needed, resolves conflicts, retries flaky

--- a/examples/maker-WORKFLOW.md
+++ b/examples/maker-WORKFLOW.md
@@ -32,6 +32,7 @@ tracker:
   inactive_states:
     - Human Review
     - In Progress
+    - Merging
 
 polling:
   interval_ms: 30000
@@ -76,9 +77,14 @@ worktree, open a pull request, and hand the work to an independent reviewer.
 You do NOT review or merge your own work.
 
 Issue:
-- Identifier: {{ issue.identifier }}   (the human #N; use its digits for Gitea API + gitea_issue_labels)
+- Identifier: {{ issue.identifier }}   (Gitea renders this as `#<number>`, e.g. `#7`)
 - URL: {{ issue.url }}
 - Title: {{ task.title }}
+
+Issue number: let `<N>` be the digits of the identifier with the leading `#`
+stripped (e.g. `7`). Use `<N>` — never the raw `{{ issue.identifier }}` (`#7`) —
+in every Gitea API path, the `Closes` keyword, and the gitea_issue_labels tool;
+the raw value would produce `/issues/#7/comments` and `Closes ##7`.
 
 Repository: {{ repo.owner }}/{{ repo.name }} (base branch: {{ repo.branch }}).
 Your Gitea push + API credential is the basic-auth token already embedded in the
@@ -99,11 +105,11 @@ Do all of the following end to end, without asking for confirmation:
 4. Open a pull request against `{{ repo.branch }}` via the Gitea API, with a
    closing keyword so the merge resolves the issue:
    `POST /repos/{{ repo.owner }}/{{ repo.name }}/pulls`
-   body `{"head":"<branch>","base":"{{ repo.branch }}","title":"<type(scope): summary>","body":"Closes #{{ issue.identifier }}\n\n<what + how tested>"}`.
+   body `{"head":"<branch>","base":"{{ repo.branch }}","title":"<type(scope): summary>","body":"Closes #<N>\n\n<what + how tested>"}`.
    Use the basic-auth credential from `origin` for the call.
 5. Comment the PR URL on this issue (the reviewer reads the newest PR-URL comment
    to find your change):
-   `POST /repos/{{ repo.owner }}/{{ repo.name }}/issues/{{ issue.identifier }}/comments`.
+   `POST /repos/{{ repo.owner }}/{{ repo.name }}/issues/<N>/comments`.
 6. Hand off for review: set this issue to the "Human Review" state via the
    `gitea_issue_labels` tool (do NOT use a raw token; the orchestrator proxies it).
    Do this exactly once, as your LAST action.

--- a/examples/maker-WORKFLOW.md
+++ b/examples/maker-WORKFLOW.md
@@ -82,8 +82,8 @@ Issue:
 
 Issue number: let `<N>` be the digits of the identifier with the leading `#`
 stripped (e.g. `7`). Use `<N>` — never the raw `{{ issue.identifier }}` (`#7`) —
-in every Gitea API path, the `Closes` keyword, and the gitea_issue_labels tool;
-the raw value would produce `/issues/#7/comments` and `Closes ##7`.
+in every Gitea API path, the PR-body issue reference, and the gitea_issue_labels
+tool; the raw value would produce `/issues/#7/comments` and `Refs ##7`.
 
 Repository: {{ repo.owner }}/{{ repo.name }} (base branch: {{ repo.branch }}).
 Your Gitea push + API credential is the basic-auth token already embedded in the
@@ -101,10 +101,16 @@ Do all of the following end to end, without asking for confirmation:
    Add tests that would fail if your change were reverted (no placebo tests).
 3. Commit, then push the work branch:
    `git push -u origin "$(git rev-parse --abbrev-ref HEAD)"`.
-4. Open a pull request against `{{ repo.branch }}` via the Gitea API, with a
-   closing keyword so the merge resolves the issue:
+4. Open a pull request against `{{ repo.branch }}` via the Gitea API. Reference
+   the issue with a NON-closing keyword — `Refs #<N>`, NOT `Closes #<N>`. A
+   closing keyword makes the forge close the issue the instant the PR merges; on
+   the auto-merge path that strands it, because the reviewer issues `Done` only
+   *after* it confirms the merge, and the poller lists `Human Review` issues with
+   `state=open` — a merge-closed issue drops out of the reviewer's poll before
+   `Done` is ever set, deadlocking the issue and its `Depends on #N` dependents.
+   The reviewer owns issue closure.
    `POST /repos/{{ repo.owner }}/{{ repo.name }}/pulls`
-   body `{"head":"<branch>","base":"{{ repo.branch }}","title":"<type(scope): summary>","body":"Closes #<N>\n\n<what + how tested>"}`.
+   body `{"head":"<branch>","base":"{{ repo.branch }}","title":"<type(scope): summary>","body":"Refs #<N>\n\n<what + how tested>"}`.
    Use the basic-auth credential from `origin` for the call.
 5. Comment the PR URL on this issue (the reviewer reads the newest PR-URL comment
    to find your change):

--- a/examples/maker-WORKFLOW.md
+++ b/examples/maker-WORKFLOW.md
@@ -32,7 +32,6 @@ tracker:
   inactive_states:
     - Human Review
     - In Progress
-    - Merging
 
 polling:
   interval_ms: 30000

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -119,7 +119,11 @@ PASS (every item passes):
      `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>` → `merged: true`
      (a short bounded wait — e.g. poll every ~30s for a few attempts, not a busy
      loop; required CI here is fast).
-       - Merged → set the label to `aiops/done` via gitea_issue_labels. LAST action.
+       - Merged → set the label to `aiops/done` via gitea_issue_labels, then close
+         the issue: `PATCH /repos/{{ repo.owner }}/{{ repo.name }}/issues/<N>`
+         body `{"state":"closed"}`. The maker referenced the issue with a
+         non-closing `Refs #<N>`, so the forge did NOT close it on merge — you own
+         closure, after `Done`. This is your LAST action.
        - Not merged within your budget (slow/flaky CI) → do NOT flip any label.
          Leave the issue in `Human Review` and stop. It stays in your active set,
          so the next poll re-claims it and re-checks the merge (Step 1 sends you
@@ -134,8 +138,9 @@ FAIL (any item fails):
 
 ## Hard constraints (review-only)
 - Do NOT modify, commit, or push code. Your only writes are tracker/PR writes: the
-  review comment, the approval, enabling auto-merge, and the verdict label flip
-  (`aiops/done` after the merge is confirmed, or `aiops/rework` on failure).
+  review comment, the approval, enabling auto-merge, the verdict label flip
+  (`aiops/done` after the merge is confirmed, or `aiops/rework` on failure), and —
+  on the Done path — closing the issue (the maker left it open via `Refs #<N>`).
 - Judge only what the diff and its tests prove; unverified PR-description claims
   count for nothing.
 - Issue the terminal verdict exactly once: `aiops/done` only after the merge is

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -110,8 +110,14 @@ but work out the situation first, in this order:
      do not assume auto-merge survived a prior crash between approve (Step 3b) and
      enable (Step 3c): re-issue Step 3c. You call the merge endpoint directly, so
      handle its response — on success or "already scheduled" (HTTP 409) auto-merge
-     is set, so poll Step 3d; on "already merged" (HTTP 405) it just landed, so
-     flip `aiops/done` + close and stop (no polling).
+     is set, so poll Step 3d. On any error (Gitea returns HTTP 405 for an
+     already-merged PR but ALSO for not-mergeable / WIP / no-permission states), do
+     NOT conclude it merged: re-check `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>`
+     and take the Done path (flip `aiops/done` + close) ONLY if `merged:true`;
+     otherwise — unmerged, or the check itself did not confirm a merge — leave the
+     issue in `Human Review` for the next poll (a persistent error is an operator
+     signal). Never flip `aiops/done` without a confirming `merged:true` —
+     a status code alone is not proof.
    - **No current approval** — your only approval is `stale`/dismissed or was for
      an older commit (the head moved after you approved: a rebase or a pushed fix)
      → do NOT short-circuit. Fall through to Step 2 and review the new head from

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -38,6 +38,15 @@ agent:
   default: codex-app-server
   max_concurrent_agents: 2
   max_turns: 12
+  # Bounds the slow-CI re-poll. Every clean exit that leaves the issue in
+  # Human Review consumes from this cumulative clean-turn budget (D34). It
+  # DEFAULTS to max_turns (12) — too low to re-check across a slow CI run — and
+  # on exhaustion the orchestrator parks the issue in local `blocked`
+  # (continuation_budget), it does NOT loop forever. Set it above max_turns so
+  # several cheap merge re-checks (the Step 1 short-circuit) fit. CI routinely
+  # slower than this budget wants the dedicated Merging worker (#863), not a
+  # larger number.
+  max_continuation_turns: 36
 
 codex:
   command: codex app-server
@@ -88,10 +97,13 @@ If you cannot identify the PR, comment what you looked for and flip to
 
 If a previous poll already reviewed this PR — `GET
 /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>/reviews` shows your own
-`APPROVED` review — you already ran the rubric and enabled auto-merge (Step 3c)
-in that pass (the two happen together). Do NOT re-review or re-approve; skip
-straight to Step 3d and just re-confirm the merge. Re-running `build/test` each
-poll while CI lands is wasted work.
+`APPROVED` review — do NOT re-review or re-run `build/test` (wasted work). But do
+NOT assume auto-merge is still enabled: a prior run could have approved (Step 3b)
+then crashed/timed out before enabling it (Step 3c). Re-issue Step 3c — you call
+the merge endpoint directly, so handle its response yourself: a success means it
+is now scheduled, and a "merge already scheduled" error (Gitea returns HTTP 409)
+means a prior run already set it. Treat BOTH as success and go to Step 3d to
+confirm the merge.
 
 ## Step 2 — review against the rubric (every item must pass)
 1. The diff implements what the issue asked; each acceptance criterion is met or
@@ -127,7 +139,10 @@ PASS (every item passes):
        - Not merged within your budget (slow/flaky CI) → do NOT flip any label.
          Leave the issue in `Human Review` and stop. It stays in your active set,
          so the next poll re-claims it and re-checks the merge (Step 1 sends you
-         straight back here) — no terminal flip until `merged:true`. Done.
+         straight back here, cheaply) — no terminal flip until `merged:true`. The
+         re-poll is bounded by `agent.max_continuation_turns` (front matter); CI
+         slower than that budget parks the issue in local `blocked` for an
+         operator to redrive. Done.
   Never flip `aiops/done` before the forge reports the PR merged — `Done` is
   terminal and would unblock `Depends on #N` dependents from a stale `main`.
 

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -97,13 +97,18 @@ If you cannot identify the PR, comment what you looked for and flip to
 
 If a previous poll already reviewed this PR — `GET
 /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>/reviews` shows your own
-`APPROVED` review — do NOT re-review or re-run `build/test` (wasted work). But do
-NOT assume auto-merge is still enabled: a prior run could have approved (Step 3b)
-then crashed/timed out before enabling it (Step 3c). Re-issue Step 3c — you call
-the merge endpoint directly, so handle its response yourself: a success means it
-is now scheduled, and a "merge already scheduled" error (Gitea returns HTTP 409)
-means a prior run already set it. Treat BOTH as success and go to Step 3d to
-confirm the merge.
+`APPROVED` review — do NOT re-review or re-run `build/test` (wasted work).
+Instead, in this order:
+1. **Check whether it already merged FIRST:**
+   `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>` → if `merged:true`
+   (CI finished before this poll landed it), go straight to Step 3d's Merged
+   action — flip `aiops/done`, then close the issue. Do NOT re-post the merge
+   endpoint on a merged PR (Gitea returns HTTP 405, which would derail you).
+2. **Only if not yet merged**, do not assume auto-merge survived a prior crash
+   between approve (Step 3b) and enable (Step 3c): re-issue Step 3c. You call the
+   merge endpoint directly, so handle its response — on success or "already
+   scheduled" (HTTP 409), auto-merge is set, so poll Step 3d; on "already merged"
+   (HTTP 405) it just landed, so flip `aiops/done` + close and stop (no polling).
 
 ## Step 2 — review against the rubric (every item must pass)
 1. The diff implements what the issue asked; each acceptance criterion is met or

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -95,20 +95,28 @@ commented. Obtain the diff either way:
 If you cannot identify the PR, comment what you looked for and flip to
 `aiops/rework` so the maker re-hands-off.
 
-If a previous poll already reviewed this PR — `GET
-/repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>/reviews` shows your own
-`APPROVED` review — do NOT re-review or re-run `build/test` (wasted work).
-Instead, in this order:
-1. **Check whether it already merged FIRST:**
-   `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>` → if `merged:true`
-   (CI finished before this poll landed it), go straight to Step 3d's Merged
-   action — flip `aiops/done`, then close the issue. Do NOT re-post the merge
-   endpoint on a merged PR (Gitea returns HTTP 405, which would derail you).
-2. **Only if not yet merged**, do not assume auto-merge survived a prior crash
-   between approve (Step 3b) and enable (Step 3c): re-issue Step 3c. You call the
-   merge endpoint directly, so handle its response — on success or "already
-   scheduled" (HTTP 409), auto-merge is set, so poll Step 3d; on "already merged"
-   (HTTP 405) it just landed, so flip `aiops/done` + close and stop (no polling).
+If a previous poll already acted on this PR, do NOT blindly re-run the rubric —
+but work out the situation first, in this order:
+1. **Already merged?** `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>`
+   → if `merged:true` (CI finished before this poll landed it), go straight to
+   Step 3d's Merged action — flip `aiops/done`, then close the issue. Do NOT
+   re-post the merge endpoint on a merged PR (Gitea returns HTTP 405, which would
+   derail you).
+2. **Not merged — is your approval still CURRENT?** Check
+   `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>/reviews` for your
+   own `APPROVED` review that is NOT `stale`/dismissed AND whose `commit_id`
+   equals the PR's current `head.sha` (from step 1's response):
+   - **Current approval** → skip the rubric (no wasted `build/test` re-run), but
+     do not assume auto-merge survived a prior crash between approve (Step 3b) and
+     enable (Step 3c): re-issue Step 3c. You call the merge endpoint directly, so
+     handle its response — on success or "already scheduled" (HTTP 409) auto-merge
+     is set, so poll Step 3d; on "already merged" (HTTP 405) it just landed, so
+     flip `aiops/done` + close and stop (no polling).
+   - **No current approval** — your only approval is `stale`/dismissed or was for
+     an older commit (the head moved after you approved: a rebase or a pushed fix)
+     → do NOT short-circuit. Fall through to Step 2 and review the new head from
+     scratch, re-approving before you re-enable auto-merge. Approving an unreviewed
+     head would bypass the checker (the maker/checker split).
 
 ## Step 2 — review against the rubric (every item must pass)
 1. The diff implements what the issue asked; each acceptance criterion is met or

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -26,6 +26,7 @@ tracker:
     - Todo
     - In Progress
     - Rework
+    - Merging                    # non-terminal holding state (Done is issued only after the forge merges)
 
 polling:
   interval_ms: 30000
@@ -99,7 +100,17 @@ PASS (every item passes):
      checks are green — you do NOT merge directly):
      `POST /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>/merge`
      body `{"Do":"squash","merge_when_checks_succeed":true,"delete_branch_after_merge":true}`.
-  d. Set the label to `aiops/done` via the gitea_issue_labels tool — your LAST action.
+  d. Confirm the merge BEFORE issuing Done. Stay in this run (the issue is still
+     `Human Review`, so you are not reconcile-cancelled) and poll the PR until the
+     forge reports it merged:
+     `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>` → `merged: true`
+     (a short bounded wait; required CI here is fast).
+       - Merged → set the label to `aiops/done` via gitea_issue_labels. LAST action.
+       - Not merged within your budget (slow/flaky CI) → set `aiops/merging` (a
+         non-terminal holding state) via gitea_issue_labels and stop; a Merging
+         worker finalizes `Done` once the forge merges (see runbook). LAST action.
+  Never flip `aiops/done` before the forge reports the PR merged — `Done` is
+  terminal and would unblock `Depends on #N` dependents from a stale `main`.
 
 FAIL (any item fails):
   - Comment the failing items with concrete, actionable findings (file, line,
@@ -107,8 +118,10 @@ FAIL (any item fails):
     The maker re-runs from your findings. This is your LAST action.
 
 ## Hard constraints (review-only)
-- Do NOT modify, commit, or push code. Your only writes are: the review comment,
-  the approval, the auto-merge enablement, and the one verdict label flip.
+- Do NOT modify, commit, or push code. Your only writes are tracker/PR writes: the
+  review comment, the approval, enabling auto-merge, and the verdict label flip(s)
+  (an intermediate `aiops/merging` only if CI is slow, then the terminal verdict).
 - Judge only what the diff and its tests prove; unverified PR-description claims
   count for nothing.
-- Do the verdict label flip exactly once, as the final action.
+- Issue the terminal verdict exactly once: `aiops/done` only after the merge is
+  confirmed, or `aiops/rework` on failure — as your final action.

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -26,7 +26,6 @@ tracker:
     - Todo
     - In Progress
     - Rework
-    - Merging                    # non-terminal holding state (Done is issued only after the forge merges)
 
 polling:
   interval_ms: 30000
@@ -64,9 +63,16 @@ You review, decide a verdict, and (on pass) land it via CI-gated auto-merge.
 You do NOT write or push code.
 
 Issue under review:
-- Identifier: {{ issue.identifier }}   (the human #N; use its digits for every Gitea API call + gitea_issue_labels — never task.id)
+- Identifier: {{ issue.identifier }}   (Gitea renders this as `#<number>`, e.g. `#7`)
 - URL: {{ issue.url }}
 - Title: {{ task.title }}
+
+Issue number: let `<N>` be the digits of the identifier with the leading `#`
+stripped (e.g. `7`). Use `<N>` only for **issue-keyed** calls — the
+`/issues/<N>/comments` path and the `gitea_issue_labels` tool; never the raw
+`{{ issue.identifier }}` (`#7`, which yields `/issues/#7/...`) and never task.id.
+The **PR-keyed** paths below (`/pulls/<number>/...`) take the *pull-request*
+number from the maker's PR-URL comment — a different number from `<N>`.
 
 Repository: {{ repo.owner }}/{{ repo.name }} (base branch: {{ repo.branch }}).
 Your Gitea credential is the basic-auth token in `git remote get-url origin`;
@@ -79,6 +85,13 @@ commented. Obtain the diff either way:
 - `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>.diff`.
 If you cannot identify the PR, comment what you looked for and flip to
 `aiops/rework` so the maker re-hands-off.
+
+If a previous poll already reviewed this PR — `GET
+/repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>/reviews` shows your own
+`APPROVED` review — you already ran the rubric and enabled auto-merge (Step 3c)
+in that pass (the two happen together). Do NOT re-review or re-approve; skip
+straight to Step 3d and just re-confirm the merge. Re-running `build/test` each
+poll while CI lands is wasted work.
 
 ## Step 2 — review against the rubric (every item must pass)
 1. The diff implements what the issue asked; each acceptance criterion is met or
@@ -104,11 +117,13 @@ PASS (every item passes):
      `Human Review`, so you are not reconcile-cancelled) and poll the PR until the
      forge reports it merged:
      `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>` → `merged: true`
-     (a short bounded wait; required CI here is fast).
+     (a short bounded wait — e.g. poll every ~30s for a few attempts, not a busy
+     loop; required CI here is fast).
        - Merged → set the label to `aiops/done` via gitea_issue_labels. LAST action.
-       - Not merged within your budget (slow/flaky CI) → set `aiops/merging` (a
-         non-terminal holding state) via gitea_issue_labels and stop; a Merging
-         worker finalizes `Done` once the forge merges (see runbook). LAST action.
+       - Not merged within your budget (slow/flaky CI) → do NOT flip any label.
+         Leave the issue in `Human Review` and stop. It stays in your active set,
+         so the next poll re-claims it and re-checks the merge (Step 1 sends you
+         straight back here) — no terminal flip until `merged:true`. Done.
   Never flip `aiops/done` before the forge reports the PR merged — `Done` is
   terminal and would unblock `Depends on #N` dependents from a stale `main`.
 
@@ -119,9 +134,11 @@ FAIL (any item fails):
 
 ## Hard constraints (review-only)
 - Do NOT modify, commit, or push code. Your only writes are tracker/PR writes: the
-  review comment, the approval, enabling auto-merge, and the verdict label flip(s)
-  (an intermediate `aiops/merging` only if CI is slow, then the terminal verdict).
+  review comment, the approval, enabling auto-merge, and the verdict label flip
+  (`aiops/done` after the merge is confirmed, or `aiops/rework` on failure).
 - Judge only what the diff and its tests prove; unverified PR-description claims
   count for nothing.
 - Issue the terminal verdict exactly once: `aiops/done` only after the merge is
-  confirmed, or `aiops/rework` on failure — as your final action.
+  confirmed, or `aiops/rework` on failure — as your final action. If the merge has
+  not landed within your turn budget, leave the issue in `Human Review` (no
+  terminal flip) so the next poll re-checks — never park it in an invented state.


### PR DESCRIPTION
Closes #861
Closes #859
Closes #860

Follow-up to #858 (squash-merged → cannot be reopened), addressing the two @codex findings on that PR. **Reworked across five @codex review rounds** that hardened the example WORKFLOWs' auto-merge / slow-CI handling.

## Summary (head `acb6cf9`)
- **P1 — premature `aiops/done`**: the reviewer flipped `Done` on approval → a `Depends on #N` dependent could start from a stale `main`. Fixed: confirm the merge (`GET …/pulls/<number>` → `merged:true`, still `Human Review`) before flipping `Done`.
- **Rework #1 — invented `aiops/merging` state**: the Gitea adapter hardcodes exactly six states (`validGiteaStateLabels` / `DefaultStateLabelMappings`), so `aiops/merging` is rejected. Dropped it; slow-CI uses existing states. Native Gitea `Merging` → **#863**.
- **Rework #2 — `Closes #<N>` deadlock**: `Closes #<N>` makes the forge close the issue at merge, but the poller lists `Human Review` with `state=open`, so a merge-closed issue drops from the reviewer's poll before it can flip the post-merge `Done` — stranding it + dependents. Fixed: maker uses a non-closing **`Refs #<N>`**; the reviewer flips `aiops/done` and **closes the issue itself** post-merge.
- **Rework #3–#5 — slow-CI re-entry, hardened to an exhaustive decision tree**:
  - bound the re-poll by the D34 `agent.max_continuation_turns` budget (set `:36`; exhaustion parks the issue in local `blocked`, not an infinite loop; routinely-slow CI → #863);
  - on re-entry: (1) **already merged** → Done+close (no merge re-POST, which Gitea answers 405); (2) **not merged + current approval** (non-`stale`/dismissed AND `commit_id == head.sha`) → re-issue Step 3c then poll, confirming `merged:true` via GET before Done (never on a bare 405, which Gitea also returns for not-mergeable/WIP states); (3) **not merged + only a stale/old approval** → fall through to a full re-review of the new head — never auto-merge an unreviewed head (checker-bypass guard).
- **P2 (hazard)** — `{{ issue.identifier }}` renders as `#N`; maker derives numeric `<N>`, **swept onto the reviewer prompt** (clean-code rule 10), distinguishing issue-keyed `<N>` from PR-keyed `/pulls/<number>`.
- Runbook updated throughout (topology, state diagram, DAG, end-to-end flow, checklist, "Slow or flaky CI").

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Docs/examples only — existing six `aiops/*` states + existing agent-side tracker writes; `agent.max_continuation_turns` is an existing Config key (D34) now shown in an example. No new key, no worker phase, no SPEC-sensitive path. Native Gitea `Merging` → **#863**.

## Testing
- Docs/examples-only — no Go production code. Both example WORKFLOWs re-validated via `worker --print-config` (source=file, secrets masked, networkAccess=true, `max_continuation_turns:36` recognized), 0 errors.
- `go build ./cmd/worker` ok. CI green on `acb6cf9` (one `Docker image build` flake — Docker Hub registry i/o timeout pulling base images, unrelated to the docs diff — re-run green).

## Review (head `acb6cf9`)
- **Local dual review every round** (Codex `codex:codex-rescue` + Claude `code-reviewer`), each finding triaged against the live Go source before acting. Final round (current-approval guard): both → MERGE-READY; verified the re-entry decision tree is exhaustive and that Gitea's `stale`/`commit_id`/`dismissed` are real `PullReview` fields. Earlier rounds validated the `state=open` poll, label-derived blocker gate, `Refs` non-closing, and D34 budget semantics against source.
- `@codex review` ran on each pushed head and drove the rework; re-triggered on `acb6cf9` (comment 4702097828).
- **All 7 @codex review threads resolved** (merging state, `Closes` deadlock, auto-merge inference, continuation budget, merged-before-reissue, current-approval, 405-not-proof-of-merge) with pointers to the fixes + #863. Zero unresolved actionable threads.

### Size gate
- [x] `within budget` — 0 production files / 0 production LOC (documentation + example config only)
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked.
