### PR TITLE
feat: render trace harness proposals

### DIFF
--- a/docs/runbooks/trace-harness-report.md
+++ b/docs/runbooks/trace-harness-report.md
@@ -32,8 +32,8 @@ review comments, human reviews, CI logs, or workspace `.aiops` artifacts such as
 `.aiops/CODEX_APP_SERVER_OUTPUT.txt`, `.aiops/PLAN.md`, or `.aiops/TASK.md`.
 Those are still valid design inputs, but this command only reports from local
 worker logs already collected by the operator. It also does not automatically
-open issues or draft PRs; that belongs to the later proposal-rendering
-milestone.
+open issues or draft PRs; proposal text is rendered for an explicit operator or
+agent action.
 
 ## How the importer reads a worker log
 
@@ -71,7 +71,7 @@ kind>`) is indistinguishable from a real record and may be surfaced.
 
 ## Output schema
 
-The JSON output uses schema `trace-harness-report/v1`. Each cluster contains:
+The JSON output uses schema `trace-harness-report/v2`. Each cluster contains:
 
 - cluster id and short title
 - symptom class
@@ -82,10 +82,35 @@ The JSON output uses schema `trace-harness-report/v1`. Each cluster contains:
   byte cap requires truncating these id lists
 - evidence references with bounded excerpts
 - suspected harness surface to change
-- proposed next action, currently `issue proposal` for supported worker-log
-  failure clusters
+- proposed next action, currently `issue or draft-PR proposal` for supported
+  worker-log failure clusters
 - acceptance criteria for the proposed harness change
 - redaction note naming what was omitted
+- `proposals.github_issue.body`, a ready-to-open issue body for promoting the
+  reviewed cluster without hand-writing the issue
+- `proposals.draft_pr.plan`, a draft-PR plan a normal coding agent can use for
+  follow-through after the operator approves the intent
+
+The proposal fields repeat references and bounded metadata, not raw unbounded
+logs. They preserve the same redaction note and SPEC boundary as the cluster:
+the worker does not open the issue or PR, mutate tracker state, rewrite harness
+files, or create evaluator gates.
+
+## Promoting a reviewed cluster
+
+After reviewing a cluster, extract the generated issue body or draft-PR plan and
+pass it to the normal GitHub or coding-agent workflow:
+
+```bash
+jq -r '.clusters[] | select(.id == "runner-timeout").proposals.github_issue.body' \
+  ./trace-report.json > /tmp/runner-timeout-issue.md
+
+jq -r '.clusters[] | select(.id == "runner-timeout").proposals.draft_pr.plan' \
+  ./trace-report.json > /tmp/runner-timeout-pr-plan.md
+```
+
+Opening the issue, starting the draft PR, or running a coding agent remains an
+explicit workflow action outside this report command.
 
 ## Redaction and bounds
 

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -35,9 +35,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
-SCHEMA_VERSION = "trace-harness-report/v1"
+SCHEMA_VERSION = "trace-harness-report/v2"
 MAX_RUN_EVIDENCE_BYTES, MAX_CLUSTER_BYTES, MAX_EVIDENCE_EXCERPT_BYTES = 64 * 1024, 256 * 1024, 4 * 1024
 MAX_METADATA_BYTES, MAX_METADATA_VALUE_BYTES = 16 * 1024, 4 * 1024
+MAX_PROPOSAL_EVIDENCE_REFS, MAX_PROPOSAL_AFFECTED_VALUES = 5, 5
+MAX_PROPOSAL_INPUT_REFS, MAX_PROPOSAL_FIELD_BYTES = 3, 512
 
 FIELD_RE = re.compile(r'\b(event|task_id|issue_id|issue_identifier|session_id|pr|pr_number|pr_url|pull_request|pull_request_url)=("[^"]*"|\S+)')
 CLONE_URL_SCHEME_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9+.-]*://")
@@ -99,6 +101,7 @@ def generate(paths: list[Path]) -> dict:
     clusters: dict[str, dict] = {}
     run_bytes: dict[str, int] = {}
     inputs = [input_ref(path) for path in paths]
+    report_ref = proposal_report_reference(inputs)
     for path in paths:
         for finding in parse_worker_log(path):
             add_finding(clusters, run_bytes, finding)
@@ -110,7 +113,7 @@ def generate(paths: list[Path]) -> dict:
             "max_run_evidence_bytes": MAX_RUN_EVIDENCE_BYTES,
             "max_cluster_bytes": MAX_CLUSTER_BYTES,
         },
-        "clusters": [finalize_cluster(clusters[key]) for key in sorted(clusters)],
+        "clusters": [finalize_cluster(clusters[key], report_ref) for key in sorted(clusters)],
     }
 
 
@@ -128,6 +131,19 @@ def input_ref(path: Path) -> dict:
         "bytes": size,
         "sha256": digest.hexdigest(),
     }
+
+
+def proposal_report_reference(inputs: list[dict]) -> str:
+    refs = []
+    for item in inputs[:MAX_PROPOSAL_INPUT_REFS]:
+        sha = item.get("sha256", "")
+        refs.append(
+            f"{item.get('type', 'input')} {md_code(str(item.get('path', '')))} "
+            f"sha256:{sha[:12]} bytes:{item.get('bytes', 0)}"
+        )
+    if len(inputs) > MAX_PROPOSAL_INPUT_REFS:
+        refs.append(f"plus {len(inputs) - MAX_PROPOSAL_INPUT_REFS} more input(s) in report.inputs")
+    return f"{SCHEMA_VERSION}; inputs: " + "; ".join(refs)
 
 
 def parse_worker_log(path: Path) -> Iterator[dict]:
@@ -256,7 +272,7 @@ def new_cluster(finding: dict) -> dict:
         "_evidence_bytes": byte_len("[]"),
         "_evidence_count": 0,
         "suspected_harness_surface": "WORKFLOW.md, reviewer rubrics, skills, hooks, tests, CI, or docs",
-        "proposed_next_action": "issue proposal",
+        "proposed_next_action": "issue or draft-PR proposal",
         "acceptance_criteria": [
             "Future runs cover this failure class with a reviewed harness surface or a documented no-op decision.",
             "The change remains report/agent/workflow-owned and does not add a worker-side gate or tracker writer.",
@@ -324,14 +340,192 @@ def evidence_array_bytes_after(cluster: dict, entry_size: int) -> int:
     return cluster["_evidence_bytes"] + byte_len(",") + entry_size
 
 
-def finalize_cluster(cluster: dict) -> dict:
+def finalize_cluster(cluster: dict, report_ref: str) -> dict:
     for key in AFFECTED_KEYS:
         cluster["affected"][key].sort()
     cluster.pop("_seen", None)  # drop before any encoded_bytes call: sets are not JSON-serializable.
     cluster.pop("_evidence_bytes", None)
     cluster.pop("_evidence_count", None)
     enforce_cluster_bound(cluster)
+    cluster["proposals"] = render_proposals(cluster, report_ref)
+    enforce_cluster_bound(cluster)
+    cluster["proposals"] = render_proposals(cluster, report_ref)
+    enforce_cluster_bound(cluster)
     return cluster
+
+
+def render_proposals(cluster: dict, report_ref: str) -> dict:
+    return {
+        "github_issue": {
+            "title": f"Trace harness: address {cluster['id']} cluster",
+            "body": render_issue_body(cluster, report_ref),
+        },
+        "draft_pr": {
+            "title": f"fix(harness): address {cluster['id']} trace cluster",
+            "plan": render_draft_pr_plan(cluster, report_ref),
+        },
+    }
+
+
+def render_issue_body(cluster: dict, report_ref: str) -> str:
+    lines = [
+        "## Summary",
+        "",
+        f"Trace harness cluster {md_code(cluster['id'])} reports {cluster['symptom_class']}.",
+        "",
+        "Part of #937. Design source: `docs/design/trace-driven-harness-improvement.md`.",
+        "",
+        "## Source",
+        "",
+        f"- Report: {report_ref}",
+        f"- Cluster: {md_code(cluster['id'])}",
+        f"- Failure class: {cluster['symptom_class']}",
+        "",
+        "## Observed evidence",
+        "",
+        *affected_lines(cluster),
+        *evidence_reference_lines(cluster),
+        "",
+        "## Suspected harness surface",
+        "",
+        cluster["suspected_harness_surface"],
+        "",
+        "## Proposed scope",
+        "",
+        proposed_scope(cluster),
+        "",
+        "## Non-goals / SPEC boundary",
+        "",
+        *non_goal_lines(),
+        "",
+        "## Acceptance criteria",
+        "",
+        *checkbox_lines(cluster["acceptance_criteria"]),
+        "",
+        "## Verification expectations",
+        "",
+        *verification_lines(),
+        "",
+        "## Redaction",
+        "",
+        cluster["redaction_note"],
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_draft_pr_plan(cluster: dict, report_ref: str) -> str:
+    lines = [
+        "## Goal",
+        "",
+        proposed_scope(cluster),
+        "",
+        "## Source cluster",
+        "",
+        f"- Report: {report_ref}",
+        f"- Cluster: {md_code(cluster['id'])}",
+        f"- Failure class: {cluster['symptom_class']}",
+        "",
+        "## Evidence to review",
+        "",
+        *affected_lines(cluster),
+        *evidence_reference_lines(cluster),
+        "",
+        "## Implementation plan",
+        "",
+        "1. Inspect the suspected harness surface and confirm the smallest repo-owned change.",
+        "2. Implement that change through normal coding-agent workflow on a branch and draft PR.",
+        "3. Add or update focused tests, docs, or fixtures that pin the harness behavior.",
+        "4. Record a reviewed no-op decision instead if the cluster is not actionable.",
+        "",
+        "## Non-goals / SPEC boundary",
+        "",
+        *non_goal_lines(),
+        "",
+        "## Acceptance criteria",
+        "",
+        *checkbox_lines(cluster["acceptance_criteria"]),
+        "",
+        "## Verification expectations",
+        "",
+        *verification_lines(),
+        "",
+        "## Redaction",
+        "",
+        cluster["redaction_note"],
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def proposed_scope(cluster: dict) -> str:
+    return (
+        f"Make a reviewed harness change, or a reviewed no-op decision, that addresses "
+        f"{md_code(cluster['id'])} ({cluster['symptom_class']}) at the suspected harness surface. "
+        "Keep the worker as scheduler/runner/tracker reader and keep issue/PR creation as an explicit "
+        "operator or coding-agent action."
+    )
+
+
+def affected_lines(cluster: dict) -> list[str]:
+    lines = ["Affected ids recovered from trusted metadata:"]
+    affected = cluster.get("affected", {})
+    omitted = affected.get("omitted", {})
+    emitted = False
+    for key in AFFECTED_KEYS:
+        values = affected.get(key, [])
+        if not values and not omitted.get(key):
+            continue
+        sample = ", ".join(md_code(value) for value in values[:MAX_PROPOSAL_AFFECTED_VALUES])
+        if len(values) > MAX_PROPOSAL_AFFECTED_VALUES:
+            sample += f", plus {len(values) - MAX_PROPOSAL_AFFECTED_VALUES} more"
+        if omitted.get(key):
+            sample = f"{sample}; {omitted[key]} omitted by cluster byte cap" if sample else f"{omitted[key]} omitted by cluster byte cap"
+        lines.append(f"- {key}: {sample}")
+        emitted = True
+    if not emitted:
+        lines.append("- No affected ids were recovered beyond the evidence references.")
+    return lines
+
+
+def evidence_reference_lines(cluster: dict) -> list[str]:
+    lines = ["Evidence references:"]
+    evidence = cluster.get("evidence", [])
+    for entry in evidence[:MAX_PROPOSAL_EVIDENCE_REFS]:
+        lines.append(f"- {md_code(entry.get('ref', ''))} ({entry.get('kind', 'event')}{metadata_suffix(entry.get('metadata', {}))})")
+    remaining = len(evidence) - MAX_PROPOSAL_EVIDENCE_REFS
+    if remaining > 0:
+        lines.append(f"- plus {remaining} additional bounded evidence entries in the report cluster.")
+    if not evidence:
+        lines.append("- No bounded evidence entry was retained; inspect the source report inputs.")
+    return lines
+
+
+def metadata_suffix(metadata: dict) -> str:
+    parts = []
+    for key in ("timestamp", "method", "model", "exit_code", "timeout_ms", "elapsed_ms", "duration_ms", "output_bytes", "output_dropped"):
+        if value := metadata.get(key):
+            parts.append(f"{key}={md_code(value)}")
+    return "; " + ", ".join(parts) if parts else ""
+
+
+def checkbox_lines(values: list[str]) -> list[str]:
+    return [f"- [ ] {value}" for value in values]
+
+
+def non_goal_lines() -> list[str]:
+    return [
+        "- Do not automatically open issues or PRs from the worker.",
+        "- Do not mutate tracker state as worker business logic.",
+        "- Do not edit WORKFLOW.md, rubrics, skills, tests, CI, or docs unless a normal reviewed coding-agent change is approved.",
+        "- Do not create worker-owned verifier or evaluator gates.",
+    ]
+
+
+def verification_lines() -> list[str]:
+    return [
+        "- Add deterministic tests or fixtures for the changed harness surface.",
+        "- Run the local gate appropriate to the touched files before opening or updating the PR.",
+        "- Confirm the change preserves the redaction and SPEC-boundary constraints from the trace-driven harness design.",
+    ]
 
 
 def enforce_cluster_bound(cluster: dict) -> None:
@@ -463,6 +657,10 @@ def truncate(text: str, limit: int) -> str:
         return data[:limit].decode(errors="ignore")
     head = data[: limit - len(suffix_data)].decode(errors="ignore")
     return head + suffix
+
+
+def md_code(text: str) -> str:
+    return "`" + truncate(text, MAX_PROPOSAL_FIELD_BYTES).replace("`", "'") + "`"
 
 
 def byte_len(text: str) -> int:

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -347,11 +347,25 @@ def finalize_cluster(cluster: dict, report_ref: str) -> dict:
     cluster.pop("_evidence_bytes", None)
     cluster.pop("_evidence_count", None)
     enforce_cluster_bound(cluster)
