### PR TITLE
refactor: harden sandbox boundary tests

### DIFF
--- a/internal/runner/sandbox.go
+++ b/internal/runner/sandbox.go
@@ -13,44 +13,21 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
-func applySandbox(ctx context.Context, in RunInput, cmd *exec.Cmd) (*exec.Cmd, error) { //nolint:gocognit // baseline (#521)
+func applySandbox(ctx context.Context, in RunInput, cmd *exec.Cmd) (*exec.Cmd, error) {
 	cfg := in.Workflow.Config.Sandbox
-	if !cfg.Enabled || cfg.Backend == "" || cfg.Backend == "none" {
+	if !sandboxActive(cfg) {
 		return cmd, nil
 	}
-	if runtime.GOOS != "linux" {
-		return nil, fmt.Errorf("sandbox.backend %q requires linux host OS; current host OS is %s", cfg.Backend, runtime.GOOS)
-	}
-	if cfg.NetworkMode == "allowlist" {
-		if cfg.Backend != "firejail" {
-			return nil, fmt.Errorf("sandbox network allowlist requires sandbox.backend firejail")
-		}
-		if len(cfg.NetworkAllowlistCIDRs) == 0 {
-			return nil, fmt.Errorf("sandbox.network=allowlist requires sandbox.network_allowlist_cidrs")
-		}
-	}
-	workdir, err := filepath.Abs(in.Workdir)
-	if err != nil {
-		return nil, fmt.Errorf("resolve sandbox workdir: %w", err)
-	}
-	root := strings.TrimSpace(in.WorkspaceRoot)
-	if root == "" {
-		root = strings.TrimSpace(in.Workflow.Config.Workspace.Root)
-	}
-	if root == "" {
-		return nil, fmt.Errorf("sandbox requires runtime workspace root so the workspace-root invariant can be enforced")
-	}
-	rootAbs, err := filepath.Abs(root)
-	if err != nil {
-		return nil, fmt.Errorf("resolve runtime workspace root: %w", err)
-	}
-	if err := ensurePathWithinRoot(workdir, rootAbs); err != nil {
+	if err := validateSandboxRuntimeConfig(cfg); err != nil {
 		return nil, err
 	}
-
-	childArgs := append([]string{}, cmd.Args...)
-	if len(childArgs) == 0 {
-		return nil, fmt.Errorf("sandbox cannot wrap empty command")
+	workdir, err := sandboxWorkdirForInput(in)
+	if err != nil {
+		return nil, err
+	}
+	childArgs, err := sandboxChildArgs(cmd)
+	if err != nil {
+		return nil, err
 	}
 	env := sandboxEnv(cmd.Env, cfg.EnvAllowlist, in.Workflow.Config)
 
@@ -62,6 +39,55 @@ func applySandbox(ctx context.Context, in RunInput, cmd *exec.Cmd) (*exec.Cmd, e
 	default:
 		return nil, fmt.Errorf("sandbox.backend %q is not supported (allowed: none, bubblewrap, firejail)", cfg.Backend)
 	}
+}
+
+func sandboxActive(cfg workflow.SandboxConfig) bool {
+	return cfg.Enabled && cfg.Backend != "" && cfg.Backend != "none"
+}
+
+func validateSandboxRuntimeConfig(cfg workflow.SandboxConfig) error {
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("sandbox.backend %q requires linux host OS; current host OS is %s", cfg.Backend, runtime.GOOS)
+	}
+	if cfg.NetworkMode == "allowlist" {
+		if cfg.Backend != "firejail" {
+			return fmt.Errorf("sandbox network allowlist requires sandbox.backend firejail")
+		}
+		if len(cfg.NetworkAllowlistCIDRs) == 0 {
+			return fmt.Errorf("sandbox.network=allowlist requires sandbox.network_allowlist_cidrs")
+		}
+	}
+	return nil
+}
+
+func sandboxWorkdirForInput(in RunInput) (string, error) {
+	workdir, err := filepath.Abs(in.Workdir)
+	if err != nil {
+		return "", fmt.Errorf("resolve sandbox workdir: %w", err)
+	}
+	root := strings.TrimSpace(in.WorkspaceRoot)
+	if root == "" {
+		root = strings.TrimSpace(in.Workflow.Config.Workspace.Root)
+	}
+	if root == "" {
+		return "", fmt.Errorf("sandbox requires runtime workspace root so the workspace-root invariant can be enforced")
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve runtime workspace root: %w", err)
+	}
+	if err := ensurePathWithinRoot(workdir, rootAbs); err != nil {
+		return "", err
+	}
+	return workdir, nil
+}
+
+func sandboxChildArgs(cmd *exec.Cmd) ([]string, error) {
+	childArgs := append([]string{}, cmd.Args...)
+	if len(childArgs) == 0 {
+		return nil, fmt.Errorf("sandbox cannot wrap empty command")
+	}
+	return childArgs, nil
 }
 
 func ensurePathWithinRoot(path, root string) error {
@@ -177,7 +203,7 @@ func carryWorkerInjectedGoCache(env []string, primaryByName map[string]string, s
 	return env
 }
 
-func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir string, childArgs []string, env []string) (*exec.Cmd, error) { //nolint:gocognit // baseline (#521)
+func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir string, childArgs []string, env []string) (*exec.Cmd, error) {
 	bwrap, err := exec.LookPath("bwrap")
 	if err != nil {
 		return nil, fmt.Errorf("bubblewrap sandbox requested but bwrap binary not found in PATH: %w", err)
@@ -189,7 +215,27 @@ func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir 
 	if cfg.NetworkMode == "allowlist" {
 		return nil, fmt.Errorf("sandbox network allowlist requires firejail --netfilter support; bubblewrap only supports network: none via --unshare-net")
 	}
-	args := []string{
+	args := bubblewrapBaseArgs(workdir)
+	args, err = appendOptionalBubblewrapLib64(args)
+	if err != nil {
+		return nil, err
+	}
+	args = appendBubblewrapNetworkArgs(args, cfg)
+	args = appendBubblewrapEnvArgs(args, env)
+	args, err = appendCredentialMounts(args, cfg.CredentialFiles, bubblewrapCredentialMount)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, "--")
+	args = append(args, childArgs...)
+	wrapped := exec.CommandContext(ctx, bwrap, args...)
+	wrapped.Dir = workdir
+	wrapped.Env = env
+	return wrapped, nil
+}
+
+func bubblewrapBaseArgs(workdir string) []string {
+	return []string{
 		"--die-with-parent",
 		"--new-session",
 		"--unshare-pid",
@@ -204,28 +250,30 @@ func bubblewrapCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir 
 		"--bind", workdir, workdir,
 		"--chdir", workdir,
 	}
+}
+
+func appendOptionalBubblewrapLib64(args []string) ([]string, error) {
 	if _, err := os.Stat("/lib64"); err == nil {
 		args = append(args, "--ro-bind", "/lib64", "/lib64")
 	} else if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("check optional bubblewrap /lib64 bind source: %w", err)
 	}
+	return args, nil
+}
+
+func appendBubblewrapNetworkArgs(args []string, cfg workflow.SandboxConfig) []string {
 	if cfg.NetworkMode == "none" || cfg.NetworkMode == "" {
 		args = append(args, "--unshare-net")
 	}
+	return args
+}
+
+func appendBubblewrapEnvArgs(args []string, env []string) []string {
 	for _, envPair := range env {
 		name, value, _ := strings.Cut(envPair, "=")
 		args = append(args, "--setenv", name, value)
 	}
-	args, err = appendCredentialMounts(args, cfg.CredentialFiles, bubblewrapCredentialMount)
-	if err != nil {
-		return nil, err
-	}
-	args = append(args, "--")
-	args = append(args, childArgs...)
-	wrapped := exec.CommandContext(ctx, bwrap, args...)
-	wrapped.Dir = workdir
-	wrapped.Env = env
-	return wrapped, nil
+	return args
 }
 
 func firejailCommand(ctx context.Context, cfg workflow.SandboxConfig, workdir string, childArgs []string, env []string) (*exec.Cmd, error) {
@@ -368,34 +416,53 @@ func firejailAllowlistNetArg(cfg workflow.SandboxConfig) (string, error) {
 	return "--net=" + iface, nil
 }
 
-func writeFirejailNetfilter(cidrs []string) (string, error) { //nolint:gocognit // baseline (#521)
+func writeFirejailNetfilter(cidrs []string) (string, error) {
+	body, err := firejailNetfilterContent(cidrs)
+	if err != nil {
+		return "", err
+	}
+	return writeFirejailNetfilterFile(body)
+}
+
+func firejailNetfilterContent(cidrs []string) (string, error) {
 	if len(cidrs) == 0 {
 		return "", fmt.Errorf("sandbox network allowlist requires at least one CIDR")
 	}
 	var b strings.Builder
 	b.WriteString("*filter\n:OUTPUT DROP [0:0]\n")
 	for _, cidr := range cidrs {
-		cidr = strings.TrimSpace(cidr)
-		if cidr == "" {
-			continue
+		if err := appendFirejailNetfilterRule(&b, cidr); err != nil {
+			return "", err
 		}
-		ip, parsed, err := net.ParseCIDR(cidr)
-		if err != nil {
-			return "", fmt.Errorf("sandbox network allowlist contains invalid CIDR %q: %w", cidr, err)
-		}
-		if ip.To4() == nil {
-			return "", fmt.Errorf("sandbox network allowlist CIDR %q is IPv6; Firejail --netfilter supports IPv4 rules only", cidr)
-		}
-		b.WriteString("-A OUTPUT -d ")
-		b.WriteString(parsed.String())
-		b.WriteString(" -j ACCEPT\n")
 	}
 	b.WriteString("COMMIT\n")
+	return b.String(), nil
+}
+
+func appendFirejailNetfilterRule(b *strings.Builder, cidr string) error {
+	cidr = strings.TrimSpace(cidr)
+	if cidr == "" {
+		return nil
+	}
+	ip, parsed, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return fmt.Errorf("sandbox network allowlist contains invalid CIDR %q: %w", cidr, err)
+	}
+	if ip.To4() == nil {
+		return fmt.Errorf("sandbox network allowlist CIDR %q is IPv6; Firejail --netfilter supports IPv4 rules only", cidr)
+	}
+	b.WriteString("-A OUTPUT -d ")
+	b.WriteString(parsed.String())
+	b.WriteString(" -j ACCEPT\n")
+	return nil
+}
+
+func writeFirejailNetfilterFile(body string) (string, error) {
 	f, err := os.CreateTemp("", "aiops-firejail-netfilter-*.conf")
 	if err != nil {
 		return "", fmt.Errorf("create firejail netfilter allowlist: %w", err)
 	}
-	if _, err := f.WriteString(b.String()); err != nil {
+	if _, err := f.WriteString(body); err != nil {
 		_ = f.Close()
 		return "", fmt.Errorf("write firejail netfilter allowlist: %w", err)
 	}

--- a/internal/runner/sandbox_test.go
+++ b/internal/runner/sandbox_test.go
@@ -35,6 +35,15 @@ func requireLinuxSandboxHost(t *testing.T) {
 	}
 }
 
+func writeSandboxStub(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write %s stub: %v", name, err)
+	}
+	return path
+}
+
 func TestSandboxDisabledLeavesCommandUnwrappedAndEnvironmentInherited(t *testing.T) {
 	base := exec.CommandContext(context.Background(), "codex", "exec")
 	base.Dir = t.TempDir()
@@ -49,6 +58,109 @@ func TestSandboxDisabledLeavesCommandUnwrappedAndEnvironmentInherited(t *testing
 	}
 	if wrapped.Env != nil {
 		t.Fatalf("disabled sandbox should not scope environment, got %q", wrapped.Env)
+	}
+}
+
+func TestApplySandboxPreconditionTable(t *testing.T) {
+	requireLinuxSandboxHost(t)
+	root := t.TempDir()
+	workdir := filepath.Join(root, "issue-123")
+	if err := os.Mkdir(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		in       RunInput
+		cmd      *exec.Cmd
+		wantErr  string
+		wantSame bool
+	}{
+		{
+			name: "disabled sandbox returns original command",
+			in: RunInput{Workflow: workflow.Workflow{Config: workflow.Config{
+				Workspace: workflow.WorkspaceConfig{Root: root},
+				Sandbox:   workflow.SandboxConfig{},
+			}}, Workdir: workdir},
+			cmd:      exec.CommandContext(context.Background(), "codex", "exec"),
+			wantSame: true,
+		},
+		{
+			name: "allowlist requires firejail backend",
+			in: RunInput{Workflow: workflow.Workflow{Config: workflow.Config{
+				Workspace: workflow.WorkspaceConfig{Root: root},
+				Sandbox: workflow.SandboxConfig{
+					Enabled:               true,
+					Backend:               "bubblewrap",
+					NetworkMode:           "allowlist",
+					NetworkAllowlistCIDRs: []string{"203.0.113.10/32"},
+				},
+			}}, Workdir: workdir},
+			cmd:     exec.CommandContext(context.Background(), "codex", "exec"),
+			wantErr: "sandbox.backend firejail",
+		},
+		{
+			name: "allowlist requires cidrs",
+			in: RunInput{Workflow: workflow.Workflow{Config: workflow.Config{
+				Workspace: workflow.WorkspaceConfig{Root: root},
+				Sandbox: workflow.SandboxConfig{
+					Enabled:     true,
+					Backend:     "firejail",
+					NetworkMode: "allowlist",
+				},
+			}}, Workdir: workdir},
+			cmd:     exec.CommandContext(context.Background(), "codex", "exec"),
+			wantErr: "sandbox.network_allowlist_cidrs",
+		},
+		{
+			name: "missing workspace root rejected before wrapping",
+			in: RunInput{Workflow: workflow.Workflow{Config: workflow.Config{
+				Sandbox: workflow.SandboxConfig{Enabled: true, Backend: "bubblewrap"},
+			}}, Workdir: workdir},
+			cmd:     exec.CommandContext(context.Background(), "codex", "exec"),
+			wantErr: "runtime workspace root",
+		},
+		{
+			name: "empty command rejected",
+			in: RunInput{Workflow: workflow.Workflow{Config: workflow.Config{
+				Workspace: workflow.WorkspaceConfig{Root: root},
+				Sandbox:   workflow.SandboxConfig{Enabled: true, Backend: "bubblewrap"},
+			}}, Workdir: workdir},
+			cmd:     &exec.Cmd{},
+			wantErr: "cannot wrap empty command",
+		},
+		{
+			name: "unsupported backend rejected",
+			in: RunInput{Workflow: workflow.Workflow{Config: workflow.Config{
+				Workspace: workflow.WorkspaceConfig{Root: root},
+				Sandbox:   workflow.SandboxConfig{Enabled: true, Backend: "nsjail"},
+			}}, Workdir: workdir},
+			cmd:     exec.CommandContext(context.Background(), "codex", "exec"),
+			wantErr: "not supported",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cmd != nil {
+				tt.cmd.Dir = tt.in.Workdir
+			}
+			wrapped, err := applySandbox(context.Background(), tt.in, tt.cmd)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("applySandbox() = nil error; want substring %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("applySandbox() error = %q; want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applySandbox() error = %v; want nil", err)
+			}
+			if tt.wantSame && wrapped != tt.cmd {
+				t.Fatalf("applySandbox() returned %p; want original command %p", wrapped, tt.cmd)
+			}
+		})
 	}
 }
 
@@ -226,6 +338,127 @@ func envContains(env []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestBubblewrapCommandContractTable(t *testing.T) {
+	binDir := t.TempDir()
+	writeSandboxStub(t, binDir, "bwrap")
+	codex := writeSandboxStub(t, binDir, "codex")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	workdir := t.TempDir()
+	credential := filepath.Join(t.TempDir(), "credential")
+	if err := os.WriteFile(credential, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name            string
+		cfg             workflow.SandboxConfig
+		childArgs       []string
+		env             []string
+		wantErr         string
+		wantUnshareNet  bool
+		wantCredential  bool
+		wantSetenv      bool
+		wantResolvedCmd bool
+	}{
+		{
+			name: "network none unshares network and mounts credentials read-only",
+			cfg: workflow.SandboxConfig{
+				NetworkMode:     "none",
+				CredentialFiles: []string{credential},
+			},
+			childArgs:       []string{"codex", "exec"},
+			env:             []string{"AIOPS_RUN_TOKEN=allowed"},
+			wantUnshareNet:  true,
+			wantCredential:  true,
+			wantSetenv:      true,
+			wantResolvedCmd: true,
+		},
+		{
+			name:            "default network mode is closed",
+			cfg:             workflow.SandboxConfig{},
+			childArgs:       []string{"codex", "exec"},
+			wantUnshareNet:  true,
+			wantResolvedCmd: true,
+		},
+		{
+			name:      "allowlist network rejected for bubblewrap",
+			cfg:       workflow.SandboxConfig{NetworkMode: "allowlist"},
+			childArgs: []string{"codex", "exec"},
+			wantErr:   "firejail --netfilter",
+		},
+		{
+			name:      "empty child command rejected",
+			cfg:       workflow.SandboxConfig{},
+			childArgs: nil,
+			wantErr:   "cannot wrap empty command",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped, err := bubblewrapCommand(context.Background(), tt.cfg, workdir, tt.childArgs, tt.env)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("bubblewrapCommand() = nil error; want substring %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("bubblewrapCommand() error = %q; want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("bubblewrapCommand() error = %v; want nil", err)
+			}
+			if filepath.Base(wrapped.Path) != "bwrap" {
+				t.Fatalf("wrapped.Path = %q, want bwrap", wrapped.Path)
+			}
+			if wrapped.Dir != workdir {
+				t.Fatalf("wrapped.Dir = %q, want %q", wrapped.Dir, workdir)
+			}
+			if !reflect.DeepEqual(wrapped.Env, tt.env) {
+				t.Fatalf("wrapped.Env = %#v, want %#v", wrapped.Env, tt.env)
+			}
+			if tt.wantUnshareNet && !sandboxArgsContainSequence(wrapped.Args, "--unshare-net") {
+				t.Fatalf("bubblewrap args missing --unshare-net: %#v", wrapped.Args)
+			}
+			if tt.wantCredential && !sandboxArgsContainSequence(wrapped.Args, "--ro-bind", credential, credential) {
+				t.Fatalf("bubblewrap args missing credential read-only bind for %q: %#v", credential, wrapped.Args)
+			}
+			if tt.wantSetenv && !sandboxArgsContainSequence(wrapped.Args, "--setenv", "AIOPS_RUN_TOKEN", "allowed") {
+				t.Fatalf("bubblewrap args missing setenv pair: %#v", wrapped.Args)
+			}
+			child := sandboxArgsAfterSeparator(wrapped.Args)
+			if tt.wantResolvedCmd && (len(child) == 0 || child[0] != codex) {
+				t.Fatalf("bubblewrap child args = %#v, want first arg resolved to %q", child, codex)
+			}
+		})
+	}
+}
+
+func sandboxArgsContainSequence(args []string, want ...string) bool {
+	for i := 0; i+len(want) <= len(args); i++ {
+		matched := true
+		for j, part := range want {
+			if args[i+j] != part {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+func sandboxArgsAfterSeparator(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return args[i+1:]
+		}
+	}
+	return nil
 }
 
 func TestSandboxBubblewrapSkipsMissingLib64Bind(t *testing.T) {
@@ -706,6 +939,118 @@ func TestFirejailNetfilterAcceptsIPv4CIDR(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "-A OUTPUT -d 203.0.113.10/32 -j ACCEPT") {
 		t.Fatalf("netfilter file missing IPv4 allow rule: %s", content)
+	}
+}
+
+func TestFirejailNetfilterRulesTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		cidrs     []string
+		wantRules []string
+		wantErr   string
+	}{
+		{
+			name:      "multiple ipv4 cidrs become explicit output allow rules",
+			cidrs:     []string{" 203.0.113.10/32 ", "198.51.100.0/24"},
+			wantRules: []string{"-A OUTPUT -d 203.0.113.10/32 -j ACCEPT", "-A OUTPUT -d 198.51.100.0/24 -j ACCEPT"},
+		},
+		{
+			name:    "empty cidr list rejected",
+			cidrs:   nil,
+			wantErr: "at least one CIDR",
+		},
+		{
+			name:    "invalid cidr rejected with value",
+			cidrs:   []string{"not-a-cidr"},
+			wantErr: "not-a-cidr",
+		},
+		{
+			name:    "ipv6 cidr rejected",
+			cidrs:   []string{"2001:db8::/32"},
+			wantErr: "IPv6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := writeFirejailNetfilter(tt.cidrs)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("writeFirejailNetfilter(%q) = nil error; want substring %q", tt.cidrs, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("writeFirejailNetfilter(%q) error = %q; want substring %q", tt.cidrs, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("writeFirejailNetfilter(%q): %v", tt.cidrs, err)
+			}
+			defer func() { _ = os.Remove(path) }()
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			body := string(content)
+			if !strings.HasPrefix(body, "*filter\n:OUTPUT DROP [0:0]\n") || !strings.HasSuffix(body, "COMMIT\n") {
+				t.Fatalf("netfilter file = %q; want DROP policy header and COMMIT footer", body)
+			}
+			for _, want := range tt.wantRules {
+				if !strings.Contains(body, want) {
+					t.Fatalf("netfilter file missing %q: %s", want, body)
+				}
+			}
+		})
+	}
+}
+
+func TestWireFirejailCleanupContractTable(t *testing.T) {
+	tests := []struct {
+		name         string
+		cleanupFiles []string
+		wantShell    bool
+		wantErr      string
+	}{
+		{name: "no cleanup files runs firejail directly"},
+		{name: "one cleanup file wraps firejail with cancel and wait delay", cleanupFiles: []string{filepath.Join(t.TempDir(), "netfilter.conf")}, wantShell: true},
+		{name: "multiple cleanup files rejected", cleanupFiles: []string{"one", "two"}, wantErr: "expected one cleanup file"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped, err := wireFirejailCleanup(context.Background(), "/bin/firejail", []string{"--quiet", "--"}, tt.cleanupFiles)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("wireFirejailCleanup() = nil error; want substring %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("wireFirejailCleanup() error = %q; want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("wireFirejailCleanup(): %v", err)
+			}
+			if tt.wantShell {
+				if wrapped.Path != "/bin/sh" {
+					t.Fatalf("cleanup wrapper path = %q, want /bin/sh", wrapped.Path)
+				}
+				if wrapped.Cancel == nil {
+					t.Fatal("cleanup wrapper must install Cancel cleanup hook")
+				}
+				if wrapped.WaitDelay != 1 {
+					t.Fatalf("cleanup wrapper WaitDelay = %v, want 1", wrapped.WaitDelay)
+				}
+				if !sandboxArgsContainSequence(wrapped.Args, "aiops-firejail-cleanup", tt.cleanupFiles[0], "/bin/firejail") {
+					t.Fatalf("cleanup wrapper args missing cleanup file and firejail command: %#v", wrapped.Args)
+				}
+				return
+			}
+			if wrapped.Path != "/bin/firejail" {
+				t.Fatalf("direct firejail path = %q, want /bin/firejail", wrapped.Path)
+			}
+			if wrapped.WaitDelay != 0 {
+				t.Fatalf("direct firejail WaitDelay = %v, want 0 without cleanup wrapper", wrapped.WaitDelay)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #915

## Summary
- Added focused characterization/table tests for the sandbox boundary: backend/precondition errors, bubblewrap network/env/credential args, Firejail netfilter files, and Firejail cleanup/deadline wiring.
- Split the three #521 baseline-nolinted sandbox helpers only enough to remove the nolints after lint proved they were no longer needed.
- Preserved SPEC §1 boundaries: this stays in runner-side sandbox command construction and does not add worker/orchestrator phases, gates, artifacts, or tracker/PR writes.

## Acceptance ledger
- Precondition/backend errors: `TestApplySandboxPreconditionTable` covers disabled no-op, allowlist backend/CIDR requirements, missing workspace root, empty command, and unsupported backend.
- Credential mounts: `TestBubblewrapCommandContractTable` asserts bubblewrap credential files are mounted with `--ro-bind`.
- Network policy args/files: bubblewrap default/none network asserts `--unshare-net`; Firejail allowlist asserts DROP header, explicit IPv4 allow rules, invalid/IPv6 rejection, and COMMIT footer.
- Cleanup/deadline behavior: `TestWireFirejailCleanupContractTable` asserts wrapper shell, cleanup file handoff, `Cancel`, `WaitDelay`, direct no-wrapper path, and multi-cleanup rejection.
- Baseline nolints: removed only after `golangci-lint --issues-exit-code=1` reported `0 issues` for `./internal/runner` and full-repo lint reported `0 issues`.
- Mutation-verify against committed artifact: temporarily removed bubblewrap `--unshare-net`, changed credential mount to `--bind`, changed Firejail `:OUTPUT DROP` to `ACCEPT`, and removed cleanup `WaitDelay`; each targeted test failed, then the file was restored to `HEAD`.
- Deferrals: none.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — 1 production file, +113/-46 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=1`
- `go test ./...`
- `go build ./cmd/worker ./cmd/tui`
- `git diff --check origin/main...HEAD`
- Local independent review: Codex-family review of `origin/main...HEAD` reported no actionable regressions and ran `go test ./internal/runner`; Claude-family review reported LGTM for production diff and for the sandbox test acceptance snippets.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.

## Remote gate
- GitHub CI green on head `6efa0e326685cb162eef7675eef17e011fc9d996`: Go build and test, Security and supply-chain, E2E Gitea mock loop, Docker image build, PR Metadata, and PR Title Lint all passed.
- Actions log warning grep for CI, PR Metadata, and PR Title Lint produced no `warning:` lines.
- `@codex review` was triggered by `bytevane` and completed on reviewed commit `6efa0e3266` with: "Didn't find any major issues."
- Thread-aware review check: 0 actionable review threads, 0 outdated review threads; trigger comment eyes reaction cleared.
