### PR TITLE
fix(linear): honor pagination max pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ key with type, default, behavior, and validation rule) is
 | `tracker.active_states` | `[Todo, In Progress]` | SPEC §6.4 |
 | `tracker.terminal_states` | `[Closed, Cancelled, Canceled, Duplicate, Done]` | SPEC §6.4 |
 | `tracker.required_labels` | `[]` (gate off) — opt-in dispatch filter: an issue must carry every listed label (matched case-insensitively after trimming) to dispatch or keep running. Removing a required label makes a running agent self-stop after its current turn (per-turn refresh) and releases retry/blocked work on the next poll. A blank entry matches no issue. Labels are projected up to the Linear API's 250-per-issue page maximum; a required label beyond that window is outside the gate's evidence (an issue carrying 250+ labels is pathological — keep the marker set small). | SPEC §4.1.1 / §6.4 |
-| `tracker.pagination_max_pages` | adapter default (`github`: 10 pages; `gitea`: 20 pages; the `linear` adapter ignores this key and walks up to a fixed 200-page cap) | implementation |
+| `tracker.pagination_max_pages` | adapter default (`github`: 10 pages; `gitea`: 20 pages; `linear`: 200 pages) | implementation |
 | `workspace.root` | `<system-temp>/symphony_workspaces` (resolved via `os.TempDir()` at startup, typically `/tmp/symphony_workspaces` on Linux; per-boot — set explicitly to a long-lived path for persistence) | SPEC §6.4 |
 | `verify.commands` | none — surfaced to the agent's prompt as its own pre-handoff responsibility; the worker does not run them (SPEC §1 agent boundary) | implementation |
 

--- a/docs/runbooks/workflow-frontmatter-reference.md
+++ b/docs/runbooks/workflow-frontmatter-reference.md
@@ -63,7 +63,7 @@ truth this page approximates.
 | `tracker.terminal_states` | string list | `[Closed, Cancelled, Canceled, Duplicate, Done]` | States that end work on an issue (also used by the retry/backoff loop to stop redispatch) | — |
 | `tracker.inactive_states` | string list | `[]` | Non-terminal states that make an already-running issue ineligible: poll-tick reconciliation stops in-flight runs when an issue moves here (operator-pause states such as `Backlog`) | — |
 | `tracker.required_labels` | string list | `[]` (gate off) | Opt-in dispatch gate (SPEC §4.1.1): an issue must carry every listed label to dispatch or keep running. Entries are trimmed, lowercased, de-duped; a blank entry matches no issue. See the README table row for the Linear 250-label projection ceiling | — |
-| `tracker.pagination_max_pages` | int | `0` = adapter default (`github` 10, `gitea` 20) | Caps one tracker pagination scan for the GitHub/Gitea adapters. The Linear adapter ignores this key — its cursor walk has a fixed 200-page cap | ≥ 0 |
+| `tracker.pagination_max_pages` | int | `0` = adapter default (`github` 10, `gitea` 20, `linear` 200) | Caps one tracker pagination scan. Linear applies the same cap to issue listing and inverse-relation pagination | ≥ 0 |
 
 ## `polling`
 

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -218,21 +218,36 @@ func (c *LinearClient) ListIssuesByStates(ctx context.Context, states []string) 
 	}
 	var issues []Issue
 	var after any
