### PR TITLE
docs: add local webtodo lifecycle e2e SOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ add a bridge that imports `AGENTS.md` rather than duplicating content.
 - [Workspace cache and cleanup](docs/runbooks/workspace-cache.md)
 - [GitHub local automation](docs/runbooks/github-local-automation.md)
 - [Gitea bot and branch protection](docs/runbooks/gitea-bot-and-branch-protection.md)
+- [Local Gitea Web Todo lifecycle E2E](docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md)
 
 ## Safety notes
 

--- a/docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md
@@ -1,0 +1,362 @@
+# Local Gitea Web Todo lifecycle E2E
+
+This runbook turns the ad-hoc "binary + local Gitea + Codex + maker/reviewer"
+validation into a repeatable local operator SOP. It is intended for release
+validation, demo capture, and promotion material generation. It is not a CI
+required check: the run consumes real Codex quota, depends on local auth, and can
+take long enough that a human should supervise it.
+
+The shape is deliberately conservative:
+
+- The worker binary is run as downloaded, not from the source tree.
+- Local binary mode reuses the operator's Codex configuration by default. This
+  matches upstream Symphony's `codex app-server` posture. Use a dedicated
+  `CODEX_HOME` only when you want production-style reproducibility.
+- The maker and reviewer workers are separate processes with separate
+  workspace roots and mirror roots.
+- Scripts prepare and capture evidence, but they do not spend Codex quota or
+  mutate a real Gitea instance without the operator explicitly running those
+  commands.
+
+## What This Validates
+
+Run this when you need evidence for the complete user-visible lifecycle:
+
+1. A local Gitea repo is seeded with a Web Todo backlog.
+2. The maker worker consumes `Todo` / `Rework`, writes code, opens PRs, and
+   flips issues to `Human Review`.
+3. The reviewer worker consumes `Human Review`, verifies in a fresh context,
+   requests `Rework` when needed, and auto-merges clean PRs before flipping
+   `Done`.
+4. Control issues prove abnormal paths: no-ready idle, blocked/dependency held
+   out of dispatch, and canceling a running Codex issue.
+5. A fresh clone of the final app passes Go verification and browser smoke.
+6. Dashboards, TUI raw frames, Gitea pages, Web UI screenshots, and report
+   material are captured under one run root.
+
+## Helper Scripts
+
+The reusable helper entrypoints are intentionally small:
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/e2e-webtodo-bootstrap.sh` | Create the run-root directory skeleton, copy the maker/reviewer workflow templates, write an env template, and seed issue-body files. |
+| `scripts/e2e-webtodo-capture.py` | Capture maker/reviewer state JSON, TUI raw frames, and optional Playwright screenshots into the run root. |
+| `scripts/e2e-webtodo-report.py` | Generate a Markdown test report and promotion notes from the run root. |
+
+These scripts are resumable. If the run stalls, keep the same run root and
+continue from the failed phase.
+
+## 0. Prepare the Host Environment
+
+Do this once per machine, before creating the run root or activating issues.
+Keep these tools outside the repository and outside the disposable run root.
+
+Required host tools:
+
+- Docker or an equivalent local Gitea runtime.
+- Git, curl, Python 3, and the Go toolchain pinned by `go.mod`.
+- Downloaded release `worker` and `tui` binaries for the version under test.
+- A working local Codex configuration. Local binary mode normally reuses the
+  operator's `~/.codex`; set a dedicated `CODEX_HOME` only for
+  production-style reproducibility.
+
+Prepare the screenshot tooling in a reusable Python virtual environment. The
+capture helper uses Chromium, so it only needs that Playwright browser binary:
+
+```bash
+export AIOPS_WEBTODO_TOOLS_ROOT="${AIOPS_WEBTODO_TOOLS_ROOT:-$HOME/.cache/aiops-webtodo-e2e-tools}"
+mkdir -p "$AIOPS_WEBTODO_TOOLS_ROOT"
+python3 -m venv "$AIOPS_WEBTODO_TOOLS_ROOT/venv"
+. "$AIOPS_WEBTODO_TOOLS_ROOT/venv/bin/activate"
+python -m pip install --upgrade pip
+python -m pip install playwright
+python -m playwright install chromium
+```
+
+Smoke the screenshot stack before spending Codex quota:
+
+```bash
+python - <<'PY'
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as pw:
+    browser = pw.chromium.launch()
+    browser.close()
+print("playwright chromium OK")
+PY
+```
+
+On Linux hosts, if Chromium reports missing system packages, run
+`python -m playwright install-deps chromium` or install the equivalent host
+packages before continuing. Leave the virtual environment activated whenever
+you run `scripts/e2e-webtodo-capture.py`; without Playwright, state JSON and TUI
+capture still work, but screenshot evidence is skipped unless explicitly
+requested.
+
+## 1. Prepare the Run Root
+
+Choose ports that do not collide with existing workers. The example keeps Gitea
+on `3107`, maker on `4101`, and reviewer on `4102`.
+
+```bash
+RUN_ROOT=/tmp/aiops-webtodo-e2e-$(date +%Y%m%d-%H%M%S)
+scripts/e2e-webtodo-bootstrap.sh \
+  --run-root "$RUN_ROOT" \
+  --gitea-url http://127.0.0.1:3107 \
+  --repo-owner aiops-bot \
+  --repo-name web-todo \
+  --port-base 4100
+```
+
+The script writes:
+
+- `env.example` with the required exports and port plan.
+- `workflows/maker-WORKFLOW.md` and
+  `workflows/reviewer-automerge-WORKFLOW.md`.
+- `issues/*.md` with the Web Todo backlog and control scenarios.
+- directories for `state/`, `artifacts/`, `logs/`, `promo/`, `reports/`,
+  `mirrors/`, `workspaces/`, and `final-verify/` evidence.
+- `NEXT-STEPS.md` with the command order for this run root.
+
+Copy `env.example` to `env.local`, fill the token and clone URL values, then
+source it in every terminal used for this run:
+
+```bash
+set -euo pipefail
+cp "$RUN_ROOT/env.example" "$RUN_ROOT/env.local"
+$EDITOR "$RUN_ROOT/env.local"
+set -a
+. "$RUN_ROOT/env.local"
+set +a
+```
+
+Do not commit `env.local`; it contains credentials.
+
+## 2. Create Local Gitea State
+
+Use a disposable local Gitea instance and a low-privilege bot account. The exact
+Gitea boot method can vary by host, but the target state should be stable:
+
+- repo: `${AIOPS_WEBTODO_REPO_OWNER}/${AIOPS_WEBTODO_REPO_NAME}`
+- default branch: `main`
+- labels: `aiops/todo`, `aiops/in-progress`, `aiops/human-review`,
+  `aiops/rework`, `aiops/done`, `aiops/canceled`
+- issues: every file in `$AIOPS_WEBTODO_RUN_ROOT/issues/`
+
+Seed the first ten primary issues as ready work by adding `aiops/todo`.
+Keep control issues unlabeled until their phase:
+
+- `CONTROL no-ready issue must stay idle`: no `aiops/*` label.
+- `CONTROL cancel running codex issue`: add `aiops/todo` only when testing
+  cancellation.
+- `CONTROL blocked issue held out of ready gate`: leave unlabeled or express a
+  blocker with `Depends on #N`.
+
+Record the created issue list:
+
+```bash
+curl -fsS -H "Authorization: token $GITEA_TOKEN" \
+  "$AIOPS_WEBTODO_GITEA_URL/api/v1/repos/$AIOPS_WEBTODO_REPO_OWNER/$AIOPS_WEBTODO_REPO_NAME/issues?state=all" \
+  > "$AIOPS_WEBTODO_RUN_ROOT/state/issues-created.json"
+```
+
+## 3. Preflight
+
+Run the downloaded binary, not a source build. `worker --doctor` must pass
+before any issue is activated.
+
+```bash
+"$AIOPS_WEBTODO_WORKER_BIN" --version
+"$AIOPS_WEBTODO_TUI_BIN" --version
+
+AIOPS_WORKFLOW_PATH="$AIOPS_WEBTODO_MAKER_WORKFLOW" \
+AIOPS_MIRROR_ROOT="$AIOPS_WEBTODO_MAKER_MIRROR_ROOT" \
+  "$AIOPS_WEBTODO_WORKER_BIN" --doctor --deploy=binary --mode=real \
+  "$AIOPS_WEBTODO_MAKER_WORKFLOW" \
+  | tee "$AIOPS_WEBTODO_RUN_ROOT/artifacts/maker-doctor.log"
+
+AIOPS_WORKFLOW_PATH="$AIOPS_WEBTODO_REVIEWER_WORKFLOW" \
+AIOPS_MIRROR_ROOT="$AIOPS_WEBTODO_REVIEWER_MIRROR_ROOT" \
+  "$AIOPS_WEBTODO_WORKER_BIN" --doctor --deploy=binary --mode=real \
+  "$AIOPS_WEBTODO_REVIEWER_WORKFLOW" \
+  | tee "$AIOPS_WEBTODO_RUN_ROOT/artifacts/reviewer-doctor.log"
+```
+
+For a local desktop binary run, `CODEX_HOME` normally stays unset so Codex uses
+the operator's usual `~/.codex`. For a reproducible production-style run, set a
+dedicated `CODEX_HOME` and include it in `codex.env_passthrough`.
+
+## 4. Run Maker and Reviewer
+
+Run each worker in a separate terminal, launchd unit, or tmux pane. Their roots
+must differ.
+
+```bash
+# maker
+AIOPS_WORKFLOW_PATH="$AIOPS_WEBTODO_MAKER_WORKFLOW" \
+AIOPS_MIRROR_ROOT="$AIOPS_WEBTODO_MAKER_MIRROR_ROOT" \
+AIOPS_SERVER_HOST=127.0.0.1 \
+  "$AIOPS_WEBTODO_WORKER_BIN" \
+  --port "$AIOPS_WEBTODO_MAKER_PORT" \
+  "$AIOPS_WEBTODO_MAKER_WORKFLOW" \
+  2>&1 | tee "$AIOPS_WEBTODO_RUN_ROOT/logs/maker-worker.log"
+
+# reviewer
+AIOPS_WORKFLOW_PATH="$AIOPS_WEBTODO_REVIEWER_WORKFLOW" \
+AIOPS_MIRROR_ROOT="$AIOPS_WEBTODO_REVIEWER_MIRROR_ROOT" \
+AIOPS_SERVER_HOST=127.0.0.1 \
+  "$AIOPS_WEBTODO_WORKER_BIN" \
+  --port "$AIOPS_WEBTODO_REVIEWER_PORT" \
+  "$AIOPS_WEBTODO_REVIEWER_WORKFLOW" \
+  2>&1 | tee "$AIOPS_WEBTODO_RUN_ROOT/logs/reviewer-worker.log"
+```
+
+In another terminal, trigger the first poll:
+
+```bash
+curl -fsS -X POST -H 'X-AIOPS-Refresh: true' \
+  "$AIOPS_WEBTODO_MAKER_DASHBOARD_URL/api/v1/refresh"
+curl -fsS -X POST -H 'X-AIOPS-Refresh: true' \
+  "$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL/api/v1/refresh"
+```
+
+## 5. Capture Evidence During the Run
+
+Use the capture helper repeatedly at milestone moments:
+
+```bash
+scripts/e2e-webtodo-capture.py \
+  --run-root "$AIOPS_WEBTODO_RUN_ROOT" \
+  --maker-url "$AIOPS_WEBTODO_MAKER_DASHBOARD_URL" \
+  --reviewer-url "$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL" \
+  --gitea-url "$AIOPS_WEBTODO_GITEA_URL" \
+  --repo-owner "$AIOPS_WEBTODO_REPO_OWNER" \
+  --repo-name "$AIOPS_WEBTODO_REPO_NAME" \
+  --tui-bin "$AIOPS_WEBTODO_TUI_BIN"
+```
+
+Add named screenshots for important pages:
+
+```bash
+scripts/e2e-webtodo-capture.py \
+  --run-root "$AIOPS_WEBTODO_RUN_ROOT" \
+  --screenshot issue-04-rework="$AIOPS_WEBTODO_GITEA_URL/$AIOPS_WEBTODO_REPO_OWNER/$AIOPS_WEBTODO_REPO_NAME/issues/4" \
+  --screenshot maker-dashboard="$AIOPS_WEBTODO_MAKER_DASHBOARD_URL" \
+  --screenshot reviewer-dashboard="$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL"
+```
+
+The script writes state snapshots under `state/`, TUI frames under
+`promo/pages/`, screenshots under `promo/screenshots/`, and
+`promo/capture-index.md`. The default screenshots are best-effort: if
+Playwright is not installed, the helper still captures state JSON and TUI raw
+frames and reports that default screenshots were skipped. Explicit
+`--screenshot NAME=URL` captures remain required evidence and fail fast without
+Playwright.
+
+## 6. Exercise Control Scenarios
+
+Run these after the happy path has proven the normal maker/reviewer loop:
+
+- **No-ready idle:** confirm the no-ready issue has no PR and never appears in
+  maker state.
+- **Blocked/held:** confirm the blocked issue has no PR and never dispatches
+  before its blocker is terminal.
+- **Cancel running:** add `aiops/todo` to the cancel-control issue, wait until
+  maker state shows it running, then replace the label with `aiops/canceled`.
+  The next maker poll should classify an operator terminal stop and no PR should
+  exist for the issue.
+
+Capture before/after state JSON and the Gitea issue page for each control
+scenario.
+
+## 7. Final Verification
+
+Clone the final Gitea repo into `final-verify/web-todo`, then run:
+
+```bash
+cd "$AIOPS_WEBTODO_RUN_ROOT/final-verify/web-todo"
+gofmt -l .
+go vet ./...
+go test ./...
+make test
+make build
+```
+
+Record the output:
+
+```bash
+{
+  printf '\n$ gofmt -l .\n'
+  gofmt -l .
+  printf '\n$ go vet ./...\n'
+  go vet ./...
+  printf '\n$ go test ./...\n'
+  go test ./...
+  printf '\n$ make test\n'
+  make test
+  printf '\n$ make build\n'
+  make build
+} | tee "$AIOPS_WEBTODO_RUN_ROOT/final-verify/verification.log"
+```
+
+Use Playwright or the browser tool of your choice to smoke the final app:
+create todos, set an overdue due date, toggle completion, check filters, edit a
+title inline, delete all todos, and save screenshots/video under
+`final-verify/`.
+
+## 8. Generate the Report Pack
+
+At the end of the run, save final state:
+
+```bash
+curl -fsS "$AIOPS_WEBTODO_MAKER_DASHBOARD_URL/api/v1/state" \
+  > "$AIOPS_WEBTODO_RUN_ROOT/state/maker-final.json"
+curl -fsS "$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL/api/v1/state" \
+  > "$AIOPS_WEBTODO_RUN_ROOT/state/reviewer-final.json"
+curl -fsS -H "Authorization: token $GITEA_TOKEN" \
+  "$AIOPS_WEBTODO_GITEA_URL/api/v1/repos/$AIOPS_WEBTODO_REPO_OWNER/$AIOPS_WEBTODO_REPO_NAME/issues?state=all" \
+  > "$AIOPS_WEBTODO_RUN_ROOT/state/issues-final.json"
+curl -fsS -H "Authorization: token $GITEA_TOKEN" \
+  "$AIOPS_WEBTODO_GITEA_URL/api/v1/repos/$AIOPS_WEBTODO_REPO_OWNER/$AIOPS_WEBTODO_REPO_NAME/pulls?state=all" \
+  > "$AIOPS_WEBTODO_RUN_ROOT/state/prs-final.json"
+```
+
+Then generate report files:
+
+```bash
+scripts/e2e-webtodo-report.py --run-root "$AIOPS_WEBTODO_RUN_ROOT"
+```
+
+Review the generated files under `reports/` and `promo/notes/`. The report
+summarizes machine-readable state, then leaves the final pass/fail call to an
+operator checklist because the helper cannot prove every required screenshot,
+browser-smoke, and control-scenario assertion from JSON alone. Commit only a
+curated evidence pack:
+
+- Markdown report(s).
+- Promotion notes and capture index.
+- Useful screenshots and the final smoke video.
+- TUI raw text and final verification logs.
+
+Do not commit `env.local`, Codex auth files, downloaded binaries, cache
+directories, or credential-bearing worker configs.
+
+## Pass / Investigate Criteria
+
+Treat the run as a pass when:
+
+- All primary issues reach `aiops/done`.
+- Every primary PR is merged.
+- Control issues behave as expected.
+- Maker and reviewer dashboards are idle at closeout.
+- Fresh-clone Go verification passes.
+- Final browser smoke passes with an empty console log.
+
+Investigate, but do not automatically call it an aiops-platform bug, when:
+
+- Local Codex configuration changes token use, reasoning style, or available
+  skills/plugins. That is expected in local binary mode.
+- A PR branch probe fails but the final fresh-main smoke passes.
+- A worker shows the same issue in a short handoff overlap and then reconciles
+  cleanly on the next poll.

--- a/scripts/e2e-webtodo-bootstrap.sh
+++ b/scripts/e2e-webtodo-bootstrap.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+run_root="${AIOPS_WEBTODO_RUN_ROOT:-}"
+gitea_url="${AIOPS_WEBTODO_GITEA_URL:-http://127.0.0.1:3107}"
+repo_owner="${AIOPS_WEBTODO_REPO_OWNER:-aiops-bot}"
+repo_name="${AIOPS_WEBTODO_REPO_NAME:-web-todo}"
+port_base="${AIOPS_WEBTODO_PORT_BASE:-4100}"
+
+usage() {
+  printf 'usage: %s --run-root DIR [--gitea-url URL] [--repo-owner NAME] [--repo-name NAME] [--port-base PORT]\n' "$0" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --run-root)
+      run_root="${2:-}"; shift 2 ;;
+    --gitea-url)
+      gitea_url="${2:-}"; shift 2 ;;
+    --repo-owner)
+      repo_owner="${2:-}"; shift 2 ;;
+    --repo-name)
+      repo_name="${2:-}"; shift 2 ;;
+    --port-base)
+      port_base="${2:-}"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      usage; exit 2 ;;
+  esac
+done
+
+if [ -z "$run_root" ]; then
+  printf -- '--run-root is required\n' >&2
+  usage
+  exit 2
+fi
+case "$port_base" in
+  *[!0-9]*|"")
+    printf -- '--port-base must be numeric, got %s\n' "$port_base" >&2
+    exit 2 ;;
+esac
+
+gitea_url="${gitea_url%/}"
+maker_port=$((port_base + 1))
+reviewer_port=$((port_base + 2))
+case "$gitea_url" in
+  http://*)
+    clone_host="${gitea_url#http://}"
+    maker_clone_url="http://maker-bot:REPLACE_ME@$clone_host/$repo_owner/$repo_name.git"
+    reviewer_clone_url="http://review-bot:REPLACE_ME@$clone_host/$repo_owner/$repo_name.git"
+    ;;
+  https://*)
+    clone_host="${gitea_url#https://}"
+    maker_clone_url="https://maker-bot:REPLACE_ME@$clone_host/$repo_owner/$repo_name.git"
+    reviewer_clone_url="https://review-bot:REPLACE_ME@$clone_host/$repo_owner/$repo_name.git"
+    ;;
+  *)
+    maker_clone_url="http://maker-bot:REPLACE_ME@$gitea_url/$repo_owner/$repo_name.git"
+    reviewer_clone_url="http://review-bot:REPLACE_ME@$gitea_url/$repo_owner/$repo_name.git"
+    ;;
+esac
+
+mkdir -p \
+  "$run_root/artifacts" \
+  "$run_root/downloads" \
+  "$run_root/bin" \
+  "$run_root/workflows" \
+  "$run_root/issues" \
+  "$run_root/logs" \
+  "$run_root/state" \
+  "$run_root/promo/screenshots" \
+  "$run_root/promo/pages" \
+  "$run_root/promo/notes" \
+  "$run_root/final-verify/screenshots" \
+  "$run_root/final-verify/videos" \
+  "$run_root/reports" \
+  "$run_root/workdirs/maker" \
+  "$run_root/workdirs/reviewer" \
+  "$run_root/workspaces/maker" \
+  "$run_root/workspaces/reviewer" \
+  "$run_root/mirrors/maker" \
+  "$run_root/mirrors/reviewer"
+
+render_workflow() {
+  local src="$1"
+  local dest="$2"
+  local workspace_root="$3"
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "  owner: your-gitea-user")
+        printf '  owner: %s\n' "$repo_owner" ;;
+      "  name: your-repo")
+        printf '  name: %s\n' "$repo_name" ;;
+      "  endpoint: http://gitea.local")
+        printf '  endpoint: %s\n' "$gitea_url" ;;
+      "  clone_url: \$MAKER_CLONE_URL  #"*)
+        printf '  clone_url: $MAKER_CLONE_URL  # set in env.local\n' ;;
+      "  clone_url: \$REVIEWER_CLONE_URL  #"*)
+        printf '  clone_url: $REVIEWER_CLONE_URL  # set in env.local\n' ;;
+      "  root: ~/aiops-workspaces/maker"|"  root: ~/aiops-workspaces/reviewer")
+        printf '  root: %s\n' "$workspace_root" ;;
+      *)
+        printf '%s\n' "$line" ;;
+    esac
+  done <"$src" >"$dest"
+}
+
+render_workflow "$repo_root/examples/maker-WORKFLOW.md" "$run_root/workflows/maker-WORKFLOW.md" "$run_root/workspaces/maker"
+render_workflow "$repo_root/examples/reviewer-automerge-WORKFLOW.md" "$run_root/workflows/reviewer-automerge-WORKFLOW.md" "$run_root/workspaces/reviewer"
+
+write_issue() {
+  local number="$1"
+  local slug="$2"
+  local title="$3"
+  local body="$4"
+  local file="$run_root/issues/${number}-${slug}.md"
+  {
+    printf '# %s\n\n' "$title"
+    printf '%s\n' "$body"
+  } >"$file"
+}
+
+write_issue 01 scaffold-stdlib-server "01 scaffold stdlib server" \
+"Acceptance:
+- Add Go module and cmd/server main package.
+- Serve GET /healthz returning ok.
+- Serve static assets from web/.
+- Keep implementation stdlib-only.
+- Add tests for health and static serving."
+
+write_issue 02 json-todo-store "02 add JSON todo store" \
+"Depends on #1
+
+Acceptance:
+- Add internal/store with Todo fields id, title, completed, created_at, and optional due.
+- Persist todos to the configured JSON data file.
+- Loading a missing file starts with an empty non-nil list.
+- IDs are deterministic and incrementing.
+- Add unit tests for create/list/update persistence."
+
+write_issue 03 list-create-api "03 list and create todos API" \
+"Depends on #2
+
+Acceptance:
+- GET /api/todos returns [] for an empty list.
+- POST /api/todos accepts JSON title.
+- Empty titles and malformed JSON return 400 JSON errors.
+- Successful create returns 201 with the created todo.
+- Add httptest coverage."
+
+write_issue 04 patch-delete-api "04 patch and delete todo API" \
+"Depends on #3
+
+Acceptance:
+- PATCH /api/todos/{id} updates title, completed, and due independently.
+- completed must reject null and non-boolean JSON values.
+- DELETE /api/todos/{id} removes the todo and returns 204.
+- Unknown ids return 404 JSON errors.
+- Tests prove partial updates preserve omitted fields."
+
+write_issue 05 list-add-ui "05 render list and add form" \
+"Depends on #4
+
+Acceptance:
+- web/index.html has a form with text input and submit button.
+- web/app.js loads GET /api/todos and renders the list.
+- Submitting creates a todo through POST /api/todos.
+- Empty list renders a friendly empty state.
+- Inline errors are shown for failed create/load."
+
+write_issue 06 toggle-delete-ui "06 [EXPECT-REWORK] toggle and delete interactions" \
+"Depends on #5
+
+Acceptance:
+- Each todo has a checkbox that PATCHes completed.
+- Each todo has a delete control.
+- UI returns to empty state after deleting the final todo.
+- Failed toggle/delete displays an inline error and rolls back optimistic state.
+- Add regression coverage for delete/toggle wiring."
+
+write_issue 07 filters-counter "07 client-side filters and active counter" \
+"Depends on #6
+
+Acceptance:
+- Hash routes #/all, #/active, and #/completed filter the already-loaded list.
+- Changing filters does not refetch from the API.
+- Active todo count is shown.
+- Add behavior-level tests with mocked fetch and hashchange dispatches."
+
+write_issue 08 due-overdue "08 due dates and overdue highlighting" \
+"Depends on #7
+
+Acceptance:
+- Create and patch accept due as YYYY-MM-DD or null.
+- Invalid dates return 400 JSON error.
+- UI lets users set and clear due dates.
+- Overdue active todos are visually marked.
+- Add API and UI coverage."
+
+write_issue 09 inline-edit "09 inline title editing" \
+"Depends on #8
+
+Acceptance:
+- Double-clicking a title opens inline edit.
+- Enter saves through PATCH /api/todos/{id}.
+- Escape cancels without API call.
+- Blur saves only if changed and valid.
+- Blank title errors are shown and old title is preserved."
+
+write_issue 10 docs-makefile-smoke "10 docs, Makefile, and final smoke" \
+"Depends on #9
+
+Acceptance:
+- Add Makefile with run, test, and build targets.
+- README documents flags, API endpoints, JSON storage path, and browser flow.
+- Documentation matches actual server behavior.
+- Add a small docs/Makefile smoke test if useful."
+
+write_issue 11 control-no-ready "CONTROL no-ready issue must stay idle" \
+"Control scenario:
+- Do not add an aiops/* label.
+- The maker worker must not dispatch this issue.
+- No PR should be created."
+
+write_issue 12 control-cancel-running "CONTROL cancel running codex issue" \
+"Control scenario:
+- Add aiops/todo only when ready to test cancellation.
+- Wait for maker state to show this issue running.
+- Replace the label with aiops/canceled.
+- The maker should stop the active run and no PR should be created."
+
+write_issue 13 control-blocked-held "CONTROL blocked issue held out of ready gate" \
+"Control scenario:
+- Keep this issue unlabeled or dependent on an unfinished blocker.
+- It should not dispatch during the primary lifecycle.
+- No PR should be created."
+
+cat >"$run_root/env.example" <<EOF
+# Copy to env.local, fill secrets, then source it with set -a.
+export AIOPS_WEBTODO_RUN_ROOT="$run_root"
+export AIOPS_WEBTODO_TOOLS_ROOT="\$HOME/.cache/aiops-webtodo-e2e-tools"
+export AIOPS_WEBTODO_GITEA_URL="$gitea_url"
+export AIOPS_WEBTODO_REPO_OWNER="$repo_owner"
+export AIOPS_WEBTODO_REPO_NAME="$repo_name"
+
+export GITEA_TOKEN="REPLACE_ME"
+export MAKER_CLONE_URL="$maker_clone_url"
+export REVIEWER_CLONE_URL="$reviewer_clone_url"
+
+export AIOPS_WEBTODO_WORKER_BIN="$run_root/bin/worker"
+export AIOPS_WEBTODO_TUI_BIN="$run_root/bin/tui"
+
+export AIOPS_WEBTODO_MAKER_PORT="$maker_port"
+export AIOPS_WEBTODO_REVIEWER_PORT="$reviewer_port"
+export AIOPS_WEBTODO_MAKER_DASHBOARD_URL="http://127.0.0.1:$maker_port"
+export AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL="http://127.0.0.1:$reviewer_port"
+
+export AIOPS_WEBTODO_MAKER_WORKDIR="$run_root/workdirs/maker"
+export AIOPS_WEBTODO_REVIEWER_WORKDIR="$run_root/workdirs/reviewer"
+export AIOPS_WEBTODO_MAKER_WORKFLOW="$run_root/workflows/maker-WORKFLOW.md"
+export AIOPS_WEBTODO_REVIEWER_WORKFLOW="$run_root/workflows/reviewer-automerge-WORKFLOW.md"
+export AIOPS_WEBTODO_MAKER_MIRROR_ROOT="$run_root/mirrors/maker"
+export AIOPS_WEBTODO_REVIEWER_MIRROR_ROOT="$run_root/mirrors/reviewer"
+
+# Optional: set this for reproducible production-style Codex runs.
+# export CODEX_HOME="$run_root/codex-home"
+EOF
+
+cat >"$run_root/NEXT-STEPS.md" <<EOF
+# Web Todo lifecycle E2E next steps
+
+1. Install or verify host tools from the runbook, including the Playwright
+   venv under \`AIOPS_WEBTODO_TOOLS_ROOT\` when screenshot evidence is needed.
+2. Copy \`env.example\` to \`env.local\`, fill secrets, and source it.
+3. Put the downloaded release \`worker\` and \`tui\` binaries in \`bin/\`.
+4. Create the local Gitea repo, labels, and issues from \`issues/*.md\`.
+5. Run \`worker --doctor --deploy=binary --mode=real\` for maker and reviewer.
+6. Start maker on port $maker_port and reviewer on port $reviewer_port.
+7. Activate the Playwright venv, then use \`scripts/e2e-webtodo-capture.py\`
+   at milestones.
+8. Run final fresh-clone verification and browser smoke.
+9. Run \`scripts/e2e-webtodo-report.py --run-root "$run_root"\`.
+
+See \`docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md\` for the full SOP.
+EOF
+
+printf 'Prepared Web Todo lifecycle run root: %s\n' "$run_root"
+printf 'Edit and source: %s/env.local\n' "$run_root"
+printf 'Issue seed files: %s/issues\n' "$run_root"

--- a/scripts/e2e-webtodo-capture.py
+++ b/scripts/e2e-webtodo-capture.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Capture reusable evidence for the local Web Todo lifecycle E2E."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def parse_screenshot(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("expected NAME=URL")
+    name, url = value.split("=", 1)
+    if not name or not url:
+        raise argparse.ArgumentTypeError("expected non-empty NAME=URL")
+    return name, url
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--run-root", required=True, type=Path)
+    p.add_argument("--maker-url", default=os.getenv("AIOPS_WEBTODO_MAKER_DASHBOARD_URL", ""))
+    p.add_argument("--reviewer-url", default=os.getenv("AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL", ""))
+    p.add_argument("--gitea-url", default=os.getenv("AIOPS_WEBTODO_GITEA_URL", ""))
+    p.add_argument("--repo-owner", default=os.getenv("AIOPS_WEBTODO_REPO_OWNER", "aiops-bot"))
+    p.add_argument("--repo-name", default=os.getenv("AIOPS_WEBTODO_REPO_NAME", "web-todo"))
+    p.add_argument("--tui-bin", default=os.getenv("AIOPS_WEBTODO_TUI_BIN", "tui"))
+    p.add_argument("--state-token", default=os.getenv("AIOPS_STATE_API_TOKEN", ""))
+    p.add_argument("--tag", default=time.strftime("%H%M%S"))
+    p.add_argument("--tui-seconds", type=float, default=2.0)
+    p.add_argument("--screenshot", action="append", type=parse_screenshot, default=[])
+    p.add_argument("--no-default-screenshots", action="store_true")
+    return p
+
+
+def ensure_dirs(run_root: Path) -> dict[str, Path]:
+    dirs = {
+        "state": run_root / "state",
+        "screenshots": run_root / "promo" / "screenshots",
+        "pages": run_root / "promo" / "pages",
+        "promo": run_root / "promo",
+    }
+    for path in dirs.values():
+        path.mkdir(parents=True, exist_ok=True)
+    return dirs
+
+
+def fetch_json(url: str, dest: Path, token: str = "") -> bool:
+    if not url:
+        return False
+    req = urllib.request.Request(url.rstrip("/") + "/api/v1/state")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        dest.write_text(json.dumps({"error": str(exc)}, indent=2) + "\n")
+        return False
+    dest.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    return True
+
+
+def capture_tui(tui_bin: str, url: str, dest: Path, seconds: float, token: str) -> bool:
+    if not url:
+        return False
+    env = os.environ.copy()
+    if token:
+        env["AIOPS_STATE_API_TOKEN"] = token
+    cmd = [tui_bin, "--url", url, "--interval", "1s", "--raw"]
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+    except OSError as exc:
+        dest.write_text(f"failed to start {' '.join(cmd)}: {exc}\n")
+        return False
+    time.sleep(max(seconds, 0.5))
+    proc.send_signal(signal.SIGTERM)
+    try:
+        stdout, stderr = proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+    dest.write_text(stdout + ("\n--- stderr ---\n" + stderr if stderr else ""))
+    return proc.returncode in (0, -signal.SIGTERM)
+
+
+def default_screenshots(args: argparse.Namespace) -> list[tuple[str, str]]:
+    shots: list[tuple[str, str]] = []
+    if args.gitea_url:
+        base = args.gitea_url.rstrip("/")
+        repo = f"{base}/{args.repo_owner}/{args.repo_name}"
+        shots.extend([
+            ("gitea-repo", repo),
+            ("gitea-issues", f"{repo}/issues"),
+            ("gitea-pulls", f"{repo}/pulls"),
+        ])
+    if args.maker_url:
+        shots.append(("maker-dashboard", args.maker_url))
+    if args.reviewer_url:
+        shots.append(("reviewer-dashboard", args.reviewer_url))
+    return shots
+
+
+def safe_screenshot_stem(name: str) -> str:
+    stem = "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in name)
+    return stem.strip(".-") or "page"
+
+
+def capture_screenshots(
+    shots: list[tuple[str, str]],
+    dest_dir: Path,
+    tag: str,
+    required: bool,
+) -> list[tuple[str, str, str]]:
+    if not shots:
+        return []
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        if required:
+            raise SystemExit(
+                "Playwright is required for requested screenshots. Install it or omit --screenshot."
+            ) from exc
+        print("Playwright is not installed; skipped default screenshots")
+        return []
+    captured: list[tuple[str, str, str]] = []
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1100})
+        for name, url in shots:
+            path = dest_dir / f"{safe_screenshot_stem(name)}-{tag}.png"
+            page.goto(url, wait_until="networkidle", timeout=30_000)
+            page.screenshot(path=str(path), full_page=True)
+            captured.append((name, url, str(path)))
+        browser.close()
+    return captured
+
+
+def append_index(run_root: Path, tag: str, entries: list[tuple[str, str, str]]) -> None:
+    index = run_root / "promo" / "capture-index.md"
+    existing = index.read_text() if index.exists() else "# Page Capture Index\n"
+    lines = [existing.rstrip(), "", f"## Capture {tag}", ""]
+    for name, url, path in entries:
+        rel = Path(path).relative_to(run_root)
+        lines.append(f"- `{name}`: {url} -> `{rel}`")
+    index.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    args = parser().parse_args()
+    dirs = ensure_dirs(args.run_root)
+
+    fetch_json(args.maker_url, dirs["state"] / f"maker-{args.tag}.json", args.state_token)
+    fetch_json(args.reviewer_url, dirs["state"] / f"reviewer-{args.tag}.json", args.state_token)
+
+    capture_tui(
+        args.tui_bin,
+        args.maker_url,
+        dirs["pages"] / f"tui-maker-{args.tag}.txt",
+        args.tui_seconds,
+        args.state_token,
+    )
+    capture_tui(
+        args.tui_bin,
+        args.reviewer_url,
+        dirs["pages"] / f"tui-reviewer-{args.tag}.txt",
+        args.tui_seconds,
+        args.state_token,
+    )
+
+    explicit_shots = list(args.screenshot)
+    shots = list(explicit_shots)
+    if not args.no_default_screenshots:
+        shots = default_screenshots(args) + shots
+    entries = (
+        capture_screenshots(shots, dirs["screenshots"], args.tag, bool(explicit_shots))
+        if shots
+        else []
+    )
+    if entries:
+        append_index(args.run_root, args.tag, entries)
+    print(f"captured evidence under {args.run_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-webtodo-report.py
+++ b/scripts/e2e-webtodo-report.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Generate a Web Todo lifecycle E2E report pack from a run root."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--run-root", required=True, type=Path)
+    p.add_argument("--title", default="Web Todo E2E Lifecycle Test Report")
+    p.add_argument("--date", default=time.strftime("%Y-%m-%d"))
+    return p
+
+
+def load_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return default
+
+
+def label_names(issue: dict[str, Any]) -> str:
+    labels = issue.get("labels") or []
+    names = []
+    for label in labels:
+        if isinstance(label, dict):
+            names.append(str(label.get("name", "")))
+        else:
+            names.append(str(label))
+    return ", ".join(name for name in names if name) or "-"
+
+
+def issue_rows(issues: list[dict[str, Any]]) -> list[str]:
+    rows = ["| Issue | Title | State | Labels |", "|---|---|---|---|"]
+    for issue in sorted(issues, key=lambda item: int(item.get("number", 0))):
+        rows.append(
+            "| #{number} | {title} | {state} | {labels} |".format(
+                number=issue.get("number", ""),
+                title=str(issue.get("title", "")).replace("|", "\\|"),
+                state=issue.get("state", ""),
+                labels=label_names(issue).replace("|", "\\|"),
+            )
+        )
+    return rows
+
+
+def pr_rows(prs: list[dict[str, Any]]) -> list[str]:
+    rows = ["| PR | Title | Branch | State | Merged |", "|---|---|---|---|---|"]
+    for pr in sorted(prs, key=lambda item: int(item.get("number", 0))):
+        head = pr.get("head") or {}
+        rows.append(
+            "| #{number} | {title} | {branch} | {state} | {merged} |".format(
+                number=pr.get("number", ""),
+                title=str(pr.get("title", "")).replace("|", "\\|"),
+                branch=head.get("ref", ""),
+                state=pr.get("state", ""),
+                merged="yes" if pr.get("merged") else "no",
+            )
+        )
+    return rows
+
+
+def counts_line(name: str, state: dict[str, Any]) -> str:
+    counts = state.get("counts", {})
+    if not counts:
+        return f"- {name}: no final state snapshot found"
+    interesting = {
+        "running": counts.get("running", 0),
+        "blocked": counts.get("blocked", 0),
+        "retrying": counts.get("retrying", 0),
+        "agent_handoff_reconcile_stopped": counts.get("agent_handoff_reconcile_stopped", 0),
+        "operator_terminal_stops": counts.get("operator_terminal_stops", 0),
+    }
+    return f"- {name}: `{interesting}`"
+
+
+def collect_assets(run_root: Path) -> dict[str, list[Path]]:
+    return {
+        "promo_screenshots": sorted((run_root / "promo" / "screenshots").glob("*.png")),
+        "final_screenshots": sorted((run_root / "final-verify" / "screenshots").glob("*.png")),
+        "videos": sorted((run_root / "final-verify" / "videos").glob("*.webm")),
+        "tui": sorted((run_root / "promo" / "pages").glob("tui-*.txt")),
+        "logs": sorted((run_root / "final-verify").glob("*.log")),
+    }
+
+
+def rel(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def asset_bullets(paths: list[Path], root: Path) -> list[str]:
+    return [f"- `{rel(path, root)}`" for path in paths] or ["- none captured"]
+
+
+def automated_verdict(primary_done: list[dict[str, Any]], merged_prs: list[dict[str, Any]]) -> str:
+    if len(primary_done) == 10 and len(merged_prs) >= 10:
+        return "READY FOR OPERATOR PASS REVIEW"
+    return "INCOMPLETE"
+
+
+def operator_checklist() -> list[str]:
+    return [
+        "- [ ] Control no-ready issue never dispatched and has no PR.",
+        "- [ ] Control blocked/dependency issue stayed out of dispatch until terminal blockers.",
+        "- [ ] Control cancel-running issue stopped without creating a PR.",
+        "- [ ] Maker and reviewer dashboards are idle at closeout.",
+        "- [ ] Fresh-clone Go verification log passes.",
+        "- [ ] Final browser smoke passes with empty console output.",
+        "- [ ] Required screenshots, TUI frames, logs, and video evidence are present.",
+    ]
+
+
+def write_report(args: argparse.Namespace) -> Path:
+    run_root = args.run_root
+    reports = run_root / "reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    issues = load_json(run_root / "state" / "issues-final.json", [])
+    prs = load_json(run_root / "state" / "prs-final.json", [])
+    maker = load_json(run_root / "state" / "maker-final.json", {})
+    reviewer = load_json(run_root / "state" / "reviewer-final.json", {})
+    assets = collect_assets(run_root)
+
+    primary_done = [
+        issue for issue in issues
+        if 1 <= int(issue.get("number", 0)) <= 10 and "aiops/done" in label_names(issue)
+    ]
+    merged_prs = [pr for pr in prs if pr.get("merged")]
+    verdict = automated_verdict(primary_done, merged_prs)
+
+    lines = [
+        f"# {args.title}",
+        "",
+        f"Run root: `{run_root}`",
+        f"Date: {args.date}",
+        "",
+        "## Verdict",
+        "",
+        verdict,
+        "",
+        "The helper does not self-certify a full pass. Mark the checklist below",
+        "against the live evidence before promoting or committing the report.",
+        "",
+        "## Operator Pass Checklist",
+        "",
+        *operator_checklist(),
+        "",
+        "## Final Worker State",
+        "",
+        counts_line("Maker", maker),
+        counts_line("Reviewer", reviewer),
+        "",
+        "## Primary Issue Results",
+        "",
+        *issue_rows(issues),
+        "",
+        "## PR Results",
+        "",
+        *pr_rows(prs),
+        "",
+        "## Evidence Inventory",
+        "",
+        "Promotion screenshots:",
+        *asset_bullets(assets["promo_screenshots"], run_root),
+        "",
+        "Final Web UI screenshots:",
+        *asset_bullets(assets["final_screenshots"], run_root),
+        "",
+        "Videos:",
+        *asset_bullets(assets["videos"], run_root),
+        "",
+        "TUI raw frames:",
+        *asset_bullets(assets["tui"], run_root),
+        "",
+        "Verification / console logs:",
+        *asset_bullets(assets["logs"], run_root),
+        "",
+        "## Notes",
+        "",
+        "- Review generated rows against the live run before committing an evidence pack.",
+        "- Do not commit `env.local`, Codex auth files, downloaded binaries, or cache directories.",
+    ]
+    path = reports / "report.md"
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def write_promo_notes(args: argparse.Namespace) -> Path:
+    notes_dir = args.run_root / "promo" / "notes"
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    path = notes_dir / "promotion-materials.md"
+    lines = [
+        "# Promotion Material Notes",
+        "",
+        f"Run root: `{args.run_root}`",
+        f"Captured at: {args.date}",
+        "",
+        "## Headline Story",
+        "",
+        "- Latest binary runs locally against Gitea with real Codex app-server.",
+        "- Maker implements one issue per PR; reviewer independently verifies and merges.",
+        "- Rework is a first-class path, not a failure of the lifecycle.",
+        "- Final smoke evidence should include dashboard, Gitea issue/PR pages, TUI raw frames, Web UI screenshots, and a browser video.",
+        "",
+        "## Copy Points",
+        "",
+        "- The worker schedules and observes; agents own PRs, review comments, merges, and tracker handoff.",
+        "- Local binary mode intentionally uses the operator's Codex configuration.",
+        "- Production-style reproducibility comes from a dedicated `CODEX_HOME` and explicit workflow config.",
+        "",
+        "## Caveats",
+        "",
+        "- Token usage is environment-dependent and should not be marketed as a benchmark.",
+        "- Keep raw credentials and auth homes out of committed evidence packs.",
+    ]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def main() -> int:
+    args = parser().parse_args()
+    report = write_report(args)
+    promo = write_promo_notes(args)
+    print(f"wrote {report}")
+    print(f"wrote {promo}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/webtodo_lifecycle_e2e_test.go
+++ b/scripts/webtodo_lifecycle_e2e_test.go
@@ -1,0 +1,332 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestWebTodoLifecycleRunbookDocumentsReusableSOP(t *testing.T) {
+	root := repoRoot(t)
+	readme := readFileString(t, filepath.Join(root, "README.md"))
+	if !strings.Contains(readme, "docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md") {
+		t.Fatalf("README does not link the Web Todo lifecycle E2E runbook")
+	}
+
+	path := filepath.Join(root, "docs", "runbooks", "local-gitea-webtodo-lifecycle-e2e.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"scripts/e2e-webtodo-bootstrap.sh",
+		"scripts/e2e-webtodo-capture.py",
+		"scripts/e2e-webtodo-report.py",
+		"Local binary mode reuses the operator's Codex configuration",
+		"## 0. Prepare the Host Environment",
+		`python3 -m venv "$AIOPS_WEBTODO_TOOLS_ROOT/venv"`,
+		"python -m pip install playwright",
+		"python -m playwright install chromium",
+		"python -m playwright install-deps chromium",
+		"Create the run-root directory skeleton",
+		"set -euo pipefail",
+		"CONTROL cancel running codex issue",
+		`"$AIOPS_WEBTODO_MAKER_WORKFLOW"`,
+		`"$AIOPS_WEBTODO_REVIEWER_WORKFLOW"`,
+		"aiops/todo",
+		"aiops/human-review",
+		"aiops/rework",
+		"aiops/done",
+		"Do not commit `env.local`",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("runbook missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		`"$AIOPS_WEBTODO_MAKER_WORKDIR" \`,
+		`"$AIOPS_WEBTODO_REVIEWER_WORKDIR" \`,
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("runbook still passes workdir as worker positional argument: %q", forbidden)
+		}
+	}
+}
+
+func TestWebTodoBootstrapPreparesRunRoot(t *testing.T) {
+	root := repoRoot(t)
+	runRoot := filepath.Join(t.TempDir(), "run")
+	script := filepath.Join(root, "scripts", "e2e-webtodo-bootstrap.sh")
+	cmd := exec.Command(
+		"bash",
+		script,
+		"--run-root", runRoot,
+		"--gitea-url", "https://gitea.example.test/",
+		"--repo-owner", "aiops-bot",
+		"--repo-name", "web-todo",
+		"--port-base", "4100",
+	)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bootstrap failed: %v\n%s", err, out)
+	}
+
+	for _, rel := range []string{
+		"env.example",
+		"NEXT-STEPS.md",
+		"workflows/maker-WORKFLOW.md",
+		"workflows/reviewer-automerge-WORKFLOW.md",
+		"issues/01-scaffold-stdlib-server.md",
+		"issues/13-control-blocked-held.md",
+		"state",
+		"artifacts",
+		"logs",
+		"promo/screenshots",
+		"promo/pages",
+		"promo/notes",
+		"reports",
+		"mirrors/maker",
+		"mirrors/reviewer",
+		"workspaces/maker",
+		"workspaces/reviewer",
+		"final-verify/screenshots",
+		"final-verify/videos",
+	} {
+		if _, err := os.Stat(filepath.Join(runRoot, rel)); err != nil {
+			t.Fatalf("bootstrap did not create %s: %v", rel, err)
+		}
+	}
+
+	env := readFileString(t, filepath.Join(runRoot, "env.example"))
+	for _, want := range []string{
+		`export AIOPS_WEBTODO_MAKER_PORT="4101"`,
+		`export AIOPS_WEBTODO_REVIEWER_PORT="4102"`,
+		`export AIOPS_WEBTODO_TOOLS_ROOT="$HOME/.cache/aiops-webtodo-e2e-tools"`,
+		`export AIOPS_WEBTODO_MAKER_MIRROR_ROOT=`,
+		`export REVIEWER_CLONE_URL="https://review-bot:REPLACE_ME@gitea.example.test/aiops-bot/web-todo.git"`,
+	} {
+		if !strings.Contains(env, want) {
+			t.Fatalf("env.example missing %q\n%s", want, env)
+		}
+	}
+
+	issue := readFileString(t, filepath.Join(runRoot, "issues", "04-patch-delete-api.md"))
+	if !strings.Contains(issue, "completed must reject null") {
+		t.Fatalf("issue 04 missing abnormal PATCH acceptance:\n%s", issue)
+	}
+	nextSteps := readFileString(t, filepath.Join(runRoot, "NEXT-STEPS.md"))
+	for _, want := range []string{
+		"Install or verify host tools",
+		"Playwright venv",
+		"Activate the Playwright venv",
+	} {
+		if !strings.Contains(nextSteps, want) {
+			t.Fatalf("NEXT-STEPS.md missing %q\n%s", want, nextSteps)
+		}
+	}
+
+	makerWorkflow := readFileString(t, filepath.Join(runRoot, "workflows", "maker-WORKFLOW.md"))
+	reviewerWorkflow := readFileString(t, filepath.Join(runRoot, "workflows", "reviewer-automerge-WORKFLOW.md"))
+	for _, tc := range []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "maker",
+			body: makerWorkflow,
+			want: []string{
+				"  owner: aiops-bot",
+				"  name: web-todo",
+				"  endpoint: https://gitea.example.test",
+				"  root: " + filepath.Join(runRoot, "workspaces", "maker"),
+			},
+		},
+		{
+			name: "reviewer",
+			body: reviewerWorkflow,
+			want: []string{
+				"  owner: aiops-bot",
+				"  name: web-todo",
+				"  endpoint: https://gitea.example.test",
+				"  root: " + filepath.Join(runRoot, "workspaces", "reviewer"),
+			},
+		},
+	} {
+		for _, want := range tc.want {
+			if !strings.Contains(tc.body, want) {
+				t.Fatalf("%s workflow missing %q\n%s", tc.name, want, tc.body)
+			}
+		}
+		for _, forbidden := range []string{"your-gitea-user", "your-repo", "http://gitea.local", "~/aiops-workspaces"} {
+			if strings.Contains(tc.body, forbidden) {
+				t.Fatalf("%s workflow still contains placeholder %q\n%s", tc.name, forbidden, tc.body)
+			}
+		}
+	}
+}
+
+func TestWebTodoReportGeneratesMarkdownFromState(t *testing.T) {
+	root := repoRoot(t)
+	runRoot := filepath.Join(t.TempDir(), "run")
+	mkdirAll(t,
+		filepath.Join(runRoot, "state"),
+		filepath.Join(runRoot, "promo", "screenshots"),
+		filepath.Join(runRoot, "promo", "pages"),
+		filepath.Join(runRoot, "final-verify", "screenshots"),
+		filepath.Join(runRoot, "final-verify", "videos"),
+	)
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeDoneIssuesJSON())
+	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), fakeMergedPRsJSON())
+	writeFileString(t, filepath.Join(runRoot, "state", "maker-final.json"), `{"counts":{"running":0,"blocked":0}}`)
+	writeFileString(t, filepath.Join(runRoot, "state", "reviewer-final.json"), `{"counts":{"running":0,"blocked":0}}`)
+	writeFileString(t, filepath.Join(runRoot, "promo", "screenshots", "maker-dashboard.png"), "png")
+	writeFileString(t, filepath.Join(runRoot, "promo", "pages", "tui-maker-final.txt"), "maker frame")
+	writeFileString(t, filepath.Join(runRoot, "final-verify", "screenshots", "web-final.png"), "png")
+	writeFileString(t, filepath.Join(runRoot, "final-verify", "videos", "web-final.webm"), "video")
+	writeFileString(t, filepath.Join(runRoot, "final-verify", "verification.log"), "go test ./...")
+
+	script := filepath.Join(root, "scripts", "e2e-webtodo-report.py")
+	cmd := exec.Command("python3", script, "--run-root", runRoot, "--date", "2026-06-17")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("report failed: %v\n%s", err, out)
+	}
+
+	report := readFileString(t, filepath.Join(runRoot, "reports", "report.md"))
+	for _, want := range []string{
+		"READY FOR OPERATOR PASS REVIEW",
+		"Operator Pass Checklist",
+		"Control no-ready issue never dispatched",
+		"#1",
+		"#10",
+		"Evidence Inventory",
+		"Final Web UI screenshots",
+		"final-verify/videos/web-final.webm",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+	promo := readFileString(t, filepath.Join(runRoot, "promo", "notes", "promotion-materials.md"))
+	if !strings.Contains(promo, "Local binary mode intentionally uses the operator's Codex configuration") {
+		t.Fatalf("promo notes missing local Codex configuration caveat:\n%s", promo)
+	}
+}
+
+func TestWebTodoCaptureScriptDocumentsPlaywrightAndTUI(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "scripts", "e2e-webtodo-capture.py")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"playwright.sync_api",
+		"--screenshot",
+		"--no-default-screenshots",
+		"safe_screenshot_stem",
+		"AIOPS_STATE_API_TOKEN",
+		"tui",
+		"--raw",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("capture script missing %q", want)
+		}
+	}
+}
+
+func TestWebTodoCaptureSkipsOnlyDefaultScreenshotsWithoutPlaywright(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "e2e-webtodo-capture.py")
+	shadow := filepath.Join(t.TempDir(), "py")
+	mkdirAll(t, filepath.Join(shadow, "playwright"))
+	writeFileString(t, filepath.Join(shadow, "playwright", "__init__.py"), "")
+	writeFileString(t, filepath.Join(shadow, "playwright", "sync_api.py"), "raise ImportError('blocked playwright')\n")
+
+	runRoot := filepath.Join(t.TempDir(), "default")
+	cmd := exec.Command(
+		"python3",
+		script,
+		"--run-root", runRoot,
+		"--gitea-url", "http://127.0.0.1:9",
+	)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "PYTHONPATH="+shadow)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("default screenshot capture should skip missing Playwright, got %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "skipped default screenshots") {
+		t.Fatalf("default capture did not report skipped screenshots:\n%s", out)
+	}
+
+	explicitRunRoot := filepath.Join(t.TempDir(), "explicit")
+	cmd = exec.Command(
+		"python3",
+		script,
+		"--run-root", explicitRunRoot,
+		"--screenshot", "required=http://127.0.0.1:9",
+	)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "PYTHONPATH="+shadow)
+	out, err = cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("explicit screenshot capture should require Playwright:\n%s", out)
+	}
+	if !strings.Contains(string(out), "Playwright is required for requested screenshots") {
+		t.Fatalf("explicit capture did not report missing Playwright:\n%s", out)
+	}
+}
+
+func fakeDoneIssuesJSON() string {
+	var rows []string
+	for i := 1; i <= 10; i++ {
+		rows = append(rows, `{"number":`+itoa(i)+`,"title":"issue `+itoa(i)+`","state":"closed","labels":[{"name":"aiops/done"}]}`)
+	}
+	return "[" + strings.Join(rows, ",") + "]"
+}
+
+func fakeMergedPRsJSON() string {
+	var rows []string
+	for i := 1; i <= 10; i++ {
+		rows = append(rows, `{"number":`+itoa(i)+`,"title":"pr `+itoa(i)+`","state":"closed","merged":true,"head":{"ref":"ai/`+itoa(i)+`"}}`)
+	}
+	return "[" + strings.Join(rows, ",") + "]"
+}
+
+func itoa(n int) string {
+	return strconv.Itoa(n)
+}
+
+func mkdirAll(t *testing.T, dirs ...string) {
+	t.Helper()
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(body)
+}
+
+func writeFileString(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Closes #927

## Summary
- Add a reusable local Gitea Web Todo lifecycle E2E SOP for downloaded binary + local Codex config + maker/reviewer-automerge workflows.
- Add upfront host environment preparation, including reusable Playwright/Chromium screenshot tooling in a Python venv.
- Add bootstrap, capture, and report helpers that prepare run-root evidence folders, render run-specific workflow files, collect screenshots/TUI/state artifacts, and generate report/promotion notes.
- Link the SOP from README and cover the helper contract with focused script tests.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — docs/scripts/tests only; no production Go files changed.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,...`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `bash -n scripts/e2e-webtodo-bootstrap.sh`
- `python3 -m py_compile scripts/e2e-webtodo-capture.py scripts/e2e-webtodo-report.py`
- `git diff --check`
- `go test ./scripts -count=1`
- Mutation check: bootstrap workflow placeholder rendering removed -> `TestWebTodoBootstrapPreparesRunRoot` failed, restored -> passed.
- Mutation check: report verdict over-claimed full PASS -> `TestWebTodoReportGeneratesMarkdownFromState` failed, restored -> passed.
- Codex independent review: first pass found 3 blockers; fixed; second pass returned `VERDICT: MERGE-READY` with no findings.
- PR Codex review found the Playwright/default-screenshot blocker; fixed with regression coverage and resolved the thread.
- Final PR Codex review on `1ab26cc1e6`: `Didn't find any major issues.`
- Claude-family segmented diff review: docs, bootstrap/tests, and capture/report/tests all returned `MERGE-READY`; post-amend incremental reviews returned `MERGE-READY`.

## Notes
- The generated report intentionally says `READY FOR OPERATOR PASS REVIEW`; it does not self-certify the full real Codex/Gitea E2E as PASS without the operator checklist and evidence pack.
- The SOP documents the local-binary default of reusing the operator's `~/.codex`, with dedicated `CODEX_HOME` only for production-style reproducibility.
- Playwright install commands follow the Playwright Python documented flow: install the package, then install the required browser binary.

