### PR TITLE
docs(protocol): align subagent review authorization

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -58,7 +58,7 @@ go build ./cmd/worker ./cmd/tui
 **暂存只 add 明确路径，绝不 `git add -A` / `git add .`**（会把 `.codex/` 等本地未跟踪文件卷入 PR）。commit 前 `git status --short` 核对只暂存了预期文件。
 
 ### 5. 提交 → 双审 → 开 PR
-1. 按协议 §2–§3 commit-first + pre-push 双 reviewer；先执行协议里的 **subagent-first reviewer routing**，具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。review finding 先按当前 head、issue 计划、SPEC/Elixir 参考和相邻路径验证技术正确性，再修复 / 反证 / 延后。§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
+1. 按协议 §2–§3 commit-first + pre-push 双 reviewer；先执行协议里的 **subagent-first reviewer routing**，具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。操作者可在当前请求中写明 `handle issue N with subagent review enabled` 作为 Codex inline 的 subagent review enabled 授权短语；授权含义仍以协议为准。review finding 先按当前 head、issue 计划、SPEC/Elixir 参考和相邻路径验证技术正确性，再修复 / 反证 / 延后。§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
 2. push 后开 **一个** PR 对应该 issue，body 引用 issue（`Closes #N`），列验收项、验证命令、变异验证、风险/deferral；PR body 是活账本（协议 §7）。
 3. **每条 finding 归入 ≥1 类**：算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试；然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。
 4. **Deferred 偏差必须开 issue**（AGENTS.md rule 2）：决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -33,7 +33,7 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
    - 测试是否安慰剂（assertion 真的读到新代码改的字段吗？）
    - 错位机制（在 §1 scheduler/runner 边界的错误一侧）：worker/orchestrator 侧「消费 agent 产物」的 phase/gate/artifact/config，先 grep Elixir 有没有等价物——没有就是过度设计信号，判**删除**（非搬进 prompt、非只记 DEVIATIONS），归宿默认是 WORKFLOW prompt（worker post-turn phase 在 push 后只能 flag 不能 prevent，且抢跑 D9 reconcile-cancel / §16.5 self-stop——#557 即此；AGENTS.md 原则 6；#557/#561 拆的就是这类）
 
-2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，并先执行协议里的 **subagent-first reviewer routing**；具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。HIGH/MEDIUM/Critical 先验证技术正确性，再决定修复 / 反证 / 延后；不要盲从，也不要把 finding 当噪音略过。若 finding 证明计划本身错了，同轮更新代码、测试、SPEC/deviation 文档和 PR body。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
+2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，并先执行协议里的 **subagent-first reviewer routing**；具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。操作者可在当前请求中写明 `review this PR with subagent review enabled` 作为 Codex inline 的授权短语；授权含义仍以协议为准。HIGH/MEDIUM/Critical 先验证技术正确性，再决定修复 / 反证 / 延后；不要盲从，也不要把 finding 当噪音略过。若 finding 证明计划本身错了，同轮更新代码、测试、SPEC/deviation 文档和 PR body。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
 
 3. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria（AGENTS.md rule 2）。决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
 

--- a/docs/runbooks/github-local-automation.md
+++ b/docs/runbooks/github-local-automation.md
@@ -48,6 +48,8 @@ This runbook wires the local macOS operator flow for resolving
   [`pr-review-merge-protocol.md`](pr-review-merge-protocol.md) and is enforced
   by `scripts/local-pr-follow-through.sh`; keep concrete reviewer mechanics
   there so this automation runbook does not become a second source of truth.
+  When subagent review is unavailable or not authorized, that same contract keeps
+  local reviewer fallback time-bounded, cached, and audited.
 
 ## Prerequisites
 

--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -51,6 +51,22 @@ findings (keep each review ≤700 words) and a final verdict —
 SHA, changed files, intent (issue/PR), relevant SPEC/upstream pointers, and
 AGENTS.md policy.
 
+Subagent-first means "prefer subagent review when the current environment can do
+it and the current user request has authorized it," not automatic fan-out from a
+runbook alone. This wording closes the #891 friction: spawn_agent available but
+skipped because the user request lacked explicit authorization, followed by the
+correct CLI fallback. To opt in up front, use a current-turn phrase such as
+"handle issue N with subagent review enabled" or "review this PR with parallel
+subagents".
+
+Best-practice reviewer modes:
+
+| Mode | Use when | Required handling |
+| --- | --- | --- |
+| No subagent authorization | The request does not explicitly authorize subagent delegation, or the tool contract forbids it | Discover availability when relevant, record why subagents were not used, ask one concise authorization question before pre-push review when interactive timing allows, otherwise use bounded CLI fallback and record that reason |
+| One sidecar subagent | The diff is low-risk/docs-only or normal-risk and the user authorized subagent review | Run one independent read-only diff reviewer sidecar focused on correctness, safety/security, and test gaps, plus the existing Codex-family and Claude-family gates |
+| Parallel specialized subagents | The diff touches high-risk security, sandbox, filesystem deletion, concurrency, tracker mutation, workflow, or orchestrator behavior and the user authorized parallel review | Split read-only reviewers by concern, such as security/safety, tests/mutation gaps, races/lifecycle, and maintainability/scope, then merge their findings into the same dual-family gate |
+
 Reviewer routing is environment-dependent:
 
 - **Claude Code Agent.** Prefer the Agent tool subagents named below for