-	for page := 0; page < maxLinearIssuePages; page++ {
+	maxPages := c.issueMaxPages()
+	for page := 1; page <= maxPages; page++ {
 		mapped, pageInfo, err := c.fetchLinearIssuesPage(ctx, map[string]any{"projectSlug": projectSlug, "states": nonEmpty, "first": linearIssuePageSize, "after": after})
 		if err != nil {
 			return nil, err
 		}
 		issues = append(issues, mapped...)
-		if !pageInfo.HasNextPage {
+		nextCursor, hasNext, err := nextLinearIssueCursor(pageInfo, page, maxPages)
+		if err != nil {
+			return nil, err
+		}
+		if !hasNext {
 			return issues, nil
 		}
-		if pageInfo.EndCursor == "" {
-			return nil, NewError(CategoryLinearMissingEndCursor, "linear pagination missing endCursor", nil)
-		}
-		after = pageInfo.EndCursor
+		after = nextCursor
 	}
-	return nil, fmt.Errorf("linear pagination exceeded %d pages", maxLinearIssuePages)
+	return nil, NewError(CategoryIssueListingCapped, fmt.Sprintf("linear pagination exceeded %d pages", maxPages), nil)
+}
+
+func nextLinearIssueCursor(pageInfo linearPageInfo, page, maxPages int) (string, bool, error) {
+	if !pageInfo.HasNextPage {
+		return "", false, nil
+	}
+	if page >= maxPages {
+		return "", false, NewError(CategoryIssueListingCapped, fmt.Sprintf("linear pagination exceeded %d pages", maxPages), nil)
+	}
+	if pageInfo.EndCursor == "" {
+		return "", false, NewError(CategoryLinearMissingEndCursor, "linear pagination missing endCursor", nil)
+	}
+	return pageInfo.EndCursor, true, nil
 }
 
 // requireListIssuesConfig enforces the two ListIssuesByStates preconditions
@@ -247,6 +262,13 @@ func (c *LinearClient) requireListIssuesConfig() (string, error) {
 		return "", NewError(CategoryMissingTrackerProjectSlug, "Linear project slug is required", nil)
 	}
 	return projectSlug, nil
+}
+
+func (c *LinearClient) issueMaxPages() int {
+	if c != nil && c.Config.PaginationMaxPages > 0 {
+		return c.Config.PaginationMaxPages
+	}
+	return maxLinearIssuePages
 }
 
 // normalizeRequestedStates trims each requested state and drops empties.
@@ -600,7 +622,11 @@ func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, i
 		}
 	}
 	appendBlockers(nodes)
