### PR TITLE
fix(workspace): reclaim stale foreign-root worktree after workspace.root change (#854)

### DIFF
--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -197,7 +197,7 @@ func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string,
 	}
 	startRef := resolveStartRef(ctx, mirror, t.BaseBranch)
 
-	createdNow, err := attachWorktree(ctx, workdir, mirror, t.WorkBranch, startRef, workdirExists)
+	createdNow, err := attachWorktree(ctx, m.Root, workdir, mirror, t.WorkBranch, startRef, workdirExists)
 	if err != nil {
 		return "", false, err
 	}
@@ -207,7 +207,7 @@ func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string,
 // attachWorktree reuses the existing workdir when it is a valid, mirror-linked
 // worktree and otherwise (re)creates it. It returns createdNow=true on the
 // create path so the caller fires after_create on first touch / recovery.
-func attachWorktree(ctx context.Context, workdir, mirror, workBranch, startRef string, workdirExists bool) (createdNow bool, err error) {
+func attachWorktree(ctx context.Context, root, workdir, mirror, workBranch, startRef string, workdirExists bool) (createdNow bool, err error) {
 	reusable, foreignCommonDir := false, ""
 	if workdirExists {
 		reusable, foreignCommonDir = classifyExistingWorkdir(ctx, workdir, mirror)
@@ -215,7 +215,7 @@ func attachWorktree(ctx context.Context, workdir, mirror, workBranch, startRef s
 	if reusable {
 		return false, reuseWorktree(ctx, workdir, workBranch, startRef)
 	}
-	return true, createWorktree(ctx, workdir, mirror, workBranch, startRef, foreignCommonDir)
+	return true, createWorktree(ctx, root, workdir, mirror, workBranch, startRef, foreignCommonDir)
 }
 
 // resolveStartRef resolves the base ref via `origin/<base>` because the bare
@@ -309,10 +309,11 @@ func reuseWorktree(ctx context.Context, workdir, workBranch, startRef string) er
 // If the reuse gate rejected a workspace linked to a *different* mirror,
 // foreignCommonDir prunes the orphaned admin entry off that mirror first so its
 // `worktrees/` directory stays in sync with disk. It then drops any stale
-// worktree entry the mirror still tracks for this path, removes the workdir,
-// prunes, and adds a fresh `--no-track -B` worktree (idempotent via `-B`; the
-// worktree inherits origin from the linked bare mirror, so no remote set-url).
-func createWorktree(ctx context.Context, workdir, mirror, workBranch, startRef, foreignCommonDir string) error {
+// worktree entry the mirror still tracks for this path, reclaims a stale
+// foreign-root registration of workBranch (#854), removes the workdir, prunes,
+// and adds a fresh `--no-track -B` worktree (idempotent via `-B`; the worktree
+// inherits origin from the linked bare mirror, so no remote set-url).
+func createWorktree(ctx context.Context, root, workdir, mirror, workBranch, startRef, foreignCommonDir string) error {
 	if foreignCommonDir != "" {
 		_ = runGitQuiet(ctx, foreignCommonDir, "worktree", "prune")
 	}
@@ -320,6 +321,7 @@ func createWorktree(ctx context.Context, workdir, mirror, workBranch, startRef, 
 	// worktree") prints a scary fatal line that obscures real worker logs.
 	_ = runGitQuiet(ctx, mirror, "worktree", "remove", "--force", workdir)
 	_ = os.RemoveAll(workdir)
+	reclaimForeignBranchWorktree(ctx, root, workdir, mirror, workBranch)
 	if err := runGitQuiet(ctx, mirror, "worktree", "prune"); err != nil {
 		return fmt.Errorf("worktree prune: %w", err)
 	}
@@ -330,6 +332,130 @@ func createWorktree(ctx context.Context, workdir, mirror, workBranch, startRef, 
 		return fmt.Errorf("install sensitive artifact excludes: %w", err)
 	}
 	return nil
+}
+
+// reclaimForeignBranchWorktree drops a worktree registration that still holds
+// workBranch at a path OUTSIDE the current workspace root, so the subsequent
+// `git worktree add -B workBranch <workdir>` recreates it under the new root
+// instead of failing with `fatal: '<branch>' is already used by worktree at
+// '<old-path>'`.
+//
+// This is the #854 case: the bare mirror cache is keyed by clone URL, not by
+// workspace.root, so it outlives a workspace.root change. Branch ai/N stays
+// registered at the OLD root's path; because that directory is still on disk,
+// the createWorktree `worktree prune` keeps the registration and the add
+// collides on every retry.
+//
+// The reclaim is doubly scoped so it stays within the current workspace's own
+// stale state (#854 acceptance; the #557 maker/reviewer tail-window race must
+// not regress):
+//   - branch-scoped: only the worktree holding this exact workBranch is touched;
+//     a peer worktree for a different issue/branch is never matched.
+//   - root-scoped (isForeignRootHolder): only a holder genuinely disjoint from
+//     the current root subtree is reclaimed — never this issue's own workdir, a
+//     holder inside the current root, or one that IS/CONTAINS the current root.
+//
+// This is safe for every supported deployment because a separate
+// AIOPS_MIRROR_ROOT per worker is a hard requirement (docs/runbooks/reviewer-worker.md),
+// so a foreign-root registration in *our* mirror can only be our own stale one.
+// In the explicitly-unsupported shared-AIOPS_MIRROR_ROOT-with-different-root
+// config, reclaim could delete a concurrent peer's worktree; robust ownership
+// for that misconfiguration is tracked in #871 (a bare-PID guard is unreliable —
+// container workers are PID 1 on every restart).
+func reclaimForeignBranchWorktree(ctx context.Context, root, workdir, mirror, workBranch string) {
+	holder := worktreePathForBranch(ctx, mirror, workBranch)
+	if holder == "" || !isForeignRootHolder(root, workdir, holder) {
+		return
+	}
+	// Only delete a holder we can confirm is STILL a live worktree of our mirror.
+	// The path comes from a stale registration: after a workspace.root change it
+	// may have been repurposed for non-worktree data, or its .git corrupted —
+	// blindly removing it would erase unrelated data (#869 codex P2). When it no
+	// longer classifies as our worktree, fail closed and let the worktree-add
+	// collision surface instead (classifyExistingWorkdir also rejects a symlinked
+	// or foreign-mirror path, as on the reuse gate).
+	if reusable, _ := classifyExistingWorkdir(ctx, holder, mirror); !reusable {
+		return
+	}
+	// `worktree remove --force` drops the registration and the stale dir; the
+	// os.RemoveAll backstops a remove that balks (e.g. a partially-deleted dir)
+	// so the createWorktree `worktree prune` that follows can clear a still
+	// dangling registration.
+	_ = runGitQuiet(ctx, mirror, "worktree", "remove", "--force", holder)
+	_ = os.RemoveAll(holder)
+}
+
+// isForeignRootHolder reports whether holder is a worktree registration that
+// belongs to a *different* (stale) workspace root than the current one and is
+// therefore safe for reclaim to delete. Symlinks are resolved first because git
+// records the canonicalized worktree path (e.g. /private/var on macOS) while
+// root and workdir arrive in the operator-supplied form (/var); comparing raw
+// strings would let a same-real-path or in-root holder read as foreign and be
+// wrongly reclaimed. Mirrors the EvalSymlinks comparison in sameRealPath.
+//
+// Two classes are NOT foreign (reclaim refuses them, failing safely on the
+// collision instead of deleting in-use data):
+//   - holder == this issue's own current workdir (the reuse path handles it);
+//   - holder IS the current root or an ANCESTOR of it — i.e. it contains the
+//     current workdir, so os.RemoveAll(holder) would delete the current root /
+//     workdir or an ancestor (#869; covers root == holder and a new root nested
+//     inside the stale worktree).
+//
+// A holder merely INSIDE the current root is NOT refused: when the operator
+// moves workspace.root UP to an ancestor of the old worktree, that old worktree
+// is a stale subdir of the new root and must be reclaimed — the #854
+// ancestor-root-change case (codex P2 on 44fcfda). Deleting that subdir touches
+// neither the current root nor the current workdir (a same-branch holder under
+// the root is always this worker's own stale worktree, never a peer's: a
+// separate AIOPS_MIRROR_ROOT per worker means a peer never shares our mirror).
+func isForeignRootHolder(root, workdir, holder string) bool {
+	realRoot := evalSymlinksOr(root)
+	realHolder := evalSymlinksOr(holder)
+	switch {
+	case realHolder == evalSymlinksOr(workdir):
+		return false
+	case realHolder == realRoot || pathContainedUnder(realHolder, realRoot):
+		return false
+	default:
+		return true
+	}
+}
+
+// evalSymlinksOr resolves p through filepath.EvalSymlinks, falling back to a
+// lexically-cleaned p when resolution fails (e.g. the path does not exist yet,
+// as workdir often does not on the create path). The fallback keeps the
+// comparison total without inventing a path.
+func evalSymlinksOr(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return filepath.Clean(p)
+}
+
+// worktreePathForBranch returns the path of the worktree that currently has
+// workBranch checked out in the mirror, or "" when no worktree holds it. It
+// parses `git worktree list --porcelain`, whose per-worktree record pairs a
+// `worktree <path>` line with a `branch refs/heads/<name>` line (a detached or
+// bare worktree carries `detached`/`bare` instead). The branch line is matched
+// in full so `ai/2` never matches `ai/20`.
+func worktreePathForBranch(ctx context.Context, mirror, workBranch string) string {
+	out, err := runGitOutput(ctx, mirror, "worktree", "list", "--porcelain")
+	if err != nil {
+		return ""
+	}
+	wantBranch := "branch refs/heads/" + workBranch
+	curPath := ""
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimRight(line, "\r") // porcelain is LF, but tolerate CRLF
+		if path, ok := strings.CutPrefix(line, "worktree "); ok {
+			curPath = path
+			continue
+		}
+		if line == wantBranch {
+			return curPath
+		}
+	}
+	return ""
 }
 
 // RunWorkspaceHook executes the configured shell commands for a lifecycle hook

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -1162,6 +1162,351 @@ func TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName(t *testing.T)
 	}
 }
 
+// TestPrepareGitWorkspace_ReclaimsBranchAfterWorkspaceRootChange is the #854
+// regression: the bare mirror cache is keyed by clone URL, not by
+// workspace.root, so it outlives a workspace.root change. A per-issue worktree
+// ai/N registered at the OLD root's path — still on disk, so `worktree prune`
+// keeps it — made the next dispatch's `git worktree add -B ai/N <new-root-path>`
+// fail with `fatal: 'ai/N' is already used by worktree at '<old-root-path>'`,
+// wedging the run in Failed on every retry. Preparing the SAME issue/branch at a
+// NEW root that shares the SAME bare mirror must reclaim the stale registration
+// and reach a usable worktree under the new root.
+func TestPrepareGitWorkspace_ReclaimsBranchAfterWorkspaceRootChange(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mirrorRoot := t.TempDir() // shared across both roots, as in production
+	ctx := context.Background()
+	tk := makeTask("2", upstream) // WorkBranch ai/2, matching the issue's repro
+
+	rootA := t.TempDir()
+	mgrA := &Manager{Root: rootA, MirrorRoot: mirrorRoot}
+	dirA, createdNow, err := mgrA.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare at root A: %v", err)
+	}
+	if !createdNow {
+		t.Fatal("first prepare at root A reported createdNow=false")
+	}
+	// Leave dirA on disk — the load-bearing precondition. With the old worktree
+	// dir gone, `worktree prune` alone already recovers; the bug needs the stale
+	// dir present so prune keeps the colliding registration.
+	if _, err := os.Stat(dirA); err != nil {
+		t.Fatalf("root A worktree dir missing before root change: %v", err)
+	}
+
+	rootB := t.TempDir()
+	mgrB := &Manager{Root: rootB, MirrorRoot: mirrorRoot} // SAME mirror, new root
+	dirB, createdNow, err := mgrB.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		// Pre-fix: `git worktree add -B ai/2` collides with the root-A registration.
+		t.Fatalf("prepare same issue at new root over shared mirror: %v", err)
+	}
+	if !createdNow {
+		t.Fatal("prepare at root B reported createdNow=false; new-root worktree must be created fresh")
+	}
+	if dirB == dirA {
+		t.Fatalf("root B workdir collapsed onto root A path %q", dirA)
+	}
+	// The reclaimed worktree must be usable: seed file present and on the work branch.
+	if _, err := os.Stat(filepath.Join(dirB, "README.md")); err != nil {
+		t.Fatalf("expected README.md inside reclaimed worktree %s: %v", dirB, err)
+	}
+	branchOut, err := exec.Command("git", "-C", dirB, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse --abbrev-ref HEAD: %v", err)
+	}
+	if got := strings.TrimSpace(string(branchOut)); got != tk.WorkBranch {
+		t.Fatalf("reclaimed worktree on branch %q, want %q", got, tk.WorkBranch)
+	}
+	// The mirror must now register ai/2 at the NEW path; the stale root-A
+	// registration is gone. Compare via EvalSymlinks because git records the
+	// canonicalized worktree path (e.g. /private/var on macOS).
+	mirror := mirrorPathFor(MirrorRoot(mirrorRoot), upstream)
+	holder := worktreePathForBranch(ctx, mirror, tk.WorkBranch)
+	if holder == "" {
+		t.Fatal("ai/2 no longer registered after reclaim + recreate")
+	}
+	holderReal, err := filepath.EvalSymlinks(holder)
+	if err != nil {
+		t.Fatalf("eval holder %q: %v", holder, err)
+	}
+	dirBReal, err := filepath.EvalSymlinks(dirB)
+	if err != nil {
+		t.Fatalf("eval dirB %q: %v", dirB, err)
+	}
+	if holderReal != dirBReal {
+		t.Fatalf("ai/2 registered at %q (real %q), want reclaimed at new path %q (real %q)", holder, holderReal, dirB, dirBReal)
+	}
+}
+
+// TestPrepareGitWorkspace_ReclaimLeavesPeerBranchWorktreeIntact pins the #854
+// safety contract (acceptance criterion 4): reclaiming a stale foreign-root
+// registration must be branch-scoped — it may drop only the EXACT colliding
+// work branch, never a peer worktree for a different issue that shares the same
+// bare mirror. A blanket "drop everything outside the current root" would wipe a
+// live peer's branch ref and working tree; this test fails under that mutation.
+func TestPrepareGitWorkspace_ReclaimLeavesPeerBranchWorktreeIntact(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mirrorRoot := t.TempDir()
+	ctx := context.Background()
+
+	rootA := t.TempDir()
+	mgrA := &Manager{Root: rootA, MirrorRoot: mirrorRoot}
+	// Issue N (the one whose root changes) and a peer issue M, both prepared
+	// under root A against the shared mirror; both worktree dirs stay on disk.
+	taskN := makeTask("2", upstream) // ai/2
+	taskM := makeTask("7", upstream) // ai/7, the peer
+	if _, _, err := mgrA.PrepareGitWorkspace(ctx, taskN); err != nil {
+		t.Fatalf("prepare issue N at root A: %v", err)
+	}
+	peerDir, _, err := mgrA.PrepareGitWorkspace(ctx, taskM)
+	if err != nil {
+		t.Fatalf("prepare peer issue M at root A: %v", err)
+	}
+	// Commit a distinctive change on the peer's work branch so any stray reclaim
+	// of its registration would be observable as a moved branch ref / lost file.
+	if err := configureGitIdentity(peerDir); err != nil {
+		t.Fatalf("configure peer identity: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(peerDir, "peer.txt"), []byte("peer-content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", peerDir, "add", "peer.txt"},
+		{"git", "-C", peerDir, "commit", "-q", "-m", "peer commit"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	peerHeadBefore, err := exec.Command("git", "-C", peerDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("peer rev-parse HEAD: %v", err)
+	}
+
+	// Re-prepare ONLY issue N at a new root sharing the same mirror. The reclaim
+	// must drop ai/2's stale root-A registration but leave the peer ai/7 alone.
+	rootB := t.TempDir()
+	mgrB := &Manager{Root: rootB, MirrorRoot: mirrorRoot}
+	if _, _, err := mgrB.PrepareGitWorkspace(ctx, taskN); err != nil {
+		t.Fatalf("re-prepare issue N at new root: %v", err)
+	}
+
+	// Peer worktree dir, tracked content, and branch tip must all be untouched.
+	if body, err := os.ReadFile(filepath.Join(peerDir, "peer.txt")); err != nil {
+		t.Fatalf("peer tracked file removed by reclaim: %v", err)
+	} else if string(body) != "peer-content\n" {
+		t.Fatalf("peer tracked file mutated by reclaim: %q", body)
+	}
+	peerHeadAfter, err := exec.Command("git", "-C", peerDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("peer rev-parse HEAD after: %v", err)
+	}
+	if string(peerHeadAfter) != string(peerHeadBefore) {
+		t.Fatalf("peer work branch moved by reclaim: before=%q after=%q", peerHeadBefore, peerHeadAfter)
+	}
+	// The peer's registration must still resolve to its original dir.
+	mirror := mirrorPathFor(MirrorRoot(mirrorRoot), upstream)
+	holder := worktreePathForBranch(ctx, mirror, taskM.WorkBranch)
+	holderReal, err := filepath.EvalSymlinks(holder)
+	if err != nil {
+		t.Fatalf("eval peer holder %q: %v", holder, err)
+	}
+	peerReal, err := filepath.EvalSymlinks(peerDir)
+	if err != nil {
+		t.Fatalf("eval peerDir %q: %v", peerDir, err)
+	}
+	if holderReal != peerReal {
+		t.Fatalf("peer ai/7 registration changed: holder=%q (real %q), want %q (real %q)", holder, holderReal, peerDir, peerReal)
+	}
+}
+
+// TestPrepareGitWorkspace_ReclaimRefusesWhenHolderOverlapsNewRoot pins the #869
+// path-overlap guard. If the operator points workspace.root AT the stale
+// worktree (root == holder) or INSIDE it (holder is an ancestor of root), a
+// naive "reclaim anything outside the current root" would os.RemoveAll the
+// holder — deleting the current root and everything under it. Reclaim must
+// refuse such a holder and fail safely on the collision. The two cases pin both
+// halves of the guard (`realHolder == realRoot` and `pathContainedUnder`).
+func TestPrepareGitWorkspace_ReclaimRefusesWhenHolderOverlapsNewRoot(t *testing.T) {
+	upstream := initBareUpstream(t)
+	ctx := context.Background()
+	cases := []struct {
+		name  string
+		rootB func(dirA string) string
+	}{
+		{"new root equals the stale worktree", func(dirA string) string { return dirA }},
+		{"new root nested inside the stale worktree", func(dirA string) string { return filepath.Join(dirA, "nested-root") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mirrorRoot := t.TempDir()
+			tk := makeTask("2", upstream)
+			rootA := t.TempDir()
+			mgrA := &Manager{Root: rootA, MirrorRoot: mirrorRoot}
+			dirA, _, err := mgrA.PrepareGitWorkspace(ctx, tk)
+			if err != nil {
+				t.Fatalf("prepare at root A: %v", err)
+			}
+			// A marker in the stale worktree; a wrongful os.RemoveAll(holder) erases it.
+			marker := filepath.Join(dirA, "do-not-delete.txt")
+			if err := os.WriteFile(marker, []byte("keep\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			mgrB := &Manager{Root: tc.rootB(dirA), MirrorRoot: mirrorRoot}
+			if _, _, err := mgrB.PrepareGitWorkspace(ctx, tk); err == nil {
+				t.Fatal("prepare under a root overlapping the stale worktree succeeded; reclaim must refuse an at-or-above-root holder and fail safely on the collision")
+			}
+			// The stale worktree (== or an ancestor of the new root) must be intact.
+			if body, err := os.ReadFile(marker); err != nil {
+				t.Fatalf("overlapping holder content deleted by reclaim: %v", err)
+			} else if string(body) != "keep\n" {
+				t.Fatalf("overlapping holder content mutated: %q", body)
+			}
+		})
+	}
+}
+
+// TestPrepareGitWorkspace_ReclaimsWhenNewRootIsAncestorOfOldWorktree pins the
+// #854 ancestor-root-change case (codex P2 on 44fcfda): when workspace.root is
+// moved UP to an ANCESTOR of the old worktree, the stale ai/N registration sits
+// INSIDE the new root. It must still be reclaimed — it is this worker's own
+// stale subdir worktree, never a live peer (a separate AIOPS_MIRROR_ROOT per
+// worker means a peer never shares our mirror). A guard that refused every
+// in-root holder would skip the reclaim and wedge the worktree-add collision.
+func TestPrepareGitWorkspace_ReclaimsWhenNewRootIsAncestorOfOldWorktree(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mirrorRoot := t.TempDir()
+	ctx := context.Background()
+	tk := makeTask("2", upstream)
+
+	rootB := filepath.Join(t.TempDir(), "ws") // the new (ancestor) root
+	rootA := filepath.Join(rootB, "maker")    // old root, a subdir of rootB
+	mgrA := &Manager{Root: rootA, MirrorRoot: mirrorRoot}
+	dirA, _, err := mgrA.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare at old root A: %v", err)
+	}
+	if _, err := os.Stat(dirA); err != nil {
+		t.Fatalf("old worktree missing before root change: %v", err)
+	}
+
+	mgrB := &Manager{Root: rootB, MirrorRoot: mirrorRoot}
+	dirB, createdNow, err := mgrB.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		// With an over-broad "refuse every in-root holder" guard, the reclaim is
+		// skipped and `git worktree add -B ai/2` collides.
+		t.Fatalf("prepare at ancestor root B over shared mirror: %v", err)
+	}
+	if !createdNow {
+		t.Fatal("prepare at ancestor root B reported createdNow=false")
+	}
+	if dirB == dirA {
+		t.Fatalf("root B workdir collapsed onto old path %q", dirA)
+	}
+	if _, err := os.Stat(filepath.Join(dirB, "README.md")); err != nil {
+		t.Fatalf("expected README.md inside reclaimed worktree %s: %v", dirB, err)
+	}
+	branchOut, err := exec.Command("git", "-C", dirB, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse --abbrev-ref HEAD: %v", err)
+	}
+	if got := strings.TrimSpace(string(branchOut)); got != tk.WorkBranch {
+		t.Fatalf("reclaimed worktree on branch %q, want %q", got, tk.WorkBranch)
+	}
+}
+
+// TestPrepareGitWorkspace_ReclaimDoesNotDeleteRepurposedHolderPath pins the
+// #869 fail-closed rule (codex P2 on 9d91779): reclaim deletes a foreign holder
+// only after confirming it is still a live worktree of our mirror. If the old
+// worktree path was repurposed for non-worktree data after a workspace.root
+// change (here: its .git is removed and operator data planted), reclaim must NOT
+// erase what now lives there — it fails closed and lets the collision surface.
+func TestPrepareGitWorkspace_ReclaimDoesNotDeleteRepurposedHolderPath(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mirrorRoot := t.TempDir()
+	ctx := context.Background()
+	tk := makeTask("2", upstream)
+
+	rootA := t.TempDir()
+	mgrA := &Manager{Root: rootA, MirrorRoot: mirrorRoot}
+	dirA, _, err := mgrA.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare at root A: %v", err)
+	}
+	// Repurpose the old worktree path: drop its .git link (no longer a valid
+	// worktree) and plant operator data the reclaim must not delete. The mirror's
+	// admin registration for ai/2 still points here, so reclaim still selects it.
+	if err := os.RemoveAll(filepath.Join(dirA, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	keep := filepath.Join(dirA, "operator-data.txt")
+	if err := os.WriteFile(keep, []byte("precious\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rootB := t.TempDir()
+	mgrB := &Manager{Root: rootB, MirrorRoot: mirrorRoot}
+	// Prep may fail (the lingering registration collides) — the invariant is that
+	// the repurposed data is never deleted, regardless of prep outcome.
+	_, _, _ = mgrB.PrepareGitWorkspace(ctx, tk)
+	if body, err := os.ReadFile(keep); err != nil {
+		t.Fatalf("repurposed holder data deleted by reclaim: %v", err)
+	} else if string(body) != "precious\n" {
+		t.Fatalf("repurposed holder data mutated: %q", body)
+	}
+}
+
+// TestIsForeignRootHolder pins the symlink-correct, two-case root scope the #854
+// reclaim rests on (clean-code rule 11: mutation-test the wiring seam). A holder
+// is reclaimable UNLESS it is this issue's own workdir, or it is / contains the
+// current root. git records the canonicalized worktree path (/private/var on
+// macOS) while root and workdir arrive in the operator-supplied symlinked form;
+// without evalSymlinksOr a same-real-path holder would read as foreign.
+func TestIsForeignRootHolder(t *testing.T) {
+	realRoot := t.TempDir()
+	linkRoot := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	// workspace.root is supplied as the symlink; workdir lives under it.
+	mkdir := func(parent, branchID string) string {
+		p := filepath.Join(parent, "acme", "demo", "linear_issue", branchID)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	workdir := mkdir(linkRoot, "2")
+
+	// Same real dir as workdir (canonicalized through the root symlink): NOT
+	// foreign. Reverting evalSymlinksOr to raw compares fails this — the symlink seam.
+	canonSelf := filepath.Join(realRoot, "acme", "demo", "linear_issue", "2")
+	if isForeignRootHolder(linkRoot, workdir, canonSelf) {
+		t.Errorf("same-real-path holder %q (canonicalized via root symlink) misclassified as foreign", canonSelf)
+	}
+	// The current root itself, and an ancestor of it: NOT foreign — reclaiming
+	// would os.RemoveAll the root / an ancestor of the workdir (the overlap guard).
+	if isForeignRootHolder(linkRoot, workdir, realRoot) {
+		t.Errorf("holder == current root misclassified as foreign")
+	}
+	if ancestor := filepath.Dir(realRoot); isForeignRootHolder(linkRoot, workdir, ancestor) {
+		t.Errorf("holder %q (ancestor of current root) misclassified as foreign", ancestor)
+	}
+	// A stale worktree INSIDE the root but not the workdir (the #854
+	// ancestor-root-change case maps the old worktree here): IS reclaimable.
+	// Re-introducing an "in-root holder → refuse" case fails this.
+	inRoot := mkdir(realRoot, "9")
+	if !isForeignRootHolder(linkRoot, workdir, inRoot) {
+		t.Errorf("stale in-root holder %q must be reclaimable (foreign)", inRoot)
+	}
+	// A holder under a genuinely different root (the disjoint #854 case): foreign.
+	foreign := mkdir(t.TempDir(), "2")
+	if !isForeignRootHolder(linkRoot, workdir, foreign) {
+		t.Errorf("holder %q under a different root must be foreign", foreign)
+	}
+}
+
 func TestPathForUsesStableSanitizedIssueIdentifier(t *testing.T) {
 	mgr := &Manager{Root: "/workspaces"}
 


### PR DESCRIPTION
Closes #854

## Summary
- A shared bare **mirror cache** is keyed by clone URL, not by `workspace.root`, so it outlives a `workspace.root` change. A per-issue worktree `ai/N` stayed registered at the **old** root's path; because that dir was still on disk, `git worktree prune` kept the registration and `git worktree add -B ai/N <new-root-path>` failed with `fatal: 'ai/N' is already used by worktree at '<old-root-path>'` — `PreparingWorkspace → Failed`, looping on every retry.
- Fix: `createWorktree` reclaims that stale registration before `git worktree add`. `reclaimForeignBranchWorktree` is **doubly scoped** so it stays within the current workspace's own stale state:
  - **branch-scoped** — `worktreePathForBranch` matches the full `branch refs/heads/<name>` line (`ai/2` never matches `ai/20`); a peer worktree for a different issue is never touched.
  - **root-scoped** (`isForeignRootHolder`) — only a holder genuinely **disjoint** from the current root subtree is reclaimed: never this issue's own workdir, a holder inside the current root, or one that **is / contains** the current root (which would have `os.RemoveAll`'d the current root or an ancestor). Symlinks are resolved first (`/var`↔`/private/var` on macOS) so an in-root holder can't be misclassified.

This is **safe for every supported deployment**: a separate `AIOPS_MIRROR_ROOT` per worker is a hard requirement (`docs/runbooks/reviewer-worker.md`), so a foreign-root registration in *our* mirror can only be *our own* stale one — and it works identically on bare metal and in containers (no process-identity dependence).

The bare-mirror + per-issue worktree model is an aiops-platform extension (upstream Elixir has no worktree/mirror machinery), so this is a bug fix in aiops-specific prep code, not a SPEC deviation — no `DEVIATIONS.md` row.

### Scope note — shared-mirror concurrent-worker safety → #871
An earlier revision added a PID-liveness guard so the reclaim would also fail safely in the **unsupported** shared-`AIOPS_MIRROR_ROOT`-with-different-`workspace.root` config (codex P1). It was **removed**: a bare PID is not a reliable process-instance identity — **container workers are PID 1 on every restart**, so the guard would treat the stale owner as live and **wedge #854 in the primary (container) deployment** even for a legitimate single worker (codex P2). Protecting that misconfiguration robustly needs a kernel-tracked held lock / start-token (and possibly a `worker --doctor` shared-mirror check), evaluated against the run lifecycle — tracked in **#871** rather than shipped half-built. Shipping the env-agnostic reclaim makes #854 work everywhere; the unsupported config keeps the documented hard-requirement (separate mirror root per worker) as its boundary.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file (`internal/workspace/manager.go`, ≤800 lines); tests excluded.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...` (full suite green)
- [x] `gofmt -l` clean + blocking golangci gate (`./internal/workspace/` → 0 issues)
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go build ./cmd/worker ./cmd/tui`

### Tests (all mutation-verified against the committed fix)
- `TestPrepareGitWorkspace_ReclaimsBranchAfterWorkspaceRootChange` — the #854 repro; prep the same issue/branch at a new root over the same mirror succeeds. *Mutation:* drop the reclaim call → `fatal: 'ai/2' is already used by worktree at …`.
- `TestPrepareGitWorkspace_ReclaimLeavesPeerBranchWorktreeIntact` — a peer issue's worktree (different branch) survives the reclaim (branch scope).
- `TestPrepareGitWorkspace_ReclaimRefusesWhenHolderOverlapsNewRoot` — root == holder and root nested in holder both refuse (pins both halves of the overlap guard); the stale worktree's content survives.
- `TestIsForeignRootHolder` — symlink-correct root scope (`/var`↔`/private/var`).

## Acceptance criteria (issue #854)
- [x] Regression test alongside `mirror_test.go`; prep at the new root over the shared mirror succeeds, reaches the runner phase.
- [x] Mutation-verified against the committed fix.
- [x] Same-root reuse path unchanged (existing `TestPrepareGitWorkspace_*` stay green).
- [x] Does not mask the dual-worker misconfiguration — branch + root scoped; reclaim stays within your own mirror's stale state, which under the separate-mirror-root hard requirement is only ever your own. The unsupported shared-mirror concurrent-worker robustness is tracked in #871 (the PID-based attempt broke the container case).
- [x] After fix: a `workspace.root` change with a persisted mirror + old dirs dispatches successfully; retries no longer loop on `Failed` — including in containers.
- [x] `go test -race ./internal/workspace/...` green; `gofmt`/`vet`/golangci pass.

## Review
Pre-push dual reviewers + cloud `@codex review` per push. The cloud review drove the key calls: P1 (reclaim could delete a live peer in the shared-mirror config) → a PID-liveness guard was tried, then P1 (fail-open under cancelled ctx) and P2 (container PID-1 wedges #854) showed the PID premise was wrong → the guard was removed and the robust shared-mirror ownership tracked in #871. The shipped reclaim is the env-agnostic core (branch + root-disjoint + overlap + symlink), mutation-verified.