### PR TITLE
docs(workflow): add negative-constraint issue preflight

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -34,6 +34,18 @@ metadata:
 
 动手前先执行协议 §9 的 **issue-phase 探测**，判定命令与处置路由全部以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md#9-concurrent-sessions-on-one-pr) §9 为唯一来源，照其结果执行。**模式自主选定并通报，不询问。**
 
+### 1.5 负面约束 preflight（设计 / 边界类 issue 必须）
+如果 issue 引用了 design doc、runbook、SPEC boundary、redaction/retention rule、non-goal list，或正文里出现 "do not store / parse / mutate / persist / automate / gate" 这类负面约束，**写代码前先写短 guardrail**。至少列出：
+
+- **Required behavior**：必须生成 / 修改 / 证明什么。
+- **Negative constraints**：不得存储、解析、变更、持久化、自动化、当成 gate 的东西。
+- **Opaque boundaries**：哪些输入是任意 human / agent / protocol text，除非 issue 明确要求 parser，否则不得解析。
+- **Design challenge**：如果 redaction / retention 需求看起来必须靠 grammar / parser / heuristic 理解自由文本才能满足，先停下，说明为什么 opaque omission 不够。
+
+默认规则：对任意文本的 redaction / retention 要求，优先 **opaque omission**（整体省略 / 引用元数据 / 有界摘要），不要为了"更聪明地删敏"去写 protocol-specific parser。只有当 issue 明确要求 structured parsing 且给出 fixtures / grammar 时，才把解析器当实现范围。
+
+首轮 pre-push reviewer brief 必须带上这份 guardrail，让 reviewer 先攻击方向和边界，而不是只追 edge cases；具体 reviewer 路由仍只按共享协议 §3 执行，不在这里复述。
+
 ### 2. SPEC / upstream 调研（写代码之前）
 - 读 SPEC.md 相关章节 + 对应 Elixir 模块（`orchestrator.ex` / `codex/app_server.ex` / `tracker.ex` / `config/schema.ex`），歧义以 Elixir 为准。
 - **审查相邻路径**（AGENTS.md「Cross-cutting checklist」item 1）：grep 你要改的 SPEC 概念符号，列出其它 consumer；aiops 扩展（service routing `selectRoutedCandidates`、multi-tracker fan-out、per-state capacity caps、eligibility filter、reconcile hooks）要么也在你的新路径生效，要么写明为何不同。**踩坑实例**：blocked vs running 清理路径只兑现了一半契约。

--- a/.trellis/spec/backend/agent-workflow-guidelines.md
+++ b/.trellis/spec/backend/agent-workflow-guidelines.md
@@ -50,12 +50,14 @@ Before changing code or workflow behavior:
 1. Open or update the relevant Trellis task.
 2. Write a short plan with goal, scope, acceptance criteria, dependencies, and
    verification.
-3. For issue work driven by a design document, extract the negative constraints
-   before choosing an implementation: non-goals, unsupported inputs, redaction
-   and retention limits, forbidden runtime side effects, and any "do not store /
-   do not parse / do not mutate" wording. If the simplest design would require
-   understanding arbitrary human or agent text, treat that as a warning sign and
-   prefer an opaque boundary unless the issue explicitly asks for a parser.
+3. For issue work driven by a design document, runbook, SPEC boundary,
+   redaction/retention rule, or non-goal list, extract the negative constraints
+   before choosing an implementation: required behavior, unsupported inputs,
+   redaction and retention limits, forbidden runtime side effects, and any "do
+   not store / parse / mutate / persist / automate / gate" wording. If the
+   simplest design would require understanding arbitrary human, agent, or
+   protocol text, stop and prefer opaque omission unless the issue explicitly
+   asks for structured parsing with fixtures.
 4. Run a `grill-with-docs` review of the plan against `CONTEXT.md`, ADRs, and
    the relevant runbooks.
 5. Capture settled terminology in `CONTEXT.md` only when it is domain language,

--- a/docs/engineering-rules-rationale.md
+++ b/docs/engineering-rules-rationale.md
@@ -201,6 +201,24 @@ shipped.
   `issueHasRequiredLabels` tests passed; #683's refresh label-carry
   (`issue.Labels = st.Labels`) had no positive test until one was added.
 
