### PR TITLE
fix(workflow): tighten web todo rework convergence

### DIFF
--- a/docs/runbooks/unattended-maker-reviewer-automerge.md
+++ b/docs/runbooks/unattended-maker-reviewer-automerge.md
@@ -204,6 +204,34 @@ for this DAG"*):
    drop out of the reviewer's poll *before* it could set `Done` — stranding it
    (closed + still `Human Review`) and blocking every `Depends on #N` dependent.
 
+## Rework convergence
+
+The maker/reviewer loop is allowed to return work through `Rework`, but it must
+make progress on each lap. The observed #964 failure class was not a scheduler
+bug: the maker re-posted the same PR head on early laps, then later added a
+source-substring test for `web/app.js` that still did not execute the browser
+behavior the reviewer was rejecting.
+
+Keep the prevention in the workflow prompts, not in a worker-side verifier:
+
+- Maker Rework turns must read the latest review-bot finding first, treat it as
+  an acceptance criterion, and push a new commit before handing off again. The
+  maker comment / PR body should include a `Rework response:` section with the
+  reviewed head, new head, and how each finding was addressed.
+- A maker must not satisfy a behavior-test finding with static markup or
+  source-substring checks. For browser JavaScript, the test should execute the
+  client behavior in a DOM/browser/JS runtime with mocked `fetch`, or refactor
+  the behavior into executable testable code.
+- Reviewer Rework comments must cite the PR head SHA reviewed. If the head is
+  unchanged, the reviewer should skip the full rubric and say the same head still
+  lacks the named fix. If a new head still has the same class of placebo test,
+  the reviewer should name one mutation that would still pass so the maker has a
+  concrete target.
+- When the same class of failure has bounced twice, the reviewer should prefix
+  the next comment with `Operator attention:` and summarize the repeated failure
+  before returning to `Rework`. This gives operators a clear intervention marker
+  without adding a new tracker state or worker phase outside the SPEC boundary.
+
 ## Best-practice checklist
 
 - [ ] Distinct `workspace.root` **and** distinct `AIOPS_MIRROR_ROOT` per worker (both hard).
@@ -214,6 +242,9 @@ for this DAG"*):
 - [ ] Maker never sets `aiops/done`; reviewer is the only Done/auto-merge path.
 - [ ] Reviewer issues `aiops/done` **only after the forge confirms the merge** — never on the verdict alone (else `Depends on #N` dependents unblock from stale `main`).
 - [ ] Maker references the issue with a **non-closing** `Refs #<N>` (not `Closes`); the reviewer flips `Done` and closes the issue post-merge. A closing keyword auto-closes the issue at merge, dropping it from the reviewer's `state=open` poll before `Done` is set — stranding it and its dependents.
+- [ ] Rework turns push a new head and include a `Rework response:`; reviewer
+      comments cite the reviewed head SHA and use `Operator attention:` after
+      repeated same-class failures.
 - [ ] Maker uses the numeric issue number (digits of `{{ issue.identifier }}`, no leading `#`) in every API path / issue reference — `{{ issue.identifier }}` renders as `#N` on Gitea.
 - [ ] Branch protection: required checks + 1 approval + no direct push to `main` + squash + auto-merge enabled.
 - [ ] One-issue-per-PR; agents file follow-up issues for out-of-scope finds.

--- a/examples/maker-WORKFLOW.md
+++ b/examples/maker-WORKFLOW.md
@@ -93,6 +93,25 @@ Your Gitea push + API credential is the basic-auth token already embedded in the
 Description:
 {{ task.description }}
 
+If this dispatch is a Rework return, first read the newest review-bot issue
+comments / PR reviews and treat every unresolved reviewer finding as an
+acceptance criterion for this turn. Record the PR head SHA the reviewer cited
+and compare it with `git rev-parse HEAD` before you hand off again.
+
+Rework convergence rules:
+- Do not repost the same PR URL for an unchanged head. A Rework handoff must
+  push a new commit that directly addresses the latest reviewer findings.
+- If a reviewer says tests are placebo / static-only, add tests that execute the
+  changed behavior at the relevant boundary. For browser JavaScript behavior,
+  source-substring checks or `index.html` markup checks are not enough; use a
+  DOM/browser/JS runtime test with mocked `fetch`, or refactor the behavior into
+  executable testable code.
+- In the issue comment or PR body, include a `Rework response:` section naming
+  the reviewed head, the new head, and how each reviewer finding was addressed.
+- If you cannot produce a new commit that addresses the findings, post one
+  `Blocked rework:` comment explaining the blocker and stop without moving the
+  issue to `Human Review`; repeated unchanged handoffs only burn reviewer turns.
+
 Do all of the following end to end, without asking for confirmation:
 
 1. Implement the change in this worktree. If the issue body says `Depends on #M`,

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -96,6 +96,12 @@ commented. Obtain the diff either way:
 If you cannot identify the PR, comment what you looked for and flip to
 `aiops/rework` so the maker re-hands-off.
 