@@ -64,8 +80,8 @@ Reviewer routing is environment-dependent:
   spawning for that request. A workflow prompt or runbook instruction alone is
   not sufficient authorization to spawn. Record the agent id/verdict in review
   notes. If subagent use is not authorized for the current session, do not
-  spawn; record that eligibility result and continue with the family reviewer
-  fallback. Do not wait for a human reminder to discover the tool.
+  spawn; follow the "No subagent authorization" mode above. Do not wait for a
+  human reminder to discover the tool.
 - **codex-sub-agent.** If the current session is already a spawned sub-agent,
   obey the parent assignment and the sub-agent notice first. Do not recursively
   spawn reviewers unless the parent task explicitly asks for that; return the

--- a/scripts/reviewer_workflow_docs_test.go
+++ b/scripts/reviewer_workflow_docs_test.go
@@ -32,6 +32,15 @@ func TestReviewerProtocolDocumentsSubagentDiscoveryBeforeCLIFallback(t *testing.
 		".structured_output",
 		"Subagent review complements the two-family gate",
 		"Codex-family and Claude-family",
+		"Best-practice reviewer modes",
+		"No subagent authorization",
+		"One sidecar subagent",
+		"Parallel specialized subagents",
+		"#891",
+		"spawn_agent available but skipped",
+		"ask one concise authorization question before pre-push review when interactive timing allows",
+		"handle issue N with subagent review enabled",
+		"review this PR with parallel subagents",
 	} {
 		if !containsReviewerDocText(protocol, want) {
 			t.Fatalf("pr-review-merge-protocol.md missing %q", want)
@@ -47,6 +56,7 @@ func TestIssueAndPRSkillsPointToSubagentFirstReviewerRouting(t *testing.T) {
 		body := readReviewerDoc(t, path)
 		for _, want := range []string{
 			"subagent-first reviewer routing",
+			"subagent review enabled",
 			"pr-review-merge-protocol.md",
 		} {
 			if !containsReviewerDocText(body, want) {


### PR DESCRIPTION
Closes #892

## Summary
- Clarify that "subagent-first" review means preferred when the current environment supports it and the current user request explicitly authorizes it, not automatic spawning from runbook text alone.
- Add the best-practice reviewer modes table: no subagent authorization, one sidecar subagent, and parallel specialized subagents for high-risk diffs.
- Keep reviewer mechanics centralized in `docs/runbooks/pr-review-merge-protocol.md`, add only minimal authorization phrases to the issue/PR skills, and pin the wording with `scripts/reviewer_workflow_docs_test.go`.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Acceptance criteria
- [x] Update `docs/runbooks/pr-review-merge-protocol.md` section 3 to reconcile subagent-first wording with explicit authorization.
- [x] Update `.claude/skills/handle-issue/SKILL.md` and `.claude/skills/handle-pr/SKILL.md` with only minimal operator-facing authorization wording and canonical protocol pointers.
- [x] Keep `docs/runbooks/github-local-automation.md` bounded/auditable and avoid duplicating reviewer mechanics.
- [x] Add regression coverage in `scripts/reviewer_workflow_docs_test.go` for the authorization modes and #891 friction.
- [x] Include the "Best-practice reviewer modes" table.
- [x] Preserve hard gates: committed diff only, mutation verification, two reviewer families, no push on a single reviewer, `@codex review` per pushed head, GraphQL thread gate, and no merge without explicit permission.
- [x] Document #891 as the motivating friction: spawn_agent available but skipped because the current request lacked explicit authorization.

## Reviewer routing
- Subagent discovery: `tool_search` found `multi_agent_v1.spawn_agent`.
- Authorization result: current request did not explicitly authorize subagent delegation, so no subagent was spawned.
- Fallback used: bounded CLI reviewers per protocol.
- Codex CLI reviewer on `b5a5d84978d4f0b884379850ba88332da09c6814`: `{"blocking_findings":[]}`.
- Claude Code reviewer on `b5a5d84978d4f0b884379850ba88332da09c6814`: `{"blocking_findings":[]}`.
- GitHub Codex trigger: comment `4714099677` by `bytevane`, bound to head `b5a5d84978d4f0b884379850ba88332da09c6814` and base `main@04e0c35c085211e661e1433bbf84e18138d38799`.
- GitHub Codex result: clean comment `4714113775`, reviewed commit `b5a5d84978`.
- Review threads: GraphQL `reviewThreads` returned zero unresolved, non-outdated threads.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded). Docs/test-only diff: 5 files, 32 insertions, 4 deletions.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go build ./cmd/worker ./cmd/tui`
- `go test -count=1 ./scripts`
- Targeted docs regression test red/green: first failed on missing `Best-practice reviewer modes`, then passed after docs update.
- Mutation check against committed artifact: changed `Best-practice reviewer modes:` to `Reviewer modes:`, confirmed `TestReviewerProtocolDocumentsSubagentDiscoveryBeforeCLIFallback` failed for the intended missing phrase, restored from HEAD, and confirmed the targeted test passed.

Remote CI on head `b5a5d84978d4f0b884379850ba88332da09c6814`:
- [x] Go build and test
- [x] Validate PR metadata
- [x] Validate PR title (Conventional Commits)
- [x] Security and supply-chain
- [x] E2E Gitea mock loop
- [x] Docker image build

## Notes
- Official Codex manual cache was current on 2026-06-16 and confirmed the design inputs from `/codex/concepts/subagents.md`, `/codex/subagents.md`, `/codex/learn/best-practices.md`, and `/codex/integrations/github.md`.
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
