### PR TITLE
feat(harness): recover per-class affected ids for capped manifest runs

### DIFF
--- a/docs/runbooks/trace-evidence-manifest.md
+++ b/docs/runbooks/trace-evidence-manifest.md
@@ -31,11 +31,16 @@ for local inspection pipe it through `python3 -m json.tool` or `jq`.
 
 ## What is captured (metadata first)
 
-The output uses schema `trace-evidence-manifest/v1`.
+The output uses schema `trace-evidence-manifest/v2`.
 
 - Per input: the source log path, byte count, and `sha256` digest.
-- Per run (keyed by `task_id`, falling back to the issue id): the affected
-  issue, issue identifier, PR, run, and session ids.
+- Per run (keyed by `task_id`, falling back to the issue id): an
+  `affected_by_class` map from each resolved failure class to the affected
+  issue, issue identifier, PR, run, and session ids seen for that class. The
+  per-class summary is accumulated from every event **before** the per-run event
+  cap drops evidence, so a dropped event's ids survive under its own class and
+  the report consumer folds them into the matching cluster without ever
+  mis-attributing a dropped event to a different class.
 - Per event: `source`, the masked source reference (`path:line`), event `kind`,
   the resolved failure `class` (so consumers re-cluster without re-parsing the
   redacted excerpt), the redacted structured-prefix `excerpt`, and trusted
@@ -63,28 +68,33 @@ exactly what the report omits:
 - Evidence is bounded at **64 KiB per run** and each run group at the
   cluster-equivalent **256 KiB** cap, matching the report's per-cluster bounds on
   both axes. Whole events are dropped past the cap (reported as `dropped_events`)
-  and, if the affected-id arrays alone would still exceed the cap, those arrays
-  are truncated too with the dropped counts recorded under `affected.omitted`.
-  Larger artifacts are referenced by `path:line` plus the input digest and byte
-  count, never inlined.
+  and, if the per-class `affected_by_class` arrays alone would still exceed the
+  cap, those arrays are truncated too — the longest first — with the dropped
+  counts recorded per class under `affected_by_class.<class>.omitted`. Larger
+  artifacts are referenced by `path:line` plus the input digest and byte count,
+  never inlined.
 - Manifests are operator-owned artifacts. If committed, keep them under
   `docs/validation/` (or another explicit evidence directory) with a short
   retention rationale; otherwise treat them as local, rotation-bounded scratch
   output. The manifest is evidence for harness improvement, not scheduler state,
   and must never become restart/recovery state.
 
-### Known limitation: capped-run affected ids
+### Capped-run affected ids: faithful per-class recovery
 
 When a single run's events exceed the 64 KiB event cap, the dropped events'
