### PR TITLE
fix(workspace): guard worktree cleanup

### DIFF
--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -320,7 +320,9 @@ func createWorktree(ctx context.Context, root, workdir, mirror, workBranch, star
 	// Failures here are ignored and stderr silenced: the common case ("no such
 	// worktree") prints a scary fatal line that obscures real worker logs.
 	_ = runGitQuiet(ctx, mirror, "worktree", "remove", "--force", workdir)
-	_ = os.RemoveAll(workdir)
+	if err := SafeRemove(root, workdir); err != nil {
+		return fmt.Errorf("worktree cleanup: %w", err)
+	}
 	reclaimForeignBranchWorktree(ctx, root, workdir, mirror, workBranch)
 	if err := runGitQuiet(ctx, mirror, "worktree", "prune"); err != nil {
 		return fmt.Errorf("worktree prune: %w", err)

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -527,14 +528,12 @@ func TestPrepareGitWorkspace_RerunReusesWorkspaceAcrossRuns(t *testing.T) {
 	}
 }
 
-// TestPrepareGitWorkspace_RecreatesWhenPathIsSymlink covers the security
-// gate on the reuse path: a symlink planted at the workspace path could
-// otherwise redirect the reuse-path `git reset` / `git checkout -B` into
-// a repository outside the workspace root. PrepareGitWorkspace must
-// refuse the reuse, remove the symlink (without following it), and
-// recreate a fresh worktree linked to OUR mirror, reporting
-// `createdNow=true`.
-func TestPrepareGitWorkspace_RecreatesWhenPathIsSymlink(t *testing.T) {
+// TestPrepareGitWorkspaceRejectsWhenPathIsSymlinkOutsideRoot covers the
+// cleanup boundary on the recreate path: a symlink planted at the workspace
+// path can point outside the workspace root. PrepareGitWorkspace must refuse
+// the reuse and fail closed through SafeRemove rather than treating the path as
+// a normal cleanup target.
+func TestPrepareGitWorkspaceRejectsWhenPathIsSymlinkOutsideRoot(t *testing.T) {
 	upstream := initBareUpstream(t)
 	mgr := newTestManager(t)
 	ctx := context.Background()
@@ -548,19 +547,9 @@ func TestPrepareGitWorkspace_RecreatesWhenPathIsSymlink(t *testing.T) {
 		t.Fatal("first prepare reported createdNow=false")
 	}
 
-	// Capture the mirror's git-common-dir for later comparison.
-	firstCommon, err := exec.Command("git", "-C", dir, "rev-parse", "--git-common-dir").Output()
-	if err != nil {
-		t.Fatalf("first git-common-dir: %v", err)
-	}
-	firstCommonReal, err := filepath.EvalSymlinks(strings.TrimSpace(string(firstCommon)))
-	if err != nil {
-		t.Fatalf("eval first common: %v", err)
-	}
-
 	// Replace the workspace path with a symlink pointing at an attacker
-	// controlled git repo elsewhere on disk. The reuse path must NOT
-	// follow this symlink and run `git reset` inside it.
+	// controlled git repo elsewhere on disk. Neither the reuse path nor the
+	// recreate cleanup path may follow or delete through this symlink.
 	attacker := t.TempDir()
 	for _, args := range [][]string{
 		{"git", "init", "-q", "-b", "main", attacker},
@@ -594,15 +583,8 @@ func TestPrepareGitWorkspace_RecreatesWhenPathIsSymlink(t *testing.T) {
 		t.Fatalf("plant symlink: %v", err)
 	}
 
-	dir2, createdNow, err := mgr.PrepareGitWorkspace(ctx, tk)
-	if err != nil {
-		t.Fatalf("second prepare after symlink swap: %v", err)
-	}
-	if dir != dir2 {
-		t.Fatalf("path changed across runs: %s vs %s", dir, dir2)
-	}
-	if !createdNow {
-		t.Fatal("second prepare reported createdNow=false; symlinked path must fall back to recreate")
+	if _, _, err := mgr.PrepareGitWorkspace(ctx, tk); !errors.Is(err, ErrSafeRemoveEscapesRoot) {
+		t.Fatalf("second prepare after symlink swap err = %v, want ErrSafeRemoveEscapesRoot", err)
 	}
 
 	// The attacker repo must be untouched — its HEAD ref must not have
@@ -619,19 +601,12 @@ func TestPrepareGitWorkspace_RecreatesWhenPathIsSymlink(t *testing.T) {
 	} else if string(body) != "attacker" {
 		t.Fatalf("attacker canary file modified: %q", body)
 	}
-
-	// The recreated workspace must be linked to OUR mirror (same
-	// git-common-dir as the first prepare), not to the attacker's repo.
-	secondCommon, err := exec.Command("git", "-C", dir2, "rev-parse", "--git-common-dir").Output()
+	linkInfo, err := os.Lstat(dir)
 	if err != nil {
-		t.Fatalf("second git-common-dir: %v", err)
+		t.Fatalf("symlink path removed after rejected cleanup: %v", err)
 	}
-	secondCommonReal, err := filepath.EvalSymlinks(strings.TrimSpace(string(secondCommon)))
-	if err != nil {
-		t.Fatalf("eval second common: %v", err)
-	}
-	if secondCommonReal != firstCommonReal {
-		t.Fatalf("recreated workspace linked to a different mirror: before=%q after=%q", firstCommonReal, secondCommonReal)
+	if linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("workspace path mode = %v, want symlink left in place after rejected cleanup", linkInfo.Mode())
 	}
 }
 


### PR DESCRIPTION
Closes #874

## Summary
- Replace the worktree recreation cleanup's direct `os.RemoveAll(workdir)` with `SafeRemove(root, workdir)`.
- Preserve `git worktree remove --force`, reclaim, prune, and add behavior on the normal recreate path.
- Update manager-level coverage so an external symlink at the workspace path fails closed through the safe cleanup boundary instead of being treated as a normal recreate target.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This is workspace cleanup hardening inside the existing SPEC workspace-root invariant. It does not add a worker phase, tracker handoff, or new config surface.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: one production Go file, 3 added production lines.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go build ./cmd/worker ./cmd/tui`
- `go test ./internal/workspace/... -run '^TestPrepareGitWorkspaceRejectsWhenPathIsSymlinkOutsideRoot$' -count=1`
- `go test ./internal/workspace/... -run 'SafeRemove|PrepareGitWorkspace|Worktree' -count=1`
- `go test ./internal/workspace/... -count=1`
- `go test ./internal/workspace/... -run '^TestPrepareGitWorkspace_RecreatesCorruptedWorkdir$|^TestPrepareGitWorkspace_RecreatesWhenPathIsForeignGitRepo$|^TestPrepareGitWorkspace_RecreatesWhenPathIsSymlinkToPeerWorktree$' -count=1`

Mutation check performed against the committed artifact:
- Temporarily replacing `SafeRemove(root, workdir)` with direct `os.RemoveAll(workdir)` made `TestPrepareGitWorkspaceRejectsWhenPathIsSymlinkOutsideRoot` fail with `err = <nil>, want ErrSafeRemoveEscapesRoot`; the file was restored and the test then passed again.

Reviewer checks:
- Codex CLI reviewer against `origin/main`: no discrete regression found; it also ran `go test ./...` successfully.
- Local Claude CLI reviewer was attempted in normal repo-read mode, a smaller prompt mode, and text-only stdin mode; those sessions hung without a verdict. `claude --bare` is not logged in in this environment, so no Claude verdict is claimed.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
