### PR TITLE
fix(gitea): close terminal issues through label tool

### DIFF
--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -54,7 +54,7 @@ Two worker processes, one Gitea repo/project, **two bot accounts**:
 | `tracker.inactive_states` | `[Human Review, In Progress, Merging]` | `[Todo, In Progress, Merging, Rework]` |
 | `workspace.root` | `~/aiops-workspaces/maker` | `~/aiops-workspaces/reviewer` — **must differ (hard)** |
 | `AIOPS_MIRROR_ROOT` | `~/aiops-mirrors/maker` | `~/aiops-mirrors/reviewer` — **must differ (hard)** |
-| agent state writes | flips → `aiops/human-review`; opens PR; comments PR URL | approves + enables auto-merge; **confirms the merge, then** flips → `aiops/done`; stays in `Human Review` (re-checks next poll) if CI is still landing; `aiops/rework` on fail |
+| agent state writes | flips → `aiops/human-review`; opens PR; comments PR URL | approves + enables auto-merge; **confirms the merge, then** calls `gitea_issue_labels` with `aiops/done` + `close_issue:true`; stays in `Human Review` (re-checks next poll) if CI is still landing; `aiops/rework` on fail |
 
 ```
 Todo ──maker──▶ Human Review ──reviewer──▶ approve + enable CI-gated auto-merge
@@ -189,16 +189,18 @@ for this DAG"*):
 2. Reviewer claims `Human Review` → fetches head → runs the rubric incl.
    `build/test`. **PASS**: approves (review-bot), enables `merge_when_checks_succeed`,
    then — while still `Human Review` (so it is not reconcile-cancelled) — confirms
-   the merge via `GET …/pulls/<number>` → `merged:true`, flips `Done`, and closes
-   the issue (it owns closure, since the maker left it open). If CI is slow/flaky
-   and the merge has not landed within its budget, it makes **no** terminal flip
-   and leaves the issue in `Human Review`; the next poll re-claims it and re-checks
-   until the forge confirms the merge.
+   the merge via `GET …/pulls/<number>` → `merged:true`, and calls
+   `gitea_issue_labels` once with `aiops/done` + `close_issue:true` (it owns
+   closure, since the maker left it open). If CI is slow/flaky and the merge has
+   not landed within its budget, it makes **no** terminal flip and leaves the issue
+   in `Human Review`; the next poll re-claims it and re-checks until the forge
+   confirms the merge.
    **FAIL**: posts findings, flips `Rework` (maker re-dispatches).
 3. CI runs on the PR; when `build-test` is green and the approval is present,
    Gitea auto-merges (squash) and deletes the branch. The merge does **not** close
    the issue (the maker used `Refs #<N>`, not a closing keyword); the reviewer
-   flips `Done` and closes it only after confirming the merge, never before.
+   uses `gitea_issue_labels` with `aiops/done` + `close_issue:true` only after
+   confirming the merge, never before.
    **Why not `Closes #<N>`:** the poller lists `Human Review` (a non-terminal
    active state) with `state=open`, so an issue auto-closed at merge-time would
    drop out of the reviewer's poll *before* it could set `Done` — stranding it
@@ -213,7 +215,7 @@ for this DAG"*):
 - [ ] Maker `verify.commands` == the required CI checks (a green local run predicts a green merge).
 - [ ] Maker never sets `aiops/done`; reviewer is the only Done/auto-merge path.
 - [ ] Reviewer issues `aiops/done` **only after the forge confirms the merge** — never on the verdict alone (else `Depends on #N` dependents unblock from stale `main`).
-- [ ] Maker references the issue with a **non-closing** `Refs #<N>` (not `Closes`); the reviewer flips `Done` and closes the issue post-merge. A closing keyword auto-closes the issue at merge, dropping it from the reviewer's `state=open` poll before `Done` is set — stranding it and its dependents.
+- [ ] Maker references the issue with a **non-closing** `Refs #<N>` (not `Closes`); the reviewer uses `gitea_issue_labels` with `aiops/done` + `close_issue:true` post-merge. A closing keyword auto-closes the issue at merge, dropping it from the reviewer's `state=open` poll before `Done` is set — stranding it and its dependents.
 - [ ] Maker uses the numeric issue number (digits of `{{ issue.identifier }}`, no leading `#`) in every API path / issue reference — `{{ issue.identifier }}` renders as `#N` on Gitea.
 - [ ] Branch protection: required checks + 1 approval + no direct push to `main` + squash + auto-merge enabled.
 - [ ] One-issue-per-PR; agents file follow-up issues for out-of-scope finds.
@@ -251,11 +253,11 @@ models this landing phase as a dedicated `Merging` state with an agent that
 forge-native auto-merge, then flips the issue to `aiops/merging`. A separate
 landing worker watches `tracker.active_states: [Merging]`, follows the land loop,
 confirms the forge reports `merged:true`, and only then flips `aiops/done` and
