### PR TITLE
docs(protocol): note codex-rescue foreground use for the review gate

### DIFF
--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -99,7 +99,15 @@ explicitly the Codex-family or Claude-family reviewer for that environment.
   [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) (`Agent` tool,
   `subagent_type: "codex:codex-rescue"`); pass the full brief in the prompt. It
   wraps the Codex CLI review contract and returns structured output via
-  `codex:codex-result-handling`. **Only when** no authorized and appropriate
+  `codex:codex-result-handling`. Invoke it **foreground/synchronous** for this
+  gate — an `Agent` call without `run_in_background`, and no `--background` — so
+  the review returns inline: the rescue runtime's `task` blocks and returns by
+  default, whereas `--background` detaches a `task-worker` whose result, once the
+  spawning Claude session ends, is no longer surfaced by default
+  `/codex:status`/`/codex:result` discovery (session-scoped) and is recoverable
+  only via the retained job id (#743). Reserve `--background` for long
+  fire-and-forget work fetched with `/codex:result` in the same session.
+  **Only when** no authorized and appropriate
   Codex-family subagent path is available, fall back to plain `codex exec
   --output-schema` with the repo-specific review prompt and diff on stdin.
   Do not use `codex exec review --base` for this gate: the `review` subcommand


### PR DESCRIPTION
Closes #897

## Summary
- §3 (Pre-push dual diff-only reviewers) **prefers** `codex:codex-rescue` as the Codex-family reviewer but omitted its one real footgun. Add a one-line note: invoke it **foreground/synchronous** for the gate (an `Agent` call without `run_in_background`, no `--background`) so the review returns inline; `--background` detaches a `task-worker` that outlives the parent but, once the spawning Claude session ends, is no longer surfaced by default `/codex:status`/`/codex:result` discovery (session-scoped) and is recoverable only via the retained job id (#743). Reserve `--background` for same-session fire-and-forget.
- Earned-rules anchor: the #743 background-orphan failure + a #896 foreground success (a foreground `codex:codex-rescue` returned a real review in ~3 min).
- Source-verified against codex-plugin-cc: `codex-companion.mjs` foreground default (`runForegroundCommand` vs `if (options.background)`); `job-control.mjs::resolveResultJob` (~L258: `reference ? listJobs(...) : filterJobsForCurrentSession(...)`) — the session filter is skipped on an explicit job id.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

`pr-review-merge-protocol.md` is a runbook, not a SPEC-sensitive path; docs-only change.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 0 production code files (1 runbook, +8/−1 docs).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Review notes (pre-push, per §3 — docs change = one dual-review round)
- Round 1: Claude-family (`feature-dev:code-reviewer`) MERGE-READY (doc consistency: local-reviewer vs cloud `@codex review` distinction intact, purely additive). Foreground `codex:codex-rescue` (read the plugin source) raised the original draft **overstated** the orphan risk ("retrievable only inside the spawning session" / "orphans on session end") — an explicit job id bypasses the session filter, so a backgrounded job is recoverable cross-session.
- Fix: softened to "default discovery is session-scoped; recoverable via the retained job id". Round 2: foreground `codex:codex-rescue` re-check MERGE-READY, all claims verified accurate with source line citations.

## Testing
- [x] docs-only; no Go/scripts changed. `gofmt -l` n/a; PR title + metadata gates apply.