### PR TITLE
refactor(workspace): split sensitive artifact exclude setup

### DIFF
--- a/docs/audits/2026-06-07-baseline-521-nolint-risk-ranking.md
+++ b/docs/audits/2026-06-07-baseline-521-nolint-risk-ranking.md
@@ -89,7 +89,7 @@ Read in full; tier and decomposability are grounded in the code, not the name.
 |----------|-----------|------|-----------|------|
 | `SafeRemove` | `safe_remove.go:36` | critical | borderline | Gates `os.RemoveAll` behind containment + post-symlink re-check (§9.5/§15.2). Containment is **already** extracted to `assertContained`; the remainder is a cohesive feed-forward sequence. At most a small `resolveRootForCompare` extract for the macOS `/var` symlink edge. |
 | `WriteSensitiveArtifact` | `artifacts.go:45` | critical | cosmetic-only | TOCTOU/symlink/hardlink-resistant secret write (`O_NOFOLLOW`, pre/post hardlink recount, 0600). Ordering is load-bearing; splitting breaks the open-handle continuity that defeats the race. Keep cohesive. |
-| `EnsureSensitiveArtifactExcludes` | `artifacts.go:114` | high | **genuine** | Two independent jobs behind one name: (1) `info/exclude` append, (2) pre-commit hook install (`core.hooksPath`). Extract `ensureSensitiveArtifactExcludeFile` + `installSensitiveArtifactHook`; each drops below budget and isolates the subtle append/newline + git-config error paths. |
+| `EnsureSensitiveArtifactExcludes` | `artifacts.go:114` | high | **closed by #882** | Two independent jobs behind one name: (1) `info/exclude` append, (2) pre-commit hook install (`core.hooksPath`). #882 extracted `ensureSensitiveArtifactExcludeFile` + `installSensitiveArtifactHook`, removing the baseline while preserving the append/newline + git-config behavior. |
 | `reworkWorkspaceKeyPrefixes`, `workspaceKeysForRawIssueKeys`, `sanitizeLegacyWorkspaceKey` | `reconcile.go:454/517/543` | medium | (not individually read) | Compute the keys that drive reconcile keep/remove decisions (feed `SafeRemove`); cohesive sanitizer/matcher logic. `reworkWorkspaceKeyPrefixes` was just simplified under #679 but is still gocognit 13. |
 
 ### Cluster D — runner lifecycle
