### PR TITLE
refactor(worker): extract runner error classification helper

### DIFF
--- a/internal/worker/runner_error_test.go
+++ b/internal/worker/runner_error_test.go
@@ -1,0 +1,206 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+)
+
+// TestClassifyRunnerError is the decision table that isolates the runner error
+// taxonomy from RunRunnerWithTimeout's timeout/event orchestration (#886). Each
+// row pins the terminal phase, the ordered event kinds, the exact discriminating
+// payload fields, and the surfaced error for one error class; deleting or
+// flipping any one branch in classifyRunnerError fails a row here.
+//
+// wantFields and wantAbsent are asserted on EVERY emitted event in the row, so
+// the stall path's two events (stalled, runner_timeout) are both checked — that
+// pins their shared budget payload as well as the ordering.
+func TestClassifyRunnerError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		model   = "codex-app-server"
+		elapsed = 70 * time.Millisecond
+		budget  = time.Second
+	)
+	res := runner.Result{OutputBytes: 12, OutputHead: "head", OutputTail: "tail"}
+
+	stall := &runner.StallError{Timeout: 30 * time.Millisecond, Elapsed: 60 * time.Millisecond}
+	turn := &runner.TurnTimeoutError{Timeout: 30 * time.Millisecond, Elapsed: 60 * time.Millisecond}
+	read := &runner.ReadTimeoutError{Timeout: 30 * time.Millisecond}
+	outer := &runner.TimeoutError{Timeout: 30 * time.Millisecond, Elapsed: 60 * time.Millisecond}
+	wrappedOuter := fmt.Errorf("agent layer: %w", outer)
+	plain := errors.New("agent crashed")
+
+	reconcileCtx, cancelReconcile := context.WithCancelCause(context.Background())
+	cancelReconcile(ErrReconcileCancel) // the orchestrator's eligibility stop
+
+	cases := []struct {
+		name              string
+		ctx               context.Context
+		runErr            error
+		runCtxErr         error
+		wantPhase         task.RunAttemptPhase
+		wantKinds         []string
+		wantFields        map[string]any // exact payload values asserted on every event
+		wantAbsent        []string       // payload keys that must NOT be present on any event
+		wantMessage       string         // exact event message (constant-message classes); "" skips
+		wantErrIs         error          // errors.Is target the surfaced error must satisfy
+		wantTimeout       bool           // surfaced error must satisfy runner.IsTimeout
+		wantWrapsDeadline bool           // surfaced error must be a synthesized *TimeoutError wrapping the deadline
+	}{
+		{
+			name: "stall", ctx: context.Background(), runErr: stall,
+			wantPhase:  task.PhaseStalled,
+			wantKinds:  []string{task.EventStalled, task.EventRunnerTimeout},
+			wantFields: map[string]any{"timeout_ms": int64(30), "elapsed_ms": int64(60)},
+			wantAbsent: []string{"ok", "reason", "duration_ms"},
+			wantErrIs:  stall,
+		},
+		{
+			name: "turn_timeout", ctx: context.Background(), runErr: turn,
+			wantPhase:  task.PhaseTimedOut,
+			wantKinds:  []string{task.EventRunnerTimeout},
+			wantFields: map[string]any{"timeout_ms": int64(30), "elapsed_ms": int64(60)},
+			wantAbsent: []string{"ok", "reason", "duration_ms"},
+			wantErrIs:  turn,
+		},
+		{
+			// read_timeout has no Elapsed field of its own; elapsed_ms must be the
+			// OUTER wall-clock elapsed, not a budget-derived value.
+			name: "read_timeout", ctx: context.Background(), runErr: read,
+			wantPhase:  task.PhaseTimedOut,
+			wantKinds:  []string{task.EventRunnerTimeout},
+			wantFields: map[string]any{"timeout_ms": int64(30), "elapsed_ms": int64(70)},
+			wantAbsent: []string{"ok", "reason", "duration_ms"},
+			wantErrIs:  read,
+		},
+		{
+			name: "outer_timeout", ctx: context.Background(), runErr: outer,
+			wantPhase:   task.PhaseTimedOut,
+			wantKinds:   []string{task.EventRunnerTimeout},
+			wantFields:  map[string]any{"timeout_ms": int64(30), "elapsed_ms": int64(60)},
+			wantAbsent:  []string{"ok", "reason", "duration_ms"},
+			wantErrIs:   outer,
+			wantTimeout: true,
+		},
+		{
+			// A *TimeoutError reaches the classifier wrapped by an outer layer:
+			// the SURFACED error must stay the wrapper (errors.Is target = the
+			// wrapper, not the inner te), while the payload uses the inner te's
+			// budget/elapsed. Catches a regression that surfaces the unwrapped te.
+			name: "wrapped_outer_timeout", ctx: context.Background(), runErr: wrappedOuter,
+			wantPhase:   task.PhaseTimedOut,
+			wantKinds:   []string{task.EventRunnerTimeout},
+			wantFields:  map[string]any{"timeout_ms": int64(30), "elapsed_ms": int64(60)},
+			wantAbsent:  []string{"ok", "reason", "duration_ms"},
+			wantErrIs:   wrappedOuter,
+			wantTimeout: true,
+		},
+		{
+			// Bare deadline + the run context's own deadline → synthesize a
+			// *TimeoutError{Timeout: budget, Elapsed: elapsed, Cause: deadline}.
+			name: "bare_deadline_normalized", ctx: context.Background(),
+			runErr: context.DeadlineExceeded, runCtxErr: context.DeadlineExceeded,
+			wantPhase:         task.PhaseTimedOut,
+			wantKinds:         []string{task.EventRunnerTimeout},
+			wantFields:        map[string]any{"timeout_ms": int64(1000), "elapsed_ms": int64(70)},
+			wantAbsent:        []string{"ok", "reason", "duration_ms"},
+			wantErrIs:         context.DeadlineExceeded,
+			wantTimeout:       true,
+			wantWrapsDeadline: true,
+		},
+		{
+			name: "reconcile_cancel", ctx: reconcileCtx, runErr: context.Canceled,
+			wantPhase:   task.PhaseCanceledByReconciliation,
+			wantKinds:   []string{task.EventRunnerStopped},
+			wantFields:  map[string]any{"duration_ms": int64(70), "ok": true, "reason": "reconcile_ineligible"},
+			wantAbsent:  []string{"timeout_ms", "elapsed_ms", "error"},
+			wantMessage: "runner stopped: reconcile ineligible",
+			wantErrIs:   context.Canceled,
+		},
+		{
+			name: "plain_error", ctx: context.Background(), runErr: plain,
+			wantPhase:   task.PhaseFailed,
+			wantKinds:   []string{task.EventRunnerEnd},
+			wantFields:  map[string]any{"duration_ms": int64(70), "ok": false, "error": plain.Error()},
+			wantAbsent:  []string{"timeout_ms", "elapsed_ms", "reason"},
+			wantMessage: "runner failed",
+			wantErrIs:   plain,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyRunnerError(tc.ctx, tc.runErr, tc.runCtxErr, res, model, elapsed, budget)
+
+			if got.phase != tc.wantPhase {
+				t.Errorf("classifyRunnerError(%s) phase = %q; want %q", tc.name, got.phase, tc.wantPhase)
+			}
+
+			var gotKinds []string
+			for _, e := range got.events {
+				gotKinds = append(gotKinds, e.kind)
+				assertEventPayload(t, tc.name, e, model, res, tc.wantFields, tc.wantAbsent, tc.wantMessage)
+			}
+			if !slices.Equal(gotKinds, tc.wantKinds) {
+				t.Errorf("classifyRunnerError(%s) event kinds = %v; want %v", tc.name, gotKinds, tc.wantKinds)
+			}
+
+			if tc.wantErrIs != nil && !errors.Is(got.err, tc.wantErrIs) {
+				t.Errorf("classifyRunnerError(%s) err = %v; want errors.Is target %v", tc.name, got.err, tc.wantErrIs)
+			}
+			if tc.wantTimeout && !runner.IsTimeout(got.err) {
+				t.Errorf("classifyRunnerError(%s) err = %v; want runner.IsTimeout", tc.name, got.err)
+			}
+			if tc.wantWrapsDeadline {
+				var te *runner.TimeoutError
+				if !errors.As(got.err, &te) {
+					t.Errorf("classifyRunnerError(%s) surfaced %T; want a synthesized *runner.TimeoutError", tc.name, got.err)
+				} else if !errors.Is(te.Cause, context.DeadlineExceeded) {
+					t.Errorf("classifyRunnerError(%s) TimeoutError.Cause = %v; want it to wrap the bare deadline", tc.name, te.Cause)
+				}
+			}
+		})
+	}
+}
+
+// assertEventPayload pins one emitted event's message and payload: the shared
+// model + output telemetry, every exact field in wantFields, the absence of
+// every key in wantAbsent, and the exact message when wantMessage is set.
+func assertEventPayload(t *testing.T, name string, e terminalRunnerEvent, model string, res runner.Result, wantFields map[string]any, wantAbsent []string, wantMessage string) {
+	t.Helper()
+	if e.message == "" {
+		t.Errorf("classifyRunnerError(%s) emitted empty message for kind %q", name, e.kind)
+	}
+	if wantMessage != "" && e.message != wantMessage {
+		t.Errorf("classifyRunnerError(%s) %s message = %q; want %q", name, e.kind, e.message, wantMessage)
+	}
+	if e.payload["model"] != model {
+		t.Errorf("classifyRunnerError(%s) %s payload[model] = %v; want %q", name, e.kind, e.payload["model"], model)
+	}
+	// addOutputFields must thread the runner telemetry into every terminal payload.
+	if e.payload["output_bytes"] != res.OutputBytes {
+		t.Errorf("classifyRunnerError(%s) %s payload[output_bytes] = %v; want %v", name, e.kind, e.payload["output_bytes"], res.OutputBytes)
+	}
+	if e.payload["output_head"] != res.OutputHead {
+		t.Errorf("classifyRunnerError(%s) %s payload[output_head] = %v; want %q", name, e.kind, e.payload["output_head"], res.OutputHead)
+	}
+	for k, want := range wantFields {
+		if got := e.payload[k]; got != want {
+			t.Errorf("classifyRunnerError(%s) %s payload[%s] = %#v; want %#v", name, e.kind, k, got, want)
+		}
+	}
+	for _, k := range wantAbsent {
+		if _, present := e.payload[k]; present {
+			t.Errorf("classifyRunnerError(%s) %s payload has unexpected %s = %#v", name, e.kind, k, e.payload[k])
+		}
+	}
+}

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -437,15 +437,13 @@ func isTerminalPhase(phase task.RunAttemptPhase) bool {
 	}
 }
 
