### PR TITLE
chore(devex): add local validation script

### DIFF
--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -33,7 +33,8 @@ needs Postgres, it is stale — file an issue.
 
 ## Prerequisites
 
-- Go 1.25 or newer (matches `go.mod`).
+- Go 1.25.11 or newer (the exact patch floor pinned in `go.mod` and the
+  Dockerfile).
 - `git` and `curl`.
 - Tracker credentials matching the workflow you're running:
   - `tracker.kind: linear` → a Linear personal API key.
@@ -51,6 +52,27 @@ needs Postgres, it is stale — file an issue.
   `agent.default: codex-app-server` and want a real model loop.
 
 `cmd/worker` does **not** need Postgres.
+
+## Quick local validation
+
+From a fresh checkout, run the lightweight non-container validation shim before
+starting a worker loop or opening a PR:
+
+```bash
+./scripts/dev-test.sh
+```
+
+The script reads the pinned Go version from `go.mod`, checks the effective
+`go env GOVERSION`, then runs the credential-free Go path: `gofmt -l`,
+`go mod tidy` with a clean `go.mod` / `go.sum` diff, and `go test ./...`.
+It does not require tracker credentials, dashboard dependencies, or an e2e
+container runtime.
+
+Keep `GOTOOLCHAIN=auto` enabled unless you have already installed the pinned Go
+toolchain locally. With `GOTOOLCHAIN=auto`, modern Go can download the required
+toolchain when the checkout asks for Go 1.25.11. If the machine is offline or
+the download is blocked, install Go 1.25.11 first (or pre-seed the toolchain)
+and re-run `./scripts/dev-test.sh`.
 
 ## 1. Configure the workflow and environment
 

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/dev-test.sh [quick]
+
+Runs the credential-free local Go validation path:
+  - verify the effective Go toolchain satisfies go.mod
+  - check gofmt output
+  - run go mod tidy and require go.mod/go.sum to stay clean
+  - run go test ./...
+USAGE
+}
+
+die() {
+  echo "dev-test: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required on PATH"
+}
+
+version_ge() {
+  local have="${1#go}"
+  local need="$2"
+  local have_major have_minor have_patch need_major need_minor need_patch
+  IFS=. read -r have_major have_minor have_patch _ <<<"$have"
+  IFS=. read -r need_major need_minor need_patch _ <<<"$need"
+  have_patch="${have_patch:-0}"
+  need_patch="${need_patch:-0}"
+  for part in "$have_major" "$have_minor" "$have_patch" "$need_major" "$need_minor" "$need_patch"; do
+    [[ "$part" =~ ^[0-9]+$ ]] || return 1
+  done
+  if ((have_major != need_major)); then
+    ((have_major > need_major))
+    return
+  fi
+  if ((have_minor != need_minor)); then
+    ((have_minor > need_minor))
+    return
+  fi
+  ((have_patch >= need_patch))
+}
+
+check_go_toolchain() {
+  local required current
+  required="$(awk '/^go [0-9]/ {print $2; exit}' go.mod)"
+  [[ -n "$required" ]] || die "could not read Go version from go.mod"
+
+  if ! current="$(go env GOVERSION 2>/dev/null)"; then
+    die "go cannot satisfy go.mod's Go $required floor. With GOTOOLCHAIN=auto, modern Go can download the pinned toolchain; if this machine is offline, install Go $required first or pre-seed the toolchain."
+  fi
+  if ! version_ge "$current" "$required"; then
+    die "effective Go toolchain is $current, but go.mod requires Go $required or newer. Leave GOTOOLCHAIN=auto to let Go download it, or install Go $required before running local validation."
+  fi
+  echo "Go toolchain OK: $current satisfies go.mod Go $required"
+}
+
+check_gofmt() {
+  local go_files fmt_out
+  go_files="$(git ls-files '*.go')"
+  if [[ -z "$go_files" ]]; then
+    return
+  fi
+  fmt_out="$(printf '%s\n' "$go_files" | xargs gofmt -l)"
+  if [[ -n "$fmt_out" ]]; then
+    echo "dev-test: gofmt needed:" >&2
+    echo "$fmt_out" >&2
+    exit 1
+  fi
+}
+
+mode="${1:-quick}"
+case "$mode" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  quick)
+    ;;
+  *)
+    usage >&2
+    die "unknown mode: $mode"
+    ;;
+esac
+
+require_command git
+require_command go
+require_command gofmt
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "must run inside a git checkout"
+cd "$repo_root"
+
+check_go_toolchain
+
+echo "==> checking gofmt"
+check_gofmt
+
+echo "==> verifying go mod tidy"
+go mod tidy
+git diff --exit-code -- go.mod go.sum
+
+echo "==> running Go unit tests"
+go test ./...

