### PR TITLE
fix(tooling): re-check NOT-CONFIRMED head for a late Codex review

### DIFF
--- a/scripts/local-pr-follow-through.sh
+++ b/scripts/local-pr-follow-through.sh
@@ -850,10 +850,12 @@ assert_no_actionable_threads() {
 
 # Records the NOT-CONFIRMED verdict for this head and emits the single
 # structured handoff line the operator acts on: PR, head/base, trigger id, the
-# observed signal (none — no Codex review object for this head), and any open
-# thread ids. Distinct from a network/hard error; means "human action required".
+# original trigger time (started_at — lets the next sweep re-check for a Codex
+# review that landed after the deadline, #894), the observed signal (none — no
+# Codex review object for this head), and any open thread ids. Distinct from a
+# network/hard error; means "human action required".
 record_github_codex_not_confirmed() {
-  local pr="$1" head_oid="$2" base_oid="$3" base_ref="$4" trigger_id="$5"
+  local pr="$1" head_oid="$2" base_oid="$3" base_ref="$4" trigger_id="$5" started_at="$6"
   local state_file tmp open_threads
   state_file="$(github_codex_not_confirmed_state_file "$pr" "$head_oid" "$base_oid" "$base_ref")"
   open_threads="$(collect_actionable_thread_ids "$pr" || true)"
@@ -864,10 +866,36 @@ record_github_codex_not_confirmed() {
     --arg base_oid "$base_oid" \
     --arg base_ref "$base_ref" \
     --arg trigger_id "$trigger_id" \
+    --arg started_at "$started_at" \
     --arg open_threads "$open_threads" \
-    '{pr:$pr, head_oid:$head_oid, base_oid:$base_oid, base_ref:$base_ref, trigger_id:$trigger_id, signal:"none", open_threads:$open_threads, status:"NOT-CONFIRMED"}' > "$tmp"
+    '{pr:$pr, head_oid:$head_oid, base_oid:$base_oid, base_ref:$base_ref, trigger_id:$trigger_id, started_at:$started_at, signal:"none", open_threads:$open_threads, status:"NOT-CONFIRMED"}' > "$tmp"
   mv "$tmp" "$state_file"
   audit_log "github_codex_review_not_confirmed" "pr=$pr head=$head_oid base=$base_oid base_ref=$base_ref trigger_id=$trigger_id signal=none open_threads=${open_threads:-none} state_file=$state_file action=human_review_required"
+}
+
+# Single non-polling re-check for a suppressed (NOT-CONFIRMED) head: did a Codex
+# FINDINGS review object for this head land *after* the no-signal deadline (a
+# slow/throttled review — the #879 run repeatedly hit Codex usage limits and
+# reviews landed minutes late)? One reviews API call, never re-enters the poll
+# loop. Exit codes: 0 on a FINDINGS object bound to this head (clear the
+# suppression); 3 on a find-findings identity conflict (a spoofed
+# chatgpt-codex-connector login — propagated so the caller hard-fails like the
+# poll loop, never folding a spoof into the benign keep-suppression path); other
+# non-zero on NONE or a fetch error (caller keeps the suppression). (#894)
+recheck_suppressed_codex_findings() {
+  local pr="$1" head_oid="$2" started_at="$3"
+  local signal_script="$repo_root/scripts/codex_review_signal.py"
+  local reviews_json classification rc
+  reviews_json="$(gh_cmd api --paginate --slurp "repos/${repo_owner}/${repo_name}/pulls/${pr}/reviews?per_page=100")" || return 1
+  rc=0
+  # Capture the exit code via `|| rc=$?` (not `local x=$(...)`, whose `local`
+  # masks it; not `if !`, which collapses every non-zero to a single boolean) so
+  # the identity-conflict code 3 stays distinct from NONE. Version-independent.
+  classification="$(printf "%s" "$reviews_json" | python3 "$signal_script" find-findings "$head_oid" "$started_at")" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    return "$rc"
+  fi
+  [[ "$classification" == FINDINGS* ]]
 }
 
 assert_review_decision_clean() {
@@ -932,12 +960,43 @@ wait_for_github_codex_review() {
   local head_oid="$2"
   local base_oid="$3"
   local base_ref="$4"
-  local cached_comment_json cached_body existing_trigger trigger_json trigger_id started_at state_file tmp not_confirmed_file rc
+  local cached_comment_json cached_body existing_trigger trigger_json trigger_id started_at state_file tmp not_confirmed_file nc_started_at recheck_rc rc
   # If this exact head already reached NOT-CONFIRMED, hand back to the human
   # without re-triggering or re-waiting — the state file is keyed by head, so a
   # new push clears the suppression. (design #870 D5)
   not_confirmed_file="$(github_codex_not_confirmed_state_file "$pr" "$head_oid" "$base_oid" "$base_ref")"
   if [[ -f "$not_confirmed_file" ]]; then
+    # Before honoring the suppression, do one non-polling re-check: a Codex
+    # review object may have landed after the no-signal deadline (#894). If so,
+    # clear the suppression and fall through to the normal FINDINGS path (the
+    # all-thread gate decides mergeability). started_at is read from the state
+    # file; if it is absent (an older state file), skip the re-check and keep
+    # the existing hand-to-human behavior.
+    nc_started_at="$(jq -r '.started_at // empty' "$not_confirmed_file" 2>/dev/null || true)"
+    if [[ -n "$nc_started_at" ]]; then
+      recheck_rc=0
+      recheck_suppressed_codex_findings "$pr" "$head_oid" "$nc_started_at" || recheck_rc=$?
+      if [[ "$recheck_rc" -eq 0 ]]; then
+        rm -f "$not_confirmed_file"
+        audit_log "github_codex_review_not_confirmed_cleared" "pr=$pr head=$head_oid base=$base_oid base_ref=$base_ref state_file=$not_confirmed_file action=findings_landed_late"
+        # Mirrors the normal FINDINGS tail: return 0 so the caller proceeds. The
+        # authoritative pre-merge thread gate is in the main loop after CI
+        # (assert_no_actionable_threads, errexit-active there); this in-function
+        # call is advisory only — errexit is suppressed inside a function invoked
+        # as `… || review_rc=$?`, so its failure does not abort here.
+        assert_no_actionable_threads "$pr"
+        return 0
+      elif [[ "$recheck_rc" -eq 3 ]]; then
+        # find-findings rejected the review set on an identity conflict (a
+        # spoofed chatgpt-codex-connector login). Match the poll loop: a spoof is
+        # a hard error, never folded into the benign keep-suppression/exit-20
+        # path. Leave the suppression in place and surface it loudly.
+        echo "GitHub Codex identity conflict re-checking suppressed PR #$pr at $head_oid" >&2
+        audit_log "github_codex_review_recheck_identity_conflict" "pr=$pr head=$head_oid base=$base_oid base_ref=$base_ref state_file=$not_confirmed_file action=hard_error"
+        return 1
+      fi
+      # recheck_rc is NONE / fetch error: no review landed, keep the suppression.
+    fi
     audit_log "github_codex_review_not_confirmed_suppressed" "pr=$pr head=$head_oid base=$base_oid base_ref=$base_ref state_file=$not_confirmed_file action=human_review_required"
     return 20
   fi
@@ -1102,7 +1161,7 @@ base_ref: ${base_ref}")"
     # No Codex review object appeared in the window. The script cannot tell
     # "reviewed clean" from "not yet reviewed" (no reliable structured clean
     # signal), so it hands to a human and never auto-merges. (design #870 D5)
-    record_github_codex_not_confirmed "$pr" "$head_oid" "$base_oid" "$base_ref" "$trigger_id"
+    record_github_codex_not_confirmed "$pr" "$head_oid" "$base_oid" "$base_ref" "$trigger_id" "$started_at"
     return 20
   fi
   # Drift / binding mismatch / spoof, or the outer timeout 124 (a command hung

--- a/scripts/local_pr_follow_through_test.go
+++ b/scripts/local_pr_follow_through_test.go
@@ -797,3 +797,115 @@ func TestLocalPRFollowThroughDurationToSeconds(t *testing.T) {
 		}
 	}
 }
+
+// Drives the REAL recheck_suppressed_codex_findings helper against fixture
+// reviews JSON (gh_cmd stubbed). It must return 0 only when a Codex FINDINGS
+// review object for the head landed after started_at — the late-review case the
+// suppression re-check exists to catch (#894) — and non-zero (keep the
+// suppression, hand to a human) on no review, a different head, or a review
+// older than the trigger. Mutation: gut the find-findings call and the
+// FINDINGS/NONE cases diverge.
+func TestLocalPRFollowThroughRecheckSuppressedFindings(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not found on PATH; the shell helper invokes python3 directly")
+	}
+	body, err := os.ReadFile("local-pr-follow-through.sh")
+	if err != nil {
+		t.Fatalf("ReadFile(local-pr-follow-through.sh): %v", err)
+	}
+	fnBody := shellFunctionBody(t, string(body), "recheck_suppressed_codex_findings")
+	const head, started = "abc123head", "2026-06-15T12:00:00Z"
+	codex := sigUser{ID: intPtr(codexBotID), Login: "chatgpt-codex-connector[bot]", Type: "Bot"}
+	human := sigUser{ID: intPtr(42), Login: "alice", Type: "User"}
+	spoof := sigUser{ID: intPtr(42), Login: "chatgpt-codex-connector[bot]", Type: "Bot"}
+	for _, tc := range []struct {
+		name     string
+		reviews  []sigReview
+		wantCode int // 0 => clear suppression; 3 => identity-conflict hard error; other non-zero => keep suppression
+	}{
+		{"findings landed late", []sigReview{{ID: 10, User: codex, CommitID: head, SubmittedAt: "2026-06-15T12:05:00Z"}}, 0},
+		{"still no review", []sigReview{}, 1},
+		{"review of a different head", []sigReview{{ID: 11, User: codex, CommitID: "OTHERhead", SubmittedAt: "2026-06-15T12:05:00Z"}}, 1},
+		{"review older than the trigger", []sigReview{{ID: 12, User: codex, CommitID: head, SubmittedAt: "2026-06-15T11:00:00Z"}}, 1},
+		{"human review of head is not codex findings", []sigReview{{ID: 13, User: human, CommitID: head, SubmittedAt: "2026-06-15T12:05:00Z"}}, 1},
+		// A spoofed Codex login (wrong id) must propagate find-findings' exit 3
+		// as a distinct hard error, NOT collapse into the NONE keep-suppression
+		// path — so the caller hard-fails like the poll loop. (#894 / PR #903 P2)
+		{"identity conflict (spoofed codex login)", []sigReview{{ID: 14, User: spoof, CommitID: head, SubmittedAt: "2026-06-15T12:05:00Z"}}, 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prog := "set -euo pipefail\n" +
+				"repo_root=\"$(dirname \"$PWD\")\"\n" +
+				"repo_owner=o\nrepo_name=n\n" +
+				"gh_cmd() { printf '%s' \"$REVIEWS\"; }\n" +
+				"recheck_suppressed_codex_findings() {\n" + fnBody + "\n}\n" +
+				"recheck_suppressed_codex_findings 7 " + head + " " + started + "\n"
+			cmd := exec.Command("bash", "-c", prog)
+			cmd.Env = append(os.Environ(), "REVIEWS="+mustJSON(t, tc.reviews))
+			var out, errb bytes.Buffer
+			cmd.Stdout, cmd.Stderr = &out, &errb
+			code := 0
+			if runErr := cmd.Run(); runErr != nil {
+				var ee *exec.ExitError
+				if !errors.As(runErr, &ee) {
+					t.Fatalf("run recheck helper: %v (stderr=%q)", runErr, errb.String())
+				}
+				code = ee.ExitCode()
+			}
+			if code != tc.wantCode {
+				t.Fatalf("recheck_suppressed_codex_findings(%s) exit=%d; want %d (stderr=%q)",
+					tc.name, code, tc.wantCode, errb.String())
+			}
+		})
+	}
+}
+
+// Pins the wiring that makes the late-review re-check effective: the suppression
+// branch reads started_at, re-checks, clears the state file and returns 0 via
+// the FINDINGS path on a hit; record_github_codex_not_confirmed persists
+// started_at and its caller passes it. Deleting the re-check wiring fails here.
+func TestLocalPRFollowThroughClearsSuppressionOnLateFindings(t *testing.T) {
+	body, err := os.ReadFile("local-pr-follow-through.sh")
+	if err != nil {
+		t.Fatalf("ReadFile(local-pr-follow-through.sh): %v", err)
+	}
+	script := string(body)
+	for _, want := range []string{
+		// state file now carries started_at, and the caller supplies it.
+		`local pr="$1" head_oid="$2" base_oid="$3" base_ref="$4" trigger_id="$5" started_at="$6"`,
+		`started_at:$started_at,`,
+		`record_github_codex_not_confirmed "$pr" "$head_oid" "$base_oid" "$base_ref" "$trigger_id" "$started_at"`,
+		// suppression branch re-checks before honoring the suppression, and
+		// distinguishes the FINDINGS (clear) / identity-conflict (hard error) /
+		// NONE (keep) outcomes by the helper's exit code.
+		`nc_started_at="$(jq -r '.started_at // empty' "$not_confirmed_file" 2>/dev/null || true)"`,
+		`recheck_suppressed_codex_findings "$pr" "$head_oid" "$nc_started_at" || recheck_rc=$?`,
+		`if [[ "$recheck_rc" -eq 0 ]]; then`,
+		`rm -f "$not_confirmed_file"`,
+		`audit_log "github_codex_review_not_confirmed_cleared"`,
+		`action=findings_landed_late`,
+		// a spoof (find-findings exit 3) is a hard error, like the poll loop —
+		// never folded into the benign keep-suppression/exit-20 path.
+		`elif [[ "$recheck_rc" -eq 3 ]]; then`,
+		`audit_log "github_codex_review_recheck_identity_conflict"`,
+		`action=hard_error`,
+		// one API call; the helper propagates find-findings' exit code so the
+		// conflict code 3 stays distinct from NONE; FINDINGS-only success.
+		`reviews_json="$(gh_cmd api --paginate --slurp "repos/${repo_owner}/${repo_name}/pulls/${pr}/reviews?per_page=100")" || return 1`,
+		`classification="$(printf "%s" "$reviews_json" | python3 "$signal_script" find-findings "$head_oid" "$started_at")" || rc=$?`,
+		`if [[ "$rc" -ne 0 ]]; then`,
+		`[[ "$classification" == FINDINGS* ]]`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("local-pr-follow-through.sh missing %q", want)
+		}
+	}
+	// The cleared path must reach the all-thread gate then return 0, and must do
+	// so without re-entering the poll loop (no second run_with_timeout between
+	// the re-check and its return 0).
+	clearIdx := strings.Index(script, `audit_log "github_codex_review_not_confirmed_cleared"`)
+	threadIdx := strings.Index(script, `assert_no_actionable_threads "$pr"`)
+	if clearIdx < 0 || threadIdx < clearIdx {
+		t.Fatal("cleared suppression must fall through to assert_no_actionable_threads then return 0")
+	}
+}


