### PR TITLE
docs: refresh Codex Docker version references

### DIFF
--- a/deploy/docker-compose.codex.yml
+++ b/deploy/docker-compose.codex.yml
@@ -9,7 +9,7 @@
 #
 # The overlay builds the `codex-worker` Dockerfile target and feeds sensitive
 # values through Docker-supported secret files where possible. Codex auth/config
-# live in a CODEX_HOME directory, which Codex CLI 0.133 writes while loading
+# live in a CODEX_HOME directory, which Codex CLI writes while loading
 # configuration and refreshing auth state.
 services:
   worker:
@@ -34,9 +34,9 @@ services:
       - worker
     volumes:
       - ${AIOPS_WORKFLOW_PATH:?set AIOPS_WORKFLOW_PATH to a workflow file}:/app/WORKFLOW.md:ro
-      # CODEX_HOME is a restricted writable volume: Codex CLI 0.133 writes while
-      # loading config and persists refreshed ChatGPT-login tokens here. Keep it
-      # owned by the worker UID/GID and out of git; auth.json is a secret.
+      # CODEX_HOME is a restricted writable volume: Codex CLI writes config and
+      # persists refreshed ChatGPT-login tokens here. Keep it owned by the worker
+      # UID/GID and out of git; auth.json is a secret.
       - ${AIOPS_CODEX_HOME_PATH:?set AIOPS_CODEX_HOME_PATH to a Codex home directory}:/home/aiops/.codex
       # Optional, recommended (#465): mount a version-controlled, NON-SECRET
       # config.toml read-only OVER the writable home so model/provider/reasoning

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -8,7 +8,7 @@ For the full new-operator path, including support matrix, Docker Compose
 secrets, `worker --doctor`, and the todo smoke test, start with
 [`first-run-docker-linear-codex.md`](first-run-docker-linear-codex.md).
 
-## Current installer status
+## Historical installer failure
 
 On 2026-05-26, the online installer failed inside the Linux ARM64 worker image:
 
@@ -16,7 +16,7 @@ On 2026-05-26, the online installer failed inside the Linux ARM64 worker image:
 curl -fsSL https://chatgpt.com/codex/install.sh | sh
 ```
 
-Observed:
+Observed historical output:
 
 ```text
 ==> Installing Codex CLI
@@ -26,8 +26,9 @@ Observed:
 Could not find SHA-256 digest for codex-package-aarch64-unknown-linux-musl.tar.gz in codex-package_SHA256SUMS.
 ```
 
-Until the installer works for this platform, use a deterministic release-package
-install in the worker image.
+This historical output is retained to explain why the worker image uses a
+deterministic release-package install. The current pinned Codex CLI version is
+the Dockerfile `CODEX_CLI_VERSION` value described below.
 
 The repository Dockerfile now exposes this as the `codex-worker` target:
 


### PR DESCRIPTION
Closes #912

## Summary
- Removed stale active `Codex CLI 0.133` wording from the Codex Docker Compose overlay comments.
- Reframed the Docker app-server runbook's `0.133.0` installer output as historical evidence and pointed current version authority back to Dockerfile `CODEX_CLI_VERSION`.
- Left Docker pins, checksums, build targets, and runtime behavior unchanged.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Acceptance criteria
- [x] `deploy/docker-compose.codex.yml` no longer hard-codes stale `0.133` wording in active CODEX_HOME comments.
- [x] `docs/runbooks/codex-app-server-docker.md` clearly marks the `0.133.0` installer output as historical.
- [x] Remaining Codex Docker version references either match the Dockerfile pin or are historical validation/rationale records.
- [x] No Codex CLI upgrade, checksum change, or Docker build behavior change.

## Version-reference scan
`rg -n "0\\.133|0\\.137|CODEX_CLI_VERSION" Dockerfile deploy docs` now reports:
- Current pin/source references: `Dockerfile`, `docs/runbooks/codex-app-server-docker.md`, `docs/runbooks/first-run-docker-linear-codex.md`, `docs/runbooks/reviewer-worker.md`.
- Historical/rationale references: `docs/runbooks/codex-app-server-docker.md` historical installer section, `docs/validation/2026-05-26-docker-linear-e2e.md`, `docs/engineering-rules-rationale.md`.
- No remaining active `deploy/` comment references to `0.133`.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 2 files, 9 insertions, 8 deletions; production behavior unchanged.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Local validation
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (`0 issues.`)
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'` (first run hit a transient timeout-marker failure; targeted rerun of `test_task_hooks_timeout.py` passed, then full rerun passed: `Ran 5 tests ... OK`)
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `rg -n "0\\.133|0\\.137|CODEX_CLI_VERSION" Dockerfile deploy docs`
- [x] `rg -n "current-installer-status|historical-installer-failure|Historical installer failure" docs README.md deploy .github AGENTS.md` (no stale anchor refs)

## Local independent review
- Subagent discovery: `tool_search multi_agent spawn_agent` found `spawn_agent`, but Codex inline tool contract requires explicit current-turn subagent authorization. This request authorized auto-merge, not subagent delegation, so I used the protocol CLI fallback.
- Codex-family CLI review on committed `origin/main...HEAD`: `MERGE-READY`, no findings.
- Claude-family CLI review on committed `origin/main...HEAD`: `MERGE-READY`, no findings. Non-blocking anchor caveat checked with `rg`; no stale references found.

## Mutation / regression discipline
- Not applicable: docs/comment-only drift cleanup with no executable code path. The acceptance scan above is the self-verifying artifact for this issue.

## Remote gates
- [x] Head SHA: `e0163edc3ddaaf4af6785c8c43e28caa8b133b62` against base `main@153e16b893afce9af79b1aeae1f49de636fb27b4`.
- [x] CI green on current head: `gh pr checks 913 --watch --fail-fast` passed; CI run `27627505089` jobs passed (`Security and supply-chain`, `E2E Gitea mock loop`, `Go build and test`, `Docker image build`); PR Metadata run `27627505201` passed; PR title lint run `27627503241` passed.
- [x] `@codex review` clean on current head: trigger comment `4720283646` by `bytevane`; bot initially emitted usage-limit comment `4720283852`, then completed clean review comment `4720330922` with `Reviewed commit: e0163edc3d` and no major issues.
- [x] GraphQL review threads: `reviewThreads(first:100)` returned `active: []`, `hasNext: false`.
- [x] Merge state before final body update: `CLEAN`; review decision did not report requested changes.