-// RunRunnerWithTimeout invokes the runner under a per-task timeout derived
-// from agent.timeout. It emits structured task events
-// (runner_start, runner_end, runner_timeout) so retry policy and observers
-// can distinguish a clean exit from a kill due to deadline. The returned
-// runner.Result carries any output telemetry the runner captured; on failure
-// (timeout or non-zero exit) the same Result is returned so that partial
-// telemetry (OutputBytes, OutputHead, OutputTail, etc.) is still available to
-// the caller.
-func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner, in runner.RunInput, timeout time.Duration, workflowSource string) (runner.Result, error) { //nolint:gocognit,funlen // baseline (#521)
+// RunRunnerWithTimeout invokes the runner under a per-task timeout derived from
+// agent.timeout. It emits runner_start plus the terminal event classifyRunnerError
+// selects, so retry policy and observers can distinguish a clean exit from a
+// deadline kill. The runner.Result is returned on both success and failure so
+// partial output telemetry (OutputBytes, OutputHead, OutputTail, …) stays
+// available to the caller.
+func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner, in runner.RunInput, timeout time.Duration, workflowSource string) (runner.Result, error) {
 	if timeout <= 0 {
 		timeout = 30 * time.Minute
 	}
@@ -455,30 +453,9 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 		"timeout_ms":      timeout.Milliseconds(),
 		"workflow_source": workflowSource,
 	})