-issue/session/PR ids are still preserved in that run's class-less `affected`
-summary, but the report does **not** re-cluster them: the summary is not
-partitioned by failure class, so attributing a dropped event's ids to a retained
-cluster could mis-label them (e.g. fold a dropped `turn_input_required` id into a
-`runner-timeout` cluster). For such capped runs the report's affected counts can
-therefore be lower than the raw `--worker-log` path. Faithful per-class recovery
-(persisting affected summaries by failure class in the manifest) is tracked in
-#958. This only affects very chatty runs that overflow the per-run cap;
-non-capped runs round-trip with identical affected ids.
+issue/session/PR ids are still recovered on the report round trip, attributed to
+their own failure class (#958). Because `affected_by_class` is partitioned by the
+class resolved at parse time, the consumer folds each class's summary into the
+matching cluster, so a dropped `turn_input_required` id lands in an
+`input-required` cluster — never in a retained `runner-timeout` one. When *every*
+event of a class was dropped, the report still creates an **evidence-less**
+cluster for that class carrying only the recovered affected ids. It contributes
+no evidence-derived occurrences but still carries the summary's byte-cap
+`omitted` counts, so its recurrence signal — `candidate-only` or
+`positive-recurring` — matches whatever the raw `--worker-log` path reports for
+the same class; it is never a *false* escalation, because both paths count the
+same distinct trimmed ids. Capped and non-capped runs therefore round-trip the
+same per-class affected ids the raw `--worker-log` path reports.
 
 ## How it is consumed
 

--- a/scripts/trace-evidence-manifest.py
+++ b/scripts/trace-evidence-manifest.py
@@ -99,7 +99,9 @@ def build_manifest(paths: list[Path]) -> dict:
 def fold_event(runs: dict[str, dict], finding: dict) -> None:
     run_id = finding["run"] or finding["issue"] or "unknown"
     group = runs.setdefault(run_id, new_run_group(run_id))
-    record_affected(group, finding)
+    # Record the per-class affected summary before the cap check so a later
+    # dropped event's ids survive under its own failure class (#958).
+    record_affected_by_class(group, finding)
     excerpt = report.truncate(report.mask(finding["excerpt"]), report.MAX_EVIDENCE_EXCERPT_BYTES)
     entry = report.evidence_entry(finding, excerpt)
     # Record the resolved failure class so consumers re-cluster without re-parsing
@@ -116,27 +118,36 @@ def fold_event(runs: dict[str, dict], finding: dict) -> None:
 def new_run_group(run_id: str) -> dict:
     return {
         "run": run_id,
-        "affected": {key: [] for key in report.AFFECTED_KEYS},
-        # O(1) dedup membership per affected key; emitted arrays stay sorted.
-        "_seen": {key: set() for key in report.AFFECTED_KEYS},
+        # Affected ids partitioned by resolved failure class so the report consumer
+        # folds a dropped event's ids into the correct cluster (#958). Each bucket
+        # mirrors a cluster's affected dict (AFFECTED_KEYS arrays + an omitted map).
+        "affected_by_class": {},
+        # O(1) dedup membership per class/affected key; emitted arrays stay sorted.
+        "_seen_by_class": {},
         "events": [],
         "_bytes": 0,
         "_dropped": 0,
     }
 
 
-def record_affected(group: dict, finding: dict) -> None:
+def record_affected_by_class(group: dict, finding: dict) -> None:
+    class_id = finding["id"]
     for affected_key, finding_key in AFFECTED_FROM_FINDING:
         value = (finding.get(finding_key) or "").strip()
-        if value and value not in group["_seen"][affected_key]:
-            group["_seen"][affected_key].add(value)
-            group["affected"][affected_key].append(value)
+        if not value:
+            continue
+        seen = group["_seen_by_class"].setdefault(class_id, {key: set() for key in report.AFFECTED_KEYS})
+        affected = group["affected_by_class"].setdefault(class_id, {key: [] for key in report.AFFECTED_KEYS})
+        if value not in seen[affected_key]:
+            seen[affected_key].add(value)
+            affected[affected_key].append(value)
 
 
 def finalize_run(group: dict) -> dict:
-    for key in report.AFFECTED_KEYS:
-        group["affected"][key].sort()
-    group.pop("_seen", None)  # drop before any encoded_bytes call: sets are not JSON-serializable.
+    for affected in group["affected_by_class"].values():
+        for key in report.AFFECTED_KEYS:
+            affected[key].sort()
+    group.pop("_seen_by_class", None)  # drop before any encoded_bytes call: sets are not JSON-serializable.
     group.pop("_bytes", None)
     # Keep dropped_events in the dict while enforcing the cap so its bytes are
     # accounted for; remove it only when nothing was dropped.
@@ -150,30 +161,32 @@ def finalize_run(group: dict) -> dict:
 def enforce_run_group_bound(group: dict) -> None:
     # Cluster-equivalent cap (#952): keep the whole run group under the same
     # 256 KiB ceiling, matching the report's enforce_cluster_bound on both axes —
-    # trim events first, then the affected-id arrays (recording omitted counts) so
-    # an affected-id explosion cannot push the group over the cap.
+    # trim events first, then the per-class affected-id arrays (recording omitted
+    # counts) so an affected-id explosion cannot push the group over the cap.
     trim_events_to_cap(group)
     if report.encoded_bytes(group) <= report.MAX_CLUSTER_BYTES:
         return
-    affected = group["affected"]
-    omitted = affected.setdefault("omitted", {})
-    base = {key: int(omitted.get(key, 0)) for key in report.AFFECTED_KEYS}
-    originals = {key: list(affected[key]) for key in report.AFFECTED_KEYS}
-    for key in sorted(report.AFFECTED_KEYS, key=lambda name: len(originals[name]), reverse=True):
-        if report.encoded_bytes(group) <= report.MAX_CLUSTER_BYTES:
-            break
-        values = originals[key]
-        if not values:
-            continue
-        keep = report.max_affected_keep_count(group, key, values, base[key])
-        affected[key] = values[:keep]
-        report.set_affected_omitted(group, key, base[key] + len(values) - keep)
-    for key, count in list(omitted.items()):
-        if count <= 0:
-            omitted.pop(key)
-    if not omitted:
-        affected.pop("omitted", None)
+    trim_affected_by_class(group)
     trim_events_to_cap(group)
+
+
+def trim_affected_by_class(group: dict) -> None:
+    # Trim the longest id arrays across every (class, key) slot first, reusing the
+    # report's single trim implementation so the producer and the report cluster
+    # cap stay one source of truth. `size` measures the whole run group's bytes.
+    size = lambda: report.encoded_bytes(group)  # noqa: E731 - small local size probe
+    affected_by_class = group["affected_by_class"]
+    slots = [(cid, key) for cid, affected in affected_by_class.items() for key in report.AFFECTED_KEYS if affected.get(key)]
+    slots.sort(key=lambda slot: len(affected_by_class[slot[0]][slot[1]]), reverse=True)
+    for class_id, key in slots:
+        if size() <= report.MAX_CLUSTER_BYTES:
+            break
+        affected = affected_by_class[class_id]
+        values = list(affected[key])
+        base = int(affected.get("omitted", {}).get(key, 0))
+        keep = report.max_affected_keep_count(affected, key, values, base, size)
+        affected[key] = values[:keep]
+        report.set_affected_omitted(affected, key, base + len(values) - keep)
 
 
 def trim_events_to_cap(group: dict) -> None:

--- a/scripts/trace-harness-report.py
+++ b/scripts/trace-harness-report.py
@@ -31,7 +31,7 @@ import hashlib
 import json
 import re
 import sys
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
@@ -39,7 +39,7 @@ from urllib.parse import urlsplit, urlunsplit
 SCHEMA_VERSION = "trace-harness-report/v3"
 # Single source of truth for the manifest schema id, shared by the producer
 # (trace-evidence-manifest.py) and the --evidence-manifest consumer's validation.
-EVIDENCE_MANIFEST_SCHEMA_VERSION = "trace-evidence-manifest/v1"
+EVIDENCE_MANIFEST_SCHEMA_VERSION = "trace-evidence-manifest/v2"
 EVALUATOR_RESULT_SCHEMA_VERSION = "trace-harness-advisory-evaluator-result/v1"
 EVALUATOR_RESULTS_ARTIFACT_SCHEMA_VERSION = "trace-harness-advisory-evaluator-results/v1"
 MAX_RUN_EVIDENCE_BYTES, MAX_CLUSTER_BYTES, MAX_EVIDENCE_EXCERPT_BYTES = 64 * 1024, 256 * 1024, 4 * 1024
@@ -253,16 +253,62 @@ def fold_manifest(clusters: dict, run_bytes: dict, path: Path) -> None:
 
 
 def fold_manifest_run(clusters: dict, run_bytes: dict, run: dict) -> None:
-    # Cluster only from retained events. The manifest's per-run `affected` summary
-    # also holds ids from events dropped by its 64 KiB cap, but that summary is
-    # not partitioned by failure class, so folding it would mis-attribute a
-    # dropped event's ids to a retained class (and could invent a cluster the raw
-    # path would key differently). The capped-run undercount is a documented
-    # limitation; faithful per-class recovery is tracked in #958.
+    # The run's per-class `affected_by_class` summary is the authoritative source of
+    # affected ids: it was accumulated from every event (retained and cap-dropped)
+    # before the 64 KiB cap, so it is the superset of the retained events' own ids.
+    # Fold the retained events for evidence only (record_affected=False) and recover
+    # all affected ids — including dropped events' — from the summary, attributed to
+    # each id's own failure class (#958). Sourcing ids from one place keeps the
+    # kept+omitted accounting exact and never mis-attributes across classes.
     for event in run.get("events", []):
         finding = manifest_event_finding(event)
         if finding:
-            add_finding(clusters, run_bytes, finding)
+            add_finding(clusters, run_bytes, finding, record_affected=False)
+    fold_manifest_affected_by_class(clusters, run.get("affected_by_class", {}))
+
+
+def fold_manifest_affected_by_class(clusters: dict, affected_by_class: dict) -> None:
+    if not isinstance(affected_by_class, dict):
+        return
+    for class_id, affected in affected_by_class.items():
+        event_class = CLASS_BY_ID.get(class_id)
+        if not event_class or not isinstance(affected, dict):
+            continue
+        # A class whose events were all dropped has no retained evidence, so create
+        # an evidence-less cluster carrying only the recovered affected ids. It
+        # contributes no evidence-derived occurrences but still carries the summary's
+        # byte-cap omitted counts, so its signal (candidate-only or positive-recurring)
+        # matches whatever the raw --worker-log path reports for the same class — never
+        # a *false* escalation, since both count the same distinct trimmed ids.
+        cluster = clusters.get(class_id) or new_evidence_less_cluster(clusters, event_class)
+        for key in AFFECTED_KEYS:
+            for value in affected.get(key, []):
+                add_unique(cluster, key, value)
+        merge_manifest_affected_omitted(cluster, affected.get("omitted", {}))
+
+
+def new_evidence_less_cluster(clusters: dict, event_class: tuple[str, str, str]) -> dict:
+    cid, title, symptom = event_class
+    cluster = new_cluster({"id": cid, "title": title, "symptom": symptom})
+    clusters[cid] = cluster
+    return cluster
+
+
+def merge_manifest_affected_omitted(cluster: dict, omitted: dict) -> None:
+    # Carry the summary's own byte-cap omitted counts into the cluster. Kept ids come
+    # solely from these summaries (events add no ids), so for a single manifest
+    # kept + omitted equals the class's true distinct-id count, matching the raw
+    # path. Counts from separate summaries are summed because the dropped id *values*
+    # are gone (the byte bound discarded them), so overlapping inputs cannot be
+    # deduped here and may inflate omitted — an advisory-only count; the kept id
+    # lists stay correct. Tracked in #961.
+    if not isinstance(omitted, dict):
+        return
+    for key in AFFECTED_KEYS:
+        count = int(omitted.get(key, 0) or 0)
+        if count > 0:
+            target = cluster["affected"].setdefault("omitted", {})
+            target[key] = int(target.get(key, 0)) + count
 
 
 def manifest_event_finding(event: dict) -> dict | None:
@@ -355,13 +401,17 @@ def evidence_excerpt(prefix: str, has_payload: bool) -> str:
     return f"{excerpt} payload=[redacted-payload]" if has_payload else excerpt
 
 
-def add_finding(clusters: dict[str, dict], run_bytes: dict[str, int], finding: dict) -> None:
+def add_finding(clusters: dict[str, dict], run_bytes: dict[str, int], finding: dict, record_affected: bool = True) -> None:
     cluster = clusters.setdefault(finding["id"], new_cluster(finding))
-    add_unique(cluster, "issues", finding["issue"])
-    add_unique(cluster, "issue_identifiers", finding["identifier"])
-    add_unique(cluster, "pull_requests", finding["pull_request"])
-    add_unique(cluster, "runs", finding["run"])
-    add_unique(cluster, "sessions", finding["session"])
+    # The manifest path passes record_affected=False: its per-class summary, not the
+    # retained evidence, is the authoritative source of cluster-level affected ids.
+    # The evidence entry still carries its own affected for occurrence counting.
+    if record_affected:
+        add_unique(cluster, "issues", finding["issue"])
+        add_unique(cluster, "issue_identifiers", finding["identifier"])
+        add_unique(cluster, "pull_requests", finding["pull_request"])
+        add_unique(cluster, "runs", finding["run"])
+        add_unique(cluster, "sessions", finding["session"])
     entry, entry_size = bounded_evidence_entry(cluster, run_bytes, finding)
     if not entry:
         return
@@ -1032,34 +1082,38 @@ def enforce_cluster_bound(cluster: dict) -> None:
     if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
         return
 
-    omitted = cluster["affected"].setdefault("omitted", {})
+    trim_affected_to_cap(cluster["affected"], lambda: encoded_bytes(cluster))
+    trim_evidence_to_cluster_bound(cluster)
+
+
+def trim_affected_to_cap(affected: dict, size: Callable[[], int]) -> None:
+    # Shared by the report cluster and the manifest's per-class summary (one trim
+    # implementation). `size` reports the bytes of the enclosing object so the same
+    # 256 KiB ceiling applies whether the affected dict is a cluster's or a run
+    # group's per-class bucket. Trim the longest id arrays first, recording omitted.
+    omitted = affected.setdefault("omitted", {})
     base_omitted = {key: int(omitted.get(key, 0)) for key in AFFECTED_KEYS}
-    originals = {key: list(cluster["affected"][key]) for key in AFFECTED_KEYS}
+    originals = {key: list(affected.get(key, [])) for key in AFFECTED_KEYS}
     for key in sorted(AFFECTED_KEYS, key=lambda name: len(originals[name]), reverse=True):
-        if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
+        if size() <= MAX_CLUSTER_BYTES:
             break
         values = originals[key]
         if not values:
             continue
-        keep = max_affected_keep_count(cluster, key, values, base_omitted[key])
-        cluster["affected"][key] = values[:keep]
-        set_affected_omitted(cluster, key, base_omitted[key] + len(values) - keep)
-
-    for key, count in list(omitted.items()):
-        if count <= 0:
-            omitted.pop(key)
-    if not omitted:
-        cluster["affected"].pop("omitted", None)
-    trim_evidence_to_cluster_bound(cluster)
+        keep = max_affected_keep_count(affected, key, values, base_omitted[key], size)
+        affected[key] = values[:keep]
+        set_affected_omitted(affected, key, base_omitted[key] + len(values) - keep)
+    if not affected.get("omitted"):
+        affected.pop("omitted", None)
 
 
-def max_affected_keep_count(cluster: dict, key: str, values: list[str], base_omitted: int) -> int:
+def max_affected_keep_count(affected: dict, key: str, values: list[str], base_omitted: int, size: Callable[[], int]) -> int:
     low, high, best = 0, len(values), 0
     while low <= high:
         keep = (low + high) // 2
-        cluster["affected"][key] = values[:keep]
-        set_affected_omitted(cluster, key, base_omitted + len(values) - keep)
-        if encoded_bytes(cluster) <= MAX_CLUSTER_BYTES:
+        affected[key] = values[:keep]
+        set_affected_omitted(affected, key, base_omitted + len(values) - keep)
+        if size() <= MAX_CLUSTER_BYTES:
             best = keep
             low = keep + 1
         else:
@@ -1067,14 +1121,14 @@ def max_affected_keep_count(cluster: dict, key: str, values: list[str], base_omi
     return best
 
 
-def set_affected_omitted(cluster: dict, key: str, count: int) -> None:
-    omitted = cluster["affected"].setdefault("omitted", {})
+def set_affected_omitted(affected: dict, key: str, count: int) -> None:
+    omitted = affected.setdefault("omitted", {})
     if count > 0:
         omitted[key] = count
     else:
         omitted.pop(key, None)
     if not omitted:
-        cluster["affected"].pop("omitted", None)
+        affected.pop("omitted", None)
 
 
 def trim_evidence_to_cluster_bound(cluster: dict) -> None:

--- a/scripts/trace_evidence_manifest_test.go
+++ b/scripts/trace_evidence_manifest_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -32,7 +33,7 @@ func TestTraceEvidenceManifestRunbookDocumentsCaptureOmissionAndConsumers(t *tes
 	text := strings.Join(strings.Fields(string(body)), " ")
 	for _, want := range []string{
 		"python3 scripts/trace-evidence-manifest.py",
-		"trace-evidence-manifest/v1",
+		"trace-evidence-manifest/v2",
 		"--evidence-manifest",
 		"a trace database, queue, metrics store",
 		"restart recovery stays tracker/filesystem-driven",
@@ -70,8 +71,8 @@ func TestTraceEvidenceManifestGroupsRunsAndRedactsOpaquePayload(t *testing.T) {
 	raw := manifestRawBytes(t, root, body)
 	manifest := parseManifest(t, raw)
 
-	if manifest.SchemaVersion != "trace-evidence-manifest/v1" {
-		t.Fatalf("schema_version = %q; want trace-evidence-manifest/v1", manifest.SchemaVersion)
+	if manifest.SchemaVersion != "trace-evidence-manifest/v2" {
+		t.Fatalf("schema_version = %q; want trace-evidence-manifest/v2", manifest.SchemaVersion)
 	}
 	if manifest.Bounds.MaxRunEvidenceBytes != 64*1024 || manifest.Bounds.MaxClusterBytes != 256*1024 {
 		t.Fatalf("bounds = %#v; want 65536/262144", manifest.Bounds)
@@ -83,8 +84,14 @@ func TestTraceEvidenceManifestGroupsRunsAndRedactsOpaquePayload(t *testing.T) {
 	if len(run1.Events) != 2 {
 		t.Fatalf("run-1 events = %d; want 2 (timeout + runner failure)\n%s", len(run1.Events), raw)
 	}
-	if !contains(run1.Affected.Issues, "issue-1") || !contains(run1.Affected.Sessions, "session-1") {
-		t.Fatalf("run-1 affected = %#v; want issue-1/session-1", run1.Affected)
+	// Affected ids are partitioned by failure class: the timeout event's ids land
+	// under runner-timeout, the runner_end event's under runner-failure.
+	rtAffected := classAffected(t, run1, "runner-timeout")
+	if !contains(rtAffected.Issues, "issue-1") || !contains(rtAffected.Sessions, "session-1") {
+		t.Fatalf("run-1 runner-timeout affected = %#v; want issue-1/session-1", rtAffected)
+	}
+	if !contains(classAffected(t, run1, "runner-failure").Issues, "issue-1") {
+		t.Fatalf("run-1 runner-failure affected = %#v; want issue-1", run1.AffectedByClass["runner-failure"])
 	}
 	if run1.Events[0].Metadata["output_bytes"] != "70000" || run1.Events[0].Metadata["timestamp"] != "2026/06/18 09:00:00" {
 		t.Fatalf("run-1 first event metadata = %#v; want metadata-first scalars before the opaque key", run1.Events[0].Metadata)
@@ -99,8 +106,9 @@ func TestTraceEvidenceManifestGroupsRunsAndRedactsOpaquePayload(t *testing.T) {
 	if len(run2.Events) != 1 || run2.Events[0].Class != "input-required" {
 		t.Fatalf("run-2 = %#v; want one input-required event", run2.Events)
 	}
-	if !contains(run2.Affected.Issues, "issue-2") || !contains(run2.Affected.Sessions, "session-2") {
-		t.Fatalf("run-2 affected = %#v; want issue-2/session-2", run2.Affected)
+	run2Affected := classAffected(t, run2, "input-required")
+	if !contains(run2Affected.Issues, "issue-2") || !contains(run2Affected.Sessions, "session-2") {
+		t.Fatalf("run-2 input-required affected = %#v; want issue-2/session-2", run2Affected)
 	}
 	// Mutation-style redaction check: dropping the reused mask()/opaque omission
 	// would surface the clone-URL userinfo and the raw payload here.
@@ -167,9 +175,10 @@ func TestTraceEvidenceManifestBoundsPerRunEvidenceBytes(t *testing.T) {
 	if len(encoded) > 64*1024+2*1024 {
 		t.Fatalf("per-run evidence bytes = %d; want bounded near 65536", len(encoded))
 	}
-	// The byte cap drops whole events but never the affected-id summary.
-	if !contains(run.Affected.Issues, "issue-1") {
-		t.Fatalf("byte cap dropped the affected id summary: %#v", run.Affected)
+	// The byte cap drops whole events but never the per-class affected-id summary.
+	rtAffected := classAffected(t, run, "runner-timeout")
+	if !contains(rtAffected.Issues, "issue-1") {
+		t.Fatalf("byte cap dropped the affected id summary: %#v", rtAffected)
 	}
 }
 
@@ -200,15 +209,16 @@ func TestTraceEvidenceManifestBoundsRunGroupByBytesIncludingAffectedIDs(t *testi
 	if len(encoded) > 256*1024 {
 		t.Fatalf("run group bytes = %d; want <= 262144 (affected-id arrays must be capped too)", len(encoded))
 	}
-	if run.Affected.Omitted["issues"] == 0 {
-		t.Fatalf("affected id explosion did not record omitted counts: %#v", run.Affected.Omitted)
+	rtAffected := classAffected(t, run, "runner-timeout")
+	if rtAffected.Omitted["issues"] == 0 {
+		t.Fatalf("affected id explosion did not record omitted counts: %#v", rtAffected.Omitted)
 	}
-	if len(run.Affected.Issues) == 0 {
-		t.Fatalf("run group lost every concrete affected issue id: omitted=%#v", run.Affected.Omitted)
+	if len(rtAffected.Issues) == 0 {
+		t.Fatalf("run group lost every concrete affected issue id: omitted=%#v", rtAffected.Omitted)
 	}
 	// Accounting must be complete: kept + omitted equals every distinct issue id.
-	if got := len(run.Affected.Issues) + run.Affected.Omitted["issues"]; got != total {
-		t.Fatalf("issues accounted for = %d; want %d (kept=%d omitted=%d)", got, total, len(run.Affected.Issues), run.Affected.Omitted["issues"])
+	if got := len(rtAffected.Issues) + rtAffected.Omitted["issues"]; got != total {
+		t.Fatalf("issues accounted for = %d; want %d (kept=%d omitted=%d)", got, total, len(rtAffected.Issues), rtAffected.Omitted["issues"])
 	}
 }
 
@@ -261,30 +271,92 @@ func TestTraceEvidenceManifestRoundTripDoesNotFabricateRunWithoutTaskID(t *testi
 	}
 }
 
-func TestTraceEvidenceManifestRoundTripDoesNotMisattributeDroppedEventClass(t *testing.T) {
+func TestTraceEvidenceManifestRoundTripRecoversDroppedEventClassPerClass(t *testing.T) {
 	root := repoRoot(t)
-	// Many runner_timeout events fill the manifest's 64 KiB event cap, then a
-	// later turn_input_required event for the same run is dropped. Its session id
-	// survives only in the run-level affected summary, which is class-less: the
-	// consumer must not fold it into the retained runner-timeout cluster.
+	// Many runner_timeout events fill the manifest's 64 KiB event cap, then a large
+	// turn_input_required event for the same run is dropped whole — leaving the
+	// input-required class with no retained evidence. Its session id must still be
+	// recovered under an input-required cluster (not the retained runner-timeout
+	// one), matching the raw --worker-log path with no cross-class mis-attribution.
 	var body strings.Builder
 	for i := 0; i < 60; i++ {
 		body.WriteString(`2026/06/18 09:00:00 event=runner_timeout task_id=run-1 issue_id=issue-1 session_id=session-rt msg="`)
 		body.WriteString(strings.Repeat("x", 1500))
 		body.WriteString(`"` + "\n")
 	}
-	body.WriteString(`2026/06/18 09:00:01 event=turn_input_required task_id=run-1 issue_id=issue-1 session_id=session-ir msg="input"` + "\n")
+	body.WriteString(`2026/06/18 09:00:01 event=turn_input_required task_id=run-1 issue_id=issue-1 session_id=session-ir msg="`)
+	body.WriteString(strings.Repeat("y", 5000))
+	body.WriteString(`"` + "\n")
 
-	manifest := runTraceEvidenceManifest(t, root, body.String())
-	run := manifestRun(t, manifest, "run-1")
-	if run.DroppedEvents == 0 || !contains(run.Affected.Sessions, "session-ir") {
-		t.Fatalf("setup invalid: want dropped events and session-ir preserved in the run summary: dropped=%d sessions=%#v", run.DroppedEvents, run.Affected.Sessions)
+	// The class is dropped whole at the event cap, so it survives only in the
+	// per-class summary — never in a retained event for that class.
+	run := manifestRun(t, runTraceEvidenceManifest(t, root, body.String()), "run-1")
+	if run.DroppedEvents == 0 {
+		t.Fatalf("setup invalid: want a dropped event from the 64 KiB cap, got dropped=%d", run.DroppedEvents)
+	}
+	if got := classAffected(t, run, "input-required").Sessions; !contains(got, "session-ir") {
+		t.Fatalf("dropped class summary lost session-ir: %#v", got)
 	}
 
-	cluster := findCluster(t, reportFromManifest(t, root, body.String()), "runner-timeout")
-	if contains(cluster.Affected.Sessions, "session-ir") {
-		t.Fatalf("dropped input-required session was mis-attributed to the runner-timeout cluster: %#v", cluster.Affected.Sessions)
+	report := reportFromManifest(t, root, body.String())
+	timeout := findCluster(t, report, "runner-timeout")
+	if contains(timeout.Affected.Sessions, "session-ir") {
+		t.Fatalf("dropped input-required session was mis-attributed to runner-timeout: %#v", timeout.Affected.Sessions)
 	}
+	// Faithful per-class recovery: an evidence-less input-required cluster carries
+	// the dropped session id under its own class.
+	inputRequired := findCluster(t, report, "input-required")
+	if !contains(inputRequired.Affected.Sessions, "session-ir") {
+		t.Fatalf("dropped class session-ir was not recovered under input-required: %#v", inputRequired.Affected.Sessions)
+	}
+	if len(inputRequired.Evidence) != 0 {
+		t.Fatalf("input-required cluster should be evidence-less (its events were all dropped): %#v", inputRequired.Evidence)
+	}
+
+	// Affected ids round-trip to exactly what the raw --worker-log path reports.
+	raw := runTraceHarnessReport(t, root, body.String())
+	assertSamePerClassAffected(t, report, raw)
+}
+
+func assertSamePerClassAffected(t *testing.T, got, want traceReport) {
+	t.Helper()
+	wantByID := map[string]traceCluster{}
+	for _, cluster := range want.Clusters {
+		wantByID[cluster.ID] = cluster
+	}
+	for _, cluster := range got.Clusters {
+		other, ok := wantByID[cluster.ID]
+		if !ok {
+			t.Fatalf("manifest report has cluster %q absent from the raw path", cluster.ID)
+		}
+		if a, b := sortedStrings(cluster.Affected.Sessions), sortedStrings(other.Affected.Sessions); !equalStrings(a, b) {
+			t.Fatalf("cluster %q sessions = %v; raw path = %v", cluster.ID, a, b)
+		}
+		if a, b := sortedStrings(cluster.Affected.Issues), sortedStrings(other.Affected.Issues); !equalStrings(a, b) {
+			t.Fatalf("cluster %q issues = %v; raw path = %v", cluster.ID, a, b)
+		}
+	}
+	if len(got.Clusters) != len(want.Clusters) {
+		t.Fatalf("manifest produced %d clusters; raw path produced %d", len(got.Clusters), len(want.Clusters))
+	}
+}
+
+func sortedStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func reportFromManifest(t *testing.T, root, body string) traceReport {
@@ -410,7 +482,7 @@ func TestTraceHarnessReportRejectsNonManifestJSONOnEvidenceManifest(t *testing.T
 	if err == nil {
 		t.Fatalf("report accepted a v3 report as an evidence manifest:\n%s", out)
 	}
-	if !strings.Contains(string(out), "not a trace-evidence-manifest/v1 evidence manifest") {
+	if !strings.Contains(string(out), "not a trace-evidence-manifest/v2 evidence manifest") {
 		t.Fatalf("misuse error did not name the schema mismatch:\n%s", out)
 	}
 }
@@ -505,17 +577,21 @@ type traceManifest struct {
 	Runs []traceManifestRun `json:"runs"`
 }
 
+type traceAffectedSummary struct {
+	Issues           []string       `json:"issues"`
+	IssueIdentifiers []string       `json:"issue_identifiers"`
+	PullRequests     []string       `json:"pull_requests"`
+	Runs             []string       `json:"runs"`
+	Sessions         []string       `json:"sessions"`
+	Omitted          map[string]int `json:"omitted"`
+}
+
 type traceManifestRun struct {
-	Run      string `json:"run"`
-	Affected struct {
-		Issues           []string       `json:"issues"`
-		IssueIdentifiers []string       `json:"issue_identifiers"`
-		PullRequests     []string       `json:"pull_requests"`
-		Runs             []string       `json:"runs"`
-		Sessions         []string       `json:"sessions"`
-		Omitted          map[string]int `json:"omitted"`
-	} `json:"affected"`
-	Events []struct {
+	Run string `json:"run"`
+	// Affected ids partitioned by resolved failure class (#958), so a dropped
+	// event's ids are recovered under its own class on the report round trip.
+	AffectedByClass map[string]traceAffectedSummary `json:"affected_by_class"`
+	Events          []struct {
 		Source   string            `json:"source"`
 		Ref      string            `json:"ref"`
 		Kind     string            `json:"kind"`
@@ -528,4 +604,13 @@ type traceManifestRun struct {
 		} `json:"affected"`
 	} `json:"events"`
 	DroppedEvents int `json:"dropped_events"`
+}
+
+func classAffected(t *testing.T, run traceManifestRun, classID string) traceAffectedSummary {
+	t.Helper()
+	affected, ok := run.AffectedByClass[classID]
+	if !ok {
+		t.Fatalf("missing affected_by_class[%q] in %#v", classID, run.AffectedByClass)
+	}
+	return affected
 }


### PR DESCRIPTION
Closes #958

## Summary
- The trace-evidence manifest preserved a per-run **class-less** `affected` id summary that the `trace-harness-report.py --evidence-manifest` consumer did **not** fold, so a run whose events overflow the 64 KiB per-run event cap undercounted affected ids versus the raw `--worker-log` path.
- Replace it with **`affected_by_class`** (manifest schema **v1→v2**): affected ids partitioned by the failure class already resolved at parse time (`finding["id"]`, from the trusted `event=` prefix — never the redacted excerpt/payload), accumulated **before** the cap drops events. The consumer folds each class's summary into the matching cluster, so a dropped event's ids are recovered under their **own** class and are **never** mis-attributed to a retained class.
- When *every* event of a class is dropped, the report creates an **evidence-less** cluster carrying only the recovered ids. It contributes no evidence-derived occurrences but still carries the summary's `omitted` counts, so its recurrence signal (`candidate-only` or `positive-recurring`) matches whatever the raw path reports for that class — never a *false* escalation.
- Root-cause delta found during review: folding both retained-event ids and the summary double-counts `omitted`. Fixed by making `affected_by_class` the **single authoritative source** of cluster affected ids on the manifest path (retained events fold for evidence only, `add_finding(..., record_affected=False)`), so `kept + omitted == distinct count` per class with no double counting. The cluster / per-class trim is unified in one helper (`trim_affected_to_cap`).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Pure `scripts/` analysis tooling over operator-retained logs (the #937/#952 trace-driven harness loop input). No worker/orchestrator change, no new evidence source, restart recovery untouched (#73/#407).

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff = 2 Python files / ~129 added LOC (tests + docs excluded). Well under ~12 files / ~300 LOC.
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues on `./scripts/...`)
- [x] additional validation noted below

### Acceptance criteria (issue #958)
- [x] Capped run round-trips affected ids matching the raw `--worker-log` path, each id attributed to its own failure class (no cross-class mis-attribution) — asserted by `TestTraceEvidenceManifestRoundTripRecoversDroppedEventClassPerClass` (raw-path parity via `assertSamePerClassAffected`).
- [x] Byte bounds + redaction unchanged; per-class summaries bounded — 64 KiB/run + 256 KiB/run-group enforced by `trim_affected_by_class`; verified a two-class id explosion stays ≤ 256 KiB with exact `kept+omitted==distinct` accounting.
- [x] Multi-class capped run round-trips with correct per-class attribution; **mutation-verified** (disabling the fold drops the `input-required` cluster → test fails; restored).
- [x] Docs updated; the known-limitation note in `docs/runbooks/trace-evidence-manifest.md` removed/replaced with the implemented per-class recovery behavior.

### Manual parity validation (manifest path == raw `--worker-log` path)
- Event-capped multi-class run: per-class affected **sets** identical to the raw path (`session-ir` under `input-required`, never `runner-timeout`).
- Fully-dropped class: evidence-less `input-required` cluster (`ev#0`) carries `session-ir`; signal/kept/omitted identical to the raw path, including the `positive-recurring` case once the summary is byte-trimmed.

## Notes
- Review: pre-push local Claude code-reviewer cleared all boundaries (cross-class routing, no free-text parsing, byte bounds, accounting, SPEC boundary, clean-code) and flagged one doc/comment-accuracy defect (evidence-less clusters can report `positive-recurring`, not only `candidate-only`) — fixed in this PR; behavior was already faithful to the raw path.
- Schema bumped v1→v2 with no dual-emit / back-compat shim; stale v1 manifests are now rejected loudly by the consumer. No committed v1 artifacts exist to migrate.
- `@codex review` (round 1, head `0ba4ce5`): 1 finding (P2) — `omitted` affected-id counts double-count across **overlapping** manifests (kept id lists stay correct; advisory-only). Inherent to the bounded count summary; **deferred to #961** (reproduction + options), thread resolved, and the `merge_manifest_affected_omitted` comment now scopes the raw-path claim to a single manifest.