### PR TITLE
fix: harden env passthrough boundaries

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -348,6 +348,7 @@ func startupReconcileConfigForWorkflow(cfg workflow.Config, trackerClient worker
 		Tracker:            trackerClient,
 		Emitter:            worker.LogEventEmitter{},
 		ReconcileTaskID:    "reconcile-startup",
+		WorkflowConfig:     cfg,
 		BeforeRemoveHook:   hooks.BeforeRemove,
 		HookTimeoutMillis:  hooks.TimeoutMs,
 		HookEnvPassthrough: hooks.EnvPassthrough,

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1867,9 +1867,11 @@ func TestLoadWorkflowForStartupReconcileLogsConfiguredGiteaWorkflow(t *testing.T
 
 func TestStartupReconcileConfigUsesEffectiveWorkspaceHooks(t *testing.T) {
 	cfg := workflow.DefaultConfig()
+	cfg.Tracker.APIKey = "tracker-secret"
 	cfg.Hooks = workflow.WorkspaceHooks{
-		BeforeRemove: workflow.WorkspaceHook{Commands: []string{"printf top-level"}},
-		TimeoutMs:    1234,
+		BeforeRemove:   workflow.WorkspaceHook{Commands: []string{"printf top-level"}},
+		TimeoutMs:      1234,
+		EnvPassthrough: []string{"AIOPS_TRACKER_SECRET"},
 	}
 
 	reconcile := startupReconcileConfigForWorkflow(cfg, nil)
@@ -1878,6 +1880,12 @@ func TestStartupReconcileConfigUsesEffectiveWorkspaceHooks(t *testing.T) {
 	}
 	if reconcile.HookTimeoutMillis != 1234 {
 		t.Fatalf("HookTimeoutMillis = %d, want top-level effective timeout", reconcile.HookTimeoutMillis)
+	}
+	if !reflect.DeepEqual(reconcile.HookEnvPassthrough, []string{"AIOPS_TRACKER_SECRET"}) {
+		t.Fatalf("HookEnvPassthrough = %#v, want top-level effective passthrough", reconcile.HookEnvPassthrough)
+	}
+	if reconcile.WorkflowConfig.Tracker.APIKey != cfg.Tracker.APIKey {
+		t.Fatalf("WorkflowConfig.Tracker.APIKey = %q, want startup workflow config to feed before_remove env deny", reconcile.WorkflowConfig.Tracker.APIKey)
 	}
 }
 

--- a/docs/design/hook-verify-env-allowlist.md
+++ b/docs/design/hook-verify-env-allowlist.md
@@ -1,14 +1,13 @@
-# Hook & verify subprocess env allowlist (#227)
+# Hook subprocess env allowlist (#227)
 
 ## Problem
 
-`workspace.runWorkspaceHookCommand` and `workspace.RunVerify` construct
-`exec.CommandContext("sh", "-lc", script)` without setting `cmd.Env`.
-Go's stdlib `exec.Cmd` inherits the parent's environment when `Env` is
-nil, so every hook script and every verify command runs with full
-access to the worker process's environment — `LINEAR_API_KEY`,
-`GITHUB_TOKEN`, `GITEA_TOKEN`, `SSH_AUTH_SOCK`, and any other secret in
-the operator's `.env`.
+`workspace.runWorkspaceHookCommand` used to construct hook subprocesses
+without setting `cmd.Env`. Go's stdlib `exec.Cmd` inherits the parent's
+environment when `Env` is nil, so every hook script ran with full access
+to the worker process's environment — `LINEAR_API_KEY`, `GITHUB_TOKEN`,
+`GITEA_TOKEN`, `SSH_AUTH_SOCK`, and any other secret in the operator's
+`.env`.
 
 SPEC §15.4 frames hooks as "fully trusted configuration", but §15.5
 recommends narrowing client-side credentials to the minimum the
@@ -19,20 +18,18 @@ could `env > /tmp/dump` and exfiltrate.
 
 ## Decision
 
-Hooks and verify commands build their subprocess environment from an
-explicit allowlist rather than inheriting. Operators can opt specific
-additional vars in via two new schema fields:
+Hooks build their subprocess environment from an explicit allowlist rather
+than inheriting. Operators can opt specific additional vars in via
+`hooks.env_passthrough`:
 
 ```yaml
 hooks:
   env_passthrough: [CARGO_HOME, GIT_AUTHOR_NAME]
-verify:
-  env_passthrough: [CARGO_HOME, NPM_CONFIG_USERCONFIG]
 ```
 
 ### Baseline allowlist
 
-Both hook and verify subprocesses always inherit, when set:
+Hook subprocesses always inherit, when set:
 
 - `PATH`
 - `HOME`
@@ -49,17 +46,26 @@ secrets are excluded by default.
 
 ### Per-config passthrough
 
-`hooks.env_passthrough` and `verify.env_passthrough` are separate
-fields, not a shared one. Hooks and verify run at different lifecycle
-points and typically need different env: hooks may want
-git-identity vars, verify may want build-tool caches (`CARGO_HOME`,
-`GOMODCACHE`). Operators set each list explicitly to the union of vars
-those scripts actually consume.
+`hooks.env_passthrough` is a top-level workflow field for hook
+subprocesses. It is not shared with verification: per SPEC §1,
+verification commands are surfaced to the coding agent as prompt
+instructions and are not worker-run subprocesses. The removed
+`verify.env_passthrough` key is rejected at load with replacement
+guidance.
 
 A name in `env_passthrough` that is not set in the worker's env is
 silently dropped (no error, no empty `NAME=` entry) so passthrough
 lists can include "may or may not be present" vars without spurious
 config-validation noise.
+
+`env_passthrough` is still subject to the tracker/API credential deny
+policy shared with agent subprocess env construction. Hard-coded tracker
+token names such as `LINEAR_API_KEY`, `GITHUB_TOKEN`, and `GITEA_TOKEN`,
+the configured `tracker.api_key` env-var name, and any env var whose
+current value equals the configured `tracker.api_key` are dropped even
+when listed explicitly. Tracker credentials stay behind orchestrator-owned
+tools/proxies; hooks should receive narrower purpose-built credentials
+instead.
 
 ### Why allow-list rather than deny-list
 
@@ -71,11 +77,12 @@ in `WorkspaceConfig` (config.go:307).
 ## Migration
 
 Existing workflows that depended on a specific env var being inherited
-must add it to `hooks.env_passthrough` or `verify.env_passthrough`.
-Concretely: any hook that read `$LINEAR_API_KEY`, `$GITHUB_TOKEN`,
-`$GITEA_TOKEN`, etc. directly will now see an empty string. The
-workflow loader does not flag this — it's a runtime behavior change
-visible in hook output.
+must add it to `hooks.env_passthrough`. Concretely: any hook that read
+`$LINEAR_API_KEY`, `$GITHUB_TOKEN`, `$GITEA_TOKEN`, or a configured
+`tracker.api_key` value directly will now see an empty string even if that
+variable is listed in passthrough. The workflow loader does not flag this
+specific deny-layer drop — it's a runtime behavior change visible in hook
+output.
 
 The release note (`docs/security-posture.md`, "What is defended today")
 spells out the new behavior so operators reviewing security can audit
@@ -85,25 +92,25 @@ it.
 
 - Schema validation for env-var name shape: stdlib does the right thing
   for malformed names already; the loader does not need a regex.
-- Setting `cmd.Env` for the agent subprocess itself: SPEC §15.3 already
-  treats the agent as a trusted-config-driven actor, and the existing
-  `sandbox.env_allowlist` covers the supported reduction.
 - Allowing per-hook (rather than per-WorkspaceHooks) passthrough:
   per-hook overrides could come later if real workflows need them;
   YAGNI for now.
 
 ## Implementation
 
-1. Add `EnvPassthrough []string` field to `WorkspaceHooks` and
-   `VerifyConfig` (workflow/config.go).
-2. New `workspace.subprocessEnv(passthrough []string)` helper builds
-   `[]string{"K=V", ...}` from baseline allowlist + passthrough.
-3. `RunWorkspaceHook` grows an `envPassthrough []string` parameter;
-   passes it to `runWorkspaceHookCommand` which sets `cmd.Env`.
-4. `RunVerify` reads `wf.Verify.EnvPassthrough` and sets `cmd.Env` on
-   each verify command.
-5. `internal/worker/runtask.go` plumbs `wcfg.Hooks.EnvPassthrough`
-   into the `RunWorkspaceHook` call.
-6. Tests: hook subprocess env does not contain `LINEAR_API_KEY` by
-   default; verify subprocess env does not contain `LINEAR_API_KEY` by
-   default; explicit passthrough surfaces a named var.
+1. Add `EnvPassthrough []string` field to `WorkspaceHooks`
+   (workflow/config.go).
+2. New `envpolicy.BuildSanitizedEnv` helper builds `[]string{"K=V", ...}`
+   from baseline allowlist + passthrough and applies the shared tracker
+   credential deny policy.
+3. `workspace.subprocessEnv(passthrough []string, cfg workflow.Config)` and
+   `runner.agentEnvWithLookup(...)` share that helper so hook and agent env
+   construction cannot drift.
+4. `RunWorkspaceHook` takes `envPassthrough []string` plus the workflow config;
+   `internal/worker/runtask.go` and cleanup paths plumb
+   `wcfg.Hooks.EnvPassthrough` plus the workflow config into the call so
+   tracker credential denial sees the effective tracker configuration.
+5. Tests: hook subprocess env does not contain `LINEAR_API_KEY` by default;
+   explicit passthrough surfaces a named non-secret var; configured
+   `tracker.api_key` values are still denied on the RunTask and cleanup
+   production paths.

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -135,9 +135,10 @@ The current Go implementation provides these safety controls:
   in the worker's `.env` are excluded — a malicious or buggy WORKFLOW.md cannot
   `env > /tmp/dump` and exfiltrate them. Operators opt non-tracker vars back in
   per workflow with `codex.env_passthrough`, `claude.env_passthrough`, or
-  `hooks.env_passthrough`; agent passthrough
-  rejects tracker/repo API token names so those credentials stay behind
-  orchestrator-owned tools. See
+  `hooks.env_passthrough`; agent and hook passthrough reject tracker/repo API
+  token names, the configured `tracker.api_key` env-var name, and env vars
+  whose current value equals the configured `tracker.api_key`, so those
+  credentials stay behind orchestrator-owned tools. See
   [`docs/design/hook-verify-env-allowlist.md`](design/hook-verify-env-allowlist.md);
 - allow-listed redaction of Codex `turn/failed`, `turn/cancelled`, and failed
   `turn/completed` protocol payloads: returned error strings and

--- a/internal/envpolicy/env.go
+++ b/internal/envpolicy/env.go
@@ -1,0 +1,79 @@
+package envpolicy
+
+import (
+	"strings"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+// BuildSanitizedEnv returns an explicit cmd.Env list from the allowed baseline
+// plus workflow-configured passthrough names. Tracker credentials are rejected
+// before lookup values are copied into a child process environment.
+func BuildSanitizedEnv(
+	baseline []string,
+	passthrough []string,
+	cfg workflow.Config,
+	lookup func(string) (string, bool),
+	loginPath func() string,
+) []string {
+	b := envBuilder{
+		cfg:    cfg,
+		lookup: lookup,
+		path:   loginPath,
+		seen:   make(map[string]struct{}, len(baseline)+len(passthrough)),
+		env:    make([]string, 0, len(baseline)+len(passthrough)),
+	}
+	b.addNames(baseline)
+	b.addNames(passthrough)
+	return b.env
+}
+
+type envBuilder struct {
+	cfg    workflow.Config
+	lookup func(string) (string, bool)
+	path   func() string
+	seen   map[string]struct{}
+	env    []string
+}
+
+func (b *envBuilder) addNames(names []string) {
+	for _, name := range names {
+		b.add(name)
+	}
+}
+
+func (b *envBuilder) add(raw string) {
+	name, ok := b.allowedName(raw)
+	if !ok {
+		return
+	}
+	value, ok := b.value(name)
+	if !ok {
+		return
+	}
+	b.seen[name] = struct{}{}
+	b.env = append(b.env, name+"="+value)
+}
+
+func (b *envBuilder) allowedName(raw string) (string, bool) {
+	name := strings.TrimSpace(raw)
+	if name == "" || strings.Contains(name, "=") {
+		return "", false
+	}
+	if _, ok := b.seen[name]; ok {
+		return "", false
+	}
+	if workflow.AgentEnvPassthroughDenyReasonForConfigWithLookup(name, b.cfg, b.lookup) != "" {
+		return "", false
+	}
+	return name, true
+}
+
+func (b *envBuilder) value(name string) (string, bool) {
+	if name == "PATH" && b.path != nil {
+		if value := b.path(); value != "" {
+			return value, true
+		}
+	}
+	return b.lookup(name)
+}

--- a/internal/envpolicy/env_test.go
+++ b/internal/envpolicy/env_test.go
@@ -1,0 +1,104 @@
+package envpolicy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestBuildSanitizedEnvDeniesTrackerCredentialsAndDeduplicates(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{APIKey: "configured-tracker-secret"},
+	}
+	lookupValues := map[string]string{
+		"PATH":                       "/worker/path",
+		"HOME":                       "/home/agent",
+		"AIOPS_ALLOWED":              "allowed-value",
+		"AIOPS_DUPLICATE":            "duplicate-value",
+		"GITHUB_TOKEN":               "github-secret",
+		"AIOPS_CONFIGURED_TRACKER":   "configured-tracker-secret",
+		"AIOPS_UNRELATED_TRACKERISH": "not-the-configured-secret",
+	}
+
+	env := BuildSanitizedEnv(
+		[]string{"PATH", "HOME"},
+		[]string{
+			"AIOPS_ALLOWED",
+			"GITHUB_TOKEN",
+			"AIOPS_CONFIGURED_TRACKER",
+			"AIOPS_UNRELATED_TRACKERISH",
+			"AIOPS_DUPLICATE",
+			"AIOPS_DUPLICATE",
+			"BAD=NAME",
+			"",
+		},
+		cfg,
+		func(name string) (string, bool) {
+			value, ok := lookupValues[name]
+			return value, ok
+		},
+		func() string { return "/login/path" },
+	)
+
+	values, counts := envPolicyEnvByName(env)
+	for _, tc := range []struct {
+		name      string
+		wantValue string
+	}{
+		{name: "PATH", wantValue: "/login/path"},
+		{name: "HOME", wantValue: "/home/agent"},
+		{name: "AIOPS_ALLOWED", wantValue: "allowed-value"},
+		{name: "AIOPS_DUPLICATE", wantValue: "duplicate-value"},
+		{name: "AIOPS_UNRELATED_TRACKERISH", wantValue: "not-the-configured-secret"},
+	} {
+		if values[tc.name] != tc.wantValue {
+			t.Fatalf("%s = %q, want %q in env %#v", tc.name, values[tc.name], tc.wantValue, env)
+		}
+		if counts[tc.name] != 1 {
+			t.Fatalf("%s appeared %d times, want 1 in env %#v", tc.name, counts[tc.name], env)
+		}
+	}
+	for _, denied := range []string{"GITHUB_TOKEN", "AIOPS_CONFIGURED_TRACKER", "BAD"} {
+		if counts[denied] != 0 {
+			t.Fatalf("denied env %s appeared %d times in env %#v", denied, counts[denied], env)
+		}
+	}
+}
+
+func TestBuildSanitizedEnvFallsBackToLookupPATH(t *testing.T) {
+	env := BuildSanitizedEnv(
+		[]string{"PATH"},
+		nil,
+		workflow.Config{},
+		func(name string) (string, bool) {
+			if name == "PATH" {
+				return "/worker/path", true
+			}
+			return "", false
+		},
+		func() string { return "" },
+	)
+
+	values, counts := envPolicyEnvByName(env)
+	if values["PATH"] != "/worker/path" {
+		t.Fatalf("PATH = %q, want worker PATH fallback in env %#v", values["PATH"], env)
+	}
+	if counts["PATH"] != 1 {
+		t.Fatalf("PATH appeared %d times, want 1 in env %#v", counts["PATH"], env)
+	}
+}
+
+func envPolicyEnvByName(env []string) (map[string]string, map[string]int) {
+	values := make(map[string]string, len(env))
+	counts := make(map[string]int, len(env))
+	for _, pair := range env {
+		name, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		values[name] = value
+		counts[name]++
+	}
+	return values, counts
+}

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -278,6 +278,7 @@ func (d *RuntimeDispatcher) CleanupReconciledWorkspace(ctx context.Context, w Re
 		Identifier:         w.Identifier,
 		State:              w.State,
 		Reason:             w.Reason,
+		WorkflowConfig:     cfg,
 		BeforeRemoveHook:   hooks.BeforeRemove,
 		HookTimeoutMillis:  hooks.TimeoutMs,
 		HookEnvPassthrough: hooks.EnvPassthrough,

--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -3,6 +3,9 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -242,6 +245,60 @@ func TestRuntimeDispatcherConfigForSnapshotReturnsNilWithoutRefresher(t *testing
 	if cfg.IssueStateRefresher != nil {
 		t.Fatal("IssueStateRefresher should be nil when dispatcher has no tracker refresher set")
 	}
+}
+
+func TestRuntimeDispatcherCleanupRejectsTrackerAPIKeyValuePassthrough(t *testing.T) {
+	root := t.TempDir()
+	workdir := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+	t.Setenv("AIOPS_TRACKER_SECRET", "active-tracker-secret")
+	marker := filepath.Join(root, "hook-env")
+	cfg := workflow.DefaultConfig()
+	cfg.Tracker.APIKey = "active-tracker-secret"
+	cfg.Hooks = workflow.WorkspaceHooks{
+		EnvPassthrough: []string{"EXTRA_BUILD_VAR", "AIOPS_TRACKER_SECRET"},
+		BeforeRemove: workflow.WorkspaceHook{Commands: []string{
+			`printf '<%s><%s>' "$EXTRA_BUILD_VAR" "$AIOPS_TRACKER_SECRET" > ` + shellQuoteRuntimeTest(marker),
+		}},
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{
+		Initial: &workflow.Workflow{Config: cfg, Source: workflow.SourceDefault},
+		Source:  workflow.SourceDefault,
+	})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	dispatcher, err := NewRuntimeDispatcher(runtime, worker.Config{}, &recordingWorkerEmitter{})
+	if err != nil {
+		t.Fatalf("new runtime dispatcher: %v", err)
+	}
+
+	dispatcher.CleanupReconciledWorkspace(context.Background(), ReconciledWorkspace{
+		IssueID:    IssueID("issue-1"),
+		Identifier: "LIN-1",
+		Path:       workdir,
+		Root:       root,
+		State:      "Done",
+		Reason:     "terminal",
+	})
+
+	body, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read before_remove marker: %v", err)
+	}
+	if got := string(body); got != "<let-me-in><>" {
+		t.Fatalf("before_remove env marker = %q, want tracker secret slot empty", got)
+	}
+	if _, err := os.Stat(workdir); !os.IsNotExist(err) {
+		t.Fatalf("cleanup workdir stat err = %v, want removed", err)
+	}
+}
+
+func shellQuoteRuntimeTest(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 // TestRuntimePollerWiresRefresherOntoProvidedDispatcher pins #791: the

--- a/internal/runner/env.go
+++ b/internal/runner/env.go
@@ -2,8 +2,8 @@ package runner
 
 import (
 	"os"
-	"strings"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/envpolicy"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
 )
@@ -39,36 +39,6 @@ func AgentEnvForPreflight(agent string, cfg workflow.Config) []string {
 	}
 }
 
-func agentEnvWithLookup(passthrough []string, cfg workflow.Config, lookup func(string) (string, bool), loginPath func() string) []string { //nolint:gocognit // baseline (#521)
-	seen := make(map[string]struct{}, len(baselineAgentEnvAllowlist)+len(passthrough))
-	env := make([]string, 0, len(baselineAgentEnvAllowlist)+len(passthrough))
-	add := func(name string) {
-		name = strings.TrimSpace(name)
-		if name == "" || strings.Contains(name, "=") {
-			return
-		}
-		if workflow.AgentEnvPassthroughDenyReasonForConfig(name, cfg) != "" {
-			return
-		}
-		if _, ok := seen[name]; ok {
-			return
-		}
-		seen[name] = struct{}{}
-		if name == "PATH" {
-			if value := loginPath(); value != "" {
-				env = append(env, "PATH="+value)
-				return
-			}
-		}
-		if value, ok := lookup(name); ok {
-			env = append(env, name+"="+value)
-		}
-	}
-	for _, name := range baselineAgentEnvAllowlist {
-		add(name)
-	}
-	for _, name := range passthrough {
-		add(name)
-	}
-	return env
+func agentEnvWithLookup(passthrough []string, cfg workflow.Config, lookup func(string) (string, bool), loginPath func() string) []string {
+	return envpolicy.BuildSanitizedEnv(baselineAgentEnvAllowlist, passthrough, cfg, lookup, loginPath)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -276,6 +276,40 @@ func TestShellRunnerHonorsExplicitEnvPassthrough(t *testing.T) {
 	}
 }
 
+func TestShellRunnerRejectsTrackerAPIKeyValuePassthrough(t *testing.T) {
+	workdir := shellTestWorkdir(t)
+	t.Setenv("AIOPS_RUNNER_CANARY", "allowed-value")
+	t.Setenv("AIOPS_TRACKER_SECRET", "tracker-secret")
+
+	wf := workflow.Workflow{Config: workflow.Config{
+		Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
+		Tracker:   workflow.TrackerConfig{APIKey: "tracker-secret"},
+		Claude: workflow.CommandConfig{
+			Command:        "env > shell-env.txt",
+			EnvPassthrough: []string{"AIOPS_RUNNER_CANARY", "AIOPS_TRACKER_SECRET"},
+		},
+	}}
+
+	if _, err := (ShellRunner{Name: "claude"}).Run(context.Background(), RunInput{
+		Task:     task.Task{ID: "tsk_shell_env_tracker_deny"},
+		Workflow: wf,
+		Workdir:  workdir,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(workdir, "shell-env.txt"))
+	if err != nil {
+		t.Fatalf("read shell-env.txt: %v", err)
+	}
+	if !strings.Contains(string(body), "AIOPS_RUNNER_CANARY=allowed-value") {
+		t.Fatalf("runner env missing explicit passthrough:\n%s", body)
+	}
+	if strings.Contains(string(body), "AIOPS_TRACKER_SECRET=") {
+		t.Fatalf("runner env leaked configured tracker API key value:\n%s", body)
+	}
+}
+
 func TestAgentEnvRejectsTrackerTokenPassthrough(t *testing.T) {
 	t.Setenv("AIOPS_RUNNER_CANARY", "allowed-value")
 	t.Setenv("LINEAR_API_KEY", "linear-secret")
@@ -328,6 +362,84 @@ func TestAgentEnvUsesLoginShellPATHSnapshot(t *testing.T) {
 	if strings.Contains(body, "PATH=/worker/path") {
 		t.Fatalf("agent env used raw worker PATH instead of login-shell snapshot:\n%s", body)
 	}
+}
+
+func TestAgentEnvWithLookupBoundaryTable(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{APIKey: "configured-tracker-secret"},
+	}
+	lookupValues := map[string]string{
+		"PATH":                       "/worker/path",
+		"HOME":                       "/home/agent",
+		"USER":                       "agent-user",
+		"AIOPS_ALLOWED":              "allowed-value",
+		"AIOPS_DUPLICATE":            "duplicate-value",
+		"LINEAR_API_KEY":             "linear-secret",
+		"GITEA_TOKEN":                "gitea-secret",
+		"GITHUB_TOKEN":               "github-secret",
+		"AIOPS_CONFIGURED_TRACKER":   "configured-tracker-secret",
+		"AIOPS_UNRELATED_TRACKERISH": "not-the-configured-secret",
+	}
+	env := agentEnvWithLookup(
+		[]string{
+			"AIOPS_ALLOWED",
+			"LINEAR_API_KEY",
+			"GITEA_TOKEN",
+			"GITHUB_TOKEN",
+			"AIOPS_CONFIGURED_TRACKER",
+			"AIOPS_UNRELATED_TRACKERISH",
+			"AIOPS_DUPLICATE",
+			"AIOPS_DUPLICATE",
+			"BAD=NAME",
+			"",
+			"PATH",
+		},
+		cfg,
+		func(name string) (string, bool) {
+			value, ok := lookupValues[name]
+			return value, ok
+		},
+		func() string { return "/login/path" },
+	)
+
+	values, counts := envByName(env)
+	for _, tc := range []struct {
+		name      string
+		wantValue string
+	}{
+		{name: "PATH", wantValue: "/login/path"},
+		{name: "HOME", wantValue: "/home/agent"},
+		{name: "USER", wantValue: "agent-user"},
+		{name: "AIOPS_ALLOWED", wantValue: "allowed-value"},
+		{name: "AIOPS_DUPLICATE", wantValue: "duplicate-value"},
+		{name: "AIOPS_UNRELATED_TRACKERISH", wantValue: "not-the-configured-secret"},
+	} {
+		if values[tc.name] != tc.wantValue {
+			t.Fatalf("%s = %q, want %q in env %#v", tc.name, values[tc.name], tc.wantValue, env)
+		}
+		if counts[tc.name] != 1 {
+			t.Fatalf("%s appeared %d times, want 1 in env %#v", tc.name, counts[tc.name], env)
+		}
+	}
+	for _, denied := range []string{"LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN", "AIOPS_CONFIGURED_TRACKER", "BAD"} {
+		if counts[denied] != 0 {
+			t.Fatalf("denied env %s appeared %d times in env %#v", denied, counts[denied], env)
+		}
+	}
+}
+
+func envByName(env []string) (map[string]string, map[string]int) {
+	values := make(map[string]string, len(env))
+	counts := make(map[string]int, len(env))
+	for _, pair := range env {
+		name, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		values[name] = value
+		counts[name]++
+	}
+	return values, counts
 }
 
 func TestIsTimeoutNilAndOther(t *testing.T) {

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -36,6 +36,7 @@ type ReconcileConfig struct {
 	Tracker            ReconcileTracker
 	Emitter            EventEmitter
 	ReconcileTaskID    string
+	WorkflowConfig     workflow.Config
 	BeforeRemoveHook   workflow.WorkspaceHook
 	HookTimeoutMillis  int
 	HookEnvPassthrough []string
@@ -385,6 +386,7 @@ func removeWorkspace(ctx context.Context, cfg ReconcileConfig, taskID, path stri
 		Identifier:         issue.Identifier,
 		State:              issue.State,
 		Reason:             reason,
+		WorkflowConfig:     cfg.WorkflowConfig,
 		BeforeRemoveHook:   cfg.BeforeRemoveHook,
 		HookTimeoutMillis:  cfg.HookTimeoutMillis,
 		HookEnvPassthrough: cfg.HookEnvPassthrough,
@@ -402,6 +404,7 @@ type RemoveWorkspaceRequest struct {
 	Identifier         string
 	State              string
 	Reason             string
+	WorkflowConfig     workflow.Config
 	BeforeRemoveHook   workflow.WorkspaceHook
 	HookTimeoutMillis  int
 	HookEnvPassthrough []string
@@ -417,7 +420,7 @@ type RemoveWorkspaceRequest struct {
 // upstream Workspace.remove_issue_workspaces, which both paths also share.
 // It returns true when the directory was removed.
 func RemoveIssueWorkspace(ctx context.Context, ev EventEmitter, req RemoveWorkspaceRequest) (bool, error) {
-	if err := runWorkspaceHook(ctx, ev, req.TaskID, req.Identifier, req.Path, workspace.HookBeforeRemove, req.BeforeRemoveHook, req.HookTimeoutMillis, req.HookEnvPassthrough); err != nil {
+	if err := runWorkspaceHook(ctx, ev, req.TaskID, req.Identifier, req.Path, workspace.HookBeforeRemove, req.BeforeRemoveHook, req.HookTimeoutMillis, req.HookEnvPassthrough, req.WorkflowConfig); err != nil {
 		log.Printf("event=before_remove_hook_failed task_id=%s issue_id=%s issue_identifier=%s reason=%s workspace=%q error=%q", req.TaskID, req.IssueID, req.Identifier, req.Reason, req.Path, err)
 	}
 	if err := workspace.SafeRemove(req.WorkspaceRoot, req.Path); err != nil {

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -703,6 +703,40 @@ func TestReconcileStartupRunsBeforeRemoveHookAndStillRemovesOnFailure(t *testing
 	}
 }
 
+func TestReconcileStartupBeforeRemoveRejectsTrackerAPIKeyValuePassthrough(t *testing.T) {
+	root := t.TempDir()
+	terminalPath := filepath.Join(root, "acme", "repo", "linear-issue", "LIN-1")
+	if err := os.MkdirAll(terminalPath, 0o755); err != nil {
+		t.Fatalf("mkdir terminal workspace: %v", err)
+	}
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+	t.Setenv("AIOPS_TRACKER_SECRET", "reconcile-tracker-secret")
+	marker := filepath.Join(root, "hook-env")
+
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:      root,
+		ActiveStates:       []string{"Todo"},
+		TerminalStates:     []string{"Done"},
+		TrackerKind:        "linear",
+		Tracker:            fakeReconcileTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Done"}}},
+		WorkflowConfig:     workflow.Config{Tracker: workflow.TrackerConfig{APIKey: "reconcile-tracker-secret"}},
+		HookEnvPassthrough: []string{"EXTRA_BUILD_VAR", "AIOPS_TRACKER_SECRET"},
+		BeforeRemoveHook: workflow.WorkspaceHook{Commands: []string{
+			`printf '<%s><%s>' "$EXTRA_BUILD_VAR" "$AIOPS_TRACKER_SECRET" > ` + shellQuote(marker),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup: %v", err)
+	}
+	body, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read before_remove marker: %v", err)
+	}
+	if got := string(body); got != "<let-me-in><>" {
+		t.Fatalf("before_remove env marker = %q, want tracker secret slot empty", got)
+	}
+}
+
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/internal/worker/runtask.go
+++ b/internal/worker/runtask.go
@@ -115,7 +115,7 @@ func emitHookResults(ctx context.Context, ev EventEmitter, taskID, identifier st
 	}
 }
 
-func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, identifier, workdir string, name workspace.HookName, hook workflow.WorkspaceHook, timeoutMs int, envPassthrough []string) error {
+func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, identifier, workdir string, name workspace.HookName, hook workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, cfg workflow.Config) error {
 	if len(hook.Commands) == 0 {
 		return nil
 	}
@@ -124,13 +124,13 @@ func runWorkspaceHook(ctx context.Context, ev EventEmitter, taskID, identifier, 
 		"commands":   len(hook.Commands),
 		"timeout_ms": timeoutMs,
 	})
-	results, err := workspace.RunWorkspaceHook(ctx, workdir, name, hook, timeoutMs, envPassthrough)
+	results, err := workspace.RunWorkspaceHook(ctx, workdir, name, hook, timeoutMs, envPassthrough, cfg)
 	emitHookResults(ctx, ev, taskID, identifier, results)
 	return err
 }
 
-func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, identifier, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, reason string) {
-	if err := runWorkspaceHook(ctx, ev, taskID, identifier, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs, envPassthrough); err != nil {
+func removeWorkdirAfterHookFailure(ctx context.Context, ev EventEmitter, taskID, identifier, workspaceRoot, workdir string, beforeRemove workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, cfg workflow.Config, reason string) {
+	if err := runWorkspaceHook(ctx, ev, taskID, identifier, workdir, workspace.HookBeforeRemove, beforeRemove, timeoutMs, envPassthrough, cfg); err != nil {
 		LogTaskIDEventf(taskID, identifier, "before_remove_hook_failed", "reason=%s error=%q", reason, err)
 	}
 	if err := workspace.SafeRemove(workspaceRoot, workdir); err != nil {
@@ -243,8 +243,8 @@ func (rs *runState) prepareWorkspace() *RunTaskError {
 		// is newly created. Reuses skip it so bootstrap commands
 		// (`npm ci`, `pip install`, …) remain the one-time init they're
 		// documented as.
-		if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterCreate, rs.hooks.AfterCreate, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
-			removeWorkdirAfterHookFailure(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workspaceRoot, rs.workdir, rs.hooks.BeforeRemove, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough, "after_create")
+		if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterCreate, rs.hooks.AfterCreate, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough, rs.wcfg); err != nil {
+			removeWorkdirAfterHookFailure(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workspaceRoot, rs.workdir, rs.hooks.BeforeRemove, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough, rs.wcfg, "after_create")
 			rs.releaseWorkspaceOwnership()
 			return &RunTaskError{Cfg: rs.wcfg, Err: err}
 		}
@@ -333,7 +333,7 @@ func (rs *runState) runAgent() *RunTaskError {
 		return rtErr
 	}
 
-	if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookBeforeRun, rs.hooks.BeforeRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
+	if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookBeforeRun, rs.hooks.BeforeRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough, rs.wcfg); err != nil {
 		return &RunTaskError{Cfg: rs.wcfg, Err: err}
 	}
 
@@ -362,7 +362,7 @@ func (rs *runState) runAgent() *RunTaskError {
 		return rs.handleRunnerFailure(runErr)
 	}
 
-	if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterRun, rs.hooks.AfterRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
+	if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterRun, rs.hooks.AfterRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough, rs.wcfg); err != nil {
 		LogIssueSessionEventf(rs.t, rs.sessionID, "after_run_hook_failed", "error=%q", err)
 	}
 	return nil
@@ -379,7 +379,7 @@ func (rs *runState) runAgent() *RunTaskError {
 // `worker --doctor` (#542) is the preventive layer that catches the host
 // misconfiguration before dispatch.
 func (rs *runState) handleRunnerFailure(runErr error) *RunTaskError {
-	if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterRun, rs.hooks.AfterRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough); err != nil {
+	if err := runWorkspaceHook(rs.ctx, rs.ev, rs.t.ID, rs.t.SourceEventID, rs.workdir, workspace.HookAfterRun, rs.hooks.AfterRun, rs.hooks.TimeoutMs, rs.hooks.EnvPassthrough, rs.wcfg); err != nil {
 		LogIssueSessionEventf(rs.t, rs.sessionID, "after_run_hook_failed", "after_runner_error=true error=%q", err)
 	}
 	return &RunTaskError{Cfg: rs.wcfg, Err: runErr}

--- a/internal/worker/runtask_integration_test.go
+++ b/internal/worker/runtask_integration_test.go
@@ -331,6 +331,82 @@ func TestRunTaskExecutesWorkspaceHooksAroundRunner(t *testing.T) {
 	}
 }
 
+func TestRunTaskWorkspaceHooksRejectTrackerAPIKeyValuePassthrough(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+	t.Setenv("AIOPS_TRACKER_SECRET", "task-tracker-secret")
+
+	ev := &fakeEmitter{}
+	cfg := workerCfgForIntegration(t)
+	cfg.Workflow.Config.Tracker.APIKey = "task-tracker-secret"
+	cfg.Workflow.Config.Hooks = workflow.WorkspaceHooks{
+		EnvPassthrough: []string{"EXTRA_BUILD_VAR", "AIOPS_TRACKER_SECRET"},
+		AfterCreate:    workflow.WorkspaceHook{Commands: []string{hookEnvLogCommand("after_create")}},
+		BeforeRun:      workflow.WorkspaceHook{Commands: []string{hookEnvLogCommand("before_run")}},
+		AfterRun:       workflow.WorkspaceHook{Commands: []string{hookEnvLogCommand("after_run")}},
+	}
+
+	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		t.Fatalf("runTask: %v", rterr.Err)
+	}
+
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
+	body, err := os.ReadFile(filepath.Join(workdir, "hook-env.log"))
+	if err != nil {
+		t.Fatalf("read hook-env.log: %v", err)
+	}
+	got := string(body)
+	for _, want := range []string{
+		"after_create:<let-me-in><>\n",
+		"before_run:<let-me-in><>\n",
+		"after_run:<let-me-in><>\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("hook env log missing %q; got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "task-tracker-secret") {
+		t.Fatalf("hook env leaked configured tracker API key value:\n%s", got)
+	}
+}
+
+func TestRunTaskWorkspaceHooksRejectTrackerAPIKeySourceEnvPassthrough(t *testing.T) {
+	workflowBody := strings.Replace(linearWorkflowBody, "  project_slug: platform\n", "  project_slug: platform\n  api_key: $AIOPS_TRACKER_SECRET\n", 1)
+	if workflowBody == linearWorkflowBody {
+		t.Fatal("test workflow fixture no longer contains tracker project_slug insertion point")
+	}
+	t.Setenv("AIOPS_TRACKER_SECRET", "loaded-tracker-secret")
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, workflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+
+	ev := &fakeEmitter{}
+	cfg := workerCfgForIntegrationWithWorkflow(t, workflowBody)
+	t.Setenv("AIOPS_TRACKER_SECRET", "rotated-tracker-secret")
+	cfg.Workflow.Config.Hooks = workflow.WorkspaceHooks{
+		EnvPassthrough: []string{"EXTRA_BUILD_VAR", "AIOPS_TRACKER_SECRET"},
+		BeforeRun:      workflow.WorkspaceHook{Commands: []string{hookEnvLogCommand("before_run_source_env")}},
+	}
+
+	if rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg); rterr != nil {
+		t.Fatalf("runTask: %v", rterr.Err)
+	}
+
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
+	body, err := os.ReadFile(filepath.Join(workdir, "hook-env.log"))
+	if err != nil {
+		t.Fatalf("read hook-env.log: %v", err)
+	}
+	if got := string(body); got != "before_run_source_env:<let-me-in><>\n" {
+		t.Fatalf("hook env log = %q, want tracker source env slot empty after env value rotation", got)
+	}
+}
+
+func hookEnvLogCommand(hook string) string {
+	return fmt.Sprintf("printf '%s:<%%s><%%s>\\n' \"$EXTRA_BUILD_VAR\" \"$AIOPS_TRACKER_SECRET\" >> hook-env.log", hook)
+}
+
 // The worker RUN_SUMMARY.md gate was removed under #561 (it ran after the agent
 // had already pushed, so it could only flag — never prevent — and it raced
 // reconcile-cancel like the verify gate did in #557). The characterization test
@@ -627,14 +703,18 @@ func TestRunTaskDoesNotExecuteAfterRunHookWhenRunnerSetupFails(t *testing.T) {
 func TestRunTaskRunsBeforeRemoveHookWhenAfterCreateFails(t *testing.T) {
 	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
 	t.Setenv("REPO_URL", cloneURL)
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+	t.Setenv("AIOPS_TRACKER_SECRET", "cleanup-tracker-secret")
 
 	ev := &fakeEmitter{}
 	cfg := workerCfgForIntegration(t)
+	cfg.Workflow.Config.Tracker.APIKey = "cleanup-tracker-secret"
 	marker := filepath.Join(cfg.WorkspaceRoot, "before-remove.marker")
 	cfg.Workflow.Config.Hooks = workflow.WorkspaceHooks{
-		AfterCreate: workflow.WorkspaceHook{Commands: []string{"printf after_create > hook.log", "exit 7"}},
+		EnvPassthrough: []string{"EXTRA_BUILD_VAR", "AIOPS_TRACKER_SECRET"},
+		AfterCreate:    workflow.WorkspaceHook{Commands: []string{"printf after_create > hook.log", "exit 7"}},
 		BeforeRemove: workflow.WorkspaceHook{Commands: []string{
-			"test -d . && printf before_remove > " + shellQuoteForTest(marker),
+			`test -d . && printf '<%s><%s>' "$EXTRA_BUILD_VAR" "$AIOPS_TRACKER_SECRET" > ` + shellQuoteForTest(marker),
 		}},
 	}
 
@@ -647,8 +727,8 @@ func TestRunTaskRunsBeforeRemoveHookWhenAfterCreateFails(t *testing.T) {
 	if _, err := os.Stat(workdir); !os.IsNotExist(err) {
 		t.Fatalf("workdir stat err = %v, want removed after after_create failure", err)
 	}
-	if body, err := os.ReadFile(marker); err != nil || string(body) != "before_remove" {
-		t.Fatalf("before_remove marker = %q, %v; want hook to run before removing failed workspace", body, err)
+	if body, err := os.ReadFile(marker); err != nil || string(body) != "<let-me-in><>" {
+		t.Fatalf("before_remove marker = %q, %v; want hook to run before removing failed workspace without tracker secret", body, err)
 	}
 	var beforeRemoveStarts int
 	for _, e := range ev.byKind(task.EventWorkspaceHookStart) {
@@ -662,6 +742,37 @@ func TestRunTaskRunsBeforeRemoveHookWhenAfterCreateFails(t *testing.T) {
 	}
 	if beforeRemoveStarts != 1 {
 		t.Fatalf("before_remove hook starts = %d, want 1; events=%#v", beforeRemoveStarts, ev.events)
+	}
+}
+
+func TestRunTaskAfterRunHookRejectsTrackerAPIKeyValuePassthroughOnRunnerFailure(t *testing.T) {
+	cloneURL, tk := initBareUpstreamWithWorkflow(t, linearWorkflowBody)
+	t.Setenv("REPO_URL", cloneURL)
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+	t.Setenv("AIOPS_TRACKER_SECRET", "runner-failure-tracker-secret")
+	tk.Model = "claude"
+
+	ev := &fakeEmitter{}
+	cfg := workerCfgForIntegration(t)
+	cfg.Workflow.Config.Tracker.APIKey = "runner-failure-tracker-secret"
+	cfg.Workflow.Config.Claude.Command = "exit 3"
+	cfg.Workflow.Config.Hooks = workflow.WorkspaceHooks{
+		EnvPassthrough: []string{"EXTRA_BUILD_VAR", "AIOPS_TRACKER_SECRET"},
+		AfterRun:       workflow.WorkspaceHook{Commands: []string{hookEnvLogCommand("after_run_failure")}},
+	}
+
+	rterr := worker.RunTaskForTest(context.Background(), ev, tk, cfg)
+	if rterr == nil {
+		t.Fatal("runTask succeeded, want runner failure")
+	}
+
+	workdir := filepath.Join(cfg.WorkspaceRoot, "acme", "demo", "linear_issue", "issue-uuid")
+	body, err := os.ReadFile(filepath.Join(workdir, "hook-env.log"))
+	if err != nil {
+		t.Fatalf("read hook-env.log: %v", err)
+	}
+	if got := string(body); got != "after_run_failure:<let-me-in><>\n" {
+		t.Fatalf("after_run hook env log = %q, want tracker secret slot empty", got)
 	}
 }
 

--- a/internal/workflow/agent_env_policy.go
+++ b/internal/workflow/agent_env_policy.go
@@ -28,6 +28,13 @@ func AgentEnvPassthroughDenyReason(name string) string {
 }
 
 func AgentEnvPassthroughDenyReasonForConfig(name string, cfg Config) string {
+	return AgentEnvPassthroughDenyReasonForConfigWithLookup(name, cfg, os.LookupEnv)
+}
+
+// AgentEnvPassthroughDenyReasonForConfigWithLookup is
+// AgentEnvPassthroughDenyReasonForConfig with an injectable environment lookup
+// so env construction tests can pin value-based tracker secret denial.
+func AgentEnvPassthroughDenyReasonForConfigWithLookup(name string, cfg Config, lookup func(string) (string, bool)) string {
 	name = strings.TrimSpace(name)
 	if reason := AgentEnvPassthroughDenyReason(name); reason != "" {
 		return reason
@@ -36,7 +43,7 @@ func AgentEnvPassthroughDenyReasonForConfig(name string, cfg Config) string {
 		return "tracker.api_key environment variable must stay behind orchestrator tools"
 	}
 	if cfg.Tracker.APIKey != "" {
-		if value, ok := os.LookupEnv(name); ok && value == cfg.Tracker.APIKey {
+		if value, ok := lookup(name); ok && value == cfg.Tracker.APIKey {
 			return "tracker.api_key value must stay behind orchestrator tools"
 		}
 	}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -487,9 +487,9 @@ func worktreePathForBranch(ctx context.Context, mirror, workBranch string) strin
 // allowlist plus envPassthrough — secrets in the worker's environment that
 // are not in either list are dropped. See
 // docs/design/hook-verify-env-allowlist.md (#227).
-func RunWorkspaceHook(ctx context.Context, workdir string, name HookName, hook workflow.WorkspaceHook, timeoutMs int, envPassthrough []string) ([]HookResult, error) {
+func RunWorkspaceHook(ctx context.Context, workdir string, name HookName, hook workflow.WorkspaceHook, timeoutMs int, envPassthrough []string, cfg workflow.Config) ([]HookResult, error) {
 	timeoutMs = EffectiveWorkspaceHookTimeoutMs(timeoutMs)
-	env := subprocessEnv(envPassthrough)
+	env := subprocessEnv(envPassthrough, cfg)
 	results := make([]HookResult, 0, len(hook.Commands))
 	for _, raw := range hook.Commands {
 		command := strings.TrimSpace(raw)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -26,7 +26,7 @@ func TestRunWorkspaceHookStopsOnNonZeroAndCapturesOutput(t *testing.T) {
 		"printf never > should-not-exist",
 	}}
 
-	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil)
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil, workflow.Config{})
 	if err == nil {
 		t.Fatalf("RunWorkspaceHook should fail on non-zero exit")
 	}
@@ -56,7 +56,7 @@ func TestRunWorkspaceHookTimeoutStopsCommand(t *testing.T) {
 	hook := workflow.WorkspaceHook{Commands: []string{"sleep 2"}}
 
 	start := time.Now()
-	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50, nil)
+	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50, nil, workflow.Config{})
 	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatalf("RunWorkspaceHook should fail on timeout")
@@ -86,7 +86,7 @@ func TestRunWorkspaceHookTimeoutDoesNotWaitForeverOnEscapedDescendantOutput(t *t
 	hook := workflow.WorkspaceHook{Commands: []string{"setsid sh -c 'while true; do printf x; sleep 1; done' & sleep 2"}}
 
 	start := time.Now()
-	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50, nil)
+	results, err := RunWorkspaceHook(context.Background(), dir, HookAfterRun, hook, 50, nil, workflow.Config{})
 	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatalf("RunWorkspaceHook should fail on timeout")
@@ -134,7 +134,7 @@ func TestRunWorkspaceHookEnvDropsNonAllowlistedSecretsByDefault(t *testing.T) {
 		`printf '<%s><%s><%s>' "$LINEAR_API_KEY" "$GITHUB_TOKEN" "$PATH"`,
 	}}
 
-	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil)
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil, workflow.Config{})
 	if err != nil {
 		t.Fatalf("RunWorkspaceHook: %v", err)
 	}
@@ -166,7 +166,7 @@ func TestRunWorkspaceHookEnvPassthroughLetsNamedVarThrough(t *testing.T) {
 		`printf '<%s><%s>' "$LINEAR_API_KEY" "$EXTRA_BUILD_VAR"`,
 	}}
 
-	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, []string{"EXTRA_BUILD_VAR"})
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, []string{"EXTRA_BUILD_VAR"}, workflow.Config{})
 	if err != nil {
 		t.Fatalf("RunWorkspaceHook: %v", err)
 	}
@@ -176,6 +176,41 @@ func TestRunWorkspaceHookEnvPassthroughLetsNamedVarThrough(t *testing.T) {
 	}
 	if !strings.Contains(out, "let-me-in") {
 		t.Fatalf("EXTRA_BUILD_VAR did not pass through: %q", out)
+	}
+}
+
+func TestRunWorkspaceHookEnvRejectsTrackerAPIKeyValuePassthrough(t *testing.T) {
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+	t.Setenv("AIOPS_TRACKER_SECRET", "hook-tracker-secret")
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{
+		`printf '<%s><%s>' "$EXTRA_BUILD_VAR" "$AIOPS_TRACKER_SECRET"`,
+	}}
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{APIKey: "hook-tracker-secret"},
+	}
+
+	results, err := RunWorkspaceHook(
+		context.Background(),
+		dir,
+		HookBeforeRun,
+		hook,
+		0,
+		[]string{"EXTRA_BUILD_VAR", "AIOPS_TRACKER_SECRET"},
+		cfg,
+	)
+	if err != nil {
+		t.Fatalf("RunWorkspaceHook: %v", err)
+	}
+	out := results[0].Output
+	if !strings.Contains(out, "let-me-in") {
+		t.Fatalf("EXTRA_BUILD_VAR did not pass through: %q", out)
+	}
+	if strings.Contains(out, "hook-tracker-secret") {
+		t.Fatalf("hook env leaked configured tracker API key value: %q", out)
+	}
+	if !strings.Contains(out, "<let-me-in><>") {
+		t.Fatalf("hook output = %q, want tracker secret slot empty", out)
 	}
 }
 
@@ -196,7 +231,7 @@ func TestRunWorkspaceHookDoesNotSourceUserLoginProfile(t *testing.T) {
 	dir := t.TempDir()
 	hook := workflow.WorkspaceHook{Commands: []string{`printf clean`}}
 
-	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil)
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil, workflow.Config{})
 	if err != nil {
 		t.Fatalf("RunWorkspaceHook: %v", err)
 	}
@@ -214,7 +249,7 @@ func TestSubprocessEnvSkipsUnsetPassthroughNames(t *testing.T) {
 		t.Fatalf("Unsetenv(%q) = %v; want nil", "DEFINITELY_UNSET_227", err)
 	}
 
-	env := subprocessEnv([]string{"DEFINITELY_SET_227", "DEFINITELY_UNSET_227", "DEFINITELY_SET_227"})
+	env := subprocessEnv([]string{"DEFINITELY_SET_227", "DEFINITELY_UNSET_227", "DEFINITELY_SET_227"}, workflow.Config{})
 
 	var sawSet, sawUnsetMarker int
 	for _, kv := range env {
@@ -231,4 +266,82 @@ func TestSubprocessEnvSkipsUnsetPassthroughNames(t *testing.T) {
 	if sawUnsetMarker != 0 {
 		t.Fatalf("unset passthrough name leaked into env: %v", env)
 	}
+}
+
+func TestSubprocessEnvWithLookupBoundaryTable(t *testing.T) {
+	cfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{APIKey: "configured-tracker-secret"},
+	}
+	lookupValues := map[string]string{
+		"PATH":                       "/worker/path",
+		"HOME":                       "/home/hook",
+		"USER":                       "hook-user",
+		"AIOPS_ALLOWED":              "allowed-value",
+		"AIOPS_DUPLICATE":            "duplicate-value",
+		"LINEAR_API_KEY":             "linear-secret",
+		"GITEA_TOKEN":                "gitea-secret",
+		"GITHUB_TOKEN":               "github-secret",
+		"AIOPS_CONFIGURED_TRACKER":   "configured-tracker-secret",
+		"AIOPS_UNRELATED_TRACKERISH": "not-the-configured-secret",
+	}
+	env := subprocessEnvWithLookup(
+		[]string{
+			"AIOPS_ALLOWED",
+			"LINEAR_API_KEY",
+			"GITEA_TOKEN",
+			"GITHUB_TOKEN",
+			"AIOPS_CONFIGURED_TRACKER",
+			"AIOPS_UNRELATED_TRACKERISH",
+			"AIOPS_DUPLICATE",
+			"AIOPS_DUPLICATE",
+			"BAD=NAME",
+			"",
+			"PATH",
+		},
+		cfg,
+		func(name string) (string, bool) {
+			value, ok := lookupValues[name]
+			return value, ok
+		},
+		func() string { return "/login/path" },
+	)
+
+	values, counts := workspaceEnvByName(env)
+	for _, tc := range []struct {
+		name      string
+		wantValue string
+	}{
+		{name: "PATH", wantValue: "/login/path"},
+		{name: "HOME", wantValue: "/home/hook"},
+		{name: "USER", wantValue: "hook-user"},
+		{name: "AIOPS_ALLOWED", wantValue: "allowed-value"},
+		{name: "AIOPS_DUPLICATE", wantValue: "duplicate-value"},
+		{name: "AIOPS_UNRELATED_TRACKERISH", wantValue: "not-the-configured-secret"},
+	} {
+		if values[tc.name] != tc.wantValue {
+			t.Fatalf("%s = %q, want %q in env %#v", tc.name, values[tc.name], tc.wantValue, env)
+		}
+		if counts[tc.name] != 1 {
+			t.Fatalf("%s appeared %d times, want 1 in env %#v", tc.name, counts[tc.name], env)
+		}
+	}
+	for _, denied := range []string{"LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN", "AIOPS_CONFIGURED_TRACKER", "BAD"} {
+		if counts[denied] != 0 {
+			t.Fatalf("denied env %s appeared %d times in env %#v", denied, counts[denied], env)
+		}
+	}
+}
+
+func workspaceEnvByName(env []string) (map[string]string, map[string]int) {
+	values := make(map[string]string, len(env))
+	counts := make(map[string]int, len(env))
+	for _, pair := range env {
+		name, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		values[name] = value
+		counts[name]++
+	}
+	return values, counts
 }

--- a/internal/workspace/subprocess_env.go
+++ b/internal/workspace/subprocess_env.go
@@ -1,12 +1,16 @@
 package workspace
 
-import "os"
+import (
+	"os"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/envpolicy"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
 
 // baselineHookEnvAllowlist is the always-inherited env-var allowlist for hook
-// and verify subprocesses. Operators extend it per-workflow via
-// `hooks.env_passthrough` / `verify.env_passthrough`. Tracker tokens, SSH
-// credentials, and any other secret outside this list are excluded by default.
-// See docs/design/hook-verify-env-allowlist.md (#227).
+// subprocesses. Operators extend it per-workflow via `hooks.env_passthrough`.
+// Tracker tokens, SSH credentials, and any other secret outside this list are
+// excluded by default. See docs/design/hook-verify-env-allowlist.md (#227).
 var baselineHookEnvAllowlist = []string{
 	"PATH",
 	"HOME",
@@ -18,43 +22,18 @@ var baselineHookEnvAllowlist = []string{
 	"TERM",
 }
 
-// subprocessEnv builds the `cmd.Env` slice for a hook or verify subprocess.
+// subprocessEnv builds the `cmd.Env` slice for a hook subprocess.
 // Names from baselineHookEnvAllowlist plus passthrough are inherited from the
 // worker's environment when set. Names that are not set in the worker's env
 // are silently dropped so passthrough lists can include "may or may not be
 // present" vars without spurious config-validation noise. Duplicate names
 // across the two sources are deduplicated so `cmd.Env` does not carry the
-// same `K=V` twice.
-func subprocessEnv(passthrough []string) []string { //nolint:gocognit // baseline (#521)
-	seen := make(map[string]struct{}, len(baselineHookEnvAllowlist)+len(passthrough))
-	env := make([]string, 0, len(baselineHookEnvAllowlist)+len(passthrough))
-	add := func(name string) {
-		if name == "" {
-			return
-		}
-		if _, dup := seen[name]; dup {
-			return
-		}
-		seen[name] = struct{}{}
-		if name == "PATH" {
-			// Use the once-captured login-shell PATH so the subprocess
-			// inherits version-manager additions (nvm, rustup, etc.) without
-			// sourcing the login profile per command — which would otherwise
-			// echo profile stdout into the hook/verify output buffer (#314).
-			if v := LoginPATH(); v != "" {
-				env = append(env, "PATH="+v)
-				return
-			}
-		}
-		if v, ok := os.LookupEnv(name); ok {
-			env = append(env, name+"="+v)
-		}
-	}
-	for _, name := range baselineHookEnvAllowlist {
-		add(name)
-	}
-	for _, name := range passthrough {
-		add(name)
-	}
-	return env
+// same `K=V` twice. Tracker credentials stay denied even when named in
+// passthrough.
+func subprocessEnv(passthrough []string, cfg workflow.Config) []string {
+	return subprocessEnvWithLookup(passthrough, cfg, os.LookupEnv, LoginPATH)
+}
+
+func subprocessEnvWithLookup(passthrough []string, cfg workflow.Config, lookup func(string) (string, bool), loginPath func() string) []string {
+	return envpolicy.BuildSanitizedEnv(baselineHookEnvAllowlist, passthrough, cfg, lookup, loginPath)
 }

--- a/test/e2e/fixtures/scripted-agent.md
+++ b/test/e2e/fixtures/scripted-agent.md
@@ -6,6 +6,7 @@ repo:
   clone_url: http://localhost:3000/aiops-bot/demo-scripted-agent.git
 tracker:
   kind: gitea
+  api_key: $AIOPS_TRACKER_SECRET
   active_states:
     - Todo
   terminal_states:
@@ -19,6 +20,12 @@ claude:
   # scripted-agent shell script (the script path is only known at test
   # runtime, so it cannot be checked in).
   command: __SCRIPTED_AGENT_COMMAND__
+hooks:
+  env_passthrough:
+    - EXTRA_BUILD_VAR
+    - AIOPS_TRACKER_SECRET
+  before_remove:
+    - printf '<%s><%s>' "$EXTRA_BUILD_VAR" "$AIOPS_TRACKER_SECRET" > ../before-remove-env
 policy:
   mode: draft_pr
 verify:

--- a/test/e2e/scripted_agent_test.go
+++ b/test/e2e/scripted_agent_test.go
@@ -118,10 +118,6 @@ func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
 
 	agentBranch := fmt.Sprintf("agent/%d", issueNum)
 	scriptPath := writeScriptedAgent(t, owner, repo, agentBranch, issueNum)
-	serviceWorkflow, err := workflow.Load(writeScriptedAgentServiceWorkflow(t, cloneURL, scriptPath))
-	if err != nil {
-		t.Fatalf("load service workflow: %v", err)
-	}
 
 	// Put the tracker credential into the WORKER process environment so the
 	// script's GITEA_TOKEN-absence guard pins something real: the runner
@@ -131,6 +127,13 @@ func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
 	// (Passthrough *requests* for GITEA_TOKEN are already rejected one layer
 	// earlier, at workflow load; see validateAgentEnvPassthrough.)
 	t.Setenv("GITEA_TOKEN", bed.gitea.botToken)
+	t.Setenv("AIOPS_TRACKER_SECRET", bed.gitea.botToken)
+	t.Setenv("EXTRA_BUILD_VAR", "let-me-in")
+	serviceWorkflow, err := workflow.Load(writeScriptedAgentServiceWorkflow(t, cloneURL, scriptPath))
+	if err != nil {
+		t.Fatalf("load service workflow: %v", err)
+	}
+	t.Setenv("AIOPS_TRACKER_SECRET", "rotated-e2e-tracker-secret")
 
 	// The hand-set fields below deliberately mirror the fixture front matter
 	// (test/e2e/fixtures/scripted-agent.md) — the suite-wide assembly pattern
@@ -146,6 +149,7 @@ func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
 	cfg.Tracker.APIKey = bed.gitea.botToken
 	cfg.Tracker.ActiveStates = serviceWorkflow.Config.Tracker.ActiveStates
 	cfg.Tracker.TerminalStates = serviceWorkflow.Config.Tracker.TerminalStates
+	serviceWorkflow.Config.Tracker.APIKey = bed.gitea.botToken
 	client := gitea.NewTrackerClient(cfg.Tracker, bed.gitea.baseURL, owner, repo)
 	client.HTTP = httpClientForE2E()
 
@@ -177,9 +181,10 @@ func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
 		// worker.RemoveIssueWorkspace routine so the SPEC §18.1 terminal
 		// cleanup path under test matches the deployed seam.
 		WorkspaceCleaner: &scriptedAgentWorkspaceCleaner{
-			emitter:       events,
-			workspaceRoot: workspaceRoot,
-			hooks:         serviceWorkflow.Config.WorkspaceHooks(),
+			emitter:        events,
+			workspaceRoot:  workspaceRoot,
+			workflowConfig: serviceWorkflow.Config,
+			hooks:          serviceWorkflow.Config.WorkspaceHooks(),
 		},
 	})
 	orchCtx, orchCancel := context.WithCancel(ctx)
@@ -259,6 +264,14 @@ func TestGiteaScriptedAgentLoop_PositiveHandoff(t *testing.T) {
 		}
 		return true, nil
 	})
+	beforeRemoveMarker := filepath.Join(filepath.Dir(workspacePath), "before-remove-env")
+	body, err := os.ReadFile(beforeRemoveMarker)
+	if err != nil {
+		t.Fatalf("read before_remove env marker: %v", err)
+	}
+	if got := string(body); got != "<let-me-in><>" {
+		t.Fatalf("before_remove env marker = %q, want tracker secret slot empty", got)
+	}
 
 	// Re-check the tracker after reconciliation: the worker must not have
 	// rewritten the agent's label flip or opened a PR of its own.
@@ -415,9 +428,10 @@ func (d *scriptedAgentDispatcher) preparedWorkspacePath() string {
 // sweep uses, so before_remove and the reconcile_workspace event contract
 // match the deployed worker.
 type scriptedAgentWorkspaceCleaner struct {
-	emitter       worker.EventEmitter
-	workspaceRoot string
-	hooks         workflow.WorkspaceHooks
+	emitter        worker.EventEmitter
+	workspaceRoot  string
+	workflowConfig workflow.Config
+	hooks          workflow.WorkspaceHooks
 }
 
 func (c *scriptedAgentWorkspaceCleaner) CleanupReconciledWorkspace(ctx context.Context, w orchestrator.ReconciledWorkspace) {
@@ -433,6 +447,7 @@ func (c *scriptedAgentWorkspaceCleaner) CleanupReconciledWorkspace(ctx context.C
 		Identifier:         w.Identifier,
 		State:              w.State,
 		Reason:             w.Reason,
+		WorkflowConfig:     c.workflowConfig,
 		BeforeRemoveHook:   c.hooks.BeforeRemove,
 		HookTimeoutMillis:  c.hooks.TimeoutMs,
 		HookEnvPassthrough: c.hooks.EnvPassthrough,


### PR DESCRIPTION
Closes #910

## Summary
- Centralize agent/hook env construction in `internal/envpolicy` so `agentEnvWithLookup` and `subprocessEnv` share baseline, passthrough, dedupe, PATH, and tracker-secret denial behavior.
- Thread the effective workflow config into hook execution on RunTask, after_create cleanup, startup reconciliation, and runtime terminal cleanup so configured `tracker.api_key` source names and values stay denied on production paths.
- Remove the `baseline (#521)` nolints from the env boundary helpers after table coverage and lint verification.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded). Production Go diff: 9 files, +125/-85 LOC.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Acceptance / deferral
- [x] Added characterization/table tests for `agentEnvWithLookup` and `subprocessEnv`: baseline env, configured passthrough, tracker token denial, configured tracker-key value denial, duplicate/conflicting values.
- [x] Removed only the env-boundary `baseline (#521)` nolints after `gofmt`/golangci verification.
- [x] Mutation-verified committed env/hook wiring seams; restored to a clean tree afterward.
- [x] Sandbox helper scope (`applySandbox`, `bubblewrapCommand`, `writeFirejailNetfilter`) was split to follow-up #915 before touching those helpers.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go test ./...`
- `go build ./cmd/worker ./cmd/tui`
- `go test -tags e2e ./test/e2e -run 'TestGiteaScriptedAgentLoop_PositiveHandoff' -count=1`
- Mutation checks: broke runner env cfg threading, workspace hook cfg threading, RunTask/cleanup/reconcile cfg threading, startup reconcile cfg propagation, after_create failure cleanup, after_run failure cleanup, runtime cleanup cfg, and `tracker.api_key` source-env denial; each caused the targeted test to fail before restore.
- Local Codex pre-push review on `b657fd48d4f352d850ebf34cae9dc1eed06a8dff`: `MERGE-READY`; no confirmed blockers. Claude CLI auxiliary review was attempted twice but produced no output before being interrupted, so it is not counted as a gate.

Remote gate ledger:
- Head SHA: `b657fd48d4f352d850ebf34cae9dc1eed06a8dff`.
- CI: all required checks passed on head (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`, `Validate PR metadata`, `Validate PR title`).
- `@codex review`: trigger comment `4724713113` by `bytevane` at `2026-06-17T00:07:30Z`; clean Codex comment `4724743152` by bot id `199175422` at `2026-06-17T00:13:42Z`, body says no major issues and `Reviewed commit: b657fd48d4`.
- Review threads: GraphQL `reviewThreads(first:100)` returned `[]`; zero unresolved non-outdated threads.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