+## Workflow and PR protocol
+
+- **Issue workflow negative-constraint preflight.** For issues that cite a
+  design doc, runbook, SPEC boundary, redaction/retention rule, or non-goal
+  list, convert the negative constraints into a short implementation guardrail
+  before writing code, and include that guardrail in the first pre-push reviewer
+  brief. Redaction/retention over arbitrary human, agent, protocol, or Go `%v`
+  map text defaults to opaque omission unless the issue explicitly asks for
+  structured parsing with fixtures. **Earned by:** #938 / PR #942, where the
+  design already said bounded evidence, metadata-first output, no raw GraphQL
+  payloads, and no worker/runtime mutation, but the first implementation still
+  chased a complex parser for GraphQL-like runner output and `%v` map text.
+  Review pressure then found parser/redaction edge cases one by one instead of
+  challenging the boundary choice up front. This is separate from #943, which
+  tracks the LOC/readability budget incentive exposed by the same PR; #944 is
+  the direction-setting lesson: choose an opaque boundary before parser edge
+  cases exist.
+
 ## Conventions
 
 - **All external I/O is timeout-bounded.** **Earned by:** #287

--- a/docs/runbooks/pr-review-merge-protocol.md
+++ b/docs/runbooks/pr-review-merge-protocol.md
@@ -51,6 +51,13 @@ findings (keep each review ≤700 words) and a final verdict —
 SHA, changed files, intent (issue/PR), relevant SPEC/upstream pointers, and
 AGENTS.md policy.
 
+For issue work that required a negative-constraint preflight, the **first**
+pre-push reviewer brief must also include that guardrail: required behavior,
+negative constraints, opaque boundaries, and the decision to omit arbitrary text
+opaquely unless the issue explicitly asks for structured parsing with fixtures.
+Ask reviewers to challenge the implementation direction and boundary before
+spending their review budget on parser or redaction edge cases.
+
 Subagent review is the **default** in main interactive sessions when the tool
 contract exposes a default-on reviewer path. Interactive Claude Code uses the
 Agent tool and a Codex-family subagent (`codex:codex-rescue`); Codex inline uses


### PR DESCRIPTION
Closes #944

## Summary
- Add an issue-phase negative-constraint preflight to `handle-issue` for design/runbook/SPEC/redaction/non-goal issues.
- Require the first pre-push reviewer brief to include that guardrail so review can challenge direction before parser/redaction edge cases.
- Record #938 / PR #942 as the provenance and distinguish #943 as the separate LOC/readability follow-up.
- Keep Trellis workflow guidance aligned with the canonical issue workflow wording.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs/workflow-only change. No worker/orchestrator runtime behavior, parser, tracker write, merge gate, or CI gate is added.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — 4 documentation/spec files, no production Go LOC.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [ ] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [ ] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [ ] `go vet ./...`
- [ ] `go test -race -covermode=atomic ./...`
- [ ] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- [x] `git diff --check origin/main...HEAD`
- [x] `rg -n "do not store / parse / mutate / persist / automate / gate|Workflow and PR protocol|negative-constraint preflight|opaque omission|structured parsing|#938|#942|#943|commit/amend first|Subagent review is the \\*\\*default\\*\\*|subagent-first" .claude/skills/handle-issue/SKILL.md .trellis/spec/backend/agent-workflow-guidelines.md docs/runbooks/pr-review-merge-protocol.md docs/engineering-rules-rationale.md`

Go/test gates not run locally because this is a docs/workflow-only change and the working tree also contains unrelated Trellis upgrade edits that are intentionally kept out of this PR.

## Review ledger
- Issue-phase owner probe before implementation: no open PR mentioning #944 and no remote `fix/944-*` branch.
- Pre-push subagent path: contract-blocked by current Codex inline instruction to not dispatch implement/check sub-agents; used CLI fallback.
- First-round Codex-family CLI review: `NEEDS-CHANGES`, MEDIUM finding that Trellis task scaffolding / seed JSONL / `in_progress` task state should not be committed.
- First-round Claude-family CLI review: `MERGE-READY`, with LOW polish suggestions about wording drift and rationale placement.
- Fixes applied: removed Trellis task directory from the committed diff, aligned Trellis spec wording to the canonical trigger verbs, and moved provenance into a workflow/protocol section.
- Second-round Codex-family CLI review: `MERGE-READY`, no findings.
- Second-round Claude-family CLI review: unavailable due to Claude CLI session limit 429; operator explicitly directed not to wait and to continue.

## Acceptance criteria
- [x] `handle-issue` or shared PR protocol requires a negative-constraint preflight for issues that reference a design doc, runbook, SPEC boundary, redaction/retention rule, or non-goal list.
- [x] Guidance explicitly says redaction/retention requirements over arbitrary text should default to opaque omission, not protocol-specific parsing, unless the issue asks for structured parsing and fixtures.
- [x] Reviewer prompts/briefs for the pre-push dual-review gate include the negative constraints and opaque-boundary decision.
- [x] Rationale/provenance docs cite the #938/#942 failure and distinguish it from #943's separate LOC/readability failure.
- [x] Existing subagent-first and commit-first review flow is preserved.
