### PR TITLE
fix(runner): drain codex app-server stderr before cmd.Wait

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -83,19 +83,27 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 		terminateProcess(cmd)
 	}
 	_ = stdin.Close()
-	// Drain stdout to EOF BEFORE cmd.Wait — the os/exec idiom (StdoutPipe doc:
-	// "incorrect to call Wait before all reads from the pipe have completed").
-	// The reader keeps scanning as the drain receives, so the child can never
-	// block writing to a full pipe; it finishes, observes the stdin EOF above (or
-	// the kill), exits, and its stdout EOF makes the reader close readCh, ending
-	// the drain. Waiting before draining would deadlock: a reader parked on an
-	// unconsumed send stalls stdout, the child blocks on write and never exits,
-	// and cmd.Wait never returns. Draining also joins the reader so no goroutine
-	// outlives this call (Go Code Review Comments, "Goroutine Lifetimes").
+	// Drain BOTH pipes to EOF BEFORE cmd.Wait — the os/exec idiom (StdoutPipe /
+	// StderrPipe docs: "incorrect to call Wait before all reads from the pipe
+	// have completed", because Wait closes the pipe once it sees the process
+	// exit). The reader keeps scanning as the drain receives, so the child can
+	// never block writing to a full pipe; it finishes, observes the stdin EOF
+	// above (or the kill), exits, and its stdout EOF makes the reader close
+	// readCh, ending the drain. Waiting before draining would deadlock: a reader
+	// parked on an unconsumed send stalls stdout, the child blocks on write and
+	// never exits, and cmd.Wait never returns. Draining also joins the reader so
+	// no goroutine outlives this call (Go Code Review Comments, "Goroutine
+	// Lifetimes").
 	for range client.readCh { //nolint:revive // drain-to-close joins the reader goroutine
 	}
-	waitErr := cmd.Wait()
+	// Join the stderr drain BEFORE Wait for the same reason: Wait closes the
+	// StderrPipe fd on process exit, which would truncate a final stderr write —
+	// e.g. a bwrap sandbox-startup denial that classifySandboxStartupFailure
+	// depends on (#550) — if io.Copy were still reading. io.Copy returns once the
+	// child closes stderr on exit (concurrent draining means the child never
+	// blocks on a full stderr pipe), so this join never stalls Wait.
 	<-stderrDone
+	waitErr := cmd.Wait()
 	elapsed := time.Since(start)
 
 	writeAppServerArtifact(in.Workdir, buf)


### PR DESCRIPTION
Closes #907

## Summary
`RunCodexAppServer` (`internal/runner/codex_app_server.go`) joined the stderr drain (`<-stderrDone`) *after* `cmd.Wait()`. The pipe is `cmd.StderrPipe()`, whose Go doc states it is *"incorrect to call Wait before all reads from the pipe have completed"* (Wait closes the pipe on process exit). The adjacent **stdout** path already drains-before-Wait correctly (with a comment citing the StdoutPipe doc); stderr was asymmetric.

A final stderr write emitted as the child exits — e.g. a bwrap `setting up uid map: Permission denied` denial that `classifySandboxStartupFailure` depends on for the #550 cooldown — could be truncated when `Wait` closed the read fd under the in-flight `io.Copy`, reverting to hot per-tick retry.

**Fix:** join `<-stderrDone` before `cmd.Wait()`, mirroring stdout. No deadlock — `io.Copy` returns when the child closes stderr on exit, and stderr is drained concurrently from `cmd.Start` so the child never blocks on a full pipe and the join never stalls Wait. Verified against `go doc os/exec.Cmd.StderrPipe` on the pinned Go 1.25.

> A second finding from the same audit — `responseForID` classifying JSON-RPC messages by id shape rather than `method` presence — was **split out to #909** as a design question. The naive guard was prototyped here and rejected in review (it would silently drop an interleaved `method`+`id` server request and could stall `request()` to its read timeout); the correct handshake behavior needs the upstream Elixir `app_server.ex` as tiebreaker, so it is not bundled into this fix.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Behavior-preserving; touches only `internal/runner` (not a SPEC-sensitive path). No SPEC deviation.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file / +18/-10 LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...` (full repo green; `internal/runner` re-run green after the revert)
- [x] `gofmt -l` clean + blocking golangci gate (0 issues on `internal/runner/...`)
- [x] additional: correctness-by-construction per the Go `StderrPipe` doc + the existing stdout drain pattern; backstopped by the `-race` runner suite. Deadlock-freedom on the clean / kill (`terminateProcess` SIGTERM+SIGKILL) / context-cancel exit paths confirmed in dual local review.

## Notes
- GraphQL mutation gate, sandbox arg construction, and all SPEC-sensitive paths untouched.