-    cluster["proposals"] = render_proposals(cluster, report_ref)
-    enforce_cluster_bound(cluster)
-    cluster["proposals"] = render_proposals(cluster, report_ref)
-    enforce_cluster_bound(cluster)
+    sync_proposals(cluster, report_ref)
     return cluster
+
+
+def sync_proposals(cluster: dict, report_ref: str) -> None:
+    while True:
+        before = proposal_source_signature(cluster)
+        cluster["proposals"] = render_proposals(cluster, report_ref)
+        enforce_cluster_bound(cluster)
+        if proposal_source_signature(cluster) == before:
+            return
+
+
+def proposal_source_signature(cluster: dict) -> str:
+    return json.dumps(
+        {"affected": cluster.get("affected", {}), "evidence": cluster.get("evidence", [])},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
 
 
 def render_proposals(cluster: dict, report_ref: str) -> dict:

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -551,6 +551,7 @@ def enforce_cluster_bound(cluster: dict) -> None:
         return
 
     omitted = cluster["affected"].setdefault("omitted", {})
+    base_omitted = {key: int(omitted.get(key, 0)) for key in AFFECTED_KEYS}
     originals = {key: list(cluster["affected"][key]) for key in AFFECTED_KEYS}
     for key in sorted(AFFECTED_KEYS, key=lambda name: len(originals[name]), reverse=True):
         if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
@@ -558,12 +559,9 @@ def enforce_cluster_bound(cluster: dict) -> None:
         values = originals[key]
         if not values:
             continue
-        keep = max_affected_keep_count(cluster, key, values)
+        keep = max_affected_keep_count(cluster, key, values, base_omitted[key])
         cluster["affected"][key] = values[:keep]
-        if len(values) > keep:
-            omitted[key] = len(values) - keep
-        else:
-            omitted.pop(key, None)
+        set_affected_omitted(cluster, key, base_omitted[key] + len(values) - keep)
 
     for key, count in list(omitted.items()):
         if count <= 0:
@@ -573,18 +571,28 @@ def enforce_cluster_bound(cluster: dict) -> None:
     trim_evidence_to_cluster_bound(cluster)
 
 
-def max_affected_keep_count(cluster: dict, key: str, values: list[str]) -> int:
+def max_affected_keep_count(cluster: dict, key: str, values: list[str], base_omitted: int) -> int:
     low, high, best = 0, len(values), 0
     while low <= high:
         keep = (low + high) // 2
         cluster["affected"][key] = values[:keep]
-        cluster["affected"]["omitted"][key] = len(values) - keep
+        set_affected_omitted(cluster, key, base_omitted + len(values) - keep)
         if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
             best = keep
             low = keep + 1
         else:
             high = keep - 1
     return best
+
+
+def set_affected_omitted(cluster: dict, key: str, count: int) -> None:
+    omitted = cluster["affected"].setdefault("omitted", {})
+    if count > 0:
+        omitted[key] = count
+    else:
+        omitted.pop(key, None)
+    if not omitted:
+        cluster["affected"].pop("omitted", None)
 
 
 def trim_evidence_to_cluster_bound(cluster: dict) -> None:

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -717,6 +717,22 @@ func TestTraceHarnessReportScriptRerendersProposalsAfterFinalClusterTrimming(t *
 	}
 }
 
