### PR TITLE
test(e2e): pass dashboard urls to doctor preflight

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -68,7 +68,7 @@ func parseDoctorArgs(args []string) (doctor.Options, error) {
 	fs := flag.NewFlagSet("worker --doctor", flag.ContinueOnError)
 	mode := fs.String("mode", "mock", "preflight depth: mock or real")
 	deploy := fs.String("deploy", "docker", "deployment target for remediation hints and Docker checks: binary or docker")
-	dashboardURL := fs.String("dashboard-url", "", "optional worker dashboard base URL to verify /api/v1/state auth")
+	dashboardURL := fs.String("dashboard-url", "", "optional worker dashboard base URL to verify /livez, /readyz, and /api/v1/state")
 	goTestDir := fs.String("go-test-dir", "", "repository module root for real-mode targeted go test")
 	githubIssue := fs.Int("github-issue", 0, "optional GitHub issue number for agent-environment gh and git push preflight")
 	githubRepo := fs.String("github-repo", "", "optional owner/name or clone_url repo for --github-issue when a workflow configures multiple GitHub repos (use clone_url to disambiguate one owner/name routed to multiple clone URLs)")

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -127,8 +127,8 @@ Expected output is action-oriented:
 PASS Linear auth: API key authenticated and project is visible
 FAIL Codex auth: ...
      Fix: Run codex --login in the same CODEX_HOME/container user context.
-WARN Dashboard state API: not checked; no dashboard URL supplied
-     Fix: Pass --dashboard-url while the worker is running to verify state API auth.
+WARN Dashboard endpoints: not checked; no dashboard URL supplied
+     Fix: Pass --dashboard-url while the worker is running to verify /livez, /readyz, and /api/v1/state.
 ```
 
 `--mode=mock` fails on missing workflow, missing `repo.clone_url`, missing

--- a/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
@@ -130,8 +130,9 @@ Required labels:
 - `aiops/canceled`
 - `aiops/stress`
 
-Create issues from `issues/*.md`. Label issues 1-12 with `aiops/todo`.
-Keep control issues staged:
+Create issues from `issues/*.md` without `aiops/*` state labels. Keep product
+issues inactive until the dashboard doctor passes; after that gate, activate
+issues 1-12 by adding `aiops/todo`. Keep control issues staged:
 
 - Issue 13: no `aiops/*` label.
 - Issue 14: add `aiops/todo` only when testing cancellation.
@@ -189,7 +190,27 @@ AIOPS_SERVER_HOST=127.0.0.1 \
   2>&1 | tee "$AIOPS_CROWDRUNNER_RUN_ROOT/logs/reviewer-worker.log"
 ```
 
-Trigger a poll:
+After both workers are listening, validate the dashboard endpoints before
+activating product issues:
+
+```bash
+AIOPS_WORKFLOW_PATH="$AIOPS_CROWDRUNNER_MAKER_WORKFLOW" \
+AIOPS_MIRROR_ROOT="$AIOPS_CROWDRUNNER_MAKER_MIRROR_ROOT" \
+  "$AIOPS_CROWDRUNNER_WORKER_BIN" --doctor --deploy=binary --mode=real \
+  --dashboard-url "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL" \
+  "$AIOPS_CROWDRUNNER_MAKER_WORKFLOW" \
+  | tee "$AIOPS_CROWDRUNNER_RUN_ROOT/artifacts/maker-dashboard-doctor.log"
+
+AIOPS_WORKFLOW_PATH="$AIOPS_CROWDRUNNER_REVIEWER_WORKFLOW" \
+AIOPS_MIRROR_ROOT="$AIOPS_CROWDRUNNER_REVIEWER_MIRROR_ROOT" \
+  "$AIOPS_CROWDRUNNER_WORKER_BIN" --doctor --deploy=binary --mode=real \
+  --dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL" \
+  "$AIOPS_CROWDRUNNER_REVIEWER_WORKFLOW" \
+  | tee "$AIOPS_CROWDRUNNER_RUN_ROOT/artifacts/reviewer-dashboard-doctor.log"
+```
+
+After both dashboard doctors pass, add `aiops/todo` to issues 1-12. Use the
+Gitea UI or API, then trigger a work poll:
 
 ```bash
 curl -fsS -X POST -H 'X-AIOPS-Refresh: true' \

--- a/docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md
@@ -142,10 +142,12 @@ Gitea boot method can vary by host, but the target state should be stable:
 - default branch: `main`
 - labels: `aiops/todo`, `aiops/in-progress`, `aiops/human-review`,
   `aiops/rework`, `aiops/done`, `aiops/canceled`
-- issues: every file in `$AIOPS_WEBTODO_RUN_ROOT/issues/`
+- issues: every file in `$AIOPS_WEBTODO_RUN_ROOT/issues/`, initially without
+  `aiops/*` state labels
 
-Seed the first ten primary issues as ready work by adding `aiops/todo`.
-Keep control issues unlabeled until their phase:
+Keep every issue inactive until the dashboard doctor passes. After that gate,
+activate the first ten primary issues by adding `aiops/todo`. Keep control
+issues unlabeled until their phase:
 
 - `CONTROL no-ready issue must stay idle`: no `aiops/*` label.
 - `CONTROL cancel running codex issue`: add `aiops/todo` only when testing
@@ -212,7 +214,27 @@ AIOPS_SERVER_HOST=127.0.0.1 \
   2>&1 | tee "$AIOPS_WEBTODO_RUN_ROOT/logs/reviewer-worker.log"
 ```
 
-In another terminal, trigger the first poll:
+After both workers are listening, validate the dashboard endpoints before you
+activate issues:
+
+```bash
+AIOPS_WORKFLOW_PATH="$AIOPS_WEBTODO_MAKER_WORKFLOW" \
+AIOPS_MIRROR_ROOT="$AIOPS_WEBTODO_MAKER_MIRROR_ROOT" \
+  "$AIOPS_WEBTODO_WORKER_BIN" --doctor --deploy=binary --mode=real \
+  --dashboard-url "$AIOPS_WEBTODO_MAKER_DASHBOARD_URL" \
+  "$AIOPS_WEBTODO_MAKER_WORKFLOW" \
+  | tee "$AIOPS_WEBTODO_RUN_ROOT/artifacts/maker-dashboard-doctor.log"
+
+AIOPS_WORKFLOW_PATH="$AIOPS_WEBTODO_REVIEWER_WORKFLOW" \
+AIOPS_MIRROR_ROOT="$AIOPS_WEBTODO_REVIEWER_MIRROR_ROOT" \
+  "$AIOPS_WEBTODO_WORKER_BIN" --doctor --deploy=binary --mode=real \
+  --dashboard-url "$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL" \
+  "$AIOPS_WEBTODO_REVIEWER_WORKFLOW" \
+  | tee "$AIOPS_WEBTODO_RUN_ROOT/artifacts/reviewer-dashboard-doctor.log"
+```
+
+After both dashboard doctors pass, add `aiops/todo` to issues 1-10. Use the
+Gitea UI or API, then trigger a work poll:
 
 ```bash
 curl -fsS -X POST -H 'X-AIOPS-Refresh: true' \

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -27,6 +27,7 @@ const (
 	aiopsModulePath       = "github.com/xrf9268-hue/aiops-platform"
 	defaultCommandTimeout = 10 * time.Second
 	goTestProbeTimeout    = 2 * time.Minute
+	dashboardReadyPoll    = 250 * time.Millisecond
 )
 
 type Check struct {
@@ -292,29 +293,97 @@ func (r *reportBuilder) checkDockerCompose(ctx context.Context) {
 }
 
 func (r *reportBuilder) checkDashboard(ctx context.Context) {
-	if strings.TrimSpace(r.opts.DashboardURL) == "" {
-		r.warn("Dashboard state API", "not checked; no dashboard URL supplied", "Pass --dashboard-url while the worker is running to verify state API auth.")
+	baseURL := strings.TrimRight(strings.TrimSpace(r.opts.DashboardURL), "/")
+	if baseURL == "" {
+		r.warn("Dashboard endpoints", "not checked; no dashboard URL supplied", "Pass --dashboard-url while the worker is running to verify /livez, /readyz, and /api/v1/state.")
 		return
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(r.opts.DashboardURL, "/")+"/api/v1/state", nil)
+	for _, endpoint := range dashboardEndpoints {
+		r.checkDashboardEndpoint(ctx, baseURL, endpoint)
+	}
+}
+
+type dashboardEndpoint struct {
+	name string
+	path string
+	fix  string
+}
+
+type dashboardHTTPResult struct {
+	status     string
+	statusCode int
+	err        error
+	fix        string
+}
+
+var dashboardEndpoints = []dashboardEndpoint{
+	{name: "Dashboard /livez", path: "/livez", fix: "Start the worker or fix the dashboard URL/network mapping."},
+	{name: "Dashboard /readyz", path: "/readyz", fix: "Wait for startup readiness or fix the dashboard URL/network mapping."},
+	{name: "Dashboard state API", path: "/api/v1/state", fix: "Set AIOPS_STATE_API_TOKEN or use the loopback-only URL."},
+}
+
+func (r *reportBuilder) checkDashboardEndpoint(ctx context.Context, baseURL string, endpoint dashboardEndpoint) {
+	result := r.fetchDashboardEndpoint(ctx, baseURL, endpoint)
+	if endpoint.path == "/readyz" && result.statusCode == http.StatusServiceUnavailable {
+		result = r.retryDashboardReady(ctx, baseURL, endpoint, result)
+	}
+	r.addDashboardResult(endpoint, result)
+}
+
+func (r *reportBuilder) fetchDashboardEndpoint(ctx context.Context, baseURL string, endpoint dashboardEndpoint) dashboardHTTPResult {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+endpoint.path, nil)
 	if err != nil {
-		r.fail("Dashboard state API", err.Error(), "Pass a valid dashboard base URL.")
-		return
+		return dashboardHTTPResult{err: err, fix: "Pass a valid dashboard base URL."}
 	}
-	if tok := os.Getenv("AIOPS_STATE_API_TOKEN"); tok != "" {
-		req.Header.Set("Authorization", "Bearer "+tok)
+	if endpoint.path == "/api/v1/state" {
+		if tok := os.Getenv("AIOPS_STATE_API_TOKEN"); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
 	}
 	resp, err := r.opts.HTTPClient.Do(req)
 	if err != nil {
-		r.fail("Dashboard state API", err.Error(), "Start the worker or fix the dashboard URL/network mapping.")
-		return
+		return dashboardHTTPResult{err: err}
 	}
 	defer closeBody(resp.Body)
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		r.fail("Dashboard state API", resp.Status, "Set AIOPS_STATE_API_TOKEN or use the loopback-only URL.")
+	return dashboardHTTPResult{status: resp.Status, statusCode: resp.StatusCode}
+}
+
+func (r *reportBuilder) retryDashboardReady(ctx context.Context, baseURL string, endpoint dashboardEndpoint, last dashboardHTTPResult) dashboardHTTPResult {
+	readyCtx, cancel := context.WithTimeout(ctx, defaultCommandTimeout)
+	defer cancel()
+	ticker := time.NewTicker(dashboardReadyPoll)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-readyCtx.Done():
+			if errors.Is(readyCtx.Err(), context.DeadlineExceeded) {
+				return last
+			}
+			return dashboardHTTPResult{err: readyCtx.Err()}
+		case <-ticker.C:
+			next := r.fetchDashboardEndpoint(readyCtx, baseURL, endpoint)
+			last = next
+			if next.statusCode != http.StatusServiceUnavailable {
+				return next
+			}
+		}
+	}
+}
+
+func (r *reportBuilder) addDashboardResult(endpoint dashboardEndpoint, result dashboardHTTPResult) {
+	if result.err != nil {
+		fix := endpoint.fix
+		if result.fix != "" {
+			fix = result.fix
+		}
+		r.fail(endpoint.name, result.err.Error(), fix)
 		return
 	}
-	r.pass("Dashboard state API", resp.Status)
+	if result.statusCode < 200 || result.statusCode >= 300 {
+		r.fail(endpoint.name, result.status, endpoint.fix)
+		return
+	}
+	r.pass(endpoint.name, result.status)
 }
 
 func closeBody(body io.Closer) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -271,6 +271,93 @@ func TestCheckSandboxWarnsForCustomCodexCommand(t *testing.T) {
 	}
 }
 
+func TestCheckDashboardVerifiesHealthReadinessAndStateEndpoints(t *testing.T) {
+	var gotPaths []string
+	var gotStateAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		if r.URL.Path == "/api/v1/state" {
+			gotStateAuth = r.Header.Get("Authorization")
+		}
+		switch r.URL.Path {
+		case "/livez", "/readyz", "/api/v1/state":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("AIOPS_STATE_API_TOKEN", "state-token")
+	r := &reportBuilder{opts: Options{DashboardURL: srv.URL, HTTPClient: srv.Client()}}
+	r.checkDashboard(context.Background())
+
+	if !slices.Equal(gotPaths, []string{"/livez", "/readyz", "/api/v1/state"}) {
+		t.Fatalf("dashboard paths = %v; want /livez, /readyz, /api/v1/state", gotPaths)
+	}
+	if gotStateAuth != "Bearer state-token" {
+		t.Fatalf("state Authorization = %q; want bearer token", gotStateAuth)
+	}
+	report := Report{Checks: r.checks}
+	for _, name := range []string{"Dashboard /livez", "Dashboard /readyz", "Dashboard state API"} {
+		check := findCheck(t, report, name)
+		if check.Status != Pass {
+			t.Fatalf("%s status = %s; want PASS (detail=%q)", name, check.Status, check.Detail)
+		}
+		if !strings.Contains(check.Detail, "200 OK") {
+			t.Fatalf("%s detail = %q; want checked HTTP status", name, check.Detail)
+		}
+	}
+}
+
+func TestCheckDashboardRetriesReadinessDuringStartup(t *testing.T) {
+	var readyCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/livez", "/api/v1/state":
+			w.WriteHeader(http.StatusOK)
+		case "/readyz":
+			readyCalls++
+			if readyCalls == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	r := &reportBuilder{opts: Options{DashboardURL: srv.URL, HTTPClient: srv.Client()}}
+	r.checkDashboard(context.Background())
+
+	if readyCalls != 2 {
+		t.Fatalf("/readyz calls = %d; want retry after transient 503", readyCalls)
+	}
+	check := findCheck(t, Report{Checks: r.checks}, "Dashboard /readyz")
+	if check.Status != Pass {
+		t.Fatalf("Dashboard /readyz status = %s; want PASS (detail=%q)", check.Status, check.Detail)
+	}
+	if !strings.Contains(check.Detail, "200 OK") {
+		t.Fatalf("Dashboard /readyz detail = %q; want final passing status", check.Detail)
+	}
+}
+
+func TestCheckDashboardWarnsWhenURLNotSupplied(t *testing.T) {
+	r := &reportBuilder{}
+	r.checkDashboard(context.Background())
+
+	check := findCheck(t, Report{Checks: r.checks}, "Dashboard endpoints")
+	if check.Status != Warn {
+		t.Fatalf("Dashboard endpoints status = %s; want WARN", check.Status)
+	}
+	if !strings.Contains(check.Detail, "not checked; no dashboard URL supplied") {
+		t.Fatalf("detail = %q; want not checked explanation", check.Detail)
+	}
+	if !strings.Contains(check.Fix, "/livez, /readyz, and /api/v1/state") {
+		t.Fatalf("fix = %q; want all dashboard endpoints named", check.Fix)
+	}
+}
+
 func TestCheckSandboxSkipsProbeWhenTurnPolicyOverridesToFullAccess(t *testing.T) {
 	noContainer(t)
 	// thread_sandbox stays workspace-write, but an explicit turn_sandbox_policy

--- a/scripts/aiops_todo_smoke_test.go
+++ b/scripts/aiops_todo_smoke_test.go
@@ -41,6 +41,9 @@ func TestTodoSmokeScriptRunsDoctorAndWritesReport(t *testing.T) {
 			t.Fatalf("smoke script missing %q", want)
 		}
 	}
+	if strings.Contains(text, `doctor_args+=(--dashboard-url "$dashboard_url")`) {
+		t.Fatalf("smoke script must not pass dashboard-url to doctor before the worker starts")
+	}
 }
 
 func TestTodoSmokeScriptSupportsGitHubDraftPRValidation(t *testing.T) {

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -32,12 +32,24 @@ func TestCrowdRunnerLifecycleRunbookDocumentsReusableSOP(t *testing.T) {
 		"CONTROL cancel running Codex issue",
 		"Continuation budget",
 		"npm run test:e2e",
+		"without `aiops/*` state labels",
+		"add `aiops/todo` to issues 1-12",
+		`--dashboard-url "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL"`,
+		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
 		"Do not commit `env.local`",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("runbook missing %q", want)
 		}
 	}
+	assertInOrder(t, text, []string{
+		"## 5. Run Maker and Reviewer",
+		`"$AIOPS_CROWDRUNNER_WORKER_BIN" --port "$AIOPS_CROWDRUNNER_MAKER_PORT"`,
+		`--dashboard-url "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL"`,
+		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
+		"add `aiops/todo` to issues 1-12",
+		"trigger a work poll:",
+	})
 }
 
 func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
@@ -131,6 +143,24 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 			t.Fatalf("issue 07 missing %q\n%s", want, issue)
 		}
 	}
+
+	nextSteps := readFileString(t, filepath.Join(runRoot, "NEXT-STEPS.md"))
+	for _, want := range []string{
+		`--dashboard-url "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL"`,
+		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
+		"without\n   `aiops/*` state labels",
+		"Add `aiops/todo` to product issues 01-12",
+	} {
+		if !strings.Contains(nextSteps, want) {
+			t.Fatalf("NEXT-STEPS.md missing %q\n%s", want, nextSteps)
+		}
+	}
+	assertInOrder(t, nextSteps, []string{
+		"Start maker on port",
+		`--dashboard-url "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL"`,
+		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
+		"Add `aiops/todo` to product issues 01-12",
+	})
 
 	makerWorkflow := readFileString(t, filepath.Join(runRoot, "workflows", "maker-WORKFLOW.md"))
 	reviewerWorkflow := readFileString(t, filepath.Join(runRoot, "workflows", "reviewer-automerge-WORKFLOW.md"))

--- a/scripts/e2e-crowdrunner-bootstrap.sh
+++ b/scripts/e2e-crowdrunner-bootstrap.sh
@@ -460,15 +460,18 @@ cat >"$run_root/NEXT-STEPS.md" <<EOF
 3. Download and verify the $release_tag release archive into \`downloads/\`,
    then extract \`worker\` and \`tui\` into \`bin/\`.
 4. Create the local Gitea repo from \`seed-repo/\`.
-5. Create labels and issues from \`issues/*.md\`; initially label product issues
-   01-12 with \`aiops/todo\`, keep controls staged as described in their bodies.
+5. Create labels and issues from \`issues/*.md\`; leave product issues without
+   \`aiops/*\` state labels and keep controls staged as described in their bodies.
 6. Run maker/reviewer \`worker --doctor --deploy=binary --mode=real\`.
 7. Start maker on port $maker_port and reviewer on port $reviewer_port.
-8. Use \`scripts/e2e-crowdrunner-capture.py\` at start, mid-run, Rework,
+8. After both dashboards are listening, run maker \`worker --doctor --deploy=binary --mode=real --dashboard-url "\$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL"\`
+   and reviewer \`worker --doctor --deploy=binary --mode=real --dashboard-url "\$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"\`.
+9. Add \`aiops/todo\` to product issues 01-12, then trigger a dashboard refresh.
+10. Use \`scripts/e2e-crowdrunner-capture.py\` at start, mid-run, Rework,
    cancellation, stress, and final milestones.
-9. Fresh-clone final main into \`final-verify/crowd-runner-product\` and run
+11. Fresh-clone final main into \`final-verify/crowd-runner-product\` and run
    npm verification plus Playwright smoke.
-10. Run \`scripts/e2e-crowdrunner-report.py --run-root "$run_root"\`.
+12. Run \`scripts/e2e-crowdrunner-report.py --run-root "$run_root"\`.
 
 See \`docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md\` for the full SOP.
 EOF

--- a/scripts/e2e-webtodo-bootstrap.sh
+++ b/scripts/e2e-webtodo-bootstrap.sh
@@ -275,13 +275,17 @@ cat >"$run_root/NEXT-STEPS.md" <<EOF
    venv under \`AIOPS_WEBTODO_TOOLS_ROOT\` when screenshot evidence is needed.
 2. Copy \`env.example\` to \`env.local\`, fill secrets, and source it.
 3. Put the downloaded release \`worker\` and \`tui\` binaries in \`bin/\`.
-4. Create the local Gitea repo, labels, and issues from \`issues/*.md\`.
-5. Run \`worker --doctor --deploy=binary --mode=real\` for maker and reviewer.
+4. Create the local Gitea repo, labels, and issues from \`issues/*.md\`; leave
+   issues without \`aiops/*\` state labels.
+5. Run maker/reviewer \`worker --doctor --deploy=binary --mode=real\`.
 6. Start maker on port $maker_port and reviewer on port $reviewer_port.
-7. Activate the Playwright venv, then use \`scripts/e2e-webtodo-capture.py\`
+7. After both dashboards are listening, run maker \`worker --doctor --deploy=binary --mode=real --dashboard-url "\$AIOPS_WEBTODO_MAKER_DASHBOARD_URL"\`
+   and reviewer \`worker --doctor --deploy=binary --mode=real --dashboard-url "\$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL"\`.
+8. Add \`aiops/todo\` to primary issues 01-10, then trigger a dashboard refresh.
+9. Activate the Playwright venv, then use \`scripts/e2e-webtodo-capture.py\`
    at milestones.
-8. Run final fresh-clone verification and browser smoke.
-9. Run \`scripts/e2e-webtodo-report.py --run-root "$run_root"\`.
+10. Run final fresh-clone verification and browser smoke.
+11. Run \`scripts/e2e-webtodo-report.py --run-root "$run_root"\`.
 
 See \`docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md\` for the full SOP.
 EOF

--- a/scripts/webtodo_lifecycle_e2e_test.go
+++ b/scripts/webtodo_lifecycle_e2e_test.go
@@ -37,6 +37,10 @@ func TestWebTodoLifecycleRunbookDocumentsReusableSOP(t *testing.T) {
 		"CONTROL cancel running codex issue",
 		`"$AIOPS_WEBTODO_MAKER_WORKFLOW"`,
 		`"$AIOPS_WEBTODO_REVIEWER_WORKFLOW"`,
+		`--dashboard-url "$AIOPS_WEBTODO_MAKER_DASHBOARD_URL"`,
+		`--dashboard-url "$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL"`,
+		"initially without\n  `aiops/*` state labels",
+		"add `aiops/todo` to issues 1-10",
 		"aiops/todo",
 		"aiops/human-review",
 		"aiops/rework",
@@ -47,6 +51,14 @@ func TestWebTodoLifecycleRunbookDocumentsReusableSOP(t *testing.T) {
 			t.Fatalf("runbook missing %q", want)
 		}
 	}
+	assertInOrder(t, text, []string{
+		"## 4. Run Maker and Reviewer",
+		`--port "$AIOPS_WEBTODO_MAKER_PORT"`,
+		`--dashboard-url "$AIOPS_WEBTODO_MAKER_DASHBOARD_URL"`,
+		`--dashboard-url "$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL"`,
+		"add `aiops/todo` to issues 1-10",
+		"trigger a work poll:",
+	})
 	for _, forbidden := range []string{
 		`"$AIOPS_WEBTODO_MAKER_WORKDIR" \`,
 		`"$AIOPS_WEBTODO_REVIEWER_WORKDIR" \`,
@@ -124,11 +136,21 @@ func TestWebTodoBootstrapPreparesRunRoot(t *testing.T) {
 		"Install or verify host tools",
 		"Playwright venv",
 		"Activate the Playwright venv",
+		`--dashboard-url "$AIOPS_WEBTODO_MAKER_DASHBOARD_URL"`,
+		`--dashboard-url "$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL"`,
+		"without `aiops/*` state labels",
+		"Add `aiops/todo` to primary issues 01-10",
 	} {
 		if !strings.Contains(nextSteps, want) {
 			t.Fatalf("NEXT-STEPS.md missing %q\n%s", want, nextSteps)
 		}
 	}
+	assertInOrder(t, nextSteps, []string{
+		"Start maker on port",
+		`--dashboard-url "$AIOPS_WEBTODO_MAKER_DASHBOARD_URL"`,
+		`--dashboard-url "$AIOPS_WEBTODO_REVIEWER_DASHBOARD_URL"`,
+		"Add `aiops/todo` to primary issues 01-10",
+	})
 
 	makerWorkflow := readFileString(t, filepath.Join(runRoot, "workflows", "maker-WORKFLOW.md"))
 	reviewerWorkflow := readFileString(t, filepath.Join(runRoot, "workflows", "reviewer-automerge-WORKFLOW.md"))


### PR DESCRIPTION
## Summary
- Extend `worker --doctor --dashboard-url` to check `/livez`, `/readyz`, and `/api/v1/state` as explicit dashboard endpoint checks.
- Keep pre-start binary lifecycle doctor preflight URL-free, then run dashboard URL doctor checks after maker/reviewer workers are listening and before the first poll.
- Update doctor/runbook evidence text so omitted dashboard checks are reported as "not checked" rather than silently skipped.

Closes #992

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level WORKFLOW.md/Config key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream Elixir reference — cite the matching file and line from the openai/symphony Elixir tree in the body below.
- [ ] Adds one, tracked as a DEVIATIONS.md row + an area:spec-alignment issue, updated in this PR.

## Acceptance
- [x] Binary lifecycle runbooks pass dashboard URLs into doctor once each configured worker dashboard is expected to be listening.
- [x] Doctor verifies `/livez`, `/readyz`, and `/api/v1/state` when a dashboard URL is supplied.
- [x] Evidence distinguishes `not checked` when no dashboard URL is supplied from checked-and-passed endpoint rows.
- [x] No worker-side tracker mutation, PR creation, or SPEC §1 scheduler boundary change.

## Review feedback
- Addressed Codex review P1: `scripts/aiops-todo-smoke.sh` no longer passes `--dashboard-url` into `worker --doctor` before the worker has started.
- Addressed Codex review P2: lifecycle runbook/bootstrap dashboard doctor commands moved after worker startup and before the first poll.

## Size
within budget

## Tests
- `go test ./internal/doctor -run 'TestCheckDashboard' -count=1`
- `go test ./scripts -run 'TestTodoSmokeScriptRunsDoctorAndWritesReport|TestCrowdRunnerLifecycleRunbookDocumentsReusableSOP|TestCrowdRunnerBootstrapPreparesRunRoot|TestWebTodoLifecycleRunbookDocumentsReusableSOP|TestWebTodoBootstrapPreparesRunRoot' -count=1`
- `go test ./cmd/worker -run 'TestParseDoctorArgs' -count=1`
- `go test ./internal/doctor ./cmd/worker ./scripts -count=1`
- `go test ./scripts -run 'TestTodoSmokeScriptRunsDoctorAndWritesReport|TestTodoSmokeScriptAcceptsDraftPRCreatedAfterBaseline' -count=1 -v`
- Mutation verification: removed the committed Web Todo maker `--dashboard-url` from the lifecycle runbook; `TestWebTodoLifecycleRunbookDocumentsReusableSOP` failed, then restored from `HEAD`.
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/tui`
