### PR TITLE
refactor(runner): drop obsolete codex approval_policy.reject translator

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -373,14 +373,12 @@ func (c *appServerClient) initSession(in RunInput) {
 	c.turnTimeoutMs = in.Workflow.Config.Codex.TurnTimeoutMs
 	c.readTimeoutMs = in.Workflow.Config.Codex.ReadTimeoutMs
 	c.stallTimeoutMs = in.Workflow.Config.Codex.StallTimeoutMs
-	// Translate once at this boundary and reuse the same value for both the
-	// codex wire payload (thread/start, turn/start) and the harness-side
-	// auto-approve decisions (autoApproveRequest). Storing the raw workflow
-	// value here while sending the translated one to codex desyncs the two:
-	// a legacy reject:{...} config would reach codex as granular:{...} (codex
-	// emits approval prompts) but autoApproveRequest, which no longer handles
-	// reject:, would decline them unconditionally and flip behavior (#335).
-	c.approvalPolicy = codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
+	// The workflow loader rejects the obsolete codex `reject:` approval shape
+	// (#969), so the stored value is already a current codex AskForApproval
+	// value. The same value feeds both the codex wire payload (thread/start,
+	// turn/start) and the harness-side auto-approve decisions
+	// (autoApproveRequest), so the two can never desync.
+	c.approvalPolicy = in.Workflow.Config.Codex.ApprovalPolicy
 }
 
 // startThread runs the SPEC §10.1 handshake — initialize, initialized,

--- a/internal/runner/codex_app_server_approval.go
+++ b/internal/runner/codex_app_server_approval.go
@@ -173,57 +173,6 @@ func approvalRuleEnabled(rules map[string]any, key string) bool {
 	return enabled
 }
 
