### PR TITLE
feat(trace): generate harness reports from worker logs

### DIFF
--- a/.trellis/spec/backend/agent-workflow-guidelines.md
+++ b/.trellis/spec/backend/agent-workflow-guidelines.md
@@ -50,12 +50,18 @@ Before changing code or workflow behavior:
 1. Open or update the relevant Trellis task.
 2. Write a short plan with goal, scope, acceptance criteria, dependencies, and
    verification.
-3. Run a `grill-with-docs` review of the plan against `CONTEXT.md`, ADRs, and
+3. For issue work driven by a design document, extract the negative constraints
+   before choosing an implementation: non-goals, unsupported inputs, redaction
+   and retention limits, forbidden runtime side effects, and any "do not store /
+   do not parse / do not mutate" wording. If the simplest design would require
+   understanding arbitrary human or agent text, treat that as a warning sign and
+   prefer an opaque boundary unless the issue explicitly asks for a parser.
+4. Run a `grill-with-docs` review of the plan against `CONTEXT.md`, ADRs, and
    the relevant runbooks.
-4. Capture settled terminology in `CONTEXT.md` only when it is domain language,
+5. Capture settled terminology in `CONTEXT.md` only when it is domain language,
    and capture durable trade-off decisions in `docs/adr/` only when they meet
    the ADR bar.
-5. Before pre-push review, follow
+6. Before pre-push review, follow
    [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md)
    as the single source of truth. Do not restate reviewer-routing mechanics in
    Trellis specs or task notes.

--- a/.trellis/spec/guides/cross-layer-thinking-guide.md
+++ b/.trellis/spec/guides/cross-layer-thinking-guide.md
@@ -188,3 +188,35 @@ can hold Issues:read without Pull requests:read — so a token could pass
 doctor and fail every poll. Fixed by probing the worker's actual poll
 endpoints (`internal/doctor/doctor_tracker.go`, request shapes pinned in
 `doctor_tracker_preflight_test.go`).
+
+---
+
+## Evidence Importers Need Opaque Text Boundaries
+
+Reports and importers often sit between structured runtime metadata and
+human-formatted text. Treat that as a cross-layer boundary: the importer should
+extract only fields whose format is owned by the emitting layer, and should
+redact arbitrary agent output, protocol payloads, tool arguments, and error text
+as opaque unless the issue explicitly requires a reviewed parser.
+
+### Checklist: When Importing Logs, Reports, Or Agent Output
+
+- [ ] Identify which fields are owned structured metadata and which fields are
+  human/agent/protocol text.
+- [ ] Preserve safe scalar metadata first; redact text payloads wholesale when
+  they can contain secrets, GraphQL, tool arguments, prompts, or copied issue
+  content.
+- [ ] Do not recover ids from free-form text just because it contains
+  key-shaped substrings such as `session_id:` or `pr_number:`.
+- [ ] If a scalar opaque value is followed by key-shaped text, stop parsing at
+  the opaque boundary unless there is a structured delimiter proving the next
+  field is top-level.
+- [ ] Add tests that fail if opaque text leaks or becomes affected metadata.
+
+**Real-world example (#938 / PR #942)**: the trace harness report importer
+originally tried to identify GraphQL and parse Go `%v` `map[...]` payloads
+inside runner output and error text. The issue and design already said not to
+include raw GraphQL payloads, but the implementation translated that into a
+complex redaction parser instead of an opaque boundary. The safer fix was to
+extract trusted top-level scalar metadata and redact `output_head`,
+`output_tail`, `error`, `arguments`, `raw`, and `params` wholesale.

--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ add a bridge that imports `AGENTS.md` rather than duplicating content.
 - [Binary (non-Docker) deployment runbook](docs/runbooks/binary-deployment.md)
 - [CI/CD runbook](docs/runbooks/ci.md)
 - [Runtime debugging API](docs/runbooks/task-api.md)
+- [Trace harness report](docs/runbooks/trace-harness-report.md)
 - [Workspace cache and cleanup](docs/runbooks/workspace-cache.md)
 - [GitHub local automation](docs/runbooks/github-local-automation.md)
 - [Gitea bot and branch protection](docs/runbooks/gitea-bot-and-branch-protection.md)

--- a/docs/design/trace-driven-harness-improvement.md
+++ b/docs/design/trace-driven-harness-improvement.md
@@ -121,6 +121,13 @@ state of the loop.
 - Do not store full prompts, full agent streams, full CI logs, raw GraphQL
   payloads, tokens, clone URLs with userinfo, or complete tracker comments by
   default.
+- Treat human-formatted runner output, error text, unsupported tool arguments,
+  raw protocol payloads, and runtime params as opaque. The report importer may
+  keep trusted top-level scalar metadata, but it should redact those opaque
+  payload fields wholesale instead of trying to parse GraphQL or recover ids
+  from free-form text. The first opaque payload key is a hard boundary for the
+  rest of that payload, including values that look bracket-balanced: losing
+  trailing metadata is safer than promoting agent text as affected ids.
 - Use the existing `workflow.MaskCloneURL` convention for any clone URL that
   enters a report.
 - A generated report should cap each run's embedded evidence at 64 KiB and each

--- a/docs/runbooks/trace-harness-report.md
+++ b/docs/runbooks/trace-harness-report.md
@@ -1,0 +1,101 @@
+# Trace harness report
+
+Use this read-only command to generate the first trace-driven harness report
+from existing evidence. It implements the Milestone 1 subset from
+`docs/design/trace-driven-harness-improvement.md`: group bounded evidence into
+reviewable clusters. It does not mutate tracker state. It does not open PRs.
+It does not edit prompts. It does not create a worker phase, merge gate, or
+evaluator gate.
+
+```bash
+python3 scripts/trace-harness-report.py \
+  --worker-log /path/to/worker.log \
+  --json-out /tmp/trace-harness-report.json
+```
+
+## Supported inputs
+
+- worker process logs emitted by the existing worker event emitter, including
+  `runner_timeout`, failed `runner_end`, `turn_input_required`,
+  `unsupported_tool_call`, and malformed protocol runtime events.
+
+Multiple `--worker-log` flags are allowed.
+
+The command writes compact JSON so the emitted report uses the same byte
+accounting as the documented bounds. For local inspection, pipe the file through
+`python3 -m json.tool` or `jq`.
+
+## Unsupported inputs
+
+This first subset does not fetch tracker comments, PR review threads, Codex
+review comments, human reviews, CI logs, or workspace `.aiops` artifacts such as
+`.aiops/CODEX_APP_SERVER_OUTPUT.txt`, `.aiops/PLAN.md`, or `.aiops/TASK.md`.
+Those are still valid design inputs, but this command only reports from local
+worker logs already collected by the operator. It also does not automatically
+open issues or draft PRs; that belongs to the later proposal-rendering
+milestone.
+
+## Output schema
+
+The JSON output uses schema `trace-harness-report/v1`. Each cluster contains:
+
+- cluster id and short title
+- symptom class
+- affected issue, issue identifier, PR, run, and session ids when present in
+  the structured prefix or in trusted top-level scalar payload fields before the
+  first opaque payload key;
+  pathological clusters may include `affected.omitted` counts when the cluster
+  byte cap requires truncating these id lists
+- evidence references with bounded excerpts
+- suspected harness surface to change
+- proposed next action, currently `issue proposal` for supported worker-log
+  failure clusters
+- acceptance criteria for the proposed harness change
+- redaction note naming what was omitted
+
+## Redaction and bounds
+
+The report stores metadata first: event kind, timestamp, issue/run/session ids,
+source path, line number, and known scalar payload fields. Text evidence is
+excerpted only to prove grouping. Payload fields that can contain arbitrary
+agent, protocol, or tool text are opaque: `output_head`, `output_tail`, `error`,
+`arguments`, `arguments_raw`, `raw`, and `params` are redacted from excerpts
+instead of parsed. The importer keeps safe scalar metadata before the first
+opaque payload key, then treats the rest of that payload as opaque; it does not
+parse GraphQL or other embedded protocol text. This hard boundary applies even
+when an opaque value looks bracket-balanced, because Go's human-readable
+`map[...]` formatting does not escape arbitrary string values and cannot prove
+that later key-shaped text is a real top-level field. The same rule applies to
+ambiguous multiline closures: a single trailing `]` inside an opaque value does
+not prove that a following event-shaped line is a real worker log record, so the
+importer prefers omission over fabricating affected issues.
+
+Bounds are enforced at 64 KiB per run and 256 KiB per cluster. Individual
+evidence excerpts are smaller, known scalar metadata is byte-bounded per field
+and in aggregate, and oversized affected id lists are truncated with omitted
+counts, so a reviewer can inspect the cluster without opening full prompts,
+full agent streams, full CI logs, raw GraphQL payloads, tokens, clone URLs with
+userinfo, or complete tracker comments. Clone URL userinfo that appears in
+trusted scalar metadata is masked with the same `MaskCloneURL` convention used
+by worker diagnostics, and token-like prefixes are replaced with
+`[redacted-token]`; clone URLs inside opaque text are omitted with the rest of
+the opaque payload.
+
+## Examples
+
+Worker-log only:
+
+```bash
+python3 scripts/trace-harness-report.py \
+  --worker-log ./worker.log \
+  --json-out ./trace-report.json
+```
+
+Multiple worker logs:
+
+```bash
+python3 scripts/trace-harness-report.py \
+  --worker-log ./maker.log \
+  --worker-log ./reviewer.log \
+  --json-out ./trace-report.json
+```

--- a/docs/runbooks/trace-harness-report.md
+++ b/docs/runbooks/trace-harness-report.md
@@ -46,15 +46,21 @@ key-sorted, and free-form values can span multiple physical lines and contain
 arbitrary brackets, timestamps, and `event=` text. That rendering is a one-way
 diagnostic format, not a parseable one, so the importer never tries to find
 where a `map[...]` ends. It reads trusted scalar metadata from the record's
-first line only, stops at the first opaque payload key, and treats the rest of
-the payload — including continuation lines — as opaque and never parsed.
+first line only, as a contiguous left-to-right run of space-free `key:value`
+chunks, and stops at the first chunk that is not a recognized safe scalar — an
+opaque payload key, an agent-controlled key (the chosen `tool` name, whose value
+Go renders unquoted and may contain spaces), an unrecognized key, or free-form
+text. The rest of the payload — including continuation lines — is treated as
+opaque and never parsed. Stopping at that boundary is what keeps text inside an
+earlier unquoted value from being promoted as if it were a later top-level key.
 
 ### Known limitation
 
-Because a scalar Go sorts behind an opaque key lands on a skipped continuation
-line, its value is not recovered: `unsupported_tool_call` sorts `arguments`
-before `tool`, `turn_input_required` sorts `params` before `session_id`, and
-`runner_timeout` sorts `output_head`/`output_tail` before `timeout_ms`. The
+Because a scalar Go sorts behind that boundary lands past it (often on a skipped
+continuation line), its value is not recovered: `unsupported_tool_call` exposes
+`arguments` (opaque) and the agent-controlled `tool`, `turn_input_required`
+sorts `params` before `session_id`, and `runner_timeout` sorts
+`output_head`/`output_tail` before `timeout_ms`. The
 cluster still reports the failure class and the affected run/issue ids from the
 prefix. The harness fix is for the worker to emit a structured payload (for
 example a `%q`-quoted JSON object) so those scalars become recoverable; that is

--- a/docs/runbooks/trace-harness-report.md
+++ b/docs/runbooks/trace-harness-report.md
@@ -35,14 +35,42 @@ worker logs already collected by the operator. It also does not automatically
 open issues or draft PRs; that belongs to the later proposal-rendering
 milestone.
 
+## How the importer reads a worker log
+
+Each worker event is one log record beginning with the Go log timestamp and
+`event=<kind>`. The structured prefix up to ` payload=` is single line and
+`%q`-escaped, so the importer reads event kind, `task_id`/`issue_id`,
+`issue_identifier`, `session_id`, and PR ids from it directly. The
+`payload=map[...]` region is Go's `%v` map rendering: unescaped, lexically
+key-sorted, and free-form values can span multiple physical lines and contain
+arbitrary brackets, timestamps, and `event=` text. That rendering is a one-way
+diagnostic format, not a parseable one, so the importer never tries to find
+where a `map[...]` ends. It reads trusted scalar metadata from the record's
+first line only, stops at the first opaque payload key, and treats the rest of
+the payload — including continuation lines — as opaque and never parsed.
+
+### Known limitation
+
+Because a scalar Go sorts behind an opaque key lands on a skipped continuation
+line, its value is not recovered: `unsupported_tool_call` sorts `arguments`
+before `tool`, `turn_input_required` sorts `params` before `session_id`, and
+`runner_timeout` sorts `output_head`/`output_tail` before `timeout_ms`. The
+cluster still reports the failure class and the affected run/issue ids from the
+prefix. The harness fix is for the worker to emit a structured payload (for
+example a `%q`-quoted JSON object) so those scalars become recoverable; that is
+exactly the kind of improvement this report is meant to surface. A related,
+unavoidable consequence of the unescaped format is that opaque output which
+reproduces the full record-start grammar (a log timestamp plus `event=<known
+kind>`) is indistinguishable from a real record and may be surfaced.
+
 ## Output schema
 
 The JSON output uses schema `trace-harness-report/v1`. Each cluster contains:
 
 - cluster id and short title
 - symptom class
-- affected issue, issue identifier, PR, run, and session ids when present in
-  the structured prefix or in trusted top-level scalar payload fields before the
+- affected issue, issue identifier, PR, run, and session ids read from the
+  structured prefix or from trusted top-level scalar payload fields before the
   first opaque payload key;
   pathological clusters may include `affected.omitted` counts when the cluster
   byte cap requires truncating these id lists
@@ -56,30 +84,24 @@ The JSON output uses schema `trace-harness-report/v1`. Each cluster contains:
 ## Redaction and bounds
 
 The report stores metadata first: event kind, timestamp, issue/run/session ids,
-source path, line number, and known scalar payload fields. Text evidence is
-excerpted only to prove grouping. Payload fields that can contain arbitrary
-agent, protocol, or tool text are opaque: `output_head`, `output_tail`, `error`,
-`arguments`, `arguments_raw`, `raw`, and `params` are redacted from excerpts
-instead of parsed. The importer keeps safe scalar metadata before the first
-opaque payload key, then treats the rest of that payload as opaque; it does not
-parse GraphQL or other embedded protocol text. This hard boundary applies even
-when an opaque value looks bracket-balanced, because Go's human-readable
-`map[...]` formatting does not escape arbitrary string values and cannot prove
-that later key-shaped text is a real top-level field. The same rule applies to
-ambiguous multiline closures: a single trailing `]` inside an opaque value does
-not prove that a following event-shaped line is a real worker log record, so the
-importer prefers omission over fabricating affected issues.
+source path, line number, and known scalar payload fields. Text evidence is the
+record's structured prefix only; the entire `payload=map[...]` region is omitted
+from excerpts and replaced with `payload=[redacted-payload]`, so arbitrary
+agent, protocol, or tool text in `output_head`, `output_tail`, `error`,
+`arguments`, `arguments_raw`, `raw`, and `params` is never reproduced. The
+importer keeps safe scalar metadata before the first opaque payload key, which
+is a hard boundary for the rest of that payload; it does not parse GraphQL or
+other embedded protocol text.
 
 Bounds are enforced at 64 KiB per run and 256 KiB per cluster. Individual
 evidence excerpts are smaller, known scalar metadata is byte-bounded per field
 and in aggregate, and oversized affected id lists are truncated with omitted
 counts, so a reviewer can inspect the cluster without opening full prompts,
 full agent streams, full CI logs, raw GraphQL payloads, tokens, clone URLs with
-userinfo, or complete tracker comments. Clone URL userinfo that appears in
-trusted scalar metadata is masked with the same `MaskCloneURL` convention used
-by worker diagnostics, and token-like prefixes are replaced with
-`[redacted-token]`; clone URLs inside opaque text are omitted with the rest of
-the opaque payload.
+userinfo, or complete tracker comments. Clone URL userinfo that reaches the
+prefix or trusted scalar metadata is masked with the same `MaskCloneURL`
+convention used by worker diagnostics, and token-like prefixes are replaced with
+`[redacted-token]`.
 
 ## Examples
 

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Generate grouped trace-driven harness reports from worker logs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+SCHEMA_VERSION = "trace-harness-report/v1"
+MAX_RUN_EVIDENCE_BYTES, MAX_CLUSTER_BYTES, MAX_EVIDENCE_EXCERPT_BYTES = 64 * 1024, 256 * 1024, 4 * 1024
+MAX_METADATA_BYTES, MAX_METADATA_VALUE_BYTES = 16 * 1024, 4 * 1024
+
+FIELD_RE = re.compile(r'\b(event|task_id|issue_id|issue_identifier|session_id|pr|pr_number|pr_url|pull_request|pull_request_url)=("[^"]*"|\S+)')
+PAYLOAD_KEY_RE = re.compile(r"(?:^|\s)([A-Za-z0-9_]+):")
+CLONE_URL_SCHEME_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9+.-]*://")
+TIMESTAMP_RE = re.compile(r"^(\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?)\b")
+WORKER_RECORD_START_RE = re.compile(r"^\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?\s+event=")
+TOKEN_RE = re.compile(
+    r"\b(?:gh[opurs]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|"
+    r"glpat-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|"
+    r"lin_api_[A-Za-z0-9_]{8,}|sk-(?:ant-)?[A-Za-z0-9_-]{20,})\b"
+)
+PR_KEYS = ("pr", "pr_number", "pr_url", "pull_request", "pull_request_url")
+AFFECTED_KEYS = ("issues", "issue_identifiers", "pull_requests", "runs", "sessions")
+OPAQUE_PAYLOAD_KEYS = (
+    "arguments",
+    "arguments_raw",
+    "error",
+    "output_head",
+    "output_tail",
+    "params",
+    "raw",
+)
+FREEFORM_PAYLOAD_KEYS = OPAQUE_PAYLOAD_KEYS
+SAFE_PAYLOAD_KEYS = set(
+    "elapsed_ms timeout_ms duration_ms output_bytes output_dropped model method task_id issue_id "
+    "issue_identifier session_id pr pr_number pr_url pull_request pull_request_url exit_code ok tool".split()
+)
+PAYLOAD_KEYS = SAFE_PAYLOAD_KEYS | set(OPAQUE_PAYLOAD_KEYS)
+ERROR_REDACTION = "[redacted-error]"
+CLASS_BY_EVENT = {
+    "runner_timeout": ("runner-timeout", "Runner timeouts", "runner timeout"),
+    "turn_input_required": ("input-required", "Input required stops", "input required"),
+    "unsupported_tool_call": ("tool-unsupported", "Unsupported tool calls", "tool unsupported"),
+    "malformed": ("malformed-protocol", "Malformed protocol output", "malformed protocol output"),
+}
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--worker-log", action="append", default=[], type=Path)
+    p.add_argument("--json-out", type=Path, help="write JSON report to this path; default stdout")
+    return p
+
+
+def main(argv: list[str]) -> int:
+    args = parser().parse_args(argv)
+    try:
+        report = generate(args.worker_log)
+        raw = report_json(report)
+        if args.json_out:
+            args.json_out.write_text(raw)
+        else:
+            sys.stdout.write(raw)
+    except Exception as exc:  # argparse has already handled usage errors.
+        print(mask(str(exc)), file=sys.stderr)
+        return 1
+    return 0
+
+
+def generate(paths: list[Path]) -> dict:
+    if not paths:
+        raise ValueError("at least one --worker-log is required")
+    clusters: dict[str, dict] = {}
+    run_bytes: dict[str, int] = {}
+    inputs = [input_ref(path) for path in paths]
+    for path in paths:
+        for finding in parse_worker_log(path):
+            add_finding(clusters, run_bytes, finding)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "inputs": inputs,
+        "bounds": {
+            "max_run_evidence_bytes": MAX_RUN_EVIDENCE_BYTES,
+            "max_cluster_bytes": MAX_CLUSTER_BYTES,
+        },
+        "clusters": [finalize_cluster(clusters[key]) for key in sorted(clusters)],
+    }
+
+
+def input_ref(path: Path) -> dict:
+    data = path.read_bytes()
+    return {
+        "type": "worker_log",
+        "path": mask(str(path)),
+        "bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def parse_worker_log(path: Path) -> list[dict]:
+    findings = []
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line_no, record in worker_log_records(handle):
+            if parsed := parse_line(path, line_no, record):
+                findings.append(parsed)
+    return findings
+
+
+def worker_log_records(lines):
+    current, start_line = [], 0
+    for line_no, line in enumerate(lines, 1):
+        text = line.rstrip("\n")
+        if current:
+            if record_payload_open(current):
+                if event_after_freeform_bracket(current, text):
+                    yield start_line, "\n".join(current)
+                    current, start_line = [text], line_no
+                    continue
+                if timestamped_log_after_freeform_bracket(current, text):
+                    yield start_line, "\n".join(current)
+                    current, start_line = [], 0
+                else:
+                    current.append(text)
+                    continue
+            yield start_line, "\n".join(current)
+            current, start_line = [], 0
+        if is_worker_log_record_start(text):
+            current, start_line = [text], line_no
+        else:
+            yield line_no, text
+    if current:
+        yield start_line, "\n".join(current)
+
+
+def is_worker_log_record_start(line: str) -> bool:
+    return bool(WORKER_RECORD_START_RE.match(line))
+
+
+def record_payload_open(lines: list[str]) -> bool:
+    if not lines:
+        return False
+    _, payload = split_payload("\n".join(lines))
+    return payload.startswith("map[") and not record_map_payload_closed(payload)
+
+
+def event_after_freeform_bracket(lines: list[str], text: str) -> bool:
+    if not is_worker_log_record_start(text):
+        return False
+    return freeform_bracket_closes_record(lines)
+
+
+def timestamped_log_after_freeform_bracket(lines: list[str], text: str) -> bool:
+    if not TIMESTAMP_RE.match(text) or is_worker_log_record_start(text):
+        return False
+    return freeform_bracket_closes_record(lines)
+
+
+def freeform_bracket_closes_record(lines: list[str]) -> bool:
+    _, payload = split_payload("\n".join(lines))
+    if not payload.startswith("map["):
+        return False
+    body = map_payload_body(payload)
+    if freeform_payload_start(body) == len(body):
+        return False
+    return freeform_terminal_bracket_closes_map(lines[-1])
+
+
+def parse_line(path: Path, line_no: int, line: str) -> dict | None:
+    if not is_worker_log_record_start(line):
+        return None
+    prefix, payload = split_payload(line)
+    fields = prefix_field_values(prefix)
+    kind = fields.get("event", "")
+    metadata = scalar_payload(payload, kind)
+    if timestamp := line_timestamp(prefix):
+        metadata.setdefault("timestamp", timestamp)
+    event_class = classify(kind, prefix, metadata)
+    if not event_class:
+        return None
+    cid, title, symptom = event_class
+    return {
+        "id": cid,
+        "title": title,
+        "symptom": symptom,
+        "ref": f"{mask(str(path))}:{line_no}",
+        "kind": kind,
+        "excerpt": evidence_excerpt(kind, line),
+        "metadata": metadata,
+        "issue": fields.get("issue_id", "") or metadata.get("issue_id", ""),
+        "identifier": fields.get("issue_identifier", "") or metadata.get("issue_identifier", ""),
+        "run": fields.get("task_id", "") or metadata.get("task_id", ""),
+        "session": fields.get("session_id", "") or metadata.get("session_id", ""),
+        "pull_request": first_mapped_value(fields, metadata, PR_KEYS),
+    }
+
+
+def classify(kind: str, line: str, metadata: dict) -> tuple[str, str, str] | None:
+    if kind in CLASS_BY_EVENT:
+        return CLASS_BY_EVENT[kind]
+    lower = line.lower()
+    if kind == "runner_end" and runner_end_failed(lower, metadata):
+        return ("runner-failure", "Runner failures", "runner failure")
+    return None
+
+
+def runner_end_failed(line: str, metadata: dict) -> bool:
+    ok = metadata.get("ok", "").lower()
+    if ok == "true":
+        return False
+    if ok == "false":
+        return True
+    if "runner failed" in line:
+        return True
+    return bool(metadata.get("error"))
+
+
+def split_payload(line: str) -> tuple[str, str]:
+    if " payload=" not in line:
+        return line, ""
+    prefix, payload = line.split(" payload=", 1)
+    return prefix, payload
+
+
+def line_timestamp(prefix: str) -> str:
+    match = TIMESTAMP_RE.match(prefix)
+    return mask(match.group(1)) if match else ""
+
+
+def prefix_fields(prefix: str) -> str:
+    return prefix.split(" msg=", 1)[0]
+
+
+def prefix_field_values(prefix: str) -> dict:
+    return {m.group(1): mask(m.group(2).strip('"')) for m in FIELD_RE.finditer(prefix_fields(prefix))}
+
+
+def scalar_payload(payload: str, kind: str) -> dict:
+    if not payload:
+        return {}
+    payload = mask(payload)
+    if payload.startswith("map["):
+        payload = map_payload_body(payload)
+    return scalar_payload_fields(payload)
+
+
+def map_payload_body(payload: str) -> str:
+    body = payload[4:]
+    return body[:-1] if map_payload_closed(payload) else body
+
+
+def scalar_payload_fields(payload: str) -> dict:
+    fields = {}
+    for key, value in top_level_payload_fields(payload):
+        if key in fields:
+            continue
+        if key in SAFE_PAYLOAD_KEYS and value:
+            fields[key] = metadata_value(value)
+            continue
+        if key == "error":
+            fields[key] = ERROR_REDACTION
+    return fields
+
+
+def metadata_value(value: str) -> str:
+    return mask(value.strip().strip('"'))
+
+
+def map_payload_closed(payload: str) -> bool:
+    return payload.rstrip().endswith("]")
+
+
+def record_map_payload_closed(payload: str) -> bool:
+    if not map_payload_closed(payload):
+        return False
+    body = map_payload_body(payload)
+    if "\n" not in payload:
+        return single_line_map_payload_closed(payload)
+    if freeform_payload_start(body) < len(body) and not freeform_terminal_bracket_strongly_closes_map(payload):
+        return False
+    if freeform_payload_start(body) == len(body):
+        return True
+    last_line = payload.rsplit("\n", 1)[-1]
+    return freeform_terminal_bracket_strongly_closes_map(last_line)
+
+
+def single_line_map_payload_closed(payload: str) -> bool:
+    raw_body = payload[4:].rstrip() if payload.startswith("map[") else payload.rstrip()
+    start = freeform_payload_start(raw_body)
+    if start == len(raw_body):
+        return True
+    if freeform_terminal_bracket_strongly_closes_map(payload):
+        return True
+    return not terminal_bracket_may_close_payload_text(raw_body[start:])
+
+
+def terminal_bracket_may_close_payload_text(value: str) -> bool:
+    text = value.rstrip()
+    if not text.endswith("]"):
+        return False
+    before_terminal = text[:-1]
+    return before_terminal.count("[") > before_terminal.count("]")
+
+
+def freeform_terminal_bracket_closes_map(line: str) -> bool:
+    return freeform_terminal_bracket_strongly_closes_map(line)
+
+
+def freeform_terminal_bracket_strongly_closes_map(line: str) -> bool:
+    text = line.rstrip()
+    return text.endswith("]]") or text.endswith("] ]")
+
+
+def evidence_excerpt(kind: str, line: str) -> str:
+    if kind == "malformed":
+        return redact_malformed_payload(line)
+    prefix, payload = split_payload(line)
+    if not payload:
+        return mask(line)
+    if payload_has_opaque_field(payload):
+        return f"{mask(prefix)} payload=[redacted-payload]"
+    return f"{mask(prefix)} payload={mask(payload)}"
+
+
+def redact_malformed_payload(line: str) -> str:
+    prefix, payload = split_payload(line)
+    if not payload:
+        return mask(line)
+    return f"{mask(prefix)} payload=[redacted-malformed-payload]"
+
+
+def freeform_payload_start(payload: str) -> int:
+    starts = [idx for key in FREEFORM_PAYLOAD_KEYS if (idx := payload.find(f"{key}:")) >= 0]
+    return min(starts) if starts else len(payload)
+
+
+def payload_has_opaque_field(payload: str) -> bool:
+    if payload.startswith("map["):
+        payload = map_payload_body(payload)
+    return any(key in OPAQUE_PAYLOAD_KEYS for key, _ in top_level_payload_fields(payload))
+
+
+def top_level_payload_fields(payload: str) -> list[tuple[str, str]]:
+    fields, cursor = [], 0
+    while cursor < len(payload):
+        match = next_payload_field(payload, cursor)
+        if not match:
+            break
+        key = match.group(1)
+        value_start = match.end()
+        value_end, keep_scanning = top_level_value_end(payload, value_start, key)
+        fields.append((key, payload[value_start:value_end].strip()))
+        if not keep_scanning:
+            break
+        cursor = value_end
+    return fields
+
+
+def next_payload_field(payload: str, start: int) -> re.Match | None:
+    for match in PAYLOAD_KEY_RE.finditer(payload, start):
+        if match.group(1) in PAYLOAD_KEYS:
+            return match
+    return None
+
+
+def top_level_value_end(payload: str, start: int, key: str) -> tuple[int, bool]:
+    value_start = first_non_space(payload, start)
+    if key in OPAQUE_PAYLOAD_KEYS:
+        return len(payload), False
+    bracket_end = bracketed_value_end(payload, value_start)
+    if bracket_end > value_start:
+        return bracket_end, True
+    next_key = next_payload_field_boundary(payload, value_start)
+    return (next_key, True) if next_key >= 0 else (len(payload), False)
+
+
+def first_non_space(text: str, start: int) -> int:
+    while start < len(text) and text[start].isspace():
+        start += 1
+    return start
+
+
+def bracketed_value_end(text: str, start: int) -> int:
+    if text.startswith("map[", start):
+        return scan_balanced(text, start + len("map"), "[", "]")
+    if start < len(text) and text[start] in "[{":
+        return scan_balanced(text, start, text[start], "]" if text[start] == "[" else "}")
+    return -1
+
+
+def scan_balanced(text: str, start: int, opener: str, closer: str) -> int:
+    depth, in_string, escape = 0, False, False
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == opener:
+            depth += 1
+            continue
+        if ch == closer and depth:
+            depth -= 1
+            if depth == 0:
+                return idx + 1
+    return -1
+
+
+def next_payload_field_boundary(payload: str, start: int) -> int:
+    for match in PAYLOAD_KEY_RE.finditer(payload, start):
+        if match.group(1) in PAYLOAD_KEYS:
+            return match.start()
+    return -1
+
+
+def add_finding(clusters: dict[str, dict], run_bytes: dict[str, int], finding: dict) -> None:
+    cluster = clusters.setdefault(finding["id"], new_cluster(finding))
+    add_unique(cluster["affected"]["issues"], finding["issue"])
+    add_unique(cluster["affected"]["issue_identifiers"], finding["identifier"])
+    add_unique(cluster["affected"]["pull_requests"], finding["pull_request"])
+    add_unique(cluster["affected"]["runs"], finding["run"])
+    add_unique(cluster["affected"]["sessions"], finding["session"])
+    entry, entry_size = bounded_evidence_entry(cluster, run_bytes, finding)
+    if not entry:
+        return
+    cluster["evidence"].append(entry)
+    cluster["_evidence_bytes"] = evidence_array_bytes_after(cluster, entry_size)
+    cluster["_evidence_count"] += 1
+
+
+def new_cluster(finding: dict) -> dict:
+    return {
+        "id": finding["id"],
+        "title": finding["title"],
+        "symptom_class": finding["symptom"],
+        "affected": {"issues": [], "issue_identifiers": [], "pull_requests": [], "runs": [], "sessions": []},
+        "evidence": [],
+        "_evidence_bytes": byte_len("[]"),
+        "_evidence_count": 0,
+        "suspected_harness_surface": "WORKFLOW.md, reviewer rubrics, skills, hooks, tests, CI, or docs",
+        "proposed_next_action": "issue proposal",
+        "acceptance_criteria": [
+            "Future runs cover this failure class with a reviewed harness surface or a documented no-op decision.",
+            "The change remains report/agent/workflow-owned and does not add a worker-side gate or tracker writer.",
+        ],
+        "redaction_note": "Evidence stores trusted metadata before opaque payloads; output_head, output_tail, error, arguments, arguments_raw, raw, and params are omitted from excerpts. Clone URL userinfo follows workflow.MaskCloneURL, and token-like values are redacted.",
+    }
+
+
+def bounded_evidence_entry(cluster: dict, run_bytes: dict[str, int], finding: dict) -> tuple[dict | None, int]:
+    run = finding["run"] or finding["issue"] or "unknown"
+    used = run_bytes.get(run, 0)
+    text = mask(finding["excerpt"])
+    best, best_size = None, 0
+    low, high = 1, min(MAX_EVIDENCE_EXCERPT_BYTES, byte_len(text))
+    while low <= high:
+        limit = (low + high) // 2
+        entry = evidence_entry(finding, truncate(text, limit))
+        entry_size = evidence_entry_bytes(entry)
+        if entry_size <= MAX_RUN_EVIDENCE_BYTES - used and evidence_array_bytes_after(cluster, entry_size) <= MAX_CLUSTER_BYTES:
+            best, best_size = entry, entry_size
+            low = limit + 1
+        else:
+            high = limit - 1
+    if best:
+        run_bytes[run] = used + best_size
+    return best, best_size
+
+
+def evidence_entry(finding: dict, excerpt: str) -> dict:
+    return {
+        "source": "worker_log",
+        "ref": finding["ref"],
+        "kind": finding["kind"],
+        "excerpt": excerpt,
+        "metadata": bounded_metadata(finding["metadata"]),
+    }
+
+
+def bounded_metadata(metadata: dict) -> dict:
+    bounded = {key: truncate(value, MAX_METADATA_VALUE_BYTES) for key, value in metadata.items()}
+    while encoded_bytes(bounded) > MAX_METADATA_BYTES and bounded:
+        key = max(bounded, key=lambda item: byte_len(bounded[item]))
+        value = bounded[key]
+        if not value:
+            break
+        overage = encoded_bytes(bounded) - MAX_METADATA_BYTES
+        limit = max(0, byte_len(value) - overage - byte_len("... [truncated]"))
+        next_value = truncate(value, limit)
+        bounded[key] = "" if next_value == value else next_value
+    return bounded
+
+
+def evidence_entry_bytes(entry: dict) -> int:
+    return byte_len(json.dumps(entry, separators=(",", ":"), sort_keys=True))
+
+
+def evidence_array_bytes_after(cluster: dict, entry_size: int) -> int:
+    if cluster["_evidence_count"] == 0:
+        return entry_size + byte_len("[]")
+    return cluster["_evidence_bytes"] + byte_len(",") + entry_size
+
+
+def finalize_cluster(cluster: dict) -> dict:
+    for key in AFFECTED_KEYS:
+        values = cluster["affected"][key]
+        values.sort()
+    cluster.pop("_evidence_bytes", None)
+    cluster.pop("_evidence_count", None)
+    enforce_cluster_bound(cluster)
+    return cluster
+
+
+def enforce_cluster_bound(cluster: dict) -> None:
+    if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
+        return
+
+    trim_evidence_to_cluster_bound(cluster)
+    if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
+        return
+
+    omitted = cluster["affected"].setdefault("omitted", {})
+    originals = {key: list(cluster["affected"][key]) for key in AFFECTED_KEYS}
+    for key in sorted(AFFECTED_KEYS, key=lambda name: len(originals[name]), reverse=True):
+        if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
+            break
+        values = originals[key]
+        if not values:
+            continue
+        keep = max_affected_keep_count(cluster, key, values)
+        cluster["affected"][key] = values[:keep]
+        if len(values) > keep:
+            omitted[key] = len(values) - keep
+        else:
+            omitted.pop(key, None)
+
+    for key, count in list(omitted.items()):
+        if count <= 0:
+            omitted.pop(key)
+    if not omitted:
+        cluster["affected"].pop("omitted", None)
+    trim_evidence_to_cluster_bound(cluster)
+
+
+def max_affected_keep_count(cluster: dict, key: str, values: list[str]) -> int:
+    low, high, best = 0, len(values), 0
+    while low <= high:
+        keep = (low + high) // 2
+        cluster["affected"][key] = values[:keep]
+        cluster["affected"]["omitted"][key] = len(values) - keep
+        if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
+            best = keep
+            low = keep + 1
+        else:
+            high = keep - 1
+    return best
+
+
+def trim_evidence_to_cluster_bound(cluster: dict) -> None:
+    while len(cluster["evidence"]) > 1 and encoded_bytes(cluster) > MAX_CLUSTER_BYTES:
+        cluster["evidence"].pop()
+
+
+def add_unique(values: list[str], value: str) -> None:
+    value = value.strip()
+    if value and value not in values:
+        values.append(value)
+
+
+def first_mapped_value(primary: dict, secondary: dict, keys: tuple[str, ...]) -> str:
+    for source in (primary, secondary):
+        for key in keys:
+            if value := source.get(key):
+                return value
+    return ""
+
+
+def mask(text: str) -> str:
+    masked = []
+    cursor = 0
+    for match in CLONE_URL_SCHEME_RE.finditer(text):
+        start = match.start()
+        if start < cursor:
+            continue
+        url_end = clone_url_end(text, start)
+        candidate = text[start:url_end]
+        replacement = mask_clone_url(candidate)
+        if replacement == candidate:
+            continue
+        masked.append(text[cursor:start])
+        masked.append(replacement)
+        cursor = url_end
+    masked.append(text[cursor:])
+    return TOKEN_RE.sub("[redacted-token]", "".join(masked))
+
+
+def clone_url_end(text: str, start: int) -> int:
+    auth_start = text.find("://", start) + len("://")
+    scan_end = first_index(text, "/?#", auth_start)
+    at = text.rfind("@", auth_start, scan_end)
+    if at < 0:
+        return scan_end
+    return first_index(text, " \t\r\n]", at + 1)
+
+
+def first_index(text: str, chars: str, start: int) -> int:
+    found = [idx for ch in chars if (idx := text.find(ch, start)) >= 0]
+    return min(found, default=len(text))
+
+
+def mask_clone_url(raw: str) -> str:
+    try:
+        parsed = urlsplit(raw)
+        if not parsed.username and parsed.password is None:
+            return raw
+        host = parsed.hostname or ""
+        if parsed.port:
+            host += f":{parsed.port}"
+        return urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+    except ValueError:
+        scheme, rest = raw.split("://", 1)
+        end = min((idx for ch in "/?#" if (idx := rest.find(ch)) >= 0), default=len(rest))
+        authority, tail = rest[:end], rest[end:]
+        if "@" not in authority:
+            return raw
+        return scheme + "://" + authority.rsplit("@", 1)[1] + tail
+
+
+def truncate(text: str, limit: int) -> str:
+    suffix = "... [truncated]"
+    data = text.encode()
+    if len(data) <= limit:
+        return text
+    suffix_data = suffix.encode()
+    if limit <= len(suffix_data):
+        return data[:limit].decode(errors="ignore")
+    head = data[: limit - len(suffix_data)].decode(errors="ignore")
+    return head + suffix
+
+
+def byte_len(text: str) -> int:
+    return len(text.encode())
+
+
+def encoded_bytes(value: dict | list) -> int:
+    return byte_len(json.dumps(value, separators=(",", ":"), sort_keys=True))
+
+
+def report_json(report: dict) -> str:
+    return json.dumps(report, separators=(",", ":"), sort_keys=False) + "\n"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -1,5 +1,24 @@
 #!/usr/bin/env python3
-"""Generate grouped trace-driven harness reports from worker logs."""
+"""Generate grouped trace-driven harness reports from worker logs.
+
+The worker emits one structured log line per event:
+
+    <timestamp> event=<kind> task_id=<id> issue_id=<id> [issue_identifier=<id>]
+        [session_id=<id>] msg=<%q-quoted> payload=<%v map rendering>
+
+Everything up to ` payload=` is a single line of Go `key=value` logging with a
+`%q`-escaped `msg`, so it is safe to parse. Everything after ` payload=` is Go's
+`%v` rendering of a map: it is unescaped, lexically key-sorted, and free-form
+values (output, errors, tool arguments, params) can span multiple physical lines
+and contain arbitrary brackets, timestamps, and `event=` text. That rendering is
+a one-way diagnostic format, not a parseable one, so this importer never tries to
+find where a `map[...]` ends. It reads trusted scalar metadata from the first
+physical line only, stops at the first opaque payload key, and treats the rest of
+the payload (including continuation lines) as opaque. The documented cost is that
+scalars Go sorts behind an opaque key (e.g. `tool`, `timeout_ms`, payload
+`session_id`) are not recovered; the harness fix is to make the worker emit a
+structured payload, which this report is meant to surface as an improvement.
+"""
 
 from __future__ import annotations
 
@@ -17,7 +36,7 @@ MAX_RUN_EVIDENCE_BYTES, MAX_CLUSTER_BYTES, MAX_EVIDENCE_EXCERPT_BYTES = 64 * 102
 MAX_METADATA_BYTES, MAX_METADATA_VALUE_BYTES = 16 * 1024, 4 * 1024
 
 FIELD_RE = re.compile(r'\b(event|task_id|issue_id|issue_identifier|session_id|pr|pr_number|pr_url|pull_request|pull_request_url)=("[^"]*"|\S+)')
-PAYLOAD_KEY_RE = re.compile(r"(?:^|\s)([A-Za-z0-9_]+):")
+PAYLOAD_FIELD_RE = re.compile(r"(?:^|\s)([A-Za-z0-9_]+):(\S+)")
 CLONE_URL_SCHEME_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9+.-]*://")
 TIMESTAMP_RE = re.compile(r"^(\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?)\b")
 WORKER_RECORD_START_RE = re.compile(r"^\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?\s+event=")
