### PR TITLE
refactor(api): extract loopback Host normalization helper

### DIFF
--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1478,6 +1478,36 @@ func TestIsLoopbackHTTPHost(t *testing.T) {
 	}
 }
 
+func TestNormalizeHostFromHostport(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantHost string
+		wantOK   bool
+	}{
+		{"127.0.0.1:4000", "127.0.0.1", true},
+		{"127.0.0.1", "127.0.0.1", true},
+		{"localhost:4000", "localhost", true},
+		{"localhost", "localhost", true},
+		{"[::1]:4000", "::1", true},
+		{"[::1]", "::1", true}, // bracketed IPv6, no port — strip-without-port path
+		{"evil.example", "evil.example", true},
+		{"evil.example:4000", "evil.example", true},
+		// Fail-closed: a host the gate cannot parse unambiguously must report ok=false.
+		{"", "", false},
+		{"::1", "", false},  // unbracketed IPv6 "host:port" that fails to split
+		{"[::1", "", false}, // opening bracket without a closing one
+		{"::1]", "", false}, // closing bracket without an opening one
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			gotHost, gotOK := normalizeHostFromHostport(c.in)
+			if gotHost != c.wantHost || gotOK != c.wantOK {
+				t.Fatalf("normalizeHostFromHostport(%q) = (%q, %v), want (%q, %v)", c.in, gotHost, gotOK, c.wantHost, c.wantOK)
+			}
+		})
+	}
+}
+
 func TestStartStateHTTPServerSkipsDisabledPort(t *testing.T) {
 	handle := startStateHTTPServer(context.Background(), "127.0.0.1", -1, func(context.Context) (orchestrator.StateView, error) {
 		t.Fatal("disabled state server must not evaluate snapshot")

--- a/cmd/worker/statehttp_server.go
+++ b/cmd/worker/statehttp_server.go
@@ -403,32 +403,46 @@ func stateHTTPTokenMatches(got, want string) bool {
 	}
 	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
 }
-func isLoopbackHTTPHost(hostport string) bool { //nolint:gocognit // baseline (#521)
-	if hostport == "" {
+func isLoopbackHTTPHost(hostport string) bool {
+	host, ok := normalizeHostFromHostport(hostport)
+	if !ok {
 		return false
-	}
-	host := hostport
-	if h, _, err := net.SplitHostPort(hostport); err == nil {
-		host = h
-	} else if strings.Contains(hostport, ":") && !strings.HasPrefix(hostport, "[") {
-		// "host:port" without IPv6 brackets that failed to split — malformed.
-		return false
-	}
-	// Strip IPv6 brackets only when the host is properly bracketed (e.g. "[::1]").
-	// Reject unpaired brackets — "[::1" or "::1]" are malformed Host values.
-	if strings.HasPrefix(host, "[") || strings.HasSuffix(host, "]") {
-		if !strings.HasPrefix(host, "[") || !strings.HasSuffix(host, "]") {
-			return false
-		}
-		host = host[1 : len(host)-1]
 	}
 	if host == "localhost" {
 		return true
 	}
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
-		return true
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// normalizeHostFromHostport extracts the bare host from an HTTP Host value,
+// dropping an optional port and matched IPv6 brackets. It fails closed
+// (ok=false) for any Host the no-auth loopback gate cannot parse unambiguously
+// — empty input, an unbracketed "host:port" that failed to split, or unpaired
+// IPv6 brackets — so a malformed Host can never reach the loopback decision and
+// authorize a request alongside a non-loopback peer.
+func normalizeHostFromHostport(hostport string) (host string, ok bool) {
+	if hostport == "" {
+		return "", false
 	}
-	return false
+	host = hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	} else if strings.Contains(hostport, ":") && !strings.HasPrefix(hostport, "[") {
+		// "host:port" without IPv6 brackets that failed to split — malformed.
+		return "", false
+	}
+	// Strip IPv6 brackets only when the host is properly bracketed (e.g. "[::1]").
+	// An opening bracket without a closing one (or vice versa) is a malformed
+	// Host value, so reject it rather than guessing.
+	hasOpen, hasClose := strings.HasPrefix(host, "["), strings.HasSuffix(host, "]")
+	if hasOpen != hasClose {
+		return "", false
+	}
+	if hasOpen {
+		host = host[1 : len(host)-1]
+	}
+	return host, true
 }
 func isLoopbackHTTPRemoteAddr(remoteAddr string) bool {
 	host, _, err := net.SplitHostPort(remoteAddr)


### PR DESCRIPTION
## Summary

Refactors the security-sensitive `isLoopbackHTTPHost` predicate (the no-auth
loopback gate for the state HTTP API) per #888. Host normalization — port
splitting, IPv6 bracket pairing, malformed-Host rejection — is extracted into
`normalizeHostFromHostport(hostport) (host string, ok bool)`, which **fails
closed** (`ok=false`) for any Host the gate cannot parse unambiguously. The
loopback decision in `isLoopbackHTTPHost` is now a flat `localhost`/loopback-IP
check on the normalized host. Behavior is fully preserved; the peer-address
pairing in `stateHTTPAccessGuard.wrap` (loopback Host **and** loopback peer) is
untouched, so a spoofed loopback Host from a non-loopback peer is still rejected.

This is an aiops security extension, not a SPEC concept — no upstream Symphony
equivalent to align against; the refactor is behavior-preserving by design.

Closes #888

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Behavior-preserving decomposition of an existing aiops security predicate; no
new key, phase, gate, or artifact — adjacent SPEC code paths untouched.

## Acceptance criteria

- [x] Preserve ACCEPT of `localhost`, `localhost:port`, IPv4 loopback (+port), `[::1]`, `[::1]:port`.
- [x] Preserve REJECT of unbracketed IPv6 (`::1`), unpaired brackets (`[::1`, `::1]`), non-loopback domains/IPs, empty host, malformed `host:port`.
- [x] Loopback Host alone does not authorize a non-loopback peer (`stateHTTPAccessGuard.wrap` pairing unchanged; `TestStateHTTPServerRejectsSpoofedLoopbackHostFromNonLoopbackPeer` covers it).
- [x] Added `TestNormalizeHostFromHostport` table tests around the extracted helper (incl. every fail-closed branch).
- [x] Removed the `//nolint:gocognit // baseline (#521)` directive — gocognit passes without it (refactored complexity ≈6, threshold min-complexity 10).
- [x] Mutation-verified a malformed-host branch against the committed artifact.
- [x] Ran targeted `cmd/worker` tests plus the standard local gate.

## Non-goals (honored)
- No change to state-API auth-token behavior.
- No broadening of the no-auth loopback exception.
- No refactor of unrelated state-API handlers (the 3 other `baseline (#521)` nolints in this file are left in place).

## Verification

```
gofmt -l $(git ls-files '*.go')            # clean
go mod tidy && git diff --exit-code go.mod go.sum   # clean
go vet ./...                                # clean
golangci-lint run ./cmd/worker             # no gocognit/loopback findings
go test -run 'TestNormalizeHostFromHostport|TestIsLoopbackHTTPHost|TestStateHTTPServer' ./cmd/worker  # ok
go test -race -covermode=atomic ./cmd/worker   # ok (76.8%)
go test -run '^TestProductionGoFilesStayWithinSizeBudget$' ./scripts   # ok
go build ./cmd/worker ./cmd/tui            # ok
```

**Mutation check (against committed artifact):** flipped the unpaired-bracket
rejection `if hasOpen != hasClose` → `==`; the malformed-host rows in
`TestNormalizeHostFromHostport` (`[::1` returned `("::", true)` vs expected
`("", false)`) and several accept rows FAILED. Restored; `git diff HEAD` empty.

## Review
- Pre-push dual reviewers (subagent, diff-only, conclusion withheld): Codex (`codex:codex-rescue`) → **MERGE-READY** (no findings); Claude (`feature-dev:code-reviewer`) → **MERGE-READY** (one LOW false-positive test-completeness note; the flagged `[::1]` row was already present — added a clarifying comment).
- `@codex review` (as `bytevane`) **clean on head `ed709b1`** — "Didn't find any major issues", `Reviewed commit: ed709b15cf`. An earlier same-trigger response hit a usage limit, then the retry returned clean.
- GraphQL `reviewThreads`: **zero unresolved, non-outdated** threads.
- CI: all required checks green on `ed709b1` (Go build/test, Security, E2E, Docker, PR Metadata, PR title).

### Size gate
- [x] `within budget` — 2 files (1 production), +60/-16; production diff is one function pair.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
