### PR TITLE
refactor(runner): split linear graphql mutation gate

### DIFF
--- a/internal/runner/linear_graphql_proxy.go
+++ b/internal/runner/linear_graphql_proxy.go
@@ -38,12 +38,19 @@ type linearGraphQLProxy struct {
 	currentIssueGuard currentIssueMutationGuard
 }
 
+type linearGraphQLAuthorization struct {
+	currentIssueHandoff currentIssueHandoffClassification
+	rejected            bool
+	result              string
+	err                 error
+}
+
 // call is the gated entry point exposed to the agent through the
 // linear_graphql dynamic tool. It parses the operation kind/name,
 // applies the SPEC §15.5 narrowing, fires the optional audit sink, and
 // otherwise delegates to callRaw. Subscription operations are rejected
 // unconditionally because the runner has no streaming surface for them.
-func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, error) { //nolint:gocognit // baseline (#521)
+func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, error) {
 	query := strings.TrimSpace(call.Query)
 	if query == "" {
 		return dynamicToolFailure(map[string]any{
@@ -59,6 +66,19 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 			},
 		})
 	}
+	op := parseLinearGraphQLOperation(query)
+	authorization := p.authorizeMutation(ctx, query, op, call.Variables)
+	if authorization.rejected {
+		return authorization.result, authorization.err
+	}
+	if authorization.currentIssueHandoff.nonActive {
+		ctx = withLinearGraphQLCurrentIssueHandoff(ctx, authorization.currentIssueHandoff)
+	}
+
+	return p.dispatch(ctx, query, op, call.Variables)
+}
+
+func (p linearGraphQLProxy) authorizeMutation(ctx context.Context, query string, op linearGraphQLOperation, variables map[string]any) linearGraphQLAuthorization {
 	// The gate keys on the GraphQL operation keyword (`query` /
 	// `mutation` / `subscription`), not on the selected root field's
 	// type. `query Q { issueDelete(id: "1") { success } }` therefore
@@ -67,74 +87,79 @@ func (p linearGraphQLProxy) call(ctx context.Context, call ToolCall) (string, er
 	// field, so the destructive operation is never executed. Maintaining
 	// a client-side denylist of Linear mutation field names would drift
 	// every time Linear adds a mutation; we rely on Linear's type system
-	// for that defense layer instead. The Authorization header still
-	// carries the workspace token on the rejected request, which is
-	// broadly comparable to the surface ordinary read queries already
-	// expose — but two soft signals differ: Linear records the rejected
-	// request in its server-side audit log (an attempted-write signal
-	// for operators watching Linear directly), and repeated rejections
-	// could plausibly contribute to Linear-side rate limiting on the
-	// token. Neither alters the destructive-operation guarantee.
-	op := parseLinearGraphQLOperation(query)
+	// for that defense layer instead. The rejected request still carries
+	// the workspace token to Linear, which can leave a Linear-side audit
+	// trace or contribute to Linear-side rate limits, but neither signal
+	// alters the destructive-operation guarantee.
 	switch op.Kind {
 	case linearGraphQLOperationSubscription:
-		return dynamicToolFailure(map[string]any{
+		return rejectLinearGraphQLOperation(map[string]any{
 			"error": map[string]any{
 				"message": "linear_graphql does not accept subscription operations; submit a query or mutation instead",
 			},
 		})
 	case linearGraphQLOperationMutation:
-		if !p.allowMutations {
-			return dynamicToolFailure(map[string]any{
+		return p.authorizeMutationOperation(ctx, query, op, variables)
+	}
+	return linearGraphQLAuthorization{}
+}
+
+func (p linearGraphQLProxy) authorizeMutationOperation(ctx context.Context, query string, op linearGraphQLOperation, variables map[string]any) linearGraphQLAuthorization {
+	if !p.allowMutations {
+		return rejectLinearGraphQLOperation(map[string]any{
+			"error": map[string]any{
+				"message":          "linear_graphql mutations are disabled by this workflow; set codex.linear_graphql.allow_mutations: true in WORKFLOW.md to opt in (SPEC §15.5)",
+				"operation":        string(op.Kind),
+				"operation_field":  op.FieldName,
+				"workflow_setting": "codex.linear_graphql.allow_mutations",
+			},
+		})
+	}
+	if len(p.allowedMutations) > 0 {
+		if op.FieldName == "" {
+			return rejectLinearGraphQLOperation(map[string]any{
 				"error": map[string]any{
-					"message":          "linear_graphql mutations are disabled by this workflow; set codex.linear_graphql.allow_mutations: true in WORKFLOW.md to opt in (SPEC §15.5)",
-					"operation":        string(op.Kind),
+					"message":          "linear_graphql could not identify the top-level mutation field; rewrite the mutation so its selection set starts with a single Mutation root field",
+					"workflow_setting": "codex.linear_graphql.allowed_mutations",
+				},
+			})
+		}
+		if _, ok := p.allowedMutations[op.FieldName]; !ok {
+			return rejectLinearGraphQLOperation(map[string]any{
+				"error": map[string]any{
+					"message":          "linear_graphql mutation is not in the workflow's allowed_mutations list",
 					"operation_field":  op.FieldName,
-					"workflow_setting": "codex.linear_graphql.allow_mutations",
+					"workflow_setting": "codex.linear_graphql.allowed_mutations",
 				},
 			})
-		}
-		if len(p.allowedMutations) > 0 {
-			if op.FieldName == "" {
-				return dynamicToolFailure(map[string]any{
-					"error": map[string]any{
-						"message":          "linear_graphql could not identify the top-level mutation field; rewrite the mutation so its selection set starts with a single Mutation root field",
-						"workflow_setting": "codex.linear_graphql.allowed_mutations",
-					},
-				})
-			}
-			if _, ok := p.allowedMutations[op.FieldName]; !ok {
-				return dynamicToolFailure(map[string]any{
-					"error": map[string]any{
-						"message":          "linear_graphql mutation is not in the workflow's allowed_mutations list",
-						"operation_field":  op.FieldName,
-						"workflow_setting": "codex.linear_graphql.allowed_mutations",
-					},
-				})
-			}
-		}
-		rejection, reject, currentIssueHandoff := p.checkCurrentIssueUpdate(ctx, query, call.Variables)
-		if reject {
-			if sink := linearGraphQLMutationRejectedSinkFrom(ctx); sink != nil {
-				sink(rejection)
-			}
-			return dynamicToolFailure(map[string]any{
-				"error": map[string]any{
-					"message":         currentIssueMutationRejectMessage(rejection.Reason),
-					"operation_field": rejection.OperationField,
-					"reason":          rejection.Reason,
-					"found":           rejection.Found,
-					"state":           rejection.State,
-					"terminal":        rejection.Terminal,
-				},
-			})
-		}
-		if currentIssueHandoff.nonActive {
-			ctx = withLinearGraphQLCurrentIssueHandoff(ctx, currentIssueHandoff)
 		}
 	}
+	return p.authorizeCurrentIssueMutation(ctx, query, variables)
+}
 
-	return p.dispatch(ctx, query, op, call.Variables)
+func (p linearGraphQLProxy) authorizeCurrentIssueMutation(ctx context.Context, query string, variables map[string]any) linearGraphQLAuthorization {
+	rejection, reject, currentIssueHandoff := p.checkCurrentIssueUpdate(ctx, query, variables)
+	if reject {
+		if sink := linearGraphQLMutationRejectedSinkFrom(ctx); sink != nil {
+			sink(rejection)
+		}
+		return rejectLinearGraphQLOperation(map[string]any{
+			"error": map[string]any{
+				"message":         currentIssueMutationRejectMessage(rejection.Reason),
+				"operation_field": rejection.OperationField,
+				"reason":          rejection.Reason,
+				"found":           rejection.Found,
+				"state":           rejection.State,
+				"terminal":        rejection.Terminal,
+			},
+		})
+	}
+	return linearGraphQLAuthorization{currentIssueHandoff: currentIssueHandoff}
+}
+
+func rejectLinearGraphQLOperation(payload map[string]any) linearGraphQLAuthorization {
+	result, err := dynamicToolFailure(payload)
+	return linearGraphQLAuthorization{rejected: true, result: result, err: err}
 }
 
 // callRaw is the harness-internal transport. It does NOT apply the

--- a/internal/runner/tools_test.go
+++ b/internal/runner/tools_test.go
@@ -575,6 +575,167 @@ func TestLinearGraphQLRejectsSubscriptions(t *testing.T) {
 	}
 }
 
+func TestLinearGraphQLAuthorizeMutationPolicyOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		proxy         linearGraphQLProxy
+		op            linearGraphQLOperation
+		query         string
+		wantRejected  bool
+		wantFailure   []string
+		wantHandoff   bool
+		wantTerminal  bool
+		wantTermState string
+	}{
+		{
+			name:         "default-deny mutation",
+			op:           linearGraphQLOperation{Kind: linearGraphQLOperationMutation, FieldName: "issueUpdate"},
+			query:        `mutation { issueUpdate(id: "1", input: {}) { success } }`,
+			wantRejected: true,
+			wantFailure:  []string{"mutations are disabled by this workflow", "codex.linear_graphql.allow_mutations", "issueUpdate"},
+		},
+		{
+			name:  "allowed mutation",
+			proxy: linearGraphQLProxy{allowMutations: true, allowedMutations: linearGraphQLAllowSet([]string{"issueUpdate"})},
+			op:    linearGraphQLOperation{Kind: linearGraphQLOperationMutation, FieldName: "issueUpdate"},
+			query: `mutation { issueUpdate(id: "1", input: {}) { success } }`,
+		},
+		{
+			name:         "disallowed mutation field",
+			proxy:        linearGraphQLProxy{allowMutations: true, allowedMutations: linearGraphQLAllowSet([]string{"issueUpdate"})},
+			op:           linearGraphQLOperation{Kind: linearGraphQLOperationMutation, FieldName: "issueDelete"},
+			query:        `mutation { issueDelete(id: "1") { success } }`,
+			wantRejected: true,
+			wantFailure:  []string{"not in the workflow's allowed_mutations list", "issueDelete"},
+		},
+		{
+			name:         "unidentified mutation field",
+			proxy:        linearGraphQLProxy{allowMutations: true, allowedMutations: linearGraphQLAllowSet([]string{"issueUpdate"})},
+			op:           linearGraphQLOperation{Kind: linearGraphQLOperationMutation},
+			query:        `mutation Broken`,
+			wantRejected: true,
+			wantFailure:  []string{"could not identify the top-level mutation field", "codex.linear_graphql.allowed_mutations"},
+		},
+		{
+			name:         "subscription rejected",
+			proxy:        linearGraphQLProxy{allowMutations: true},
+			op:           linearGraphQLOperation{Kind: linearGraphQLOperationSubscription, FieldName: "issues"},
+			query:        `subscription { issues { id } }`,
+			wantRejected: true,
+			wantFailure:  []string{"does not accept subscription operations"},
+		},
+		{
+			name:  "query allowed without mutation gate",
+			op:    linearGraphQLOperation{Kind: linearGraphQLOperationQuery, FieldName: "viewer"},
+			query: `query { viewer { id } }`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			authorization := tc.proxy.authorizeMutation(context.Background(), tc.query, tc.op, nil)
+			if authorization.rejected != tc.wantRejected {
+				t.Fatalf("authorizeMutation(%q).rejected = %v; want %v", tc.query, authorization.rejected, tc.wantRejected)
+			}
+			if tc.wantRejected {
+				assertStructuredFailure(t, authorization.result, authorization.err, tc.wantFailure...)
+				return
+			}
+			if authorization.result != "" || authorization.err != nil {
+				t.Fatalf("authorizeMutation(%q) returned result=%q err=%v; want allowed without failure", tc.query, authorization.result, authorization.err)
+			}
+			if authorization.currentIssueHandoff.nonActive != tc.wantHandoff {
+				t.Fatalf("authorizeMutation(%q) handoff = %v; want %v", tc.query, authorization.currentIssueHandoff.nonActive, tc.wantHandoff)
+			}
+			if got := authorization.currentIssueHandoff.terminalState != ""; got != tc.wantTerminal {
+				t.Fatalf("authorizeMutation(%q) terminal handoff = %v; want %v", tc.query, got, tc.wantTerminal)
+			}
+			if authorization.currentIssueHandoff.terminalState != tc.wantTermState {
+				t.Fatalf("authorizeMutation(%q) terminal state = %q; want %q", tc.query, authorization.currentIssueHandoff.terminalState, tc.wantTermState)
+			}
+		})
+	}
+}
+
+func TestLinearGraphQLAuthorizeMutationCurrentIssueOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		snapshot      IssueStateSnapshot
+		stateIDs      map[string]string
+		query         string
+		wantRejected  bool
+		wantReason    string
+		wantHandoff   bool
+		wantTerminal  bool
+		wantTermState string
+	}{
+		{
+			name:         "current issue active-state update rejected",
+			snapshot:     IssueStateSnapshot{Found: true, State: "In Progress", Active: true},
+			stateIDs:     map[string]string{"In Progress": "state-active"},
+			query:        `mutation { issueUpdate(id: "issue-current", input: { stateId: "state-active" }) { success } }`,
+			wantRejected: true,
+			wantReason:   currentIssueRejectActiveStateUpdate,
+		},
+		{
+			name:         "current issue non-active handoff allowed",
+			snapshot:     IssueStateSnapshot{Found: true, State: "In Progress", Active: true},
+			stateIDs:     map[string]string{"In Progress": "state-active"},
+			query:        `mutation { issueUpdate(id: "issue-current", input: { stateId: "state-review" }) { success } }`,
+			wantHandoff:  true,
+			wantTerminal: false,
+		},
+		{
+			name:          "current issue terminal handoff allowed",
+			snapshot:      IssueStateSnapshot{Found: true, State: "In Progress", Active: true},
+			stateIDs:      map[string]string{"In Progress": "state-active", "Done": "state-done"},
+			query:         `mutation { issueUpdate(id: "issue-current", input: { stateId: "state-done" }) { success } }`,
+			wantHandoff:   true,
+			wantTerminal:  true,
+			wantTermState: "Done",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &fakeLinearStateMutationServer{stateIDs: tc.stateIDs}
+			httpServer := httptest.NewServer(server.handler())
+			defer httpServer.Close()
+
+			proxy := guardedLinearProxy(httpServer, tc.snapshot)
+			proxy.currentIssueGuard.terminalStates = []string{"Done"}
+			var rejections []linearGraphQLMutationRejected
+			ctx := WithLinearGraphQLMutationRejectedSink(context.Background(), func(rejection linearGraphQLMutationRejected) {
+				rejections = append(rejections, rejection)
+			})
+			op := linearGraphQLOperation{Kind: linearGraphQLOperationMutation, FieldName: "issueUpdate"}
+
+			authorization := proxy.authorizeMutation(ctx, tc.query, op, nil)
+			if authorization.rejected != tc.wantRejected {
+				t.Fatalf("authorizeMutation(%q).rejected = %v; want %v", tc.query, authorization.rejected, tc.wantRejected)
+			}
+			if tc.wantRejected {
+				assertStructuredFailure(t, authorization.result, authorization.err, tc.wantReason)
+				if len(rejections) != 1 || rejections[0].Reason != tc.wantReason {
+					t.Fatalf("rejections = %+v; want one reason %s", rejections, tc.wantReason)
+				}
+				return
+			}
+			if len(rejections) != 0 {
+				t.Fatalf("rejections = %+v; want none for allowed handoff", rejections)
+			}
+			if authorization.currentIssueHandoff.nonActive != tc.wantHandoff {
+				t.Fatalf("authorizeMutation(%q) handoff = %v; want %v", tc.query, authorization.currentIssueHandoff.nonActive, tc.wantHandoff)
+			}
+			if got := authorization.currentIssueHandoff.terminalState != ""; got != tc.wantTerminal {
+				t.Fatalf("authorizeMutation(%q) terminal handoff = %v; want %v", tc.query, got, tc.wantTerminal)
+			}
+			if authorization.currentIssueHandoff.terminalState != tc.wantTermState {
+				t.Fatalf("authorizeMutation(%q) terminal state = %q; want %q", tc.query, authorization.currentIssueHandoff.terminalState, tc.wantTermState)
+			}
+			if got := server.issueUpdateRequests(); got != 0 {
+				t.Fatalf("issueUpdate HTTP requests = %d; want 0 during authorization", got)
+			}
+		})
+	}
+}
+
 // TestLinearGraphQLEmitsAuditEventForSuccessfulMutation covers the
 // audit-trail layer (#298 Layer 3): when the context carries a mutation
 // sink, the proxy fires it exactly once per successful mutation, with