+func TestTraceHarnessReportScriptPreservesCumulativeOmittedAffectedCounts(t *testing.T) {
+	root := repoRoot(t)
+	const totalSessions = 18000
+	var body strings.Builder
+	for idx := 0; idx < totalSessions; idx++ {
+		fmt.Fprintf(&body, "2026/06/18 09:00:00 event=runner_timeout task_id=run-%d issue_id=issue-shared session_id=session-%d msg=\"x\"\n", idx%64, idx)
+	}
+	report := runTraceHarnessReport(t, root, body.String())
+
+	cluster := findCluster(t, report, "runner-timeout")
+	got := len(cluster.Affected.Sessions) + cluster.Affected.Omitted["sessions"]
+	if got != totalSessions {
+		t.Fatalf("sessions accounted for = %d; want %d (kept=%d omitted=%d)", got, totalSessions, len(cluster.Affected.Sessions), cluster.Affected.Omitted["sessions"])
+	}
+}
+
 func TestTraceHarnessReportScriptBoundsLargeScalarMetadata(t *testing.T) {
 	root := repoRoot(t)
 	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[model:` + strings.Repeat("m", 300*1024) + ` timeout_ms:60000]` + "\n"

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -700,6 +700,23 @@ func TestTraceHarnessReportScriptBoundsFullClusterByBytes(t *testing.T) {
 	}
 }
 
+func TestTraceHarnessReportScriptRerendersProposalsAfterFinalClusterTrimming(t *testing.T) {
+	root := repoRoot(t)
+	var body strings.Builder
+	for idx := 0; idx < 9500; idx++ {
+		fmt.Fprintf(&body, "2026/06/18 09:00:00 event=runner_timeout task_id=run-%d issue_id=issue-%d session_id=session-%d msg=\"x\"\n", idx%64, idx, idx)
+	}
+	report := runTraceHarnessReport(t, root, body.String())
+
+	cluster := findCluster(t, report, "runner-timeout")
+	for key, omitted := range cluster.Affected.Omitted {
+		want := fmt.Sprintf("%d omitted by cluster byte cap", omitted)
+		if !strings.Contains(cluster.Proposals.GitHubIssue.Body, want) || !strings.Contains(cluster.Proposals.DraftPR.Plan, want) {
+			t.Fatalf("proposal omitted count for %s is stale: want %q\nissue:\n%s\nplan:\n%s", key, want, cluster.Proposals.GitHubIssue.Body, cluster.Proposals.DraftPR.Plan)
+		}
+	}
+}
+
 func TestTraceHarnessReportScriptBoundsLargeScalarMetadata(t *testing.T) {
 	root := repoRoot(t)
 	body := `2026/06/18 09:00:00 event=runner_timeout task_id=issue-1 issue_id=issue-1 msg="timeout" payload=map[model:` + strings.Repeat("m", 300*1024) + ` timeout_ms:60000]` + "\n"

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -34,6 +34,7 @@ func TestTraceHarnessReportRunbookDocumentsSupportedInputsAndBounds(t *testing.T
 	for _, want := range []string{
 		"python3 scripts/trace-harness-report.py",
 		"--worker-log",
+		"trace-harness-report/v2",
 		"Supported inputs",
 		"worker process logs",
 		"64 KiB per run",
@@ -51,6 +52,9 @@ func TestTraceHarnessReportRunbookDocumentsSupportedInputsAndBounds(t *testing.T
 		"Known limitation",
 		"Unsupported inputs",
 		"workspace `.aiops` artifacts",
+		"proposals.github_issue.body",
+		"proposals.draft_pr.plan",
+		"without hand-writing",
 		"Examples",
 	} {
 		if !strings.Contains(normalizedText, want) {
@@ -84,7 +88,7 @@ func TestTraceHarnessReportScriptGroupsWorkerLogsAndRedactsCloneURLs(t *testing.
 		t.Fatalf("read report: %v", err)
 	}
 	report := parseTraceReport(t, raw)
-	if report.SchemaVersion != "trace-harness-report/v1" || len(report.Clusters) != 2 {
+	if report.SchemaVersion != "trace-harness-report/v2" || len(report.Clusters) != 2 {
 		t.Fatalf("unexpected report: %#v", report)
 	}
 	timeout := findCluster(t, report, "runner-timeout")
@@ -169,6 +173,83 @@ func TestTraceHarnessReportScriptReportsAffectedPullRequests(t *testing.T) {
 	cluster := findCluster(t, report, "runner-timeout")
 	if !contains(cluster.Affected.PullRequests, "938") {
 		t.Fatalf("pull request id was not reported as affected: %#v", cluster.Affected.PullRequests)
+	}
+}
+
+func TestTraceHarnessReportScriptRendersActionableProposals(t *testing.T) {
+	root := repoRoot(t)
+	body := `2026/06/18 09:00:00 event=runner_timeout task_id=run-1 issue_id=issue-1 issue_identifier=GH-1 session_id=session-1 msg="timeout" payload=map[elapsed_ms:60000 output_bytes:70000 output_head:secret-output]` + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	if cluster.ProposedNextAction != "issue or draft-PR proposal" {
+		t.Fatalf("ProposedNextAction = %q; want issue or draft-PR proposal", cluster.ProposedNextAction)
+	}
+	if cluster.Proposals.GitHubIssue.Title != "Trace harness: address runner-timeout cluster" {
+		t.Fatalf("GitHub issue title = %q", cluster.Proposals.GitHubIssue.Title)
+	}
+	issueBody := cluster.Proposals.GitHubIssue.Body
+	for _, want := range []string{
+		"Trace harness cluster `runner-timeout` reports runner timeout.",
+		"Part of #937",
+		"docs/design/trace-driven-harness-improvement.md",
+		"Report: trace-harness-report/v2",
+		"Failure class: runner timeout",
+		"- issues: `issue-1`",
+		"- issue_identifiers: `GH-1`",
+		"- runs: `run-1`",
+		"- sessions: `session-1`",
+		"Evidence references:",
+		"worker.log:1",
+		"Suspected harness surface",
+		"Non-goals / SPEC boundary",
+		"Do not automatically open issues or PRs from the worker.",
+		"Acceptance criteria",
+		"Verification expectations",
+		"Redaction",
+	} {
+		if !strings.Contains(issueBody, want) {
+			t.Fatalf("issue proposal missing %q\n%s", want, issueBody)
+		}
+	}
+	if strings.Contains(issueBody, "secret-output") || strings.Contains(issueBody, "output_head:secret-output") {
+		t.Fatalf("issue proposal leaked opaque payload:\n%s", issueBody)
+	}
+
+	plan := cluster.Proposals.DraftPR.Plan
+	for _, want := range []string{
+		"## Goal",
+		"## Implementation plan",
+		"normal coding-agent workflow",
+		"Record a reviewed no-op decision",
+		"Do not create worker-owned verifier or evaluator gates.",
+		"Confirm the change preserves the redaction and SPEC-boundary constraints",
+	} {
+		if !strings.Contains(plan, want) {
+			t.Fatalf("draft PR plan missing %q\n%s", want, plan)
+		}
+	}
+	if cluster.Proposals.DraftPR.Title != "fix(harness): address runner-timeout trace cluster" {
+		t.Fatalf("draft PR title = %q", cluster.Proposals.DraftPR.Title)
+	}
+}
+
+func TestTraceHarnessReportScriptRendersStableProposalText(t *testing.T) {
+	root := repoRoot(t)
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "worker.log")
+	body := []byte(`2026/06/18 09:00:00 event=turn_input_required task_id=run-1 issue_id=issue-1 msg="input" payload=map[method:approval]` + "\n")
+	if err := os.WriteFile(logPath, body, 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	first := findCluster(t, parseTraceReport(t, runTraceHarnessReportRawPath(t, root, logPath)), "input-required")
+	second := findCluster(t, parseTraceReport(t, runTraceHarnessReportRawPath(t, root, logPath)), "input-required")
+	if first.Proposals.GitHubIssue.Body != second.Proposals.GitHubIssue.Body || first.Proposals.DraftPR.Plan != second.Proposals.DraftPR.Plan {
+		t.Fatalf("proposal text was not deterministic\nfirst issue:\n%s\nsecond issue:\n%s", first.Proposals.GitHubIssue.Body, second.Proposals.GitHubIssue.Body)
+	}
+	if strings.Contains(first.Proposals.GitHubIssue.Body, "generated_at") || strings.Contains(first.Proposals.DraftPR.Plan, "generated_at") {
+		t.Fatalf("proposal should not include generation time:\n%s\n%s", first.Proposals.GitHubIssue.Body, first.Proposals.DraftPR.Plan)
 	}
 }
 
@@ -766,8 +847,9 @@ type traceReport struct {
 }
 
 type traceCluster struct {
-	ID       string `json:"id"`
-	Affected struct {
+	ID                 string `json:"id"`
+	ProposedNextAction string `json:"proposed_next_action"`
+	Affected           struct {
 		Issues           []string       `json:"issues"`
 		IssueIdentifiers []string       `json:"issue_identifiers"`
 		PullRequests     []string       `json:"pull_requests"`
@@ -779,4 +861,14 @@ type traceCluster struct {
 		Excerpt  string            `json:"excerpt"`
 		Metadata map[string]string `json:"metadata"`
 	} `json:"evidence"`
+	Proposals struct {
+		GitHubIssue struct {
+			Title string `json:"title"`
+			Body  string `json:"body"`
+		} `json:"github_issue"`
+		DraftPR struct {
+			Title string `json:"title"`
+			Plan  string `json:"plan"`
+		} `json:"draft_pr"`
+	} `json:"proposals"`
 }


### PR DESCRIPTION
Closes #939

## Summary
- Extend `scripts/trace-harness-report.py` to emit schema `trace-harness-report/v2` clusters with deterministic `proposals.github_issue` and `proposals.draft_pr` text.
- Keep proposal rendering inside the existing read-only report command: it references bounded evidence, redaction notes, #937, and `docs/design/trace-driven-harness-improvement.md`, but does not open issues/PRs, mutate tracker state, edit harness files, or create gates.
- Update the trace-harness runbook with `jq` extraction examples so an operator or agent can promote a reviewed cluster without hand-writing the body.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Boundary notes:
- The worker remains a scheduler/runner/tracker reader.
- Proposal creation is report rendering only; opening issues, opening draft PRs, and running follow-through agents stay explicit operator/agent workflow actions.
- Opaque payloads remain omitted rather than parsed; proposals repeat refs and bounded metadata only.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Acceptance criteria
- [x] A generated cluster can render a ready-to-open GitHub issue body.
- [x] A generated cluster can render a draft-PR plan suitable for a normal coding agent.
- [x] Output includes evidence references and redaction notes rather than raw unbounded logs.
- [x] Proposal rendering is deterministic enough to test with fixtures.
- [x] Docs show how an operator or agent promotes a cluster to an issue/plan without hand-writing the body.
- [x] The implementation keeps creation as an explicit operator/agent workflow action, not worker-owned behavior.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `python3 -m py_compile scripts/trace-harness-report.py`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test -run 'TestTraceHarnessReport' -count=1 ./scripts`
- `go test -count=1 ./scripts`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (`0 issues.`)
- `go build ./cmd/worker ./cmd/tui`
- `git diff --check`

Mutation verification:
- Mutated the renderer seam to write `proposal` instead of `proposals`; `TestTraceHarnessReportScriptRendersActionableProposals` failed with an empty GitHub issue title.
- Restored the seam and reran `go test -run 'TestTraceHarnessReportScriptRendersActionableProposals|TestTraceHarnessReportScriptRendersStableProposalText' -count=1 ./scripts` successfully.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.


Review feedback round 1:
- Addressed Codex inline thread `PRRT_kwDOSN-Foc6KzF2s`: proposals are now regenerated until the post-render cap enforcement no longer mutates `affected` or `evidence`.
- Added `TestTraceHarnessReportScriptRerendersProposalsAfterFinalClusterTrimming`, which reproduced stale omitted counts at 9500 runner-timeout records before the fix.
- Local validation after the fix: `python3 -m py_compile scripts/trace-harness-report.py`; `go test -run 'TestTraceHarnessReportScriptRerendersProposalsAfterFinalClusterTrimming|TestTraceHarnessReportScriptBoundsFullClusterByBytes|TestTraceHarnessReportScriptRendersActionableProposals' -count=1 ./scripts`; `go test -run 'TestTraceHarnessReport' -count=1 ./scripts`; `go test -count=1 ./scripts`; `gofmt -l` clean; `git diff --check`.


Review feedback round 2:
- Addressed fresh Codex review `PRR_kwDOSN-Foc8AAAABDiD6JQ` / thread `PRRT_kwDOSN-Foc6KzRbU`: repeated cluster trimming now preserves cumulative `affected.omitted` totals instead of overwriting them with only the additional drop.
- Added `TestTraceHarnessReportScriptPreservesCumulativeOmittedAffectedCounts`, which reproduced the undercount with 18000 unique `session_id` values before the fix.
- Local validation after the fix: `python3 -m py_compile scripts/trace-harness-report.py`; `go test -run 'TestTraceHarnessReportScriptPreservesCumulativeOmittedAffectedCounts|TestTraceHarnessReportScriptRerendersProposalsAfterFinalClusterTrimming|TestTraceHarnessReportScriptBoundsFullClusterByBytes' -count=1 ./scripts`; `go test -run 'TestTraceHarnessReport' -count=1 ./scripts`; `go test -count=1 ./scripts`; `gofmt -l` clean; `git diff --check`.
- Current head: `cb79af998110848db6d81c747cc88266db3bd652`.
- Fresh `@codex review` trigger for current head: https://github.com/xrf9268-hue/aiops-platform/pull/948#issuecomment-4750631135.


Fresh Codex review after round 2:
- Trigger: https://github.com/xrf9268-hue/aiops-platform/pull/948#issuecomment-4750631135 (`@codex review` by `bytevane`, 2026-06-19T10:15:54Z).
- Result: https://github.com/xrf9268-hue/aiops-platform/pull/948#issuecomment-4750675449 (`Codex Review: Didn't find any major issues. Breezy!`, reviewed commit `cb79af9981`).
- Thread state after fresh review: `PRRT_kwDOSN-Foc6KzF2s` is outdated/unresolved; `PRRT_kwDOSN-Foc6KzRbU` is still non-outdated/unresolved in GitHub but its requested omitted-count fix is implemented and covered by `TestTraceHarnessReportScriptPreservesCumulativeOmittedAffectedCounts`.
- CI for head `cb79af998110848db6d81c747cc88266db3bd652`: all checks passed, including Docker image build, E2E Gitea mock loop, Go build and test, Security and supply-chain, Validate PR metadata, and Validate PR title.
