### PR TITLE
refactor(runner): extract worker-injected Go cache carry-through helper

### DIFF
--- a/internal/runner/go_cache_test.go
+++ b/internal/runner/go_cache_test.go
@@ -44,6 +44,68 @@ func TestSandboxEnvDoesNotCarryOperatorOrHostGoCaches(t *testing.T) {
 	}
 }
 
+// TestCarryWorkerInjectedGoCacheCarriesOnlyWorkerInjected pins the leak-vs-no-leak
+// boundary of the extracted helper directly: a worker-injected value (under
+// aiopsGoCacheRoot) is carried, while an operator path the allowlist loop did
+// not admit stays blocked (codex review #548).
+func TestCarryWorkerInjectedGoCacheCarriesOnlyWorkerInjected(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	workerCache := filepath.Join(aiopsGoCacheRoot(), "build", "k")
+	primaryByName := map[string]string{
+		"GOCACHE":    workerCache,     // worker-injected -> carried
+		"GOMODCACHE": "/operator/mod", // operator path -> blocked
+	}
+	seen := map[string]struct{}{}
+	body := strings.Join(carryWorkerInjectedGoCache(nil, primaryByName, seen), "\n")
+	if !strings.Contains(body, "GOCACHE="+workerCache) {
+		t.Errorf("carryWorkerInjectedGoCache(%q) dropped worker-injected GOCACHE; got:\n%s", workerCache, body)
+	}
+	if strings.Contains(body, "GOMODCACHE") {
+		t.Errorf("carryWorkerInjectedGoCache leaked operator GOMODCACHE=/operator/mod past the boundary; got:\n%s", body)
+	}
+	if _, ok := seen["GOCACHE"]; !ok {
+		t.Errorf("carryWorkerInjectedGoCache(%q) did not mark carried GOCACHE seen; seen=%v", workerCache, seen)
+	}
+}
+
+// TestCarryWorkerInjectedGoCacheSkipsAlreadySeen pins the no-duplicate invariant:
+// a name the allowlist loop already emitted (recorded in seen) is not re-appended.
+func TestCarryWorkerInjectedGoCacheSkipsAlreadySeen(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	workerCache := filepath.Join(aiopsGoCacheRoot(), "build", "k")
+	primaryByName := map[string]string{"GOCACHE": workerCache}
+	seen := map[string]struct{}{"GOCACHE": {}} // allowlist loop already emitted it
+	env := carryWorkerInjectedGoCache([]string{"GOCACHE=" + workerCache}, primaryByName, seen)
+	if got := strings.Count(strings.Join(env, "\n"), "GOCACHE="); got != 1 {
+		t.Errorf("carryWorkerInjectedGoCache duplicated an already-seen GOCACHE; want 1 occurrence, got %d in %q", got, env)
+	}
+}
+
+// TestCarryWorkerInjectedGoCacheSkipsAbsentName pins that nothing is fabricated
+// when no Go cache name is present in primary (e.g. a non-codex runner path).
+func TestCarryWorkerInjectedGoCacheSkipsAbsentName(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	env := carryWorkerInjectedGoCache(nil, map[string]string{"PATH": "/login"}, map[string]struct{}{})
+	if len(env) != 0 {
+		t.Errorf("carryWorkerInjectedGoCache fabricated env for absent Go cache names; got %q", env)
+	}
+}
+
+// TestSandboxEnvEmitsSingleGoCacheWhenAllowlistedAndWorkerInjected pins the
+// WIRING SEAM (clean-code rule 11), not just the leaf: sandboxEnv must share its
+// seen set between the allowlist loop and carryWorkerInjectedGoCache so a GOCACHE
+// that is BOTH allowlisted and worker-injected is emitted exactly once. The
+// helper-level dedup test stays green even if sandboxEnv drops its allowlist-loop
+// seen mark or hands carry a fresh map, so this drives the production wiring.
+func TestSandboxEnvEmitsSingleGoCacheWhenAllowlistedAndWorkerInjected(t *testing.T) {
+	t.Setenv("TMPDIR", "/sandbox-tmp")
+	workerCache := filepath.Join(aiopsGoCacheRoot(), "build", "k")
+	env := sandboxEnv([]string{"GOCACHE=" + workerCache}, []string{"GOCACHE"}, workflow.Config{})
+	if got := strings.Count(strings.Join(env, "\n"), "GOCACHE="); got != 1 {
+		t.Errorf("sandboxEnv emitted GOCACHE %d times; want exactly 1 (allowlisted + worker-injected must not duplicate): %q", got, env)
+	}
+}
+
 func TestWithSandboxGoToolchainCachesDefaults(t *testing.T) {
 	t.Setenv("TMPDIR", "/sandbox-tmp")
 	got := withSandboxGoToolchainCaches([]string{"PATH=/login"}, "/ws/issue-1")

--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -98,55 +98,81 @@ func scopedEnv(allow []string, cfg workflow.Config) []string {
 	return sandboxEnv(nil, allow, cfg)
 }
 
-func sandboxEnv(primary []string, allow []string, cfg workflow.Config) []string { //nolint:gocognit // baseline (#521)
+func sandboxEnv(primary []string, allow []string, cfg workflow.Config) []string {
 	if len(allow) == 0 {
 		return []string{}
 	}
-	primaryByName := make(map[string]string, len(primary))
-	for _, envPair := range primary {
-		name, value, ok := strings.Cut(envPair, "=")
-		if ok && name != "" {
-			primaryByName[name] = value
-		}
-	}
+	primaryByName := indexEnvByName(primary)
 	seen := map[string]struct{}{}
 	var env []string
 	for _, name := range allow {
 		name = strings.TrimSpace(name)
-		if name == "" || strings.Contains(name, "=") {
-			continue
-		}
-		if workflow.AgentEnvPassthroughDenyReasonForConfig(name, cfg) != "" {
-			continue
-		}
 		if _, ok := seen[name]; ok {
 			continue
 		}
-		seen[name] = struct{}{}
-		if value, ok := primaryByName[name]; ok {
-			env = append(env, name+"="+value)
+		value, ok := allowlistedEnvValue(name, primaryByName, cfg)
+		if !ok {
 			continue
 		}
-		if value, ok := os.LookupEnv(name); ok {
-			env = append(env, name+"="+value)
+		seen[name] = struct{}{}
+		env = append(env, name+"="+value)
+	}
+	return carryWorkerInjectedGoCache(env, primaryByName, seen)
+}
+
+// indexEnvByName maps each KEY=VALUE pair in env to KEY->VALUE, keeping the last
+// value for a repeated key. Pairs without a non-empty name are skipped.
+func indexEnvByName(env []string) map[string]string {
+	byName := make(map[string]string, len(env))
+	for _, pair := range env {
+		name, value, ok := strings.Cut(pair, "=")
+		if ok && name != "" {
+			byName[name] = value
 		}
 	}
-	// Carry the worker-injected Go toolchain cache defaults (#544) through the
-	// allowlist: setupAppServerCommand sets GOCACHE/GOMODCACHE as agent-runtime
-	// requirements, not operator passthrough, so the operator should not have to
-	// allowlist them for the agent's first `go test` to find a writable cache.
-	// Only WORKER-INJECTED values (under aiopsGoCacheRoot) are carried — an
-	// operator's own GOCACHE/GOMODCACHE that they kept out of env_allowlist still
-	// respects that boundary (codex review #548). The bwrap/firejail tmpfs /tmp
-	// keeps the default writable.
+	return byName
+}
+
+// allowlistedEnvValue resolves the value an allowlisted name contributes to the
+// sandbox env, or reports ok=false when the name must not cross the boundary.
+// It enforces the default-deny boundary: a malformed name, or one the tracker
+// token deny filter rejects, resolves to nothing; an admitted name takes its
+// worker-supplied value (primary) ahead of the host environment.
+func allowlistedEnvValue(name string, primaryByName map[string]string, cfg workflow.Config) (string, bool) {
+	if name == "" || strings.Contains(name, "=") {
+		return "", false
+	}
+	if workflow.AgentEnvPassthroughDenyReasonForConfig(name, cfg) != "" {
+		return "", false
+	}
+	if value, ok := primaryByName[name]; ok {
+		return value, true
+	}
+	return os.LookupEnv(name)
+}
+
+// carryWorkerInjectedGoCache appends the worker-injected Go toolchain cache
+// defaults (#544) that the allowlist loop did not already admit, so the agent's
+// first `go test` finds a writable cache under the optional bubblewrap/firejail
+// wrapper (its tmpfs /tmp keeps the default writable). setupAppServerCommand
+// sets GOCACHE/GOMODCACHE as agent-runtime requirements, not operator
+// passthrough, so the operator should not have to allowlist them.
+//
+// Only WORKER-INJECTED values (under aiopsGoCacheRoot) are carried — an
+// operator's own GOCACHE/GOMODCACHE kept out of sandbox.env_allowlist still
+// respects that deny boundary (codex review #548). seen records the names the
+// allowlist already emitted so a carried name is never duplicated.
+func carryWorkerInjectedGoCache(env []string, primaryByName map[string]string, seen map[string]struct{}) []string {
 	for _, name := range goCacheNames() {
 		if _, ok := seen[name]; ok {
 			continue
 		}
-		if value, ok := primaryByName[name]; ok && isWorkerInjectedGoCache(value) {
-			seen[name] = struct{}{}
-			env = append(env, name+"="+value)
+		value, ok := primaryByName[name]
+		if !ok || !isWorkerInjectedGoCache(value) {
+			continue
 		}
+		seen[name] = struct{}{}
+		env = append(env, name+"="+value)
 	}
 	return env
 }

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -123,6 +123,25 @@ func TestScopedEnvRejectsTrackerAPIKeyValue(t *testing.T) {
 	}
 }
 
+// TestAllowlistedEnvValueDeniesTrackerToken isolates the deny boundary in the
+// extracted resolver: a tracker token name resolves to nothing even when a
+// value is present in primary, so it can never cross into the sandbox.
+func TestAllowlistedEnvValueDeniesTrackerToken(t *testing.T) {
+	if value, ok := allowlistedEnvValue("GITHUB_TOKEN", map[string]string{"GITHUB_TOKEN": "from-primary"}, workflow.Config{}); ok {
+		t.Errorf("allowlistedEnvValue(GITHUB_TOKEN) = (%q, true); want denied", value)
+	}
+}
+
+// TestAllowlistedEnvValuePrefersPrimaryOverHost isolates the lookup order: a
+// worker-supplied (primary) value wins over the host environment.
+func TestAllowlistedEnvValuePrefersPrimaryOverHost(t *testing.T) {
+	t.Setenv("AIOPS_RUNNER_CANARY", "from-host")
+	value, ok := allowlistedEnvValue("AIOPS_RUNNER_CANARY", map[string]string{"AIOPS_RUNNER_CANARY": "from-primary"}, workflow.Config{})
+	if !ok || value != "from-primary" {
+		t.Errorf("allowlistedEnvValue(AIOPS_RUNNER_CANARY) = (%q, %v); want (from-primary, true)", value, ok)
+	}
+}
+
 func TestSandboxEnvTreatsAllowlistAsFinalBoundary(t *testing.T) {
 	t.Setenv("AIOPS_RUNNER_CANARY", "from-worker-env")
 	t.Setenv("AIOPS_SANDBOX_CANARY", "from-sandbox-allowlist")


### PR DESCRIPTION
Closes #887

## Summary
- Split `internal/runner/sandbox.go`'s `sandboxEnv` (the secret/credential boundary into the optional bubblewrap/firejail sandbox) into three focused, directly-testable helpers and remove its `//nolint:gocognit // baseline (#521)` directive:
  - **`carryWorkerInjectedGoCache`** — the Go cache carry-through (audit-requested anchor): GOCACHE/GOMODCACHE pass the allowlist **only** when worker-injected (value under `aiopsGoCacheRoot`); an operator/host value kept out of `env_allowlist` stays blocked (#544 defaults, #548 review).
  - **`allowlistedEnvValue`** — the deny filter + primary-over-host resolution (the tracker-token deny boundary in isolation).
  - **`indexEnvByName`** — the primary `KEY=VALUE` indexing.
- Behavior-preserving: the returned env slice is identical for all inputs. `seen` is now marked on emit rather than on every admissible name; this is output-neutral because a Go cache name only carries when its value is present in `primary`, so an admissible-but-valueless name reaches the carry loop with the same outcome either way (proven by both review families + a seam test).

This is an aiops deep-defense extension (the optional sandbox env builder); upstream codex carries its own sandbox, so there is no SPEC/upstream contract surface — a pure internal decomposition. From `docs/audits/2026-06-07-baseline-521-nolint-risk-ranking.md` First-batch item #5.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file (`internal/runner/sandbox.go`, ~+56/−30 LOC); test files excluded.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Acceptance criteria (#887)
- [x] Preserve `sandboxEnv` default-deny + tracker-token deny behavior — pinned by `TestAllowlistedEnvValueDeniesTrackerToken`, `TestScopedEnvRejectsTrackerTokenNames/APIKeyValue`, `TestSandboxEnvTreatsAllowlistAsFinalBoundary`.
- [x] Preserve worker-injected carry-through only under aiops root — `TestCarryWorkerInjectedGoCacheCarriesOnlyWorkerInjected`, `TestSandboxEnvCarriesWorkerInjectedGoCaches`.
- [x] Preserve rejection of operator/host caches not allowlisted — `TestSandboxEnvDoesNotCarryOperatorOrHostGoCaches`.
- [x] Add focused characterization tests around the extracted helper — direct `carryWorkerInjectedGoCache` + `allowlistedEnvValue` tests, plus a **wiring-seam** test (`TestSandboxEnvEmitsSingleGoCacheWhenAllowlistedAndWorkerInjected`) driving the real `sandboxEnv` path.
- [x] Remove the `baseline (#521)` directive from `sandboxEnv` — gocognit passes (`sandboxEnv`+3 helpers each ≤10, min-complexity 10; `0 issues` on the full blocking gate). The three remaining baseline nolints (`applySandbox`, `bubblewrapCommand`, `writeFirejailNetfilter`) are untouched pre-existing debt.
- [x] Mutation-verify the extracted rule against the committed artifact (see below).

## Mutation verification (against committed artifact)
| Mutation | Test that fails |
|---|---|
| carry drops the `!isWorkerInjectedGoCache` guard (carry everything) | `TestCarryWorkerInjectedGoCacheCarriesOnlyWorkerInjected` |
| carry drops the already-seen dedup | `TestCarryWorkerInjectedGoCacheSkipsAlreadySeen` |
| `allowlistedEnvValue` drops the deny filter | `TestAllowlistedEnvValueDeniesTrackerToken`, `TestScopedEnvRejectsTrackerTokenNames` |
| `allowlistedEnvValue` host-before-primary order swap | `TestAllowlistedEnvValuePrefersPrimaryOverHost` |
| `sandboxEnv` drops allowlist-loop `seen` mark / hands carry a fresh map | `TestSandboxEnvEmitsSingleGoCacheWhenAllowlistedAndWorkerInjected` |

## Review notes (pre-push dual-family gate, per pr-review-merge-protocol §3)
- Round 1 (head `0dbf7f7`): Codex-family (`codex:codex-rescue`, session `019ecf01…`) MERGE-READY; Claude-family (`feature-dev:code-reviewer`) MERGE-READY. A third cross-check (`codex exec`) raised one **MEDIUM**: the no-duplicate invariant was tested only at the leaf helper, not the `sandboxEnv` wiring seam (clean-code rule 11). Confirmed the gap (dropping the seam `seen` mark left existing tests green), then added `TestSandboxEnvEmitsSingleGoCacheWhenAllowlistedAndWorkerInjected` and mutation-verified it catches both named compiling mutations.
- Round 2 (head `649e9d2`): Codex-family (`codex exec`) `blocking_findings: []`; Claude-family (`feature-dev:code-reviewer`) MERGE-READY — confirmed the seam test is a genuine guard (not a placebo) and the `seen`-mark reorder is output-neutral across all inputs (incl. `scopedEnv` primary=nil).

## Testing
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...` (exit 0)
- [x] `gofmt -l` clean + blocking golangci gate (`0 issues` on `internal/runner`)
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go build ./cmd/worker ./cmd/tui`