-	for page := 0; hasNextPage && page < maxLinearIssuePages; page++ {
+	maxPages := c.issueMaxPages()
+	for page := 1; hasNextPage; page++ {
+		if page >= maxPages {
+			return nil, NewError(CategoryIssueListingCapped, fmt.Sprintf("linear inverse relation pagination exceeded %d pages for issue %s", maxPages, issueID), nil)
+		}
 		if endCursor == "" {
 			return nil, NewError(CategoryLinearMissingEndCursor, fmt.Sprintf("linear inverse relation pagination missing endCursor for issue %s", issueID), nil)
 		}
@@ -632,9 +658,6 @@ func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, i
 		appendBlockers(out.Data.Issue.InverseRelations.Nodes)
 		hasNextPage = out.Data.Issue.InverseRelations.PageInfo.HasNextPage
 		endCursor = out.Data.Issue.InverseRelations.PageInfo.EndCursor
-	}
-	if hasNextPage {
-		return nil, fmt.Errorf("linear inverse relation pagination exceeded %d pages for issue %s", maxLinearIssuePages, issueID)
 	}
 	return blockers, nil
 }

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -693,8 +693,31 @@ func TestListIssuesByStatesErrorsWhenMaxPagesExceeded(t *testing.T) {
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
 
 	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
-	if err == nil || !strings.Contains(err.Error(), "linear pagination exceeded") {
-		t.Fatalf("ListIssuesByStates error = %v, want max pages error", err)
+	if !errors.Is(err, ErrIssueListingCapped) {
+		t.Fatalf("ListIssuesByStates error = %v, want ErrIssueListingCapped", err)
+	}
+}
+
+func TestListIssuesByStatesUsesConfiguredPaginationMaxPages(t *testing.T) {
+	var requests atomic.Int32
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if requests.Load() == 1 {
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops", PaginationMaxPages: 1})
+
+	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if !errors.Is(err, ErrIssueListingCapped) {
+		t.Fatalf("ListIssuesByStates error = %v, want ErrIssueListingCapped after configured one-page cap", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("ListIssuesByStates requests = %d, want 1 from pagination_max_pages", got)
 	}
 }
 
@@ -721,8 +744,42 @@ func TestListIssuesByStatesErrorsWhenInverseRelationMaxPagesExceeded(t *testing.
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
 
 	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
-	if err == nil || !strings.Contains(err.Error(), "linear inverse relation pagination exceeded") {
-		t.Fatalf("ListIssuesByStates error = %v, want inverse relation max pages error", err)
+	if !errors.Is(err, ErrIssueListingCapped) {
+		t.Fatalf("ListIssuesByStates error = %v, want ErrIssueListingCapped from inverse relation cap", err)
+	}
+}
+
+func TestListIssuesByStatesUsesConfiguredInverseRelationPaginationMaxPages(t *testing.T) {
+	var perIssueRelationRequests atomic.Int32
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		w.Header().Set("Content-Type", "application/json")
+		switch opNameFromQuery(payload.Query) {
+		case "ListIssues":
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+		case "ListIssuesInverseRelations":
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"same-relation-cursor"}}}]}}}`)
+		default:
+			if perIssueRelationRequests.Add(1) == 1 {
+				_, _ = io.WriteString(w, `{"data":{"issue":{"inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"same-relation-cursor"}}}}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"data":{"issue":{"inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`)
+		}
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops", PaginationMaxPages: 1})
+
+	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if !errors.Is(err, ErrIssueListingCapped) {
+		t.Fatalf("ListIssuesByStates error = %v, want ErrIssueListingCapped after configured inverse-relation cap", err)
+	}
+	if got := perIssueRelationRequests.Load(); got != 0 {
+		t.Fatalf("per-issue inverse relation requests = %d, want 0 because the batched relation page counts toward pagination_max_pages", got)
 	}
 }
 


### PR DESCRIPTION
Closes #873

## Summary
- Thread `tracker.pagination_max_pages` through the Linear issue-listing path while keeping the default cap at 200 pages.
- Apply the same cap to Linear inverse-relation pagination so blocker hydration cannot silently use a separate hidden limit.
- Return `ErrIssueListingCapped` for Linear issue-list and inverse-relation cap overflow, and update docs that previously said Linear ignored the key.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Existing `tracker.pagination_max_pages` behavior is now applied consistently to the Linear adapter. The cap overflow remains a fetch failure with `ErrIssueListingCapped`, so reconciliation callers do not need Linear-specific branching and no partial Linear result set is handed off as complete.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: one production Go file plus docs, within the guideline. Tests add focused coverage for the issue-list cap, inverse-relation cap, typed errors, and the configured cap wiring seam.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go test ./internal/tracker/... -run 'ListIssuesByStatesUsesConfigured.*PaginationMaxPages|ListIssuesByStatesErrorsWhen.*MaxPagesExceeded' -count=1`
- `go test ./internal/tracker/... -run 'Linear.*Pagination|IssueListingCapped|InverseRelation' -count=1`
- `go test ./internal/worker/... -run 'Reconcile.*Capped|StartupSafeWhenActiveListingCapped' -count=1`
- `go test ./internal/workflow/... -run 'PaginationMaxPages' -count=1`

Mutation checks performed against the committed artifact:
- Mutating `issueMaxPages()` to ignore `PaginationMaxPages` made the configured cap tests fail, then the file was restored.
- Mutating inverse-relation cap comparison from `page >= maxPages` to `page > maxPages` made the inverse configured-cap test fail by issuing an overflow request, then the file was restored.

Reviewer checks:
- Claude-family reviewer: `MERGE-READY` after the inverse-relation cap fix; requested this PR body note the grep confirmation.
- Codex-family reviewer: first pass found the inverse-relation off-by-one; fixed in the amended commit. Second pass: no findings, `MERGE-READY`.
- Grep confirmation: `rg -n "maxLinearIssuePages|PaginationMaxPages" internal/tracker internal/gitea README.md docs/runbooks/workflow-frontmatter-reference.md -S` shows Linear now reaches the default constant only through `issueMaxPages()` plus focused tests/docs; no third Linear pagination loop directly bypasses the configured cap.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