@@ -28,28 +47,20 @@ TOKEN_RE = re.compile(
 )
 PR_KEYS = ("pr", "pr_number", "pr_url", "pull_request", "pull_request_url")
 AFFECTED_KEYS = ("issues", "issue_identifiers", "pull_requests", "runs", "sessions")
-OPAQUE_PAYLOAD_KEYS = (
-    "arguments",
-    "arguments_raw",
-    "error",
-    "output_head",
-    "output_tail",
-    "params",
-    "raw",
-)
-FREEFORM_PAYLOAD_KEYS = OPAQUE_PAYLOAD_KEYS
+# Free-form payload values: unescaped, possibly multi-line, never parsed. The
+# first of these keys on a record's first line ends trusted scalar extraction.
+OPAQUE_PAYLOAD_KEYS = ("arguments", "arguments_raw", "error", "output_head", "output_tail", "params", "raw")
 SAFE_PAYLOAD_KEYS = set(
     "elapsed_ms timeout_ms duration_ms output_bytes output_dropped model method task_id issue_id "
     "issue_identifier session_id pr pr_number pr_url pull_request pull_request_url exit_code ok tool".split()
 )
-PAYLOAD_KEYS = SAFE_PAYLOAD_KEYS | set(OPAQUE_PAYLOAD_KEYS)
-ERROR_REDACTION = "[redacted-error]"
 CLASS_BY_EVENT = {
     "runner_timeout": ("runner-timeout", "Runner timeouts", "runner timeout"),
     "turn_input_required": ("input-required", "Input required stops", "input required"),
     "unsupported_tool_call": ("tool-unsupported", "Unsupported tool calls", "tool unsupported"),
     "malformed": ("malformed-protocol", "Malformed protocol output", "malformed protocol output"),
 }
+
 
 def parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
@@ -107,91 +118,32 @@ def input_ref(path: Path) -> dict:
 def parse_worker_log(path: Path) -> list[dict]:
     findings = []
     with path.open(encoding="utf-8", errors="replace") as handle:
-        for line_no, record in worker_log_records(handle):
-            if parsed := parse_line(path, line_no, record):
+        for line_no, line in enumerate(handle, 1):
+            if parsed := parse_line(path, line_no, line.rstrip("\n")):
                 findings.append(parsed)
     return findings
 
 