-// codexWireApprovalPolicy maps aiops-platform's ApprovalPolicy value to the
-// codex app-server JSON-RPC wire format. Codex's `AskForApproval` enum
-// (codex-rs/protocol/src/protocol.rs and
-// codex-rs/app-server-protocol/src/protocol/v2/shared.rs) accepts exactly
-// {"untrusted", "on-failure", "on-request", "granular": {...}, "never"}.
-// Sending anything else makes thread/start return JSON-RPC -32600
-// `Invalid request: unknown variant ...` and breaks startup (#329).
-//
-// The obsolete `{"reject": {...}}` shape — which used to be valid in codex
-// up to PR #14516 (commit b7dba72db, renamed to `granular` and field
-// polarity inverted on 2026-03-12) — is translated here for back-compat
-// with WORKFLOW.md files written against the old protocol. The polarity
-// flip (`reject.sandbox_approval=true` meant "reject"; the new
-// `granular.sandbox_approval=true` means "allow") is preserved so the
-// translated payload retains the operator's original intent.
-//
-// All codex-recognized values (`"untrusted"`/`"on-failure"`/`"on-request"`/
-// `"never"` strings, and the `{"granular": {...}}` map) pass through
-// unchanged. Unrecognized shapes also pass through so codex's own
-// validation error reaches the operator verbatim rather than getting
-// masked behind a translator silently rewriting their payload.
-func codexWireApprovalPolicy(internal any) any {
-	policy, ok := internal.(map[string]any)
-	if !ok {
-		return internal
-	}
-	rejectShape, hasReject := policy["reject"].(map[string]any)
-	if !hasReject {
-		return internal
-	}
-	// Translate obsolete reject:{flag:true} → granular:{flag:false} per the
-	// codex #14516 polarity flip. Pass through any extra keys verbatim so a
-	// future codex addition doesn't get lost.
-	granular := make(map[string]any, len(rejectShape))
-	for k, v := range rejectShape {
-		if b, ok := v.(bool); ok {
-			granular[k] = !b
-			continue
-		}
-		granular[k] = v
-	}
-	translated := make(map[string]any, len(policy))
-	for k, v := range policy {
-		if k == "reject" {
-			continue
-		}
-		translated[k] = v
-	}
-	translated["granular"] = granular
-	return translated
-}
 func protocolUserInputResult(msg map[string]any) map[string]any {
 	params, _ := msg["params"].(map[string]any)
 	questions, _ := params["questions"].([]any)

--- a/internal/runner/codex_app_server_schema_test.go
+++ b/internal/runner/codex_app_server_schema_test.go
@@ -86,8 +86,7 @@ func TestCodexAppServerInitializePayloadMatchesSchema(t *testing.T) {
 
 func TestCodexAppServerThreadStartPayloadMatchesSchema(t *testing.T) {
 	in := codexSchemaTestInput(t)
-	approval := codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
-	payload := buildThreadStartParams(in, approval)
+	payload := buildThreadStartParams(in, in.Workflow.Config.Codex.ApprovalPolicy)
 
 	// Guard: the input must actually carry a dynamic tool, else this would
 	// validate the optional-absent path and never exercise DynamicToolSpec.
@@ -109,7 +108,7 @@ func TestCodexAppServerThreadConfigMatchesSchema(t *testing.T) {
 
 func TestCodexAppServerTurnStartPayloadMatchesSchema(t *testing.T) {
 	in := codexSchemaTestInput(t)
-	approval := codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
+	approval := in.Workflow.Config.Codex.ApprovalPolicy
 	payload := buildTurnStartParams(in, "thread-1", "do the task", 1, approval)
 	sch := compileCodexDef(t, codexSchemaCompiler(t), "TurnStartParams")
 	if err := validateWire(t, sch, payload); err != nil {
@@ -123,7 +122,7 @@ func TestCodexAppServerTurnStartPayloadMatchesSchema(t *testing.T) {
 // the UserInput oneOf discriminator, not just a top-level required key.
 func TestCodexAppServerTurnStartPayloadRejectsDrift(t *testing.T) {
 	in := codexSchemaTestInput(t)
-	approval := codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
+	approval := in.Workflow.Config.Codex.ApprovalPolicy
 	base := buildTurnStartParams(in, "thread-1", "do the task", 1, approval)
 	sch := compileCodexDef(t, codexSchemaCompiler(t), "TurnStartParams")
 
@@ -175,7 +174,7 @@ func TestCodexAppServerTurnStartPayloadRejectsDrift(t *testing.T) {
 // without needing the codex binary.
 func TestCodexAppServerPayloadKeysKnownToSchema(t *testing.T) {
 	in := codexSchemaTestInput(t)
-	approval := codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
+	approval := in.Workflow.Config.Codex.ApprovalPolicy
 	props := codexSchemaDefProps(t)
 
 	cases := []struct {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -282,9 +282,7 @@ func TestBuildThreadStartParamsDisablesInheritedCodexAppTools(t *testing.T) {
 	in := appServerInput(codexWorkdir(t, "disable app tools"))
 	in.Workflow.Config.Tracker.Kind = "linear"
 	in.Workflow.Config.Tracker.APIKey = "linear-secret"
-	approval := codexWireApprovalPolicy(in.Workflow.Config.Codex.ApprovalPolicy)
-
-	payload := buildThreadStartParams(in, approval)
+	payload := buildThreadStartParams(in, in.Workflow.Config.Codex.ApprovalPolicy)
 
 	config, ok := payload["config"].(map[string]any)
 	if !ok {
@@ -2519,21 +2517,14 @@ for line in sys.stdin:
 	}
 }
 
-// TestCodexAppServerRunnerTranslatesLegacyRejectPolicyForApprovalDecisions
-// pins the boundary contract from #335: the approval policy is translated to
-// codex's `granular` wire shape exactly once (codexWireApprovalPolicy) and the
-// SAME translated value drives both the wire payload and the harness-side
-// auto-approve decision (autoApproveRequest).
-//
-// The config below is the obsolete reject:{...} shape with every flag false —
-// legacy operator intent "don't reject, allow these approval flows". Codex
-// receives the translated granular:{...true} (so it emits approval prompts),
-// and autoApproveRequest — which no longer special-cases reject: since #334 —
-// only produces the right ALLOW decision if it is fed the translated value.
-// If c.approvalPolicy were instead the raw reject:{...} map, autoApproveRequest
-// would fall through to its safe-fallback decline, the runner would emit
-// turn_input_required + InputRequiredError, and Run would error here.
-func TestCodexAppServerRunnerTranslatesLegacyRejectPolicyForApprovalDecisions(t *testing.T) {
+// TestCodexAppServerRunnerFeedsGranularApprovalPolicyToWireAndDecisions pins the
+// boundary invariant from #335: the stored approval policy drives BOTH the codex
+// wire payload (thread/start, turn/start) and the harness-side auto-approve
+// decision (autoApproveRequest), so the two cannot desync. granular: is the
+// default shape (config.go cheat-sheet defaults), so a granular policy that
+// allows sandbox/command-exec prompts must auto-approve the command-exec request
+// with acceptForSession and reach codex carrying that same granular policy.
+func TestCodexAppServerRunnerFeedsGranularApprovalPolicyToWireAndDecisions(t *testing.T) {
 	binDir := codexAppServerStubScript(t, `
 import json
 log=open(os.environ['CODEX_STDIN_LOG'], 'w')
@@ -2556,12 +2547,12 @@ for line in sys.stdin:
 `)
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
-	// Obsolete reject:{flag:false} == "don't reject; allow these prompts".
-	in.Workflow.Config.Codex.ApprovalPolicy = map[string]any{"reject": map[string]any{"sandbox_approval": false, "rules": false, "mcp_elicitations": false}}
+	// granular sandbox_approval:true == "allow sandbox/command-exec prompts".
+	in.Workflow.Config.Codex.ApprovalPolicy = map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "request_permissions": false}}
 
 	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
 	if err != nil {
-		t.Fatalf("Run: %v (legacy reject:{false} must auto-approve, not decline)", err)
+		t.Fatalf("Run: %v (granular sandbox_approval:true must auto-approve, not decline)", err)
 	}
 	if res.Summary != "approvals handled" {
 		t.Fatalf("Summary = %q, want approvals handled", res.Summary)
@@ -2576,13 +2567,10 @@ for line in sys.stdin:
 	if !strings.Contains(string(stdin), `"decision":"acceptForSession"`) {
 		t.Fatalf("stdin missing acceptForSession in approval response: %s", stdin)
 	}
-	// The translated granular payload — not the raw reject: shape — must be
-	// what reached codex on the wire.
-	if strings.Contains(string(stdin), `"reject"`) {
-		t.Fatalf("raw reject: shape leaked onto the wire: %s", stdin)
-	}
+	// The same granular policy that drove the acceptForSession decision must
+	// also reach codex on the wire (thread/start, turn/start).
 	if !strings.Contains(string(stdin), `"granular"`) {
-		t.Fatalf("stdin missing translated granular policy on the wire: %s", stdin)
+		t.Fatalf("stdin missing granular approval policy on the wire: %s", stdin)
 	}
 }
 
@@ -2634,13 +2622,11 @@ func TestProtocolServerRequestResultApprovalPolicyMatrix(t *testing.T) {
 		{name: "on-request", policy: "on-request", wantModernDecision: "decline"},
 		{name: "untrusted", policy: "untrusted", wantModernDecision: "decline"},
 		{name: "on-failure", policy: "on-failure", wantModernDecision: "acceptForSession", wantPermissions: true},
-		// `reject:` is the obsolete codex variant renamed to `granular:` in
-		// PR #14516 (b7dba72db). Harness no longer special-cases it — the
-		// codexWireApprovalPolicy boundary translates it to granular before
-		// going to codex, so by the time protocolServerRequestResult sees a
-		// payload it should never observe a raw reject:. The case below
-		// pins the safe fallback: unknown shapes don't auto-approve.
-		{name: "reject legacy map (unknown to harness)", policy: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true}}, wantModernDecision: "decline"},
+		// The obsolete `reject:` shape is now rejected at load time (#969), so
+		// protocolServerRequestResult can never see it from a real config. It is
+		// kept here only as a representative *unknown* approval shape, pinning the
+		// safe fallback: an unrecognized policy never auto-approves.
+		{name: "unknown approval shape declines", policy: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true}}, wantModernDecision: "decline"},
 		{name: "granular denies all disabled allowances", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": false}}, wantModernDecision: "decline"},
 		{name: "granular allows sandbox only", policy: map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "request_permissions": false}}, wantModernDecision: "acceptForSession"},
 		{name: "granular allows permissions only", policy: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "request_permissions": true}}, wantModernDecision: "decline", wantPermissions: true},
@@ -2675,84 +2661,6 @@ func TestProtocolServerRequestResultApprovalPolicyMatrix(t *testing.T) {
 	}
 	if _, ok := elicitationResult["content"]; !ok || elicitationResult["content"] != nil {
 		t.Fatalf("elicitation content = %#v, present %v; want explicit null content", elicitationResult["content"], ok)
-	}
-}
-
-// TestCodexWireApprovalPolicy pins the translation contract between
-// aiops-platform's ApprovalPolicy value and codex's `AskForApproval` wire
-// format (codex-rs/protocol/src/protocol.rs `AskForApproval`).
-//
-// The codex enum is the source of truth: codex commit b7dba72db (PR #14516,
-// 2026-03-12) renamed the `Reject` variant to `Granular` and inverted the
-// field polarity (true = ALLOW, was true = REJECT). Sending the obsolete
-// `{"reject": {...}}` payload to a current codex returns
-// `-32600 unknown variant ` and breaks startup (#329).
-//
-// Future maintainers: do NOT "fix" this by reverting to `reject:` — the
-// rename is a deliberate codex protocol change. Check
-// codex-rs/protocol/src/protocol.rs `pub enum AskForApproval` first.
-func TestCodexWireApprovalPolicy(t *testing.T) {
-	cases := []struct {
-		name string
-		in   any
-		want any
-	}{
-		{
-			name: "never string passes through",
-			in:   "never",
-			want: "never",
-		},
-		{
-			name: "untrusted string passes through",
-			in:   "untrusted",
-			want: "untrusted",
-		},
-		{
-			name: "on-failure string passes through",
-			in:   "on-failure",
-			want: "on-failure",
-		},
-		{
-			name: "on-request string passes through",
-			in:   "on-request",
-			want: "on-request",
-		},
-		{
-			name: "granular map passes through unchanged",
-			in:   map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "mcp_elicitations": true}},
-			want: map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "mcp_elicitations": true}},
-		},
-		{
-			name: "legacy reject:{true} translates to granular:{false}",
-			// Operator intent: reject sandbox+rules+mcp prompts.
-			in: map[string]any{"reject": map[string]any{"sandbox_approval": true, "rules": true, "mcp_elicitations": true}},
-			// Codex equivalent: granular flags ALL false (none allowed).
-			want: map[string]any{"granular": map[string]any{"sandbox_approval": false, "rules": false, "mcp_elicitations": false}},
-		},
-		{
-			name: "legacy reject:{false} translates to granular:{true}",
-			// Operator intent: don't reject; allow sandbox approvals.
-			in:   map[string]any{"reject": map[string]any{"sandbox_approval": false, "rules": true, "mcp_elicitations": true}},
-			want: map[string]any{"granular": map[string]any{"sandbox_approval": true, "rules": false, "mcp_elicitations": false}},
-		},
-		{
-			name: "unrecognized shape passes through so codex surfaces its own validation error",
-			in:   map[string]any{"future_variant": map[string]any{"x": 1}},
-			want: map[string]any{"future_variant": map[string]any{"x": 1}},
-		},
-		{
-			name: "nil passes through",
-			in:   nil,
-			want: nil,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := codexWireApprovalPolicy(tc.in)
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("codexWireApprovalPolicy(%#v) = %#v, want %#v", tc.in, got, tc.want)
-			}
-		})
 	}
 }
 

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -1634,6 +1634,77 @@ prompt body
 	}
 }
 
