### PR TITLE
docs(research): fix scheduler/runner boundary phrasing in Grit note ("merge the result back")

### DIFF
--- a/docs/research/2026-06-chacon-grit-rust-git.md
+++ b/docs/research/2026-06-chacon-grit-rust-git.md
@@ -18,7 +18,7 @@ Author: Scott Chacon (co-founder, GitHub & GitButler)
 
 Scott Chacon used coding agents to rewrite all of Git from scratch as a library-first, memory-safe Rust crate ("Grit"), passing 99.3% (41,715 / 42,001) of the Git test suite. The cost of getting there: ~45B tokens, ~$10–15k, 500+ PRs, 7000+ commits, across two bursts (early April, early June 2026).
 
-Mechanically, what he did by hand is what aiops-platform does as a product: pick a unit of work, give an agent an isolated checkout, let it run a coding agent against a verification signal, and merge the result back. His pains are therefore our design concerns, observed without our automation.
+Mechanically, what he did by hand is what aiops-platform does as a product: pick a unit of work, give an agent an isolated checkout, let it run a coding agent against a verification signal, and let the agent open a PR for operator review. His pains are therefore our design concerns, observed without our automation.
 
 ## A. Grit independently validates three of our architectural bets
 


### PR DESCRIPTION
Closes #867
Closes #866

Fixes the scheduler/runner boundary phrasing flagged by `@codex review` on merged PR #865.

## Summary
`docs/research/2026-06-chacon-grit-rust-git.md:21` described the aiops-platform loop as ending in **"and merge the result back"**, which attributes PR/merge handoff to the orchestrator. That contradicts the scheduler/runner boundary: the worker is scheduler/runner + tracker reader only; the **agent** opens PRs / pushes branches through its own tool surface, and merge is operator-gated. In a note registered as practitioner guidance, the old wording risks reintroducing the D8/#76 misconception.

Change (docs-only, 1 line):
> …let it run a coding agent against a verification signal, ~~and merge the result back~~ **and let the agent open a PR for operator review**.

Boundary refs: `AGENTS.md:35`, `AGENTS.md:501-502` ("the worker must not push, open, merge, or otherwise manage PR handoff on the agent's behalf"); closed deviations D8 / #76.

### Acceptance criteria (#867)
- [x] Reword line 21 so the loop ends with the **agent** opening a PR for operator review — not aiops-platform merging.
- [x] Audit the rest of the note for other phrasing attributing push/merge/PR/tracker-write to the orchestrator — confirmed line 21 was the only instance (lines 29/37 correctly keep handoff/push agent-side; lines 19/43 concern Chacon's manual work / generic PRs).
- [x] Docs-only; no SPEC change. Single squash PR.

#866 is the `capture-unresolved-reviews` auto-filed duplicate of the same PR #865 Codex thread, so this PR closes both.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (1 file, 1 line).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- Docs-only — no `.go`, config, or SPEC-sensitive path touched; Go gates (gofmt/vet/`go test -race`/build) trivially N/A.
- `grep -nEi 'merge|push|open.*pr|hand' docs/research/2026-06-chacon-grit-rust-git.md` — only agent-side / scheduler-side phrasing remains.
- Pre-push dual diff-only review (protocol §3): Codex-family (`codex:codex-rescue`) = **MERGE-READY**, no findings; Claude-family (`feature-dev:code-reviewer`) = **MERGE-READY**, no findings (independently re-ran the AC #2 audit).

## Notes
Governance/docs lane (`handle-issue` §5.5) — single PR from `main`, no code.

---
### Gate status (final) — head `0e1bec6`
- CI: all green (run `27519195577`) — Go build/test, E2E, Security, Docker, PR metadata, title lint.
- `@codex review` (trigger `4703846180`, bytevane): **clean** — "Didn't find any major issues. Reviewed commit: `0e1bec6581`" (an earlier usage-limit notice preceded it; the clean review on the exact head superseded it).
- Review threads: **0 total, 0 unresolved actionable** (GraphQL).
- Status: **merge-ready** — awaiting explicit merge permission (protocol §8).
