### PR TITLE
feat(harness): add trace advisory evaluator candidates

### DIFF
--- a/docs/runbooks/trace-harness-follow-through.md
+++ b/docs/runbooks/trace-harness-follow-through.md
@@ -14,7 +14,7 @@ any other issue.
 
 ## Inputs
 
-- source report JSON using schema `trace-harness-report/v2`
+- source report JSON using schema `trace-harness-report/v3`
 - approved cluster id
 - generated `proposals.github_issue.body` or `proposals.draft_pr.plan`
 - operator approval record, such as an issue comment, chat instruction, or

--- a/docs/runbooks/trace-harness-report.md
+++ b/docs/runbooks/trace-harness-report.md
@@ -1,11 +1,12 @@
 # Trace harness report
 
 Use this read-only command to generate the first trace-driven harness report
-from existing evidence. It implements the Milestone 1 subset from
-`docs/design/trace-driven-harness-improvement.md`: group bounded evidence into
-reviewable clusters. It does not mutate tracker state. It does not open PRs.
-It does not edit prompts. It does not create a worker phase, merge gate, or
-evaluator gate.
+from existing evidence. It implements the Milestone 1 grouped-report path plus
+the later proposal surfaces from
+`docs/design/trace-driven-harness-improvement.md`: issue/draft-PR proposals and
+advisory evaluator candidates. It does not mutate tracker state. It does not
+open PRs. It does not edit prompts. It does not create a worker phase, merge
+gate, runtime gate, or evaluator gate.
 
 ```bash
 python3 scripts/trace-harness-report.py \
@@ -71,7 +72,7 @@ kind>`) is indistinguishable from a real record and may be surfaced.
 
 ## Output schema
 
-The JSON output uses schema `trace-harness-report/v2`. Each cluster contains:
+The JSON output uses schema `trace-harness-report/v3`. Each cluster contains:
 
 - cluster id and short title
 - symptom class
@@ -80,16 +81,21 @@ The JSON output uses schema `trace-harness-report/v2`. Each cluster contains:
   first opaque payload key;
   pathological clusters may include `affected.omitted` counts when the cluster
   byte cap requires truncating these id lists
-- evidence references with bounded excerpts
+- evidence references with bounded excerpts and the affected ids recovered for
+  each retained evidence entry
 - suspected harness surface to change
-- proposed next action, currently `issue or draft-PR proposal` for supported
-  worker-log failure clusters
+- proposed next action, currently `issue, draft-PR, or advisory evaluator
+  proposal` for supported worker-log failure clusters
 - acceptance criteria for the proposed harness change
 - redaction note naming what was omitted
 - `proposals.github_issue.body`, a ready-to-open issue body for promoting the
   reviewed cluster without hand-writing the issue
 - `proposals.draft_pr.plan`, a draft-PR plan a normal coding agent can use for
   follow-through after the operator approves the intent
+- `proposals.advisory_evaluator`, a report-only evaluator candidate with
+  recovered affected ids, bounded fixtures/examples, expected true-positive and
+  false-positive behavior, a future report-output contract, and the evidence
+  required before a later gate-promotion PR
 
 The proposal fields repeat references and bounded metadata, not raw unbounded
 logs. They preserve the same redaction note and SPEC boundary as the cluster:
@@ -114,6 +120,36 @@ explicit workflow action outside this report command.
 Use [`trace-harness-follow-through.md`](trace-harness-follow-through.md) for
 the approved-proposal handoff into a normal coding-agent branch, PR, or no-op
 closure.
+
+## Advisory evaluator candidates
+
+Each cluster also renders an advisory evaluator candidate:
+
+```bash
+jq '.clusters[] | select(.id == "runner-timeout").proposals.advisory_evaluator' \
+  ./trace-report.json > /tmp/runner-timeout-evaluator-candidate.json
+```
+
+The candidate is report-only. Its `execution` block explicitly records that it
+does not block CI, runtime, or merge. Its `recovered_affected_ids` block is an
+independently bounded issue/run/session/PR summary with omitted counts, not a
+full duplicate of the cluster's top-level affected arrays. It carries enough of
+the references used to compute `current_signal` for the candidate to remain
+reviewable when it is extracted on its own. `current_signal` counts independent
+retained evidence occurrences by
+merging entries that share a recovered affected id; same-column omitted counts
+from byte-bound clusters still count as recurrence evidence. Its fixtures are
+bounded examples copied from the cluster's
+already-redacted evidence references, not raw logs or prompt text. Its
+`expected_signal_behavior.false_positive` section names cases the candidate must
+not treat as signal, including successful or unrelated events that only mention
+the failure inside opaque payload text.
+
+The candidate's `future_report_output` schema is stable enough for a future L4
+report importer to cite evaluator results, but this command does not install a
+gate. Promotion to a required CI/runtime/merge gate needs a separate reviewed PR
+after multiple reviewed reports show stable true positives and documented false
+positive handling.
 
 ## Redaction and bounds
 

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -627,7 +627,10 @@ def evaluator_recovered_affected_ids(cluster: dict) -> dict:
 
 
 def independent_occurrence_count(cluster: dict) -> int:
