### PR TITLE
fix(workspace): guard live worktree reclaim

### DIFF
--- a/docs/runbooks/reviewer-worker.md
+++ b/docs/runbooks/reviewer-worker.md
@@ -93,7 +93,10 @@ design:
   (`git worktree add --no-track -B <branch>`), and git refuses to check out
   a branch that another worktree of the same repository already has checked
   out. While the maker's worktree holds `ai/<issue.ID>`, the reviewer's
-  workspace preparation for that issue fails outright.
+  workspace preparation for that issue fails safely. The worker holds a
+  per-worktree ownership `flock` for the active run, so foreign-root reclaim
+  refuses to delete or branch-reset that live peer; it does **not** make the
+  shared-mirror topology supported.
 
 Set a distinct `AIOPS_MIRROR_ROOT` for each worker process. It costs one
 extra bare clone on disk and removes both the branch-namespace collision

--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -128,6 +128,12 @@ Operational notes:
 - The lock is **host-scoped**. Two workers must run on the same OS
   instance for the lock to mediate them; cross-host concurrency is not
   supported, because `flock(2)` is a per-kernel primitive.
+- The mirror lock only serializes mirror operations. During an active agent
+  run, the worker also holds a per-worktree ownership `flock` in that worktree's
+  git-admin directory so stale foreign-root reclaim fails safely when another
+  process is still using the old worktree. That guard protects against deletion;
+  it does not make shared `AIOPS_MIRROR_ROOT` maker/reviewer topologies
+  supported.
 - **NFS mirror roots are unsupported.** `flock(2)` on NFS is silently
   best-effort on Linux (depends on `lockd` being healthy) and not
   honoured on macOS. Use a local filesystem.

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -157,6 +157,7 @@ type runState struct {
 	hooks          workflow.WorkspaceHooks
 	workspaceRoot  string
 	workdir        string
+	releaseWorkdir func()
 	prompt         string
 	res            runner.Result
 	sessionID      string
@@ -203,6 +204,7 @@ func RunTaskWithResult(ctx context.Context, ev EventEmitter, t task.Task, cfg Co
 	if rtErr := rs.prepareWorkspace(); rtErr != nil {
 		return result, rtErr
 	}
+	defer rs.releaseWorkspaceOwnership()
 	if rtErr := rs.buildPrompt(); rtErr != nil {
 		return result, rtErr
 	}
@@ -230,24 +232,34 @@ func (rs *runState) prepareWorkspace() *RunTaskError {
 	rs.workspaceRoot = EffectiveWorkspaceRoot(rs.cfg, rs.wcfg)
 	mgr := workspace.New(rs.workspaceRoot)
 	mgr.MirrorRoot = rs.cfg.MirrorRoot
-	workdir, createdNow, err := mgr.PrepareGitWorkspace(rs.ctx, rs.t)
+	prepared, err := mgr.PrepareGitWorkspaceOwned(rs.ctx, rs.t)
 	if err != nil {
 		return &RunTaskError{Cfg: rs.wcfg, Err: err}
 	}
-	rs.workdir = workdir
-	if createdNow {
+	rs.workdir = prepared.Workdir
+	rs.releaseWorkdir = prepared.Release
+	if prepared.CreatedNow {
 		// SPEC §9.4: after_create runs only when a workspace directory
 		// is newly created. Reuses skip it so bootstrap commands
 		// (`npm ci`, `pip install`, …) remain the one-time init they're
 		// documented as.
-		if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, workdir, workspace.HookAfterCreate, rs.hooks.AfterCreate, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
-			removeWorkdirAfterHookFailure(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workspaceRoot, workdir, rs.hooks.BeforeRemove, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough, "after_create")
+		if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterCreate, rs.hooks.AfterCreate, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
+			removeWorkdirAfterHookFailure(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workspaceRoot, rs.workdir, rs.hooks.BeforeRemove, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough, "after_create")
+			rs.releaseWorkspaceOwnership()
 			return &RunTaskError{Cfg: rs.wcfg, Err: err}
 		}
 	}
 
 	rs.applyDefaultModel()
 	return nil
+}
+
+func (rs *runState) releaseWorkspaceOwnership() {
+	if rs.releaseWorkdir == nil {
+		return
+	}
+	rs.releaseWorkdir()
+	rs.releaseWorkdir = nil
 }
 
 // applyDefaultModel resolves the task model from the workflow default when the

--- a/internal/worker/worktree_ownership_test.go
+++ b/internal/worker/worktree_ownership_test.go
@@ -1,0 +1,138 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
+)
+
+type blockingOwnershipRunner struct {
+	started chan runner.RunInput
+	release chan struct{}
+}
+
+func (b blockingOwnershipRunner) Run(ctx context.Context, in runner.RunInput) (runner.Result, error) {
+	b.started <- in
+	select {
+	case <-b.release:
+		return runner.Result{Summary: "ok"}, nil
+	case <-ctx.Done():
+		return runner.Result{}, ctx.Err()
+	}
+}
+
+func TestRunTaskHoldsWorktreeOwnershipDuringRunner(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree ownership uses flock on Unix")
+	}
+	cloneURL := initOwnershipBareUpstream(t)
+	tk := task.Task{
+		ID:            "871",
+		Title:         "ownership",
+		Description:   "hold worktree ownership",
+		Actor:         "tester",
+		Model:         "blocking-owner",
+		RepoOwner:     "acme",
+		RepoName:      "demo",
+		CloneURL:      cloneURL,
+		BaseBranch:    "main",
+		WorkBranch:    "ai/871",
+		SourceType:    "linear_issue",
+		SourceEventID: "871",
+	}
+	wf := &workflow.Workflow{Config: workflow.DefaultConfig()}
+	wf.PromptTemplate = "do {{ task.title }}"
+	wf.Config.Agent.Default = "blocking-owner"
+
+	rootA := t.TempDir()
+	mirrorRoot := t.TempDir()
+	started := make(chan runner.RunInput, 1)
+	release := make(chan struct{})
+	oldNewRunner := newRunner
+	newRunner = func(string) (runner.Runner, error) {
+		return blockingOwnershipRunner{started: started, release: release}, nil
+	}
+	t.Cleanup(func() { newRunner = oldNewRunner })
+
+	errCh := make(chan *RunTaskError, 1)
+	go func() {
+		errCh <- RunTask(context.Background(), &fakeEmitter{}, tk, Config{
+			WorkspaceRoot: rootA,
+			MirrorRoot:    mirrorRoot,
+			Workflow:      wf,
+		})
+	}()
+
+	runInput := <-started
+	marker := filepath.Join(runInput.Workdir, "live-run-marker.txt")
+	if err := os.WriteFile(marker, []byte("live\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rootB := t.TempDir()
+	mgrB := workspace.New(rootB)
+	mgrB.MirrorRoot = mirrorRoot
+	if _, _, err := mgrB.PrepareGitWorkspace(context.Background(), tk); err == nil {
+		t.Fatal("foreign-root prepare succeeded while RunTask runner still held the worktree ownership lock")
+	}
+	if body, err := os.ReadFile(marker); err != nil {
+		t.Fatalf("active runner worktree deleted by reclaim: %v", err)
+	} else if string(body) != "live\n" {
+		t.Fatalf("active runner marker mutated by reclaim: %q", body)
+	}
+
+	close(release)
+	if rterr := <-errCh; rterr != nil {
+		t.Fatalf("RunTask returned error: %v", rterr.Err)
+	}
+	if _, _, err := mgrB.PrepareGitWorkspace(context.Background(), tk); err != nil {
+		t.Fatalf("foreign-root prepare after RunTask released ownership: %v", err)
+	}
+}
+
+func initOwnershipBareUpstream(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	work := filepath.Join(root, "work")
+	bare := filepath.Join(root, "upstream.git")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "init", "-q", "-b", "main", work},
+		{"git", "-C", work, "config", "user.email", "u@example.com"},
+		{"git", "-C", work, "config", "user.name", "u"},
+		{"git", "-C", work, "config", "commit.gpgsign", "false"},
+		{"git", "-C", work, "config", "tag.gpgsign", "false"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", work, "add", "."},
+		{"git", "-C", work, "commit", "-q", "-m", "seed"},
+		{"git", "init", "--bare", "-q", "-b", "main", bare},
+		{"git", "-C", work, "remote", "add", "origin", bare},
+		{"git", "-C", work, "push", "-q", "origin", "main"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	return "file://" + bare
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -174,34 +174,51 @@ func issueWorkspaceKey(t task.Task) string {
 //     (cached deps, build outputs) survive across
 //     runs.
 func (m *Manager) PrepareGitWorkspace(ctx context.Context, t task.Task) (string, bool, error) {
+	prepared, err := m.PrepareGitWorkspaceOwned(ctx, t)
+	if err != nil {
+		return "", false, err
+	}
+	prepared.Release()
+	return prepared.Workdir, prepared.CreatedNow, nil
+}
+
+// PrepareGitWorkspaceOwned is PrepareGitWorkspace plus a held per-worktree
+// ownership lease. Callers that run an agent in the worktree must hold the
+// lease until the run exits so foreign-root reclaim can fail safely when a
+// shared mirror observes a live peer worktree.
+func (m *Manager) PrepareGitWorkspaceOwned(ctx context.Context, t task.Task) (PreparedGitWorkspace, error) {
 	workdir := m.PathFor(t)
 	if err := os.MkdirAll(filepath.Dir(workdir), 0o755); err != nil {
-		return "", false, err
+		return PreparedGitWorkspace{}, err
 	}
 	info, statErr := os.Stat(workdir)
 	if statErr != nil && !os.IsNotExist(statErr) {
-		return "", false, statErr
+		return PreparedGitWorkspace{}, statErr
 	}
 	workdirExists := statErr == nil && info.IsDir()
 
 	mirror := mirrorPathFor(MirrorRoot(m.MirrorRoot), t.CloneURL)
 	unlock, err := acquireMirrorLock(mirror)
 	if err != nil {
-		return "", false, err
+		return PreparedGitWorkspace{}, err
 	}
 	defer unlock()
 
 	mirror, err = m.ensureMirrorLocked(ctx, t.CloneURL, mirror)
 	if err != nil {
-		return "", false, err
+		return PreparedGitWorkspace{}, err
 	}
 	startRef := resolveStartRef(ctx, mirror, t.BaseBranch)
 
 	createdNow, err := attachWorktree(ctx, m.Root, workdir, mirror, t.WorkBranch, startRef, workdirExists)
 	if err != nil {
-		return "", false, err
+		return PreparedGitWorkspace{}, err
 	}
-	return workdir, createdNow, nil
+	release, err := acquireWorktreeOwnership(ctx, workdir)
+	if err != nil {
+		return PreparedGitWorkspace{}, err
+	}
+	return PreparedGitWorkspace{Workdir: workdir, CreatedNow: createdNow, release: release}, nil
 }
 
 // attachWorktree reuses the existing workdir when it is a valid, mirror-linked
@@ -361,9 +378,10 @@ func createWorktree(ctx context.Context, root, workdir, mirror, workBranch, star
 // AIOPS_MIRROR_ROOT per worker is a hard requirement (docs/runbooks/reviewer-worker.md),
 // so a foreign-root registration in *our* mirror can only be our own stale one.
 // In the explicitly-unsupported shared-AIOPS_MIRROR_ROOT-with-different-root
-// config, reclaim could delete a concurrent peer's worktree; robust ownership
-// for that misconfiguration is tracked in #871 (a bare-PID guard is unreliable —
-// container workers are PID 1 on every restart).
+// config, a live peer worktree is protected by its held ownership lock; reclaim
+// then fails safely on the later worktree-add collision instead of deleting or
+// branch-resetting that peer. A bare-PID guard is intentionally not used:
+// container workers are PID 1 on every restart.
 func reclaimForeignBranchWorktree(ctx context.Context, root, workdir, mirror, workBranch string) {
 	holder := worktreePathForBranch(ctx, mirror, workBranch)
 	if holder == "" || !isForeignRootHolder(root, workdir, holder) {
@@ -377,6 +395,9 @@ func reclaimForeignBranchWorktree(ctx context.Context, root, workdir, mirror, wo
 	// collision surface instead (classifyExistingWorkdir also rejects a symlinked
 	// or foreign-mirror path, as on the reuse gate).
 	if reusable, _ := classifyExistingWorkdir(ctx, holder, mirror); !reusable {
+		return
+	}
+	if worktreeOwnershipLockHeld(ctx, holder) {
 		return
 	}
 	// `worktree remove --force` drops the registration and the stale dir; the

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -1213,6 +1213,85 @@ func TestPrepareGitWorkspace_ReclaimsBranchAfterWorkspaceRootChange(t *testing.T
 	}
 }
 
+func TestPrepareGitWorkspace_ReclaimRefusesLiveOwnedForeignRootWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree ownership uses flock on Unix")
+	}
+	upstream := initBareUpstream(t)
+	mirrorRoot := t.TempDir()
+	ctx := context.Background()
+	tk := makeTask("2", upstream)
+
+	rootA := t.TempDir()
+	mgrA := &Manager{Root: rootA, MirrorRoot: mirrorRoot}
+	ownedA, err := mgrA.PrepareGitWorkspaceOwned(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare owned at root A: %v", err)
+	}
+	defer ownedA.Release()
+	marker := filepath.Join(ownedA.Workdir, "live-peer-marker.txt")
+	if err := os.WriteFile(marker, []byte("live\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rootB := t.TempDir()
+	mgrB := &Manager{Root: rootB, MirrorRoot: mirrorRoot}
+	if _, _, err := mgrB.PrepareGitWorkspace(ctx, tk); err == nil {
+		t.Fatal("prepare same branch at new root succeeded while the foreign-root owner lock was held; reclaim must fail safely")
+	}
+	if body, err := os.ReadFile(marker); err != nil {
+		t.Fatalf("live peer worktree deleted by reclaim: %v", err)
+	} else if string(body) != "live\n" {
+		t.Fatalf("live peer marker mutated by reclaim: %q", body)
+	}
+
+	mirror := mirrorPathFor(MirrorRoot(mirrorRoot), upstream)
+	holder := worktreePathForBranch(ctx, mirror, tk.WorkBranch)
+	holderReal, err := filepath.EvalSymlinks(holder)
+	if err != nil {
+		t.Fatalf("eval holder %q: %v", holder, err)
+	}
+	ownedReal, err := filepath.EvalSymlinks(ownedA.Workdir)
+	if err != nil {
+		t.Fatalf("eval owned workdir %q: %v", ownedA.Workdir, err)
+	}
+	if holderReal != ownedReal {
+		t.Fatalf("live ai/2 registration moved: holder=%q (real %q), want %q (real %q)", holder, holderReal, ownedA.Workdir, ownedReal)
+	}
+}
+
+func TestPrepareGitWorkspace_ReclaimsReleasedOwnedWorktreeAfterRootChange(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree ownership uses flock on Unix")
+	}
+	upstream := initBareUpstream(t)
+	mirrorRoot := t.TempDir()
+	ctx := context.Background()
+	tk := makeTask("2", upstream)
+
+	rootA := t.TempDir()
+	mgrA := &Manager{Root: rootA, MirrorRoot: mirrorRoot}
+	ownedA, err := mgrA.PrepareGitWorkspaceOwned(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare owned at root A: %v", err)
+	}
+	oldDir := ownedA.Workdir
+	ownedA.Release()
+
+	rootB := t.TempDir()
+	mgrB := &Manager{Root: rootB, MirrorRoot: mirrorRoot}
+	dirB, createdNow, err := mgrB.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare same issue at new root after owner release: %v", err)
+	}
+	if !createdNow {
+		t.Fatal("prepare after owner release reported createdNow=false")
+	}
+	if dirB == oldDir {
+		t.Fatalf("root B workdir collapsed onto old path %q", oldDir)
+	}
+}
+
 // TestPrepareGitWorkspace_ReclaimLeavesPeerBranchWorktreeIntact pins the #854
 // safety contract (acceptance criterion 4): reclaiming a stale foreign-root
 // registration must be branch-scoped — it may drop only the EXACT colliding

--- a/internal/workspace/ownership_lock.go
+++ b/internal/workspace/ownership_lock.go
@@ -1,0 +1,74 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ErrWorktreeOwnershipLockHeld reports that a live process currently owns the
+// worktree. It is returned only by non-blocking lock probes.
+var ErrWorktreeOwnershipLockHeld = errors.New("worktree ownership lock held")
+
+const worktreeOwnershipLockName = "aiops-owner.lock"
+
+// PreparedGitWorkspace is a prepared git worktree plus the ownership lease that
+// protects it from foreign-root reclaim while an agent run is active.
+type PreparedGitWorkspace struct {
+	Workdir    string
+	CreatedNow bool
+
+	release func()
+}
+
+// Release drops the ownership lease. It is idempotent so callers can safely
+// defer it immediately after a successful prepare.
+func (p *PreparedGitWorkspace) Release() {
+	if p == nil || p.release == nil {
+		return
+	}
+	p.release()
+	p.release = nil
+}
+
+func acquireWorktreeOwnership(ctx context.Context, workdir string) (func(), error) {
+	lockPath, err := worktreeOwnershipLockPath(ctx, workdir)
+	if err != nil {
+		return nil, err
+	}
+	release, err := acquireWorktreeOwnershipFileLock(lockPath, false)
+	if err != nil {
+		return nil, err
+	}
+	return release, nil
+}
+
+func worktreeOwnershipLockHeld(ctx context.Context, workdir string) bool {
+	lockPath, err := worktreeOwnershipLockPath(ctx, workdir)
+	if err != nil {
+		return true
+	}
+	release, err := acquireWorktreeOwnershipFileLock(lockPath, true)
+	if err == nil {
+		release()
+		return false
+	}
+	return true
+}
+
+func worktreeOwnershipLockPath(ctx context.Context, workdir string) (string, error) {
+	out, err := runGitOutput(ctx, workdir, "rev-parse", "--git-dir")
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree git dir: %w", err)
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if gitDir == "" {
+		return "", errors.New("resolve worktree git dir: empty path")
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(workdir, gitDir)
+	}
+	return filepath.Join(gitDir, worktreeOwnershipLockName), nil
+}

--- a/internal/workspace/ownership_lock_unix.go
+++ b/internal/workspace/ownership_lock_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func acquireWorktreeOwnershipFileLock(lockPath string, nonblock bool) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir worktree ownership lock parent: %w", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open worktree ownership lock %s: %w", lockPath, err)
+	}
+	flags := syscall.LOCK_EX
+	if nonblock {
+		flags |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(f.Fd()), flags); err != nil {
+		_ = f.Close()
+		if nonblock && (errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)) {
+			return nil, ErrWorktreeOwnershipLockHeld
+		}
+		return nil, fmt.Errorf("flock worktree ownership %s: %w", lockPath, err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/workspace/ownership_lock_windows.go
+++ b/internal/workspace/ownership_lock_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package workspace
+
+func acquireWorktreeOwnershipFileLock(lockPath string, nonblock bool) (func(), error) {
+	return func() {}, nil
+}


### PR DESCRIPTION
Closes #871

## Summary
- Add a held per-worktree ownership lock so foreign-root reclaim refuses a live peer before removing the worktree or resetting the branch.
- Hold the ownership lease across the worker runner lifetime and release it on all RunTask return paths, including after_create hook failure.
- Preserve #854 recovery after a workspace.root change once the old owner releases or exits, and clarify that shared maker/reviewer mirror topology remains unsupported.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional local validation:
- `git status --short` clean before push and after rebase.
- `go mod tidy` plus `git diff --exit-code -- go.mod go.sum`.
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`.
- `go build ./cmd/worker ./cmd/tui`.
- Targeted regression tests: `go test ./internal/workspace ./internal/worker -run 'TestPrepareGitWorkspace_Reclaim(RefusesLiveOwnedForeignRootWorktree|ReclaimsReleasedOwnedWorktreeAfterRootChange|sBranchAfterWorkspaceRootChange)|TestRunTaskHoldsWorktreeOwnershipDuringRunner' -count=1`.
- Package sweep: `go test ./internal/workspace ./internal/worker -count=1`.
- After GitHub reported the branch behind, rebased onto `origin/main` `e665974f35d1dec416d90d863ab5b42d56c0f572`, force-with-lease pushed final head `0cacc4856670fd500823f5ce89194202fd8fbdfb`, and reran the full local gate successfully.

Remote validation:
- GitHub checks on final head `0cacc4856670fd500823f5ce89194202fd8fbdfb`: Go build and test, E2E Gitea mock loop, Security and supply-chain, Docker image build, PR Metadata, and PR Title Lint all passed.
- GraphQL review thread check returned no review threads.

Mutation verification:
- Removed the `worktreeOwnershipLockHeld(ctx, holder)` reclaim guard from `internal/workspace/manager.go` and confirmed `TestPrepareGitWorkspace_ReclaimRefusesLiveOwnedForeignRootWorktree` plus `TestRunTaskHoldsWorktreeOwnershipDuringRunner` fail because a foreign-root prepare succeeds while the live owner lock is held.
- Restored the guard and reran the same targeted tests successfully.

Review ledger:
- Codex spawn_agent `019ecab4-bd11-7d40-938b-bd21aad79bc9` / Archimedes: `MERGE-READY`; also ran `git diff --check`, targeted tests, `go test -race ./internal/workspace ./internal/worker`, and `go test -race ./...`.
- Claude CLI read-only review: `MERGE-READY`; checked held flock reclaim safety, released/dead owner recovery, RunTask lease lifetime, docs scope, and production-wiring tests.
- GitHub `@codex review`: first attempt hit usage limits before the rebase; second attempt reviewed commit `0cacc48566` and reported no major issues.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