@@ -126,7 +126,7 @@ Each is its own behavior-preserving, characterization-test-first PR (see
    external-process exit taxonomy that feeds the reconcile-cancel race
    #543/#557; dual `gocognit,funlen`). Decision-table unit tests for
    stall/timeout/reconcile-cancel/failure/success.
-4. **`artifacts.go:EnsureSensitiveArtifactExcludes` → `ensureSensitiveArtifactExcludeFile` + `installSensitiveArtifactHook`** (high; secret-leak guard; two genuinely independent jobs).
+4. **Done in #882:** `artifacts.go:EnsureSensitiveArtifactExcludes` → `ensureSensitiveArtifactExcludeFile` + `installSensitiveArtifactHook` (high; secret-leak guard; two genuinely independent jobs).
 5. **`sandbox.go:sandboxEnv` → extract `carryWorkerInjectedGoCache`** (high;
    isolates the #548 "only worker-injected GOCACHE passes" leak rule for direct
    testing).

--- a/internal/workspace/artifacts.go
+++ b/internal/workspace/artifacts.go
@@ -92,7 +92,14 @@ func linkCount(info os.FileInfo) (uint64, bool) {
 	return uint64(st.Nlink), true
 }
 
-func EnsureSensitiveArtifactExcludes(ctx context.Context, workdir string) error { //nolint:gocognit // baseline (#521)
+func EnsureSensitiveArtifactExcludes(ctx context.Context, workdir string) error {
+	if err := ensureSensitiveArtifactExcludeFile(ctx, workdir); err != nil {
+		return err
+	}
+	return installSensitiveArtifactHook(ctx, workdir)
+}
+
+func ensureSensitiveArtifactExcludeFile(ctx context.Context, workdir string) error {
 	excludePath, err := gitPath(ctx, workdir, "info/exclude")
 	if err != nil {
 		return err
@@ -104,6 +111,14 @@ func EnsureSensitiveArtifactExcludes(ctx context.Context, workdir string) error 
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	add := missingSensitiveArtifactExcludes(existing)
+	if len(add) > 0 {
+		return appendSensitiveArtifactExcludes(excludePath, existing, add)
+	}
+	return nil
+}
+
+func missingSensitiveArtifactExcludes(existing []byte) []string {
 	seen := map[string]struct{}{}
 	for _, line := range strings.Split(string(existing), "\n") {
 		seen[strings.TrimSpace(line)] = struct{}{}
@@ -114,30 +129,36 @@ func EnsureSensitiveArtifactExcludes(ctx context.Context, workdir string) error 
 			add = append(add, rel)
 		}
 	}
-	if len(add) > 0 {
-		f, err := os.OpenFile(excludePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-		if err != nil {
+	return add
+}
+
+func appendSensitiveArtifactExcludes(excludePath string, existing []byte, add []string) error {
+	f, err := os.OpenFile(excludePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	closeFile := true
+	defer func() {
+		if closeFile {
+			_ = f.Close()
+		}
+	}()
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		if _, err := f.WriteString("\n"); err != nil {
 			return err
-		}
-		closeFile := true
-		defer func() {
-			if closeFile {
-				_ = f.Close()
-			}
-		}()
-		if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
-			if _, err := f.WriteString("\n"); err != nil {
-				return err
-			}
-		}
-		if _, err := f.WriteString(strings.Join(add, "\n") + "\n"); err != nil {
-			return err
-		}
-		closeFile = false
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("close git exclude %s: %w", excludePath, err)
 		}
 	}
+	if _, err := f.WriteString(strings.Join(add, "\n") + "\n"); err != nil {
+		return err
+	}
+	closeFile = false
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close git exclude %s: %w", excludePath, err)
+	}
+	return nil
+}
+
+func installSensitiveArtifactHook(ctx context.Context, workdir string) error {
 	out, err := runGitOutput(ctx, workdir, "rev-parse", "--absolute-git-dir")
 	if err != nil {
 		return fmt.Errorf("resolve worktree git dir: %w", err)

--- a/internal/workspace/artifacts_test.go
+++ b/internal/workspace/artifacts_test.go
@@ -1,0 +1,50 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureSensitiveArtifactExcludeFileAppendsMissingPatternsOnce(t *testing.T) {
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "-C", repo, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	if err := os.WriteFile(excludePath, []byte("existing-pattern"), 0o644); err != nil {
+		t.Fatalf("write existing exclude: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := ensureSensitiveArtifactExcludeFile(ctx, repo); err != nil {
+		t.Fatalf("ensureSensitiveArtifactExcludeFile first run: %v", err)
+	}
+	first, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude after first run: %v", err)
+	}
+	text := string(first)
+	if !strings.HasPrefix(text, "existing-pattern\n") {
+		t.Fatalf("exclude prefix = %q; want existing pattern followed by newline", text)
+	}
+	for _, rel := range sensitiveArtifactExcludePatterns {
+		if got := strings.Count(text, rel); got != 1 {
+			t.Fatalf("strings.Count(exclude, %q) = %d; want 1\n%s", rel, got, text)
+		}
+	}
+
+	if err := ensureSensitiveArtifactExcludeFile(ctx, repo); err != nil {
+		t.Fatalf("ensureSensitiveArtifactExcludeFile second run: %v", err)
+	}
+	second, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude after second run: %v", err)
+	}
+	if string(second) != text {
+		t.Fatalf("second ensure changed exclude:\nfirst=%q\nsecond=%q", text, string(second))
+	}
+}


### PR DESCRIPTION
Closes #882

## Summary
- Split `EnsureSensitiveArtifactExcludes` into focused helpers for `info/exclude` maintenance and pre-commit hook installation, removing the `baseline (#521)` nolint from the high-risk function without changing behavior.
- Added characterization coverage for missing-pattern append, newline preservation, and idempotence.
- Updated the #521 baseline risk audit to mark this slice closed by #882.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This is a behavior-preserving workspace helper refactor. SPEC/upstream research found workspace path and hook mechanics, but no upstream equivalent for this repo-specific `.aiops` sensitive-artifact exclusion guard; this PR does not add a new phase, gate, artifact type, or config surface.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — 3 changed files, production diff is 42 added / 21 deleted LOC in `internal/workspace/artifacts.go` plus docs/test coverage.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `go test -count=1 ./internal/workspace -run 'TestEnsureSensitiveArtifactExcludeFileAppendsMissingPatternsOnce|TestPrepareGitWorkspaceProtectsSensitiveAiopsArtifacts'`

## Review Ledger
- Head SHA: `192b63a456cd0e0609e019e462cbc802c3e61269`
- Base: `main` at `8b0ea717bd4f5bee226194758ffa928db3d9ff01`
- Mutation check: changed `missingSensitiveArtifactExcludes` from missing-pattern append to seen-pattern append; `go test -count=1 ./internal/workspace -run '^TestEnsureSensitiveArtifactExcludeFileAppendsMissingPatternsOnce$'` failed on the newline/pattern assertion, then passed after restoring.
- Subagent routing: `tool_search` found `multi_agent_v1.spawn_agent`, but the tool contract requires explicit user authorization for subagent delegation; no subagent was spawned. CLI fallback used per `docs/runbooks/pr-review-merge-protocol.md`.
- Claude-family local review: `claude -p` structured JSON returned `{"blocking_findings":[]}`.
- Codex-family local review: `codex exec --output-schema` returned `{"blocking_findings":[]}`.
- GitHub `@codex review`: triggered by `bytevane` in comment `4713597209`; Codex clean comment `4713610150` says it did not find major issues for reviewed commit `192b63a456`.
- Review threads: GraphQL `reviewThreads` unresolved + non-outdated query returned `[]`.
- CI/checks: `gh pr checks --watch --fail-fast` passed all checks: Docker image build, E2E Gitea mock loop, Go build and test, Security and supply-chain, Validate PR metadata, Validate PR title.
