### PR TITLE
feat(dashboard): expose per-run workflow profile on /api/v1/state

### DIFF
--- a/cmd/tui/layout_test.go
+++ b/cmd/tui/layout_test.go
@@ -145,6 +145,8 @@ func representativeState(now time.Time) *stateapi.StateResponse {
 			CodexAppServerPID: 12345,
 			AgentProvider:     "codex-app-server",
 			AgentModel:        "gpt-5.3-codex-spark",
+			WorkflowSource:    "file",
+			WorkflowPath:      "/srv/reviewer/WORKFLOW.md",
 		}},
 		Retrying: []stateapi.Retry{{
 			Identifier: "ENG-9999",
@@ -250,6 +252,68 @@ func TestRenderFrame_ShowsAgentModel(t *testing.T) {
 	// model as "unknown" — it is resolved per-run, not configured (#977).
 	if !strings.Contains(frame, "Default:    codex-app-server · model unknown") {
 		t.Fatalf("renderFrame missing worker default provider/model line: %q", frame)
+	}
+}
+
+// TestResolvedWorkflowLabel pins every branch of the #983 TUI profile summary:
+// path is the discriminator, source is the fallback when no path was resolved
+// (default workflow), an unreported row is skipped (continue, not break) so a
+// later profile is still found, identical profiles dedupe, and distinct
+// profiles (a hot reload mid-flight) are joined so the summary hides none.
+func TestResolvedWorkflowLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		rows []stateapi.Running
+		want string
+	}{
+		{"no rows", nil, "unknown"},
+		{"row present but no profile reported yet", []stateapi.Running{{Identifier: "ENG-1"}}, "unknown"},
+		{"path is the discriminator", []stateapi.Running{{WorkflowSource: "file", WorkflowPath: "/srv/reviewer/WORKFLOW.md"}}, "/srv/reviewer/WORKFLOW.md"},
+		{"falls back to source when path absent", []stateapi.Running{{WorkflowSource: "default"}}, "default"},
+		{"skips an unreported row and still finds a later profile", []stateapi.Running{{Identifier: "ENG-1"}, {WorkflowPath: "/srv/reviewer/WORKFLOW.md"}}, "/srv/reviewer/WORKFLOW.md"},
+		{"dedupes identical profiles", []stateapi.Running{{WorkflowPath: "/srv/maker/WORKFLOW.md"}, {WorkflowPath: "/srv/maker/WORKFLOW.md"}}, "/srv/maker/WORKFLOW.md"},
+		{"joins distinct profiles", []stateapi.Running{{WorkflowPath: "/srv/maker/WORKFLOW.md"}, {WorkflowPath: "/srv/reviewer/WORKFLOW.md"}}, "/srv/maker/WORKFLOW.md, /srv/reviewer/WORKFLOW.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolvedWorkflowLabel(tc.rows); got != tc.want {
+				t.Errorf("resolvedWorkflowLabel(%+v) = %q; want %q", tc.rows, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderFrame_ShowsWorkflowProfile pins #983 on the TUI surface: the header
+// summarizes which WORKFLOW.md (the profile) produced the active runs, sourced
+// from the per-claim workflow_path the worker reported.
+func TestRenderFrame_ShowsWorkflowProfile(t *testing.T) {
+	orig := liveTerminalWidth
+	t.Cleanup(func() { liveTerminalWidth = orig })
+	liveTerminalWidth = func() (int, bool) { return 160, true }
+
+	now := time.Now()
+	frame := visibleString(renderFrame(representativeState(now), nil, now, 0, "http://127.0.0.1:4001", 5*time.Second))
+
+	if !strings.Contains(frame, "Workflow:   /srv/reviewer/WORKFLOW.md") {
+		t.Fatalf("renderFrame missing resolved workflow profile line: %q", frame)
+	}
+}
+
+// TestRenderFrame_RendersUnknownWorkflowWhenAbsent pins the "unknown, never
+// blank" criterion for the profile: with no running claim reporting a workflow,
+// the header line renders "unknown" rather than an empty value (#983).
+func TestRenderFrame_RendersUnknownWorkflowWhenAbsent(t *testing.T) {
+	orig := liveTerminalWidth
+	t.Cleanup(func() { liveTerminalWidth = orig })
+	liveTerminalWidth = func() (int, bool) { return 160, true }
+
+	now := time.Now()
+	state := representativeState(now)
+	state.Running = nil
+	frame := visibleString(renderFrame(state, nil, now, 0, "http://127.0.0.1:4001", 5*time.Second))
+
+	if !strings.Contains(frame, "Workflow:   unknown") {
+		t.Fatalf("renderFrame should render an absent workflow profile as \"unknown\": %q", frame)
 	}
 }
 

--- a/cmd/tui/render.go
+++ b/cmd/tui/render.go
@@ -83,6 +83,13 @@ func renderFrame(state *stateapi.StateResponse, fetchErr error, now time.Time, t
 			colorize(orUnknown(state.AgentDefault), ansiCyan) +
 			colorize(" · model ", ansiGray) +
 			colorize("unknown", ansiGray),
+		// Which WORKFLOW.md (the profile, e.g. reviewer vs maker) produced the
+		// active runs (#983). /api/v1/state carries the profile per claim, but a
+		// single TUI views one worker — which resolves one workflow — so a
+		// per-row column would be identical cells stealing width from EVENT;
+		// summarize it once here, "unknown" until a run reports it.
+		colorize("│ Workflow:   ", ansiBold) +
+			colorize(resolvedWorkflowLabel(state.Running), ansiCyan),
 		colorize("│ Handoffs: ", ansiBold) +
 			colorize("completed "+formatCount(state.Counts.CompletedTotal), ansiGreen) +
 			colorize(" | ", ansiGray) +
@@ -227,6 +234,35 @@ func orUnknown(s string) string {
 		return "unknown"
 	}
 	return s
+}
+
+// resolvedWorkflowLabel summarizes which WORKFLOW.md produced the active runs
+// (#983). The path is the discriminator operators recognize; a default-workflow
+// run reports source=default with no path. The worker resolves one workflow, so
+// every running row carries the same profile and the first reported one is the
+// label; distinct profiles (a hot reload mid-flight) are joined so the summary
+// never hides one. Returns "unknown" until a run reports a profile.
+func resolvedWorkflowLabel(rows []stateapi.Running) string {
+	seen := map[string]struct{}{}
+	var labels []string
+	for _, r := range rows {
+		label := strings.TrimSpace(r.WorkflowPath)
+		if label == "" {
+			label = strings.TrimSpace(r.WorkflowSource)
+		}
+		if label == "" {
+			continue
+		}
+		if _, dup := seen[label]; dup {
+			continue
+		}
+		seen[label] = struct{}{}
+		labels = append(labels, label)
+	}
+	if len(labels) == 0 {
+		return "unknown"
+	}
+	return strings.Join(labels, ", ")
 }
 
 // formatRetryRow mirrors format_retry_summary/1.

--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -49,6 +49,15 @@ function sinceISO(iso) {
 function issueLabel(row) {
   return row.issue_identifier || row.issue_id || 'unknown issue';
 }
+
+// Which WORKFLOW.md (the profile, e.g. reviewer vs maker) produced a run (#983).
+// The path is the discriminator operators recognize; a default-workflow run
+// reports source=default with no path. A missing value renders "unknown" so the
+// cell is explicit diagnostic data, never blank (matching the model/provider
+// convention from #977).
+function workflowProfile(row) {
+  return row.workflow_path || row.workflow_source || 'unknown';
+}
 function detailPath(row) {
   const id = row.issue_identifier || row.issue_id;
   return id ? `/api/v1/${encodeURIComponent(id)}` : '/api/v1/state';
@@ -310,13 +319,14 @@ function RunningTable({ rows }) {
             // into the issue detail line for narrow layouts (#977).
             const model = r.agent_model || 'unknown';
             const provider = r.agent_provider || 'unknown';
+            const profile = workflowProfile(r);
             return (
             <tr key={r.issue_id}>
               <td className="issue-cell">
                 <div className="issue">
                   <IssueLink row={r} />
                   <div className="upd" style={{ maxWidth: '38ch' }} title={r.last_message}>{r.last_message}</div>
-                  <span className="wp">model {model} · {provider} · {r.workspace_path} · {r.session_id}{r.codex_app_server_pid ? ` · pid ${r.codex_app_server_pid}` : ''}</span>
+                  <span className="wp">model {model} · {provider} · workflow {profile} · {r.workspace_path} · {r.session_id}{r.codex_app_server_pid ? ` · pid ${r.codex_app_server_pid}` : ''}</span>
                 </div>
               </td>
               <td data-label="State"><Badge kind="running">{r.state}</Badge><div className="dim">turn {r.turn_count}</div></td>

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -29,6 +29,7 @@ function busyState(overrides = {}) {
         tokens: { input_tokens: 286400, output_tokens: 41200, total_tokens: 327600 },
         codex_app_server_pid: 48213,
         agent_provider: 'codex-app-server', agent_model: 'gpt-5.3-codex-spark',
+        workflow_source: 'file', workflow_path: '/srv/reviewer/WORKFLOW.md',
       },
     ],
     retrying: [
@@ -153,6 +154,45 @@ describe('Worker status dashboard', () => {
     const modelCell = container.querySelector('td[data-label="Model"]');
     expect(modelCell.textContent).toContain('unknown');
     expect(modelCell.textContent.trim()).not.toBe('');
+  });
+
+  it('shows which WORKFLOW.md (the profile) produced each running claim', async () => {
+    const { container } = render(<App />);
+    await screen.findByRole('link', { name: 'MT-614' });
+    const detail = container.querySelector('tbody .wp');
+    expect(detail).toBeTruthy();
+    expect(detail.textContent).toContain('workflow /srv/reviewer/WORKFLOW.md');
+  });
+
+  it('falls back to the workflow source when no path is reported (default workflow)', async () => {
+    current = busyState({
+      running: [{
+        issue_id: 'wf-default', issue_identifier: 'MT-983D', state: 'In Progress',
+        session_id: 'thread-x', turn_count: 1, last_event: 'turn_started',
+        started_at: iso(1000), last_event_at: iso(1000), workspace_path: '/tmp/w',
+        tokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+        workflow_source: 'default',
+      }],
+    });
+    const { container } = render(<App />);
+    await screen.findByRole('link', { name: 'MT-983D' });
+    const detail = container.querySelector('tbody .wp');
+    expect(detail.textContent).toContain('workflow default');
+  });
+
+  it('renders a missing workflow profile as "unknown", never blank', async () => {
+    current = busyState({
+      running: [{
+        issue_id: 'no-wf', issue_identifier: 'MT-983', state: 'In Progress',
+        session_id: 'thread-x', turn_count: 1, last_event: 'turn_started',
+        started_at: iso(1000), last_event_at: iso(1000), workspace_path: '/tmp/w',
+        tokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+      }],
+    });
+    const { container } = render(<App />);
+    await screen.findByRole('link', { name: 'MT-983' });
+    const detail = container.querySelector('tbody .wp');
+    expect(detail.textContent).toContain('workflow unknown');
   });
 
   it('renders Codex rate-limit windows as percent bars, not raw JSON', async () => {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -201,6 +201,65 @@ func TestApiStateSurfacesAgentModelMetadata(t *testing.T) {
 	stringKey(t, noDefault, "agent_default", "")
 }
 
+// TestApiStateSurfacesWorkflowProfileMetadata pins the #983 projection seam: a
+// running row carries workflow_source/workflow_path when the worker reported
+// them and omits each key (omitempty) otherwise — a default-workflow run keeps
+// workflow_source=default with no workflow_path. Mutation: dropping a field in
+// apiRunningFromView fails the "present" case; dropping omitempty fails "absent".
+func TestApiStateSurfacesWorkflowProfileMetadata(t *testing.T) {
+	stringKey := func(t *testing.T, raw []byte, key, want string) {
+		t.Helper()
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		v, ok := got[key]
+		if want == "" {
+			if ok {
+				t.Fatalf("%s present; want omitted (omitempty) in %s", key, raw)
+			}
+			return
+		}
+		if !ok {
+			t.Fatalf("%s missing; want %q in %s", key, want, raw)
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			t.Fatalf("%s unmarshal: %v", key, err)
+		}
+		if s != want {
+			t.Fatalf("%s = %q; want %q", key, s, want)
+		}
+	}
+
+	withFile, err := json.Marshal(apiRunningFromView(orchestrator.RunningView{
+		IssueID: "i1", Identifier: "MT-983",
+		WorkflowSource: "file", WorkflowPath: "/srv/reviewer/WORKFLOW.md",
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	stringKey(t, withFile, "workflow_source", "file")
+	stringKey(t, withFile, "workflow_path", "/srv/reviewer/WORKFLOW.md")
+
+	// Default workflow: source=default with no resolved file path.
+	withDefault, err := json.Marshal(apiRunningFromView(orchestrator.RunningView{
+		IssueID: "i1", Identifier: "MT-983", WorkflowSource: "default",
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	stringKey(t, withDefault, "workflow_source", "default")
+	stringKey(t, withDefault, "workflow_path", "")
+
+	none, err := json.Marshal(apiRunningFromView(orchestrator.RunningView{IssueID: "i1", Identifier: "MT-983"}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	stringKey(t, none, "workflow_source", "")
+	stringKey(t, none, "workflow_path", "")
+}
+
 func TestApiIssueFromViewFindsRecentTerminalEventByIdentifier(t *testing.T) {
 	view := orchestrator.StateView{
 		Completed: []orchestrator.IssueID{"linear-global-id"},

--- a/cmd/worker/runbook_drift_test.go
+++ b/cmd/worker/runbook_drift_test.go
@@ -125,6 +125,10 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 				TotalTokens:  2000,
 			},
 			CodexAppServerPID: 12345,
+			AgentProvider:     "codex-app-server",
+			AgentModel:        "gpt-5.3-codex-spark",
+			WorkflowSource:    "file",
+			WorkflowPath:      "/srv/reviewer/WORKFLOW.md",
 		}},
 		Blocked: []stateapi.Blocked{{
 			IssueID:           "issue-2",

--- a/cmd/worker/stateapi.go
+++ b/cmd/worker/stateapi.go
@@ -386,6 +386,8 @@ func apiRunningFromView(row orchestrator.RunningView) stateapi.Running {
 		CodexAppServerPID: row.CodexAppServerPID,
 		AgentProvider:     row.AgentProvider,
 		AgentModel:        row.AgentModel,
+		WorkflowSource:    row.WorkflowSource,
+		WorkflowPath:      row.WorkflowPath,
 	}
 }
 func apiRetryFromView(row orchestrator.RetryView) stateapi.Retry {

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -169,7 +169,11 @@ the shape here without updating the handler — or vice versa — fails the buil
         "output_tokens": 800,
         "total_tokens": 2000
       },
-      "codex_app_server_pid": 12345
+      "codex_app_server_pid": 12345,
+      "agent_provider": "codex-app-server",
+      "agent_model": "gpt-5.3-codex-spark",
+      "workflow_source": "file",
+      "workflow_path": "/srv/reviewer/WORKFLOW.md"
     }
   ],
   "blocked": [
@@ -313,6 +317,20 @@ Each entry in the `running` array follows SPEC §13.7.2:
   the active session.
 - `codex_app_server_pid` — OS pid of the Codex subprocess, populated from
   `session_started`; absent when the runner did not emit a pid.
+- `agent_provider` / `agent_model` — the runtime/runner (e.g.
+  `codex-app-server`) and the resolved model (e.g. `gpt-5.3-codex-spark`)
+  driving this claim, folded from `session_started` (and re-surfaced on a Codex
+  model reroute), so an operator can tell which model/runtime produced a run
+  (#977). Each is omitted until observed; the dashboard renders a missing value
+  as `unknown`.
+- `workflow_source` / `workflow_path` — which WORKFLOW.md (the profile, e.g.
+  reviewer vs maker) produced this run, folded from the worker's
+  `workflow_resolved` event (#983). `workflow_source` is one of `file`,
+  `prompt_only`, or `default`; `workflow_path` is absent when the run used the
+  built-in defaults (`source == default`). Lets an operator running maker +
+  reviewer workflows correlate a failure with the workflow that produced it,
+  not just the model. Each is omitted until observed; the dashboard renders a
+  missing value as `unknown`.
 
 ## Tracker pagination overflow
 

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -977,6 +977,39 @@ func TestRuntimeEventForwardingEmitterDropsNotificationFromOperatorLog(t *testin
 	}
 }
 
+// TestRuntimeEventForwardingEmitterForwardsWorkflowResolved pins the #983
+// wiring seam: workflow_resolved is not in the SPEC §10.4 runtimeEventKinds set,
+// so the forwarding emitter must forward it explicitly to RecordRuntimeEvent
+// (folding the profile into /api/v1/state) while still delegating it to the
+// base emitter so it stays persisted as a task event (it is not a notification).
+func TestRuntimeEventForwardingEmitterForwardsWorkflowResolved(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-WF-FWD")
+	defer cancel()
+
+	base := &recordingWorkerEmitter{}
+	emitter := runtimeEventForwardingEmitter{EventEmitter: base, Orchestrator: o, IssueID: issueID}
+	payload := map[string]any{"source": "file", "path": "/srv/reviewer/WORKFLOW.md"}
+	if err := emitter.AddEventWithPayload(context.Background(), "task-1", task.EventWorkflowResolved, task.EventWorkflowResolved, payload); err != nil {
+		t.Fatalf("AddEventWithPayload(workflow_resolved): %v", err)
+	}
+
+	// Still delegated to the operator log / task-event store.
+	if len(base.kinds) != 1 || base.kinds[0] != task.EventWorkflowResolved {
+		t.Fatalf("operator-log kinds = %v; want [%s] (workflow_resolved must stay a persisted task event)", base.kinds, task.EventWorkflowResolved)
+	}
+	// And folded into the live state surface.
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 1 {
+		t.Fatalf("running rows = %d, want 1", len(view.Running))
+	}
+	if got := view.Running[0].WorkflowPath; got != "/srv/reviewer/WORKFLOW.md" {
+		t.Fatalf("Running[0].WorkflowPath = %q; want %q (forwarding emitter must fold the profile)", got, "/srv/reviewer/WORKFLOW.md")
+	}
+}
+
 // TestRecordRuntimeEventPropagatesCodexAppServerPID pins the SPEC §4.1.6 /
 // §10.4 round-trip: a `session_started` event carrying
 // `codex_app_server_pid` populates RunningView.CodexAppServerPID so
@@ -1084,6 +1117,81 @@ func TestRecordRuntimeEventModelRerouteOverwritesAgentModel(t *testing.T) {
 	}
 	if got := view.Running[0].AgentProvider; got != "codex-app-server" {
 		t.Fatalf("RunningView.AgentProvider = %q, want %q (provider stays sticky across reroute)", got, "codex-app-server")
+	}
+}
+
+// TestRecordRuntimeEventPropagatesWorkflowProfile pins the #983 fold: a
+// `workflow_resolved` event carrying source/path populates RunningView so
+// `/api/v1/state` surfaces which WORKFLOW.md (the profile) produced a claim.
+func TestRecordRuntimeEventPropagatesWorkflowProfile(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-WF")
+	defer cancel()
+
+	if err := o.RecordRuntimeEvent(context.Background(), issueID, task.RuntimeEvent{
+		Event: task.EventWorkflowResolved,
+		Payload: map[string]any{
+			"source": "file",
+			"path":   "/srv/reviewer/WORKFLOW.md",
+		},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent: %v", err)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 1 {
+		t.Fatalf("running rows = %d, want 1", len(view.Running))
+	}
+	if got := view.Running[0].WorkflowSource; got != "file" {
+		t.Fatalf("RunningView.WorkflowSource = %q, want %q (workflow_resolved payload)", got, "file")
+	}
+	if got := view.Running[0].WorkflowPath; got != "/srv/reviewer/WORKFLOW.md" {
+		t.Fatalf("RunningView.WorkflowPath = %q, want %q (workflow_resolved payload)", got, "/srv/reviewer/WORKFLOW.md")
+	}
+}
+
+// TestRecordWorkflowResolvedDoesNotTouchLastEvent pins the #983 design choice
+// that workflow_resolved is a worker lifecycle event, not a SPEC §10.4 runtime
+// event: folding its profile must not land it in last_event/last_message or
+// reset the §8.5 stall clock (last_event_at). A later real runtime event still
+// owns those fields; the profile rides alongside without polluting them.
+func TestRecordWorkflowResolvedDoesNotTouchLastEvent(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-WF-LASTEVENT")
+	defer cancel()
+
+	// A real runtime event establishes last_event/last_message first.
+	if err := o.RecordRuntimeEvent(context.Background(), issueID, task.RuntimeEvent{
+		Event:   task.EventNotification,
+		Payload: map[string]any{"message": "Working on it..."},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent notification: %v", err)
+	}
+	// workflow_resolved arrives afterwards: it must not become the last_event.
+	if err := o.RecordRuntimeEvent(context.Background(), issueID, task.RuntimeEvent{
+		Event:   task.EventWorkflowResolved,
+		Payload: map[string]any{"source": "file", "path": "/srv/maker/WORKFLOW.md", "message": "workflow resolved"},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent workflow_resolved: %v", err)
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(view.Running) != 1 {
+		t.Fatalf("running rows = %d, want 1", len(view.Running))
+	}
+	row := view.Running[0]
+	if row.LastEvent != task.EventNotification {
+		t.Errorf("LastEvent = %q, want %q (workflow_resolved must not overwrite the last runtime event)", row.LastEvent, task.EventNotification)
+	}
+	if row.LastMessage != "Working on it..." {
+		t.Errorf("LastMessage = %q, want %q (workflow_resolved payload message must not leak into last_message)", row.LastMessage, "Working on it...")
+	}
+	if row.WorkflowPath != "/srv/maker/WORKFLOW.md" {
+		t.Errorf("WorkflowPath = %q, want %q (profile still folded)", row.WorkflowPath, "/srv/maker/WORKFLOW.md")
 	}
 }
 

--- a/internal/orchestrator/runtime_events.go
+++ b/internal/orchestrator/runtime_events.go
@@ -60,6 +60,14 @@ func (s *OrchestratorState) recordRuntimeEvent(run *RunningEntry, event task.Run
 	if s == nil || run == nil || event.Event == "" {
 		return
 	}
+	// workflow_resolved is a worker lifecycle event, not a SPEC §10.4 app-server
+	// runtime event: fold its profile identity but return before the general
+	// fold so it never lands in last_event/last_message or resets the §8.5 stall
+	// clock (LastEventAt) — the runner's session/turn events own those.
+	if event.Event == task.EventWorkflowResolved {
+		s.recordWorkflowFields(run, event)
+		return
+	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -140,6 +148,26 @@ func (s *OrchestratorState) recordInputRequiredFields(run *RunningEntry, event t
 	payload, _ := asStringMap(event.Payload)
 	if method, ok := stringField(payload, "method"); ok {
 		run.InputRequiredMethod = method
+	}
+}
+
+// recordWorkflowFields folds the workflow_resolved event's profile identity
+// (Resolution.Source / .Path) into the live session so /api/v1/state can report
+// which WORKFLOW.md produced a run (#983). The worker omits `path` from the
+// payload when Source == default, so WorkflowPath stays empty there while
+// WorkflowSource still records "default". The worker emits workflow_resolved
+// once per task (ResolveWorkflow), so this is effectively a single write;
+// last-write-wins is intentional should a future caller re-resolve mid-run.
+func (s *OrchestratorState) recordWorkflowFields(run *RunningEntry, event task.RuntimeEvent) {
+	payload, ok := asStringMap(event.Payload)
+	if !ok {
+		return
+	}
+	if source, ok := stringField(payload, "source"); ok {
+		run.Session.WorkflowSource = source
+	}
+	if path, ok := stringField(payload, "path"); ok {
+		run.Session.WorkflowPath = path
 	}
 }
 
@@ -391,7 +419,12 @@ func (e runtimeEventForwardingEmitter) AddEvent(ctx context.Context, taskID, typ
 }
 
 func (e runtimeEventForwardingEmitter) AddEventWithPayload(ctx context.Context, taskID, typ, msg string, payload any) error {
-	if _, ok := runtimeEventKinds[typ]; ok && e.Orchestrator != nil && e.IssueID != "" {
+	// workflow_resolved is forwarded explicitly rather than via runtimeEventKinds
+	// membership: that set is the SPEC §10.4 runner app-server vocabulary, and
+	// workflow_resolved is a worker lifecycle event. recordRuntimeEvent special-
+	// cases it to fold only the profile identity (#983), not the last-event fold.
+	_, isRuntimeEvent := runtimeEventKinds[typ]
+	if (isRuntimeEvent || typ == task.EventWorkflowResolved) && e.Orchestrator != nil && e.IssueID != "" {
 		_ = e.Orchestrator.RecordRuntimeEvent(ctx, e.IssueID, task.RuntimeEvent{Event: typ, Payload: payload})
 	}
 	// The generic per-notification stream (SPEC §10.4 agent-driven notifications:

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -61,6 +61,16 @@ type LiveSession struct {
 	// "unknown".
 	AgentProvider string
 	AgentModel    string
+	// WorkflowSource / WorkflowPath identify which WORKFLOW.md (the "profile",
+	// e.g. reviewer vs maker) produced this run, folded from the worker's
+	// `workflow_resolved` event (Resolution.Source / .Path). Surfacing them per
+	// claim lets an operator running maker + reviewer workflows correlate a
+	// failure with the workflow that produced it, not just the model (#983).
+	// WorkflowSource is one of file / prompt_only / default; WorkflowPath is
+	// empty when Source == default (built-in defaults, no file). Empty until the
+	// event is observed; the dashboard renders a missing value as "unknown".
+	WorkflowSource string
+	WorkflowPath   string
 }
 
 // RateLimitSnapshot is the latest SPEC §13.3 rate-limits payload emitted by

--- a/internal/orchestrator/state_snapshot.go
+++ b/internal/orchestrator/state_snapshot.go
@@ -99,6 +99,8 @@ func (s *OrchestratorState) snapshotRunningViews() []RunningView {
 			CodexAppServerPID: r.Session.CodexAppServerPID,
 			AgentProvider:     r.Session.AgentProvider,
 			AgentModel:        r.Session.AgentModel,
+			WorkflowSource:    r.Session.WorkflowSource,
+			WorkflowPath:      r.Session.WorkflowPath,
 		})
 	}
 	return rows

--- a/internal/orchestrator/views.go
+++ b/internal/orchestrator/views.go
@@ -33,6 +33,11 @@ type RunningView struct {
 	// this claim (#977); empty until the runner reports them.
 	AgentProvider string
 	AgentModel    string
+	// WorkflowSource / WorkflowPath expose which WORKFLOW.md (the profile, e.g.
+	// reviewer vs maker) produced this claim (#983); empty until the worker's
+	// workflow_resolved event is observed.
+	WorkflowSource string
+	WorkflowPath   string
 }
 
 // TokensView mirrors the SPEC §13.7.2 per-issue `tokens` object: the

--- a/internal/stateapi/types.go
+++ b/internal/stateapi/types.go
@@ -132,6 +132,15 @@ type Running struct {
 	// missing value as "unknown", so older payloads stay usable.
 	AgentProvider string `json:"agent_provider,omitempty"`
 	AgentModel    string `json:"agent_model,omitempty"`
+	// WorkflowSource / WorkflowPath identify which WORKFLOW.md (the profile, e.g.
+	// reviewer vs maker) produced this run, so an operator running maker +
+	// reviewer workflows can correlate a failure with the workflow that produced
+	// it, not just the model (#983). WorkflowSource is one of file / prompt_only
+	// / default; WorkflowPath is absent when the run used built-in defaults
+	// (Source == default). omitempty drops each key when unknown; the dashboard
+	// renders a missing value as "unknown", so older payloads stay usable.
+	WorkflowSource string `json:"workflow_source,omitempty"`
+	WorkflowPath   string `json:"workflow_path,omitempty"`
 }
 
 // RunningTokens mirrors SPEC §13.7.2's per-running-row `tokens` object.


### PR DESCRIPTION
## What

Surface which WORKFLOW.md (the "profile", e.g. reviewer vs maker) produced each active claim on `/api/v1/state` and the web + TUI dashboards, so an operator running maker + reviewer workflows can correlate a failure with the workflow that produced it — not just the model/provider shipped in #982. Follow-up to #977/#982.

`Closes #983`

## How

Folds the worker's existing `workflow_resolved` task event (`workflow.Resolution` `source`/`path`) into the orchestrator's live session, mirroring #982's session-fold pattern:

- **orchestrator**: `LiveSession.WorkflowSource/WorkflowPath` ← `workflow_resolved`, projected `RunningView → stateapi.Running`. The event is forwarded to `RecordRuntimeEvent` **explicitly** (an extra clause in `runtimeEventForwardingEmitter`), **not** by adding it to `task.RuntimeEvents()` — that set is the SPEC §10.4 runner app-server vocabulary, and `workflow_resolved` is a worker lifecycle event. `recordRuntimeEvent` special-cases it: folds only the profile and returns **before** the general fold, so it never lands in `last_event`/`last_message` or resets the §8.5 stall clock (`last_event_at`).
- **stateapi**: `Running.workflow_source`/`workflow_path` (both `omitempty`; a missing value renders "unknown"). SPEC §13.7.2 permits added summary fields — pure read-only observability, **no** worker phase/gate/tracker write.
- **web dashboard**: per-claim detail line gains `workflow <path|source|unknown>` alongside model/provider.
- **TUI**: a worker-level `Workflow:` header line summarizing the resolved workflow from the running rows. A single TUI views one worker, which resolves one workflow, so a per-row column would be N identical cells stealing width from the EVENT column; the per-claim API field remains the source of truth (and serves cross-worker aggregation).
- **docs/tests**: documents the 4 keys in `runtime-status.md` and pins them in the drift synthetic; also closes a #982 gap where `agent_provider`/`agent_model` were surfaced but never documented or set in the drift synthetic (so the drift detector silently skipped them).

## Acceptance criteria

- [x] `workflow_source`/`workflow_path` exposed per active claim on `/api/v1/state` (RunningEntry → RunningView → stateapi.Running), named from the existing `Resolution` domain (not the illustrative `agent_profile`).
- [x] Rendered on web (per-claim detail line) and TUI (worker-level header), "unknown" when unreported — never blank.
- [x] Default-workflow run (`source=default`, no path) distinguishable from not-yet-resolved.
- [x] No new worker/orchestrator phase, gate, or tracker write (boundary principle 6).

## Verification

```
gofmt -l … (clean) · go vet ./… (clean) · golangci-lint v2.12.2 (0 issues)
go test -race ./internal/orchestrator/… ./cmd/worker/… ./cmd/tui/… (pass)
go build ./cmd/worker ./cmd/tui (ok) · web vitest (24 pass)
```
Full `go test -race ./...` green except `./scripts` `TestTodoSmokeScriptRecordsDraftPRWhenWorkerFails`, which times out under full `-race` load (10s budget) and passes in isolation (5.1s); the diff touches no `scripts/` file (known timing flake, not a regression).

## Mutation verification (against the committed artifact)

Every new production seam was broken and the matching test confirmed to FAIL, then restored: forwarding clause, the `recordRuntimeEvent` early-return (last_event isolation), `recordWorkflowFields` fold, snapshot projection, `apiRunningFromView` mapping, TUI `resolvedWorkflowLabel` (all branches: path-preference, source-fallback, continue-not-break, dedup, join, unknown), and the web `workflowProfile` helper.

## Review

Pre-push dual review (Codex-family + Claude-family subagents) both confirmed the production code correct and the observability boundary clean, and flagged one class: the `WorkflowSource`-only fallback arm + dedup/join branch of `resolvedWorkflowLabel`/`workflowProfile` weren't pinned by render tests. Closed structurally with a comprehensive mutation-tight table test (`TestResolvedWorkflowLabel`) + a web fallback case; production code unchanged (one clarifying comment added). Declined the lifecycle-ordering hardening test: the `run != nil` no-op is a general property of all runtime-event folds (the Claude reviewer separately confirmed nil/ordering safety), so a contrived race test would be a placebo.

### Size gate
- [x] `within budget` — production diff is 8 files / ~107 LOC (mostly doc-comments); tests + docs excluded.

https://claude.ai/code/session_01EkiVcnH5eXSxZfz3wnmEc5

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This PR adds only SPEC §13.7.2-permitted per-claim observability summary fields (`workflow_source`/`workflow_path`), folded from an event the worker already emits — no new Config key, phase, gate, artifact, or tracker write.

## `@codex review` status
The GitHub Codex bot returned **"reached your Codex usage limits for code reviews"** on this head (`c5fbd13`) — externally unavailable, not a clean/finding signal. Per the review protocol §4, this is compensated by the equivalent independent **dual subagent review** run pre-push (Codex-family + Claude-family), both of which confirmed the production code correct and the observability boundary clean; their only findings (test-coverage gaps in the profile-label fallback/dedup/join arms) were closed with the mutation-verified `TestResolvedWorkflowLabel` table test + a web fallback case. The current head's production code is unchanged from the reviewed head (`e6e0842`) apart from one clarifying comment; the amend was test-only. No unresolved, non-outdated review threads.