### PR DESCRIPTION
Closes #884

## Summary
- Extracts the agent-visible `linear_graphql` operation authorization decision from `linearGraphQLProxy.call` into focused helper methods while preserving structured failure payloads and dispatch order.
- Adds direct characterization tests for default-deny, allowed mutation, disallowed field, unidentified mutation field, subscription rejection, current-issue rejection, and current-issue handoff outcomes.
- Keeps `callRaw` as ungated harness-internal transport and removes the `baseline (#521)` directive from `linearGraphQLProxy.call` after the runner lint gate passed without it.

## Acceptance criteria
- [x] Default-deny, allowed mutation, disallowed field, missing/unidentified mutation field, subscription rejection, current-issue rejection, and current-issue handoff are pinned by tests.
- [x] Helper extraction preserves HTTP dispatch behavior and tool failure payload shape.
- [x] `callRaw` remains ungated; workpad bypass coverage still passes.
- [x] Removed `baseline (#521)` from `linearGraphQLProxy.call`; `golangci-lint` runner/full gates passed.
- [x] Mutation-verified against committed artifact.
- [x] Targeted runner tests and standard local gate passed.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

SPEC/upstream notes: reviewed `docs/research/SPEC.md` `linear_graphql` extension contract / §15.5 hardening notes and `/tmp/symphony-upstream/elixir/lib/symphony_elixir/codex/dynamic_tool.ex`. This PR is a behavior-preserving Go hardening refactor; it adds no new SPEC deviation.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: 1 production file, under the 300 production LOC guideline; tests are excluded from the production budget.