-def worker_log_records(lines):
-    current, start_line = [], 0
-    for line_no, line in enumerate(lines, 1):
-        text = line.rstrip("\n")
-        if current:
-            if record_payload_open(current):
-                if event_after_freeform_bracket(current, text):
-                    yield start_line, "\n".join(current)
-                    current, start_line = [text], line_no
-                    continue
-                if timestamped_log_after_freeform_bracket(current, text):
-                    yield start_line, "\n".join(current)
-                    current, start_line = [], 0
-                else:
-                    current.append(text)
-                    continue
-            yield start_line, "\n".join(current)
-            current, start_line = [], 0
-        if is_worker_log_record_start(text):
-            current, start_line = [text], line_no
-        else:
-            yield line_no, text
-    if current:
-        yield start_line, "\n".join(current)
-
-
-def is_worker_log_record_start(line: str) -> bool:
-    return bool(WORKER_RECORD_START_RE.match(line))
-
-
-def record_payload_open(lines: list[str]) -> bool:
-    if not lines:
-        return False
-    _, payload = split_payload("\n".join(lines))
-    return payload.startswith("map[") and not record_map_payload_closed(payload)
-
-
-def event_after_freeform_bracket(lines: list[str], text: str) -> bool:
-    if not is_worker_log_record_start(text):
-        return False
-    return freeform_bracket_closes_record(lines)
-
-
-def timestamped_log_after_freeform_bracket(lines: list[str], text: str) -> bool:
-    if not TIMESTAMP_RE.match(text) or is_worker_log_record_start(text):
-        return False
-    return freeform_bracket_closes_record(lines)
-
-
-def freeform_bracket_closes_record(lines: list[str]) -> bool:
-    _, payload = split_payload("\n".join(lines))
-    if not payload.startswith("map["):
-        return False
-    body = map_payload_body(payload)
-    if freeform_payload_start(body) == len(body):
-        return False
-    return freeform_terminal_bracket_closes_map(lines[-1])
-
-
 def parse_line(path: Path, line_no: int, line: str) -> dict | None:
-    if not is_worker_log_record_start(line):
+    if not WORKER_RECORD_START_RE.match(line):
         return None
-    prefix, payload = split_payload(line)
+    prefix, payload, has_payload = split_payload(line)
     fields = prefix_field_values(prefix)
     kind = fields.get("event", "")
-    metadata = scalar_payload(payload, kind)
-    if timestamp := line_timestamp(prefix):
-        metadata.setdefault("timestamp", timestamp)
-    event_class = classify(kind, prefix, metadata)
+    event_class = classify(kind, prefix)
     if not event_class:
         return None
     cid, title, symptom = event_class
+    metadata = scalar_payload(payload)
+    if timestamp := line_timestamp(prefix):
+        metadata.setdefault("timestamp", timestamp)
     return {
         "id": cid,
         "title": title,
         "symptom": symptom,
         "ref": f"{mask(str(path))}:{line_no}",
         "kind": kind,
-        "excerpt": evidence_excerpt(kind, line),
+        "excerpt": evidence_excerpt(prefix, has_payload),
         "metadata": metadata,
         "issue": fields.get("issue_id", "") or metadata.get("issue_id", ""),
         "identifier": fields.get("issue_identifier", "") or metadata.get("issue_identifier", ""),
@@ -201,31 +153,19 @@ def parse_line(path: Path, line_no: int, line: str) -> dict | None:
     }
 
 
-def classify(kind: str, line: str, metadata: dict) -> tuple[str, str, str] | None:
+def classify(kind: str, prefix: str) -> tuple[str, str, str] | None:
     if kind in CLASS_BY_EVENT:
         return CLASS_BY_EVENT[kind]
-    lower = line.lower()
-    if kind == "runner_end" and runner_end_failed(lower, metadata):
+    if kind == "runner_end" and "runner failed" in prefix.lower():
         return ("runner-failure", "Runner failures", "runner failure")
     return None
 
 
-def runner_end_failed(line: str, metadata: dict) -> bool:
-    ok = metadata.get("ok", "").lower()
-    if ok == "true":
-        return False
-    if ok == "false":
-        return True
-    if "runner failed" in line:
-        return True
-    return bool(metadata.get("error"))
-
-
-def split_payload(line: str) -> tuple[str, str]:
+def split_payload(line: str) -> tuple[str, str, bool]:
     if " payload=" not in line:
-        return line, ""
+        return line, "", False
     prefix, payload = line.split(" payload=", 1)
-    return prefix, payload
+    return prefix, payload, True
 
 
 def line_timestamp(prefix: str) -> str:
@@ -233,197 +173,40 @@ def line_timestamp(prefix: str) -> str:
     return mask(match.group(1)) if match else ""
 
 
-def prefix_fields(prefix: str) -> str:
-    return prefix.split(" msg=", 1)[0]
-
-
 def prefix_field_values(prefix: str) -> dict:
-    return {m.group(1): mask(m.group(2).strip('"')) for m in FIELD_RE.finditer(prefix_fields(prefix))}
+    # Cut at ` msg=` so the %q-quoted message body is never scanned for fields.
+    head = prefix.split(" msg=", 1)[0]
+    return {m.group(1): mask(m.group(2).strip('"')) for m in FIELD_RE.finditer(head)}
 
 
-def scalar_payload(payload: str, kind: str) -> dict:
-    if not payload:
+def scalar_payload(payload: str) -> dict:
+    if not payload.startswith("map["):
         return {}
-    payload = mask(payload)
-    if payload.startswith("map["):
-        payload = map_payload_body(payload)
-    return scalar_payload_fields(payload)
-
-
-def map_payload_body(payload: str) -> str:
-    body = payload[4:]
-    return body[:-1] if map_payload_closed(payload) else body
-
-
-def scalar_payload_fields(payload: str) -> dict:
-    fields = {}
-    for key, value in top_level_payload_fields(payload):
-        if key in fields:
-            continue
-        if key in SAFE_PAYLOAD_KEYS and value:
-            fields[key] = metadata_value(value)
-            continue
-        if key == "error":
-            fields[key] = ERROR_REDACTION
-    return fields
-
-
-def metadata_value(value: str) -> str:
-    return mask(value.strip().strip('"'))
-
-
-def map_payload_closed(payload: str) -> bool:
-    return payload.rstrip().endswith("]")
-
-
-def record_map_payload_closed(payload: str) -> bool:
-    if not map_payload_closed(payload):
-        return False
-    body = map_payload_body(payload)
-    if "\n" not in payload:
-        return single_line_map_payload_closed(payload)
-    if freeform_payload_start(body) < len(body) and not freeform_terminal_bracket_strongly_closes_map(payload):
-        return False
-    if freeform_payload_start(body) == len(body):
-        return True
-    last_line = payload.rsplit("\n", 1)[-1]
-    return freeform_terminal_bracket_strongly_closes_map(last_line)
-
-
-def single_line_map_payload_closed(payload: str) -> bool:
-    raw_body = payload[4:].rstrip() if payload.startswith("map[") else payload.rstrip()
-    start = freeform_payload_start(raw_body)
-    if start == len(raw_body):
-        return True
-    if freeform_terminal_bracket_strongly_closes_map(payload):
-        return True
-    return not terminal_bracket_may_close_payload_text(raw_body[start:])
-
-
-def terminal_bracket_may_close_payload_text(value: str) -> bool:
-    text = value.rstrip()
-    if not text.endswith("]"):
-        return False
-    before_terminal = text[:-1]
-    return before_terminal.count("[") > before_terminal.count("]")
-
-
-def freeform_terminal_bracket_closes_map(line: str) -> bool:
-    return freeform_terminal_bracket_strongly_closes_map(line)
-
-
-def freeform_terminal_bracket_strongly_closes_map(line: str) -> bool:
-    text = line.rstrip()
-    return text.endswith("]]") or text.endswith("] ]")
-
-
-def evidence_excerpt(kind: str, line: str) -> str:
-    if kind == "malformed":
-        return redact_malformed_payload(line)
-    prefix, payload = split_payload(line)
-    if not payload:
-        return mask(line)
-    if payload_has_opaque_field(payload):
-        return f"{mask(prefix)} payload=[redacted-payload]"
-    return f"{mask(prefix)} payload={mask(payload)}"
-
-
-def redact_malformed_payload(line: str) -> str:
-    prefix, payload = split_payload(line)
-    if not payload:
-        return mask(line)
-    return f"{mask(prefix)} payload=[redacted-malformed-payload]"
-
-
-def freeform_payload_start(payload: str) -> int:
-    starts = [idx for key in FREEFORM_PAYLOAD_KEYS if (idx := payload.find(f"{key}:")) >= 0]
-    return min(starts) if starts else len(payload)
-
-
-def payload_has_opaque_field(payload: str) -> bool:
-    if payload.startswith("map["):
-        payload = map_payload_body(payload)
-    return any(key in OPAQUE_PAYLOAD_KEYS for key, _ in top_level_payload_fields(payload))
-
-
-def top_level_payload_fields(payload: str) -> list[tuple[str, str]]:
-    fields, cursor = [], 0
-    while cursor < len(payload):
-        match = next_payload_field(payload, cursor)
-        if not match:
-            break
+    body = map_payload_first_line_body(payload)
+    fields: dict[str, str] = {}
+    for match in PAYLOAD_FIELD_RE.finditer(body):
         key = match.group(1)
-        value_start = match.end()
-        value_end, keep_scanning = top_level_value_end(payload, value_start, key)
-        fields.append((key, payload[value_start:value_end].strip()))
-        if not keep_scanning:
-            break
-        cursor = value_end
+        if key in OPAQUE_PAYLOAD_KEYS:
+            break  # design hard boundary: stop at the first opaque payload key.
+        if key in SAFE_PAYLOAD_KEYS and key not in fields:
+            fields[key] = mask(match.group(2))
     return fields
 
 
-def next_payload_field(payload: str, start: int) -> re.Match | None:
-    for match in PAYLOAD_KEY_RE.finditer(payload, start):
-        if match.group(1) in PAYLOAD_KEYS:
-            return match
-    return None
+def map_payload_first_line_body(payload: str) -> str:
+    # `payload` is the first physical line only. Drop `map[` and, when this is a
+    # single-line payload, the matching trailing `]`. A multi-line payload's
+    # first line has no trailing `]`, and its continuation lines are skipped by
+    # parse_line because they do not start a worker record.
+    body = payload[len("map["):]
+    return body[:-1] if body.endswith("]") else body
 
 
-def top_level_value_end(payload: str, start: int, key: str) -> tuple[int, bool]:
-    value_start = first_non_space(payload, start)
-    if key in OPAQUE_PAYLOAD_KEYS:
-        return len(payload), False
-    bracket_end = bracketed_value_end(payload, value_start)
-    if bracket_end > value_start:
-        return bracket_end, True
-    next_key = next_payload_field_boundary(payload, value_start)
-    return (next_key, True) if next_key >= 0 else (len(payload), False)
-
-
-def first_non_space(text: str, start: int) -> int:
-    while start < len(text) and text[start].isspace():
-        start += 1
-    return start
-
-
-def bracketed_value_end(text: str, start: int) -> int:
-    if text.startswith("map[", start):
-        return scan_balanced(text, start + len("map"), "[", "]")
-    if start < len(text) and text[start] in "[{":
-        return scan_balanced(text, start, text[start], "]" if text[start] == "[" else "}")
-    return -1
-
-
-def scan_balanced(text: str, start: int, opener: str, closer: str) -> int:
-    depth, in_string, escape = 0, False, False
-    for idx in range(start, len(text)):
-        ch = text[idx]
-        if in_string:
-            if escape:
-                escape = False
-            elif ch == "\\":
-                escape = True
-            elif ch == '"':
-                in_string = False
-            continue
-        if ch == '"':
-            in_string = True
-            continue
-        if ch == opener:
-            depth += 1
-            continue
-        if ch == closer and depth:
-            depth -= 1
-            if depth == 0:
-                return idx + 1
-    return -1
-
-
-def next_payload_field_boundary(payload: str, start: int) -> int:
-    for match in PAYLOAD_KEY_RE.finditer(payload, start):
-        if match.group(1) in PAYLOAD_KEYS:
-            return match.start()
-    return -1
+def evidence_excerpt(prefix: str, has_payload: bool) -> str:
+    # The payload region is never reproduced: trusted scalars already live in
+    # metadata, and opaque values are unescaped free-form text.
+    excerpt = mask(prefix)
+    return f"{excerpt} payload=[redacted-payload]" if has_payload else excerpt
 
 
 def add_finding(clusters: dict[str, dict], run_bytes: dict[str, int], finding: dict) -> None:
@@ -456,7 +239,12 @@ def new_cluster(finding: dict) -> dict:
             "Future runs cover this failure class with a reviewed harness surface or a documented no-op decision.",
             "The change remains report/agent/workflow-owned and does not add a worker-side gate or tracker writer.",
         ],
-        "redaction_note": "Evidence stores trusted metadata before opaque payloads; output_head, output_tail, error, arguments, arguments_raw, raw, and params are omitted from excerpts. Clone URL userinfo follows workflow.MaskCloneURL, and token-like values are redacted.",
+        "redaction_note": (
+            "Every payload=map[...] region is omitted from excerpts because Go's %v map rendering is unescaped "
+            "and not reliably parseable. Only trusted top-level scalar metadata before the first opaque payload "
+            "key is kept; output_head, output_tail, error, arguments, arguments_raw, raw, and params are treated "
+            "as opaque. Clone URL userinfo follows workflow.MaskCloneURL, and token-like values are redacted."
+        ),
     }
 
 
@@ -516,8 +304,7 @@ def evidence_array_bytes_after(cluster: dict, entry_size: int) -> int:
 
 def finalize_cluster(cluster: dict) -> dict:
     for key in AFFECTED_KEYS:
-        values = cluster["affected"][key]
-        values.sort()
+        cluster["affected"][key].sort()
     cluster.pop("_evidence_bytes", None)
     cluster.pop("_evidence_count", None)
     enforce_cluster_bound(cluster)

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -30,6 +30,7 @@ import hashlib
 import json
 import re
 import sys
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
@@ -129,13 +130,13 @@ def input_ref(path: Path) -> dict:
     }
 
 
-def parse_worker_log(path: Path) -> list[dict]:
-    findings = []
+def parse_worker_log(path: Path) -> Iterator[dict]:
+    # Yield findings so generate() folds them into bounded cluster state one at a
+    # time; a large log never materializes every hit in memory at once.
     with path.open(encoding="utf-8", errors="replace") as handle:
         for line_no, line in enumerate(handle, 1):
             if parsed := parse_line(path, line_no, line.rstrip("\n")):
-                findings.append(parsed)
-    return findings
+                yield parsed
 
 
 def parse_line(path: Path, line_no: int, line: str) -> dict | None:

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -114,12 +114,18 @@ def generate(paths: list[Path]) -> dict:
 
 
 def input_ref(path: Path) -> dict:
-    data = path.read_bytes()
+    # Stream the digest/byte count so a multi-GB production log is never read
+    # whole into memory; the parser below already reads it line by line.
+    digest, size = hashlib.sha256(), 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+            size += len(chunk)
     return {
         "type": "worker_log",
         "path": mask(str(path)),
-        "bytes": len(data),
-        "sha256": hashlib.sha256(data).hexdigest(),
+        "bytes": size,
+        "sha256": digest.hexdigest(),
     }
 
 

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -13,11 +13,14 @@ values (output, errors, tool arguments, params) can span multiple physical lines
 and contain arbitrary brackets, timestamps, and `event=` text. That rendering is
 a one-way diagnostic format, not a parseable one, so this importer never tries to
 find where a `map[...]` ends. It reads trusted scalar metadata from the first