### PR DESCRIPTION
## Summary

The unattended `local-pr-follow-through.sh` poll loop
(`wait_for_github_codex_review`) records **NOT-CONFIRMED** (sentinel 75) and
writes a head-keyed suppression state file when its no-signal deadline elapses
with no Codex review object, then on the next sweep returns 20 immediately —
**without re-querying** — if the head is unchanged. If Codex posted its review
**after** the deadline (slow / usage-throttled — a real #879 condition), the
automation never auto-detected it for that head until a new push.

This fix adds a **single, non-polling** re-check before honoring the
suppression:

- `recheck_suppressed_codex_findings`: one `pulls/{pr}/reviews` call piped to
  `codex_review_signal.py find-findings "$head" "$started_at"`. Returns 0 **only**
  on a head-bound Codex **FINDINGS** review object; non-zero on `NONE`, an
  identity conflict (the `if !` guard fails closed, like the poll loop), or a
  fetch error — so the caller keeps the suppression and hands to a human.
- The suppression branch: if a review has since landed → `rm` the state file,
  audit `..._not_confirmed_cleared` (`action=findings_landed_late`), fall through
  to the normal FINDINGS path (`return 0`); else keep `return 20`. One API call,
  never re-enters the 20-min poll loop.
- `started_at` is now persisted in the NOT-CONFIRMED state file (read back with
  `jq '.started_at // empty'`; absent → re-check skipped, old behavior).

Closes #894

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Local PR-follow-through tooling (aiops-specific automation, not a Symphony SPEC concept); no key/phase/gate/artifact, no orchestrator/worker code.

## Acceptance criteria
- [x] Suppressed head whose Codex review has since landed → next `wait_for_github_codex_review` clears the suppression and returns 0 (FINDINGS), not 20.
- [x] Still-no-review suppressed head → returns 20 with **one** API call (no re-entry into the poll loop).
- [x] Fixture/mutation-verified test in `local_pr_follow_through_test.go` (`TestLocalPRFollowThroughRecheckSuppressedFindings` drives the real helper + real `find-findings`; `TestLocalPRFollowThroughClearsSuppressionOnLateFindings` pins the wiring).
- [x] `started_at` persisted in the NOT-CONFIRMED state file and read back by the re-check.

## Verification
- `go test -race ./scripts` green; `bash -n` clean; gofmt/vet clean.
- **Mutation** (against committed artifact): flipped `[[ "$classification" == FINDINGS* ]]` → `NONE*`; the `findings-landed-late` + NONE cases FAIL (NONE wrongly reads as cleared). Restored; `git diff HEAD` empty.

## Reviewer finding investigated & resolved (no merge bug)
A reviewer flagged that the cleared path's in-function `assert_no_actionable_threads "$pr"` is **swallowed**: because `wait_for_github_codex_review` is invoked as `… || review_rc=$?`, bash `set -e` is suppressed inside the function, so that assert's failure does not abort. **Confirmed true empirically** — but it is **not a merge bug**: the authoritative pre-merge thread gate is the **bare** `assert_no_actionable_threads "$pr"` in the *main loop* (errexit-active, after CI, before `gh pr merge`), which aborts the script on unresolved threads. The in-function call is advisory defense-in-depth, **identical to the pre-existing normal FINDINGS tail**. Added a code comment documenting this so the swallow is not mistaken for a gate. (Both subagent reviewers + the empirical `set -e`/`||` test agree on the final picture.)

## Review (final head `df84f9b`)
- Pre-push dual reviewers (subagent, default-on per #900, diff-only): MERGE-READY across rounds — fail-closed preserved, one API call / no re-poll, tests drive the real helper + real `find-findings`.
- **GitHub `@codex review` P2 — fixed.** On an earlier head Codex flagged that the re-check collapsed a `find-findings` **identity conflict** (exit 3, a spoofed `chatgpt-codex-connector` login) into the same `return 1` as NONE — losing the poll loop's hard-fail-on-spoof semantics (it would log the benign `_suppressed` event and exit 20). Fixed in `df84f9b`: the helper now propagates `find-findings`'s exit code (FINDINGS→0, NONE→1, conflict→3, fetch-error→1); the caller hard-fails on `recheck_rc==3` (`github_codex_review_recheck_identity_conflict`, `action=hard_error`, `return 1` → run aborts), matching the poll loop. New spoof test case asserts exit 3; mutation-verified. Thread replied + resolved.
- `@codex review` (as `bytevane`) **clean on head `df84f9b`** — "Didn't find any major issues", `Reviewed commit: df84f9b1c4`. GraphQL `reviewThreads`: **zero unresolved, non-outdated**. CI all green; `mergeStateStatus: CLEAN`.

### Size gate
- [x] `within budget` — 1 production file (`local-pr-follow-through.sh`) + 1 test file; +~30 production LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`