-    return max(independent_evidence_occurrence_count(cluster), independent_affected_column_count(cluster))
+    # Retained evidence is overlap-merged so records sharing a recovered affected id
+    # count once; byte-bound trimmed records survive only as omitted counts, so add
+    # them rather than letting a single column max override the overlap merge (#941).
+    return independent_evidence_occurrence_count(cluster) + trimmed_affected_occurrence_count(cluster)
 
 
 def independent_evidence_occurrence_count(cluster: dict) -> int:
@@ -659,13 +662,12 @@ def add_occurrence_component(components: list[set[str]], tokens: set[str]) -> No
     components.append(merged)
 
 
-def independent_affected_column_count(cluster: dict) -> int:
-    affected = cluster.get("affected", {})
-    omitted = affected.get("omitted", {})
-    counts = []
-    for key in AFFECTED_KEYS:
-        counts.append(len(affected.get(key, [])) + int(omitted.get(key, 0)))
-    return max(counts, default=0)
+def trimmed_affected_occurrence_count(cluster: dict) -> int:
+    # Only counts affected ids dropped by the byte cap: retained ids are already
+    # represented in (overlap-merged) evidence, so counting them here would let the
+    # cluster cap inflate recurrence beyond independent records.
+    omitted = cluster.get("affected", {}).get("omitted", {})
+    return max((int(omitted.get(key, 0)) for key in AFFECTED_KEYS), default=0)
 
 
 def evaluator_fixtures(cluster: dict) -> list[dict]:

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -35,11 +35,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
-SCHEMA_VERSION = "trace-harness-report/v2"
+SCHEMA_VERSION = "trace-harness-report/v3"
 MAX_RUN_EVIDENCE_BYTES, MAX_CLUSTER_BYTES, MAX_EVIDENCE_EXCERPT_BYTES = 64 * 1024, 256 * 1024, 4 * 1024
 MAX_METADATA_BYTES, MAX_METADATA_VALUE_BYTES = 16 * 1024, 4 * 1024
 MAX_PROPOSAL_EVIDENCE_REFS, MAX_PROPOSAL_AFFECTED_VALUES = 5, 5
 MAX_PROPOSAL_INPUT_REFS, MAX_PROPOSAL_FIELD_BYTES = 3, 512
+MAX_EVALUATOR_FIXTURES, MAX_EVALUATOR_FIXTURE_EXCERPT_BYTES = 3, 512
 
 FIELD_RE = re.compile(r'\b(event|task_id|issue_id|issue_identifier|session_id|pr|pr_number|pr_url|pull_request|pull_request_url)=("[^"]*"|\S+)')
 CLONE_URL_SCHEME_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9+.-]*://")
@@ -272,7 +273,7 @@ def new_cluster(finding: dict) -> dict:
         "_evidence_bytes": byte_len("[]"),
         "_evidence_count": 0,
         "suspected_harness_surface": "WORKFLOW.md, reviewer rubrics, skills, hooks, tests, CI, or docs",
-        "proposed_next_action": "issue or draft-PR proposal",
+        "proposed_next_action": "issue, draft-PR, or advisory evaluator proposal",
         "acceptance_criteria": [
             "Future runs cover this failure class with a reviewed harness surface or a documented no-op decision.",
             "The change remains report/agent/workflow-owned and does not add a worker-side gate or tracker writer.",
@@ -312,8 +313,20 @@ def evidence_entry(finding: dict, excerpt: str) -> dict:
         "ref": finding["ref"],
         "kind": finding["kind"],
         "excerpt": excerpt,
+        "affected": finding_affected(finding),
         "metadata": bounded_metadata(finding["metadata"]),
     }
+
+
+def finding_affected(finding: dict) -> dict:
+    keys = (
+        ("issues", "issue"),
+        ("issue_identifiers", "identifier"),
+        ("pull_requests", "pull_request"),
+        ("runs", "run"),
+        ("sessions", "session"),
+    )
+    return {affected_key: [finding[finding_key]] for affected_key, finding_key in keys if finding.get(finding_key)}
 
 
 def bounded_metadata(metadata: dict) -> dict:
