### PR TITLE
feat(harness): document trace proposal follow-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ add a bridge that imports `AGENTS.md` rather than duplicating content.
 - [CI/CD runbook](docs/runbooks/ci.md)
 - [Runtime debugging API](docs/runbooks/task-api.md)
 - [Trace harness report](docs/runbooks/trace-harness-report.md)
+- [Trace harness proposal follow-through](docs/runbooks/trace-harness-follow-through.md)
 - [Workspace cache and cleanup](docs/runbooks/workspace-cache.md)
 - [GitHub local automation](docs/runbooks/github-local-automation.md)
 - [Gitea bot and branch protection](docs/runbooks/gitea-bot-and-branch-protection.md)

--- a/docs/runbooks/trace-harness-follow-through.md
+++ b/docs/runbooks/trace-harness-follow-through.md
@@ -1,0 +1,143 @@
+# Trace harness proposal follow-through
+
+Use this runbook after an operator approves an actionable cluster from
+[`trace-harness-report.md`](trace-harness-report.md). It implements the
+Milestone 3 handoff from
+[`docs/design/trace-driven-harness-improvement.md`](../design/trace-driven-harness-improvement.md):
+an approved proposal becomes ordinary reviewed repo cargo through a normal
+coding-agent workflow.
+
+This is not a worker command. The worker does not open issues or PRs, mutate
+tracker state, rewrite prompts, merge branches, or create evaluator gates. The
+coding agent acts through the same branch, review, test, and PR flow it uses for
+any other issue.
+
+## Inputs
+
+- source report JSON using schema `trace-harness-report/v2`
+- approved cluster id
+- generated `proposals.github_issue.body` or `proposals.draft_pr.plan`
+- operator approval record, such as an issue comment, chat instruction, or
+  review note naming the cluster and intended harness surface
+
+The proposal text is evidence and planning context. Do not parse arbitrary
+report, review, log, prompt, or agent text in the worker to make the decision.
+
+## Operator approval points
+
+Approve only after checking the cluster's evidence references, redaction note,
+suspected harness surface, proposed acceptance criteria, and target repo-owned
+surface. Valid follow-through surfaces include `WORKFLOW.md`, reviewer rubrics,
+`LEARNINGS.md`, skills, hooks, tests, CI, and docs.
+
+Approval gives the coding agent permission to start a normal implementation
+run. It does not authorize unattended merge, worker-side PR creation, worker
+tracker writeback, automatic prompt/rubric/skill rewrite, or evaluator gate
+promotion.
+
+## Preferred path: create a tracking issue first
+
+Create or reuse a tracker issue before asking the coding agent to implement the
+proposal. This keeps the final PR compatible with the repository's required
+`Closes #N` metadata and gives no-op decisions a durable place to land.
+
+```bash
+report=./trace-report.json
+cluster_id=runner-timeout
+
+jq -r --arg id "$cluster_id" \
+  '.clusters[] | select(.id == $id).proposals.github_issue.body' \
+  "$report" > /tmp/trace-harness-issue.md
+
+title="$(jq -r --arg id "$cluster_id" \
+  '.clusters[] | select(.id == $id).proposals.github_issue.title' \
+  "$report")"
+
+gh issue create --title "$title" --body-file /tmp/trace-harness-issue.md
+```
+
+Then hand the issue number, report path, cluster id, and extracted draft-PR plan
+to the normal issue workflow. In this repository that means
+[`.claude/skills/handle-issue/SKILL.md`](../../.claude/skills/handle-issue/SKILL.md)
+for issue-to-PR work, followed by
+[`.claude/skills/handle-pr/SKILL.md`](../../.claude/skills/handle-pr/SKILL.md)
+and [`pr-review-merge-protocol.md`](pr-review-merge-protocol.md) for review
+follow-through.
+
+## Agent handoff prompt
+
+Use this prompt shape when the outside coding agent needs a concrete entrypoint:
+
+```text
+Follow through the approved trace harness proposal.
+
+Inputs:
+- tracking issue: #<issue>
+- source report: <path or artifact URL>
+- cluster id: <cluster-id>
+- proposal plan: <path containing proposals.draft_pr.plan>
+- operator approval: <comment, review note, or instruction>
+
+Before editing, read the source report cluster, the generated proposal, and
+docs/design/trace-driven-harness-improvement.md. Implement only the smallest
+repo-owned harness change needed for the approved proposal. Use an owned branch
+from the current base, run the appropriate verification, and open or update a
+normal PR that closes the tracking issue.
+
+If the proposal is already satisfied or should not change the harness, record a
+closed no-op with evidence on the issue or draft PR instead of landing empty
+churn.
+
+Do not add worker-side PR/tracker writeback, post-turn verifier phases,
+automatic prompt/rubric/skill rewrites, unattended merge, or evaluator gates.
+```
+
+## PR ledger
+
+The implementation PR body remains the public ledger. Include:
+
+- `Closes #N`
+- source report path or artifact URL, schema, input digest when available, and
+  cluster id
+- proposal source: `proposals.github_issue.body` or `proposals.draft_pr.plan`
+- evidence references and redaction note copied from the report, not raw logs
+- operator approval reference
+- exact harness surface changed
+- verification commands and results
+- size-gate classification from `pr-review-merge-protocol.md`
+- statement that the change adds no worker-side writeback, unattended merge, or
+  evaluator gate
+
+Use the shared PR protocol for local gates, dual review, `@codex review`, CI,
+unresolved thread handling, and merge readiness. Trace harness follow-through
+stops at merge-ready; no unattended merge is allowed in this workflow.
+
+## Closed no-op with evidence
+
+A no-op is valid only when it is recorded where reviewers can audit it. If the
+agent proves no repo change is needed, comment on and close the tracking issue,
+or close the draft PR if one already exists. The no-op record must name:
+
+- source report and cluster id
+- original proposal title or plan path
+- operator approval reference
+- evidence checked
+- reason no repo-owned harness change is warranted
+- verification performed, or why verification was not applicable
+- recurrence signal that would justify reopening or filing a new proposal
+
+Do not merge an empty PR just to satisfy the loop.
+
+## Failure reporting
+
+If the agent cannot produce a merge-ready PR or a justified no-op, leave a
+failure report on the issue or PR and keep the tracker state consistent with the
+normal workflow. Include the failing command, blocked dependency, missing
+evidence, or rejected scope, plus the source report, cluster id, and operator
+approval reference.
+
+That issue or PR comment is the L4 evidence trail for this milestone. Do not
+write worker state, mutate the report JSON, or silently promote the failure into
+prompt, rubric, skill, hook, CI, or evaluator changes. A future trace report may
+consume tracker or PR state when that input source is explicitly supported, but
+the current handoff stays in the normal forge review flow.

