### PR TITLE
fix(workflow): claim GitHub dogfood PR before long gates

### DIFF
--- a/examples/github-local-WORKFLOW.md
+++ b/examples/github-local-WORKFLOW.md
@@ -83,25 +83,36 @@ Hard requirements:
 - Read AGENTS.md, README.md, the issue text, and the relevant SPEC/reference paths before design-sensitive changes.
 - Use a focused failing test before production code changes when adding behavior or fixing bugs.
 - Keep changes small enough for review. Respect the configured policy limits unless the issue explicitly requires a larger change.
-- Run the configured verify commands before pushing.
-- Before opening or updating a PR, run two independent local reviews of the
-  final diff: Codex review and Claude Code review. Both are mandatory gates.
+- Before opening or updating a PR, check for an existing open PR that closes the
+  assigned issue (`gh pr list --state open --search "#<issue-number>"` plus a
+  direct PR-body/linked-issue check). If one exists, update and reuse that PR
+  and branch; do not open a duplicate PR for the same issue.
+- After the first meaningful commit, push the branch and open or update a draft
+  PR with an explicit issue claim before long verification or review gates. The
+  draft PR body may mark local verification, local reviews, GitHub Codex review,
+  CI, and merge readiness as pending; update the same PR body after each gate
+  completes.
+- Open or update a draft PR with a body that names the issue, summarizes
+  pending or completed tests, and records pending or completed local review
+  results.
+- The PR body must include an explicit issue claim line for the assigned GitHub
+  issue, preferably `Closes #<issue-number>`; `Issue #<issue-number>` is also
+  recognized by the local tracker as an active PR claim. Do not use only casual
+  references such as `See also #...` for the assigned issue.
+- Run the configured verify commands after the draft PR claim exists and before
+  marking the PR ready or mergeable.
+- Before marking the PR ready or mergeable, run two independent local reviews
+  of the final diff: Codex review and Claude Code review. Both are mandatory
+  gates.
 - Follow `docs/runbooks/pr-review-merge-protocol.md` for subagent-first reviewer
   routing, machine-validated review shape, Codex/Claude family coverage, and CLI
   fallback conditions. Do not inline reviewer command mechanics here.
 - Treat non-JSON output, command failure, or any non-empty
   `blocking_findings` list from either local reviewer as blocking. Fix findings
   with tests before push.
-- Before opening a PR, check for an existing open PR that closes the assigned
-  issue (`gh pr list --state open --search "#<issue-number>"` plus a direct
-  PR-body/linked-issue check). If one exists, update and reuse that PR and
-  branch; do not open a duplicate PR for the same issue.
-- Open or update a draft PR with a body that names the issue, summarizes tests,
-  and records both local review results.
-- The PR body must include an explicit issue claim line for the assigned GitHub
-  issue, preferably `Closes #<issue-number>`; `Issue #<issue-number>` is also
-  recognized by the local tracker as an active PR claim. Do not use only casual
-  references such as `See also #...` for the assigned issue.
+- Before marking the PR ready or mergeable, update the PR body with final
+  verification and local review evidence so the follow-through gate has a fresh
+  ledger for the current head.
 - Do not post ad hoc `@codex review` comments yourself. Leave the PR for the
   follow-through automation, which posts or reuses a current-head-bound GitHub
   Codex review trigger and merges only after CI and review gates are clean.

--- a/scripts/workflow_examples_test.go
+++ b/scripts/workflow_examples_test.go
@@ -22,6 +22,32 @@ func TestGitHubLocalWorkflowRunsUncachedFileSizeGate(t *testing.T) {
 	}
 }
 
+func TestGitHubLocalWorkflowClaimsPRBeforeLongGates(t *testing.T) {
+	body, err := os.ReadFile("../examples/github-local-WORKFLOW.md")
+	if err != nil {
+		t.Fatalf("ReadFile(github-local-WORKFLOW.md): %v", err)
+	}
+	text := string(body)
+	claimGate := "After the first meaningful commit"
+	verifyGate := "Run the configured verify commands"
+	reviewGate := "run two independent local reviews"
+	finalGate := "Before marking the PR ready or mergeable"
+	reuseGate := "check for an existing open PR"
+
+	for _, want := range []string{claimGate, verifyGate, reviewGate, finalGate, reuseGate, "Open or update a draft PR"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("github-local-WORKFLOW.md missing %q", want)
+		}
+	}
+	claimIndex := strings.Index(text, claimGate)
+	if verifyIndex := strings.Index(text, verifyGate); claimIndex > verifyIndex {
+		t.Fatalf("github-local-WORKFLOW.md claim gate index = %d; want before verify gate index %d", claimIndex, verifyIndex)
+	}
+	if reviewIndex := strings.Index(text, reviewGate); claimIndex > reviewIndex {
+		t.Fatalf("github-local-WORKFLOW.md claim gate index = %d; want before review gate index %d", claimIndex, reviewIndex)
+	}
+}
+
 func TestWebTodoWorkflowsDocumentReworkConvergence(t *testing.T) {
 	for _, tc := range []struct {
 		path string


### PR DESCRIPTION
Closes #994

## Summary
- Updates `examples/github-local-WORKFLOW.md` so GitHub dogfood agents create or reuse a draft PR claim after the first meaningful commit, before long verification/review gates.
- Keeps final local verification, local reviews, GitHub Codex/follow-through, CI, and merge gates intact before ready/merge.
- Adds a script-level prompt-order guard so the workflow cannot regress back to long-gates-before-claim ordering.

## Acceptance criteria
- [x] Workflow tells the agent to push a branch and open/update a draft PR with an explicit `Closes #N` / `Issue #N` claim after the first meaningful commit and before long local verification/review gates.
- [x] Draft PR body may mark checks/reviews as pending and must be updated after each gate.
- [x] Final local verification, Codex review, Claude review, GitHub Codex review, CI, and merge gates stay intact before ready/merge.
- [x] Retries/continuations detect and reuse an existing claimed PR/branch instead of creating duplicates.
- [x] Lightweight guard test prevents prompt ordering regression.
- [x] No worker-side PR creation or tracker mutation added.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run 'TestGitHubLocalWorkflowClaimsPRBeforeLongGates' -count=1 ./scripts` failed before the workflow change with missing early-claim text.
- [x] `go test -run 'TestGitHubLocalWorkflow' -count=1 ./scripts`
- [x] Mutation verification against committed `b2c325b`: replacing `After the first meaningful commit` made `TestGitHubLocalWorkflowClaimsPRBeforeLongGates` fail; restored from HEAD and confirmed no committed-file diff.
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'` (first full run hit a hook-timeout timing failure; isolated rerun of the failing test passed, then full suite passed)
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

## Review and merge ledger
- Head SHA: `b2c325bff0de7ba7c6f78e381d3453bd60ab67f9`
- Local/AI code review: skipped by explicit operator instruction for this batch because current Claude Code quota is unavailable.
- GitHub CI: passed on head `b2c325bff0de7ba7c6f78e381d3453bd60ab67f9`.
- Review threads: GraphQL audit found `0` unresolved non-outdated threads and no review threads.
- PR Metadata after final body update: pending rerun.
- Deferrals: none.