@@ -378,6 +391,7 @@ def render_proposals(cluster: dict, report_ref: str) -> dict:
             "title": f"fix(harness): address {cluster['id']} trace cluster",
             "plan": render_draft_pr_plan(cluster, report_ref),
         },
+        "advisory_evaluator": render_advisory_evaluator_candidate(cluster, report_ref),
     }
 
 
@@ -540,6 +554,139 @@ def verification_lines() -> list[str]:
         "- Run the local gate appropriate to the touched files before opening or updating the PR.",
         "- Confirm the change preserves the redaction and SPEC-boundary constraints from the trace-driven harness design.",
     ]
+
+
+def render_advisory_evaluator_candidate(cluster: dict, report_ref: str) -> dict:
+    return {
+        "id": f"{cluster['id']}-advisory-evaluator",
+        "title": f"Advisory evaluator candidate for {cluster['id']} trace cluster",
+        "mode": "report-only/advisory",
+        "target_failure_class": cluster["symptom_class"],
+        "source": {
+            "report": report_ref,
+            "cluster_id": cluster["id"],
+        },
+        "current_signal": evaluator_current_signal(cluster),
+        "recovered_affected_ids": evaluator_recovered_affected_ids(cluster),
+        "fixtures": evaluator_fixtures(cluster),
+        "expected_signal_behavior": {
+            "true_positive": [
+                f"Report {cluster['symptom_class']} when a future grouped report has at least two independent recovered issue, run, session, or PR references for {cluster['id']}.",
+                "Use only trusted metadata and redacted evidence references already present in trace harness reports.",
+            ],
+            "false_positive": [
+                "Do not fire on successful or unrelated events that only mention the failure in opaque payload text.",
+                "Do not parse raw logs, forge comments, prompts, model output, GraphQL payloads, or other natural language as a machine contract.",
+            ],
+        },
+        "execution": {
+            "mode": "report-only",
+            "blocks_ci": False,
+            "blocks_runtime": False,
+            "blocks_merge": False,
+        },
+        "future_report_output": {
+            "schema": "trace-harness-advisory-evaluator-result/v1",
+            "fields": [
+                "evaluator_id",
+                "source_cluster_id",
+                "mode",
+                "signal",
+                "evidence_refs",
+                "false_positive_notes",
+            ],
+        },
+        "gate_promotion_evidence": [
+            "Multiple reviewed reports show stable true positives for the same failure class.",
+            "False positives are triaged and documented with fixtures or examples.",
+            "A separate PR explicitly proposes gate promotion after review history exists.",
+        ],
+    }
+
+
+def evaluator_current_signal(cluster: dict) -> str:
+    if independent_occurrence_count(cluster) >= 2:
+        return "positive-recurring-cluster"
+    return "candidate-only-needs-more-evidence"
+
+
+def evaluator_recovered_affected_ids(cluster: dict) -> dict:
+    affected = cluster.get("affected", {})
+    existing_omitted = affected.get("omitted", {})
+    recovered = {}
+    omitted = {}
+    for key in AFFECTED_KEYS:
+        values = list(affected.get(key, []))
+        recovered[key] = values[:MAX_PROPOSAL_AFFECTED_VALUES]
+        omitted_count = len(values) - len(recovered[key]) + int(existing_omitted.get(key, 0))
+        if omitted_count > 0:
+            omitted[key] = omitted_count
+    if omitted:
+        recovered["omitted"] = omitted
+    return recovered
+
+
+def independent_occurrence_count(cluster: dict) -> int:
+    return max(independent_evidence_occurrence_count(cluster), independent_affected_column_count(cluster))
+
+
+def independent_evidence_occurrence_count(cluster: dict) -> int:
+    components: list[set[str]] = []
+    for entry in cluster.get("evidence", []):
+        tokens = evidence_affected_tokens(entry.get("affected", {}))
+        if tokens:
+            add_occurrence_component(components, tokens)
+    return len(components)
+
+
+def evidence_affected_tokens(affected: dict) -> set[str]:
+    tokens = set()
+    for key in AFFECTED_KEYS:
+        for value in affected.get(key, []):
+            if value:
+                tokens.add(f"{key}:{value}")
+    return tokens
+
+
+def add_occurrence_component(components: list[set[str]], tokens: set[str]) -> None:
+    overlaps = [idx for idx, component in enumerate(components) if component & tokens]
+    if not overlaps:
+        components.append(tokens)
+        return
+    merged = set(tokens)
+    for idx in reversed(overlaps):
+        merged.update(components.pop(idx))
+    components.append(merged)
+
+
+def independent_affected_column_count(cluster: dict) -> int:
+    affected = cluster.get("affected", {})
+    omitted = affected.get("omitted", {})
+    counts = []
+    for key in AFFECTED_KEYS:
+        counts.append(len(affected.get(key, [])) + int(omitted.get(key, 0)))
+    return max(counts, default=0)
+
+
+def evaluator_fixtures(cluster: dict) -> list[dict]:
+    fixtures = []
+    for idx, entry in enumerate(cluster.get("evidence", [])[:MAX_EVALUATOR_FIXTURES], 1):
+        fixtures.append(
+            {
+                "name": f"{cluster['id']}-positive-{idx}",
+                "source_ref": entry.get("ref", ""),
+                "event_kind": entry.get("kind", ""),
+                "expected": "match",
+                "bounded_excerpt": truncate(entry.get("excerpt", ""), MAX_EVALUATOR_FIXTURE_EXCERPT_BYTES),
+                "metadata": evaluator_fixture_metadata(entry.get("metadata", {})),
+            }
+        )
+    return fixtures
+
+
+def evaluator_fixture_metadata(metadata: dict) -> dict:
+    keep = ("timestamp", "method", "model", "exit_code", "timeout_ms", "elapsed_ms", "duration_ms", "output_bytes", "output_dropped")
+    return {key: metadata[key] for key in keep if metadata.get(key)}
 
 
 def enforce_cluster_bound(cluster: dict) -> None:

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -34,7 +34,7 @@ func TestTraceHarnessReportRunbookDocumentsSupportedInputsAndBounds(t *testing.T
 	for _, want := range []string{
 		"python3 scripts/trace-harness-report.py",
 		"--worker-log",
-		"trace-harness-report/v2",
+		"trace-harness-report/v3",
 		"Supported inputs",
 		"worker process logs",
 		"64 KiB per run",
@@ -54,6 +54,13 @@ func TestTraceHarnessReportRunbookDocumentsSupportedInputsAndBounds(t *testing.T
 		"workspace `.aiops` artifacts",
 		"proposals.github_issue.body",
 		"proposals.draft_pr.plan",
+		"proposals.advisory_evaluator",
+		"report-only evaluator candidate",
+		"expected true-positive and false-positive",
+		"future report-output contract",
+		"does not block CI, runtime, or merge",
+		"false_positive",
+		"gate-promotion PR",
 		"without hand-writing",
 		"Examples",
 	} {
@@ -90,7 +97,7 @@ func TestTraceHarnessFollowThroughRunbookDocumentsAgentBoundary(t *testing.T) {
 	normalizedText := strings.Join(strings.Fields(text), " ")
 	for _, want := range []string{
 		"approved proposal",
-		"trace-harness-report/v2",
+		"trace-harness-report/v3",
 		"approved cluster id",
 		"proposals.github_issue.body",
 		"proposals.draft_pr.plan",
@@ -151,7 +158,7 @@ func TestTraceHarnessReportScriptGroupsWorkerLogsAndRedactsCloneURLs(t *testing.
 		t.Fatalf("read report: %v", err)
 	}
 	report := parseTraceReport(t, raw)
-	if report.SchemaVersion != "trace-harness-report/v2" || len(report.Clusters) != 2 {
+	if report.SchemaVersion != "trace-harness-report/v3" || len(report.Clusters) != 2 {
 		t.Fatalf("unexpected report: %#v", report)
 	}
 	timeout := findCluster(t, report, "runner-timeout")
@@ -245,8 +252,8 @@ func TestTraceHarnessReportScriptRendersActionableProposals(t *testing.T) {
 	report := runTraceHarnessReport(t, root, body)
 
 	cluster := findCluster(t, report, "runner-timeout")
-	if cluster.ProposedNextAction != "issue or draft-PR proposal" {
-		t.Fatalf("ProposedNextAction = %q; want issue or draft-PR proposal", cluster.ProposedNextAction)
+	if cluster.ProposedNextAction != "issue, draft-PR, or advisory evaluator proposal" {
+		t.Fatalf("ProposedNextAction = %q; want issue, draft-PR, or advisory evaluator proposal", cluster.ProposedNextAction)
 	}
 	if cluster.Proposals.GitHubIssue.Title != "Trace harness: address runner-timeout cluster" {
 		t.Fatalf("GitHub issue title = %q", cluster.Proposals.GitHubIssue.Title)
@@ -256,7 +263,7 @@ func TestTraceHarnessReportScriptRendersActionableProposals(t *testing.T) {
 		"Trace harness cluster `runner-timeout` reports runner timeout.",
 		"Part of #937",
 		"docs/design/trace-driven-harness-improvement.md",
-		"Report: trace-harness-report/v2",
+		"Report: trace-harness-report/v3",
 		"Failure class: runner timeout",
 		"- issues: `issue-1`",
 		"- issue_identifiers: `GH-1`",
@@ -294,6 +301,118 @@ func TestTraceHarnessReportScriptRendersActionableProposals(t *testing.T) {
 	}
 	if cluster.Proposals.DraftPR.Title != "fix(harness): address runner-timeout trace cluster" {
 		t.Fatalf("draft PR title = %q", cluster.Proposals.DraftPR.Title)
+	}
+}
+
+func TestTraceHarnessReportScriptRendersAdvisoryEvaluatorCandidate(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout msg="timeout" payload=map[issue_id:issue-1 issue_identifier:GH-1 task_id:run-1 session_id:session-1 elapsed_ms:60000 output_bytes:70000 output_head:secret-output]`,
+		`2026/06/18 09:01:00 event=runner_timeout msg="timeout" payload=map[issue_id:issue-2 issue_identifier:GH-2 task_id:run-2 session_id:session-2 elapsed_ms:61000 output_bytes:71000 output_head:another-secret]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	evaluator := cluster.Proposals.AdvisoryEvaluator
+	if evaluator.ID != "runner-timeout-advisory-evaluator" {
+		t.Fatalf("evaluator ID = %q", evaluator.ID)
+	}
+	if evaluator.Mode != "report-only/advisory" || evaluator.TargetFailureClass != "runner timeout" {
+		t.Fatalf("evaluator mode/class = %q/%q", evaluator.Mode, evaluator.TargetFailureClass)
+	}
+	if evaluator.CurrentSignal != "positive-recurring-cluster" {
+		t.Fatalf("current signal = %q; want positive recurring cluster", evaluator.CurrentSignal)
+	}
+	if len(evaluator.Fixtures) != 2 {
+		t.Fatalf("fixtures = %d; want 2", len(evaluator.Fixtures))
+	}
+	if !contains(evaluator.RecoveredAffectedIDs.Issues, "issue-1") ||
+		!contains(evaluator.RecoveredAffectedIDs.Issues, "issue-2") ||
+		!contains(evaluator.RecoveredAffectedIDs.IssueIdentifiers, "GH-1") ||
+		!contains(evaluator.RecoveredAffectedIDs.Runs, "run-1") ||
+		!contains(evaluator.RecoveredAffectedIDs.Sessions, "session-2") {
+		t.Fatalf("evaluator recovered affected ids = %#v", evaluator.RecoveredAffectedIDs)
+	}
+	if !contains(cluster.Evidence[0].Affected.Issues, "issue-1") ||
+		!contains(cluster.Evidence[0].Affected.IssueIdentifiers, "GH-1") ||
+		!contains(cluster.Evidence[0].Affected.Runs, "run-1") ||
+		!contains(cluster.Evidence[0].Affected.Sessions, "session-1") {
+		t.Fatalf("first evidence affected ids = %#v", cluster.Evidence[0].Affected)
+	}
+	first := evaluator.Fixtures[0]
+	if first.Name != "runner-timeout-positive-1" || first.EventKind != "runner_timeout" || first.Expected != "match" {
+		t.Fatalf("first fixture = %#v", first)
+	}
+	if !strings.Contains(first.SourceRef, "worker.log:1") || !strings.Contains(first.BoundedExcerpt, "payload=[redacted-payload]") {
+		t.Fatalf("first fixture missing redacted source evidence: %#v", first)
+	}
+	raw, err := json.Marshal(evaluator)
+	if err != nil {
+		t.Fatalf("marshal evaluator: %v", err)
+	}
+	if strings.Contains(string(raw), "secret-output") || strings.Contains(string(raw), "another-secret") {
+		t.Fatalf("evaluator leaked opaque payload:\n%s", raw)
+	}
+	for _, want := range []string{"two independent recovered issue, run, session, or PR references", "trusted metadata", "redacted evidence references"} {
+		if !containsSubstring(evaluator.ExpectedSignalBehavior.TruePositive, want) {
+			t.Fatalf("true-positive behavior missing %q: %#v", want, evaluator.ExpectedSignalBehavior.TruePositive)
+		}
+	}
+	for _, want := range []string{"opaque payload text", "natural language as a machine contract"} {
+		if !containsSubstring(evaluator.ExpectedSignalBehavior.FalsePositive, want) {
+			t.Fatalf("false-positive behavior missing %q: %#v", want, evaluator.ExpectedSignalBehavior.FalsePositive)
+		}
+	}
+	if evaluator.Execution.Mode != "report-only" || evaluator.Execution.BlocksCI || evaluator.Execution.BlocksRuntime || evaluator.Execution.BlocksMerge {
+		t.Fatalf("evaluator execution should be report-only and non-blocking: %#v", evaluator.Execution)
+	}
+	if evaluator.FutureReportOutput.Schema != "trace-harness-advisory-evaluator-result/v1" {
+		t.Fatalf("future report schema = %q", evaluator.FutureReportOutput.Schema)
+	}
+	for _, want := range []string{"evaluator_id", "source_cluster_id", "signal", "false_positive_notes"} {
+		if !contains(evaluator.FutureReportOutput.Fields, want) {
+			t.Fatalf("future output fields missing %q: %#v", want, evaluator.FutureReportOutput.Fields)
+		}
+	}
+	if !contains(evaluator.GatePromotionEvidence, "A separate PR explicitly proposes gate promotion after review history exists.") {
+		t.Fatalf("gate promotion evidence missing separate-PR requirement: %#v", evaluator.GatePromotionEvidence)
+	}
+}
+
+func TestTraceHarnessReportScriptMarksMixedAffectedEvidenceRecurring(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=run-only msg="timeout" payload=map[elapsed_ms:60000]`,
+		`2026/06/18 09:01:00 event=runner_timeout msg="timeout" payload=map[issue_id:issue-only elapsed_ms:61000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	evaluator := cluster.Proposals.AdvisoryEvaluator
+	if got := evaluator.CurrentSignal; got != "positive-recurring-cluster" {
+		t.Fatalf("current signal for mixed affected evidence = %q; want positive-recurring-cluster", got)
+	}
+	if !contains(cluster.Evidence[0].Affected.Runs, "run-only") ||
+		!contains(cluster.Evidence[1].Affected.Issues, "issue-only") {
+		t.Fatalf("mixed evidence affected ids = %#v / %#v", cluster.Evidence[0].Affected, cluster.Evidence[1].Affected)
+	}
+}
+
+func TestTraceHarnessReportScriptDoesNotMarkDuplicateEvidenceRecurring(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=run-1 issue_id=issue-1 session_id=session-1 msg="timeout" payload=map[elapsed_ms:60000]`,
+		`2026/06/18 09:01:00 event=runner_timeout task_id=run-1 issue_id=issue-1 session_id=session-1 msg="timeout" payload=map[elapsed_ms:61000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	evaluator := cluster.Proposals.AdvisoryEvaluator
+	if got := evaluator.CurrentSignal; got != "candidate-only-needs-more-evidence" {
+		t.Fatalf("current signal for duplicate evidence = %q; want candidate-only-needs-more-evidence", got)
+	}
+	if len(evaluator.Fixtures) != 2 {
+		t.Fatalf("duplicate evidence fixtures = %d; want retained examples even when signal is candidate-only", len(evaluator.Fixtures))
 	}
 }
 
@@ -761,6 +880,16 @@ func TestTraceHarnessReportScriptBoundsFullClusterByBytes(t *testing.T) {
 	if got := cluster.Affected.Omitted["issues"]; got == 0 {
 		t.Fatalf("affected omitted counts were not reported: %#v", cluster.Affected.Omitted)
 	}
+	if len(cluster.Affected.Issues) == 0 || len(cluster.Affected.Sessions) == 0 {
+		t.Fatalf("cluster lost all concrete affected ids: issues=%d sessions=%d omitted=%#v", len(cluster.Affected.Issues), len(cluster.Affected.Sessions), cluster.Affected.Omitted)
+	}
+	evaluator := cluster.Proposals.AdvisoryEvaluator
+	if len(evaluator.RecoveredAffectedIDs.Issues) > 5 || len(evaluator.RecoveredAffectedIDs.Sessions) > 5 {
+		t.Fatalf("evaluator recovered affected ids are unbounded: %#v", evaluator.RecoveredAffectedIDs)
+	}
+	if evaluator.RecoveredAffectedIDs.Omitted["issues"] == 0 || evaluator.RecoveredAffectedIDs.Omitted["sessions"] == 0 {
+		t.Fatalf("evaluator recovered affected ids omitted counts missing: %#v", evaluator.RecoveredAffectedIDs)
+	}
 }
 
 func TestTraceHarnessReportScriptRerendersProposalsAfterFinalClusterTrimming(t *testing.T) {
@@ -937,6 +1066,15 @@ func contains(values []string, want string) bool {
 	return false
 }
 
+func containsSubstring(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
 type traceReport struct {
 	SchemaVersion string `json:"schema_version"`
 	Clusters      []traceCluster
@@ -956,6 +1094,14 @@ type traceCluster struct {
 	Evidence []struct {
 		Excerpt  string            `json:"excerpt"`
 		Metadata map[string]string `json:"metadata"`
+		Affected struct {
+			Issues           []string       `json:"issues"`
+			IssueIdentifiers []string       `json:"issue_identifiers"`
+			PullRequests     []string       `json:"pull_requests"`
+			Runs             []string       `json:"runs"`
+			Sessions         []string       `json:"sessions"`
+			Omitted          map[string]int `json:"omitted"`
+		} `json:"affected"`
 	} `json:"evidence"`
 	Proposals struct {
 		GitHubIssue struct {
@@ -966,5 +1112,43 @@ type traceCluster struct {
 			Title string `json:"title"`
 			Plan  string `json:"plan"`
 		} `json:"draft_pr"`
+		AdvisoryEvaluator struct {
+			ID                   string `json:"id"`
+			Title                string `json:"title"`
+			Mode                 string `json:"mode"`
+			TargetFailureClass   string `json:"target_failure_class"`
+			CurrentSignal        string `json:"current_signal"`
+			RecoveredAffectedIDs struct {
+				Issues           []string       `json:"issues"`
+				IssueIdentifiers []string       `json:"issue_identifiers"`
+				PullRequests     []string       `json:"pull_requests"`
+				Runs             []string       `json:"runs"`
+				Sessions         []string       `json:"sessions"`
+				Omitted          map[string]int `json:"omitted"`
+			} `json:"recovered_affected_ids"`
+			Fixtures []struct {
+				Name           string            `json:"name"`
+				SourceRef      string            `json:"source_ref"`
+				EventKind      string            `json:"event_kind"`
+				Expected       string            `json:"expected"`
+				BoundedExcerpt string            `json:"bounded_excerpt"`
+				Metadata       map[string]string `json:"metadata"`
+			} `json:"fixtures"`
+			ExpectedSignalBehavior struct {
+				TruePositive  []string `json:"true_positive"`
+				FalsePositive []string `json:"false_positive"`
+			} `json:"expected_signal_behavior"`
+			Execution struct {
+				Mode          string `json:"mode"`
+				BlocksCI      bool   `json:"blocks_ci"`
+				BlocksRuntime bool   `json:"blocks_runtime"`
+				BlocksMerge   bool   `json:"blocks_merge"`
+			} `json:"execution"`
+			FutureReportOutput struct {
+				Schema string   `json:"schema"`
+				Fields []string `json:"fields"`
+			} `json:"future_report_output"`
+			GatePromotionEvidence []string `json:"gate_promotion_evidence"`
+		} `json:"advisory_evaluator"`
 	} `json:"proposals"`
 }

--- a/scripts/trace_harness_report_docs_test.go
+++ b/scripts/trace_harness_report_docs_test.go
@@ -416,6 +416,21 @@ func TestTraceHarnessReportScriptDoesNotMarkDuplicateEvidenceRecurring(t *testin
 	}
 }
 
+func TestTraceHarnessReportScriptMergesRetainedEvidenceSharingAffectedID(t *testing.T) {
+	root := repoRoot(t)
+	body := strings.Join([]string{
+		`2026/06/18 09:00:00 event=runner_timeout task_id=run-1 issue_id=issue-1 session_id=session-1 msg="timeout" payload=map[elapsed_ms:60000]`,
+		`2026/06/18 09:01:00 event=runner_timeout task_id=run-2 issue_id=issue-1 session_id=session-2 msg="timeout" payload=map[elapsed_ms:61000]`,
+	}, "\n") + "\n"
+	report := runTraceHarnessReport(t, root, body)
+
+	cluster := findCluster(t, report, "runner-timeout")
+	evaluator := cluster.Proposals.AdvisoryEvaluator
+	if got := evaluator.CurrentSignal; got != "candidate-only-needs-more-evidence" {
+		t.Fatalf("current signal for retained evidence sharing issue-1 = %q; want candidate-only-needs-more-evidence", got)
+	}
+}
+
 func TestTraceHarnessReportScriptRendersStableProposalText(t *testing.T) {
 	root := repoRoot(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #941

## Summary
- Extend `scripts/trace-harness-report.py` to emit `trace-harness-report/v3` clusters with `proposals.advisory_evaluator`.
- The evaluator candidate is report-only/advisory, includes recovered affected ids, bounded redacted fixtures/examples, expected true-positive and false-positive behavior, a future evaluator-result output contract, and gate-promotion evidence requirements.
- Update the trace report and follow-through runbooks for schema v3 and the non-blocking evaluator semantics.
- Add regression coverage for generated advisory candidates, recovered-id preservation, mixed affected-id recurrence, bounded evaluator affected ids, redaction, non-blocking execution flags, future output fields, and duplicate evidence that must not be treated as recurring.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Boundary notes:
- No worker command, phase, post-turn verifier, PR/tracker writeback, prompt/rubric/skill rewrite, durable trace store, natural-language parser contract, or required CI/runtime/merge gate is added.
- The candidate's `execution` block is explicitly report-only and non-blocking.
- Required gate promotion remains a separate future PR after reviewed report history and false-positive evidence.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — <=12 production files / <=300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,...`)
- [x] additional validation noted below when needed

Additional validation:
- `python3 -m py_compile scripts/trace-harness-report.py`
- `go test -run 'TestTraceHarnessReportScriptMarksMixedAffectedEvidenceRecurring|TestTraceHarnessReportScriptDoesNotMarkDuplicateEvidenceRecurring|TestTraceHarnessReportScriptRendersAdvisoryEvaluatorCandidate' -count=1 ./scripts`
- `go test -run 'TestTraceHarnessReportScriptBoundsFullClusterByBytes|TestTraceHarnessReportScriptRendersAdvisoryEvaluatorCandidate' -count=1 ./scripts`
- `go test -run '^TestTraceHarnessReportScriptBoundsFullClusterByBytes$' -count=1 ./scripts`
- `go test -run '^TestTraceHarnessReportScriptRendersAdvisoryEvaluatorCandidate$' -count=1 ./scripts`
- `go test -count=1 ./scripts`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go build ./cmd/worker ./cmd/tui`
- `git diff --check`

Mutation verification:
- Changed the recurring threshold from `>= 2` to `> 2`; `TestTraceHarnessReportScriptRendersAdvisoryEvaluatorCandidate` failed as expected, then passed after restore.
- Changed evaluator recurrence back to raw evidence-count logic; `TestTraceHarnessReportScriptDoesNotMarkDuplicateEvidenceRecurring` failed as expected, then passed after restore.
- Removed `recovered_affected_ids` from the advisory evaluator candidate; `TestTraceHarnessReportScriptRendersAdvisoryEvaluatorCandidate` failed with empty recovered affected ids, then passed after restore.
- Reverted recurrence to the old same-column affected-id count; `TestTraceHarnessReportScriptMarksMixedAffectedEvidenceRecurring` failed, then passed after restore.
- Reverted evaluator `recovered_affected_ids` to full affected-array copying; `TestTraceHarnessReportScriptBoundsFullClusterByBytes` failed because top-level concrete affected ids were trimmed to zero, then passed after restore.

## Review notes
- Subagent reviewer path was not used; current session instructions require inline implementation/checking only, and available `spawn_agent` metadata requires explicit delegation.
- Codex CLI diff review on initial head `fb38975` returned `NEEDS-CHANGES`; it found that recurring signal was inferred from raw evidence count rather than independent occurrences.
- Fixed by deriving positive recurring signal from distinct recovered affected IDs (`issues`, `issue_identifiers`, `pull_requests`, `runs`, `sessions`, including omitted counts) and adding a duplicate-evidence regression test.
- Codex CLI diff review on head `139b647` returned `MERGE-READY` with no findings.
- Official `@codex review` on `139b647` found one P2: extracted advisory evaluator candidates lost recovered IDs when the ids came only from trusted payload scalars. Fixed by adding `recovered_affected_ids` to the candidate, documenting it, and adding regression + mutation coverage. The review thread is resolved.
- Official `@codex review` on `c6f0399` found one P2: mixed affected-id evidence could under-report recurrence because the signal used a max count within one affected-id column. Fixed by storing recovered affected ids per retained evidence entry and counting independent evidence occurrences while merging entries that share a recovered id.
- Official `@codex review` on `027f5a2` found one P2: full evaluator affected-id copying could force top-level affected arrays to trim to zero under the 256 KiB cap. Fixed in current head `b790578` by independently bounding evaluator `recovered_affected_ids` and folding skipped values into its omitted counts.
- Fresh `@codex review` trigger on current head `b790578`: https://github.com/xrf9268-hue/aiops-platform/pull/950#issuecomment-4751232525.
- Claude CLI reviewer still hit a 429 session limit. Per the user's explicit instruction not to wait for Claude CLI, this PR proceeds with that disclosed reviewer exception.

## Notes
- Schema is bumped from `trace-harness-report/v2` to `trace-harness-report/v3` because cluster proposal shape now includes an advisory evaluator candidate.
- Current head: `b7905787fd3c21b65552ca44e4d74c0646190f86`.