--- a/docs/runbooks/trace-harness-report.md
+++ b/docs/runbooks/trace-harness-report.md
@@ -111,6 +111,9 @@ jq -r '.clusters[] | select(.id == "runner-timeout").proposals.draft_pr.plan' \
 
 Opening the issue, starting the draft PR, or running a coding agent remains an
 explicit workflow action outside this report command.
+Use [`trace-harness-follow-through.md`](trace-harness-follow-through.md) for
+the approved-proposal handoff into a normal coding-agent branch, PR, or no-op
+closure.
 
 ## Redaction and bounds
 

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -63,6 +63,69 @@ func TestTraceHarnessReportRunbookDocumentsSupportedInputsAndBounds(t *testing.T
 	}
 }
 
+func TestTraceHarnessFollowThroughRunbookDocumentsAgentBoundary(t *testing.T) {
+	root := repoRoot(t)
+	readme, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if !strings.Contains(string(readme), "docs/runbooks/trace-harness-follow-through.md") {
+		t.Fatalf("README does not link the trace harness follow-through runbook")
+	}
+
+	reportRunbook, err := os.ReadFile(filepath.Join(root, "docs", "runbooks", "trace-harness-report.md"))
+	if err != nil {
+		t.Fatalf("read trace harness report runbook: %v", err)
+	}
+	if !strings.Contains(string(reportRunbook), "trace-harness-follow-through.md") {
+		t.Fatalf("trace harness report runbook does not link follow-through runbook")
+	}
+
+	path := filepath.Join(root, "docs", "runbooks", "trace-harness-follow-through.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(body)
+	normalizedText := strings.Join(strings.Fields(text), " ")
+	for _, want := range []string{
+		"approved proposal",
+		"trace-harness-report/v2",
+		"approved cluster id",
+		"proposals.github_issue.body",
+		"proposals.draft_pr.plan",
+		"source report",
+		"cluster id",
+		"operator approval",
+		"WORKFLOW.md",
+		"reviewer rubrics",
+		"LEARNINGS.md",
+		"skills",
+		"hooks",
+		"tests",
+		"CI",
+		"docs",
+		"owned branch",
+		"normal PR",
+		"closed no-op with evidence",
+		"no worker-side writeback",
+		"unattended merge",
+		"evaluator gates",
+		"pr-review-merge-protocol.md",
+		".claude/skills/handle-issue/SKILL.md",
+		".claude/skills/handle-pr/SKILL.md",
+		"failure report",
+		"L4 evidence trail",
+	} {
+		if !strings.Contains(normalizedText, want) {
+			t.Fatalf("follow-through runbook missing %q\n%s", want, text)
+		}
+	}
+	if got, want := strings.Count(normalizedText, "operator approval reference"), 3; got < want {
+		t.Fatalf("follow-through runbook mentions operator approval reference %d times; want at least %d\n%s", got, want, text)
+	}
+}
+
 func TestTraceHarnessReportScriptGroupsWorkerLogsAndRedactsCloneURLs(t *testing.T) {
 	root := repoRoot(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #940

## Summary
- Add `docs/runbooks/trace-harness-follow-through.md` as the approved-proposal handoff for Trace L4 Milestone 3.
- Link the follow-through runbook from the trace report runbook and README.
- Add docs regression coverage so the handoff keeps operator approval, owned branch/normal PR, no-op evidence, failure reporting, and no worker-side writeback boundaries visible.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go test -count=1 ./scripts`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go build ./cmd/worker ./cmd/tui`
- `git diff --check`

## Review notes
- Subagent reviewer path was discovered but contract-blocked: current `spawn_agent` metadata requires explicit delegation, so it was not used.
- Codex CLI diff review on `7193a40` returned `NEEDS-CHANGES`; it found the runbook accidentally allowed an unattended merge exception and missed approval references for no-op/failure outcomes. Both were fixed before amend.
- Codex CLI diff review on final head `35d1591` returned `MERGE-READY` with no findings.
- Claude CLI reviewer hit a 429 session limit (`resets 7:40pm Asia/Shanghai`). The user explicitly instructed not to wait for Claude CLI, so this PR proceeds with that disclosed reviewer exception.

## Notes
- This PR intentionally adds no worker command, worker phase, tracker writeback, PR writer, automatic prompt/rubric/skill rewrite, unattended merge path, or evaluator gate.
- The follow-through runbook stops at merge-ready; merge remains a separate human action for this workflow.
