### PR TITLE
feat(dashboard): show active agent model and runtime profile

### DIFF
--- a/cmd/tui/layout_test.go
+++ b/cmd/tui/layout_test.go
@@ -96,7 +96,7 @@ func TestFormatRunningRow_TokensDoNotCorruptAlignment(t *testing.T) {
 	now := time.Now()
 	started := now.Add(-90 * time.Second)
 	const eventWidth = 44
-	wantWidth := fixedRunningWidth() + chromeWidth + eventWidth // 66 + 10 + 44 = 120
+	wantWidth := fixedRunningWidth() + chromeWidth + eventWidth // 86 + 11 + 44 = 141
 
 	r := stateapi.Running{
 		Identifier:        "ENG-1234",
@@ -125,6 +125,7 @@ func representativeState(now time.Time) *stateapi.StateResponse {
 	due := now.Add(30 * time.Second)
 	return &stateapi.StateResponse{
 		MaxConcurrentAgents: 10,
+		AgentDefault:        "codex-app-server",
 		Counts: stateapi.Counts{
 			CompletedTotal:                    12,
 			AgentHandoffReconcileStoppedTotal: 3,
@@ -142,6 +143,8 @@ func representativeState(now time.Time) *stateapi.StateResponse {
 			LastEventAt:       &now,
 			Tokens:            stateapi.RunningTokens{TotalTokens: 1_000_000_000},
 			CodexAppServerPID: 12345,
+			AgentProvider:     "codex-app-server",
+			AgentModel:        "gpt-5.3-codex-spark",
 		}},
 		Retrying: []stateapi.Retry{{
 			Identifier: "ENG-9999",
@@ -223,6 +226,48 @@ func TestRenderFrame_ShowsAgentHandoffCount(t *testing.T) {
 
 	if !strings.Contains(frame, "Handoffs: completed 12 | agent 3 (recent 2)") {
 		t.Fatalf("renderFrame missing agent handoff count: %q", frame)
+	}
+}
+
+// TestRenderFrame_ShowsAgentModel pins #977 on the TUI surface: the running
+// table carries a MODEL column with the per-claim model, and the header shows
+// the worker default provider. A wide terminal avoids truncating the column.
+func TestRenderFrame_ShowsAgentModel(t *testing.T) {
+	orig := liveTerminalWidth
+	t.Cleanup(func() { liveTerminalWidth = orig })
+	liveTerminalWidth = func() (int, bool) { return 160, true }
+
+	now := time.Now()
+	frame := visibleString(renderFrame(representativeState(now), nil, now, 0, "http://127.0.0.1:4001", 5*time.Second))
+
+	if !strings.Contains(frame, "MODEL") {
+		t.Fatalf("renderFrame missing MODEL running-table column: %q", frame)
+	}
+	if !strings.Contains(frame, "gpt-5.3-codex-spark") {
+		t.Fatalf("renderFrame missing per-claim model: %q", frame)
+	}
+	// The worker default line pins the provider (agent.default) and renders the
+	// model as "unknown" — it is resolved per-run, not configured (#977).
+	if !strings.Contains(frame, "Default:    codex-app-server · model unknown") {
+		t.Fatalf("renderFrame missing worker default provider/model line: %q", frame)
+	}
+}
+
+// TestRenderFrame_RendersUnknownModelWhenAbsent pins the "unknown, never blank"
+// criterion: a running claim with no reported model still renders "unknown" in
+// the MODEL column rather than an empty cell (#977).
+func TestRenderFrame_RendersUnknownModelWhenAbsent(t *testing.T) {
+	orig := liveTerminalWidth
+	t.Cleanup(func() { liveTerminalWidth = orig })
+	liveTerminalWidth = func() (int, bool) { return 160, true }
+
+	now := time.Now()
+	state := representativeState(now)
+	state.Running[0].AgentModel = ""
+	frame := visibleString(renderFrame(state, nil, now, 0, "http://127.0.0.1:4001", 5*time.Second))
+
+	if !strings.Contains(frame, "unknown") {
+		t.Fatalf("renderFrame should render an absent model as \"unknown\": %q", frame)
 	}
 }
 

--- a/cmd/tui/render.go
+++ b/cmd/tui/render.go
@@ -26,9 +26,10 @@ const (
 	colAge      = 12
 	colTokens   = 10
 	colSession  = 14
+	colModel    = 20
 	colEventMin = 12
 	colEventDef = 44
-	chromeWidth = 10 // "│  ● " prefix + spacing
+	chromeWidth = 11 // "│ ● " prefix + one space between each of the 8 running columns
 
 	defaultTermCols = 115 // Elixir @default_terminal_columns
 )
@@ -75,6 +76,13 @@ func renderFrame(state *stateapi.StateResponse, fetchErr error, now time.Time, t
 			colorize(formatCount(int64(agentCount)), ansiGreen) +
 			colorize("/", ansiGray) +
 			colorize(formatCount(int64(maxAgents)), ansiGray),
+		// Worker default runtime/provider (agent.default). The model is resolved
+		// per-run by the agent (shown per-claim in the MODEL column), so the
+		// worker-level default model is "unknown" rather than hidden (#977).
+		colorize("│ Default:    ", ansiBold) +
+			colorize(orUnknown(state.AgentDefault), ansiCyan) +
+			colorize(" · model ", ansiGray) +
+			colorize("unknown", ansiGray),
 		colorize("│ Handoffs: ", ansiBold) +
 			colorize("completed "+formatCount(state.Counts.CompletedTotal), ansiGreen) +
 			colorize(" | ", ansiGray) +
@@ -151,6 +159,7 @@ func runningTableHeader(eventWidth int) string {
 		padRight("AGE / TURN", colAge),
 		padLeft("TOKENS", colTokens),
 		padRight("SESSION", colSession),
+		padRight("MODEL", colModel),
 		padRight("EVENT", eventWidth),
 	}, " ")
 	return "│   " + colorize(header, ansiGray)
@@ -158,12 +167,12 @@ func runningTableHeader(eventWidth int) string {
 
 // runningTableSep mirrors running_table_separator_row/1.
 func runningTableSep(eventWidth int) string {
-	width := fixedRunningWidth() + eventWidth + 6
+	width := fixedRunningWidth() + eventWidth + 7
 	return "│   " + colorize(strings.Repeat("─", width), ansiGray)
 }
 
 func fixedRunningWidth() int {
-	return colID + colStage + colPID + colAge + colTokens + colSession
+	return colID + colStage + colPID + colAge + colTokens + colSession + colModel
 }
 
 // formatRunningRow mirrors format_running_summary/2.
@@ -186,6 +195,7 @@ func formatRunningRow(r stateapi.Running, now time.Time, eventWidth int) string 
 	// token count must not widen the row and push EVENT out of alignment (#466).
 	tokens := cellRight(formatCount(r.Tokens.TotalTokens), colTokens)
 	session := cell(compactSession(r.SessionID), colSession)
+	model := cell(orUnknown(r.AgentModel), colModel)
 
 	eventText := r.LastMessage
 	if eventText == "" {
@@ -206,7 +216,17 @@ func formatRunningRow(r stateapi.Running, now time.Time, eventWidth int) string 
 		colorize(age, ansiMagenta) + " " +
 		colorize(tokens, ansiYellow) + " " +
 		colorize(session, ansiCyan) + " " +
+		colorize(model, ansiGray) + " " +
 		colorize(event, dotColor)
+}
+
+// orUnknown renders an agent model/provider value, falling back to "unknown" so
+// a missing value is explicit diagnostic data rather than a blank cell (#977).
+func orUnknown(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "unknown"
+	}
+	return s
 }
 
 // formatRetryRow mirrors format_retry_summary/1.

--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -300,25 +300,33 @@ function RunningTable({ rows }) {
       <table className="sessions">
         <caption className="sr-only">Running sessions</caption>
         <thead><tr>
-          <th scope="col">Issue</th><th scope="col">State</th><th scope="col">Runtime</th>
+          <th scope="col">Issue</th><th scope="col">State</th><th scope="col">Model</th><th scope="col">Runtime</th>
           <th scope="col">Latest activity</th><th scope="col" className="r tok-h">Tokens<span className="th-sub"> in / out</span></th>
         </tr></thead>
         <tbody>
-          {rows.map((r) => (
+          {rows.map((r) => {
+            // Resolved per-claim model/runtime; a missing model renders as
+            // "unknown" (explicit diagnostic data, never blank) and collapses
+            // into the issue detail line for narrow layouts (#977).
+            const model = r.agent_model || 'unknown';
+            const provider = r.agent_provider || 'unknown';
+            return (
             <tr key={r.issue_id}>
               <td className="issue-cell">
                 <div className="issue">
                   <IssueLink row={r} />
                   <div className="upd" style={{ maxWidth: '38ch' }} title={r.last_message}>{r.last_message}</div>
-                  <span className="wp">{r.workspace_path} · {r.session_id}{r.codex_app_server_pid ? ` · pid ${r.codex_app_server_pid}` : ''}</span>
+                  <span className="wp">model {model} · {provider} · {r.workspace_path} · {r.session_id}{r.codex_app_server_pid ? ` · pid ${r.codex_app_server_pid}` : ''}</span>
                 </div>
               </td>
               <td data-label="State"><Badge kind="running">{r.state}</Badge><div className="dim">turn {r.turn_count}</div></td>
+              <td data-label="Model"><span className="mono" style={{ fontSize: '11.5px' }}>{model}</span><div className="dim">{provider}</div></td>
               <td data-label="Runtime"><span className="runtime tnum">{sinceISO(r.started_at)}</span><div className="dim">started</div></td>
               <td data-label="Latest activity"><span className="mono" style={{ fontSize: '11.5px' }}>{r.last_event}</span><div className="dim">{sinceISO(r.last_event_at)} ago</div></td>
               <td className="tok" data-label="Tokens in / out"><b>{compact(r.tokens?.input_tokens)}</b> / {compact(r.tokens?.output_tokens)}</td>
             </tr>
-          ))}
+            );
+          })}
         </tbody>
       </table>
     </div>
@@ -492,6 +500,9 @@ export default function App() {
   const rl = s.rate_limits;
   const total = (c.running || 0) + (c.retrying || 0) + (c.blocked || 0);
   const pollSec = Math.round((s.poll_interval_ms || 0) / 1000);
+  // Worker default runtime/provider (agent.default). The model is resolved
+  // per-run by the agent, so the worker-level default model is unknown (#977).
+  const agentDefault = s.agent_default || 'unknown';
   const maxConc = s.max_concurrent_agents ?? '—';
   const byState = s.max_concurrent_agents_by_state;
   const byStateStr = byState && Object.keys(byState).length
@@ -531,6 +542,7 @@ export default function App() {
         <div className="title-meta">
           <div className="row"><span>poll</span><b>every {pollSec}s</b></div>
           <div className="row"><span>concurrency</span><b>{maxConc} max{byStateStr}</b></div>
+          <div className="row"><span>default agent</span><b>{agentDefault} · model unknown</b></div>
         </div>
       </div>
 

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -10,6 +10,7 @@ function busyState(overrides = {}) {
   return {
     generated_at: iso(0),
     poll_interval_ms: 20000,
+    agent_default: 'codex-app-server',
     max_concurrent_agents: 3,
     max_concurrent_agents_by_state: { 'In Progress': 3 },
     counts: {
@@ -27,6 +28,7 @@ function busyState(overrides = {}) {
         workspace_path: '/tmp/aiops_workspaces/MT-614',
         tokens: { input_tokens: 286400, output_tokens: 41200, total_tokens: 327600 },
         codex_app_server_pid: 48213,
+        agent_provider: 'codex-app-server', agent_model: 'gpt-5.3-codex-spark',
       },
     ],
     retrying: [
@@ -124,6 +126,33 @@ describe('Worker status dashboard', () => {
     const link = await screen.findByRole('link', { name: 'MT-614' });
     expect(link.getAttribute('href')).toBe('/api/v1/MT-614');
     expect(screen.getByText('Wired counter into reconciler.')).toBeTruthy();
+  });
+
+  it('shows the active agent model per running claim and the worker default provider', async () => {
+    const { container } = render(<App />);
+    await screen.findByRole('link', { name: 'MT-614' });
+    const modelCell = container.querySelector('td[data-label="Model"]');
+    expect(modelCell).toBeTruthy();
+    expect(modelCell.textContent).toContain('gpt-5.3-codex-spark');
+    expect(modelCell.textContent).toContain('codex-app-server'); // provider sub-line
+    // worker default provider in the title meta (the model is resolved per-run).
+    expect(screen.getByText('codex-app-server · model unknown')).toBeTruthy();
+  });
+
+  it('renders a missing agent model as "unknown", never blank', async () => {
+    current = busyState({
+      running: [{
+        issue_id: 'no-model', issue_identifier: 'MT-700', state: 'In Progress',
+        session_id: 'thread-x', turn_count: 1, last_event: 'turn_started',
+        started_at: iso(1000), last_event_at: iso(1000), workspace_path: '/tmp/w',
+        tokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+      }],
+    });
+    const { container } = render(<App />);
+    await screen.findByRole('link', { name: 'MT-700' });
+    const modelCell = container.querySelector('td[data-label="Model"]');
+    expect(modelCell.textContent).toContain('unknown');
+    expect(modelCell.textContent.trim()).not.toBe('');
   });
 
   it('renders Codex rate-limit windows as percent bars, not raw JSON', async () => {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -383,6 +383,7 @@ func run(ctx context.Context, args []string) error { //nolint:gocognit,funlen //
 
 	state := orchestrator.NewOrchestratorState(int64(wf.Config.Polling.IntervalMs), wf.Config.Agent.MaxConcurrentAgents)
 	state.MaxContinuationTurns = wf.Config.Agent.MaxContinuationTurns
+	state.AgentDefault = wf.Config.Agent.Default
 	runtime, err := orchestrator.NewWorkflowRuntime(orchestrator.WorkflowRuntimeConfig{
 		Initial:              wf,
 		Path:                 resolution.Path,

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -140,6 +140,67 @@ func TestApiStateRowsEmitIssueURLWhenAvailable(t *testing.T) {
 	keyAbsent(t, rawBlockedNo)
 }
 
+// TestApiStateSurfacesAgentModelMetadata pins the #977 projection seam: a
+// running row carries agent_provider/agent_model when the runner reported them
+// and omits the keys (omitempty) otherwise, and the top-level worker default
+// surfaces as agent_default. Mutation: dropping a field in apiRunningFromView /
+// apiStateFromView fails the "present" case; dropping omitempty fails "absent".
+func TestApiStateSurfacesAgentModelMetadata(t *testing.T) {
+	stringKey := func(t *testing.T, raw []byte, key, want string) {
+		t.Helper()
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		v, ok := got[key]
+		if want == "" {
+			if ok {
+				t.Fatalf("%s present; want omitted (omitempty) in %s", key, raw)
+			}
+			return
+		}
+		if !ok {
+			t.Fatalf("%s missing; want %q in %s", key, want, raw)
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			t.Fatalf("%s unmarshal: %v", key, err)
+		}
+		if s != want {
+			t.Fatalf("%s = %q; want %q", key, s, want)
+		}
+	}
+
+	withModel, err := json.Marshal(apiRunningFromView(orchestrator.RunningView{
+		IssueID: "i1", Identifier: "MT-649",
+		AgentProvider: "codex-app-server", AgentModel: "gpt-5.3-codex-spark",
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	stringKey(t, withModel, "agent_provider", "codex-app-server")
+	stringKey(t, withModel, "agent_model", "gpt-5.3-codex-spark")
+
+	noModel, err := json.Marshal(apiRunningFromView(orchestrator.RunningView{IssueID: "i1", Identifier: "MT-649"}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	stringKey(t, noModel, "agent_provider", "")
+	stringKey(t, noModel, "agent_model", "")
+
+	withDefault, err := json.Marshal(apiStateFromView(orchestrator.StateView{AgentDefault: "codex-app-server"}))
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	stringKey(t, withDefault, "agent_default", "codex-app-server")
+
+	noDefault, err := json.Marshal(apiStateFromView(orchestrator.StateView{}))
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	stringKey(t, noDefault, "agent_default", "")
+}
+
 func TestApiIssueFromViewFindsRecentTerminalEventByIdentifier(t *testing.T) {
 	view := orchestrator.StateView{
 		Completed: []orchestrator.IssueID{"linear-global-id"},

--- a/cmd/worker/stateapi.go
+++ b/cmd/worker/stateapi.go
@@ -384,6 +384,8 @@ func apiRunningFromView(row orchestrator.RunningView) stateapi.Running {
 			TotalTokens:  row.Tokens.TotalTokens,
 		},
 		CodexAppServerPID: row.CodexAppServerPID,
+		AgentProvider:     row.AgentProvider,
+		AgentModel:        row.AgentModel,
 	}
 }
 func apiRetryFromView(row orchestrator.RetryView) stateapi.Retry {
@@ -469,6 +471,7 @@ func apiStateFromView(view orchestrator.StateView) stateapi.StateResponse {
 	operatorStops := sortedAPIOperatorTerminalStops(view.OperatorTerminalStops)
 	return stateapi.StateResponse{
 		Version:                      resolveVersion(),
+		AgentDefault:                 view.AgentDefault,
 		GeneratedAt:                  generatedAt,
 		PollIntervalMs:               view.PollIntervalMs,
 		MaxConcurrentAgents:          view.MaxConcurrentAgents,

--- a/internal/orchestrator/actor_config.go
+++ b/internal/orchestrator/actor_config.go
@@ -128,6 +128,33 @@ func (o *Orchestrator) UpdateMaxContinuationTurns(ctx context.Context, maxContin
 	}
 }
 
+// UpdateAgentDefault applies the reloaded default runner/provider through the
+// actor so the /api/v1/state top-summary provider tracks a hot WORKFLOW.md
+// reload that changes `agent.default` — dispatch already reads the live
+// snapshot, so without this the summary would report the startup runner while
+// new runs launch with the reloaded default (#977 / #982 review). An empty
+// value is ignored so a malformed reload never blanks the surfaced default.
+func (o *Orchestrator) UpdateAgentDefault(ctx context.Context, agentDefault string) error {
+	if strings.TrimSpace(agentDefault) == "" {
+		return nil
+	}
+	done := make(chan struct{}, 1)
+	op := opFunc(func(st *OrchestratorState) func() {
+		st.AgentDefault = agentDefault
+		done <- struct{}{}
+		return nil
+	})
+	if err := o.submit(ctx, op); err != nil {
+		return err
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // UpdatePollIntervalMs applies reloaded workflow poll cadence metadata through
 // the actor so /api/v1/state reflects the runtime cadence after workflow reload.
 func (o *Orchestrator) UpdatePollIntervalMs(ctx context.Context, pollIntervalMs int64) error {

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -1009,6 +1009,39 @@ func TestRecordRuntimeEventPropagatesCodexAppServerPID(t *testing.T) {
 	}
 }
 
+// TestRecordRuntimeEventPropagatesAgentModel pins the #977 round-trip: a
+// `session_started` event carrying agent_provider/agent_model populates
+// RunningView so `/api/v1/state` surfaces which model/runtime drove a claim.
+func TestRecordRuntimeEventPropagatesAgentModel(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-MODEL")
+	defer cancel()
+
+	if err := o.RecordRuntimeEvent(context.Background(), issueID, task.RuntimeEvent{
+		Event: task.EventSessionStarted,
+		Payload: map[string]any{
+			"session_id":     "thread-1-turn-1",
+			"agent_provider": "codex-app-server",
+			"agent_model":    "gpt-5.3-codex-spark",
+		},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 1 {
+		t.Fatalf("running rows = %d, want 1", len(view.Running))
+	}
+	if got := view.Running[0].AgentProvider; got != "codex-app-server" {
+		t.Fatalf("RunningView.AgentProvider = %q, want %q (session_started payload)", got, "codex-app-server")
+	}
+	if got := view.Running[0].AgentModel; got != "gpt-5.3-codex-spark" {
+		t.Fatalf("RunningView.AgentModel = %q, want %q (session_started payload)", got, "gpt-5.3-codex-spark")
+	}
+}
+
 // TestRecordRuntimeEventTracksLastEventAndMessage pins SPEC §13.7.2:
 // last_event surfaces the most-recent runtime event kind on the running row,
 // and last_message captures the payload `message` field when present (e.g.
@@ -3005,6 +3038,29 @@ func TestUpdatePollIntervalMsRefreshesSnapshotMetadata(t *testing.T) {
 	}
 	if view.PollIntervalMs != 42000 {
 		t.Fatalf("PollIntervalMs = %d, want 42000", view.PollIntervalMs)
+	}
+}
+
+// TestUpdateAgentDefaultRefreshesSnapshotProviderAndIgnoresEmpty pins the #982
+// review fix at the actor: a reloaded default updates the surfaced provider, and
+// an empty value is ignored so a malformed reload never blanks it.
+func TestUpdateAgentDefaultRefreshesSnapshotProviderAndIgnoresEmpty(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{Dispatcher: disp})
+	defer cancel()
+
+	if err := o.UpdateAgentDefault(context.Background(), "codex-app-server"); err != nil {
+		t.Fatalf("UpdateAgentDefault: %v", err)
+	}
+	if got := snapshotAgentDefault(t, context.Background(), o); got != "codex-app-server" {
+		t.Fatalf("AgentDefault = %q, want %q", got, "codex-app-server")
+	}
+	// An empty reload value must not clobber the surfaced default.
+	if err := o.UpdateAgentDefault(context.Background(), "  "); err != nil {
+		t.Fatalf("UpdateAgentDefault(empty): %v", err)
+	}
+	if got := snapshotAgentDefault(t, context.Background(), o); got != "codex-app-server" {
+		t.Fatalf("AgentDefault after empty update = %q, want unchanged %q", got, "codex-app-server")
 	}
 }
 

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -1042,6 +1042,51 @@ func TestRecordRuntimeEventPropagatesAgentModel(t *testing.T) {
 	}
 }
 
+// TestRecordRuntimeEventModelRerouteOverwritesAgentModel pins the #982 reroute
+// fold: a later event carrying a fresh agent_model (the runner re-surfaces a
+// codex model/rerouted toModel as the canonical agent_model) overwrites the
+// sticky session_started model, so /api/v1/state and the dashboards track the
+// model actually running after a mid-claim fallback.
+func TestRecordRuntimeEventModelRerouteOverwritesAgentModel(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-REROUTE")
+	defer cancel()
+
+	if err := o.RecordRuntimeEvent(context.Background(), issueID, task.RuntimeEvent{
+		Event: task.EventSessionStarted,
+		Payload: map[string]any{
+			"session_id":     "thread-1-turn-1",
+			"agent_provider": "codex-app-server",
+			"agent_model":    "gpt-5.3-codex-spark",
+		},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent session_started: %v", err)
+	}
+	if err := o.RecordRuntimeEvent(context.Background(), issueID, task.RuntimeEvent{
+		Event: task.EventNotification,
+		Payload: map[string]any{
+			"from_model":  "gpt-5.3-codex-spark",
+			"to_model":    "gpt-5.3-codex",
+			"agent_model": "gpt-5.3-codex",
+		},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent reroute: %v", err)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 1 {
+		t.Fatalf("running rows = %d, want 1", len(view.Running))
+	}
+	if got := view.Running[0].AgentModel; got != "gpt-5.3-codex" {
+		t.Fatalf("RunningView.AgentModel = %q, want %q (reroute toModel overwrites session_started model)", got, "gpt-5.3-codex")
+	}
+	if got := view.Running[0].AgentProvider; got != "codex-app-server" {
+		t.Fatalf("RunningView.AgentProvider = %q, want %q (provider stays sticky across reroute)", got, "codex-app-server")
+	}
+}
+
 // TestRecordRuntimeEventTracksLastEventAndMessage pins SPEC §13.7.2:
 // last_event surfaces the most-recent runtime event kind on the running row,
 // and last_message captures the payload `message` field when present (e.g.

--- a/internal/orchestrator/runtime_events.go
+++ b/internal/orchestrator/runtime_events.go
@@ -157,6 +157,12 @@ func (s *OrchestratorState) recordSessionFields(run *RunningEntry, event task.Ru
 	if pid, ok := intField(payload, "codex_app_server_pid"); ok && pid > 0 {
 		run.Session.CodexAppServerPID = pid
 	}
+	if provider, ok := stringField(payload, "agent_provider"); ok {
+		run.Session.AgentProvider = provider
+	}
+	if model, ok := stringField(payload, "agent_model"); ok {
+		run.Session.AgentModel = model
+	}
 	if event.Event == task.EventTurnCompleted {
 		run.Session.TurnCount++
 	}

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -80,6 +80,9 @@ func (p *RuntimePoller) PollOnce(ctx context.Context) error {
 	if err := p.orchestrator.UpdatePollIntervalMs(ctx, snap.PollInterval.Milliseconds()); err != nil {
 		return err
 	}
+	if err := p.orchestrator.UpdateAgentDefault(ctx, snap.AgentDefault); err != nil {
+		return err
+	}
 	if err := p.orchestrator.UpdateRetryScheduler(ctx, RetryScheduler{MaxBackoff: snap.MaxRetryBackoff}); err != nil {
 		return err
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -53,6 +53,14 @@ type LiveSession struct {
 	TurnID            string
 	TurnCount         int
 	CodexAppServerPID int
+	// AgentProvider is the runtime/runner identity (e.g. "codex-app-server")
+	// and AgentModel the resolved model (e.g. "gpt-5.3-codex-spark"), both
+	// folded from the runner's `session_started` event payload and surfaced on
+	// /api/v1/state so an operator can tell which model/runtime produced a run
+	// (#977). Empty until observed; the dashboard renders missing values as
+	// "unknown".
+	AgentProvider string
+	AgentModel    string
 }
 
 // RateLimitSnapshot is the latest SPEC §13.3 rate-limits payload emitted by
@@ -210,6 +218,11 @@ type OrchestratorState struct {
 	MaxConcurrentAgents        int
 	MaxConcurrentAgentsByState map[string]int
 	MaxContinuationTurns       int
+	// AgentDefault is the worker's configured default runner/provider
+	// (`agent.default`, e.g. "codex-app-server"). It is surfaced as the
+	// top-summary worker default provider on /api/v1/state (#977); the model is
+	// resolved per-run by the agent, so there is no worker-default model.
+	AgentDefault string
 
 	Running       map[IssueID]*RunningEntry
 	Blocked       map[IssueID]*BlockedEntry

--- a/internal/orchestrator/state_snapshot.go
+++ b/internal/orchestrator/state_snapshot.go
@@ -21,6 +21,10 @@ type StateView struct {
 	PollIntervalMs             int64
 	MaxConcurrentAgents        int
 	MaxConcurrentAgentsByState map[string]int
+	// AgentDefault is the worker's configured default runner/provider
+	// (`agent.default`), surfaced as the top-summary worker default on
+	// /api/v1/state (#977).
+	AgentDefault string
 
 	Running  []RunningView
 	Blocked  []BlockedView
@@ -93,6 +97,8 @@ func (s *OrchestratorState) snapshotRunningViews() []RunningView {
 				TotalTokens:  r.CodexTotalTokens,
 			},
 			CodexAppServerPID: r.Session.CodexAppServerPID,
+			AgentProvider:     r.Session.AgentProvider,
+			AgentModel:        r.Session.AgentModel,
 		})
 	}
 	return rows
@@ -132,6 +138,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 		PollIntervalMs:               s.PollIntervalMs,
 		MaxConcurrentAgents:          s.MaxConcurrentAgents,
 		MaxConcurrentAgentsByState:   copyStateConcurrencyLimits(s.MaxConcurrentAgentsByState),
+		AgentDefault:                 s.AgentDefault,
 		Blocked:                      make([]BlockedView, 0, len(s.Blocked)),
 		Retrying:                     make([]RetryView, 0, len(s.RetryAttempts)),
 		Completed:                    make([]IssueID, 0, len(s.completedOrder)),

--- a/internal/orchestrator/views.go
+++ b/internal/orchestrator/views.go
@@ -29,6 +29,10 @@ type RunningView struct {
 	WorkspacePath     string
 	Tokens            TokensView
 	CodexAppServerPID int
+	// AgentProvider / AgentModel expose the runtime and resolved model driving
+	// this claim (#977); empty until the runner reports them.
+	AgentProvider string
+	AgentModel    string
 }
 
 // TokensView mirrors the SPEC §13.7.2 per-issue `tokens` object: the

--- a/internal/orchestrator/workflow_reloader_test.go
+++ b/internal/orchestrator/workflow_reloader_test.go
@@ -228,6 +228,62 @@ func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsToDispatchCapacity(t *te
 	waitForBlockingDispatcherCount(t, dispatcher, 2)
 }
 
+// TestRuntimePollerAppliesReloadedAgentDefaultToStateSummary pins the #982
+// review fix: dispatch already reads the live snapshot's agent.default, so a hot
+// WORKFLOW.md reload that changes it must also refresh the /api/v1/state
+// top-summary provider — otherwise the dashboard reports the startup runner
+// while new runs launch with the reloaded default. Mutation: dropping the
+// PollOnce->UpdateAgentDefault wiring (or the snapshot field) leaves
+// AgentDefault at the reloaded miss and fails the second assertion.
+func TestRuntimePollerAppliesReloadedAgentDefaultToStateSummary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	path := writeWorkflowForReloadTest(t, "linear", 30000)
+	initial, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("load initial workflow: %v", err)
+	}
+	runtime, err := NewWorkflowRuntime(WorkflowRuntimeConfig{Initial: initial, Path: path, Source: workflow.SourceFile})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	trackerClient := &fakeIssueStateTracker{}
+	orch := New(NewOrchestratorState(30000, initial.Config.Agent.MaxConcurrentAgents), Deps{Dispatcher: &blockingDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+	poller := newRuntimePollerForTest(t, trackerClient, orch, runtime)
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("first poll: %v", err)
+	}
+	if got := snapshotAgentDefault(t, ctx, orch); got != "mock" {
+		t.Fatalf("AgentDefault after first poll = %q, want %q (startup default)", got, "mock")
+	}
+
+	writeWorkflowForReloadTestAt(t, path, "linear", 30000, "Todo", withReloadTestAgentDefault("codex-app-server"))
+	if err := runtime.ReloadOnce(ctx); err != nil {
+		t.Fatalf("reload workflow: %v", err)
+	}
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("second poll: %v", err)
+	}
+	if got := snapshotAgentDefault(t, ctx, orch); got != "codex-app-server" {
+		t.Fatalf("AgentDefault after reload = %q, want %q (reloaded default)", got, "codex-app-server")
+	}
+}
+
+func snapshotAgentDefault(t *testing.T, ctx context.Context, orch *Orchestrator) string {
+	t.Helper()
+	view, err := orch.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	return view.AgentDefault
+}
+
 func TestRuntimePollerAppliesReloadedMaxConcurrentAgentsByStateToDispatchCapacity(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -728,7 +784,7 @@ func writeWorkflowForReloadTest(t *testing.T, trackerKind string, pollIntervalMs
 
 func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIntervalMs int, activeState string, opts ...reloadWorkflowTestOption) {
 	t.Helper()
-	cfg := reloadWorkflowTestConfig{maxConcurrentAgents: 100, maxRetryBackoffMs: 300000}
+	cfg := reloadWorkflowTestConfig{maxConcurrentAgents: 100, maxRetryBackoffMs: 300000, agentDefault: "mock"}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -746,7 +802,7 @@ func writeWorkflowForReloadTestAt(t *testing.T, path, trackerKind string, pollIn
 		"polling:\n" +
 		"  interval_ms: " + itoaForReloadTest(pollIntervalMs) + "\n" +
 		"agent:\n" +
-		"  default: mock\n" +
+		"  default: " + cfg.agentDefault + "\n" +
 		"  max_concurrent_agents: " + itoaForReloadTest(cfg.maxConcurrentAgents) + "\n" +
 		"  max_retry_backoff_ms: " + itoaForReloadTest(cfg.maxRetryBackoffMs) + "\n" +
 		reloadTestMaxContinuationTurnsYAML(cfg.maxContinuationTurns) +
@@ -770,9 +826,16 @@ type reloadWorkflowTestConfig struct {
 	maxRetryBackoffMs          int
 	maxContinuationTurns       int
 	maxConcurrentAgentsByState map[string]int
+	agentDefault               string
 }
 
 type reloadWorkflowTestOption func(*reloadWorkflowTestConfig)
+
+func withReloadTestAgentDefault(d string) reloadWorkflowTestOption {
+	return func(cfg *reloadWorkflowTestConfig) {
+		cfg.agentDefault = d
+	}
+}
 
 func withReloadTestMaxConcurrentAgents(n int) reloadWorkflowTestOption {
 	return func(cfg *reloadWorkflowTestConfig) {

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -66,8 +66,13 @@ type WorkflowSnapshot struct {
 	MaxConcurrentAgentsByState map[string]int
 	MaxContinuationTurns       int
 	MaxRetryBackoff            time.Duration
-	Reconciliation             ReconciliationConfig
-	Fingerprint                string
+	// AgentDefault is the reloaded default runner/provider (`agent.default`).
+	// It rides the snapshot so a hot WORKFLOW.md reload that changes the default
+	// refreshes the /api/v1/state top-summary provider alongside dispatch, which
+	// already reads the live snapshot (#977 / #982 review).
+	AgentDefault   string
+	Reconciliation ReconciliationConfig
+	Fingerprint    string
 }
 
 func NewWorkflowRuntime(cfg WorkflowRuntimeConfig) (*WorkflowRuntime, error) {
@@ -217,6 +222,7 @@ func (r *WorkflowRuntime) snapshotFromWorkflow(wf *workflow.Workflow, fingerprin
 		MaxConcurrentAgentsByState: copyStateConcurrencyLimits(wf.Config.Agent.MaxConcurrentAgentsByState),
 		MaxContinuationTurns:       wf.Config.Agent.MaxContinuationTurns,
 		MaxRetryBackoff:            time.Duration(wf.Config.Agent.MaxRetryBackoffMs) * time.Millisecond,
+		AgentDefault:               wf.Config.Agent.Default,
 		Reconciliation:             reconcile,
 		Fingerprint:                fingerprint,
 	}

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -277,13 +277,20 @@ type appServerClient struct {
 	// consumer. readCh carries lines and is closed only by the reader; readErr is
 	// the sticky terminal scan error, published before close(readCh) so the close
 	// is the happens-before edge that lets the consumer read it race-free.
-	readCh              chan []byte
-	readErr             error
-	out                 io.Writer
-	nextID              int
-	codexAppServerPID   int
-	threadID            string
-	turnID              string
+	readCh            chan []byte
+	readErr           error
+	out               io.Writer
+	nextID            int
+	codexAppServerPID int
+	threadID          string
+	turnID            string
+	// agentModel is the resolved model identity the app-server reports in the
+	// thread/start response (ThreadStartResponse `model`). It is captured from
+	// the protocol — the authoritative source — rather than parsed out of the
+	// operator's free-text codex.command, and surfaces on /api/v1/state so an
+	// operator can tell which model produced a run (#977). Empty when the
+	// app-server omits it; the dashboard renders that as "unknown".
+	agentModel          string
 	lastMessage         string
 	runtimeEvents       []task.RuntimeEvent
 	runtimeEventSink    func(task.RuntimeEvent)
@@ -404,6 +411,10 @@ func (c *appServerClient) startThread(ctx context.Context, in RunInput) (string,
 		return "", fmt.Errorf("codex app-server thread/start: %w", err)
 	}
 	c.threadID = threadID
+	// model is a top-level ThreadStartResponse field; capture best-effort so a
+	// protocol that omits it leaves agentModel empty (rendered "unknown") rather
+	// than failing the handshake.
+	c.agentModel, _ = threadResult["model"].(string)
 	c.recordPhaseTransition(task.PhaseLaunchingAgentProcess, task.PhaseInitializingSession)
 	return threadID, nil
 }
@@ -560,6 +571,13 @@ func (c *appServerClient) recordFirstTurnStarted(threadID, turnID string) {
 		"session_id": threadID + "-" + turnID,
 		"thread_id":  threadID,
 		"turn_id":    turnID,
+		// agent_provider is the runtime/runner identity; for this client it is
+		// always the codex app-server. agent_model is the resolved model (may be
+		// empty). Both surface per-claim on /api/v1/state (#977).
+		"agent_provider": NameCodexAppServer,
+	}
+	if c.agentModel != "" {
+		payload["agent_model"] = c.agentModel
 	}
 	if c.codexAppServerPID > 0 {
 		payload["codex_app_server_pid"] = c.codexAppServerPID

--- a/internal/runner/codex_app_server_events.go
+++ b/internal/runner/codex_app_server_events.go
@@ -21,6 +21,36 @@ func (c *appServerClient) recordRuntimeMessage(event string, msg map[string]any)
 	}
 	c.recordRuntimeEvent(event, c.withRuntimeContext(payload))
 }
+
+// codexModelReroutedMethod is the SPEC §10.4 notification (ModelReroutedNotification
+// in the app-server schema) codex emits when it falls back mid-claim from one
+// model to another — e.g. the requested model is unavailable. Its toModel is the
+// model now actually running the turn.
+const codexModelReroutedMethod = "model/rerouted"
+
+// recordModelRerouted folds a model/rerouted notification's toModel into the
+// canonical agent_model the orchestrator reads (recordSessionFields). The
+// thread/start model is captured once on session_started; a later reroute must
+// update it, or /api/v1/state, the web dashboard, and the TUI keep reporting the
+// originally requested model for the rest of the claim — wrong in exactly the
+// fallback/reroute case #977 must surface. The raw notification is still recorded
+// as EventNotification (so the reason/from_model stay observable); agent_model is
+// added so the existing session-field fold tracks the new model without a second
+// event kind.
+func (c *appServerClient) recordModelRerouted(msg map[string]any) {
+	params, _ := msg["params"].(map[string]any)
+	if to, _ := params["toModel"].(string); strings.TrimSpace(to) != "" {
+		c.agentModel = strings.TrimSpace(to)
+	}
+	payload := normalizeRuntimePayload(params)
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	if c.agentModel != "" {
+		payload["agent_model"] = c.agentModel
+	}
+	c.recordRuntimeEvent(task.EventNotification, c.withRuntimeContext(payload))
+}
 func (c *appServerClient) recordOtherRuntimeMessage(msg map[string]any, raw []byte) {
 	payload := normalizeRuntimePayload(msg)
 	if payload == nil {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -472,6 +472,55 @@ for line in sys.stdin:
 	}
 }
 
+// TestCodexAppServerRunnerFoldsModelRerouteIntoAgentModel pins the #977/#982
+// reroute fix: when codex emits a model/rerouted notification mid-claim, the
+// runner re-surfaces the new toModel as the canonical agent_model so the
+// orchestrator updates the running row instead of keeping the thread/start
+// model for the rest of the claim. The fallback/reroute case is exactly where
+// the displayed model matters most.
+func TestCodexAppServerRunnerFoldsModelRerouteIntoAgentModel(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}, 'model': 'gpt-5.3-codex-spark'}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'model/rerouted', 'params': {'fromModel': 'gpt-5.3-codex-spark', 'toModel': 'gpt-5.3-codex', 'reason': 'fallback', 'threadId': 'thread-1', 'turnId': 'turn-1'}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'turnId': 'turn-1'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "model reroute capture")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := runtimeEventField(t, res.RuntimeEvents[0], "agent_model"); got != "gpt-5.3-codex-spark" {
+		t.Fatalf("session_started agent_model = %#v, want gpt-5.3-codex-spark (thread/start response)", got)
+	}
+	notifs := runtimeEventsNamed(res.RuntimeEvents, task.EventNotification)
+	if len(notifs) != 1 {
+		t.Fatalf("notification events = %d, want the reroute notification preserved; events=%#v", len(notifs), res.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, notifs[0], "agent_model"); got != "gpt-5.3-codex" {
+		t.Fatalf("reroute notification agent_model = %#v, want gpt-5.3-codex (toModel folded into canonical field)", got)
+	}
+	if got := runtimeEventField(t, notifs[0], "to_model"); got != "gpt-5.3-codex" {
+		t.Fatalf("reroute notification to_model = %#v, want raw toModel preserved alongside agent_model", got)
+	}
+	if got := runtimeEventField(t, notifs[0], "from_model"); got != "gpt-5.3-codex-spark" {
+		t.Fatalf("reroute notification from_model = %#v, want raw fromModel preserved for observability", got)
+	}
+	if got := runtimeEventField(t, notifs[0], "reason"); got != "fallback" {
+		t.Fatalf("reroute notification reason = %#v, want raw reason preserved for observability", got)
+	}
+}
+
 func TestCodexAppServerRunnerIgnoresDeprecationNoticeForSummary(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -406,6 +406,15 @@ for line in sys.stdin:
 	if n, _ := pid.(int); n <= 0 {
 		t.Fatalf("session_started codex_app_server_pid = %#v, want positive int (real codex subprocess PID)", pid)
 	}
+	// This thread/start response carries no `model`, so agent_model must be
+	// omitted (leaving RunningView.AgentModel empty → "unknown"), while the
+	// runtime/provider is always reported (#977).
+	if got := runtimeEventField(t, res.RuntimeEvents[0], "agent_provider"); got != NameCodexAppServer {
+		t.Fatalf("session_started agent_provider = %#v, want %q", got, NameCodexAppServer)
+	}
+	if got := runtimeEventField(t, res.RuntimeEvents[0], "agent_model"); got != nil {
+		t.Fatalf("session_started agent_model = %#v, want absent when thread/start omits model", got)
+	}
 	if res.RuntimeEvents[1].Event != task.EventTurnStarted {
 		t.Fatalf("second event = %q, want %q", res.RuntimeEvents[1].Event, task.EventTurnStarted)
 	}
@@ -423,6 +432,43 @@ for line in sys.stdin:
 	}
 	if got := runtimeEventField(t, res.RuntimeEvents[3], "turn_id"); got != "turn-1" {
 		t.Fatalf("turn_completed turn_id = %#v, want turn-1", got)
+	}
+}
+
+// TestCodexAppServerRunnerEmitsAgentModelOnSessionStarted pins the #977 capture
+// seam: the model resolved in the thread/start response surfaces on the
+// session_started event as agent_model, alongside agent_provider, so
+// /api/v1/state can show which model/runtime drove the claim. The model is read
+// from the protocol response, not parsed out of the operator's codex.command.
+func TestCodexAppServerRunnerEmitsAgentModelOnSessionStarted(t *testing.T) {
+	codexAppServerStubScript(t, `
+import json
+for line in sys.stdin:
+    msg=json.loads(line)
+    method=msg.get('method')
+    if method == 'initialize':
+        print(json.dumps({'id': msg['id'], 'result': {}}), flush=True)
+    elif method == 'thread/start':
+        print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}, 'model': 'gpt-5.3-codex-spark'}}), flush=True)
+    elif method == 'turn/start':
+        print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'turnId': 'turn-1'}}), flush=True)
+        break
+`)
+	wd := codexWorkdir(t, "agent model capture")
+
+	res, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.RuntimeEvents) == 0 || res.RuntimeEvents[0].Event != task.EventSessionStarted {
+		t.Fatalf("first event = %#v, want session_started", res.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, res.RuntimeEvents[0], "agent_model"); got != "gpt-5.3-codex-spark" {
+		t.Fatalf("session_started agent_model = %#v, want gpt-5.3-codex-spark (thread/start response)", got)
+	}
+	if got := runtimeEventField(t, res.RuntimeEvents[0], "agent_provider"); got != NameCodexAppServer {
+		t.Fatalf("session_started agent_provider = %#v, want %q", got, NameCodexAppServer)
 	}
 }
 

--- a/internal/runner/codex_app_server_turn.go
+++ b/internal/runner/codex_app_server_turn.go
@@ -199,6 +199,10 @@ func (c *appServerClient) handleTurnNotification(msg map[string]any, method stri
 	}
 	c.lastTerminal = time.Now()
 	c.handleNotification(msg)
+	if method == codexModelReroutedMethod {
+		c.recordModelRerouted(msg)
+		return false, nil
+	}
 	c.recordRuntimeMessage(task.EventNotification, msg)
 	return false, nil
 }

--- a/internal/stateapi/types.go
+++ b/internal/stateapi/types.go
@@ -22,7 +22,14 @@ type StateResponse struct {
 	// VCS-revision fallback, or "devel"), so a bug report can name the exact
 	// build. omitempty drops the key only when the resolved version is empty —
 	// which the "devel" default normally prevents (#796).
-	Version                    string         `json:"version,omitempty"`
+	Version string `json:"version,omitempty"`
+	// AgentDefault is the worker's configured default runner/provider
+	// (`agent.default`, e.g. "codex-app-server"), surfaced as the dashboard's
+	// top-summary worker default provider (#977). The model is resolved per-run
+	// by the agent (see Running.AgentModel), so there is no worker-default
+	// model. omitempty keeps older payloads (and the mock/unconfigured default)
+	// from forcing the key; the dashboard renders a missing value as "unknown".
+	AgentDefault               string         `json:"agent_default,omitempty"`
 	GeneratedAt                time.Time      `json:"generated_at"`
 	PollIntervalMs             int64          `json:"poll_interval_ms"`
 	MaxConcurrentAgents        int            `json:"max_concurrent_agents"`
@@ -117,6 +124,14 @@ type Running struct {
 	WorkspacePath     string        `json:"workspace_path,omitempty"`
 	Tokens            RunningTokens `json:"tokens"`
 	CodexAppServerPID int           `json:"codex_app_server_pid,omitempty"`
+	// AgentProvider is the runtime/runner driving this claim (e.g.
+	// "codex-app-server") and AgentModel the resolved model (e.g.
+	// "gpt-5.3-codex-spark"), so an operator can tell which model/runtime
+	// produced a run rather than reconstructing it from workflow files or logs
+	// (#977). omitempty drops the key when unknown; the dashboard renders a
+	// missing value as "unknown", so older payloads stay usable.
+	AgentProvider string `json:"agent_provider,omitempty"`
+	AgentModel    string `json:"agent_model,omitempty"`
 }
 
 // RunningTokens mirrors SPEC §13.7.2's per-running-row `tokens` object.


### PR DESCRIPTION
Closes #977

## Summary
- Surfaces which **agent model** and **runtime/provider** drove each active claim on `/api/v1/state` and the worker dashboards, so an operator can tell a project/harness defect apart from model-specific behavior without reconstructing it from workflow files or logs.
- The model identity is captured from the codex app-server **`thread/start` response** (`ThreadStartResponse.model`) — the authoritative structured source — **not** parsed out of the operator's free-text `codex.command` — and is kept current across a mid-claim **`model/rerouted`** fallback.

### What changed (one capture seam, end to end)
- **runner** (`internal/runner/codex_app_server.go`): capture the resolved `model` from the `thread/start` response and emit `agent_model` + `agent_provider` (always `codex-app-server` for this client) on the `session_started` event. `agent_model` is omitted when the response carries no model (best-effort; never fails the handshake).
- **runner — model reroute** (`internal/runner/codex_app_server_events.go`, `codex_app_server_turn.go`): codex can reroute mid-claim (`model/rerouted` notification, `ModelReroutedNotification.toModel` in the v0.141 schema) when the requested model is unavailable. `recordModelRerouted` re-surfaces the new `toModel` as the canonical `agent_model` on the recorded notification (raw `from_model`/`to_model`/`reason` preserved for observability), so the running row tracks the model actually running instead of the thread/start model for the rest of the claim — the fallback/reroute case is exactly where the displayed model matters most (#982 review fix).
- **orchestrator**: fold `agent_provider`/`agent_model` into `LiveSession` (sticky — later events don't clear it, but an explicit new value overwrites), surface per running claim through `RunningView` → `StateView`; expose the worker default provider (`agent.default`) on the snapshot. The existing `recordSessionFields` fold reads `agent_model` from any event, so the reroute event updates the row with no second event kind.
- **stateapi**: `Running.agent_provider`/`agent_model` + top-level `agent_default` (all `omitempty`; a missing value renders `unknown`, so older payloads stay usable).
- **dashboards**: web `RunningTable` gains a **Model** column + mobile detail line + a worker-default row; the **TUI** gains a **MODEL** column + a `Default:` header line. Missing model → `unknown`, never blank. Rate-limit fields stay in their own panel and are **not** treated as model identity.
- **reload consistency**: dispatch already reads the live workflow snapshot's `agent.default`, so `agent.default` rides `WorkflowSnapshot` and a new `UpdateAgentDefault` actor hook is called from `RuntimePoller.PollOnce` — a hot `WORKFLOW.md` reload that changes the default now refreshes the top-summary provider instead of reporting the startup runner.
- **capture/report**: `scripts/e2e-webtodo-capture.py` writes `/api/v1/state` verbatim and captures the TUI render, so the new fields are captured automatically — no script change needed.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference**.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue.

`/api/v1/state` is SPEC **§13.7.2**, an OPTIONAL observability extension that explicitly permits "*any additional tracked summary fields*" (and per-issue "*any information the implementation tracks that is useful for debugging*"). These are read-only projections of a fact the agent runtime already reports — no post-turn phase, no tracker write. The reroute fold is the runner translating codex's own protocol notification (`model/rerouted`) into the canonical `agent_model`, same seam as the `thread/start` model. Upstream `presenter.ex` has no model field, but the aiops `Running` DTO already extends upstream's (workspace_path, codex_app_server_pid, retry_attempt…); this stays within that envelope.

## Acceptance criteria (#977)
- [x] `/api/v1/state` exposes model/provider metadata for active claims when available (`agent_provider`/`agent_model`, also on `/api/v1/<issue>`).
- [x] Dashboard Running section displays the active model per claim (web Model column + TUI MODEL column).
- [x] Active model stays correct across a mid-claim `model/rerouted` fallback (runner folds `toModel` into `agent_model`; orchestrator overwrites the sticky thread/start model).
- [x] Top summary displays the worker default provider when a single default is configured (`agent_default` → web "default agent" row / TUI "Default:" line).
- [x] Missing model rendered explicitly as `unknown`, not blank (Go `orUnknown`, JS `|| 'unknown'`, `omitempty` wire).
- [x] Rate-limit fields remain in the Rate limits panel, not treated as model identity (unchanged).
- [x] Capture/report output includes the metadata (capture script dumps `/api/v1/state` + TUI verbatim).
- [x] Older/missing payloads still yield a usable dashboard (`omitempty` + `unknown` fallback).
- [ ] **Deferred — `agent_profile` (reviewer/maker workflow identity).** The issue flags its field names as illustrative; there is no existing per-run workflow-identity concept on the state surface, so a distinct `agent_profile`/`workflow_path` field is tracked as a follow-up (#983) rather than invented here. Provider (= runtime) + model satisfy the core "defect vs model-specific behavior" intent.

## Testing
- [x] `go test -race -covermode=atomic ./...` (locally: runner + orchestrator `-race` green; full suite on CI)
- [x] `go vet ./...` · `gofmt -l` clean · blocking golangci gate (`0 issues`) on touched packages
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] dashboard `npm test` (21 vitest pass) + `npm run build` (vite build OK)

### Mutation verification (committed artifact)
Every new test was mutation-checked against its production line — each fails when the matching production line is reverted:
- runner emit (session_started `agent_model`), orchestrator fold, cmd/worker mapping present + `omitempty` absent, TUI MODEL render + unknown fallback, web Model cell + default row + unknown fallback.
- **reroute (#982):** removing the `agent_model` injection in `recordModelRerouted`, removing the `model/rerouted` dispatch branch, breaking the orchestrator `agent_model` fold, and replacing `normalizeRuntimePayload` with an empty payload each fail `TestCodexAppServerRunnerFoldsModelRerouteIntoAgentModel` / `TestRecordRuntimeEventModelRerouteOverwritesAgentModel`.

## Pre-push review
**Round 2 — head `f9a9a1e` (reroute fix):**
- **Codex (`codex:codex-rescue`)** — MERGE-READY. 1 LOW (raw `from_model`/`reason` preservation not pinned in the runner test) — **fixed** (added assertions, mutation-verified).
- **Claude (`feature-dev:code-reviewer`)** — MERGE-READY. No findings above threshold; confirmed no double-record, nil/empty-`toModel` safety, §1 boundary, single canonical `agent_model` key, non-placebo tests.

**Round 1 — head `c5858ad`:**
- **Codex / Claude** — MERGE-READY on the base feature (TUI default-line label pinned; runner model-absent assertion added; `chromeWidth` comment refuted as correct).
- **`@codex review` (GitHub, head `1b0d423`)** — 1 P2: `agent_default` went stale after a hot `WORKFLOW.md` reload. **Fixed** at c5858ad (reload-consistency item) with `TestRuntimePollerAppliesReloadedAgentDefaultToStateSummary`.
- **`@codex review` (GitHub, head `c5858ad`)** — 1 P2: active model not updated on `model/rerouted`. **Fixed** at f9a9a1e (reroute fold above).
- **`@codex review` (GitHub, head `f9a9a1e`)** — the bytevane trigger returned **"You have reached your Codex usage limits for code reviews"** (06:04:52Z); the push-time auto-review left only an empty review object with no findings, which is not a reliable clean signal. Per the review protocol §4, GitHub Codex being externally usage-limited is compensated by the equivalent independent **dual subagent review on the f9a9a1e diff** (Codex-family `codex:codex-rescue` + Claude-family `feature-dev:code-reviewer`, both MERGE-READY above) plus green CI. Re-trigger `@codex review` once the bot's limit resets for a final GitHub pass before merge.

Both prior P2 threads are replied-to with the fix evidence and resolved; **0 unresolved non-outdated review threads**. CI is **green** on f9a9a1e (Go build/test, Docker, E2E, Security, PR metadata, PR title).

## PR diff size budget
- [ ] `within budget`
- [x] `size-gated: justified overage` — **15 production files / +186 −17 production LOC** (test files excluded). Over the ~12-file guideline (LOC well under ~300). The overage is correctness coverage for the #977 feature plus the two Codex-flagged correctness fixes (reload-consistency and the `model/rerouted` fold); splitting the reroute fix into its own PR would ship a feature that mis-reports the model on fallback, then a follow-up to correct it — not separable without losing atomicity with the feature it completes. **Needs human size-gate sign-off before merge.**

### Size gate
- [ ] `within budget` — diff fits the ~12-file / ~300-LOC review guideline
- [x] `size-gated: justified overage` — rationale: 15 production files (over the ~12-file guideline; +186 LOC, under ~300). Correctness coverage for #977 plus the two Codex-flagged fixes; not auto-mergeable, **needs human size-gate sign-off**.
- [ ] `size-gated: split recommended`

head: f9a9a1e
