### PR TITLE
feat(gitea): add merging state label

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ label:
 | `Todo` | `aiops/todo` |
 | `In Progress` | `aiops/in-progress` |
 | `Human Review` | `aiops/human-review` |
+| `Merging` | `aiops/merging` |
 | `Rework` | `aiops/rework` |
 | `Done` | `aiops/done` |
 | `Canceled` | `aiops/canceled` |

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -489,7 +489,7 @@ func defaultInactiveStateCandidates(kind string) []string {
 	case "github":
 		return nil
 	case "gitea":
-		return []string{"Human Review"}
+		return []string{"Human Review", "Merging"}
 	default:
 		return []string{"Backlog", "Human Review"}
 	}

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -2154,6 +2154,25 @@ func TestWorkerReconciliationConfigDoesNotProbeUnmappedGiteaInactiveStates(t *te
 	if !containsState(reconcile.InactiveStates, "Human Review") {
 		t.Fatalf("inactive reconciliation states = %v, want mapped Gitea Human Review state", reconcile.InactiveStates)
 	}
+	if !containsState(reconcile.InactiveStates, "Merging") {
+		t.Fatalf("inactive reconciliation states = %v, want mapped Gitea Merging state", reconcile.InactiveStates)
+	}
+}
+
+func TestWorkerReconciliationConfigFiltersActiveGiteaMergingState(t *testing.T) {
+	cfg := workflow.DefaultConfig()
+	cfg.Repo.CloneURL = "git@example.com:o/r.git"
+	cfg.Tracker.Kind = "gitea"
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress", "Merging"}
+	cfg.Tracker.TerminalStates = []string{"Done", "Canceled"}
+
+	reconcile := reconciliationConfigForWorkflow(cfg)
+	if containsState(reconcile.InactiveStates, "Merging") {
+		t.Fatalf("inactive reconciliation states = %v, must not include active Merging state", reconcile.InactiveStates)
+	}
+	if !containsState(reconcile.InactiveStates, "Human Review") {
+		t.Fatalf("inactive reconciliation states = %v, want mapped Gitea Human Review state", reconcile.InactiveStates)
+	}
 }
 
 func TestWorkerReconciliationConfigUsesWorkflowInactiveStates(t *testing.T) {

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -275,6 +275,7 @@ tool surface, not the worker. Default state labels:
 | `Todo` | `aiops/todo` |
 | `In Progress` | `aiops/in-progress` |
 | `Human Review` | `aiops/human-review` |
+| `Merging` | `aiops/merging` |
 | `Rework` | `aiops/rework` |
 | `Done` | `aiops/done` |
 | `Canceled` | `aiops/canceled` |

--- a/docs/runbooks/reviewer-worker.md
+++ b/docs/runbooks/reviewer-worker.md
@@ -34,7 +34,7 @@ Two worker processes, one tracker project:
 |---|---|---|
 | `WORKFLOW.md` | implementation prompt | rubric/review prompt ([example](../../examples/reviewer-WORKFLOW.md)) |
 | `tracker.active_states` | `[Todo, Rework]` | `[Human Review]` |
-| `tracker.inactive_states` | `[Human Review]` | `[Todo, In Progress, Rework]` |
+| `tracker.inactive_states` | `[Human Review, Merging]` | `[Todo, In Progress, Merging, Rework]` |
 | `workspace.root` | e.g. `~/aiops-workspaces/maker` | **a different root — hard requirement, see below** |
 | `AIOPS_MIRROR_ROOT` env | e.g. `~/aiops-mirrors/maker` | **a different mirror root — hard requirement, see below** |
 | state writes (agent-side) | flips to `aiops/human-review` | flips to `aiops/done` / `aiops/rework` |

--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -51,7 +51,7 @@ Two worker processes, one Gitea repo/project, **two bot accounts**:
 | `WORKFLOW.md` | `examples/maker-WORKFLOW.md` | `examples/reviewer-automerge-WORKFLOW.md` |
 | Bot account | `maker-bot` (Write) | `review-bot` (Write) — **must differ** |
 | `tracker.active_states` | `[Todo, Rework]` | `[Human Review]` |
-| `tracker.inactive_states` | `[Human Review, In Progress]` | `[Todo, In Progress, Rework]` |
+| `tracker.inactive_states` | `[Human Review, In Progress, Merging]` | `[Todo, In Progress, Merging, Rework]` |
 | `workspace.root` | `~/aiops-workspaces/maker` | `~/aiops-workspaces/reviewer` — **must differ (hard)** |
 | `AIOPS_MIRROR_ROOT` | `~/aiops-mirrors/maker` | `~/aiops-mirrors/reviewer` — **must differ (hard)** |
 | agent state writes | flips → `aiops/human-review`; opens PR; comments PR URL | approves + enables auto-merge; **confirms the merge, then** flips → `aiops/done`; stays in `Human Review` (re-checks next poll) if CI is still landing; `aiops/rework` on fail |
@@ -74,7 +74,9 @@ off the terminal `aiops/*` label, not the forge merge) could unblock and start
 N+1 from a stale `main` while CI is still running or later fails. When CI has not
 landed within the reviewer's turn budget, it makes **no** terminal flip and leaves
 the issue in `Human Review`; the next poll re-claims it and re-checks (see
-[Slow or flaky CI](#slow-or-flaky-ci)) — there is no separate holding state.
+[Slow or flaky CI](#slow-or-flaky-ci)). The default two-worker topology does not
+need a separate holding state; routinely slow CI can add a dedicated `Merging`
+worker without making `Merging` terminal.
 
 The two hard isolation requirements (separate `workspace.root` **and** separate
 `AIOPS_MIRROR_ROOT` per worker — same issue resolves to the same `PathFor`
@@ -221,37 +223,50 @@ for this DAG"*):
 
 For fast, stable CI the reviewer confirms the merge inline (poll → `Done`), so you
 need nothing more. When CI is slow or flaky, the merge may not land within the
-reviewer's turn budget. The reviewer then makes **no terminal flip** and leaves the
-issue in `Human Review`; because that is the reviewer's active state, the next poll
-re-claims the issue and re-checks the PR — flipping `Done` only once the forge
-reports `merged:true`. This re-poll only works because the maker used a non-closing
-`Refs #<N>`: an issue auto-closed at merge would drop out of the poller's
-`state=open` listing for `Human Review` before `Done` is set. Dependents stay gated
-throughout, since the issue never reaches a terminal state before the merge. (On re-claim the reviewer detects its own
-**current (non-stale)** prior approval and skips straight to the merge re-check, so it does not re-run the
-full rubric every poll.) This re-poll is **bounded**, not infinite: each clean
-exit consumes from `agent.max_continuation_turns` (D34; it defaults to `max_turns`,
-so the reviewer WORKFLOW sets it explicitly higher). When the budget is exhausted —
-e.g. CI stays red after approval (a local-pass / CI-fail mismatch the reviewer's own
-`build/test` did not catch) — the orchestrator parks the issue in local `blocked`
-(`continuation_budget`); its dependents stay gated, and an operator must investigate
-the mismatch and redrive it (raising the budget does not auto-redrive a blocked
-claim) — not force `Done`/`Canceled`, either of which would unblock dependents from a
-`main` that never received the change. For CI that is *routinely* slower than the
-budget, the dedicated Merging worker (#863) is the right tool, not an ever-larger
-number.
+reviewer's turn budget. The default two-worker topology can still make **no
+terminal flip** and leave the issue in `Human Review`; because that is the
+reviewer's active state, the next poll re-claims the issue and re-checks the PR —
+flipping `Done` only once the forge reports `merged:true`. This re-poll only works
+because the maker used a non-closing `Refs #<N>`: an issue auto-closed at merge
+would drop out of the poller's `state=open` listing for `Human Review` before
+`Done` is set. Dependents stay gated throughout, since the issue never reaches a
+terminal state before the merge. (On re-claim the reviewer detects its own
+**current (non-stale)** prior approval and skips straight to the merge re-check, so
+it does not re-run the full rubric every poll.) This re-poll is **bounded**, not
+infinite: each clean exit consumes from `agent.max_continuation_turns` (D34; it
+defaults to `max_turns`, so the reviewer WORKFLOW sets it explicitly higher).
+When the budget is exhausted — e.g. CI stays red after approval (a local-pass /
+CI-fail mismatch the reviewer's own `build/test` did not catch) — the orchestrator
+parks the issue in local `blocked` (`continuation_budget`); its dependents stay
+gated, and an operator must investigate the mismatch and redrive it (raising the
+budget does not auto-redrive a blocked claim) — not force `Done`/`Canceled`, either
+of which would unblock dependents from a `main` that never received the change.
 
-Upstream Symphony models this landing phase as a dedicated **Merging** state with an
-agent that *"watches CI, rebases when needed, resolves conflicts, retries flaky
-checks"* ([blog](../research/2026-04-27-openai-symphony-blog.md); upstream
-`elixir/WORKFLOW.md`). The Gitea adapter's state set is currently fixed to the six
-`aiops/*` labels in the topology table — `validGiteaStateLabels`
-(`internal/runner/gitea_tools.go`) rejects any other label, and
-`DefaultStateLabelMappings` (`internal/gitea/label_state.go`) has no `Merging` — so a
-native `Merging` state is a tracked **code** enhancement
-([#863](https://github.com/xrf9268-hue/aiops-platform/issues/863)), not something you
-can configure today. Until it lands, the `Human Review` re-poll above is the slow-CI
-path.
+For CI that is *routinely* slower than the reviewer budget, deploy a dedicated
+**Merging** worker instead of making that budget ever larger. Upstream Symphony
+models this landing phase as a dedicated `Merging` state with an agent that
+*"watches CI, rebases when needed, resolves conflicts, retries flaky checks"*
+([blog](../research/2026-04-27-openai-symphony-blog.md); upstream
+`elixir/WORKFLOW.md`). On Gitea, the reviewer approves the PR, enables
+forge-native auto-merge, then flips the issue to `aiops/merging`. A separate
+landing worker watches `tracker.active_states: [Merging]`, follows the land loop,
+confirms the forge reports `merged:true`, and only then flips `aiops/done` and
+closes the issue. Add `Merging` to the maker/reviewer workers' inactive states
+so the handoff reconcile-cancels any still-running prior owner. `Merging` is
+non-terminal: `Depends on #N` dependents remain blocked until the landing worker
+reaches `Done` (or an operator intentionally uses the terminal `Canceled` escape
+hatch).
+
+The landing worker is a third worker with its own `workspace.root`,
+`AIOPS_MIRROR_ROOT`, and bot credentials. Its workflow should keep `Merging` as
+the only active state and treat the other handoff states as inactive:
+
+```yaml
+tracker:
+  active_states: [Merging]
+  inactive_states: [Todo, In Progress, Human Review, Rework]
+  terminal_states: [Done, Canceled]
+```
 
 ## What this is NOT
 

--- a/examples/gitea-WORKFLOW.md
+++ b/examples/gitea-WORKFLOW.md
@@ -24,6 +24,7 @@ tracker:
     - Canceled
   inactive_states:
     - Human Review
+    - Merging
 
 polling:
   interval_ms: 30000

--- a/examples/maker-WORKFLOW.md
+++ b/examples/maker-WORKFLOW.md
@@ -32,6 +32,7 @@ tracker:
   inactive_states:
     - Human Review
     - In Progress
+    - Merging
 
 polling:
   interval_ms: 30000

--- a/examples/reviewer-WORKFLOW.md
+++ b/examples/reviewer-WORKFLOW.md
@@ -28,12 +28,13 @@ tracker:
   terminal_states:
     - Done
     - Canceled
-  # Maker-owned states make a running review ineligible: a Rework verdict
-  # (or an operator pulling the issue back) cancels the in-flight reviewer
-  # run on the next poll.
+  # Maker/landing-owned states make a running review ineligible: a Rework or
+  # Merging verdict (or an operator pulling the issue back) cancels the
+  # in-flight reviewer run on the next poll.
   inactive_states:
     - Todo
     - In Progress
+    - Merging
     - Rework
 
 polling:

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -22,9 +22,10 @@ tracker:
   terminal_states:
     - Done
     - Canceled
-  inactive_states:               # maker-owned states cancel an in-flight review (Rework pull-back)
+  inactive_states:               # maker/landing-owned states cancel an in-flight review
     - Todo
     - In Progress
+    - Merging
     - Rework
 
 polling:
@@ -44,8 +45,8 @@ agent:
   # on exhaustion the orchestrator parks the issue in local `blocked`
   # (continuation_budget), it does NOT loop forever. Set it above max_turns so
   # several cheap merge re-checks (the Step 1 short-circuit) fit. CI routinely
-  # slower than this budget wants the dedicated Merging worker (#863), not a
-  # larger number.
+  # slower than this budget wants a dedicated Merging worker, not a larger
+  # number.
   max_continuation_turns: 36
 
 codex:

--- a/internal/gitea/label_state.go
+++ b/internal/gitea/label_state.go
@@ -34,7 +34,9 @@ type StateDiagnostic struct {
 // DefaultStateLabelMappings defines the repo's Gitea tracker label convention.
 // The order is also the deterministic conflict priority: active/rework labels
 // win over terminal labels so an issue is not silently dropped when a stale
-// terminal label remains alongside a label that requests work.
+// terminal label remains alongside a label that requests work. Merging sits
+// before Human Review so a stale review label does not hide the agent-owned
+// landing phase.
 //
 // aiops/todo MUST map to the SPEC state name "Todo": the §8.2 blocker rule
 // only gates issues whose state is literally Todo, so a renamed pre-dispatch
@@ -43,6 +45,7 @@ func DefaultStateLabelMappings() []StateLabelMapping {
 	return []StateLabelMapping{
 		{Label: "aiops/rework", State: "Rework"},
 		{Label: "aiops/in-progress", State: "In Progress"},
+		{Label: "aiops/merging", State: "Merging"},
 		{Label: "aiops/human-review", State: "Human Review"},
 		{Label: "aiops/todo", State: "Todo"},
 		{Label: "aiops/done", State: "Done"},

--- a/internal/gitea/label_state_test.go
+++ b/internal/gitea/label_state_test.go
@@ -17,6 +17,20 @@ func TestIssueStateFromLabelsMapsSingleAIOpsLabel(t *testing.T) {
 	}
 }
 
+func TestIssueStateFromLabelsMapsMergingAndPrioritizesItOverHumanReview(t *testing.T) {
+	state, diagnostics := IssueStateFromLabels([]Label{{Name: "aiops/human-review"}, {Name: "aiops/merging"}}, DefaultStateLabelMappings())
+
+	if state != "Merging" {
+		t.Fatalf("state = %q, want Merging to win conflict priority over Human Review", state)
+	}
+	if !hasDiagnostic(diagnostics, "conflicting_aiops_state_labels") {
+		t.Fatalf("diagnostics = %#v, want conflicting_aiops_state_labels", diagnostics)
+	}
+	if !strings.Contains(diagnostics[0].Message, "aiops/merging") || !strings.Contains(diagnostics[0].Message, "aiops/human-review") {
+		t.Fatalf("diagnostic message = %q, want conflicting labels named", diagnostics[0].Message)
+	}
+}
+
 func TestIssueStateFromLabelsReportsMissingState(t *testing.T) {
 	state, diagnostics := IssueStateFromLabels([]Label{{Name: "bug"}}, DefaultStateLabelMappings())
 
@@ -54,8 +68,8 @@ func TestIssueStateFromLabelsIgnoresUnknownAIOpsLabels(t *testing.T) {
 }
 
 func TestStateLabelNamesForStatesFiltersConfiguredStates(t *testing.T) {
-	got := StateLabelNamesForStates([]string{"Todo", "Rework", "Done", "Not Configured"}, DefaultStateLabelMappings())
-	want := []string{"aiops/todo", "aiops/rework", "aiops/done"}
+	got := StateLabelNamesForStates([]string{"Todo", "Merging", "Rework", "Done", "Not Configured"}, DefaultStateLabelMappings())
+	want := []string{"aiops/todo", "aiops/merging", "aiops/rework", "aiops/done"}
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("StateLabelNamesForStates = %#v, want %#v", got, want)

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -615,6 +615,55 @@ func TestTrackerClientListIssuesByStatesNormalizesLabelsAndBlockedBy(t *testing.
 	}
 }
 
+func TestTrackerClientListIssuesByStatesTreatsMergingBlockerAsNonTerminal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]Issue{{
+				ID:     101,
+				Number: 1,
+				Title:  "dependent",
+				Body:   "Depends on #42",
+				Labels: []Label{{Name: "aiops/todo"}},
+			}})
+		case "/api/v1/repos/owner/repo/issues/42":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(Issue{
+				ID:     142,
+				Number: 42,
+				Title:  "blocker landing",
+				Labels: []Label{{Name: "aiops/merging"}},
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewTrackerClient(workflow.TrackerConfig{
+		APIKey:       "secret",
+		ActiveStates: []string{"Todo"},
+	}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want 1", len(issues))
+	}
+	blockedBy := issues[0].BlockedBy
+	if len(blockedBy) != 1 || blockedBy[0].Identifier != "#42" || blockedBy[0].State != "Merging" {
+		t.Fatalf("BlockedBy = %#v, want #42 in Merging state", blockedBy)
+	}
+	terminal := map[string]struct{}{"done": {}, "canceled": {}}
+	if !tracker.BlockedByNonTerminal(blockedBy, terminal) {
+		t.Fatalf("BlockedByNonTerminal(%#v) = false, want true because Merging is non-terminal", blockedBy)
+	}
+}
+
 // TestTrackerClientListIssuesByStatesTolerantOfBlockerLookupFailure: a
 // definitively deleted blocker (404) silently drops out of BlockedBy rather
 // than aborting candidate enumeration — it can never become terminal, so

--- a/internal/orchestrator/poller_gitea_seam_test.go
+++ b/internal/orchestrator/poller_gitea_seam_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
 // TestGiteaPreDispatchStateIsBlockerGated pins the producer/consumer seam
@@ -42,5 +43,29 @@ func TestGiteaPreDispatchStateIsBlockerGated(t *testing.T) {
 	released.BlockedBy = []tracker.BlockerRef{{ID: "4", Identifier: "#4", State: terminal}}
 	if out := filterEligibleCandidates([]tracker.Issue{released}, terminalStates, nil); len(out) != 1 {
 		t.Fatalf("filterEligibleCandidates(issue in %q blocked by terminal %q) = %d issues, want 1", preDispatch, terminal, len(out))
+	}
+}
+
+func TestGiteaMergingStateIsNonTerminalForDefaultBlockerGate(t *testing.T) {
+	mappings := gitea.DefaultStateLabelMappings()
+	preDispatch, diags := gitea.IssueStateFromLabels([]gitea.Label{{Name: "aiops/todo"}}, mappings)
+	if len(diags) != 0 {
+		t.Fatalf("IssueStateFromLabels(aiops/todo) diagnostics = %v, want none", diags)
+	}
+	merging, diags := gitea.IssueStateFromLabels([]gitea.Label{{Name: "aiops/merging"}}, mappings)
+	if len(diags) != 0 {
+		t.Fatalf("IssueStateFromLabels(aiops/merging) diagnostics = %v, want none", diags)
+	}
+
+	dependent := tracker.Issue{
+		ID:         "10",
+		Identifier: "#10",
+		Title:      "blocked while dependency lands",
+		State:      preDispatch,
+		BlockedBy:  []tracker.BlockerRef{{ID: "4", Identifier: "#4", State: merging}},
+	}
+	terminalStates := workflow.DefaultConfig().Tracker.TerminalStates
+	if out := filterEligibleCandidates([]tracker.Issue{dependent}, terminalStates, nil); len(out) != 0 {
+		t.Fatalf("filterEligibleCandidates(issue in %q blocked by %q, terminal=%v) = %d issues, want 0", preDispatch, merging, terminalStates, len(out))
 	}
 }

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -241,6 +242,8 @@ func (p giteaIssueLabelsProxy) validateDesiredStateLabels(call ToolCall) (desire
 		return nil, failureResult, failureErr, false
 	}
 	desiredStateLabels := make([]string, 0, len(call.Labels))
+	validLabels := validGiteaStateLabels()
+	validLabelList := strings.Join(validGiteaStateLabelNames(), ", ")
 	for _, label := range call.Labels {
 		label = strings.TrimSpace(label)
 		if label == "" || !strings.HasPrefix(strings.ToLower(label), "aiops/") {
@@ -249,9 +252,9 @@ func (p giteaIssueLabelsProxy) validateDesiredStateLabels(call ToolCall) (desire
 			})
 			return nil, failureResult, failureErr, false
 		}
-		if _, ok := validGiteaStateLabels()[strings.ToLower(label)]; !ok {
+		if _, ok := validLabels[strings.ToLower(label)]; !ok {
 			failureResult, failureErr = dynamicToolFailure(map[string]any{
-				"error": map[string]any{"message": "gitea_issue_labels label must be one of: aiops/canceled, aiops/done, aiops/human-review, aiops/in-progress, aiops/rework, aiops/todo"},
+				"error": map[string]any{"message": fmt.Sprintf("gitea_issue_labels label must be one of: %s", validLabelList)},
 			})
 			return nil, failureResult, failureErr, false
 		}
@@ -458,14 +461,25 @@ func (p giteaIssueLabelsProxy) decodeIssueLabelsFromToolResult(result, source st
 }
 
 func validGiteaStateLabels() map[string]struct{} {
-	return map[string]struct{}{
-		"aiops/canceled":     {},
-		"aiops/done":         {},
-		"aiops/human-review": {},
-		"aiops/in-progress":  {},
-		"aiops/rework":       {},
-		"aiops/todo":         {},
+	labels := validGiteaStateLabelNames()
+	out := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		out[label] = struct{}{}
 	}
+	return out
+}
+
+func validGiteaStateLabelNames() []string {
+	mappings := gitea.DefaultStateLabelMappings()
+	labels := make([]string, 0, len(mappings))
+	for _, mapping := range mappings {
+		label := strings.ToLower(strings.TrimSpace(mapping.Label))
+		if label != "" && !containsLabelFold(labels, label) {
+			labels = append(labels, label)
+		}
+	}
+	sort.Strings(labels)
+	return labels
 }
 
 func containsLabelFold(labels []string, label string) bool {

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -506,10 +506,53 @@ func TestGiteaIssueLabelsRejectsUnknownAIOpsStateLabelWithoutHTTPRequest(t *test
 
 	result, err := giteaIssueLabelsProxy{token: "token", baseURL: httpServer.URL, owner: "owner", repo: "repo", http: httpServer.Client()}.
 		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/inprogress"}})
-	assertStructuredFailure(t, result, err, "gitea_issue_labels label must be one of: aiops/canceled, aiops/done, aiops/human-review, aiops/in-progress, aiops/rework, aiops/todo")
+	assertStructuredFailure(t, result, err, "gitea_issue_labels label must be one of: aiops/canceled, aiops/done, aiops/human-review, aiops/in-progress, aiops/merging, aiops/rework, aiops/todo")
 	_, _, requests := server.recorded()
 	if requests != 0 {
 		t.Fatalf("server received %d requests, want 0", requests)
+	}
+}
+
+func TestGiteaIssueLabelsAcceptsMergingStateLabel(t *testing.T) {
+	server := &fakeGiteaLabelServer{}
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		server.mu.Lock()
+		server.requests++
+		server.methods = append(server.methods, r.Method)
+		server.paths = append(server.paths, r.URL.String())
+		server.bodies = append(server.bodies, string(body))
+		server.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/todo"},{"id":202,"name":"bug"}]`)
+		case http.MethodPost:
+			_, _ = io.WriteString(w, `{"labels":[{"name":"aiops/merging"}]}`)
+		case http.MethodDelete:
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer httpServer.Close()
+
+	result, err := giteaIssueLabelsProxy{token: "token", baseURL: httpServer.URL, owner: "owner", repo: "repo", http: httpServer.Client()}.
+		call(context.Background(), ToolCall{IssueNumber: 7, Labels: []string{"aiops/merging"}})
+	if err != nil {
+		t.Fatalf("gitea_issue_labels call: %v", err)
+	}
+	if !strings.Contains(result, `"success":true`) {
+		t.Fatalf("result = %q, want success", result)
+	}
+
+	methods, _, bodies := server.recordedSequence()
+	if strings.Join(methods, ",") != "GET,POST,DELETE" {
+		t.Fatalf("methods = %#v, want GET, POST desired label, DELETE stale label", methods)
+	}
+	if !strings.Contains(bodies[1], "aiops/merging") {
+		t.Fatalf("POST body = %s, want aiops/merging desired label", bodies[1])
 	}
 }
 


### PR DESCRIPTION
Closes #863

## Summary
- add the default Gitea lifecycle mapping `aiops/merging` -> `Merging` and derive the write allowlist from the mapping source of truth
- keep `Merging` non-terminal for dependency blocking, with tracker-client and orchestrator seam coverage
- make default Gitea reconciliation treat `Merging` as an inactive handoff state for non-landing workers, while filtering it out when a worker actively owns `Merging`
- document the upstream/SPEC placement of `Merging` and the slow-CI dedicated Merging-worker topology

## Acceptance criteria
- [x] `DefaultStateLabelMappings()` includes `aiops/merging` -> `Merging`
- [x] Gitea issue-label writes accept `aiops/merging`
- [x] `Depends on #N` dependents remain blocked while the blocker is `Merging`
- [x] default Gitea maker/reviewer reconciliation treats `Merging` as inactive, and landing workers with `active_states: [Merging]` do not cancel themselves
- [x] docs/examples describe where Merging sits relative to upstream/SPEC state handling and how slow CI should use a real Merging worker
- [x] mutation checks prove deleting either the state mapping row or worker default inactive `Merging` row fails tests

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Upstream evidence: `openai/symphony/elixir/WORKFLOW.md` lists `Merging` as an active workflow state for the land loop, while `openai/symphony/elixir/lib/symphony_elixir/config/schema.ex` keeps terminal states as the explicit tracker terminal set. This PR only teaches the Gitea adapter, reconciliation defaults, and docs about that existing state name; it does not add a worker-side merge phase.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — <=12 production files / <=300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,...`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go build ./cmd/worker ./cmd/tui`
- `go test ./cmd/worker -run 'TestWorkerReconciliationConfig(DoesNotProbeUnmappedGiteaInactiveStates|FiltersActiveGiteaMergingState)' -count=1`
- mutation check 1: temporarily deleting `{Label: "aiops/merging", State: "Merging"}` fails the Gitea state mapping tests, runner issue-label tests, tracker blocker test, and orchestrator non-terminal seam test; file restored and tree verified clean before push
- mutation check 2: temporarily deleting `Merging` from the Gitea default inactive candidates fails `TestWorkerReconciliationConfigDoesNotProbeUnmappedGiteaInactiveStates`; file restored and tree verified clean before push

## Review ledger
- Current head SHA: `e9a3d13ee76022205ebbb6b7b32a784e2b59784d`
- Codex reviewer before first push: spawn_agent `019eca90-fc15-7003-9073-754e683eee18` / Noether returned `MERGE-READY`
- Claude reviewer before first push: diff-only `claude -p` review returned `MERGE-READY`
- GitHub `@codex review` on `fa87239c8b` found P2 `Include Merging in Gitea inactive defaults`; fixed in current head
- Codex reviewer before second push: spawn_agent `019ecaa0-2b8d-7d52-837c-1b22ef2ebbee` / Planck returned `MERGE-READY`
- Claude reviewer before second push: diff-only `claude -p` review returned `MERGE-READY`
- Fresh GitHub `@codex review` on `e9a3d13ee7`: clean issue comment `Didn't find any major issues`; prior P2 thread replied and resolved
- CI on `e9a3d13ee7`: all checks passing (`Go build and test`, `E2E Gitea mock loop`, `Security and supply-chain`, `Docker image build`, `Validate PR metadata`, `Validate PR title`)

## Notes
- A full-gate run initially hit an unrelated `.trellis` 50ms hook-timeout test flake while another review process was running. The focused test file and full Trellis unittest suite passed on rerun, and the final non-concurrent full gates passed end to end.