### PR TITLE
refactor(runner): split firejail sandbox assembly

### DIFF
--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -156,15 +156,9 @@ func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir 
 	if err != nil {
 		return nil, fmt.Errorf("bubblewrap sandbox requested but bwrap binary not found in PATH: %w", err)
 	}
-	if len(childArgs) == 0 {
-		return nil, fmt.Errorf("sandbox cannot wrap empty command")
-	}
-	if !filepath.IsAbs(childArgs[0]) && !strings.ContainsAny(childArgs[0], `/\\`) {
-		resolved, err := exec.LookPath(childArgs[0])
-		if err != nil {
-			return nil, fmt.Errorf("sandbox child binary %q not found in PATH: %w", childArgs[0], err)
-		}
-		childArgs = append([]string{resolved}, childArgs[1:]...)
+	childArgs, err = resolveSandboxChildArgs(childArgs)
+	if err != nil {
+		return nil, err
 	}
 	if cfg.NetworkMode == "allowlist" {
 		return nil, fmt.Errorf("sandbox network allowlist requires firejail --netfilter support; bubblewrap only supports network: none via --unshare-net")
@@ -196,15 +190,9 @@ func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir 
 		name, value, _ := strings.Cut(envPair, "=")
 		args = append(args, "--setenv", name, value)
 	}
-	for _, f := range cfg.CredentialFiles {
-		f = strings.TrimSpace(f)
-		if f == "" {
-			continue
-		}
-		if _, err := os.Stat(f); err != nil {
-			return nil, fmt.Errorf("sandbox credential file %q is not readable: %w", f, err)
-		}
-		args = append(args, "--ro-bind", f, f)
+	args, err = appendCredentialMounts(args, cfg.CredentialFiles, bubblewrapCredentialMount)
+	if err != nil {
+		return nil, err
 	}
 	args = append(args, "--")
 	args = append(args, childArgs...)
@@ -214,48 +202,62 @@ func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir 
 	return wrapped, nil
 }
 
-func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir string, childArgs []string, env []string) (*exec.Cmd, error) { //nolint:gocognit,funlen // baseline (#521)
+func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir string, childArgs []string, env []string) (*exec.Cmd, error) {
 	firejail, err := exec.LookPath("firejail")
 	if err != nil {
 		return nil, fmt.Errorf("firejail sandbox requested but firejail binary not found in PATH: %w", err)
 	}
-	if len(childArgs) == 0 {
-		return nil, fmt.Errorf("sandbox cannot wrap empty command")
-	}
-	if !filepath.IsAbs(childArgs[0]) && !strings.ContainsAny(childArgs[0], `/\\`) {
-		resolved, err := exec.LookPath(childArgs[0])
-		if err != nil {
-			return nil, fmt.Errorf("sandbox child binary %q not found in PATH: %w", childArgs[0], err)
-		}
-		childArgs = append([]string{resolved}, childArgs[1:]...)
+	childArgs, err = resolveSandboxChildArgs(childArgs)
+	if err != nil {
+		return nil, err
 	}
 	args := []string{"--quiet", "--noprofile", "--private=" + workdir, "--whitelist=" + workdir, "--private-tmp"}
-	var cleanupFiles []string
-	cleanupOnError := false
-	if cfg.NetworkMode == "allowlist" {
-		filter, err := writeFirejailNetfilter(cfg.NetworkAllowlistCIDRs)
-		if err != nil {
-			return nil, err
-		}
-		cleanupFiles = append(cleanupFiles, filter)
-		cleanupOnError = true
-		defer func() {
-			if cleanupOnError {
-				_ = removeFiles(cleanupFiles)
-			}
-		}()
-		netArg, err := firejailAllowlistNetArg(cfg)
-		if err != nil {
-			return nil, err
-		}
-		args = append(args, netArg, "--netfilter="+filter)
-	} else {
-		args = append(args, "--net=none")
+	netArgs, cleanupFiles, err := buildFirejailNetArgs(cfg)
+	if err != nil {
+		return nil, err
 	}
+	args = append(args, netArgs...)
+	cleanupOnError := len(cleanupFiles) > 0
+	defer func() {
+		if cleanupOnError {
+			_ = removeFiles(cleanupFiles)
+		}
+	}()
 	for _, envPair := range env {
 		args = append(args, "--env="+envPair)
 	}
-	for _, f := range cfg.CredentialFiles {
+	args, err = appendCredentialMounts(args, cfg.CredentialFiles, firejailCredentialMount)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, "--")
+	args = append(args, childArgs...)
+	wrapped, err := wireFirejailCleanup(ctx, firejail, args, cleanupFiles)
+	if err != nil {
+		return nil, err
+	}
+	wrapped.Dir = workdir
+	wrapped.Env = env
+	cleanupOnError = false
+	return wrapped, nil
+}
+
+func resolveSandboxChildArgs(childArgs []string) ([]string, error) {
+	if len(childArgs) == 0 {
+		return nil, fmt.Errorf("sandbox cannot wrap empty command")
+	}
+	if filepath.IsAbs(childArgs[0]) || strings.ContainsAny(childArgs[0], `/\\`) {
+		return childArgs, nil
+	}
+	resolved, err := exec.LookPath(childArgs[0])
+	if err != nil {
+		return nil, fmt.Errorf("sandbox child binary %q not found in PATH: %w", childArgs[0], err)
+	}
+	return append([]string{resolved}, childArgs[1:]...), nil
+}
+
+func appendCredentialMounts(args []string, credentialFiles []string, mountArgs func(string) []string) ([]string, error) {
+	for _, f := range credentialFiles {
 		f = strings.TrimSpace(f)
 		if f == "" {
 			continue
@@ -263,27 +265,56 @@ func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir st
 		if _, err := os.Stat(f); err != nil {
 			return nil, fmt.Errorf("sandbox credential file %q is not readable: %w", f, err)
 		}
-		args = append(args, "--read-only="+f, "--whitelist="+f)
+		args = append(args, mountArgs(f)...)
 	}
-	args = append(args, "--")
-	args = append(args, childArgs...)
-	wrapped := exec.CommandContext(ctx, firejail, args...)
-	if len(cleanupFiles) > 0 {
-		if len(cleanupFiles) != 1 {
-			return nil, fmt.Errorf("firejail sandbox expected one cleanup file, got %d", len(cleanupFiles))
+	return args, nil
+}
+
+func bubblewrapCredentialMount(path string) []string {
+	return []string{"--ro-bind", path, path}
+}
+
+func firejailCredentialMount(path string) []string {
+	return []string{"--read-only=" + path, "--whitelist=" + path}
+}
+
+func buildFirejailNetArgs(cfg workflow.SandboxConfig) ([]string, []string, error) {
+	if cfg.NetworkMode != "allowlist" {
+		return []string{"--net=none"}, nil, nil
+	}
+	filter, err := writeFirejailNetfilter(cfg.NetworkAllowlistCIDRs)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanupFiles := []string{filter}
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError {
+			_ = removeFiles(cleanupFiles)
 		}
-		cleanupScript := `cleanup_file=$1; shift; "$@"; status=$?; rm -f "$cleanup_file"; exit "$status"`
-		shellArgs := []string{"-c", cleanupScript, "aiops-firejail-cleanup", cleanupFiles[0], firejail}
-		shellArgs = append(shellArgs, args...)
-		wrapped = exec.CommandContext(ctx, "/bin/sh", shellArgs...)
+	}()
+	netArg, err := firejailAllowlistNetArg(cfg)
+	if err != nil {
+		return nil, nil, err
 	}
-	wrapped.Dir = workdir
-	wrapped.Env = env
-	if len(cleanupFiles) > 0 {
-		cleanupOnError = false
-		wrapped.Cancel = cleanupCancel(cleanupFiles)
-		wrapped.WaitDelay = 1
+	cleanupOnError = false
+	return []string{netArg, "--netfilter=" + filter}, cleanupFiles, nil
+}
+
+func wireFirejailCleanup(ctx context.Context, firejail string, args []string, cleanupFiles []string) (*exec.Cmd, error) {
+	wrapped := exec.CommandContext(ctx, firejail, args...)
+	if len(cleanupFiles) == 0 {
+		return wrapped, nil
 	}
+	if len(cleanupFiles) != 1 {
+		return nil, fmt.Errorf("firejail sandbox expected one cleanup file, got %d", len(cleanupFiles))
+	}
+	cleanupScript := `cleanup_file=$1; shift; "$@"; status=$?; rm -f "$cleanup_file"; exit "$status"`
+	shellArgs := []string{"-c", cleanupScript, "aiops-firejail-cleanup", cleanupFiles[0], firejail}
+	shellArgs = append(shellArgs, args...)
+	wrapped = exec.CommandContext(ctx, "/bin/sh", shellArgs...)
+	wrapped.Cancel = cleanupCancel(cleanupFiles)
+	wrapped.WaitDelay = 1
 	return wrapped, nil
 }
 

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -686,6 +687,50 @@ func TestFirejailNetfilterAcceptsIPv4CIDR(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "-A OUTPUT -d 203.0.113.10/32 -j ACCEPT") {
 		t.Fatalf("netfilter file missing IPv4 allow rule: %s", content)
+	}
+}
+
+func TestBuildFirejailNetArgsBuildsAllowlistAndCleanupFile(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	args, cleanupFiles, err := buildFirejailNetArgs(workflow.SandboxConfig{
+		NetworkMode:           "allowlist",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+		NetworkInterface:      "aiops0",
+	})
+	if err != nil {
+		t.Fatalf("buildFirejailNetArgs: %v", err)
+	}
+	defer func() { _ = removeFiles(cleanupFiles) }()
+	if len(cleanupFiles) != 1 {
+		t.Fatalf("cleanupFiles = %#v; want one netfilter file", cleanupFiles)
+	}
+	wantArgs := []string{"--net=aiops0", "--netfilter=" + cleanupFiles[0]}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("buildFirejailNetArgs args = %#v; want %#v", args, wantArgs)
+	}
+	if _, err := os.Stat(cleanupFiles[0]); err != nil {
+		t.Fatalf("netfilter cleanup file should exist before wrapping: %v", err)
+	}
+}
+
+func TestBuildFirejailNetArgsRemovesNetfilterWhenInterfaceMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
+
+	_, _, err := buildFirejailNetArgs(workflow.SandboxConfig{
+		NetworkMode:           "allowlist",
+		NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+	})
+	if err == nil {
+		t.Fatal("expected missing firejail network interface error")
+	}
+	matches, globErr := filepath.Glob(filepath.Join(tmpDir, "aiops-firejail-netfilter-*.conf"))
+	if globErr != nil {
+		t.Fatalf("glob netfilter files: %v", globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("buildFirejailNetArgs setup error should remove netfilter files, left %v", matches)
 	}
 }
 


### PR DESCRIPTION
Closes #885

## Summary
- Refactor Firejail sandbox assembly into focused helpers for child command resolution, allowlist netfilter args, runtime cleanup wiring, and credential mount emission.
- Preserve existing Firejail/Bubblewrap argument shapes while sharing the credential-file validation loop across both backends.
- Add direct helper tests for allowlist arg construction and setup-error cleanup so the extracted branch is covered even on non-Linux hosts.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — 1 production file / under 300 production changed LOC. Test files and generated code excluded.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

## Notes
- Targeted: `go test -race -run 'TestBuildFirejailNetArgs|TestSandboxFirejail|TestFirejailNetfilter|TestSandboxBubblewrapNetworkNoneIgnoresStaleAllowlistCIDRs' -count=1 ./internal/runner`.
- Targeted linter: `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=1 ./internal/runner` returned `0 issues` with the `firejailCommand` baseline removed.
- Mutation check: after committing, changed `buildFirejailNetArgs` to omit `--netfilter`; `TestBuildFirejailNetArgsBuildsAllowlistAndCleanupFile` failed with `args = []string{"--net=aiops0"}; want []string{"--net=aiops0", "--netfilter=..."}`. Restored `internal/runner/sandbox.go` from HEAD and reran the test successfully.
- Pre-push owner probe: no open PR for `#885`; no remote `refs/heads/fix/885-*` branch before push.
- Pre-push reviewer routing: `tool_search` found `spawn_agent`, but subagent delegation was not used because this session did not have explicit user authorization to spawn. CLI fallback ran both families on `git diff origin/main...HEAD`: Claude-family `{"blocking_findings":[]}` and Codex-family `{"blocking_findings":[]}`.

- Post-push CI: all required checks passed (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`, `Validate PR metadata`, `Validate PR title`).
- GitHub Codex review: triggered by comment `4713902443`; clean Codex comment received at `2026-06-16T01:08:24Z` for reviewed commit `f97d915670`.
- Review threads: GraphQL `reviewThreads` returned no unresolved, non-outdated threads after Codex review.