-closes the issue. Add `Merging` to the maker/reviewer workers' inactive states
-so the handoff reconcile-cancels any still-running prior owner. `Merging` is
-non-terminal: `Depends on #N` dependents remain blocked until the landing worker
-reaches `Done` (or an operator intentionally uses the terminal `Canceled` escape
-hatch).
+closes the issue with `gitea_issue_labels` `close_issue:true`. Add `Merging` to
+the maker/reviewer workers' inactive states so the handoff reconcile-cancels any
+still-running prior owner. `Merging` is non-terminal: `Depends on #N` dependents
+remain blocked until the landing worker reaches `Done` (or an operator
+intentionally uses the terminal `Canceled` escape hatch).
 
 The landing worker is a third worker with its own `workspace.root`,
 `AIOPS_MIRROR_ROOT`, and bot credentials. Its workflow should keep `Merging` as

--- a/examples/maker-WORKFLOW.md
+++ b/examples/maker-WORKFLOW.md
@@ -109,7 +109,8 @@ Do all of the following end to end, without asking for confirmation:
    *after* it confirms the merge, and the poller lists `Human Review` issues with
    `state=open` — a merge-closed issue drops out of the reviewer's poll before
    `Done` is ever set, deadlocking the issue and its `Depends on #N` dependents.
-   The reviewer owns issue closure.
+   The reviewer owns issue closure through its terminal `gitea_issue_labels`
+   handoff.
    `POST /repos/{{ repo.owner }}/{{ repo.name }}/pulls`
    body `{"head":"<branch>","base":"{{ repo.branch }}","title":"<type(scope): summary>","body":"Refs #<N>\n\n<what + how tested>"}`.
    Use the basic-auth credential from `origin` for the call.

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -100,7 +100,8 @@ If a previous poll already acted on this PR, do NOT blindly re-run the rubric �
 but work out the situation first, in this order:
 1. **Already merged?** `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>`
    → if `merged:true` (CI finished before this poll landed it), go straight to
-   Step 3d's Merged action — flip `aiops/done`, then close the issue. Do NOT
+   Step 3d's Merged action — one `gitea_issue_labels` call with
+   `{"issue_number":<N>,"labels":["aiops/done"],"close_issue":true}`. Do NOT
    re-post the merge endpoint on a merged PR (Gitea returns HTTP 405, which would
    derail you).
 2. **Not merged — is your approval still CURRENT?** Check
@@ -114,11 +115,12 @@ but work out the situation first, in this order:
      is set, so poll Step 3d. On any error (Gitea returns HTTP 405 for an
      already-merged PR but ALSO for not-mergeable / WIP / no-permission states), do
      NOT conclude it merged: re-check `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>`
-     and take the Done path (flip `aiops/done` + close) ONLY if `merged:true`;
-     otherwise — unmerged, or the check itself did not confirm a merge — leave the
-     issue in `Human Review` for the next poll (a persistent error is an operator
-     signal). Never flip `aiops/done` without a confirming `merged:true` —
-     a status code alone is not proof.
+     and take the Done path (one `gitea_issue_labels` call with `aiops/done` and
+     `close_issue:true`) ONLY if `merged:true`; otherwise — unmerged, or the check
+     itself did not confirm a merge — leave the issue in `Human Review` for the
+     next poll (a persistent error is an operator signal). Never flip
+     `aiops/done` without a confirming `merged:true` — a status code alone is not
+     proof.
    - **No current approval** — your only approval is `stale`/dismissed or was for
      an older commit (the head moved after you approved: a rebase or a pushed fix)
      → do NOT short-circuit. Fall through to Step 2 and review the new head from
@@ -151,11 +153,12 @@ PASS (every item passes):
      `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>` → `merged: true`
      (a short bounded wait — e.g. poll every ~30s for a few attempts, not a busy
      loop; required CI here is fast).
