### PR TITLE
fix: resolve worktree base to a fully-qualified ref to survive mirror ref pollution

### DIFF
--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -235,16 +235,34 @@ func attachWorktree(ctx context.Context, root, workdir, mirror, workBranch, star
 	return true, createWorktree(ctx, root, workdir, mirror, workBranch, startRef, foreignCommonDir)
 }
 
-// resolveStartRef resolves the base ref via `origin/<base>` because the bare
-// cache stores upstream branches as remote-tracking refs (see EnsureMirror);
-// it falls back to the bare name to cover `file://` test fixtures where the
-// upstream is the same on-disk repo.
+// resolveStartRef resolves the base ref to a FULLY-QUALIFIED ref so a stray
+// local branch named `origin/<base>` (refs/heads/origin/<base>, written into
+// the shared bare mirror by an agent's `git fetch origin <base>:origin/<base>`)
+// cannot make the short name `origin/<base>` ambiguous and wedge the subsequent
+// `git worktree add` / `git checkout` with `fatal: ambiguous object name` on
+// every retry (#976). A short `origin/<base>` only warns under `rev-parse
+// --verify` (it resolves to the first match), so the ambiguity surfaces fatally
+// at `worktree add` instead — the gate has to avoid the short name entirely.
+//
+// `refs/remotes/origin/<base>` is preferred: the bare cache stores upstream
+// branches there (see EnsureMirror), and it is the freshest base — the
+// `refs/heads/<base>` that `git clone --bare` copies once goes stale after the
+// first refspec fetch. `refs/heads/<base>` is the fallback for `file://` test
+// fixtures and for a pruned remote-tracking ref. When neither resolves (a
+// base-less mirror) the canonical remote-tracking ref is returned so the
+// inevitable `worktree add` failure names the intended base, never the
+// pollution.
 func resolveStartRef(ctx context.Context, mirror, baseBranch string) string {
-	startRef := "origin/" + baseBranch
-	if err := runGitQuiet(ctx, mirror, "rev-parse", "--verify", startRef); err != nil {
-		startRef = baseBranch
+	candidates := []string{
+		"refs/remotes/origin/" + baseBranch,
+		"refs/heads/" + baseBranch,
 	}
-	return startRef
+	for _, ref := range candidates {
+		if err := runGitQuiet(ctx, mirror, "rev-parse", "--verify", ref); err == nil {
+			return ref
+		}
+	}
+	return candidates[0]
 }
 
 // classifyExistingWorkdir decides whether an existing workdir is a valid,

--- a/internal/workspace/mirror_test.go
+++ b/internal/workspace/mirror_test.go
@@ -1053,8 +1053,8 @@ func TestWriteSensitiveArtifactReplacesHardLinkedArtifact(t *testing.T) {
 // `startRef = t.BaseBranch` fallback in PrepareGitWorkspace. The production
 // path (HTTPS clone via EnsureMirror) always populates
 // `refs/remotes/origin/<base>` through the post-clone fetch refspec
-// rewrite, so `git rev-parse --verify origin/<base>` succeeds and the
-// fallback never fires in production. This test drives the fallback
+// rewrite, so `git rev-parse --verify refs/remotes/origin/<base>` succeeds
+// and the fallback never fires in production. This test drives the fallback
 // explicitly by deleting the base branch on the UPSTREAM so the next
 // `ensureMirrorLocked`'s `fetch --prune` removes `refs/remotes/origin/main`
 // from the mirror while the mirror keeps its bare `refs/heads/main` from
@@ -1102,10 +1102,10 @@ func TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName(t *testing.T)
 	}
 
 	// New task → first-touch path runs through the startRef resolution.
-	// The refresh fetch prunes `origin/main`, the `git rev-parse --verify
-	// origin/main` gate fails, and startRef falls back to bare `main`; the
-	// subsequent `git worktree add ... main` must succeed against the
-	// mirror's `refs/heads/main`.
+	// The refresh fetch prunes `refs/remotes/origin/main`, so resolveStartRef's
+	// first candidate fails `rev-parse --verify` and it falls back to
+	// `refs/heads/main`; the subsequent `git worktree add ... refs/heads/main`
+	// must succeed against the mirror's bare head.
 	tk := makeTask("task-fallback", upstream)
 	dir, createdNow, err := mgr.PrepareGitWorkspace(ctx, tk)
 	if err != nil {
@@ -1135,6 +1135,91 @@ func TestPrepareGitWorkspace_StartRefFallsBackToBareBaseBranchName(t *testing.T)
 	if got := strings.TrimSpace(string(branchOut)); got != tk.WorkBranch {
 		t.Fatalf("worktree on branch %q, want %q", got, tk.WorkBranch)
 	}
+}
+
+// TestPrepareGitWorkspace_StartRefIgnoresPollutingLocalOriginBranch is the #976
+// regression: a maker/reviewer agent with git access can run
+// `git fetch origin main:origin/main` inside its worktree, which writes a LOCAL
+// branch `refs/heads/origin/main` into the SHARED bare mirror. That makes the
+// short ref `origin/main` ambiguous, so the previous short-ref `git worktree add
+// ... origin/main` failed with `fatal: ambiguous object name: 'origin/main'` and
+// wedged every subsequent dispatch on that mirror in retry/backoff. Preparing a
+// workspace over the polluted mirror must still succeed by resolving the
+// fully-qualified remote-tracking base, never the local pollution.
+func TestPrepareGitWorkspace_StartRefIgnoresPollutingLocalOriginBranch(t *testing.T) {
+	upstream := initBareUpstream(t)
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	// Prime the mirror so refs/remotes/origin/main exists, exactly as the
+	// production HTTPS clone path builds it.
+	primer := makeTask("task-primer", upstream)
+	if _, _, err := mgr.PrepareGitWorkspace(ctx, primer); err != nil {
+		t.Fatalf("prime mirror: %v", err)
+	}
+	mirror := mirrorPathFor(MirrorRoot(mgr.MirrorRoot), upstream)
+
+	// The intended base: the remote-tracking tip the worktree must start from.
+	wantBase, err := exec.Command("git", "--git-dir", mirror, "rev-parse", "refs/remotes/origin/main").Output()
+	if err != nil {
+		t.Fatalf("mirror rev-parse refs/remotes/origin/main: %v", err)
+	}
+	wantBaseSHA := strings.TrimSpace(string(wantBase))
+
+	// Pollute exactly as the agent's bad fetch did: a local branch literally
+	// named origin/main (refs/heads/origin/main) at a DIVERGENT commit, so the
+	// short name is genuinely ambiguous AND a base mix-up would be observable in
+	// the worktree's HEAD (not merely hidden behind an identical SHA).
+	pollutingSHA := rootCommitInMirror(t, mirror)
+	if pollutingSHA == wantBaseSHA {
+		t.Fatalf("polluting commit %q must differ from the remote-tracking base", pollutingSHA)
+	}
+	if out, err := exec.Command("git", "--git-dir", mirror, "update-ref", "refs/heads/origin/main", pollutingSHA).CombinedOutput(); err != nil {
+		t.Fatalf("seed refs/heads/origin/main: %v\n%s", err, out)
+	}
+	// Precondition: the short ref is now genuinely ambiguous (the wedge trigger).
+	if err := exec.Command("git", "--git-dir", mirror, "rev-parse", "--verify", "refs/heads/origin/main").Run(); err != nil {
+		t.Fatalf("precondition: refs/heads/origin/main not seeded: %v", err)
+	}
+
+	// Real preparation path. Pre-fix this fails at `worktree add` with
+	// `fatal: ambiguous object name: 'origin/main'`.
+	tk := makeTask("task-polluted", upstream)
+	dir, createdNow, err := mgr.PrepareGitWorkspace(ctx, tk)
+	if err != nil {
+		t.Fatalf("prepare over polluted mirror: %v", err)
+	}
+	if !createdNow {
+		t.Fatal("prepare for new task reported createdNow=false")
+	}
+	// The worktree must be based on the remote-tracking ref, never the pollution.
+	headOut, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("worktree rev-parse HEAD: %v", err)
+	}
+	if got := strings.TrimSpace(string(headOut)); got != wantBaseSHA {
+		t.Fatalf("worktree HEAD = %q, want remote-tracking base %q (did startRef resolve the polluting local branch %q?)", got, wantBaseSHA, pollutingSHA)
+	}
+}
+
+// rootCommitInMirror writes a parent-less commit over the empty tree directly
+// into the bare mirror's object store and returns its SHA. It seeds a polluting
+// ref at a commit that diverges from the real base without needing a worktree;
+// the identity is passed explicitly so the test never depends on the host's
+// global git config.
+func rootCommitInMirror(t *testing.T, mirror string) string {
+	t.Helper()
+	const emptyTree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	cmd := exec.Command("git", "--git-dir", mirror, "commit-tree", emptyTree, "-m", "pollution")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=pollution", "GIT_AUTHOR_EMAIL=pollution@example.com",
+		"GIT_COMMITTER_NAME=pollution", "GIT_COMMITTER_EMAIL=pollution@example.com",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("commit-tree in mirror: %v", err)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // TestPrepareGitWorkspace_ReclaimsBranchAfterWorkspaceRootChange is the #854


### PR DESCRIPTION
Closes #976

## Summary
- A maker/reviewer agent with git access in its worktree can run `git fetch origin main:origin/main`, which writes a **local** branch `refs/heads/origin/main` into the **shared bare mirror**. Together with the normal `refs/remotes/origin/main`, that makes the short ref `origin/main` ambiguous.
- The worker prepared workspaces with `git worktree add --no-track -B ai/N <wd> origin/main`. `git rev-parse --verify origin/main` only *warns* on ambiguity and still exits 0 (resolving the first match), so `resolveStartRef`'s fallback never fired and the short name reached `worktree add`, which fails fatally: `fatal: ambiguous object name: 'origin/main'`. Every reviewer retry on that mirror wedged in retry/backoff, surfaced only as `worktree add: exit status 255`.
- **Fix:** `resolveStartRef` now resolves the base to a **fully-qualified** ref — `refs/remotes/origin/<base>` (freshest), falling back to `refs/heads/<base>` (`file://` fixtures / pruned remote-tracking ref) — instead of the short `origin/<base>`. A stray `refs/heads/origin/*` local ref can no longer shadow the base. One gate covers both the create (`worktree add`) and reuse (`checkout`) paths, which share `startRef`.

Root cause reproduced before the fix; both same-SHA and divergent-SHA pollution trigger the fatal.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

The bare-mirror + per-issue-worktree machinery is an aiops-platform Go-port extension; upstream Symphony's `elixir/lib/symphony_elixir/workspace.ex` has no `git worktree` / `origin/<base>` resolution at all (it runs hook commands via `System.cmd`). This is a port-internal correctness fix to an existing local git invocation — no SPEC concept, key, phase, or gate changes; `internal/workspace/manager.go` is not a SPEC-sensitive path.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 1 production file (`internal/workspace/manager.go`, ~11 LOC of logic + doc comment); test changes excluded.
- [ ] `size-gated: justified overage` — production diff over budget for atomic correctness/regression/race coverage.
- [ ] `size-gated: split recommended` — over budget for separable concerns.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts` (`manager.go` 793/800)
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean
- [x] additional validation: **mutation-verified** the regression — reverting `resolveStartRef` to the old short-ref behavior fails `TestPrepareGitWorkspace_StartRefIgnoresPollutingLocalOriginBranch` with `worktree add: ... fatal: ambiguous object name: 'origin/main'`.

## Regression test
`TestPrepareGitWorkspace_StartRefIgnoresPollutingLocalOriginBranch` primes a real mirror, seeds `refs/heads/origin/main` at a **divergent** commit alongside `refs/remotes/origin/main`, drives the real `PrepareGitWorkspace` path, and asserts the worktree HEAD equals the remote-tracking base (never the pollution). The existing prune-fallback test (`…StartRefFallsBackToBareBaseBranchName`) still passes; its comment was updated to the new resolution order.

## Notes
- **Deferred → #978 (issue's 3rd suggestion, surface git stderr):** the naive fix (tee `cmd.Stderr` to a buffer) converts stderr to a pipe, making os/exec drain a copy goroutine on kill and stall parent-cancel by `gitWaitGrace` (5s) — a real regression caught by `TestRunGitParentCancellationPreemptsBudget`. The correct fix (temp-`*os.File` + `manager.go` decomposition) is its own focused change, tracked in #978.
- **Not done (issue's 2nd "Consider", sanitize `refs/heads/origin/*`):** with fully-qualified resolution the pollution is benign, so adding ref-mutation to the shared mirror is broader surface than the bug warrants (harness principle 5/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8pDhqzmxVaycjNyJm42Zq)_