--- a/scripts/dev_test_script_test.go
+++ b/scripts/dev_test_script_test.go
@@ -1,0 +1,88 @@
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestDevTestScriptIsLightweightLocalValidationEntrypoint(t *testing.T) {
+	info, err := os.Stat("dev-test.sh")
+	if err != nil {
+		t.Fatalf("stat dev-test.sh: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("dev-test.sh mode = %v, want executable bit", info.Mode())
+	}
+
+	if out, err := exec.Command("bash", "-n", "dev-test.sh").CombinedOutput(); err != nil {
+		t.Fatalf("bash -n dev-test.sh: %v\n%s", err, out)
+	}
+
+	body, err := os.ReadFile("dev-test.sh")
+	if err != nil {
+		t.Fatalf("ReadFile(dev-test.sh): %v", err)
+	}
+	script := string(body)
+	for _, want := range []string{
+		`awk '/^go [0-9]/ {print $2; exit}' go.mod`,
+		`go env GOVERSION`,
+		`GOTOOLCHAIN=auto`,
+		`git ls-files '*.go'`,
+		`gofmt -l`,
+		`go mod tidy`,
+		`git diff --exit-code -- go.mod go.sum`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("dev-test.sh missing %q", want)
+		}
+	}
+	if !regexp.MustCompile(`(?m)^go test \./\.\.\.$`).MatchString(script) {
+		t.Fatal("dev-test.sh must run the full Go unit-test surface with `go test ./...`")
+	}
+	for _, forbidden := range []string{
+		"docker ",
+		"docker compose",
+		"npm ",
+		"LINEAR_API_KEY",
+		"GITEA_TOKEN",
+		"GITHUB_TOKEN",
+	} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("dev-test.sh default path must stay credential/Docker/dashboard-free; found %q", forbidden)
+		}
+	}
+}
+
+func TestLocalDevDocsMentionDevTestAndExactGoFloor(t *testing.T) {
+	goMod, err := os.ReadFile("../go.mod")
+	if err != nil {
+		t.Fatalf("ReadFile(go.mod): %v", err)
+	}
+	match := regexp.MustCompile(`(?m)^go ([0-9]+\.[0-9]+\.[0-9]+)$`).FindSubmatch(goMod)
+	if match == nil {
+		t.Fatalf("go.mod missing exact patch go directive:\n%s", goMod)
+	}
+	goVersion := string(match[1])
+
+	body, err := os.ReadFile("../docs/runbooks/local-dev.md")
+	if err != nil {
+		t.Fatalf("ReadFile(local-dev.md): %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"Go " + goVersion,
+		"./scripts/dev-test.sh",
+		"GOTOOLCHAIN=auto",
+		"offline",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("local-dev.md missing %q", want)
+		}
+	}
+	if strings.Contains(text, "Go 1.25 or newer") {
+		t.Fatal("local-dev.md still says only Go 1.25 or newer; use the exact pinned patch floor")
+	}
+}


### PR DESCRIPTION
Closes #875

## Summary
- Add `./scripts/dev-test.sh` as a lightweight local validation entrypoint for a fresh checkout.
- The default path checks the effective Go toolchain against `go.mod`, then runs `gofmt -l`, `go mod tidy` with clean `go.mod` / `go.sum`, and `go test ./...`.
- Document the exact Go 1.25.11 floor, `GOTOOLCHAIN=auto`, and offline/pre-seeded toolchain guidance in `docs/runbooks/local-dev.md`.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This is a local developer validation shim and documentation update. It does not alter worker runtime behavior, config shape, tracker behavior, or agent handoff.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: no production Go files. The new shell script is intentionally single-mode (`quick`) and does not introduce a task-runner framework.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `bash -n scripts/dev-test.sh`
- `./scripts/dev-test.sh`
- `go test ./scripts -run 'TestDevTestScript|TestLocalDevDocsMentionDevTest' -count=1`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go build ./cmd/worker ./cmd/tui`

Mutation check performed against the committed artifact:
- Temporarily changing the script's executable test command from `go test ./...` to `go test ./scripts` made `TestDevTestScriptIsLightweightLocalValidationEntrypoint` fail; the script was restored and the focused test passed again.
- The first mutation attempt exposed a weak substring assertion that only matched usage text, so the test now asserts the actual command line with a line-anchored regexp.

Reviewer checks:
- Local Codex CLI review was attempted but hit the Codex usage limit before producing a verdict.
- Local Claude text-only diff review was attempted with a 90s timeout but produced no output before timeout. No Claude verdict is claimed.
- GitHub `@codex review` will be triggered after PR creation.

Trellis test note:
- The timeout hook tests failed twice while running concurrently with heavy Go verification. Targeted rerun of `test_task_hooks_timeout.py` passed, and the final full Trellis unittest command was rerun alone and passed.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