-       - Merged → set the label to `aiops/done` via gitea_issue_labels, then close
-         the issue: `PATCH /repos/{{ repo.owner }}/{{ repo.name }}/issues/<N>`
-         body `{"state":"closed"}`. The maker referenced the issue with a
-         non-closing `Refs #<N>`, so the forge did NOT close it on merge — you own
-         closure, after `Done`. This is your LAST action.
+       - Merged → call `gitea_issue_labels` once with
+         `{"issue_number":<N>,"labels":["aiops/done"],"close_issue":true}`. The
+         tool flips `Done` and closes the issue in one agent-side handoff. The
+         maker referenced the issue with a non-closing `Refs #<N>`, so the forge
+         did NOT close it on merge — you own closure, after `Done`. This is your
+         LAST action.
        - Not merged within your budget (slow/flaky CI) → do NOT flip any label.
          Leave the issue in `Human Review` and stop. It stays in your active set,
          so the next poll re-claims it and re-checks the merge (Step 1 sends you
@@ -175,7 +178,8 @@ FAIL (any item fails):
 - Do NOT modify, commit, or push code. Your only writes are tracker/PR writes: the
   review comment, the approval, enabling auto-merge, the verdict label flip
   (`aiops/done` after the merge is confirmed, or `aiops/rework` on failure), and —
-  on the Done path — closing the issue (the maker left it open via `Refs #<N>`).
+  on the Done path — issue closure through the same `gitea_issue_labels` call with
+  `close_issue:true` (the maker left it open via `Refs #<N>`).
 - Judge only what the diff and its tests prove; unverified PR-description claims
   count for nothing.
 - Issue the terminal verdict exactly once: `aiops/done` only after the merge is

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -89,11 +89,7 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 	deletedStaleLabels, failure := p.deleteStaleStateLabels(ctx, client, labelsEndpoint, staleStateLabels)
 	labelReplaceSucceeded := failure == ""
 	if labelReplaceSucceeded && call.CloseIssue {
-		result, failure = p.closeIssue(ctx, client, issueEndpoint, result)
-		if failure != "" && p.restoreDeletedStateLabels(ctx, client, labelsEndpoint, deletedStaleLabels) == "" {
-			deletedStaleLabels = nil
-			labelReplaceSucceeded = false
-		}
+		result, deletedStaleLabels, labelReplaceSucceeded, failure = p.closeIssueAfterLabelReplace(ctx, client, issueEndpoint, labelsEndpoint, result, deletedStaleLabels)
 	}
 	p.fireMutationAudit(ctx, mutationAuditFacts{
 		issueNumber:           call.IssueNumber,
@@ -354,6 +350,17 @@ func (p giteaIssueLabelsProxy) deleteStaleStateLabels(ctx context.Context, clien
 		deleted = append(deleted, label)
 	}
 	return deleted, ""
+}
+
+func (p giteaIssueLabelsProxy) closeIssueAfterLabelReplace(ctx context.Context, client *http.Client, issueEndpoint, labelsEndpoint, labelResult string, deleted []giteaIssueLabel) (string, []giteaIssueLabel, bool, string) {
+	closedResult, failure := p.closeIssue(ctx, client, issueEndpoint, labelResult)
+	if failure == "" {
+		return closedResult, deleted, true, ""
+	}
+	if p.restoreDeletedStateLabels(ctx, client, labelsEndpoint, deleted) == "" {
+		return labelResult, nil, false, failure
+	}
+	return labelResult, deleted, true, failure
 }
 
 func (p giteaIssueLabelsProxy) restoreDeletedStateLabels(ctx context.Context, client *http.Client, endpoint string, deleted []giteaIssueLabel) string {

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -90,6 +90,10 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 	labelReplaceSucceeded := failure == ""
 	if labelReplaceSucceeded && call.CloseIssue {
 		result, failure = p.closeIssue(ctx, client, issueEndpoint, result)
+		if failure != "" && p.restoreDeletedStateLabels(ctx, client, labelsEndpoint, deletedStaleLabels) == "" {
+			deletedStaleLabels = nil
+			labelReplaceSucceeded = false
+		}
 	}
 	p.fireMutationAudit(ctx, mutationAuditFacts{
 		issueNumber:           call.IssueNumber,
@@ -350,6 +354,18 @@ func (p giteaIssueLabelsProxy) deleteStaleStateLabels(ctx context.Context, clien
 		deleted = append(deleted, label)
 	}
 	return deleted, ""
+}
+
+func (p giteaIssueLabelsProxy) restoreDeletedStateLabels(ctx context.Context, client *http.Client, endpoint string, deleted []giteaIssueLabel) string {
+	if len(deleted) == 0 {
+		return ""
+	}
+	labels := make([]string, 0, len(deleted))
+	for _, label := range deleted {
+		labels = append(labels, label.Name)
+	}
+	_, failure := p.addAndConfirmDesiredLabels(ctx, client, endpoint, labels, labels)
+	return failure
 }
 
 func (p giteaIssueLabelsProxy) addIssueLabels(ctx context.Context, client *http.Client, endpoint string, labels []string) (string, string) {

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -64,30 +64,40 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 	if !ok {
 		return failureResult, failureErr
 	}
+	// validateDesiredStateLabels proves desiredStateLabels has exactly one
+	// canonical label; close validation depends on that resolved state.
+	if failureResult, failureErr, ok := p.validateCloseIssue(call, desiredStateLabels[0]); !ok {
+		return failureResult, failureErr
+	}
 
-	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues/%d/labels", strings.TrimRight(p.baseURL, "/"), url.PathEscape(p.owner), url.PathEscape(p.repo), call.IssueNumber)
+	issueEndpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues/%d", strings.TrimRight(p.baseURL, "/"), url.PathEscape(p.owner), url.PathEscape(p.repo), call.IssueNumber)
+	labelsEndpoint := issueEndpoint + "/labels"
 	client := p.http
 	if client == nil {
 		client = http.DefaultClient
 	}
-	currentLabels, failure := p.currentIssueLabels(ctx, client, endpoint)
+	currentLabels, failure := p.currentIssueLabels(ctx, client, labelsEndpoint)
 	if failure != "" {
 		return failure, nil
 	}
 	staleStateLabels := computeStaleStateLabels(currentLabels, desiredStateLabels)
 	labelsToAdd := missingLabels(currentLabels, desiredStateLabels)
-	result, failure := p.addAndConfirmDesiredLabels(ctx, client, endpoint, labelsToAdd, desiredStateLabels)
+	result, failure := p.addAndConfirmDesiredLabels(ctx, client, labelsEndpoint, labelsToAdd, desiredStateLabels)
 	if failure != "" {
 		return failure, nil
 	}
-	deletedStaleLabels, failure := p.deleteStaleStateLabels(ctx, client, endpoint, staleStateLabels)
+	deletedStaleLabels, failure := p.deleteStaleStateLabels(ctx, client, labelsEndpoint, staleStateLabels)
+	labelReplaceSucceeded := failure == ""
+	if labelReplaceSucceeded && call.CloseIssue {
+		result, failure = p.closeIssue(ctx, client, issueEndpoint, result)
+	}
 	p.fireMutationAudit(ctx, mutationAuditFacts{
-		issueNumber:   call.IssueNumber,
-		desiredLabel:  desiredStateLabels[0],
-		currentLabels: currentLabels,
-		deletedLabels: deletedStaleLabels,
-		wroteAdd:      len(labelsToAdd) > 0,
-		fullSuccess:   failure == "",
+		issueNumber:           call.IssueNumber,
+		desiredLabel:          desiredStateLabels[0],
+		currentLabels:         currentLabels,
+		deletedLabels:         deletedStaleLabels,
+		wroteAdd:              len(labelsToAdd) > 0,
+		labelReplaceSucceeded: labelReplaceSucceeded,
 	})
 	if failure != "" {
 		return failure, nil
@@ -99,12 +109,12 @@ func (p giteaIssueLabelsProxy) call(ctx context.Context, call ToolCall) (string,
 // so the audit decision can reason about the writes that landed, not the
 // writes that were intended.
 type mutationAuditFacts struct {
-	issueNumber   int
-	desiredLabel  string
-	currentLabels []giteaIssueLabel
-	deletedLabels []giteaIssueLabel
-	wroteAdd      bool
-	fullSuccess   bool
+	issueNumber           int
+	desiredLabel          string
+	currentLabels         []giteaIssueLabel
+	deletedLabels         []giteaIssueLabel
+	wroteAdd              bool
+	labelReplaceSucceeded bool
 }
 
 // fireMutationAudit mirrors the Linear proxy's success-audit contract (#748):
@@ -132,7 +142,7 @@ func (p giteaIssueLabelsProxy) fireMutationAudit(ctx context.Context, facts muta
 		return
 	}
 	audit := p.classifyLabelMutation(facts)
-	if facts.fullSuccess || audit.CurrentIssueNonActiveStateUpdate {
+	if facts.labelReplaceSucceeded || audit.CurrentIssueNonActiveStateUpdate {
 		sink(audit)
 	}
 }
@@ -263,6 +273,26 @@ func (p giteaIssueLabelsProxy) validateDesiredStateLabels(call ToolCall) (desire
 	return desiredStateLabels, "", nil, true
 }
 
+func (p giteaIssueLabelsProxy) validateCloseIssue(call ToolCall, desiredLabel string) (failureResult string, failureErr error, ok bool) {
+	if !call.CloseIssue {
+		return "", nil, true
+	}
+	if p.currentIssueNumber <= 0 || call.IssueNumber != p.currentIssueNumber {
+		failureResult, failureErr = dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels close_issue is only supported for the current issue"},
+		})
+		return failureResult, failureErr, false
+	}
+	desiredState, _ := gitea.IssueStateFromLabels([]gitea.Label{{Name: desiredLabel}}, nil)
+	if desiredState == "" || matchStateFold(p.terminalStates, desiredState) == "" {
+		failureResult, failureErr = dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels close_issue requires a configured terminal aiops/* label"},
+		})
+		return failureResult, failureErr, false
+	}
+	return "", nil, true
+}
+
 // computeStaleStateLabels selects the aiops/* labels currently on the issue
 // that are not the desired state label and therefore must be removed.
 func computeStaleStateLabels(currentLabels []giteaIssueLabel, desiredStateLabels []string) []giteaIssueLabel {
@@ -372,6 +402,50 @@ func (p giteaIssueLabelsProxy) deleteIssueLabel(ctx context.Context, client *htt
 		return ""
 	}
 	return failure
+}
+
+func (p giteaIssueLabelsProxy) closeIssue(ctx context.Context, client *http.Client, endpoint, labelResult string) (string, string) {
+	body, err := json.Marshal(map[string]string{"state": "closed"})
+	if err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels close_issue payload could not be encoded", "reason": err.Error()},
+		})
+		return "", failure
+	}
+	if _, _, failure := p.doGiteaRequest(ctx, client, http.MethodPatch, endpoint, body); failure != "" {
+		return "", failure
+	}
+	return closedIssueToolResult(labelResult)
+}
+
+func closedIssueToolResult(labelResult string) (string, string) {
+	var envelope struct {
+		Output string `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(labelResult), &envelope); err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels close_issue label result envelope could not be decoded", "reason": err.Error()},
+		})
+		return "", failure
+	}
+	if !json.Valid([]byte(envelope.Output)) {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels close_issue label result body could not be decoded", "body": envelope.Output},
+		})
+		return "", failure
+	}
+	body, err := json.Marshal(map[string]any{
+		"closed":       true,
+		"label_result": json.RawMessage(envelope.Output),
+	})
+	if err != nil {
+		failure, _ := dynamicToolFailure(map[string]any{
+			"error": map[string]any{"message": "gitea_issue_labels close_issue result could not be encoded", "reason": err.Error()},
+		})
+		return "", failure
+	}
+	result, _ := dynamicToolResult(true, string(body))
+	return result, ""
 }
 
 func (p giteaIssueLabelsProxy) doGiteaRequest(ctx context.Context, client *http.Client, method, endpoint string, body []byte) (int, []byte, string) {

--- a/internal/runner/gitea_tools.go
+++ b/internal/runner/gitea_tools.go
@@ -353,11 +353,12 @@ func (p giteaIssueLabelsProxy) deleteStaleStateLabels(ctx context.Context, clien
 }
 
 func (p giteaIssueLabelsProxy) closeIssueAfterLabelReplace(ctx context.Context, client *http.Client, issueEndpoint, labelsEndpoint, labelResult string, deleted []giteaIssueLabel) (string, []giteaIssueLabel, bool, string) {
-	closedResult, failure := p.closeIssue(ctx, client, issueEndpoint, labelResult)
+	postHandoffCtx := context.WithoutCancel(ctx)
+	closedResult, failure := p.closeIssue(postHandoffCtx, client, issueEndpoint, labelResult)
 	if failure == "" {
 		return closedResult, deleted, true, ""
 	}
-	if p.restoreDeletedStateLabels(ctx, client, labelsEndpoint, deleted) == "" {
+	if p.restoreDeletedStateLabels(postHandoffCtx, client, labelsEndpoint, deleted) == "" {
 		return labelResult, nil, false, failure
 	}
 	return labelResult, deleted, true, failure

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -85,8 +85,8 @@ func TestDynamicToolsExposeGiteaIssueLabelsWithTokenIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tool input schema is not JSON-marshalable: %v", err)
 	}
-	if !strings.Contains(string(schemaBytes), `"issue_number"`) || strings.Contains(string(schemaBytes), token) {
-		t.Fatalf("tool input schema = %s, want issue_number field and no token leak", schemaBytes)
+	if !strings.Contains(string(schemaBytes), `"issue_number"`) || !strings.Contains(string(schemaBytes), `"close_issue"`) || strings.Contains(string(schemaBytes), token) {
+		t.Fatalf("tool input schema = %s, want issue_number and close_issue fields with no token leak", schemaBytes)
 	}
 
 	server := &fakeGiteaLabelServer{}
@@ -692,6 +692,212 @@ func TestGiteaIssueLabelsNoOpWhenDesiredAlreadyPresentAndNoStale(t *testing.T) {
 	defer mu.Unlock()
 	if strings.Join(methods, ",") != "GET" {
 		t.Fatalf("methods = %#v; want GET only for an already-satisfied issue", methods)
+	}
+}
+
+func TestGiteaIssueLabelsCloseIssueAfterTerminalLabelReplace(t *testing.T) {
+	var mu sync.Mutex
+	var methods, paths, bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		methods = append(methods, r.Method)
+		paths = append(paths, r.URL.String())
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/in-progress"}]`)
+		case http.MethodPost:
+			if !strings.Contains(string(body), "aiops/done") {
+				t.Fatalf("POST body = %s, want terminal aiops/done label", body)
+			}
+			_, _ = io.WriteString(w, `{"labels":[{"id":303,"name":"aiops/done"}]}`)
+		case http.MethodDelete:
+			_, _ = io.WriteString(w, `{}`)
+		case http.MethodPatch:
+			if r.URL.String() != "/api/v1/repos/owner/repo/issues/7" {
+				t.Fatalf("PATCH path = %q, want issue endpoint", r.URL.String())
+			}
+			if string(body) != `{"state":"closed"}` {
+				t.Fatalf("PATCH body = %s; want closed state payload", body)
+			}
+			_, _ = io.WriteString(w, `{"state":"closed"}`)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+	proxy := giteaClassificationProxy(server.URL)
+	proxy.http = server.Client()
+
+	var audits []ToolMutationAudit
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+		audits = append(audits, audit)
+	})
+	result, err := proxy.call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/done"}, CloseIssue: true})
+	if err != nil {
+		t.Fatalf("call error = %v; want nil", err)
+	}
+	if !toolResultSucceeded(result) || !strings.Contains(result, `\"closed\":true`) || !strings.Contains(result, `\"label_result\":{\"labels\"`) {
+		t.Fatalf("result = %s; want successful close_issue result with label_result", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,POST,DELETE,PATCH" {
+		t.Fatalf("methods = %#v; want GET, POST terminal label, DELETE stale label, PATCH close", methods)
+	}
+	if paths[3] != "/api/v1/repos/owner/repo/issues/7" {
+		t.Fatalf("paths = %#v; want PATCH to issue endpoint", paths)
+	}
+	if bodies[3] != `{"state":"closed"}` {
+		t.Fatalf("PATCH body = %s; want closed state payload", bodies[3])
+	}
+	want := ToolMutationAudit{
+		CurrentIssueNonActiveStateUpdate: true,
+		CurrentIssueTerminalStateUpdate:  true,
+		CurrentIssueTerminalState:        "Done",
+	}
+	if len(audits) != 1 || audits[0] != want {
+		t.Fatalf("audits = %+v; want exactly [%+v]", audits, want)
+	}
+}
+
+func TestGiteaIssueLabelsCloseIssueRepairsAlreadyTerminalOpenIssue(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":303,"name":"aiops/done"},{"id":202,"name":"bug"}]`)
+		case http.MethodPatch:
+			if string(body) != `{"state":"closed"}` {
+				t.Fatalf("PATCH body = %s; want closed state payload", body)
+			}
+			_, _ = io.WriteString(w, `{"state":"closed"}`)
+		case http.MethodPost:
+			t.Fatalf("POST must not run when terminal label is already present")
+		case http.MethodDelete:
+			t.Fatalf("DELETE must not run when there is no stale aiops label")
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+	proxy := giteaClassificationProxy(server.URL)
+	proxy.http = server.Client()
+
+	var audits []ToolMutationAudit
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+		audits = append(audits, audit)
+	})
+	result, err := proxy.call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/done"}, CloseIssue: true})
+	if err != nil {
+		t.Fatalf("call error = %v; want nil", err)
+	}
+	if !toolResultSucceeded(result) || !strings.Contains(result, `\"closed\":true`) || !strings.Contains(result, `\"label_result\":{\"labels\":[]`) {
+		t.Fatalf("result = %s; want successful close_issue result with label_result", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,PATCH" {
+		t.Fatalf("methods = %#v; want GET then PATCH close for already-terminal issue", methods)
+	}
+	if len(audits) != 0 {
+		t.Fatalf("audits = %+v; want none because no label handoff write landed", audits)
+	}
+}
+
+func TestGiteaIssueLabelsRejectsInvalidCloseIssueWithoutHTTPRequest(t *testing.T) {
+	cases := []struct {
+		name   string
+		call   ToolCall
+		reason string
+	}{
+		{
+			name:   "different issue",
+			call:   ToolCall{IssueNumber: 8, Labels: []string{"aiops/done"}, CloseIssue: true},
+			reason: "gitea_issue_labels close_issue is only supported for the current issue",
+		},
+		{
+			name:   "non-terminal label",
+			call:   ToolCall{IssueNumber: 7, Labels: []string{"aiops/human-review"}, CloseIssue: true},
+			reason: "gitea_issue_labels close_issue requires a configured terminal aiops/* label",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &fakeGiteaLabelServer{}
+			httpServer := httptest.NewServer(server.handler())
+			defer httpServer.Close()
+			proxy := giteaClassificationProxy(httpServer.URL)
+			proxy.http = httpServer.Client()
+
+			result, err := proxy.call(context.Background(), tc.call)
+			assertStructuredFailure(t, result, err, tc.reason)
+			_, _, requests := server.recorded()
+			if requests != 0 {
+				t.Fatalf("server received %d requests; want 0", requests)
+			}
+		})
+	}
+}
+
+func TestGiteaIssueLabelsReportsCloseIssueFailureAfterLabelReplace(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/in-progress"}]`)
+		case http.MethodPost:
+			_, _ = io.WriteString(w, `{"labels":[{"id":303,"name":"aiops/done"}]}`)
+		case http.MethodDelete:
+			_, _ = io.WriteString(w, `{}`)
+		case http.MethodPatch:
+			http.Error(w, `{"message":"temporary failure"}`, http.StatusBadGateway)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+	proxy := giteaClassificationProxy(server.URL)
+	proxy.http = server.Client()
+
+	var audits []ToolMutationAudit
+	ctx := WithToolMutationSink(context.Background(), func(audit ToolMutationAudit) {
+		audits = append(audits, audit)
+	})
+	result, err := proxy.call(ctx, ToolCall{IssueNumber: 7, Labels: []string{"aiops/done"}, CloseIssue: true})
+	assertStructuredFailure(t, result, err, "Gitea label request failed", "502 Bad Gateway")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "GET,POST,DELETE,PATCH" {
+		t.Fatalf("methods = %#v; want close attempt after successful label replace", methods)
+	}
+	want := ToolMutationAudit{
+		CurrentIssueNonActiveStateUpdate: true,
+		CurrentIssueTerminalStateUpdate:  true,
+		CurrentIssueTerminalState:        "Done",
+	}
+	if len(audits) != 1 || audits[0] != want {
+		t.Fatalf("audits = %+v; want terminal label handoff audit even when close fails", audits)
 	}
 }
 

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -853,12 +853,14 @@ func TestGiteaIssueLabelsRejectsInvalidCloseIssueWithoutHTTPRequest(t *testing.T
 	}
 }
 
-func TestGiteaIssueLabelsReportsCloseIssueFailureAfterLabelReplace(t *testing.T) {
+func TestGiteaIssueLabelsRestoresActiveStateWhenCloseIssueFails(t *testing.T) {
 	var mu sync.Mutex
-	var methods []string
+	var methods, bodies []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
 		mu.Lock()
 		methods = append(methods, r.Method)
+		bodies = append(bodies, string(body))
 		mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
@@ -866,7 +868,14 @@ func TestGiteaIssueLabelsReportsCloseIssueFailureAfterLabelReplace(t *testing.T)
 		case http.MethodGet:
 			_, _ = io.WriteString(w, `[{"id":101,"name":"aiops/in-progress"}]`)
 		case http.MethodPost:
-			_, _ = io.WriteString(w, `{"labels":[{"id":303,"name":"aiops/done"}]}`)
+			switch {
+			case strings.Contains(string(body), "aiops/done"):
+				_, _ = io.WriteString(w, `{"labels":[{"id":303,"name":"aiops/done"}]}`)
+			case strings.Contains(string(body), "aiops/in-progress"):
+				_, _ = io.WriteString(w, `{"labels":[{"id":101,"name":"aiops/in-progress"}]}`)
+			default:
+				t.Fatalf("POST body = %s; want terminal add or active-state restore", body)
+			}
 		case http.MethodDelete:
 			_, _ = io.WriteString(w, `{}`)
 		case http.MethodPatch:
@@ -888,16 +897,14 @@ func TestGiteaIssueLabelsReportsCloseIssueFailureAfterLabelReplace(t *testing.T)
 
 	mu.Lock()
 	defer mu.Unlock()
-	if strings.Join(methods, ",") != "GET,POST,DELETE,PATCH" {
-		t.Fatalf("methods = %#v; want close attempt after successful label replace", methods)
+	if strings.Join(methods, ",") != "GET,POST,DELETE,PATCH,POST" {
+		t.Fatalf("methods = %#v; want close failure followed by active-state restore", methods)
 	}
-	want := ToolMutationAudit{
-		CurrentIssueNonActiveStateUpdate: true,
-		CurrentIssueTerminalStateUpdate:  true,
-		CurrentIssueTerminalState:        "Done",
+	if !strings.Contains(bodies[4], "aiops/in-progress") {
+		t.Fatalf("rollback POST body = %s; want original active state restored", bodies[4])
 	}
-	if len(audits) != 1 || audits[0] != want {
-		t.Fatalf("audits = %+v; want terminal label handoff audit even when close fails", audits)
+	if len(audits) != 0 {
+		t.Fatalf("audits = %+v; want none because close failure restored retryable active state", audits)
 	}
 }
 

--- a/internal/runner/gitea_tools_test.go
+++ b/internal/runner/gitea_tools_test.go
@@ -908,6 +908,57 @@ func TestGiteaIssueLabelsRestoresActiveStateWhenCloseIssueFails(t *testing.T) {
 	}
 }
 
+func TestGiteaIssueLabelsCloseRollbackIgnoresCanceledRunContext(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPatch:
+			http.Error(w, `{"message":"temporary failure"}`, http.StatusBadGateway)
+		case http.MethodPost:
+			if !strings.Contains(string(body), "aiops/human-review") {
+				t.Fatalf("rollback POST body = %s; want active state restore", body)
+			}
+			_, _ = io.WriteString(w, `{"labels":[{"id":202,"name":"aiops/human-review"}]}`)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+	proxy := giteaClassificationProxy(server.URL)
+	proxy.http = server.Client()
+	labelResult, _ := dynamicToolResult(true, `{"labels":[{"id":303,"name":"aiops/done"}]}`)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, deleted, labelReplaceSucceeded, failure := proxy.closeIssueAfterLabelReplace(
+		ctx,
+		server.Client(),
+		server.URL+"/api/v1/repos/owner/repo/issues/7",
+		server.URL+"/api/v1/repos/owner/repo/issues/7/labels",
+		labelResult,
+		[]giteaIssueLabel{{ID: 202, Name: "aiops/human-review"}},
+	)
+	if failure == "" {
+		t.Fatalf("failure = %q; want close failure preserved", failure)
+	}
+	if result != labelResult || len(deleted) != 0 || labelReplaceSucceeded {
+		t.Fatalf("result/deleted/succeeded = %q/%+v/%t; want restored active state and failed handoff", result, deleted, labelReplaceSucceeded)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(methods, ",") != "PATCH,POST" {
+		t.Fatalf("methods = %#v; want close and rollback despite canceled parent context", methods)
+	}
+}
+
 // giteaEchoLabelServer serves the labels endpoint for handoff-classification
 // tests: GET returns currentLabels JSON, POST echoes the requested labels with
 // synthetic ids, DELETE succeeds unless the trailing label id is listed in

--- a/internal/runner/tools.go
+++ b/internal/runner/tools.go
@@ -15,15 +15,16 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
-// ToolCall is the JSON-shaped input accepted by the dynamic linear_graphql
-// tool. Query and Variables are agent-controlled. The Linear endpoint is held
-// by the orchestrator-side proxy and is not part of this public call shape, so
-// an agent cannot redirect the orchestrator-held token to another host.
+// ToolCall is the JSON-shaped input accepted by dynamic tools. Tracker
+// endpoints are held by orchestrator-side proxies and are not part of this
+// public call shape, so an agent cannot redirect orchestrator-held tokens to
+// another host.
 type ToolCall struct {
 	Query       string         `json:"query"`
 	Variables   map[string]any `json:"variables,omitempty"`
 	IssueNumber int            `json:"issue_number,omitempty"`
 	Labels      []string       `json:"labels,omitempty"`
+	CloseIssue  bool           `json:"close_issue,omitempty"`
 }
 
 // DynamicTool is a client-side tool implemented by the orchestrator and made
@@ -143,7 +144,7 @@ func DynamicToolsForWorkflow(wf workflow.Workflow, toolOptions ...DynamicToolOpt
 		}.withCurrentIssueClassification(trackerCfg, opts)
 		tools.tools["gitea_issue_labels"] = DynamicTool{
 			Name:        "gitea_issue_labels",
-			Description: "Replace the aiops/* state label on one Gitea issue using orchestrator-configured Gitea auth. Input: {issue_number:number, labels:string[]} with exactly one aiops/* label. The Gitea API token is never exposed to the agent process.",
+			Description: "Replace the aiops/* state label on one Gitea issue using orchestrator-configured Gitea auth. Input: {issue_number:number, labels:string[], close_issue?:boolean} with exactly one aiops/* label. close_issue is accepted only for the current issue with a configured terminal state label, and closes that issue in the same tool call. The Gitea API token is never exposed to the agent process.",
 			InputSchema: giteaIssueLabelsInputSchema(),
 			Call:        client.call,
 		}
@@ -201,6 +202,10 @@ func giteaIssueLabelsInputSchema() map[string]any {
 				"items":       map[string]any{"type": "string"},
 				"minItems":    1,
 				"maxItems":    1,
+			},
+			"close_issue": map[string]any{
+				"type":        "boolean",
+				"description": "When true, close the current Gitea issue after replacing it with a configured terminal aiops/* state label.",
 			},
 		},
 		"required":             []string{"issue_number", "labels"},


### PR DESCRIPTION
Closes #963

## Summary
- Add a guarded `close_issue` option to the existing `gitea_issue_labels` dynamic tool so the reviewer can flip `aiops/done` and close the current Gitea issue in one agent-side handoff.
- Keep the close capability constrained to the current issue and configured terminal labels, then update the maker/reviewer auto-merge workflow docs to use the new atomic terminal handoff.
- Root cause: the Web Todo E2E exposed a fragile two-step finalization where the reviewer set terminal `aiops/done` first, then was expected to issue a separate raw close; the terminal label could end the active lifecycle before the close write landed.
- Conflict resolution: merged `origin/main` (`81e349c`, #966) into this branch and preserved both the `close_issue:true` terminal handoff and #966's Rework convergence guidance.
- Review fixes: close failure now restores deleted active state labels so the reviewer can retry; close/rollback uses `context.WithoutCancel(ctx)` plus per-request timeouts so reconciliation cancellation after terminal handoff cannot abort finalization.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] `go test -count=1 ./internal/runner ./internal/orchestrator`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] mutation check: temporarily disabled the original `close_issue` PATCH branch and confirmed `TestGiteaIssueLabelsCloseIssue*` fails, then restored and re-ran focused tests.
- [x] conflict/review-fix checks on final head `399144f`: `go test -run 'TestGiteaIssueLabelsCloseRollbackIgnoresCanceledRunContext|TestGiteaIssueLabelsRestoresActiveStateWhenCloseIssueFails|TestGiteaIssueLabelsCloseIssueAfterTerminalLabelReplace' -count=1 ./internal/runner`; `go test -count=1 ./scripts ./internal/runner ./internal/orchestrator`; `go build ./cmd/worker ./cmd/tui`; `gofmt -l`; `go mod tidy && git diff --exit-code -- go.mod go.sum`; `go vet ./...`; full golangci blocking gate.
- [x] mutation checks for the Codex fixes: disabling active-state rollback fails `TestGiteaIssueLabelsRestoresActiveStateWhenCloseIssueFails`; replacing `context.WithoutCancel(ctx)` with `ctx` fails `TestGiteaIssueLabelsCloseRollbackIgnoresCanceledRunContext`.
- [x] GitHub checks on `399144f`: PR Metadata, PR Title Lint, Go build and test, Security and supply-chain, E2E Gitea mock loop, Docker image build all succeeded.

## Notes
- Claude read-only review found naming/result-shape concerns; fixed by renaming the audit fact to `labelReplaceSucceeded` and preserving the label result in close-path tool output.
- Codex review findings on intermediate heads were fixed and their threads resolved/outdated. Codex review on final head `399144f` reported no major issues.