-physical line only, stops at the first opaque payload key, and treats the rest of
-the payload (including continuation lines) as opaque. The documented cost is that
-scalars Go sorts behind an opaque key (e.g. `tool`, `timeout_ms`, payload
-`session_id`) are not recovered; the harness fix is to make the worker emit a
-structured payload, which this report is meant to surface as an improvement.
+physical line only, as a contiguous left-to-right run of space-free `key:value`
+chunks, stopping at the first chunk that is not a recognized safe scalar (an
+opaque key, an agent-controlled key such as the chosen `tool` name, an
+unrecognized key, or free-form text). The rest of the payload — including
+continuation lines — is treated as opaque. The documented cost is that scalars Go
+sorts behind such a boundary (e.g. `tool`, `timeout_ms`, payload `session_id`)
+are not recovered; the harness fix is to make the worker emit a structured
+payload, which this report is meant to surface as an improvement.
 """
 
 from __future__ import annotations
@@ -36,7 +39,6 @@ MAX_RUN_EVIDENCE_BYTES, MAX_CLUSTER_BYTES, MAX_EVIDENCE_EXCERPT_BYTES = 64 * 102
 MAX_METADATA_BYTES, MAX_METADATA_VALUE_BYTES = 16 * 1024, 4 * 1024
 
 FIELD_RE = re.compile(r'\b(event|task_id|issue_id|issue_identifier|session_id|pr|pr_number|pr_url|pull_request|pull_request_url)=("[^"]*"|\S+)')
-PAYLOAD_FIELD_RE = re.compile(r"(?:^|\s)([A-Za-z0-9_]+):(\S+)")
 CLONE_URL_SCHEME_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9+.-]*://")
 TIMESTAMP_RE = re.compile(r"^(\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?)\b")
 WORKER_RECORD_START_RE = re.compile(r"^\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?\s+event=")
@@ -47,12 +49,18 @@ TOKEN_RE = re.compile(
 )
 PR_KEYS = ("pr", "pr_number", "pr_url", "pull_request", "pull_request_url")
 AFFECTED_KEYS = ("issues", "issue_identifiers", "pull_requests", "runs", "sessions")
-# Free-form payload values: unescaped, possibly multi-line, never parsed. The
-# first of these keys on a record's first line ends trusted scalar extraction.
+# Free-form payload values: unescaped, possibly multi-line, never parsed. They
+# are named in the redaction note; the first of these (or any unrecognized key)
+# on a record's first line ends trusted scalar extraction.
 OPAQUE_PAYLOAD_KEYS = ("arguments", "arguments_raw", "error", "output_head", "output_tail", "params", "raw")
+# Trusted scalars: worker/tracker-generated and space-free by construction. Go
+# renders map values unquoted, so a key whose value can contain a space (e.g. the
+# agent-chosen `tool` name) is NOT listed here — its value tail would otherwise be
+# misread as later top-level keys. Such keys, like any unrecognized key, stop the
+# scan (see scalar_payload).
 SAFE_PAYLOAD_KEYS = set(
     "elapsed_ms timeout_ms duration_ms output_bytes output_dropped model method task_id issue_id "
-    "issue_identifier session_id pr pr_number pr_url pull_request pull_request_url exit_code ok tool".split()
+    "issue_identifier session_id pr pr_number pr_url pull_request pull_request_url exit_code ok".split()
 )
 CLASS_BY_EVENT = {
     "runner_timeout": ("runner-timeout", "Runner timeouts", "runner timeout"),
@@ -180,16 +188,21 @@ def prefix_field_values(prefix: str) -> dict:
 
 
 def scalar_payload(payload: str) -> dict:
+    # Scan the first line's map body as a left-to-right run of space-separated
+    # `key:value` chunks. Stop at the first chunk that is not a recognized safe
+    # scalar — an opaque key, an agent-controlled key, an unrecognized key, or
+    # free-form text. Because Go renders values unquoted, this contiguous-run
+    # boundary is the only sound way to avoid promoting text inside an earlier
+    # value as if it were a later top-level key.
     if not payload.startswith("map["):
         return {}
-    body = map_payload_first_line_body(payload)
     fields: dict[str, str] = {}
-    for match in PAYLOAD_FIELD_RE.finditer(body):
-        key = match.group(1)
-        if key in OPAQUE_PAYLOAD_KEYS:
-            break  # design hard boundary: stop at the first opaque payload key.
-        if key in SAFE_PAYLOAD_KEYS and key not in fields:
-            fields[key] = mask(match.group(2))
+    for chunk in map_payload_first_line_body(payload).split():
+        key, sep, value = chunk.partition(":")
+        if not sep or key not in SAFE_PAYLOAD_KEYS:
+            break
+        if key not in fields:
+            fields[key] = mask(value)
     return fields
 
 

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -224,11 +224,11 @@ def evidence_excerpt(prefix: str, has_payload: bool) -> str:
 
 def add_finding(clusters: dict[str, dict], run_bytes: dict[str, int], finding: dict) -> None:
     cluster = clusters.setdefault(finding["id"], new_cluster(finding))
-    add_unique(cluster["affected"]["issues"], finding["issue"])
-    add_unique(cluster["affected"]["issue_identifiers"], finding["identifier"])
-    add_unique(cluster["affected"]["pull_requests"], finding["pull_request"])
-    add_unique(cluster["affected"]["runs"], finding["run"])
-    add_unique(cluster["affected"]["sessions"], finding["session"])
+    add_unique(cluster, "issues", finding["issue"])
+    add_unique(cluster, "issue_identifiers", finding["identifier"])
+    add_unique(cluster, "pull_requests", finding["pull_request"])
+    add_unique(cluster, "runs", finding["run"])
+    add_unique(cluster, "sessions", finding["session"])
     entry, entry_size = bounded_evidence_entry(cluster, run_bytes, finding)
     if not entry:
         return
@@ -244,6 +244,8 @@ def new_cluster(finding: dict) -> dict:
         "symptom_class": finding["symptom"],
         "affected": {"issues": [], "issue_identifiers": [], "pull_requests": [], "runs": [], "sessions": []},
         "evidence": [],
+        # O(1) dedup membership per affected key; emitted arrays stay sorted.
+        "_seen": {key: set() for key in AFFECTED_KEYS},
         "_evidence_bytes": byte_len("[]"),
         "_evidence_count": 0,
         "suspected_harness_surface": "WORKFLOW.md, reviewer rubrics, skills, hooks, tests, CI, or docs",
@@ -318,6 +320,7 @@ def evidence_array_bytes_after(cluster: dict, entry_size: int) -> int:
 def finalize_cluster(cluster: dict) -> dict:
     for key in AFFECTED_KEYS:
         cluster["affected"][key].sort()
+    cluster.pop("_seen", None)  # drop before any encoded_bytes call: sets are not JSON-serializable.
     cluster.pop("_evidence_bytes", None)
     cluster.pop("_evidence_count", None)
     enforce_cluster_bound(cluster)
@@ -374,10 +377,14 @@ def trim_evidence_to_cluster_bound(cluster: dict) -> None:
         cluster["evidence"].pop()
 
 
-def add_unique(values: list[str], value: str) -> None:
+def add_unique(cluster: dict, key: str, value: str) -> None:
     value = value.strip()
-    if value and value not in values:
-        values.append(value)
+    if not value:
+        return
+    seen = cluster["_seen"][key]
+    if value not in seen:  # set membership keeps large-log accumulation linear.
+        seen.add(value)
+        cluster["affected"][key].append(value)
 
 
 def first_mapped_value(primary: dict, secondary: dict, keys: tuple[str, ...]) -> str:

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -351,6 +351,32 @@ func TestTraceHarnessReportScriptDoesNotExtractScalarsBuriedAfterOpaqueKey(t *te
 	}
 }
 
+func TestTraceHarnessReportScriptDoesNotSmuggleFakeFieldsViaUnquotedToolValue(t *testing.T) {
+	root := repoRoot(t)
+	// An unsupported_tool_call with no thread context renders `tool` first (no
+	// key sorts before it). `tool` is agent-controlled and Go renders it
+	// unquoted, so a tool name carrying spaces and key-shaped text would, if
+	// `tool` were a recognized safe scalar, resync the scan onto the embedded
+	// `session_id:`/`pr_url:` fragments. The scan must instead stop at the
+	// `tool` chunk, so no fake top-level scalar is promoted.
+	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=real-run issue_id=real-issue msg="unsupported" payload=map[tool:evil session_id:GHOST-SESSION pr_url:https://ghost/pull/1 turn_id:U]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "tool-unsupported")
+	if contains(cluster.Affected.Sessions, "GHOST-SESSION") || contains(cluster.Affected.PullRequests, "https://ghost/pull/1") {
+		t.Fatalf("unquoted tool value smuggled fake top-level fields: %#v", cluster.Affected)
+	}
+	meta := cluster.Evidence[0].Metadata
+	for _, key := range []string{"tool", "session_id", "pr_url"} {
+		if got, ok := meta[key]; ok {
+			t.Fatalf("Metadata[%s] = %q; want absent (scan must stop at the agent-controlled tool chunk)", key, got)
+		}
+	}
+	if !contains(cluster.Affected.Runs, "real-run") || !contains(cluster.Affected.Issues, "real-issue") {
+		t.Fatalf("prefix ids were dropped: %#v", cluster.Affected)
+	}
+}
+
 func TestTraceHarnessReportScriptDoesNotPromoteIdentifiersFromOpaquePayload(t *testing.T) {
 	root := repoRoot(t)
 	body := `2026/06/18 09:00:00 event=runner_timeout task_id=run-real issue_id=issue-real msg="timeout" payload=map[output_head:issue_id:ghost-issue session_id:ghost-session]` + "\n"

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -1,0 +1,1737 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestTraceHarnessReportRunbookDocumentsSupportedInputsAndBounds(t *testing.T) {
+	root := repoRoot(t)
+	readme, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if !strings.Contains(string(readme), "docs/runbooks/trace-harness-report.md") {
+		t.Fatalf("README does not link the trace harness report runbook")
+	}
+
+	path := filepath.Join(root, "docs", "runbooks", "trace-harness-report.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(body)
+	normalizedText := strings.Join(strings.Fields(text), " ")
+	for _, want := range []string{
+		"python3 scripts/trace-harness-report.py",
+		"--worker-log",
+		"Supported inputs",
+		"worker process logs",
+		"64 KiB per run",
+		"256 KiB per cluster",
+		"does not mutate tracker state",
+		"does not open PRs",
+		"does not edit prompts",
+		"does not create a worker phase",
+		"MaskCloneURL",
+		"before the first opaque payload key",
+		"does not parse GraphQL",
+		"hard boundary",
+		"ambiguous multiline closures",
+		"prefers omission over fabricating affected issues",
+		"cannot prove",
+		"known scalar metadata is byte-bounded per field and in aggregate",
+		"Unsupported inputs",
+		"workspace `.aiops` artifacts",
+		"Examples",
+	} {
+		if !strings.Contains(normalizedText, want) {
+			t.Fatalf("runbook missing %q\n%s", want, text)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptGroupsWorkerLogsAndRedactsCloneURLs(t *testing.T) {
+	root := repoRoot(t)
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "worker.log")
+	secretURL := "https://user:secret@example.test/org/repo.git"
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 issue_identifier=GH-1 session_id=session-1 msg="timeout" payload=map[elapsed_ms:60000 output_bytes:70000 output_dropped:12 output_head:` + secretURL + `]`,
+		`2026/06/18 09:01:00 event=turn_input_required task_id=issue-2 issue_id=issue-2 issue_identifier=GH-2 session_id=session-2 msg="input" payload=map[method:approval]`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(logPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	jsonPath := filepath.Join(dir, "report.json")
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "trace-harness-report.py"), "--worker-log", logPath, "--json-out", jsonPath)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("trace-harness-report failed: %v\n%s", err, out)
+	}
+
+	raw, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report struct {
+		SchemaVersion string `json:"schema_version"`
+		Clusters      []struct {
+			ID       string `json:"id"`
+			Affected struct {
+				Issues   []string `json:"issues"`
+				Sessions []string `json:"sessions"`
+			} `json:"affected"`
+			Evidence []struct {
+				Excerpt  string            `json:"excerpt"`
+				Metadata map[string]string `json:"metadata"`
+			} `json:"evidence"`
+			RedactionNote string `json:"redaction_note"`
+		} `json:"clusters"`
+	}
+	if err := json.Unmarshal(raw, &report); err != nil {
+		t.Fatalf("unmarshal report: %v\n%s", err, raw)
+	}
+	if report.SchemaVersion != "trace-harness-report/v1" || len(report.Clusters) != 2 {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+	timeout := report.Clusters[1]
+	if timeout.ID != "runner-timeout" || !contains(timeout.Affected.Issues, "issue-1") || !contains(timeout.Affected.Sessions, "session-1") {
+		t.Fatalf("timeout cluster missing affected fields: %#v", timeout)
+	}
+	if timeout.Evidence[0].Metadata["timestamp"] != "2026/06/18 09:00:00" {
+		t.Fatalf("timeout timestamp metadata = %#v", timeout.Evidence[0].Metadata)
+	}
+	if timeout.Evidence[0].Metadata["output_bytes"] != "70000" || timeout.Evidence[0].Metadata["output_dropped"] != "12" {
+		t.Fatalf("timeout metadata = %#v", timeout.Evidence[0].Metadata)
+	}
+	if strings.Contains(string(raw), "secret") || !strings.Contains(timeout.Evidence[0].Excerpt, "payload=[redacted-payload]") {
+		t.Fatalf("report leaked or retained opaque runner output:\n%s", raw)
+	}
+	for _, want := range []string{"output_head", "output_tail", "error", "arguments", "raw", "params"} {
+		if !strings.Contains(timeout.RedactionNote, want) {
+			t.Fatalf("redaction note missing omitted payload %q: %q", want, timeout.RedactionNote)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptUsesPayloadSessionID(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:01:00 event=turn_input_required task_id=issue-2 issue_id=issue-2 issue_identifier=GH-2 msg="input" payload=map[method:approval session_id:payload-session]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "input-required")
+	if !contains(cluster.Affected.Sessions, "payload-session") {
+		t.Fatalf("payload session_id was not reported as affected: %#v", cluster.Affected.Sessions)
+	}
+}
+
+func TestTraceHarnessReportScriptUsesPayloadIssueAndRunIDs(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:01:00 event=runner_timeout msg="timeout" payload=map[task_id:payload-run issue_id:payload-issue issue_identifier:PAY-1 timeout_ms:60000]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if !contains(cluster.Affected.Issues, "payload-issue") {
+		t.Fatalf("payload issue_id was not reported as affected: %#v", cluster.Affected.Issues)
+	}
+	if !contains(cluster.Affected.Runs, "payload-run") {
+		t.Fatalf("payload task_id was not reported as affected run: %#v", cluster.Affected.Runs)
+	}
+	if !contains(cluster.Affected.IssueIdentifiers, "PAY-1") {
+		t.Fatalf("payload issue_identifier was not reported as affected: %#v", cluster.Affected.IssueIdentifiers)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksMalformedCloneURLUserinfo(t *testing.T) {
+	root := repoRoot(t)
+	for _, secretURL := range []string{
+		"https://user:bad token@example.test/org/repo.git",
+		"https://:secret@example.test/org/repo.git",
+	} {
+		body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
+		raw := runTraceHarnessReportRaw(t, root, body)
+		if strings.Contains(string(raw), "secret") || strings.Contains(string(raw), "bad token") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
+			t.Fatalf("report leaked or retained malformed userinfo from opaque output %q:\n%s", secretURL, raw)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptMasksMalformedCloneURLUserinfoWithBracket(t *testing.T) {
+	root := repoRoot(t)
+	secretURL := "https://user:tok]en@example.test/org/repo.git"
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+
+	if strings.Contains(string(raw), "tok]en") || strings.Contains(string(raw), "user:") {
+		t.Fatalf("report leaked malformed bracket userinfo:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksMalformedCloneURLUserinfoInMetadata(t *testing.T) {
+	root := repoRoot(t)
+	secretURL := "https://user:tok]en@example.test/org/repo.git"
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:` + secretURL + `]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+
+	if strings.Contains(string(raw), "tok]en") || strings.Contains(string(raw), "user:") {
+		t.Fatalf("report leaked malformed bracket userinfo in metadata:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksHTTPCloneURLUserinfo(t *testing.T) {
+	root := repoRoot(t)
+	secretURL := "http://user:secret@example.test/org/repo.git"
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	if strings.Contains(string(raw), "secret") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
+		t.Fatalf("report leaked or retained HTTP userinfo from opaque output:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksSSHCloneURLUserinfo(t *testing.T) {
+	root := repoRoot(t)
+	secretURL := "ssh://user:secret@example.test/org/repo.git"
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	if strings.Contains(string(raw), "secret") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
+		t.Fatalf("report leaked or retained SSH userinfo from opaque output:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksGenericSchemeCloneURLUserinfo(t *testing.T) {
+	root := repoRoot(t)
+	for _, secretURL := range []string{
+		"git://user:secret@example.test/org/repo.git",
+		"rsync://user:secret@example.test/org/repo.git",
+		"file://user:secret@example.test/org/repo.git",
+	} {
+		body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
+		raw := runTraceHarnessReportRaw(t, root, body)
+		if strings.Contains(string(raw), "secret") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
+			t.Fatalf("report leaked or retained generic scheme userinfo from opaque output:\n%s", raw)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptMasksTokenLikeSecrets(t *testing.T) {
+	root := repoRoot(t)
+	for _, token := range []string{
+		"ghp_" + strings.Repeat("a", 36),
+		"lin_api_" + strings.Repeat("a", 40),
+	} {
+		body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:` + token + ` output_head:` + token + `]` + "\n"
+		raw := runTraceHarnessReportRaw(t, root, body)
+
+		if strings.Contains(string(raw), token) || !strings.Contains(string(raw), "payload=[redacted-payload]") || !strings.Contains(string(raw), "[redacted-error]") {
+			t.Fatalf("report leaked or retained token-like opaque payload %q:\n%s", token, raw)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptMasksPrefixAffectedFields(t *testing.T) {
+	root := repoRoot(t)
+	token := "ghp_" + strings.Repeat("a", 36)
+	secretPR := "https://user:secret@example.test/org/repo/pull/1"
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 session_id=` + token + ` pr_url=` + secretPR + ` msg="timeout"` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	maskedPR := workflow.MaskCloneURL(secretPR)
+
+	if strings.Contains(string(raw), token) || strings.Contains(string(raw), "user:secret") || !strings.Contains(string(raw), "[redacted-token]") || !strings.Contains(string(raw), maskedPR) {
+		t.Fatalf("report leaked prefix affected fields:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksInputPathRefs(t *testing.T) {
+	root := repoRoot(t)
+	token := "ghp_" + strings.Repeat("a", 36)
+	dir := filepath.Join(t.TempDir(), token)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("mkdir token path: %v", err)
+	}
+	logPath := filepath.Join(dir, "worker.log")
+	body := []byte(`2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout"` + "\n")
+	if err := os.WriteFile(logPath, body, 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	raw := runTraceHarnessReportRawPath(t, root, logPath)
+
+	if strings.Contains(string(raw), token) || !strings.Contains(string(raw), "[redacted-token]") {
+		t.Fatalf("report leaked token-like input path:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksInputPathErrors(t *testing.T) {
+	root := repoRoot(t)
+	token := "ghp_" + strings.Repeat("a", 36)
+	missing := filepath.Join(t.TempDir(), token, "missing.log")
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "trace-harness-report.py"), "--worker-log", missing)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("trace-harness-report unexpectedly succeeded for missing log:\n%s", out)
+	}
+	if strings.Contains(string(out), token) || !strings.Contains(string(out), "[redacted-token]") {
+		t.Fatalf("stderr leaked token-like input path:\n%s", out)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksOutputPathErrors(t *testing.T) {
+	root := repoRoot(t)
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "worker.log")
+	body := []byte(`2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout"` + "\n")
+	if err := os.WriteFile(logPath, body, 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	token := "ghp_" + strings.Repeat("a", 36)
+	jsonPath := filepath.Join(dir, token, "report.json")
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "trace-harness-report.py"), "--worker-log", logPath, "--json-out", jsonPath)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("trace-harness-report unexpectedly wrote missing output path:\n%s", out)
+	}
+	if strings.Contains(string(out), token) || !strings.Contains(string(out), "[redacted-token]") {
+		t.Fatalf("stderr leaked token-like output path:\n%s", out)
+	}
+}
+
+func TestTraceHarnessReportScriptBoundsExcerptsByBytes(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="` + strings.Repeat("界", 5000) + `"` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if got := len([]byte(cluster.Evidence[0].Excerpt)); got > 4*1024 {
+		t.Fatalf("excerpt byte length = %d; want <= 4096", got)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsAffectedIDsWhenEvidenceIsCapped(t *testing.T) {
+	root := repoRoot(t)
+	lines := make([]string, 0, 17)
+	for idx := 1; idx <= 17; idx++ {
+		lines = append(lines, `2026/06/18 09:00:00 event=runner_timeout task_id=run-1 issue_id=issue-`+string(rune('A'+idx-1))+` msg="`+strings.Repeat("x", 5000)+`"`)
+	}
+	report := runTraceHarnessReport(t, root, strings.Join(lines, "\n")+"\n")
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if !contains(cluster.Affected.Issues, "issue-Q") {
+		t.Fatalf("capped evidence dropped affected issue ids: %#v", cluster.Affected.Issues)
+	}
+}
+
+func TestTraceHarnessReportScriptBoundsFullEvidenceEntriesByBytes(t *testing.T) {
+	root := repoRoot(t)
+	var body strings.Builder
+	for idx := 0; idx < 4000; idx++ {
+		fmt.Fprintf(&body, "2026/06/18 09:00:00 event=runner_timeout task_id=run-%d issue_id=issue-shared msg=\"x\"\n", idx%16)
+	}
+	report := runTraceHarnessReport(t, root, body.String())
+
+	cluster := findCluster(t, report, "runner-timeout")
+	raw, err := json.Marshal(cluster.Evidence)
+	if err != nil {
+		t.Fatalf("marshal evidence: %v", err)
+	}
+	if len(raw) > 256*1024 {
+		t.Fatalf("cluster evidence bytes = %d; want <= 262144", len(raw))
+	}
+	if !contains(cluster.Affected.Issues, "issue-shared") {
+		t.Fatalf("affected ids stopped when evidence cap was reached: %#v", cluster.Affected.Issues)
+	}
+}
+
+func TestTraceHarnessReportScriptBoundsFullClusterByBytes(t *testing.T) {
+	root := repoRoot(t)
+	var body strings.Builder
+	for idx := 0; idx < 12000; idx++ {
+		fmt.Fprintf(&body, "2026/06/18 09:00:00 event=runner_timeout task_id=run-%d issue_id=issue-%d session_id=session-%d msg=\"x\"\n", idx%64, idx, idx)
+	}
+	rawReport := runTraceHarnessReportRaw(t, root, body.String())
+
+	var raw struct {
+		Clusters []json.RawMessage `json:"clusters"`
+	}
+	if err := json.Unmarshal(rawReport, &raw); err != nil {
+		t.Fatalf("unmarshal raw report: %v\n%s", err, rawReport)
+	}
+	if len(raw.Clusters) != 1 {
+		t.Fatalf("raw cluster count = %d; want 1\n%s", len(raw.Clusters), rawReport)
+	}
+	if len(raw.Clusters[0]) > 256*1024 {
+		t.Fatalf("emitted cluster bytes = %d; want <= 262144", len(raw.Clusters[0]))
+	}
+
+	var report traceReport
+	if err := json.Unmarshal(rawReport, &report); err != nil {
+		t.Fatalf("unmarshal typed report: %v\n%s", err, rawReport)
+	}
+	cluster := findCluster(t, report, "runner-timeout")
+	if len(cluster.Evidence) == 0 {
+		t.Fatalf("cluster evidence count = 0; want at least 1; omitted=%#v issues=%d sessions=%d", cluster.Affected.Omitted, len(cluster.Affected.Issues), len(cluster.Affected.Sessions))
+	}
+	encoded, err := json.Marshal(cluster)
+	if err != nil {
+		t.Fatalf("marshal cluster: %v", err)
+	}
+	if len(encoded) > 256*1024 {
+		t.Fatalf("typed cluster bytes = %d; want <= 262144", len(encoded))
+	}
+	if got := cluster.Affected.Omitted["issues"]; got == 0 {
+		t.Fatalf("affected omitted counts were not reported: %#v", cluster.Affected.Omitted)
+	}
+}
+
+func TestTraceHarnessReportScriptBoundsLargeScalarMetadata(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[model:` + strings.Repeat("m", 300*1024) + ` timeout_ms:60000]` + "\n"
+	rawReport := runTraceHarnessReportRaw(t, root, body)
+
+	var raw struct {
+		Clusters []json.RawMessage `json:"clusters"`
+	}
+	if err := json.Unmarshal(rawReport, &raw); err != nil {
+		t.Fatalf("unmarshal raw report: %v\n%s", err, rawReport)
+	}
+	if len(raw.Clusters) != 1 || len(raw.Clusters[0]) > 256*1024 {
+		t.Fatalf("raw clusters = %d, first bytes = %d; want one cluster <= 262144", len(raw.Clusters), len(raw.Clusters[0]))
+	}
+
+	report := runTraceHarnessReport(t, root, body)
+	cluster := findCluster(t, report, "runner-timeout")
+	if len(cluster.Evidence) == 0 {
+		t.Fatalf("large scalar metadata dropped all evidence")
+	}
+	model := cluster.Evidence[0].Metadata["model"]
+	if len([]byte(model)) > 4*1024 || !strings.Contains(model, "[truncated]") {
+		t.Fatalf("model metadata was not byte-bounded: len=%d value suffix=%q", len([]byte(model)), model[max(0, len(model)-32):])
+	}
+}
+
+func TestTraceHarnessReportScriptBoundsLargeScalarMetadataAcrossFields(t *testing.T) {
+	root := repoRoot(t)
+	large := strings.Repeat("m", 8*1024)
+	keys := []string{
+		"elapsed_ms",
+		"timeout_ms",
+		"duration_ms",
+		"output_bytes",
+		"output_dropped",
+		"model",
+		"method",
+		"session_id",
+		"pr",
+		"pr_number",
+		"pr_url",
+		"pull_request",
+		"pull_request_url",
+		"exit_code",
+		"error",
+		"ok",
+	}
+	var payload strings.Builder
+	for _, key := range keys {
+		fmt.Fprintf(&payload, " %s:%s", key, large)
+	}
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[` + strings.TrimSpace(payload.String()) + `]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if len(cluster.Evidence) == 0 {
+		t.Fatalf("large aggregate scalar metadata dropped all evidence")
+	}
+	rawMetadata, err := json.Marshal(cluster.Evidence[0].Metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if len(rawMetadata) > 16*1024 {
+		t.Fatalf("metadata bytes = %d; want <= 16384", len(rawMetadata))
+	}
+}
+
+func TestTraceHarnessReportScriptReportsAffectedPullRequests(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[pr_number:938]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if !contains(cluster.Affected.PullRequests, "938") {
+		t.Fatalf("pull request id was not reported as affected: %#v", cluster.Affected.PullRequests)
+	}
+}
+
+func TestTraceHarnessReportScriptClassifiesMalformedProtocolSeparately(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=malformed task_id=issue-1 issue_id=issue-1 msg="bad protocol line"` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 1 || report.Clusters[0].ID != "malformed-protocol" {
+		t.Fatalf("malformed event clusters = %#v; want malformed-protocol only", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresPlainEventText(t *testing.T) {
+	root := repoRoot(t)
+	body := `agent output says event=runner_timeout task_id=fake issue_id=fake` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("plain event-shaped text became report evidence: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresTimestampedProseEventText(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 agent output says event=runner_timeout task_id=fake issue_id=fake` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("timestamped prose became report evidence: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresKeyShapedTextInsideMessage(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="agent says task_id=fake issue_id=fake" payload=map[timeout_ms:60000]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+		t.Fatalf("message text overrode trusted prefix fields: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if !contains(cluster.Affected.Issues, "issue-real") || !contains(cluster.Affected.Runs, "issue-real") {
+		t.Fatalf("trusted prefix fields missing: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotSwallowPayloadlessEventAfterMultilineOutput(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[output_head:agent started`,
+		`agent output finished]]`,
+		`2026/06/18 09:00:01 event=malformed task_id=issue-malformed issue_id=issue-malformed msg="bad protocol line"`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	timeout := findCluster(t, report, "runner-timeout")
+	if !contains(timeout.Affected.Issues, "issue-timeout") || contains(timeout.Affected.Issues, "issue-malformed") {
+		t.Fatalf("runner-timeout affected issues = %#v; want issue-timeout only", timeout.Affected.Issues)
+	}
+	malformed := findCluster(t, report, "malformed-protocol")
+	if !contains(malformed.Affected.Issues, "issue-malformed") {
+		t.Fatalf("payloadless malformed event after multiline output was swallowed: %#v", malformed.Affected.Issues)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteEventAfterKeyShapedOpaqueLine(t *testing.T) {
+	root := repoRoot(t)
+	for _, key := range []string{"arguments", "arguments_raw", "error", "output_head", "output_tail", "params", "raw"} {
+		t.Run(key, func(t *testing.T) {
+			body := strings.Join([]string{
+				`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 ` + key + `:first line`,
+				`timeout_ms:123]`,
+				`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from opaque"`,
+				`tail done]]`,
+			}, "\n") + "\n"
+			report := runTraceHarnessReport(t, root, body)
+
+			cluster := findCluster(t, report, "runner-timeout")
+			if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+				t.Fatalf("%s opaque payload promoted fake event: issues=%#v runs=%#v", key, cluster.Affected.Issues, cluster.Affected.Runs)
+			}
+			if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+				t.Fatalf("%s elapsed_ms before opaque text = %q; want 70000; metadata=%#v", key, got, cluster.Evidence[0].Metadata)
+			}
+		})
+	}
+}
+
+func TestTraceHarnessReportScriptClassifiesFailedRunnerEndDespiteOutputOKText(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:boom output_head:agent-text-ok:true]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if !contains(cluster.Affected.Issues, "issue-1") {
+		t.Fatalf("runner_end failure was not grouped: %#v", cluster.Affected.Issues)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLSelectionSetFromRunnerErrorExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:GraphQL request: { issue(id:"secret-id") { id title } }]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if got := cluster.Evidence[0].Metadata["ok"]; got != "false" {
+		t.Fatalf("ok metadata after runner error GraphQL redaction = %q; want false; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"issue(id:", "secret-id", "{ id title }"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("runner error selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") || cluster.Evidence[0].Metadata["error"] != "[redacted-error]" {
+		t.Fatalf("runner error payload was not replaced with opaque redaction markers:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLFromRunnerErrorMetadata(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:Linear GraphQL failed: query SecretQuery($secret: String = "not-a-token-secret") { viewer { id } }]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "runner-failure")
+	metadata := cluster.Evidence[0].Metadata
+	if got := metadata["error"]; got != "[redacted-error]" {
+		t.Fatalf("runner error metadata = %q; want opaque redacted marker; metadata=%#v", got, metadata)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"SecretQuery", "$secret", "not-a-token-secret", "viewer { id }"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("runner error GraphQL metadata leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLBracketStringFromRunnerErrorMetadata(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:GraphQL request: query { issue(id:"]secret") { id title } }]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
+		t.Fatalf("runner error bracket metadata = %q; want opaque redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"]secret", "issue(id:", "{ id title }"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("runner error bracket GraphQL metadata leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteGraphQLDefaultKeyShapeFromRunnerErrorMetadata(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:Linear GraphQL failed: query SecretQuery($secret: String = " session_id:fake-session") { viewer { id } }]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if contains(cluster.Affected.Sessions, "fake-session") {
+		t.Fatalf("GraphQL default session_id was promoted into affected sessions: %#v", cluster.Affected.Sessions)
+	}
+	metadata := cluster.Evidence[0].Metadata
+	if got := metadata["error"]; got != "[redacted-error]" {
+		t.Fatalf("runner error default metadata = %q; want opaque redacted marker; metadata=%#v", got, metadata)
+	}
+	if got := metadata["session_id"]; strings.Contains(got, "fake-session") {
+		t.Fatalf("GraphQL default session_id was promoted into metadata: %#v", metadata)
+	}
+	if strings.Contains(string(raw), "fake-session") {
+		t.Fatalf("GraphQL default key-shaped value leaked in report:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsMultiWordRunnerErrorMetadata(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:agent crashed after checkout output_head:tail]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
+		t.Fatalf("multi-word runner error metadata = %q; want redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteKeyShapedRunnerErrorText(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:agent crashed with session_id:fake-session pr_number:777 after checkout output_head:tail]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if contains(cluster.Affected.Sessions, "fake-session") {
+		t.Fatalf("runner error text session_id was promoted: %#v", cluster.Affected.Sessions)
+	}
+	if contains(cluster.Affected.PullRequests, "777") {
+		t.Fatalf("runner error text pr_number was promoted: %#v", cluster.Affected.PullRequests)
+	}
+	metadata := cluster.Evidence[0].Metadata
+	for _, key := range []string{"session_id", "pr_number"} {
+		if _, ok := metadata[key]; ok {
+			t.Fatalf("runner error text %s was promoted into metadata: %#v", key, metadata)
+		}
+	}
+	if got := metadata["error"]; got != "[redacted-error]" {
+		t.Fatalf("runner error metadata = %q; want opaque redacted marker; metadata=%#v", got, metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsOrdinaryQueryWordRunnerErrorMetadata(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:database query failed after checkout output_head:tail]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
+		t.Fatalf("ordinary query-word runner error metadata = %q; want redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsOrdinaryQueryWordRunnerErrorBeforeFreeformBraces(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:database query failed after checkout output_head:agent {not graphql}]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
+		t.Fatalf("ordinary query-word runner error before freeform braces = %q; want redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsOrdinaryQueryWordRunnerErrorWithJSONBraces(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:database query failed: {"code":500} after checkout output_head:tail]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
+		t.Fatalf("ordinary query-word runner error with JSON braces = %q; want redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresOutputFailureTextForSuccessfulRunnerEnd(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner completed" payload=map[ok:true output_head:agent-text-ok:false]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("successful runner_end should not be grouped as failure: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptTrustsRunnerEndOKMetadataOverFailureMessage(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:true output_head:tail]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("runner_end ok:true should not be grouped as failure despite message text: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotParseOutputTextAsPayloadFields(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner completed" payload=map[ok:true output_head:agent text ok:false runner failed]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("output text should not override runner_end payload fields: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteOutputTextIdentifiers(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:agent text session_id:fake-session pr_number:777 error:boom ok:false]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Sessions, "fake-session") {
+		t.Fatalf("output text session_id was promoted: %#v", cluster.Affected.Sessions)
+	}
+	if contains(cluster.Affected.PullRequests, "777") {
+		t.Fatalf("output text pr_number was promoted: %#v", cluster.Affected.PullRequests)
+	}
+	metadata := cluster.Evidence[0].Metadata
+	for _, key := range []string{"error", "ok"} {
+		if _, ok := metadata[key]; ok {
+			t.Fatalf("output text %s was promoted into metadata: %#v", key, metadata)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptStopsMetadataAtOutputText(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent [ text session_id:fake-session pr_number:777 error:boom ok:false timeout_ms:111 output_tail:tail text timeout_ms:999 timeout_ms:60000]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("elapsed_ms before output text = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+	if _, ok := cluster.Evidence[0].Metadata["timeout_ms"]; ok {
+		t.Fatalf("timeout_ms after opaque output was promoted: %#v", cluster.Evidence[0].Metadata)
+	}
+	if _, ok := cluster.Evidence[0].Metadata["error"]; ok {
+		t.Fatalf("output text error was promoted into metadata: %#v", cluster.Evidence[0].Metadata)
+	}
+	if _, ok := cluster.Evidence[0].Metadata["ok"]; ok {
+		t.Fatalf("output text ok was promoted into metadata: %#v", cluster.Evidence[0].Metadata)
+	}
+	if contains(cluster.Affected.Sessions, "fake-session") || contains(cluster.Affected.PullRequests, "777") {
+		t.Fatalf("output text identifiers were promoted: sessions=%#v prs=%#v", cluster.Affected.Sessions, cluster.Affected.PullRequests)
+	}
+}
+
+func TestTraceHarnessReportScriptTreatsUnbalancedBracketScalarBeforeOpaqueAsOpaqueBoundary(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[model:[codex output_head:SECRET timeout_ms:60000]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if strings.Contains(mustJSON(t, report), "SECRET") {
+		t.Fatalf("unbalanced safe scalar hid opaque output text: %#v", cluster)
+	}
+	if !strings.Contains(cluster.Evidence[0].Excerpt, "payload=[redacted-payload]") {
+		t.Fatalf("unbalanced safe scalar excerpt was not redacted: %q", cluster.Evidence[0].Excerpt)
+	}
+	if _, ok := cluster.Evidence[0].Metadata["timeout_ms"]; ok {
+		t.Fatalf("metadata after opaque output was promoted: %#v", cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptStopsMetadataAtMultilineOutputText(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text session_id:fake-session pr_number:777 ok:false`,
+		`2026/06/18 09:00:01 output line with timeout_ms:111 but no event marker`,
+		`output_tail:tail text timeout_ms:999 timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("elapsed_ms before multiline output text = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+	if _, ok := cluster.Evidence[0].Metadata["timeout_ms"]; ok {
+		t.Fatalf("multiline timeout_ms after opaque output was promoted: %#v", cluster.Evidence[0].Metadata)
+	}
+	if contains(cluster.Affected.Sessions, "fake-session") || contains(cluster.Affected.PullRequests, "777") {
+		t.Fatalf("multiline output text identifiers were promoted: sessions=%#v prs=%#v", cluster.Affected.Sessions, cluster.Affected.PullRequests)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsEventShapedMultilineOutputInSameRecord(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
+		`output_tail:tail text timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Sessions, "fake") {
+		t.Fatalf("event-shaped output line was promoted: issues=%#v sessions=%#v", cluster.Affected.Issues, cluster.Affected.Sessions)
+	}
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("event-shaped multiline elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsBracketedEventShapedOutputInSameRecord(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent ] text`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
+		`output_tail:tail text timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+		t.Fatalf("bracketed event-shaped output line was promoted: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("bracketed event-shaped multiline elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsBracketTerminatedOutputLineInSameRecord(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
+		`stack frame [done]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
+		`output_tail:tail text timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+		t.Fatalf("bracket-terminated output line promoted event-shaped output: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("bracket-terminated multiline elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsSingleLineBracketedOpaquePayloadOpen(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:stack [done]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
+		`output_tail:tail text timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+		t.Fatalf("single-line bracketed opaque payload promoted fake event: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("single-line bracketed opaque payload elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsBareBracketOutputLineInSameRecordWhenTailFollows(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
+		`stack frame done]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
+		`output_tail:tail text timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+		t.Fatalf("bare bracket output line promoted event-shaped output: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("bare bracket output multiline elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsPayloadEventShapedOutputAfterBareBracketLineUntilTail(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
+		`stack frame done]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output" payload=map[timeout_ms:123]`,
+		`output_tail:tail text timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+		t.Fatalf("payload-bearing event-shaped output line was promoted: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("payload-bearing event-shaped output elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsBareBracketOutputLineBeforePayloadlessEventText(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
+		`stack frame done]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
+		`more output after event-shaped text`,
+		`output_tail:tail text timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+		t.Fatalf("payloadless event-shaped output line was promoted: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("payloadless event-shaped output elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsOrdinaryOutputAfterBareBracketLineUntilTail(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:first line`,
+		`stack frame done]`,
+		`ordinary output after bracket`,
+		`output_tail:tail timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("ordinary output after bracket elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteEventAfterKeyShapedOutputLine(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:first line`,
+		`timeout_ms:123]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
+		`output_tail:tail text timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
+		t.Fatalf("event after key-shaped output line was promoted: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("elapsed_ms before key-shaped output line = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotSwallowNextEventAfterBracketedOutputHeadCloses(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
+		`[INFO]]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if !contains(cluster.Affected.Issues, "issue-timeout") || !contains(cluster.Affected.Runs, "issue-timeout") {
+		t.Fatalf("timeout after bracketed output_head close was swallowed: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["timeout_ms"]; got != "60000" {
+		t.Fatalf("timeout after bracketed output_head close timeout_ms = %q; want 60000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotSwallowNextEventAfterSpacedBracketOutputHeadCloses(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
+		`[INFO] ]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if !contains(cluster.Affected.Issues, "issue-timeout") || !contains(cluster.Affected.Runs, "issue-timeout") {
+		t.Fatalf("timeout after spaced bracket output_head close was swallowed: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
+	}
+	if got := cluster.Evidence[0].Metadata["timeout_ms"]; got != "60000" {
+		t.Fatalf("timeout after spaced bracket output_head close timeout_ms = %q; want 60000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteAmbiguousEventAfterOutputHeadOnlyMultiline(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
+		`last line]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from opaque output" payload=map[timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("ambiguous event-shaped output after single-bracket close was promoted: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteAmbiguousClosedNextEventBeforeOrdinaryLog(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
+		`last line]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[timeout_ms:60000]`,
+		`ordinary log after timeout`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("ambiguous closed event-shaped output before ordinary log was promoted: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteAmbiguousEventAfterTimestampedNonEventLog(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
+		`last line]`,
+		`2026/06/18 09:00:00 state HTTP server listening on http://127.0.0.1:8080`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("ambiguous event-shaped output after timestamped non-event text was promoted: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteAmbiguousMultilineEventAfterOutputHeadOnlyMultiline(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
+		`last line]`,
+		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[elapsed_ms:60000 output_head:timeout first line`,
+		`output_tail:timeout tail timeout_ms:60000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("ambiguous multiline event-shaped output after single-bracket close was promoted: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresContinuationTextAfterClosedPayload(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent timeout_ms:60000]`,
+		`unrelated diagnostic timeout_ms:111`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
+		t.Fatalf("elapsed_ms before closed payload continuation = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
+	}
+	if _, ok := cluster.Evidence[0].Metadata["timeout_ms"]; ok {
+		t.Fatalf("timeout_ms after opaque output was promoted: %#v", cluster.Evidence[0].Metadata)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteNestedPayloadIdentifiers(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real session_id=session-real msg="tool" payload=map[tool:missing arguments:map[output_head:agent-text session_id:fake-session pr_number:777] pr_number:938]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "tool-unsupported")
+	if contains(cluster.Affected.Sessions, "fake-session") || !contains(cluster.Affected.Sessions, "session-real") {
+		t.Fatalf("nested payload session_id was promoted: %#v", cluster.Affected.Sessions)
+	}
+	if contains(cluster.Affected.PullRequests, "777") || contains(cluster.Affected.PullRequests, "938") {
+		t.Fatalf("nested payload pr_number was promoted: %#v", cluster.Affected.PullRequests)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsUnsupportedToolCallArgumentsFromExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[pr_number:938 tool:missing_graphql arguments:map[query:mutation{issueUpdate(input:{id:"secret"})} variables:map[token:abc]]]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "tool-unsupported")
+	if !contains(cluster.Affected.PullRequests, "938") {
+		t.Fatalf("top-level pr_number was lost while redacting arguments: %#v", cluster.Affected.PullRequests)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"mutation{issueUpdate", `id:\"secret\"`, "variables:map"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("unsupported tool arguments leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("unsupported tool arguments were not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsUnsupportedToolCallArgumentsWithBracketText(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[tool:missing_graphql arguments:map[query:query { issue(id: "]secret") { id } } variables:map[token:abc]] pr_number:938]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "tool-unsupported")
+	if !contains(cluster.Affected.Issues, "issue-real") {
+		t.Fatalf("issue id was lost while redacting bracketed arguments: %#v", cluster.Affected.Issues)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"issue(id:", "]secret", "variables:map"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("unsupported tool arguments with bracket text leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("unsupported tool bracket arguments were not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptStopsAtBracketedOpaquePayload(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[pr_number:938 arguments:map[text:hello] session_id:fake pr_number:777] tool:missing]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "tool-unsupported")
+	if !contains(cluster.Affected.PullRequests, "938") {
+		t.Fatalf("trusted pr_number before opaque boundary was lost: %#v", cluster.Affected.PullRequests)
+	}
+	if contains(cluster.Affected.Sessions, "fake") || contains(cluster.Affected.PullRequests, "777]") {
+		t.Fatalf("bracketed opaque payload fields were promoted: sessions=%#v prs=%#v", cluster.Affected.Sessions, cluster.Affected.PullRequests)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"hello]", "session_id:fake", "777]"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("bracketed opaque payload leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("bracketed opaque payload was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptStopsAtScalarUnsupportedToolArguments(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[arguments:not-an-object session_id:payload-session pr_number:938 tool:missing]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "tool-unsupported")
+	if contains(cluster.Affected.Sessions, "payload-session") {
+		t.Fatalf("scalar arguments trailing session_id was promoted: %#v", cluster.Affected.Sessions)
+	}
+	if contains(cluster.Affected.PullRequests, "938") {
+		t.Fatalf("scalar arguments trailing pr_number was promoted: %#v", cluster.Affected.PullRequests)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"not-an-object", "payload-session", "938", "tool:missing"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("scalar unsupported tool arguments leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("scalar unsupported tool arguments leaked in report:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteUnsupportedToolArgumentsToMetadata(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[tool:missing_graphql arguments:map[query:query { issue(id: "] SECRET_METADATA") { id } } session_id:fake-session error:SECRET_METADATA] pr_number:938]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "tool-unsupported")
+	if contains(cluster.Affected.Sessions, "fake-session") {
+		t.Fatalf("unsupported tool argument session_id was promoted: %#v", cluster.Affected.Sessions)
+	}
+	metadata := cluster.Evidence[0].Metadata
+	if metadata["session_id"] == "fake-session" || metadata["error"] == "SECRET_METADATA" {
+		t.Fatalf("unsupported tool arguments were promoted into metadata: %#v", metadata)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"fake-session", "SECRET_METADATA"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("unsupported tool arguments leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("unsupported tool arguments were not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsMalformedRawGraphQLPayloadFromExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=malformed task_id=issue-real issue_id=issue-real msg="bad protocol" payload=map[raw:{"method":"item/tool/call","arguments":{"query":"mutation { issueUpdate(input:{id:\"secret\"}) { id } }"}}]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	cluster := findCluster(t, report, "malformed-protocol")
+	if !contains(cluster.Affected.Issues, "issue-real") {
+		t.Fatalf("issue id was lost while redacting malformed payload: %#v", cluster.Affected.Issues)
+	}
+	text := string(raw)
+	for _, leaked := range []string{"issueUpdate", `id:\\\"secret\\\"`, "item/tool/call"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("malformed raw GraphQL payload leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-malformed-payload]") {
+		t.Fatalf("malformed raw payload was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { issueUpdate(input:{id:"secret"}) { id } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"issueUpdate", `id:\"secret\"`, "mutation {"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("runner output GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsNamedGraphQLFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation IssueUpdate($input: IssueUpdateInput!) { issueUpdate(input:$input) { id } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"IssueUpdate", "issueUpdate", "$input"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("named runner output GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("named runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsMinifiedScalarOnlyGraphQLFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:query Secret($token:String="not-a-token-secret"){id} timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"query Secret", "not-a-token-secret", "{id}"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("minified scalar-only GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("minified scalar-only GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsLongHeaderGraphQLFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	var vars []string
+	for idx := 0; idx < 40; idx++ {
+		vars = append(vars, fmt.Sprintf("$v%d: String", idx))
+	}
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation LongOperation(` + strings.Join(vars, ", ") + `) { issueUpdate(input:{id:"secret-long"}) { id } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"LongOperation", "issueUpdate", "secret-long"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("long-header runner output GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("long-header runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLFragmentFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:fragment SecretFields on Issue { id title privateNote } mutation M { issueUpdate(input:{id:"secret-frag"}) { id } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"fragment SecretFields", "privateNote", "secret-frag"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("fragment runner output GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("fragment runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLVariablesFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { issueUpdate(input:{id:"id-public"}) { id } } variables:{"private":"not-a-token-secret"} timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"issueUpdate", "variables:", "not-a-token-secret"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("runner output GraphQL variables leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("runner output GraphQL variables were not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsVariablesOnlyGraphQLRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:variables:{"private":"not-a-token-secret"} timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"variables:", "not-a-token-secret"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("variables-only GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("variables-only GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsJSONVariablesOnlyGraphQLRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{"arguments":{"variables":{"private":"not-a-token-secret"}}} timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"variables", "not-a-token-secret"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("JSON variables-only GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("JSON variables-only GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsEscapedJSONVariablesOnlyGraphQLRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{\"arguments\":{\"variables\":{\"private\":\"not-a-token-secret\"}}} timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{`\"variables\"`, "not-a-token-secret"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("escaped JSON variables-only GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("escaped JSON variables-only GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsJSONVariablesBeforeQueryRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{"arguments":{"variables":{"private":"not-a-token-secret"},"query":"mutation { issueUpdate(input:{id:\"id-public\"}) { id } }"}} timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"variables", "not-a-token-secret", "issueUpdate", "id-public"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("JSON variables-before-query GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("JSON variables-before-query GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotStopGraphQLRedactionAtAliasNamedTimeoutMS(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { timeout_ms:issue(id:"secret-id"){id}}]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"timeout_ms:issue", "issue(id:", "secret-id", "{id}"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("GraphQL alias named timeout_ms leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("GraphQL alias named timeout_ms was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLStringBraceFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { issue(id:"} SECRET_AFTER_BRACE") { id title } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"SECRET_AFTER_BRACE", "{ id title }", "issue(id:"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("runner output GraphQL string brace leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("runner output GraphQL string brace was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLAliasFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { model: issue(id:"secret-id") { id title } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"model: issue", "issue(id:", "secret-id"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("alias runner output GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("alias runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLSelectionSetFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{ issue(id:"secret-id") { id title } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"issue(id:", "secret-id", "{ id title }"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("selection-set runner output GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("selection-set runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsSpreadFirstGraphQLSelectionSet(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{ ...SecretFields } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"SecretFields", "{ ..."} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("spread-first selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("spread-first selection-set GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsCommentFirstGraphQLSelectionSet(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{ # leading comment`,
+		`issue(id:"secret-id") { id title } } timeout_ms:60000]`,
+	}, "\n") + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"leading comment", "issue(id:", "secret-id", "{ id title }"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("comment-first selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("comment-first selection-set GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsGraphQLCommentBracesFromRunnerOutputExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { # } SECRET_COMMENT`,
+		`issue(id:"secret-id") { id title } } timeout_ms:60000]`,
+	}, "\n") + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"SECRET_COMMENT", "issue(id:", "secret-id", "{ id title }"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("runner output GraphQL comment leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("runner output GraphQL comment was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsProsePrefixedGraphQLSelectionSet(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:GraphQL request: { issue(id:"secret-id") { id title } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"issue(id:", "secret-id", "{ id title }"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("prose-prefixed selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("prose-prefixed selection-set GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsBracketedProseGraphQLSelectionSet(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:[INFO] GraphQL request: { issue(id:"secret-id") { id title } } timeout_ms:60000]` + "\n"
+	raw := runTraceHarnessReportRaw(t, root, body)
+	report := parseTraceReport(t, raw)
+
+	findCluster(t, report, "runner-timeout")
+	text := string(raw)
+	for _, leaked := range []string{"issue(id:", "secret-id", "{ id title }"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("bracketed prose selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
+		}
+	}
+	if !strings.Contains(text, "payload=[redacted-payload]") {
+		t.Fatalf("bracketed prose selection-set GraphQL was not replaced with a redaction marker:\n%s", raw)
+	}
+}
+
+func TestTraceHarnessReportScriptKeepsTopLevelFieldsWhenOutputRepeatsKeys(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real session_id=session-real msg="timeout" payload=map[output_head:event=runner_end task_id=issue-output issue_id=issue-output session_id=session-output]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if !contains(cluster.Affected.Issues, "issue-real") || contains(cluster.Affected.Issues, "issue-output") {
+		t.Fatalf("issue ids were parsed from output text: %#v", cluster.Affected.Issues)
+	}
+	if !contains(cluster.Affected.Sessions, "session-real") || contains(cluster.Affected.Sessions, "session-output") {
+		t.Fatalf("session ids were parsed from output text: %#v", cluster.Affected.Sessions)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsInvalidUTF8InsideOpaquePayload(t *testing.T) {
+	root := repoRoot(t)
+	raw := []byte("2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg=\"timeout\" payload=map[output_head:\xff]\n")
+	reportRaw := runTraceHarnessReportRawBytes(t, root, raw)
+
+	if !strings.Contains(string(reportRaw), "runner-timeout") || !strings.Contains(string(reportRaw), "payload=[redacted-payload]") || strings.Contains(string(reportRaw), `\ufffd`) {
+		t.Fatalf("invalid UTF-8 opaque payload was not redacted:\n%s", reportRaw)
+	}
+}
+
+type traceReport struct {
+	SchemaVersion string `json:"schema_version"`
+	Clusters      []traceCluster
+}
+
+type traceCluster struct {
+	ID       string `json:"id"`
+	Affected struct {
+		Issues           []string       `json:"issues"`
+		IssueIdentifiers []string       `json:"issue_identifiers"`
+		PullRequests     []string       `json:"pull_requests"`
+		Runs             []string       `json:"runs"`
+		Sessions         []string       `json:"sessions"`
+		Omitted          map[string]int `json:"omitted"`
+	} `json:"affected"`
+	Evidence []struct {
+		Excerpt  string            `json:"excerpt"`
+		Metadata map[string]string `json:"metadata"`
+	} `json:"evidence"`
+}
+
+func runTraceHarnessReport(t *testing.T, root, body string) traceReport {
+	t.Helper()
+	raw := runTraceHarnessReportRaw(t, root, body)
+	return parseTraceReport(t, raw)
+}
+
+func parseTraceReport(t *testing.T, raw []byte) traceReport {
+	t.Helper()
+	var report traceReport
+	if err := json.Unmarshal(raw, &report); err != nil {
+		t.Fatalf("unmarshal report: %v\n%s", err, raw)
+	}
+	return report
+}
+
+func runTraceHarnessReportRaw(t *testing.T, root, body string) []byte {
+	t.Helper()
+	return runTraceHarnessReportRawBytes(t, root, []byte(body))
+}
+
+func runTraceHarnessReportRawBytes(t *testing.T, root string, body []byte) []byte {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "worker.log")
+	if err := os.WriteFile(logPath, body, 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	jsonPath := filepath.Join(dir, "report.json")
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "trace-harness-report.py"), "--worker-log", logPath, "--json-out", jsonPath)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("trace-harness-report failed: %v\n%s", err, out)
+	}
+	raw, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	return raw
+}
+
+func runTraceHarnessReportRawPath(t *testing.T, root, logPath string) []byte {
+	t.Helper()
+	jsonPath := filepath.Join(t.TempDir(), "report.json")
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "trace-harness-report.py"), "--worker-log", logPath, "--json-out", jsonPath)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("trace-harness-report failed: %v\n%s", err, out)
+	}
+	raw, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	return raw
+}
+
+func findCluster(t *testing.T, report traceReport, id string) traceCluster {
+	t.Helper()
+	for _, cluster := range report.Clusters {
+		if cluster.ID == id {
+			return cluster
+		}
+	}
+	t.Fatalf("missing cluster %q in %#v", id, report.Clusters)
+	return traceCluster{}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return string(raw)
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -1,6 +1,8 @@
 package scripts_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -133,6 +135,29 @@ func TestTraceHarnessReportScriptUsesPayloadIssueAndRunIDs(t *testing.T) {
 	}
 	if !contains(cluster.Affected.IssueIdentifiers, "PAY-1") {
 		t.Fatalf("payload issue_identifier was not reported as affected: %#v", cluster.Affected.IssueIdentifiers)
+	}
+}
+
+func TestTraceHarnessReportScriptReportsStreamedInputDigest(t *testing.T) {
+	root := repoRoot(t)
+	body := []byte(`2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout"` + "\n")
+	raw := runTraceHarnessReportRawBytes(t, root, body)
+
+	var report struct {
+		Inputs []struct {
+			Bytes  int    `json:"bytes"`
+			Sha256 string `json:"sha256"`
+		} `json:"inputs"`
+	}
+	if err := json.Unmarshal(raw, &report); err != nil {
+		t.Fatalf("unmarshal report: %v\n%s", err, raw)
+	}
+	if len(report.Inputs) != 1 {
+		t.Fatalf("inputs = %d; want 1", len(report.Inputs))
+	}
+	wantSum := sha256.Sum256(body)
+	if report.Inputs[0].Bytes != len(body) || report.Inputs[0].Sha256 != hex.EncodeToString(wantSum[:]) {
+		t.Fatalf("input digest = {%d,%s}; want {%d,%s}", report.Inputs[0].Bytes, report.Inputs[0].Sha256, len(body), hex.EncodeToString(wantSum[:]))
 	}
 }
 

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -546,6 +546,14 @@ func TestTraceHarnessReportScriptBoundsFullEvidenceEntriesByBytes(t *testing.T) 
 	if !contains(cluster.Affected.Issues, "issue-shared") {
 		t.Fatalf("affected ids stopped when evidence cap was reached: %#v", cluster.Affected.Issues)
 	}
+	// 4000 records cycle 16 distinct task_ids and one shared issue id; dedup must
+	// collapse them, not append duplicates.
+	if got := len(cluster.Affected.Runs); got != 16 {
+		t.Fatalf("len(Affected.Runs) = %d; want 16 (deduped)", got)
+	}
+	if got := len(cluster.Affected.Issues); got != 1 {
+		t.Fatalf("len(Affected.Issues) = %d; want 1 (deduped)", got)
+	}
 }
 
 func TestTraceHarnessReportScriptBoundsFullClusterByBytes(t *testing.T) {

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -41,13 +41,12 @@ func TestTraceHarnessReportRunbookDocumentsSupportedInputsAndBounds(t *testing.T
 		"does not edit prompts",
 		"does not create a worker phase",
 		"MaskCloneURL",
-		"before the first opaque payload key",
-		"does not parse GraphQL",
-		"hard boundary",
-		"ambiguous multiline closures",
-		"prefers omission over fabricating affected issues",
-		"cannot prove",
-		"known scalar metadata is byte-bounded per field and in aggregate",
+		"single line",
+		"first opaque payload key",
+		"as opaque and never parsed",
+		"is not recovered",
+		"emit a structured payload",
+		"Known limitation",
 		"Unsupported inputs",
 		"workspace `.aiops` artifacts",
 		"Examples",
@@ -82,49 +81,35 @@ func TestTraceHarnessReportScriptGroupsWorkerLogsAndRedactsCloneURLs(t *testing.
 	if err != nil {
 		t.Fatalf("read report: %v", err)
 	}
-	var report struct {
-		SchemaVersion string `json:"schema_version"`
-		Clusters      []struct {
-			ID       string `json:"id"`
-			Affected struct {
-				Issues   []string `json:"issues"`
-				Sessions []string `json:"sessions"`
-			} `json:"affected"`
-			Evidence []struct {
-				Excerpt  string            `json:"excerpt"`
-				Metadata map[string]string `json:"metadata"`
-			} `json:"evidence"`
-			RedactionNote string `json:"redaction_note"`
-		} `json:"clusters"`
-	}
-	if err := json.Unmarshal(raw, &report); err != nil {
-		t.Fatalf("unmarshal report: %v\n%s", err, raw)
-	}
+	report := parseTraceReport(t, raw)
 	if report.SchemaVersion != "trace-harness-report/v1" || len(report.Clusters) != 2 {
 		t.Fatalf("unexpected report: %#v", report)
 	}
-	timeout := report.Clusters[1]
-	if timeout.ID != "runner-timeout" || !contains(timeout.Affected.Issues, "issue-1") || !contains(timeout.Affected.Sessions, "session-1") {
+	timeout := findCluster(t, report, "runner-timeout")
+	if !contains(timeout.Affected.Issues, "issue-1") || !contains(timeout.Affected.Sessions, "session-1") {
 		t.Fatalf("timeout cluster missing affected fields: %#v", timeout)
 	}
 	if timeout.Evidence[0].Metadata["timestamp"] != "2026/06/18 09:00:00" {
 		t.Fatalf("timeout timestamp metadata = %#v", timeout.Evidence[0].Metadata)
 	}
 	if timeout.Evidence[0].Metadata["output_bytes"] != "70000" || timeout.Evidence[0].Metadata["output_dropped"] != "12" {
-		t.Fatalf("timeout metadata = %#v", timeout.Evidence[0].Metadata)
+		t.Fatalf("timeout metadata = %#v; want output_bytes/output_dropped before opaque key", timeout.Evidence[0].Metadata)
 	}
 	if strings.Contains(string(raw), "secret") || !strings.Contains(timeout.Evidence[0].Excerpt, "payload=[redacted-payload]") {
 		t.Fatalf("report leaked or retained opaque runner output:\n%s", raw)
 	}
+	note := clusterRedactionNote(t, raw, "runner-timeout")
 	for _, want := range []string{"output_head", "output_tail", "error", "arguments", "raw", "params"} {
-		if !strings.Contains(timeout.RedactionNote, want) {
-			t.Fatalf("redaction note missing omitted payload %q: %q", want, timeout.RedactionNote)
+		if !strings.Contains(note, want) {
+			t.Fatalf("redaction note missing omitted payload %q: %q", want, note)
 		}
 	}
 }
 
 func TestTraceHarnessReportScriptUsesPayloadSessionID(t *testing.T) {
 	root := repoRoot(t)
+	// session_id sorts before no opaque key here, so it is recoverable from the
+	// single first line.
 	body := `2026/06/18 09:01:00 event=turn_input_required task_id=issue-2 issue_id=issue-2 issue_identifier=GH-2 msg="input" payload=map[method:approval session_id:payload-session]` + "\n"
 	report := runTraceHarnessReport(t, root, body)
 
@@ -151,65 +136,56 @@ func TestTraceHarnessReportScriptUsesPayloadIssueAndRunIDs(t *testing.T) {
 	}
 }
 
-func TestTraceHarnessReportScriptMasksMalformedCloneURLUserinfo(t *testing.T) {
+func TestTraceHarnessReportScriptReportsAffectedPullRequests(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[pr_number:938]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if !contains(cluster.Affected.PullRequests, "938") {
+		t.Fatalf("pull request id was not reported as affected: %#v", cluster.Affected.PullRequests)
+	}
+}
+
+func TestTraceHarnessReportScriptClassifiesMalformedProtocolSeparately(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=malformed task_id=issue-1 issue_id=issue-1 msg="bad protocol line"` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 1 || report.Clusters[0].ID != "malformed-protocol" {
+		t.Fatalf("malformed event clusters = %#v; want malformed-protocol only", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptClassifiesFailedRunnerEndFromMessage(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:boom]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if !contains(cluster.Affected.Issues, "issue-1") {
+		t.Fatalf("failed runner_end was not classified: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresSuccessfulRunnerEnd(t *testing.T) {
+	root := repoRoot(t)
+	// "runner failed" appears only in opaque output; the prefix msg is a success
+	// message, so classification (prefix-only) must not surface a failure.
+	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner completed" payload=map[ok:true output_head:runner failed downstream]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("successful runner_end with failure text in output was classified: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptMasksCloneURLUserinfoSchemes(t *testing.T) {
 	root := repoRoot(t)
 	for _, secretURL := range []string{
-		"https://user:bad token@example.test/org/repo.git",
-		"https://:secret@example.test/org/repo.git",
-	} {
-		body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
-		raw := runTraceHarnessReportRaw(t, root, body)
-		if strings.Contains(string(raw), "secret") || strings.Contains(string(raw), "bad token") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
-			t.Fatalf("report leaked or retained malformed userinfo from opaque output %q:\n%s", secretURL, raw)
-		}
-	}
-}
-
-func TestTraceHarnessReportScriptMasksMalformedCloneURLUserinfoWithBracket(t *testing.T) {
-	root := repoRoot(t)
-	secretURL := "https://user:tok]en@example.test/org/repo.git"
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-
-	if strings.Contains(string(raw), "tok]en") || strings.Contains(string(raw), "user:") {
-		t.Fatalf("report leaked malformed bracket userinfo:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptMasksMalformedCloneURLUserinfoInMetadata(t *testing.T) {
-	root := repoRoot(t)
-	secretURL := "https://user:tok]en@example.test/org/repo.git"
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:` + secretURL + `]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-
-	if strings.Contains(string(raw), "tok]en") || strings.Contains(string(raw), "user:") {
-		t.Fatalf("report leaked malformed bracket userinfo in metadata:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptMasksHTTPCloneURLUserinfo(t *testing.T) {
-	root := repoRoot(t)
-	secretURL := "http://user:secret@example.test/org/repo.git"
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	if strings.Contains(string(raw), "secret") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
-		t.Fatalf("report leaked or retained HTTP userinfo from opaque output:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptMasksSSHCloneURLUserinfo(t *testing.T) {
-	root := repoRoot(t)
-	secretURL := "ssh://user:secret@example.test/org/repo.git"
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	if strings.Contains(string(raw), "secret") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
-		t.Fatalf("report leaked or retained SSH userinfo from opaque output:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptMasksGenericSchemeCloneURLUserinfo(t *testing.T) {
-	root := repoRoot(t)
-	for _, secretURL := range []string{
+		"https://user:secret@example.test/org/repo.git",
+		"http://user:secret@example.test/org/repo.git",
+		"ssh://user:secret@example.test/org/repo.git",
 		"git://user:secret@example.test/org/repo.git",
 		"rsync://user:secret@example.test/org/repo.git",
 		"file://user:secret@example.test/org/repo.git",
@@ -217,7 +193,25 @@ func TestTraceHarnessReportScriptMasksGenericSchemeCloneURLUserinfo(t *testing.T
 		body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
 		raw := runTraceHarnessReportRaw(t, root, body)
 		if strings.Contains(string(raw), "secret") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
-			t.Fatalf("report leaked or retained generic scheme userinfo from opaque output:\n%s", raw)
+			t.Fatalf("report leaked or retained %q userinfo from opaque output:\n%s", secretURL, raw)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptMasksMalformedCloneURLUserinfo(t *testing.T) {
+	root := repoRoot(t)
+	for _, secretURL := range []string{
+		"https://user:bad token@example.test/org/repo.git",
+		"https://:secret@example.test/org/repo.git",
+		"https://user:tok]en@example.test/org/repo.git",
+	} {
+		body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:` + secretURL + `]` + "\n"
+		raw := runTraceHarnessReportRaw(t, root, body)
+		if strings.Contains(string(raw), "secret") || strings.Contains(string(raw), "bad token") || strings.Contains(string(raw), "tok]en") {
+			t.Fatalf("report leaked malformed userinfo %q:\n%s", secretURL, raw)
+		}
+		if !strings.Contains(string(raw), "payload=[redacted-payload]") {
+			t.Fatalf("report did not redact opaque payload for %q:\n%s", secretURL, raw)
 		}
 	}
 }
@@ -228,11 +222,12 @@ func TestTraceHarnessReportScriptMasksTokenLikeSecrets(t *testing.T) {
 		"ghp_" + strings.Repeat("a", 36),
 		"lin_api_" + strings.Repeat("a", 40),
 	} {
-		body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:` + token + ` output_head:` + token + `]` + "\n"
+		// The token sits inside opaque output, which is redacted wholesale; the
+		// token regex is the backstop for any place a token still reaches text.
+		body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed ` + token + `" payload=map[output_head:` + token + `]` + "\n"
 		raw := runTraceHarnessReportRaw(t, root, body)
-
-		if strings.Contains(string(raw), token) || !strings.Contains(string(raw), "payload=[redacted-payload]") || !strings.Contains(string(raw), "[redacted-error]") {
-			t.Fatalf("report leaked or retained token-like opaque payload %q:\n%s", token, raw)
+		if strings.Contains(string(raw), token) || !strings.Contains(string(raw), "[redacted-token]") || !strings.Contains(string(raw), "payload=[redacted-payload]") {
+			t.Fatalf("report leaked or retained token-like value %q:\n%s", token, raw)
 		}
 	}
 }
@@ -305,6 +300,182 @@ func TestTraceHarnessReportScriptMasksOutputPathErrors(t *testing.T) {
 	}
 }
 
+func TestTraceHarnessReportScriptRedactsEveryOpaquePayloadFromExcerpt(t *testing.T) {
+	root := repoRoot(t)
+	for _, opaque := range []string{
+		"output_head:secret-output",
+		"output_tail:secret-output",
+		"error:secret-error",
+		"arguments:{\"q\":\"secret\"}",
+		"arguments_raw:secret-args",
+		"raw:secret-raw",
+		"params:secret-params",
+	} {
+		body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[` + opaque + `]` + "\n"
+		report := runTraceHarnessReport(t, root, body)
+		cluster := findCluster(t, report, "runner-timeout")
+		excerpt := cluster.Evidence[0].Excerpt
+		if !strings.Contains(excerpt, "payload=[redacted-payload]") || strings.Contains(excerpt, "secret") {
+			t.Fatalf("opaque payload %q leaked into excerpt %q", opaque, excerpt)
+		}
+	}
+}
+
+func TestTraceHarnessReportScriptStopsScalarMetadataAtFirstOpaqueKey(t *testing.T) {
+	root := repoRoot(t)
+	// timeout_ms appears only inside the opaque output_head value; the importer
+	// must stop at output_head and not promote text after it.
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[exit_code:7 model:gpt-5 output_head:agent said timeout_ms:999]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	meta := findCluster(t, report, "runner-timeout").Evidence[0].Metadata
+	if meta["exit_code"] != "7" || meta["model"] != "gpt-5" {
+		t.Fatalf("scalars before the opaque key were dropped: %#v", meta)
+	}
+	if got, ok := meta["timeout_ms"]; ok {
+		t.Fatalf("Metadata[timeout_ms] = %q; want absent (it is buried inside opaque output)", got)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotExtractScalarsBuriedAfterOpaqueKey(t *testing.T) {
+	root := repoRoot(t)
+	// Go sorts `arguments` before `tool`, so a real unsupported_tool_call log
+	// renders the opaque `arguments` first. `tool` is intentionally not
+	// recovered; this is the documented cost of the opaque-boundary design.
+	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-1 issue_id=issue-1 msg="unsupported" payload=map[arguments:{"q":"x"} tool:linear_graphql]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	meta := findCluster(t, report, "tool-unsupported").Evidence[0].Metadata
+	if got, ok := meta["tool"]; ok {
+		t.Fatalf("Metadata[tool] = %q; want absent (it sorts after the opaque arguments key)", got)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteIdentifiersFromOpaquePayload(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=run-real issue_id=issue-real msg="timeout" payload=map[output_head:issue_id:ghost-issue session_id:ghost-session]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "ghost-issue") || contains(cluster.Affected.Sessions, "ghost-session") {
+		t.Fatalf("identifiers inside opaque output were promoted: %#v", cluster.Affected)
+	}
+	if !contains(cluster.Affected.Issues, "issue-real") {
+		t.Fatalf("prefix issue id was dropped: %#v", cluster.Affected.Issues)
+	}
+}
+
+func TestTraceHarnessReportScriptRedactsInvalidUTF8InsideOpaquePayload(t *testing.T) {
+	root := repoRoot(t)
+	raw := []byte("2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg=\"timeout\" payload=map[output_head:\xff]\n")
+	reportRaw := runTraceHarnessReportRawBytes(t, root, raw)
+
+	// The report is emitted with ensure_ascii, so a leaked U+FFFD replacement
+	// char would appear as the escaped six-byte form, not as a literal rune.
+	if !strings.Contains(string(reportRaw), "runner-timeout") || !strings.Contains(string(reportRaw), "payload=[redacted-payload]") || strings.Contains(string(reportRaw), "\\ufffd") {
+		t.Fatalf("invalid UTF-8 opaque payload was not redacted:\n%s", reportRaw)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresPlainEventText(t *testing.T) {
+	root := repoRoot(t)
+	// No leading log timestamp, so this is not a worker record.
+	body := `event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout"` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("plain event-shaped text was promoted: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresTimestampedProseEventText(t *testing.T) {
+	root := repoRoot(t)
+	// `event=` is not immediately after the timestamp, so the record-start
+	// grammar does not match.
+	body := `2026/06/18 09:00:00 note about event=runner_timeout in prose` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 0 {
+		t.Fatalf("timestamped prose was promoted: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptIgnoresKeyShapedTextInsideMessage(t *testing.T) {
+	root := repoRoot(t)
+	// issue_id= inside the %q message body must not be parsed as a real field.
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="see issue_id=ghost-issue for context"` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if contains(cluster.Affected.Issues, "ghost-issue") {
+		t.Fatalf("key-shaped text inside msg was parsed as a field: %#v", cluster.Affected.Issues)
+	}
+}
+
+func TestTraceHarnessReportScriptSkipsMultilineOpaqueContinuationLines(t *testing.T) {
+	root := repoRoot(t)
+	// A multi-line %v map: the opaque output spills onto continuation lines that
+	// do not start a worker record, so they are skipped. The next real record is
+	// still parsed normally.
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:line one`,
+		`line two with brackets [INFO] and a stray ]`,
+		`timeout_ms:30000]`,
+		`2026/06/18 09:05:00 event=turn_input_required task_id=issue-2 issue_id=issue-2 msg="input" payload=map[method:approval]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 2 {
+		t.Fatalf("multiline continuation handling produced %d clusters; want 2: %#v", len(report.Clusters), report.Clusters)
+	}
+	timeout := findCluster(t, report, "runner-timeout")
+	if got, ok := timeout.Evidence[0].Metadata["timeout_ms"]; ok {
+		t.Fatalf("Metadata[timeout_ms] = %q; want absent (it is on a skipped continuation line)", got)
+	}
+	if !contains(findCluster(t, report, "input-required").Affected.Issues, "issue-2") {
+		t.Fatalf("the record after multiline output was not parsed: %#v", report.Clusters)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotPromoteEmbeddedNonRecordOutput(t *testing.T) {
+	root := repoRoot(t)
+	// Embedded agent output that looks event-shaped but lacks the leading log
+	// timestamp is a continuation line and must not become a record.
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:agent log:`,
+		`event=runner_end task_id=ghost issue_id=ghost-issue msg="runner failed"`,
+		`]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	if len(report.Clusters) != 1 || report.Clusters[0].ID != "runner-timeout" {
+		t.Fatalf("embedded non-record output was promoted: %#v", report.Clusters)
+	}
+	if contains(report.Clusters[0].Affected.Issues, "ghost-issue") {
+		t.Fatalf("ghost identifier from embedded output leaked: %#v", report.Clusters[0].Affected.Issues)
+	}
+}
+
+func TestTraceHarnessReportScriptSurfacesEmbeddedRecordShapedOutputAsKnownLimitation(t *testing.T) {
+	root := repoRoot(t)
+	// Documented limitation: Go's %v map rendering is unescaped, so opaque output
+	// that reproduces the full record-start grammar (log timestamp + event=known)
+	// is indistinguishable from a real record and is surfaced. The runbook
+	// records this and recommends a structured payload as the harness fix; this
+	// test pins the behavior so it is not "fixed" with another unsound heuristic.
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[output_head:agent replayed a log line`,
+		`2026/06/18 09:00:01 event=runner_end task_id=replayed issue_id=replayed-issue msg="runner failed"`,
+		`]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-failure")
+	if !contains(cluster.Affected.Issues, "replayed-issue") {
+		t.Fatalf("expected the known limitation to surface the replayed record: %#v", report.Clusters)
+	}
+}
+
 func TestTraceHarnessReportScriptBoundsExcerptsByBytes(t *testing.T) {
 	root := repoRoot(t)
 	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="` + strings.Repeat("界", 5000) + `"` + "\n"
@@ -372,10 +543,7 @@ func TestTraceHarnessReportScriptBoundsFullClusterByBytes(t *testing.T) {
 		t.Fatalf("emitted cluster bytes = %d; want <= 262144", len(raw.Clusters[0]))
 	}
 
-	var report traceReport
-	if err := json.Unmarshal(rawReport, &report); err != nil {
-		t.Fatalf("unmarshal typed report: %v\n%s", err, rawReport)
-	}
+	report := parseTraceReport(t, rawReport)
 	cluster := findCluster(t, report, "runner-timeout")
 	if len(cluster.Evidence) == 0 {
 		t.Fatalf("cluster evidence count = 0; want at least 1; omitted=%#v issues=%d sessions=%d", cluster.Affected.Omitted, len(cluster.Affected.Issues), len(cluster.Affected.Sessions))
@@ -407,37 +575,26 @@ func TestTraceHarnessReportScriptBoundsLargeScalarMetadata(t *testing.T) {
 		t.Fatalf("raw clusters = %d, first bytes = %d; want one cluster <= 262144", len(raw.Clusters), len(raw.Clusters[0]))
 	}
 
-	report := runTraceHarnessReport(t, root, body)
+	report := parseTraceReport(t, rawReport)
 	cluster := findCluster(t, report, "runner-timeout")
 	if len(cluster.Evidence) == 0 {
 		t.Fatalf("large scalar metadata dropped all evidence")
 	}
 	model := cluster.Evidence[0].Metadata["model"]
 	if len([]byte(model)) > 4*1024 || !strings.Contains(model, "[truncated]") {
-		t.Fatalf("model metadata was not byte-bounded: len=%d value suffix=%q", len([]byte(model)), model[max(0, len(model)-32):])
+		t.Fatalf("model metadata was not byte-bounded: len=%d value=%q", len([]byte(model)), model)
 	}
 }
 
 func TestTraceHarnessReportScriptBoundsLargeScalarMetadataAcrossFields(t *testing.T) {
 	root := repoRoot(t)
 	large := strings.Repeat("m", 8*1024)
+	// All scalar keys, listed before any opaque key, so every one is extracted
+	// and the aggregate must still be byte-bounded.
 	keys := []string{
-		"elapsed_ms",
-		"timeout_ms",
-		"duration_ms",
-		"output_bytes",
-		"output_dropped",
-		"model",
-		"method",
-		"session_id",
-		"pr",
-		"pr_number",
-		"pr_url",
-		"pull_request",
-		"pull_request_url",
-		"exit_code",
-		"error",
-		"ok",
+		"elapsed_ms", "timeout_ms", "duration_ms", "output_bytes", "output_dropped",
+		"model", "method", "session_id", "pr", "pr_number", "pr_url",
+		"pull_request", "pull_request_url", "exit_code",
 	}
 	var payload strings.Builder
 	for _, key := range keys {
@@ -459,1201 +616,9 @@ func TestTraceHarnessReportScriptBoundsLargeScalarMetadataAcrossFields(t *testin
 	}
 }
 
-func TestTraceHarnessReportScriptReportsAffectedPullRequests(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[pr_number:938]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if !contains(cluster.Affected.PullRequests, "938") {
-		t.Fatalf("pull request id was not reported as affected: %#v", cluster.Affected.PullRequests)
-	}
-}
-
-func TestTraceHarnessReportScriptClassifiesMalformedProtocolSeparately(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=malformed task_id=issue-1 issue_id=issue-1 msg="bad protocol line"` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 1 || report.Clusters[0].ID != "malformed-protocol" {
-		t.Fatalf("malformed event clusters = %#v; want malformed-protocol only", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptIgnoresPlainEventText(t *testing.T) {
-	root := repoRoot(t)
-	body := `agent output says event=runner_timeout task_id=fake issue_id=fake` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("plain event-shaped text became report evidence: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptIgnoresTimestampedProseEventText(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 agent output says event=runner_timeout task_id=fake issue_id=fake` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("timestamped prose became report evidence: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptIgnoresKeyShapedTextInsideMessage(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="agent says task_id=fake issue_id=fake" payload=map[timeout_ms:60000]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-		t.Fatalf("message text overrode trusted prefix fields: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if !contains(cluster.Affected.Issues, "issue-real") || !contains(cluster.Affected.Runs, "issue-real") {
-		t.Fatalf("trusted prefix fields missing: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotSwallowPayloadlessEventAfterMultilineOutput(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[output_head:agent started`,
-		`agent output finished]]`,
-		`2026/06/18 09:00:01 event=malformed task_id=issue-malformed issue_id=issue-malformed msg="bad protocol line"`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	timeout := findCluster(t, report, "runner-timeout")
-	if !contains(timeout.Affected.Issues, "issue-timeout") || contains(timeout.Affected.Issues, "issue-malformed") {
-		t.Fatalf("runner-timeout affected issues = %#v; want issue-timeout only", timeout.Affected.Issues)
-	}
-	malformed := findCluster(t, report, "malformed-protocol")
-	if !contains(malformed.Affected.Issues, "issue-malformed") {
-		t.Fatalf("payloadless malformed event after multiline output was swallowed: %#v", malformed.Affected.Issues)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteEventAfterKeyShapedOpaqueLine(t *testing.T) {
-	root := repoRoot(t)
-	for _, key := range []string{"arguments", "arguments_raw", "error", "output_head", "output_tail", "params", "raw"} {
-		t.Run(key, func(t *testing.T) {
-			body := strings.Join([]string{
-				`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 ` + key + `:first line`,
-				`timeout_ms:123]`,
-				`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from opaque"`,
-				`tail done]]`,
-			}, "\n") + "\n"
-			report := runTraceHarnessReport(t, root, body)
-
-			cluster := findCluster(t, report, "runner-timeout")
-			if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-				t.Fatalf("%s opaque payload promoted fake event: issues=%#v runs=%#v", key, cluster.Affected.Issues, cluster.Affected.Runs)
-			}
-			if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-				t.Fatalf("%s elapsed_ms before opaque text = %q; want 70000; metadata=%#v", key, got, cluster.Evidence[0].Metadata)
-			}
-		})
-	}
-}
-
-func TestTraceHarnessReportScriptClassifiesFailedRunnerEndDespiteOutputOKText(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:boom output_head:agent-text-ok:true]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if !contains(cluster.Affected.Issues, "issue-1") {
-		t.Fatalf("runner_end failure was not grouped: %#v", cluster.Affected.Issues)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLSelectionSetFromRunnerErrorExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:GraphQL request: { issue(id:"secret-id") { id title } }]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if got := cluster.Evidence[0].Metadata["ok"]; got != "false" {
-		t.Fatalf("ok metadata after runner error GraphQL redaction = %q; want false; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"issue(id:", "secret-id", "{ id title }"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("runner error selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") || cluster.Evidence[0].Metadata["error"] != "[redacted-error]" {
-		t.Fatalf("runner error payload was not replaced with opaque redaction markers:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLFromRunnerErrorMetadata(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:Linear GraphQL failed: query SecretQuery($secret: String = "not-a-token-secret") { viewer { id } }]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "runner-failure")
-	metadata := cluster.Evidence[0].Metadata
-	if got := metadata["error"]; got != "[redacted-error]" {
-		t.Fatalf("runner error metadata = %q; want opaque redacted marker; metadata=%#v", got, metadata)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"SecretQuery", "$secret", "not-a-token-secret", "viewer { id }"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("runner error GraphQL metadata leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLBracketStringFromRunnerErrorMetadata(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:GraphQL request: query { issue(id:"]secret") { id title } }]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
-		t.Fatalf("runner error bracket metadata = %q; want opaque redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"]secret", "issue(id:", "{ id title }"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("runner error bracket GraphQL metadata leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteGraphQLDefaultKeyShapeFromRunnerErrorMetadata(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:Linear GraphQL failed: query SecretQuery($secret: String = " session_id:fake-session") { viewer { id } }]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if contains(cluster.Affected.Sessions, "fake-session") {
-		t.Fatalf("GraphQL default session_id was promoted into affected sessions: %#v", cluster.Affected.Sessions)
-	}
-	metadata := cluster.Evidence[0].Metadata
-	if got := metadata["error"]; got != "[redacted-error]" {
-		t.Fatalf("runner error default metadata = %q; want opaque redacted marker; metadata=%#v", got, metadata)
-	}
-	if got := metadata["session_id"]; strings.Contains(got, "fake-session") {
-		t.Fatalf("GraphQL default session_id was promoted into metadata: %#v", metadata)
-	}
-	if strings.Contains(string(raw), "fake-session") {
-		t.Fatalf("GraphQL default key-shaped value leaked in report:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsMultiWordRunnerErrorMetadata(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:agent crashed after checkout output_head:tail]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
-		t.Fatalf("multi-word runner error metadata = %q; want redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteKeyShapedRunnerErrorText(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-real issue_id=issue-real msg="runner failed" payload=map[ok:false error:agent crashed with session_id:fake-session pr_number:777 after checkout output_head:tail]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if contains(cluster.Affected.Sessions, "fake-session") {
-		t.Fatalf("runner error text session_id was promoted: %#v", cluster.Affected.Sessions)
-	}
-	if contains(cluster.Affected.PullRequests, "777") {
-		t.Fatalf("runner error text pr_number was promoted: %#v", cluster.Affected.PullRequests)
-	}
-	metadata := cluster.Evidence[0].Metadata
-	for _, key := range []string{"session_id", "pr_number"} {
-		if _, ok := metadata[key]; ok {
-			t.Fatalf("runner error text %s was promoted into metadata: %#v", key, metadata)
-		}
-	}
-	if got := metadata["error"]; got != "[redacted-error]" {
-		t.Fatalf("runner error metadata = %q; want opaque redacted marker; metadata=%#v", got, metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsOrdinaryQueryWordRunnerErrorMetadata(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:database query failed after checkout output_head:tail]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
-		t.Fatalf("ordinary query-word runner error metadata = %q; want redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsOrdinaryQueryWordRunnerErrorBeforeFreeformBraces(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:database query failed after checkout output_head:agent {not graphql}]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
-		t.Fatalf("ordinary query-word runner error before freeform braces = %q; want redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsOrdinaryQueryWordRunnerErrorWithJSONBraces(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:false error:database query failed: {"code":500} after checkout output_head:tail]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-failure")
-	if got := cluster.Evidence[0].Metadata["error"]; got != "[redacted-error]" {
-		t.Fatalf("ordinary query-word runner error with JSON braces = %q; want redacted marker; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptIgnoresOutputFailureTextForSuccessfulRunnerEnd(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner completed" payload=map[ok:true output_head:agent-text-ok:false]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("successful runner_end should not be grouped as failure: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptTrustsRunnerEndOKMetadataOverFailureMessage(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner failed" payload=map[ok:true output_head:tail]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("runner_end ok:true should not be grouped as failure despite message text: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotParseOutputTextAsPayloadFields(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_end task_id=issue-1 issue_id=issue-1 msg="runner completed" payload=map[ok:true output_head:agent text ok:false runner failed]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("output text should not override runner_end payload fields: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteOutputTextIdentifiers(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:agent text session_id:fake-session pr_number:777 error:boom ok:false]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Sessions, "fake-session") {
-		t.Fatalf("output text session_id was promoted: %#v", cluster.Affected.Sessions)
-	}
-	if contains(cluster.Affected.PullRequests, "777") {
-		t.Fatalf("output text pr_number was promoted: %#v", cluster.Affected.PullRequests)
-	}
-	metadata := cluster.Evidence[0].Metadata
-	for _, key := range []string{"error", "ok"} {
-		if _, ok := metadata[key]; ok {
-			t.Fatalf("output text %s was promoted into metadata: %#v", key, metadata)
-		}
-	}
-}
-
-func TestTraceHarnessReportScriptStopsMetadataAtOutputText(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent [ text session_id:fake-session pr_number:777 error:boom ok:false timeout_ms:111 output_tail:tail text timeout_ms:999 timeout_ms:60000]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("elapsed_ms before output text = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-	if _, ok := cluster.Evidence[0].Metadata["timeout_ms"]; ok {
-		t.Fatalf("timeout_ms after opaque output was promoted: %#v", cluster.Evidence[0].Metadata)
-	}
-	if _, ok := cluster.Evidence[0].Metadata["error"]; ok {
-		t.Fatalf("output text error was promoted into metadata: %#v", cluster.Evidence[0].Metadata)
-	}
-	if _, ok := cluster.Evidence[0].Metadata["ok"]; ok {
-		t.Fatalf("output text ok was promoted into metadata: %#v", cluster.Evidence[0].Metadata)
-	}
-	if contains(cluster.Affected.Sessions, "fake-session") || contains(cluster.Affected.PullRequests, "777") {
-		t.Fatalf("output text identifiers were promoted: sessions=%#v prs=%#v", cluster.Affected.Sessions, cluster.Affected.PullRequests)
-	}
-}
-
-func TestTraceHarnessReportScriptTreatsUnbalancedBracketScalarBeforeOpaqueAsOpaqueBoundary(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[model:[codex output_head:SECRET timeout_ms:60000]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if strings.Contains(mustJSON(t, report), "SECRET") {
-		t.Fatalf("unbalanced safe scalar hid opaque output text: %#v", cluster)
-	}
-	if !strings.Contains(cluster.Evidence[0].Excerpt, "payload=[redacted-payload]") {
-		t.Fatalf("unbalanced safe scalar excerpt was not redacted: %q", cluster.Evidence[0].Excerpt)
-	}
-	if _, ok := cluster.Evidence[0].Metadata["timeout_ms"]; ok {
-		t.Fatalf("metadata after opaque output was promoted: %#v", cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptStopsMetadataAtMultilineOutputText(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text session_id:fake-session pr_number:777 ok:false`,
-		`2026/06/18 09:00:01 output line with timeout_ms:111 but no event marker`,
-		`output_tail:tail text timeout_ms:999 timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("elapsed_ms before multiline output text = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-	if _, ok := cluster.Evidence[0].Metadata["timeout_ms"]; ok {
-		t.Fatalf("multiline timeout_ms after opaque output was promoted: %#v", cluster.Evidence[0].Metadata)
-	}
-	if contains(cluster.Affected.Sessions, "fake-session") || contains(cluster.Affected.PullRequests, "777") {
-		t.Fatalf("multiline output text identifiers were promoted: sessions=%#v prs=%#v", cluster.Affected.Sessions, cluster.Affected.PullRequests)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsEventShapedMultilineOutputInSameRecord(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
-		`output_tail:tail text timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Sessions, "fake") {
-		t.Fatalf("event-shaped output line was promoted: issues=%#v sessions=%#v", cluster.Affected.Issues, cluster.Affected.Sessions)
-	}
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("event-shaped multiline elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsBracketedEventShapedOutputInSameRecord(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent ] text`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
-		`output_tail:tail text timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-		t.Fatalf("bracketed event-shaped output line was promoted: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("bracketed event-shaped multiline elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsBracketTerminatedOutputLineInSameRecord(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
-		`stack frame [done]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
-		`output_tail:tail text timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-		t.Fatalf("bracket-terminated output line promoted event-shaped output: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("bracket-terminated multiline elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsSingleLineBracketedOpaquePayloadOpen(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:stack [done]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
-		`output_tail:tail text timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-		t.Fatalf("single-line bracketed opaque payload promoted fake event: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("single-line bracketed opaque payload elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsBareBracketOutputLineInSameRecordWhenTailFollows(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
-		`stack frame done]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
-		`output_tail:tail text timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-		t.Fatalf("bare bracket output line promoted event-shaped output: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("bare bracket output multiline elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsPayloadEventShapedOutputAfterBareBracketLineUntilTail(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
-		`stack frame done]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output" payload=map[timeout_ms:123]`,
-		`output_tail:tail text timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-		t.Fatalf("payload-bearing event-shaped output line was promoted: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("payload-bearing event-shaped output elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsBareBracketOutputLineBeforePayloadlessEventText(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent text`,
-		`stack frame done]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
-		`more output after event-shaped text`,
-		`output_tail:tail text timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-		t.Fatalf("payloadless event-shaped output line was promoted: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("payloadless event-shaped output elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsOrdinaryOutputAfterBareBracketLineUntilTail(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:first line`,
-		`stack frame done]`,
-		`ordinary output after bracket`,
-		`output_tail:tail timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("ordinary output after bracket elapsed_ms = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteEventAfterKeyShapedOutputLine(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:first line`,
-		`timeout_ms:123]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from output"`,
-		`output_tail:tail text timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if contains(cluster.Affected.Issues, "fake") || contains(cluster.Affected.Runs, "fake") {
-		t.Fatalf("event after key-shaped output line was promoted: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("elapsed_ms before key-shaped output line = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotSwallowNextEventAfterBracketedOutputHeadCloses(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
-		`[INFO]]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if !contains(cluster.Affected.Issues, "issue-timeout") || !contains(cluster.Affected.Runs, "issue-timeout") {
-		t.Fatalf("timeout after bracketed output_head close was swallowed: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["timeout_ms"]; got != "60000" {
-		t.Fatalf("timeout after bracketed output_head close timeout_ms = %q; want 60000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotSwallowNextEventAfterSpacedBracketOutputHeadCloses(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
-		`[INFO] ]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if !contains(cluster.Affected.Issues, "issue-timeout") || !contains(cluster.Affected.Runs, "issue-timeout") {
-		t.Fatalf("timeout after spaced bracket output_head close was swallowed: issues=%#v runs=%#v", cluster.Affected.Issues, cluster.Affected.Runs)
-	}
-	if got := cluster.Evidence[0].Metadata["timeout_ms"]; got != "60000" {
-		t.Fatalf("timeout after spaced bracket output_head close timeout_ms = %q; want 60000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteAmbiguousEventAfterOutputHeadOnlyMultiline(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
-		`last line]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=fake issue_id=fake msg="from opaque output" payload=map[timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("ambiguous event-shaped output after single-bracket close was promoted: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteAmbiguousClosedNextEventBeforeOrdinaryLog(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
-		`last line]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[timeout_ms:60000]`,
-		`ordinary log after timeout`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("ambiguous closed event-shaped output before ordinary log was promoted: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteAmbiguousEventAfterTimestampedNonEventLog(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
-		`last line]`,
-		`2026/06/18 09:00:00 state HTTP server listening on http://127.0.0.1:8080`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("ambiguous event-shaped output after timestamped non-event text was promoted: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteAmbiguousMultilineEventAfterOutputHeadOnlyMultiline(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_end task_id=issue-ok issue_id=issue-ok msg="done" payload=map[ok:true output_head:first line`,
-		`last line]`,
-		`2026/06/18 09:00:01 event=runner_timeout task_id=issue-timeout issue_id=issue-timeout msg="timeout" payload=map[elapsed_ms:60000 output_head:timeout first line`,
-		`output_tail:timeout tail timeout_ms:60000]`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	if len(report.Clusters) != 0 {
-		t.Fatalf("ambiguous multiline event-shaped output after single-bracket close was promoted: %#v", report.Clusters)
-	}
-}
-
-func TestTraceHarnessReportScriptIgnoresContinuationTextAfterClosedPayload(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[elapsed_ms:70000 output_head:agent timeout_ms:60000]`,
-		`unrelated diagnostic timeout_ms:111`,
-	}, "\n") + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if got := cluster.Evidence[0].Metadata["elapsed_ms"]; got != "70000" {
-		t.Fatalf("elapsed_ms before closed payload continuation = %q; want 70000; metadata=%#v", got, cluster.Evidence[0].Metadata)
-	}
-	if _, ok := cluster.Evidence[0].Metadata["timeout_ms"]; ok {
-		t.Fatalf("timeout_ms after opaque output was promoted: %#v", cluster.Evidence[0].Metadata)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteNestedPayloadIdentifiers(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real session_id=session-real msg="tool" payload=map[tool:missing arguments:map[output_head:agent-text session_id:fake-session pr_number:777] pr_number:938]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "tool-unsupported")
-	if contains(cluster.Affected.Sessions, "fake-session") || !contains(cluster.Affected.Sessions, "session-real") {
-		t.Fatalf("nested payload session_id was promoted: %#v", cluster.Affected.Sessions)
-	}
-	if contains(cluster.Affected.PullRequests, "777") || contains(cluster.Affected.PullRequests, "938") {
-		t.Fatalf("nested payload pr_number was promoted: %#v", cluster.Affected.PullRequests)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsUnsupportedToolCallArgumentsFromExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[pr_number:938 tool:missing_graphql arguments:map[query:mutation{issueUpdate(input:{id:"secret"})} variables:map[token:abc]]]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "tool-unsupported")
-	if !contains(cluster.Affected.PullRequests, "938") {
-		t.Fatalf("top-level pr_number was lost while redacting arguments: %#v", cluster.Affected.PullRequests)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"mutation{issueUpdate", `id:\"secret\"`, "variables:map"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("unsupported tool arguments leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("unsupported tool arguments were not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsUnsupportedToolCallArgumentsWithBracketText(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[tool:missing_graphql arguments:map[query:query { issue(id: "]secret") { id } } variables:map[token:abc]] pr_number:938]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "tool-unsupported")
-	if !contains(cluster.Affected.Issues, "issue-real") {
-		t.Fatalf("issue id was lost while redacting bracketed arguments: %#v", cluster.Affected.Issues)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"issue(id:", "]secret", "variables:map"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("unsupported tool arguments with bracket text leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("unsupported tool bracket arguments were not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptStopsAtBracketedOpaquePayload(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[pr_number:938 arguments:map[text:hello] session_id:fake pr_number:777] tool:missing]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "tool-unsupported")
-	if !contains(cluster.Affected.PullRequests, "938") {
-		t.Fatalf("trusted pr_number before opaque boundary was lost: %#v", cluster.Affected.PullRequests)
-	}
-	if contains(cluster.Affected.Sessions, "fake") || contains(cluster.Affected.PullRequests, "777]") {
-		t.Fatalf("bracketed opaque payload fields were promoted: sessions=%#v prs=%#v", cluster.Affected.Sessions, cluster.Affected.PullRequests)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"hello]", "session_id:fake", "777]"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("bracketed opaque payload leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("bracketed opaque payload was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptStopsAtScalarUnsupportedToolArguments(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[arguments:not-an-object session_id:payload-session pr_number:938 tool:missing]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "tool-unsupported")
-	if contains(cluster.Affected.Sessions, "payload-session") {
-		t.Fatalf("scalar arguments trailing session_id was promoted: %#v", cluster.Affected.Sessions)
-	}
-	if contains(cluster.Affected.PullRequests, "938") {
-		t.Fatalf("scalar arguments trailing pr_number was promoted: %#v", cluster.Affected.PullRequests)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"not-an-object", "payload-session", "938", "tool:missing"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("scalar unsupported tool arguments leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("scalar unsupported tool arguments leaked in report:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotPromoteUnsupportedToolArgumentsToMetadata(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=unsupported_tool_call task_id=issue-real issue_id=issue-real msg="tool" payload=map[tool:missing_graphql arguments:map[query:query { issue(id: "] SECRET_METADATA") { id } } session_id:fake-session error:SECRET_METADATA] pr_number:938]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "tool-unsupported")
-	if contains(cluster.Affected.Sessions, "fake-session") {
-		t.Fatalf("unsupported tool argument session_id was promoted: %#v", cluster.Affected.Sessions)
-	}
-	metadata := cluster.Evidence[0].Metadata
-	if metadata["session_id"] == "fake-session" || metadata["error"] == "SECRET_METADATA" {
-		t.Fatalf("unsupported tool arguments were promoted into metadata: %#v", metadata)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"fake-session", "SECRET_METADATA"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("unsupported tool arguments leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("unsupported tool arguments were not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsMalformedRawGraphQLPayloadFromExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=malformed task_id=issue-real issue_id=issue-real msg="bad protocol" payload=map[raw:{"method":"item/tool/call","arguments":{"query":"mutation { issueUpdate(input:{id:\"secret\"}) { id } }"}}]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	cluster := findCluster(t, report, "malformed-protocol")
-	if !contains(cluster.Affected.Issues, "issue-real") {
-		t.Fatalf("issue id was lost while redacting malformed payload: %#v", cluster.Affected.Issues)
-	}
-	text := string(raw)
-	for _, leaked := range []string{"issueUpdate", `id:\\\"secret\\\"`, "item/tool/call"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("malformed raw GraphQL payload leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-malformed-payload]") {
-		t.Fatalf("malformed raw payload was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { issueUpdate(input:{id:"secret"}) { id } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"issueUpdate", `id:\"secret\"`, "mutation {"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("runner output GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsNamedGraphQLFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation IssueUpdate($input: IssueUpdateInput!) { issueUpdate(input:$input) { id } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"IssueUpdate", "issueUpdate", "$input"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("named runner output GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("named runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsMinifiedScalarOnlyGraphQLFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:query Secret($token:String="not-a-token-secret"){id} timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"query Secret", "not-a-token-secret", "{id}"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("minified scalar-only GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("minified scalar-only GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsLongHeaderGraphQLFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	var vars []string
-	for idx := 0; idx < 40; idx++ {
-		vars = append(vars, fmt.Sprintf("$v%d: String", idx))
-	}
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation LongOperation(` + strings.Join(vars, ", ") + `) { issueUpdate(input:{id:"secret-long"}) { id } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"LongOperation", "issueUpdate", "secret-long"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("long-header runner output GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("long-header runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLFragmentFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:fragment SecretFields on Issue { id title privateNote } mutation M { issueUpdate(input:{id:"secret-frag"}) { id } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"fragment SecretFields", "privateNote", "secret-frag"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("fragment runner output GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("fragment runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLVariablesFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { issueUpdate(input:{id:"id-public"}) { id } } variables:{"private":"not-a-token-secret"} timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"issueUpdate", "variables:", "not-a-token-secret"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("runner output GraphQL variables leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("runner output GraphQL variables were not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsVariablesOnlyGraphQLRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:variables:{"private":"not-a-token-secret"} timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"variables:", "not-a-token-secret"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("variables-only GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("variables-only GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsJSONVariablesOnlyGraphQLRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{"arguments":{"variables":{"private":"not-a-token-secret"}}} timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"variables", "not-a-token-secret"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("JSON variables-only GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("JSON variables-only GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsEscapedJSONVariablesOnlyGraphQLRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{\"arguments\":{\"variables\":{\"private\":\"not-a-token-secret\"}}} timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{`\"variables\"`, "not-a-token-secret"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("escaped JSON variables-only GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("escaped JSON variables-only GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsJSONVariablesBeforeQueryRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{"arguments":{"variables":{"private":"not-a-token-secret"},"query":"mutation { issueUpdate(input:{id:\"id-public\"}) { id } }"}} timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"variables", "not-a-token-secret", "issueUpdate", "id-public"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("JSON variables-before-query GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("JSON variables-before-query GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptDoesNotStopGraphQLRedactionAtAliasNamedTimeoutMS(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { timeout_ms:issue(id:"secret-id"){id}}]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"timeout_ms:issue", "issue(id:", "secret-id", "{id}"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("GraphQL alias named timeout_ms leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("GraphQL alias named timeout_ms was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLStringBraceFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { issue(id:"} SECRET_AFTER_BRACE") { id title } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"SECRET_AFTER_BRACE", "{ id title }", "issue(id:"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("runner output GraphQL string brace leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("runner output GraphQL string brace was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLAliasFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { model: issue(id:"secret-id") { id title } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"model: issue", "issue(id:", "secret-id"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("alias runner output GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("alias runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLSelectionSetFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{ issue(id:"secret-id") { id title } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"issue(id:", "secret-id", "{ id title }"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("selection-set runner output GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("selection-set runner output GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsSpreadFirstGraphQLSelectionSet(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{ ...SecretFields } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"SecretFields", "{ ..."} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("spread-first selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("spread-first selection-set GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsCommentFirstGraphQLSelectionSet(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:{ # leading comment`,
-		`issue(id:"secret-id") { id title } } timeout_ms:60000]`,
-	}, "\n") + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"leading comment", "issue(id:", "secret-id", "{ id title }"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("comment-first selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("comment-first selection-set GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsGraphQLCommentBracesFromRunnerOutputExcerpt(t *testing.T) {
-	root := repoRoot(t)
-	body := strings.Join([]string{
-		`2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:mutation { # } SECRET_COMMENT`,
-		`issue(id:"secret-id") { id title } } timeout_ms:60000]`,
-	}, "\n") + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"SECRET_COMMENT", "issue(id:", "secret-id", "{ id title }"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("runner output GraphQL comment leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("runner output GraphQL comment was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsProsePrefixedGraphQLSelectionSet(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:GraphQL request: { issue(id:"secret-id") { id title } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"issue(id:", "secret-id", "{ id title }"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("prose-prefixed selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("prose-prefixed selection-set GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsBracketedProseGraphQLSelectionSet(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real msg="timeout" payload=map[output_head:[INFO] GraphQL request: { issue(id:"secret-id") { id title } } timeout_ms:60000]` + "\n"
-	raw := runTraceHarnessReportRaw(t, root, body)
-	report := parseTraceReport(t, raw)
-
-	findCluster(t, report, "runner-timeout")
-	text := string(raw)
-	for _, leaked := range []string{"issue(id:", "secret-id", "{ id title }"} {
-		if strings.Contains(text, leaked) {
-			t.Fatalf("bracketed prose selection-set GraphQL leaked %q in report:\n%s", leaked, raw)
-		}
-	}
-	if !strings.Contains(text, "payload=[redacted-payload]") {
-		t.Fatalf("bracketed prose selection-set GraphQL was not replaced with a redaction marker:\n%s", raw)
-	}
-}
-
-func TestTraceHarnessReportScriptKeepsTopLevelFieldsWhenOutputRepeatsKeys(t *testing.T) {
-	root := repoRoot(t)
-	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-real issue_id=issue-real session_id=session-real msg="timeout" payload=map[output_head:event=runner_end task_id=issue-output issue_id=issue-output session_id=session-output]` + "\n"
-	report := runTraceHarnessReport(t, root, body)
-
-	cluster := findCluster(t, report, "runner-timeout")
-	if !contains(cluster.Affected.Issues, "issue-real") || contains(cluster.Affected.Issues, "issue-output") {
-		t.Fatalf("issue ids were parsed from output text: %#v", cluster.Affected.Issues)
-	}
-	if !contains(cluster.Affected.Sessions, "session-real") || contains(cluster.Affected.Sessions, "session-output") {
-		t.Fatalf("session ids were parsed from output text: %#v", cluster.Affected.Sessions)
-	}
-}
-
-func TestTraceHarnessReportScriptRedactsInvalidUTF8InsideOpaquePayload(t *testing.T) {
-	root := repoRoot(t)
-	raw := []byte("2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg=\"timeout\" payload=map[output_head:\xff]\n")
-	reportRaw := runTraceHarnessReportRawBytes(t, root, raw)
-
-	if !strings.Contains(string(reportRaw), "runner-timeout") || !strings.Contains(string(reportRaw), "payload=[redacted-payload]") || strings.Contains(string(reportRaw), `\ufffd`) {
-		t.Fatalf("invalid UTF-8 opaque payload was not redacted:\n%s", reportRaw)
-	}
-}
-
-type traceReport struct {
-	SchemaVersion string `json:"schema_version"`
-	Clusters      []traceCluster
-}
-
-type traceCluster struct {
-	ID       string `json:"id"`
-	Affected struct {
-		Issues           []string       `json:"issues"`
-		IssueIdentifiers []string       `json:"issue_identifiers"`
-		PullRequests     []string       `json:"pull_requests"`
-		Runs             []string       `json:"runs"`
-		Sessions         []string       `json:"sessions"`
-		Omitted          map[string]int `json:"omitted"`
-	} `json:"affected"`
-	Evidence []struct {
-		Excerpt  string            `json:"excerpt"`
-		Metadata map[string]string `json:"metadata"`
-	} `json:"evidence"`
-}
-
 func runTraceHarnessReport(t *testing.T, root, body string) traceReport {
 	t.Helper()
-	raw := runTraceHarnessReportRaw(t, root, body)
-	return parseTraceReport(t, raw)
+	return parseTraceReport(t, runTraceHarnessReportRaw(t, root, body))
 }
 
 func parseTraceReport(t *testing.T, raw []byte) traceReport {
@@ -1677,18 +642,7 @@ func runTraceHarnessReportRawBytes(t *testing.T, root string, body []byte) []byt
 	if err := os.WriteFile(logPath, body, 0o600); err != nil {
 		t.Fatalf("write log: %v", err)
 	}
-	jsonPath := filepath.Join(dir, "report.json")
-	cmd := exec.Command("python3", filepath.Join(root, "scripts", "trace-harness-report.py"), "--worker-log", logPath, "--json-out", jsonPath)
-	cmd.Dir = root
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("trace-harness-report failed: %v\n%s", err, out)
-	}
-	raw, err := os.ReadFile(jsonPath)
-	if err != nil {
-		t.Fatalf("read report: %v", err)
-	}
-	return raw
+	return runTraceHarnessReportRawPath(t, root, logPath)
 }
 
 func runTraceHarnessReportRawPath(t *testing.T, root, logPath string) []byte {
@@ -1707,6 +661,26 @@ func runTraceHarnessReportRawPath(t *testing.T, root, logPath string) []byte {
 	return raw
 }
 
+func clusterRedactionNote(t *testing.T, raw []byte, id string) string {
+	t.Helper()
+	var report struct {
+		Clusters []struct {
+			ID            string `json:"id"`
+			RedactionNote string `json:"redaction_note"`
+		} `json:"clusters"`
+	}
+	if err := json.Unmarshal(raw, &report); err != nil {
+		t.Fatalf("unmarshal report: %v\n%s", err, raw)
+	}
+	for _, cluster := range report.Clusters {
+		if cluster.ID == id {
+			return cluster.RedactionNote
+		}
+	}
+	t.Fatalf("missing cluster %q for redaction note", id)
+	return ""
+}
+
 func findCluster(t *testing.T, report traceReport, id string) traceCluster {
 	t.Helper()
 	for _, cluster := range report.Clusters {
@@ -1718,15 +692,6 @@ func findCluster(t *testing.T, report traceReport, id string) traceCluster {
 	return traceCluster{}
 }
 
-func mustJSON(t *testing.T, value any) string {
-	t.Helper()
-	raw, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("marshal JSON: %v", err)
-	}
-	return string(raw)
-}
-
 func contains(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
@@ -1734,4 +699,25 @@ func contains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+type traceReport struct {
+	SchemaVersion string `json:"schema_version"`
+	Clusters      []traceCluster
+}
+
+type traceCluster struct {
+	ID       string `json:"id"`
+	Affected struct {
+		Issues           []string       `json:"issues"`
+		IssueIdentifiers []string       `json:"issue_identifiers"`
+		PullRequests     []string       `json:"pull_requests"`
+		Runs             []string       `json:"runs"`
+		Sessions         []string       `json:"sessions"`
+		Omitted          map[string]int `json:"omitted"`
+	} `json:"affected"`
+	Evidence []struct {
+		Excerpt  string            `json:"excerpt"`
+		Metadata map[string]string `json:"metadata"`
+	} `json:"evidence"`
 }


### PR DESCRIPTION
Closes #938

## Summary
- Add a read-only `scripts/trace-harness-report.py` CLI that converts existing worker process logs into bounded harness-improvement clusters.
- Capture event kind, issue/run/session/PR ids, and timestamp from each record's **single-line structured prefix**, plus trusted scalar payload fields up to the first non-safe-scalar chunk.
- Treat the `payload=map[...]` region as **opaque**: it is Go's unescaped, multi-line `%v` map rendering, so it is never parsed and never reproduced in excerpts.

Current head: `cecc94669470e5c07a395faca647c161ff256dd6`

## Design correction in this revision (the substance of this PR)
The earlier head tried to robustly parse the multi-line Go `%v` `map[...]` payload to recover scalars Go sorts behind opaque keys. That is **fundamentally unsound** — `%v` map output has no escaping or delimiter that cannot appear in a value — and it produced eight successive Codex bracket-edge-case findings (the failure #944 documents). This revision removes that machinery:

- **Records are line-oriented**: a record starts at `^<timestamp> event=<known-kind>`; continuation lines (multi-line opaque payload spillover) are skipped.
- **Payload read is first-line-only, contiguous-run, stop-at-first-non-safe-chunk**: the map body is scanned as space-separated `key:value` chunks left-to-right; the scan stops at the first chunk that is not a recognized safe scalar — an opaque key (`output_head`, `output_tail`, `error`, `arguments`, `arguments_raw`, `raw`, `params`), an agent-controlled key (the chosen `tool` name, whose value Go renders unquoted), an unrecognized key, or free-form text. The importer never finds where a `map[...]` ends and never counts brackets.
- **Excerpts never reproduce the payload**: `payload=[redacted-payload]` whenever a payload is present; scalar values live in `evidence[].metadata`.
- **No unquoted-value smuggling**: because Go renders map values unquoted, a stop-at-first-non-safe-chunk run is the only sound way to keep text inside an earlier value (e.g. a spaced `tool` name) from being promoted as a later top-level key.
- **Known limitation, documented + tested**: scalars Go sorts behind that boundary (`tool`, payload `session_id`, `timeout_ms`) are not recovered; the harness fix is for the worker to emit a structured payload — exactly the kind of improvement this report exists to surface. Opaque output that reproduces the full record-start grammar is indistinguishable from a real record and may be surfaced.

Effect: all eight prior Codex bracket findings are mooted (no parser left to get wrong), the script drops 667→467 lines and the test file 1737→~745 lines, and redaction is strictly stronger (payload never reproduced).

## Acceptance criteria
- [x] Documented command generates a grouped report from a supported real input class: worker process logs.
- [x] Output schema contains cluster id/title, symptom class, affected ids, evidence refs/excerpts, suspected harness surface, proposed next action, acceptance criteria, and redaction note.
- [x] Report is generated by tooling, not hand-clustered by the operator.
- [x] Secret/size handling: clone-URL userinfo and token-like values (incl. `lin_api_`) in the prefix or trusted scalar metadata are redacted; the whole payload region is omitted from excerpts; evidence capped at 64 KiB/run; clusters capped at 256 KiB compact JSON; omitted affected-id counts reported when needed.
- [x] Tests cover line-oriented record detection, contiguous-run scalar extraction, the unquoted-`tool` smuggling guard, opaque-payload omission, embedded-output handling (skipped + documented limitation), token/clone-URL masking, and byte caps.
- [x] Documentation explains supported inputs, unsupported inputs, the line-oriented + contiguous-run/opaque-boundary read, redaction behavior, the not-recovered-scalar limitation, the structured-payload harness fix, and examples.

Unsupported in this first subset, per the runbook: tracker comments/history, PR review threads, Codex review comments, human reviews, CI logs, and workspace `.aiops` artifacts.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

Report-only operator script over already-emitted worker logs. No worker-side verifier, post-turn gate, tracker writer, prompt mutator, PR mutator, or orchestrator lifecycle phase.

## PR diff size budget (AGENTS.md)
- [ ] `within budget`
- [x] `size-gated: justified overage` — single coherent operator CLI is 467 lines (parser + grouping + conservative redaction + byte bounds), over the ~300 LOC guideline but not separable without adding public API solely to satisfy the budget (AGENTS.md forbids that). Down sharply from the prior head's 817-line classification; the test file (1737→~745) is excluded from the count. #943 tracks the size/readability lesson. **Needs explicit human size-gate sign-off before merge.**
- [ ] `size-gated: split recommended`

Follow-up #943 tracks the size/readability incentive; #944 tracks the negative-constraint preflight — this revision is the concrete realization of #944's lesson (default to an opaque boundary instead of parsing arbitrary text).

## Testing
Local on `cecc946`:
- [x] `python3 -m py_compile scripts/trace-harness-report.py` + `--help`
- [x] `go test ./scripts -count=1` (full package, incl. trace + size-budget)
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `gofmt -l` clean

Remote CI for `cecc946`: green (6/6).

## Mutation verification
Committed-artifact mutation checks (restored via `git checkout` only with the working tree otherwise clean, per the known mutation/checkout trap):
- Remove the opaque/non-safe `break` (resync across the whole body) → fails `DoesNotSmuggleFakeFieldsViaUnquotedToolValue`.
- Re-add agent-controlled `tool` to `SAFE_PAYLOAD_KEYS` → fails `DoesNotSmuggleFakeFieldsViaUnquotedToolValue`.
- Drop the `runner failed` prefix gate → fails `IgnoresSuccessfulRunnerEnd`.
- Disable per-cluster set dedup (always append) → fails `BoundsFullEvidenceEntriesByBytes`; forget to drop `_seen` before encoding → JSON serialization fails `GroupsWorkerLogsAndRedactsCloneURLs`.
- Corrupt the streamed digest/byte count → fails `ReportsStreamedInputDigest`.
- Truncate the findings generator (yield only the first) → fails `BoundsFullClusterByBytes`.
- Reproduce the payload in the excerpt → fails `RedactsEveryOpaquePayloadFromExcerpt` / `GroupsWorkerLogsAndRedactsCloneURLs`.
- Drop the `WORKER_RECORD_START_RE` gate → fails `IgnoresPlainEventText` / `IgnoresTimestampedProseEventText` / `DoesNotPromoteEmbeddedNonRecordOutput`.
Tree restored == HEAD after each.

## Review ledger
- Current-head local gate + mutation verification: green on `cecc946`.
- Eight prior-head Codex bracket findings + two open review threads: mooted by the redesign; threads resolved, then the stale bot comments/threads were cleaned up.
- Local Claude code-reviewer subagent on `87b62e7..2bf50db`: found one real P1 (unquoted-`tool` value smuggling fake top-level scalars) — fixed in `f5ec920` with a regression test and mutation check; other five dimensions clean.
- Official `@codex review` on `2bf50db`: clean ("Didn't find any major issue").
- Official `@codex review` on `f5ec920`: found one P2 (O(N^2) affected-id accumulation) — fixed in `af0860d` with a per-cluster dedup set, an assertion, and a mutation check; thread resolved.
- Stale bot review comments/threads from superseded commits were cleaned up.
- Official `@codex review` on `af0860d`: found one P2 (input_ref read whole file into memory) — fixed in `3afae89` by streaming the digest, with a pinning test and mutation checks; thread resolved.
- Official `@codex review` on `3afae89`: found one P2 (parse_worker_log buffered all findings) — fixed in `cecc946` by making it a generator; thread resolved.
- Official `@codex review` on `cecc946`: **clean** ("Didn't find any major issues. Chef's kiss.").
- Review threads: 0 unresolved.
- CI on `cecc946`: green (6/6).

## Merge gate status
CI green, official `@codex review` clean, and zero unresolved review threads on `cecc946`. Remaining before merge: still **draft**, `size-gated: justified overage` needs **explicit human size-gate sign-off**, and explicit merge permission (per the PR review/merge protocol).

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