+Before deciding whether this is a fresh review, read the prior review-bot
+findings on this issue and note the latest PR head SHA you previously reviewed.
+If the maker re-posted the same PR URL and the PR head is unchanged from your
+latest Rework comment, do not run the full rubric again: comment that the head
+is unchanged and still missing the named fix, then set `aiops/rework`.
+
 If a previous poll already acted on this PR, do NOT blindly re-run the rubric —
 but work out the situation first, in this order:
 1. **Already merged?** `GET /repos/{{ repo.owner }}/{{ repo.name }}/pulls/<number>`
@@ -129,7 +135,12 @@ but work out the situation first, in this order:
 1. The diff implements what the issue asked; each acceptance criterion is met or
    explicitly addressed in the PR body.
 2. Tests cover the changed behavior and would fail if the change were reverted
-   (no placebo tests).
+   (no placebo tests). Static source-string or markup-presence tests only cover
+   static assets. They do not cover browser/client behavior: if the change is
+   JavaScript behavior, require a test that executes that behavior in a
+   DOM/browser/JS runtime with mocked `fetch`, or an equivalent refactor into
+   executable testable code. A test that still passes when the behavior in
+   `web/app.js` is removed or its event handlers stop running is a failing test.
 3. The diff is scoped to this issue — no unrelated changes ride along.
 4. No correctness/safety problems (races, unchecked errors, secrets in code/logs).
 5. Executable gate: on the fetched head, `go build ./...` and `go test ./...` pass.
@@ -168,8 +179,14 @@ PASS (every item passes):
 
 FAIL (any item fails):
   - Comment the failing items with concrete, actionable findings (file, line,
-    what to change), then set the label to `aiops/rework` via gitea_issue_labels.
-    The maker re-runs from your findings. This is your LAST action.
+    what to change, and the PR head SHA reviewed), then set the label to
+    `aiops/rework` via gitea_issue_labels. If this is the same finding on an
+    unchanged head, say so explicitly. If the head changed but the same class of
+    placebo/coverage failure remains, name one concrete mutation that would still
+    pass so the maker can see why it has not converged. If the same class has
+    failed twice already, prefix the comment with `Operator attention:` and
+    summarize the repeated failure before setting `aiops/rework`. The maker
+    re-runs from your findings. This is your LAST action.
 
 ## Hard constraints (review-only)
 - Do NOT modify, commit, or push code. Your only writes are tracker/PR writes: the

--- a/scripts/workflow_examples_test.go
+++ b/scripts/workflow_examples_test.go
@@ -21,3 +21,51 @@ func TestGitHubLocalWorkflowRunsUncachedFileSizeGate(t *testing.T) {
 		t.Fatalf("github-local-WORKFLOW.md file-size gate index = %d; want before race gate index %d", fileSizeIndex, raceIndex)
 	}
 }
+
+func TestWebTodoWorkflowsDocumentReworkConvergence(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want []string
+	}{
+		{
+			path: "../examples/maker-WORKFLOW.md",
+			want: []string{
+				"Rework convergence rules",
+				"Do not repost the same PR URL for an unchanged head",
+				"source-substring checks or `index.html` markup checks are not enough",
+				"`Rework response:` section",
+				"`Blocked rework:` comment",
+			},
+		},
+		{
+			path: "../examples/reviewer-automerge-WORKFLOW.md",
+			want: []string{
+				"latest PR head SHA you previously reviewed",
+				"Static source-string or markup-presence tests only cover",
+				"static assets",
+				"one concrete mutation",
+				"`Operator attention:`",
+			},
+		},
+		{
+			path: "../docs/runbooks/unattended-maker-reviewer-automerge.md",
+			want: []string{
+				"## Rework convergence",
+				"observed #964 failure class",
+				"`Rework response:`",
+				"`Operator attention:`",
+				"without adding a new tracker state or worker phase outside the SPEC boundary",
+			},
+		},
+	} {
+		body, err := os.ReadFile(tc.path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", tc.path, err)
+		}
+		for _, want := range tc.want {
+			if !strings.Contains(string(body), want) {
+				t.Fatalf("%s missing %q", tc.path, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #964

## Summary
- Tighten the Web Todo maker/reviewer workflows so Rework turns must read the latest reviewer finding, push a new head, and include a `Rework response:` proving each finding was addressed.
- Strengthen the reviewer rubric so browser/client behavior cannot be accepted based on static markup or source-substring tests; repeated same-class failures now get an `Operator attention:` summary before returning to Rework.
- Document the #964 root cause in the unattended maker/reviewer runbook and add a scripts test that locks the convergence constraints into the example workflows.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] `go test -count=1 ./scripts`
- [x] `worker --print-config` on both `examples/maker-WORKFLOW.md` and `examples/reviewer-automerge-WORKFLOW.md` with dummy Gitea env values
- [x] mutation check: changed the maker prompt's unchanged-head guard and confirmed `TestWebTodoWorkflowsDocumentReworkConvergence` fails, then restored and re-ran it.

## Notes
- Claude review skipped: local Claude Code reported session limit until 18:50 Asia/Shanghai.
- Codex review attempted with a 120s timeout but produced no findings before timing out.
