### PR TITLE
build: bundle README, LICENSE, and all examples/ in release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,14 +183,17 @@ jobs:
           set -euo pipefail
           for out in dist/aiops-platform_${RELEASE_TAG}_*; do
             [ -d "$out" ] || continue
-            # Ship a runnable starting point alongside the binaries so a
-            # binary-download user has a config template without cloning (#797).
-            # Keep WORKFLOW.md under examples/ so the bundled .env.example's
-            # AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md resolves from the
-            # extracted directory.
+            # Ship a self-contained starting point so a binary-download user can
+            # configure and run without cloning (#797, #905): every examples/
+            # template (one per tracker x role; cp the whole dir so it stays a
+            # single source of truth — the canonical examples/WORKFLOW.md keeps
+            # .env.example's AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md resolving
+            # from the extracted directory), the .env template, README.md as the
+            # offline entry manual (it deep-links the runbooks), and LICENSE so
+            # the redistributed archive carries its terms.
             mkdir -p "$out/examples"
-            cp examples/WORKFLOW.md "$out/examples/"
-            cp .env.example "$out/"
+            cp -r examples/. "$out/examples/"
+            cp .env.example README.md LICENSE "$out/"
             tar -C dist -czf "${out}.tar.gz" "$(basename "$out")"
             rm -rf "$out"
           done

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ see the [binary deployment runbook](docs/runbooks/binary-deployment.md).
 Prebuilt Linux/macOS (amd64/arm64) archives are attached to each
 [GitHub Release](https://github.com/xrf9268-hue/aiops-platform/releases) as
 `aiops-platform_<tag>_<os>_<arch>.tar.gz`, bundling the `worker` and `tui`
-binaries plus `examples/WORKFLOW.md` and `.env.example`. Verify a download with
+binaries, every `examples/` WORKFLOW template, `.env.example`, `README.md`, and
+`LICENSE` — a self-contained starting point. Verify a download with
 either `gh attestation verify <archive> --repo xrf9268-hue/aiops-platform`
 (build provenance) or `sha256sum --ignore-missing -c
 aiops-platform_<tag>_SHA256SUMS` (plain checksums; `--ignore-missing` checks

--- a/docs/runbooks/binary-deployment.md
+++ b/docs/runbooks/binary-deployment.md
@@ -188,10 +188,10 @@ sudo chmod 600 /etc/aiops-platform/worker.env
 ```
 
 `examples/WORKFLOW.md` and `.env.example` ship in the source checkout
-(Option A). If you installed from a release archive (Option B), the
-archive contains only the binaries — copy these two files from the repo,
-or author a `WORKFLOW.md` from the README configuration table and a
-minimal env file by hand.
+(Option A). The release archive (Option B) is self-contained: it bundles
+every `examples/` WORKFLOW template, `.env.example`, `README.md`, and
+`LICENSE` alongside the binaries, so `cp` the example matching your
+`tracker.kind` straight from the extracted directory.
 
 The paths above use the Linux FHS layout (`/etc`, `/var/lib`). On macOS
 the conventional equivalents are `/usr/local/etc/aiops-platform` and


### PR DESCRIPTION
Closes #905

## Summary
- Release `Package release archives` (`.github/workflows/release.yml`) shipped only `examples/WORKFLOW.md` + `.env.example`, so #797's "runnable without cloning" promise held **only for Linear** and the redistributed archive carried **no LICENSE and no offline manual**.
- Each `aiops-platform_<tag>_<os>_<arch>.tar.gz` is now a self-contained starting point: `cp -r examples/.` (all templates, single source of truth) + `README.md` (offline entry manual, deep-links the runbooks) + `LICENSE` (repo already guards it via `license_test.go`).
- Canonical `examples/WORKFLOW.md` is still present, so `.env.example`'s relative `AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md` keeps resolving from the extracted directory (regression-safe).
- Root cause of a latent doc bug fixed in passing: `docs/runbooks/binary-deployment.md` Option B claimed "the archive contains only the binaries" — already wrong since #797.

## SPEC alignment (AGENTS.md principle 6/7)
Pure release packaging. Upstream Symphony is an Elixir demo that ships **no binaries**, so there is no SPEC/Elixir equivalent and nothing to cite or deviate. Not a SPEC-sensitive path (no `internal/workflow/config.go` / `internal/orchestrator` / `internal/worker` change).

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file (`release.yml`, ~+9/−6) + 2 docs (excluded from the production count).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
No `.go` / Python changes → Go and Trellis-script gates are N/A. Verified the **release artifact itself** instead of reasoning about it.

- [ ] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest …` — N/A (no script change)
- [ ] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' …` — N/A (no Go change)
- [ ] `go vet ./...` — N/A (no Go change)
- [ ] `go test -race -covermode=atomic ./...` — N/A (no Go change)
- [ ] `gofmt -l` clean + blocking golangci gate — N/A (no Go change)
- [x] **additional validation**: locally replayed the exact Package step (fake binaries + the real `cp -r examples/.` / `cp .env.example README.md LICENSE` / `tar`), then asserted the tarball listing:
  - `README.md`, `LICENSE`, `.env.example`, `worker`, `tui` present.
  - all 6 `examples/*-WORKFLOW.md` present, incl. canonical `examples/WORKFLOW.md`.
  - `.env.example` `AIOPS_WORKFLOW_PATH=examples/WORKFLOW.md` resolves against the bundled file.
  - `release.yml` valid YAML; `actionlint` shows only two **pre-existing** info/style findings (SC2129 ~L63, SC2231 at the unchanged `for` glob), identical on `origin/main` and HEAD — not introduced here; CI does not gate actionlint.

## PR title type: `build` (deliberate, per #905 AC)
Release packaging with **no runtime/binary behavior change** → `build` per the Conventional-Commits table ("build system / release packaging"), intentionally hidden from CHANGELOG. Considered `feat` (the download contents change) but rejected: it would bump the minor version for a packaging tweak while the software is identical.

## Blast radius (rule 10)
Swept every live claim of archive contents and updated atomically:
- `README.md:140` (updated) · `docs/runbooks/binary-deployment.md:190` Option B (updated — also corrects the pre-existing stale claim).
- `docs/validation/2026-06-14-v0.1.3-gitea-binary-e2e.md:59` — **intentionally left**: dated historical snapshot of what v0.1.3 actually shipped; editing it would falsify the record.

## Pre-push dual review
Two independent adversarial reviewers (feature-dev:code-reviewer + codex:codex-rescue), both **SHIP**. `cp -r examples/.` trailing-dot semantics, regression safety, fail-loud on missing files (`set -euo pipefail`), 4-platform loop idempotency, and doc consistency all confirmed; no defect requiring a fix.

## Risk / deferral
None deferred.
