### PR TITLE
docs(protocol): default subagent review on in interactive Claude Code

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -58,7 +58,7 @@ go build ./cmd/worker ./cmd/tui
 **暂存只 add 明确路径，绝不 `git add -A` / `git add .`**（会把 `.codex/` 等本地未跟踪文件卷入 PR）。commit 前 `git status --short` 核对只暂存了预期文件。
 
 ### 5. 提交 → 双审 → 开 PR
-1. 按协议 §2–§3 commit-first + pre-push 双 reviewer；先执行协议里的 **subagent-first reviewer routing**，具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。操作者可在当前请求中写明 `handle issue N with subagent review enabled` 作为 Codex inline 的 subagent review enabled 授权短语；授权含义仍以协议为准。review finding 先按当前 head、issue 计划、SPEC/Elixir 参考和相邻路径验证技术正确性，再修复 / 反证 / 延后。§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
+1. 按协议 §2–§3 commit-first + pre-push 双 reviewer；先执行协议里的 **subagent-first reviewer routing**，具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。交互式 Claude Code 下 subagent 双审**默认开启、不问授权**（#900）；操作者可在当前请求写 `CLI review only` 等短语 opt-out，Codex inline 环境仍按协议逐请求授权。review finding 先按当前 head、issue 计划、SPEC/Elixir 参考和相邻路径验证技术正确性，再修复 / 反证 / 延后。§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
 2. push 后开 **一个** PR 对应该 issue，body 引用 issue（`Closes #N`），列验收项、验证命令、变异验证、风险/deferral；PR body 是活账本（协议 §7）。
 3. **每条 finding 归入 ≥1 类**：算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试；然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。
 4. **Deferred 偏差必须开 issue**（AGENTS.md rule 2）：决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -33,7 +33,7 @@ allowed-tools: Bash(git *) Bash(ls *) Bash(grep *) Bash(find *) Bash(go *) Bash(
    - 测试是否安慰剂（assertion 真的读到新代码改的字段吗？）
    - 错位机制（在 §1 scheduler/runner 边界的错误一侧）：worker/orchestrator 侧「消费 agent 产物」的 phase/gate/artifact/config，先 grep Elixir 有没有等价物——没有就是过度设计信号，判**删除**（非搬进 prompt、非只记 DEVIATIONS），归宿默认是 WORKFLOW prompt（worker post-turn phase 在 push 后只能 flag 不能 prevent，且抢跑 D9 reconcile-cancel / §16.5 self-stop——#557 即此；AGENTS.md 原则 6；#557/#561 拆的就是这类）
 
-2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，并先执行协议里的 **subagent-first reviewer routing**；具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。操作者可在当前请求中写明 `review this PR with subagent review enabled` 作为 Codex inline 的授权短语；授权含义仍以协议为准。HIGH/MEDIUM/Critical 先验证技术正确性，再决定修复 / 反证 / 延后；不要盲从，也不要把 finding 当噪音略过。若 finding 证明计划本身错了，同轮更新代码、测试、SPEC/deviation 文档和 PR body。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
+2. **修一轮、提交一轮、push 前双审一轮**：按协议 §2–§3 对稳定 head SHA 派 Codex + Claude Code 双 reviewer，并先执行协议里的 **subagent-first reviewer routing**；具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。交互式 Claude Code 下 subagent 双审**默认开启、不问授权**（#900）；操作者可在当前请求写 `CLI review only` 等短语 opt-out，Codex inline 环境仍按协议逐请求授权。HIGH/MEDIUM/Critical 先验证技术正确性，再决定修复 / 反证 / 延后；不要盲从，也不要把 finding 当噪音略过。若 finding 证明计划本身错了，同轮更新代码、测试、SPEC/deviation 文档和 PR body。每 push 后按协议 §4 跑 `@codex review` 收敛、§5 用 GraphQL 处理 review threads。
 
 3. **Deferred 偏差必须开 issue**：标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria（AGENTS.md rule 2）。决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
 

--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -51,27 +51,41 @@ findings (keep each review ≤700 words) and a final verdict —
 SHA, changed files, intent (issue/PR), relevant SPEC/upstream pointers, and
 AGENTS.md policy.
 
-Subagent-first means "prefer subagent review when the current environment can do
-it and the current user request has authorized it," not automatic fan-out from a
-runbook alone. This wording closes the #891 friction: spawn_agent available but
-skipped because the user request lacked explicit authorization, followed by the
-correct CLI fallback. To opt in up front, use a current-turn phrase such as
-"handle issue N with subagent review enabled" or "review this PR with parallel
-subagents".
+Subagent review is the **default** in interactive Claude Code: when the Agent
+tool and a Codex-family subagent (`codex:codex-rescue`) are available, run the
+subagent dual review **without asking** — the operator's standing preference is
+the authorization. The per-request authorization ask was retired in #900 as
+pure ceremony (the operator invariably opted in, so the question only added a
+round-trip and contradicted the autonomy-first default). The #891 lesson still
+holds in the *other* direction: never *skip* an available subagent reviewer.
+Within this default, pick one sidecar reviewer (normal-risk) vs parallel
+specialized reviewers (high-risk diff) by **blast radius**, per "review depth
+matches blast radius" below — that escalation is automatic, not a second
+authorization to ask for. Two paths narrow this default:
+
+- **Opt out in-turn.** A current-turn phrase such as "CLI review only" or
+  "subagent review disabled" switches that request to the bounded CLI fallback.
+- **Codex inline is different.** When the main agent is Codex inline (not Claude
+  Code), its tool contract requires per-request authorization to spawn, so a
+  runbook instruction alone is not sufficient there — see the Codex inline
+  routing bullet below. The standing-default-on rule is scoped to interactive
+  Claude Code, where the Agent tool is first-party.
 
 Best-practice reviewer modes:
 
 | Mode | Use when | Required handling |
 | --- | --- | --- |
-| No subagent authorization | The request does not explicitly authorize subagent delegation, or the tool contract forbids it | Discover availability when relevant, record why subagents were not used, ask one concise authorization question before pre-push review when interactive timing allows, otherwise use bounded CLI fallback and record that reason |
-| One sidecar subagent | The diff is low-risk/docs-only or normal-risk and the user authorized subagent review | Run one independent read-only diff reviewer sidecar focused on correctness, safety/security, and test gaps, plus the existing Codex-family and Claude-family gates |
-| Parallel specialized subagents | The diff touches high-risk security, sandbox, filesystem deletion, concurrency, tracker mutation, workflow, or orchestrator behavior and the user authorized parallel review | Split read-only reviewers by concern, such as security/safety, tests/mutation gaps, races/lifecycle, and maintainability/scope, then merge their findings into the same dual-family gate |
+| Subagents unavailable / opted out | The Agent tool or a Codex-family subagent is unavailable, the tool contract forbids spawning (e.g. Codex inline without per-request authorization), or the operator opted out in-turn | Discover availability when relevant, record why subagents were not used, and use the bounded CLI fallback. **Do not** ask a standing-preference authorization question in interactive Claude Code — subagent review is the default there (#900) |
+| One sidecar subagent (default, normal-risk) | Interactive Claude Code with the Agent tool available, and the diff is low-risk/docs-only or normal-risk | Run one independent read-only diff reviewer sidecar focused on correctness, safety/security, and test gaps, plus the existing Codex-family and Claude-family gates. No authorization phrase required |
+| Parallel specialized subagents | The diff touches high-risk security, sandbox, filesystem deletion, concurrency, tracker mutation, workflow, or orchestrator behavior | Split read-only reviewers by concern, such as security/safety, tests/mutation gaps, races/lifecycle, and maintainability/scope, then merge their findings into the same dual-family gate |
 
 Reviewer routing is environment-dependent:
 
-- **Claude Code Agent.** Prefer the Agent tool subagents named below for
+- **Claude Code Agent.** Subagent dual review runs by default here (no
+  authorization phrase needed). Prefer the Agent tool subagents named below for
   family-specific review. Use the hardened CLI fallback only when the Agent
-  tool or requested subagent is unavailable or fails.
+  tool or requested subagent is unavailable or fails, or the operator opted out
+  in-turn.
 - **Codex inline.** When the environment hints that subagents or multi-agent
   tools are available, call `tool_search` for `multi_agent` / `spawn_agent`
   before CLI fallback. If `spawn_agent` is available, use it for an independent
@@ -80,8 +94,8 @@ Reviewer routing is environment-dependent:
   spawning for that request. A workflow prompt or runbook instruction alone is
   not sufficient authorization to spawn. Record the agent id/verdict in review
   notes. If subagent use is not authorized for the current session, do not
-  spawn; follow the "No subagent authorization" mode above. Do not wait for a
-  human reminder to discover the tool.
+  spawn; follow the "Subagents unavailable / opted out" mode above. Do not wait
+  for a human reminder to discover the tool.
 - **codex-sub-agent.** If the current session is already a spawned sub-agent,
   obey the parent assignment and the sub-agent notice first. Do not recursively
   spawn reviewers unless the parent task explicitly asks for that; return the

--- a/scripts/reviewer_workflow_docs_test.go
+++ b/scripts/reviewer_workflow_docs_test.go
@@ -33,14 +33,14 @@ func TestReviewerProtocolDocumentsSubagentDiscoveryBeforeCLIFallback(t *testing.
 		"Subagent review complements the two-family gate",
 		"Codex-family and Claude-family",
 		"Best-practice reviewer modes",
-		"No subagent authorization",
+		"Subagents unavailable / opted out",
 		"One sidecar subagent",
 		"Parallel specialized subagents",
 		"#891",
-		"spawn_agent available but skipped",
-		"ask one concise authorization question before pre-push review when interactive timing allows",
-		"handle issue N with subagent review enabled",
-		"review this PR with parallel subagents",
+		"an available subagent reviewer",
+		"subagent review is the default there (#900)",
+		"CLI review only",
+		"Codex inline is different",
 	} {
 		if !containsReviewerDocText(protocol, want) {
 			t.Fatalf("pr-review-merge-protocol.md missing %q", want)
@@ -56,7 +56,7 @@ func TestIssueAndPRSkillsPointToSubagentFirstReviewerRouting(t *testing.T) {
 		body := readReviewerDoc(t, path)
 		for _, want := range []string{
 			"subagent-first reviewer routing",
-			"subagent review enabled",
+			"CLI review only",
 			"pr-review-merge-protocol.md",
 		} {
 			if !containsReviewerDocText(body, want) {


### PR DESCRIPTION
## Summary

Retires the per-request "ask the operator to authorize subagent review" step in
`docs/runbooks/pr-review-merge-protocol.md` §3 (the single source of truth for
review routing). New rule: in **interactive Claude Code** with the Agent tool +
a Codex-family subagent (`codex:codex-rescue`) available, subagent dual review
runs **by default** — the operator's standing preference is the authorization.
The #891 lesson is preserved in the other direction (never *skip* an available
subagent); the opt-out is an in-turn phrase (`CLI review only`). The
standing-default-on rule is scoped to interactive Claude Code; **Codex inline
keeps its per-request authorization model** (its tool contract forbids standing
authorization). The `handle-issue` / `handle-pr` skills are updated to reference
the new default.

Earned by the observed friction: the §3 ask fired on every issue/PR run and the
operator invariably opted in — pure ceremony that added a round-trip and
contradicted the autonomy-first default.

Closes #900

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs/process change to our internal review protocol; no SPEC concept, no
key/phase/gate/artifact, no Go code touched.

## Changes
- `docs/runbooks/pr-review-merge-protocol.md` §3: rewrote the subagent-first
  preamble (default-on, in-turn opt-out, Codex-inline carve-out), renamed the
  first reviewer-mode row to "Subagents unavailable / opted out" (handling: use
  CLI fallback, **do not** ask), clarified that sidecar-vs-parallel escalation is
  by blast radius (automatic, not a second authorization), and updated the
  Claude-Code-Agent + Codex-inline routing bullets and the cross-reference.
- `.claude/skills/handle-issue/SKILL.md`, `.claude/skills/handle-pr/SKILL.md`:
  replaced the opt-in authorization-phrase sentence with the default-on summary +
  opt-out phrase, still deferring to the protocol as the source of truth.

## Gate integrity (unchanged)
- Two-family (Codex + Claude) requirement, per-push `@codex review` gate, and
  "review depth matches blast radius" are untouched — the change is **who
  authorizes**, not **whether two families review**.

## Review (final head `a2f1e36`)
- Pre-push dual reviewers ran twice (subagent, default-on — dogfooding #900 — diff-only, conclusion withheld). Round 1 (doc substance): Codex + Claude both **MERGE-READY** (one LOW on row-3 ambiguity → fixed by the blast-radius clarification, not by re-adding ceremony). Round 2 (the guard-test sync below): Codex + Claude both **MERGE-READY**, source-audited that the new pins are present and non-placebo.
- **Guard-test sync**: `scripts/reviewer_workflow_docs_test.go` pinned the now-retired wording; CI "Go build and test" caught it (and `@codex review` independently flagged the same as P1). Fixed atomically in `a2f1e36` — pins updated to the new canonical strings; full-repo grep confirms no retired string remains; `go test ./scripts` green. (Class-fix note: the miss was grepping only `*.md`, not Go guard tests — clean-code rule 10.)
- `@codex review` (as `bytevane`) **clean on head `a2f1e36`** — "Didn't find any major issues", `Reviewed commit: a2f1e366f8`. The P1 test-contract thread was resolved (fixed + replied). GraphQL `reviewThreads`: **zero unresolved, non-outdated**. CI: all required checks green on `a2f1e36`.

### Size gate
- [x] `within budget` — 4 files (0 production Go): docs/skills + a guard-test (`_test.go`, excluded from the budget).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