-	currentPhase := task.PhaseBuildingPrompt
-	upstreamPhaseSink := in.PhaseTransitionSink
-	in.PhaseTransitionSink = func(from, to task.RunAttemptPhase) {
-		if from == "" {
-			from = currentPhase
-		}
-		currentPhase = to
-		if upstreamPhaseSink != nil {
-			upstreamPhaseSink(from, to)
-			return
-		}
-		EmitPhaseTransition(ctx, ev, in.Task.ID, in.Task.SourceEventID, from, to)
-	}
+
+	sinks := wireRunnerSinks(ctx, ev, &in, in.Task.ID, in.Task.SourceEventID)
 	in.PhaseTransitionSink(task.PhaseBuildingPrompt, task.PhaseLaunchingAgentProcess)
-	emittedRuntimeEvents := map[string]bool{}
-	upstreamRuntimeSink := in.RuntimeEventSink
-	in.RuntimeEventSink = func(event task.RuntimeEvent) {
-		emittedRuntimeEvents[runtimeEventKey(event)] = true
-		if upstreamRuntimeSink != nil {
-			upstreamRuntimeSink(event)
-			return
-		}
-		EmitRuntimeEvents(ctx, ev, in.Task.ID, in.Task.SourceEventID, []task.RuntimeEvent{event})
-	}
 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -487,97 +464,18 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 	res, runErr := r.Run(runCtx, in)
 	elapsed := time.Since(start)
 