+// TestLoad_RejectsObsoleteCodexApprovalRejectShape verifies that the obsolete
+// codex `approval_policy: {reject: {...}}` shape fails Load with a clear error.
+// Codex renamed the `reject` approval variant to `granular` and inverted its
+// polarity (PR #14516, 2026-03-12); the runner used to translate it silently,
+// which could hand an operator the opposite policy with no signal. The loader
+// now rejects it and documents the polarity-flipped migration (#969).
+func TestLoad_RejectsObsoleteCodexApprovalRejectShape(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+agent:
+  default: codex-app-server
+codex:
+  approval_policy:
+    reject:
+      sandbox_approval: true
+      rules: true
+tracker:
+  kind: gitea
+---
+prompt body
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	_, err := Load(p)
+	if err == nil {
+		t.Fatalf("Load(codex.approval_policy.reject) = nil error; want rejection of the obsolete reject shape (#969)")
+	}
+	for _, want := range []string{"codex.approval_policy.reject", "granular"} {
+		if msg := err.Error(); !strings.Contains(msg, want) {
+			t.Fatalf("Load(codex.approval_policy.reject) error %q: want substring %q", err.Error(), want)
+		}
+	}
+}
+
+// TestLoad_AcceptsCodexApprovalGranularShape pins the positive case: the current
+// `approval_policy: {granular: {...}}` shape still loads cleanly, so the
+// reject-shape guard does not over-reject the supported approval policy (#969).
+func TestLoad_AcceptsCodexApprovalGranularShape(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "WORKFLOW.md")
+	body := `---
+repo:
+  owner: o
+  name: r
+  clone_url: git@example.com:o/r.git
+agent:
+  default: codex-app-server
+codex:
+  approval_policy:
+    granular:
+      sandbox_approval: true
+      rules: false
+tracker:
+  kind: gitea
+---
+prompt body
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	if _, err := Load(p); err != nil {
+		t.Fatalf("Load(codex.approval_policy.granular) = %v; want nil for the current approval shape", err)
+	}
+}
+
 // TestLoad_RejectsMissingCloneURL verifies that a workflow front matter
 // that omits `repo.clone_url` (or sets it to an empty string after env
 // expansion) fails Load with an error that names the file path and the

--- a/internal/workflow/reject.go
+++ b/internal/workflow/reject.go
@@ -187,12 +187,14 @@ func rejectRemovedPolicyFields(raw map[string]any) error {
 	return nil
 }
 
-// rejectRemovedCodexFields surfaces clear errors for codex.* keys that
-// configured the removed one-shot `codex exec` runner (issue #541): the
-// `codex.profile` field and a `codex.command` whose argv runs `codex exec`.
-// Both would otherwise be silently dropped or fall through to a `sh -c
-// "codex exec"` launch that the app-server runner cannot speak, failing the
-// first real run with an opaque protocol/timeout error.
+// rejectRemovedCodexFields surfaces clear errors for codex.* keys that either
+// configured the removed one-shot `codex exec` runner (issue #541) — the
+// `codex.profile` field and a `codex.command` whose argv runs `codex exec` —
+// or use the obsolete `approval_policy.reject` shape (#969). The exec keys
+// would otherwise be silently dropped or fall through to a `sh -c "codex exec"`
+// launch the app-server runner cannot speak; the `reject:` shape used to be
+// silently translated to `granular:` with an inverted polarity, which could
+// hand the operator the opposite approval policy with no signal.
 func rejectRemovedCodexFields(raw map[string]any) error {
 	codex, ok := raw["codex"].(map[string]any)
 	if !ok {
@@ -203,6 +205,11 @@ func rejectRemovedCodexFields(raw map[string]any) error {
 	}
 	if command, ok := codex["command"].(string); ok && commandRunsCodexExec(command) {
 		return fmt.Errorf("codex.command %q runs the removed one-shot `codex exec` runner (issue #541); the SPEC §10 runner is `codex app-server` — set codex.command to `codex app-server`", command)
+	}
+	if approval, ok := codex["approval_policy"].(map[string]any); ok {
+		if _, present := approval["reject"]; present {
+			return fmt.Errorf("codex.approval_policy.reject is no longer supported (#969): codex renamed the `reject` approval variant to `granular` and inverted its polarity (PR #14516, 2026-03-12). Rewrite as codex.approval_policy.granular with every flag negated — a `reject.<flag>: true` (\"reject this prompt\") becomes `granular.<flag>: false` (\"don't allow it\")")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #969

## Summary
- Remove `codexWireApprovalPolicy`, the runner-side back-compat layer that **silently translated** the obsolete codex `approval_policy: {reject: {...}}` shape into the current `{granular: {...}}` shape, **inverting the flag polarity** (codex PR #14516 / commit b7dba72db, 2026-03-12, renamed `Reject`→`Granular` and flipped `true` from "reject" to "allow").
- It was the lone surviving back-compat path for a removed wire shape, inconsistent with the loader's established policy of hard-rejecting removed config shapes (`internal/workflow/reject.go` has ~15 such, `codex_schema.go` rejects sandbox `mode`/`access`/`readOnlyAccess`). A silent polarity inversion is exactly the failure class those loud rejections exist to prevent: a subtly-wrong translation hands the operator the *opposite* approval policy with no signal.
- **Behavior-preserving for every valid config**: the translator was an identity function for all inputs except `reject:` (strings, `granular:`, unknown shapes, `nil` all passed through), so the runner now assigns `Codex.ApprovalPolicy` directly. The obsolete `reject:` shape is now rejected at **load time** with a clear error documenting the `granular:` replacement **and the polarity flip**, so an operator can migrate by hand.
- No in-repo `WORKFLOW.md`/docs use the `reject:` shape; the built-in defaults already use `granular:`. Found during a fallback/tech-debt audit (clean-code rule 2: pre-release, remove old wire names outright rather than aliasing).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This removes a translator and adds a load-time rejection of an obsolete (already-removed) wire shape — no new config key, no new worker/orchestrator phase/gate. Approval-policy translation concerns the external Codex `AskForApproval` protocol, not Symphony SPEC config shape.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage`
- [ ] `size-gated: split recommended`

Production diff: 3 files (`codex_app_server.go`, `codex_app_server_approval.go`, `reject.go`), ~+13/−58 LOC.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (0 issues)
- [x] Mutation-verified the new load-time reject: disabling the `reject:` branch fails `TestLoad_RejectsObsoleteCodexApprovalRejectShape`; restoring it passes. The granular positive test (`TestLoad_AcceptsCodexApprovalGranularShape`) passes in both states (no false coupling).

## Notes
- The reject-specific runner test was **repurposed** (not deleted) to `TestCodexAppServerRunnerFeedsGranularApprovalPolicyToWireAndDecisions`, preserving Run-level coverage that the stored approval policy drives both the wire payload and the harness-side auto-approve decision (no desync) — now exercised with the current `granular:` default shape.