## Testing
- [x] `go test ./internal/runner -run 'TestLinearGraphQLAuthorizeMutation|TestLinearGraphQLDefaultRejectsMutationsBeforeHTTPRequest|TestLinearGraphQLAllowsMutationsWhenOpted|TestLinearGraphQLAllowListRestrictsMutationFieldNames|TestLinearGraphQLRejectsSubscriptions|TestLinearGraphQLWorkpadCallsBypassMutationGate|TestLinearGraphQLRejectsCurrentIssue|TestLinearGraphQLAllowsCurrentIssue|TestLinearGraphQLMarksCurrentIssue' -count=1`
- [x] `go test ./internal/runner -count=1`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

## Mutation verification
- Committed artifact: `e0af2d2f1c6aff734207834625eb26fd498309e7`.
- Mutated `authorizeMutationOperation` from `if !p.allowMutations` to `if p.allowMutations`.
- `go test ./internal/runner -run 'TestLinearGraphQLAuthorizeMutationPolicyOutcomes/default-deny_mutation' -count=1` failed as expected: `rejected = false; want true`.
- Restored from HEAD and reran the same test: pass.

## Pre-push review
- Subagent discovery: `spawn_agent` was available, but this user request did not explicitly authorize subagent delegation; used CLI fallback per protocol.
- Codex-family CLI review on final head: No findings, `MERGE-READY`.
- Claude-family CLI review on final head: No findings, `MERGE-READY`.
- First Claude round had a LOW comment-rationale note; restored the security rationale and reran review clean.

## Remote CI and bot review
- Remote checks: green on `e0af2d2f1c6aff734207834625eb26fd498309e7`.
  - `Validate PR metadata`: pass.
  - `Validate PR title (Conventional Commits)`: pass.
  - `Security and supply-chain`: pass.
  - `E2E Gitea mock loop`: pass.
  - `Go build and test`: pass.
  - `Docker image build`: pass.
- Warning audit: `gh run view` logs for CI, PR Metadata, and PR Title Lint had no `warning:` matches.
- `@codex review`: triggered as `bytevane` in comment `4713789707`; Codex clean comment `4713808376` reviewed commit `e0af2d2f1c`; zero review threads.

## Notes
- One initial run of the Trellis Python hook suite had a transient failure in `test_background_hook_child_holding_stdout_is_bounded`; the targeted rerun and full suite rerun both passed before push.
- Final live recheck: `CLEAN` merge state, all checks green, zero review threads, Codex trigger eyes cleared, and no `warning:` matches in the final metadata/title logs.