-	for _, event := range res.RuntimeEvents {
-		if emittedRuntimeEvents[runtimeEventKey(event)] {
-			continue
-		}
-		EmitRuntimeEvents(ctx, ev, in.Task.ID, in.Task.SourceEventID, []task.RuntimeEvent{event})
-	}
+	sinks.forwardResultRuntimeEvents(ctx, ev, in.Task.ID, in.Task.SourceEventID, res)
 
 	if runErr != nil {
-		var stall *runner.StallError
-		if errors.As(runErr, &stall) {
-			in.PhaseTransitionSink(currentPhase, task.PhaseStalled)
-			stallPayload := map[string]any{
-				"model":      in.Task.Model,
-				"timeout_ms": stall.Timeout.Milliseconds(),
-				"elapsed_ms": stall.Elapsed.Milliseconds(),
-			}
-			addOutputFields(stallPayload, res)
-			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventStalled, stall.Error(), stallPayload)
-			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, stall.Error(), stallPayload)
-			return res, runErr
+		decision := classifyRunnerError(ctx, runErr, runCtx.Err(), res, in.Task.Model, elapsed, timeout)
+		in.PhaseTransitionSink(sinks.current, decision.phase)
+		for _, e := range decision.events {
+			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, e.kind, e.message, e.payload)
 		}
-		var turnTimeout *runner.TurnTimeoutError
-		if errors.As(runErr, &turnTimeout) {
-			in.PhaseTransitionSink(currentPhase, task.PhaseTimedOut)
-			timeoutPayload := map[string]any{
-				"model":      in.Task.Model,
-				"timeout_ms": turnTimeout.Timeout.Milliseconds(),
-				"elapsed_ms": turnTimeout.Elapsed.Milliseconds(),
-			}
-			addOutputFields(timeoutPayload, res)
-			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, turnTimeout.Error(), timeoutPayload)
-			return res, runErr
-		}
-		var readTimeout *runner.ReadTimeoutError
-		if errors.As(runErr, &readTimeout) {
-			in.PhaseTransitionSink(currentPhase, task.PhaseTimedOut)
-			timeoutPayload := map[string]any{
-				"model":      in.Task.Model,
-				"timeout_ms": readTimeout.Timeout.Milliseconds(),
-				"elapsed_ms": elapsed.Milliseconds(),
-			}
-			addOutputFields(timeoutPayload, res)
-			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, readTimeout.Error(), timeoutPayload)
-			return res, runErr
-		}
-		var te *runner.TimeoutError
-		if errors.As(runErr, &te) || (errors.Is(runErr, context.DeadlineExceeded) && errors.Is(runCtx.Err(), context.DeadlineExceeded)) {
-			in.PhaseTransitionSink(currentPhase, task.PhaseTimedOut)
-			if te == nil {
-				te = &runner.TimeoutError{Timeout: timeout, Elapsed: elapsed, Cause: runErr}
-				runErr = te
-			}
-			timeoutPayload := map[string]any{
-				"model":      in.Task.Model,
-				"timeout_ms": te.Timeout.Milliseconds(),
-				"elapsed_ms": te.Elapsed.Milliseconds(),
-			}
-			addOutputFields(timeoutPayload, res)
-			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerTimeout, te.Error(), timeoutPayload)
-			return res, runErr
-		}
-		if isReconcileCancel(ctx, runErr) {
-			// The orchestrator stopped this run because its tracker issue left
-			// the active set (e.g. the agent's own PR handoff to In Review).
-			// That is a supervised stop, not a runner failure: record it as
-			// stopped and do not count it as a failure for the superseded run
-			// (#543).
-			in.PhaseTransitionSink(currentPhase, task.PhaseCanceledByReconciliation)
-			stoppedPayload := map[string]any{
-				"model":       in.Task.Model,
-				"duration_ms": elapsed.Milliseconds(),
-				"ok":          true,
-				"reason":      "reconcile_ineligible",
-			}
-			addOutputFields(stoppedPayload, res)
-			Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerStopped, "runner stopped: reconcile ineligible", stoppedPayload)
-			return res, runErr
-		}
-		in.PhaseTransitionSink(currentPhase, task.PhaseFailed)
-		failurePayload := map[string]any{
-			"model":       in.Task.Model,
-			"duration_ms": elapsed.Milliseconds(),
-			"error":       ErrSummary(runErr),
-			"ok":          false,
-		}
-		addOutputFields(failurePayload, res)
-		Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerEnd, "runner failed", failurePayload)
-		return res, runErr
+		return res, decision.err
 	}
 
