### PR TITLE
fix(runner): pin codex app-server multi-agent mode

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -528,6 +528,7 @@ func buildThreadStartParams(in RunInput, approvalPolicy any) map[string]any {
 		"sandbox":        in.Workflow.Config.Codex.ThreadSandbox,
 		"cwd":            in.Workdir,
 		"dynamicTools":   appServerDynamicToolSpecs(in.Workflow.Config),
+		"multiAgentMode": "none",
 	}
 }
 

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -320,6 +320,15 @@ func TestBuildThreadStartParamsDisablesInheritedCodexAppTools(t *testing.T) {
 	}
 }
 
+func TestBuildThreadStartParamsPinsMultiAgentMode(t *testing.T) {
+	in := appServerInput(codexWorkdir(t, "pin multi-agent mode"))
+	payload := buildThreadStartParams(in, in.Workflow.Config.Codex.ApprovalPolicy)
+
+	if got := payload["multiAgentMode"]; got != "none" {
+		t.Fatalf("thread/start multiAgentMode = %#v; want none to preserve WORKFLOW-only instructions", got)
+	}
+}
+
 func TestCodexAppServerRunnerDoesNotInheritWorkerSecretsByDefault(t *testing.T) {
 	codexAppServerEnvStubScript(t, `
 import json


### PR DESCRIPTION
## Summary
- Pin `thread/start` `multiAgentMode` to `none` for Codex app-server runs so upgrading to 0.142.0 does not inherit the new `explicitRequestOnly` default.
- Add a focused runner test that fails if the field is omitted or changed away from `none`.

Closes #998

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level WORKFLOW.md/Config key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream Elixir reference — cite the matching file and line from the openai/symphony Elixir tree in the body below.
- [ ] Adds one, tracked as a DEVIATIONS.md row + an area:spec-alignment issue, updated in this PR.

## Acceptance
- [x] `buildThreadStartParams` sends an explicit `multiAgentMode` value that preserves the existing WORKFLOW-only instruction contract by avoiding injected multi-agent delegation instructions.
- [x] A focused runner test fails if the field is omitted or changed from the intended value.
- [x] The Codex app-server schema contract test still validates the `thread/start` payload against the vendored 0.142.0 schema.
- [x] No new workflow config key, worker phase, tracker mutation, or orchestrator-owned PR/status behavior is added.

## Review feedback
Addresses the unresolved Codex review thread from PR #997: https://github.com/xrf9268-hue/aiops-platform/pull/997#discussion_r3472558667

## Size
within budget

## Tests
- `go test ./internal/runner -run 'TestBuildThreadStartParamsPinsMultiAgentMode|TestBuildThreadStartParamsDisablesInheritedCodexAppTools|TestCodexAppServerThreadStartPayloadMatchesSchema' -count=1`
- `go test ./internal/runner -count=1`
- Mutation verification: changed committed `multiAgentMode` from `none` to `explicitRequestOnly`; `TestBuildThreadStartParamsPinsMultiAgentMode` failed, then restored from `HEAD`.
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/tui`