-	in.PhaseTransitionSink(currentPhase, task.PhaseFinishing)
+	in.PhaseTransitionSink(sinks.current, task.PhaseFinishing)
 	endPayload := map[string]any{
 		"model":       in.Task.Model,
 		"duration_ms": elapsed.Milliseconds(),
@@ -589,6 +487,187 @@ func RunRunnerWithTimeout(ctx context.Context, ev EventEmitter, r runner.Runner,
 	addOutputFields(endPayload, res)
 	Emit(ctx, ev, in.Task.ID, in.Task.SourceEventID, task.EventRunnerEnd, "runner completed", endPayload)
 	return res, nil
+}
+
+// runnerSinkState tracks the live run-attempt phase and the set of runtime
+// events already forwarded while the runner streams, so the timeout boundary
+// can emit the terminal phase transition from the runner's last phase and skip
+// re-emitting result events the streaming sink already delivered.
+type runnerSinkState struct {
+	current task.RunAttemptPhase
+	emitted map[string]bool
+}
+
+// wireRunnerSinks installs phase-transition and runtime-event forwarding on in
+// so the runner's streaming callbacks fan out to the task event stream (or the
+// caller-supplied upstream sink when present), returning the live sink state the
+// boundary reads after the run.
+func wireRunnerSinks(ctx context.Context, ev EventEmitter, in *runner.RunInput, taskID, identifier string) *runnerSinkState {
+	st := &runnerSinkState{current: task.PhaseBuildingPrompt, emitted: map[string]bool{}}
+	upstreamPhaseSink := in.PhaseTransitionSink
+	in.PhaseTransitionSink = func(from, to task.RunAttemptPhase) {
+		if from == "" {
+			from = st.current
+		}
+		st.current = to
+		if upstreamPhaseSink != nil {
+			upstreamPhaseSink(from, to)
+			return
+		}
+		EmitPhaseTransition(ctx, ev, taskID, identifier, from, to)
+	}
+	upstreamRuntimeSink := in.RuntimeEventSink
+	in.RuntimeEventSink = func(event task.RuntimeEvent) {
+		st.emitted[runtimeEventKey(event)] = true
+		if upstreamRuntimeSink != nil {
+			upstreamRuntimeSink(event)
+			return
+		}
+		EmitRuntimeEvents(ctx, ev, taskID, identifier, []task.RuntimeEvent{event})
+	}
+	return st
+}
+
+// forwardResultRuntimeEvents emits any runtime events the runner returned in its
+// Result that the streaming sink did not already deliver, deduped by event key.
+func (st *runnerSinkState) forwardResultRuntimeEvents(ctx context.Context, ev EventEmitter, taskID, identifier string, res runner.Result) {
+	for _, event := range res.RuntimeEvents {
+		if st.emitted[runtimeEventKey(event)] {
+			continue
+		}
+		EmitRuntimeEvents(ctx, ev, taskID, identifier, []task.RuntimeEvent{event})
+	}
+}
+
+// terminalRunnerEvent is one structured task event the timeout boundary emits
+// when the runner returns an error. The slice is ordered because the stall path
+// emits the stalled budget event before the shared runner_timeout retry-budget
+// event, and observers depend on that order.
+type terminalRunnerEvent struct {
+	kind    string
+	message string
+	payload map[string]any
+}
+
+// runnerErrorClassification maps a runner error to its SPEC §7.2 terminal phase,
+// the ordered events the boundary emits for it, and the error to surface to the
+// caller — normalized to *runner.TimeoutError for the bare context-deadline case
+// so retry policy sees one timeout type. classifyRunnerError is the single owner
+// of this taxonomy: a misclassification is then a one-line table change, not a
+// hunt through the timeout/event orchestration in RunRunnerWithTimeout (#886).
+type runnerErrorClassification struct {
+	phase  task.RunAttemptPhase
+	events []terminalRunnerEvent
+	err    error
+}
+
+// classifyRunnerError decides how a non-nil runner error maps to a terminal
+// phase and events. Order is significant and mirrors the runner error taxonomy:
+// stall, then the turn/read/outer timeout family, then a supervised
+// reconcile-cancel stop, then a plain failure. ctx carries the run's cancel
+// cause (the reconcile-cancel signal); runCtxErr is the timeout context's Err()
+// used only to normalize a bare deadline into *runner.TimeoutError.
+func classifyRunnerError(ctx context.Context, runErr, runCtxErr error, res runner.Result, model string, elapsed, timeout time.Duration) runnerErrorClassification {
+	var stall *runner.StallError
+	if errors.As(runErr, &stall) {
+		payload := timeoutBudgetPayload(model, stall.Timeout, stall.Elapsed, res)
+		return runnerErrorClassification{
+			phase: task.PhaseStalled,
+			events: []terminalRunnerEvent{
+				{task.EventStalled, stall.Error(), payload},
+				{task.EventRunnerTimeout, stall.Error(), payload},
+			},
+			err: runErr,
+		}
+	}
+	var turnTimeout *runner.TurnTimeoutError
+	if errors.As(runErr, &turnTimeout) {
+		payload := timeoutBudgetPayload(model, turnTimeout.Timeout, turnTimeout.Elapsed, res)
+		return runnerErrorClassification{
+			phase:  task.PhaseTimedOut,
+			events: []terminalRunnerEvent{{task.EventRunnerTimeout, turnTimeout.Error(), payload}},
+			err:    runErr,
+		}
+	}
+	var readTimeout *runner.ReadTimeoutError
+	if errors.As(runErr, &readTimeout) {
+		payload := timeoutBudgetPayload(model, readTimeout.Timeout, elapsed, res)
+		return runnerErrorClassification{
+			phase:  task.PhaseTimedOut,
+			events: []terminalRunnerEvent{{task.EventRunnerTimeout, readTimeout.Error(), payload}},
+			err:    runErr,
+		}
+	}
+	if te, surfaced := asTimeoutError(runErr, runCtxErr, timeout, elapsed); te != nil {
+		payload := timeoutBudgetPayload(model, te.Timeout, te.Elapsed, res)
+		return runnerErrorClassification{
+			phase:  task.PhaseTimedOut,
+			events: []terminalRunnerEvent{{task.EventRunnerTimeout, te.Error(), payload}},
+			err:    surfaced,
+		}
+	}
+	if isReconcileCancel(ctx, runErr) {
+		// SPEC D9 (#131/#543): a per-tick eligibility reconcile stopped this run
+		// because its tracker issue left the active set (e.g. the agent's own PR
+		// handoff to In Review). That is a supervised stop, not a runner failure,
+		// so it records runner_stopped (ok=true) and is not counted against the
+		// superseded run.
+		payload := map[string]any{
+			"model":       model,
+			"duration_ms": elapsed.Milliseconds(),
+			"ok":          true,
+			"reason":      "reconcile_ineligible",
+		}
+		addOutputFields(payload, res)
+		return runnerErrorClassification{
+			phase:  task.PhaseCanceledByReconciliation,
+			events: []terminalRunnerEvent{{task.EventRunnerStopped, "runner stopped: reconcile ineligible", payload}},
+			err:    runErr,
+		}
+	}
+	payload := map[string]any{
+		"model":       model,
+		"duration_ms": elapsed.Milliseconds(),
+		"error":       ErrSummary(runErr),
+		"ok":          false,
+	}
+	addOutputFields(payload, res)
+	return runnerErrorClassification{
+		phase:  task.PhaseFailed,
+		events: []terminalRunnerEvent{{task.EventRunnerEnd, "runner failed", payload}},
+		err:    runErr,
+	}
+}
+
+// asTimeoutError reports whether runErr is (or should normalize to) an outer
+// *runner.TimeoutError, returning the canonical TimeoutError for the payload and
+// the error to surface (nil, nil when it is neither). An already-typed
+// TimeoutError keeps the caller's original (possibly wrapped) error; a bare
+// context.DeadlineExceeded that fired the run context's own deadline is
+// normalized so the timeout retry bucket and event payload stay uniform.
+func asTimeoutError(runErr, runCtxErr error, timeout, elapsed time.Duration) (*runner.TimeoutError, error) {
+	var te *runner.TimeoutError
+	if errors.As(runErr, &te) {
+		return te, runErr
+	}
+	if errors.Is(runErr, context.DeadlineExceeded) && errors.Is(runCtxErr, context.DeadlineExceeded) {
+		norm := &runner.TimeoutError{Timeout: timeout, Elapsed: elapsed, Cause: runErr}
+		return norm, norm
+	}
+	return nil, nil
+}
+
+// timeoutBudgetPayload builds the runner_timeout/stalled event payload shared by
+// the stall and timeout classifications: the configured budget, the observed
+// elapsed, and any captured output telemetry.
+func timeoutBudgetPayload(model string, budget, elapsed time.Duration, res runner.Result) map[string]any {
+	payload := map[string]any{
+		"model":      model,
+		"timeout_ms": budget.Milliseconds(),
+		"elapsed_ms": elapsed.Milliseconds(),
+	}
+	addOutputFields(payload, res)
+	return payload
 }
 
 // EmitPhaseTransition records SPEC §7.2 run-attempt phase transitions with the


### PR DESCRIPTION
Closes #886

## Summary
- Extracts the runner error taxonomy + terminal event mapping out of `RunRunnerWithTimeout` into a focused `classifyRunnerError` **decision object** (`internal/worker/runtask.go`). The boundary function now just: runs the runner under timeout, forwards events, applies the decision (phase transition + ordered events), and returns the surfaced error.
- Lifts the phase-transition / runtime-event sink plumbing into `wireRunnerSinks` (+ `runnerSinkState`) so the live-phase tracking and runtime-event dedup are a named responsibility rather than two inline closures.
- Removes the dual `//nolint:gocognit,funlen // baseline (#521)` directive — `RunRunnerWithTimeout` now passes both linters without it (verified locally; golangci `0 issues`).
- **Behavior-preserving refactor** (`type:refactor`, hidden from changelog, no version bump). No change to timeout budgets, retry policy, runner interfaces, app-server protocol, or reconcile-cancel semantics.

Root cause this addresses: the riskiest part of the function (the error→phase→event taxonomy, which drives retry policy / observability / the reconcile-cancel handoff) was embedded inside the broader timeout/event orchestration. It now lives in one table-tested decision function where a misclassification is a one-line change, not a hunt through the orchestration.

## Acceptance criteria (issue #886)
- ✅ Preserves exact classification for `StallError`, `TurnTimeoutError`, `ReadTimeoutError`, outer `TimeoutError`, context-deadline normalization, reconcile cancel, and plain errors — same branch order (stall → turn → read → outer/deadline → reconcile → plain).
- ✅ Preserves emitted event kinds + payload fields: `runner_timeout`, `stalled`, `runner_stopped`, `runner_end`, phase transition targets, `ok`, `reason`, output telemetry, `timeout_ms`/`elapsed_ms`/`duration_ms`. The stall path still emits `stalled` then `runner_timeout` (ordered) sharing one payload; `read_timeout` still uses the **outer** wall-clock elapsed; the bare context-deadline is still normalized to a synthesized `*runner.TimeoutError{Cause: deadline}` while an already-typed/wrapped `*TimeoutError` keeps its original surfaced identity.
- ✅ Decision-table test (`TestClassifyRunnerError`, `internal/worker/runner_error_test.go`) drives `classifyRunnerError` directly and pins phase + ordered kinds + exact budget/`duration_ms`/`ok`/`reason` fields + absent-field discriminators + surfaced-error identity per class — deleting/flipping one branch fails a row.
- ✅ `baseline (#521)` directive removed; `gocognit`/`funlen` pass without it.
- ✅ Mutation-verified against the committed artifact (see below).
- ✅ Targeted worker tests + full local gate run (see Testing).

## Mutation verification (against committed HEAD)
1. **Classification branch** — flipped the reconcile branch `phase: PhaseCanceledByReconciliation → PhaseFailed`; `TestClassifyRunnerError/reconcile_cancel` FAILED (`phase = "Failed"; want "CanceledByReconciliation"`); restored, tree == HEAD.
2. **Surfaced-error identity** — changed `asTimeoutError` errors.As branch `return te, runErr → return te, te`; `TestClassifyRunnerError/wrapped_outer_timeout` FAILED (surfaced the unwrapped inner `*TimeoutError` instead of the wrapper); restored, tree == HEAD.

## SPEC alignment (AGENTS.md principle 6/7)
This is a behavior-preserving Go-internal decomposition: no new key/phase/gate/artifact, no protocol change, and **no new `internal/worker/` file** (all helpers stay in the existing `runtask.go`, so the PR Metadata gate does not classify it as SPEC-sensitive). Reconcile-cancel is the pre-existing aiops D9 extension (#131/#543), unchanged.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Production diff: **1 file** (`internal/worker/runtask.go`), 192+/113− = 305 changed production LOC (the new `runner_error_test.go` is a test file, excluded). 1 file is far under the 12-file guideline; the LOC sits ~5 over the 300-LOC line because the churn is **relocated** code (the inline 145-line classification deleted and re-added as structured helpers + the slimmer boundary). It is one atomic refactor — splitting it would leave an intermediate that still carries the `#521` baseline nolint.

- [ ] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [x] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`internal/worker` + `scripts`: `0 issues`, incl. `funlen`/`gocognit` without the baseline)
- [x] additional validation noted below when needed

## Pre-push dual review (protocol §3, parallel subagents — operator-authorized)
- **Claude-family** (`feature-dev:code-reviewer`): **MERGE-READY** — confirmed per-branch behavior preservation (phase targets, kind ordering, budget sources, surfaced-error identity); flagged the stall shared-payload as pre-existing, not a regression.
- **Codex-family** (`codex:codex-rescue`): **NEEDS-CHANGES** — two LOW test-rigor findings (no production behavior difference found): (1) pin exact budget/`duration_ms`/message fields incl. read-timeout's outer elapsed + stall shared payload; (2) add a wrapped-`*TimeoutError` case to pin surfaced-error identity. **Both addressed** in the strengthened decision-table test; mutation #2 above confirms the new wrapped case discriminates.

## Size gate
- [ ] `within budget`
- [x] `size-gated: justified overage` — atomic single-file refactor; ~5 LOC over the 300 guideline is relocated code (not new scope), 1 file, fully reviewed by both pre-push reviewers. Needs human size-gate sign-off.
- [ ] `size-gated: split recommended`

## Status — final head `5da4439`
- **CI: green** — all 6 required checks pass (E2E Gitea mock loop, Go build and test, Security and supply-chain, Validate PR metadata, Validate PR title, Docker image build); run `27592749434`.
- **`@codex review` (GitHub bot): clean on head `5da4439`** — re-triggered as `bytevane` (`#issuecomment-4715303408`) after an initial usage-limit window; verdict: *"Didn't find any major issues"*, **Reviewed commit: `5da4439a77`** (head-bound). No findings review object, `reviewThreads` = 0.
- **Pre-merge fresh Codex-family review on the pushed head** (`codex:codex-rescue` on the `5da4439` diff): **MERGE-READY** — re-verified classification order, `asTimeoutError` identity contract (both sub-cases), parent-ctx reconcile detection precedence, `wireRunnerSinks` parity + no race, and that the strengthened decision-table discriminates each class with no placebo assertions.
- Unresolved actionable review threads: **0**.

## Notes
- No deferrals. No new SPEC deviation.
- Merge blockers remaining: (1) human **size-gate sign-off** (`size-gated: justified overage`, ~5 LOC over for an atomic single-file refactor) and (2) explicit human merge permission (protocol §8). Not auto-merged.
