### PR TITLE
feat(e2e): add Crowd Runner milestone freeze

### DIFF
--- a/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
@@ -31,6 +31,7 @@ castle/King finale, mobile portrait play, and measurable performance.
 | --- | --- |
 | `scripts/e2e-crowdrunner-bootstrap.sh` | Create the run-root skeleton, render maker/reviewer/stress workflows, seed a minimal repo, and write product/control issue bodies. |
 | `scripts/e2e-crowdrunner-capture.py` | Capture worker state JSON, TUI raw frames, Gitea/dashboard/product screenshots, and a capture index. |
+| `scripts/e2e-crowdrunner-freeze.py` | Optionally freeze dispatch at an operator-selected product milestone by removing ready labels and writing evidence. |
 | `scripts/e2e-crowdrunner-report.py` | Generate the final Markdown report and promotion notes from saved state, PR, screenshot, trace, and verification evidence. |
 
 ## 0. Prepare the Host
@@ -233,6 +234,23 @@ scripts/e2e-crowdrunner-capture.py \
   --repo-name "$AIOPS_CROWDRUNNER_REPO_NAME" \
   --tui-bin "$AIOPS_CROWDRUNNER_TUI_BIN"
 ```
+
+Optional milestone freeze: run this in a separate terminal before the product
+run reaches the selected count. It leaves workers and dashboards running, removes
+`aiops/todo` from remaining product issues after N products reach `aiops/done`,
+and writes the stop as operator milestone evidence instead of a worker failure:
+
+```bash
+scripts/e2e-crowdrunner-freeze.py \
+  --run-root "$AIOPS_CROWDRUNNER_RUN_ROOT" \
+  --gitea-url "$AIOPS_CROWDRUNNER_GITEA_URL" \
+  --repo-owner "$AIOPS_CROWDRUNNER_REPO_OWNER" \
+  --repo-name "$AIOPS_CROWDRUNNER_REPO_NAME" \
+  --stop-after 10
+```
+
+To resume after the milestone report, re-add `aiops/todo` to the frozen product
+issues and trigger a dashboard refresh.
 
 For required evidence, pass explicit screenshots so missing Playwright fails
 fast:

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -308,6 +308,10 @@ func TestCrowdRunnerFreezeStopsDispatchAfterMilestone(t *testing.T) {
 			_, _ = w.Write([]byte(fakeCrowdRunnerMilestoneIssuesJSON()))
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/repos/aiops-bot/crowd-runner-product/issues/"):
 			deletes = append(deletes, r.URL.Path)
+			if strings.Contains(r.URL.Path, "/issues/11/") {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.String())
@@ -347,8 +351,10 @@ func TestCrowdRunnerFreezeStopsDispatchAfterMilestone(t *testing.T) {
 	for _, want := range []string{
 		`"kind": "operator_milestone_freeze"`,
 		`"completed_product_issues": 10`,
-		`"number": 11`,
 		`"number": 12`,
+		`"already_inactive_product_issues": [
+    11
+  ]`,
 	} {
 		if !strings.Contains(state, want) {
 			t.Fatalf("freeze state missing %q\n%s", want, state)

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -366,6 +366,60 @@ func TestCrowdRunnerFreezeStopsDispatchAfterMilestone(t *testing.T) {
 	}
 }
 
+func TestCrowdRunnerFreezeRedactsFailureSecrets(t *testing.T) {
+	const token = "freeze-secret-token"
+	const proxySecret = "proxy-secret"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "token "+token {
+			t.Fatalf("Authorization = %q; want token %s", got, token)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("echoed " + token + " and https://bot:" + proxySecret + "@gitea.example.test/path"))
+	}))
+	defer srv.Close()
+
+	root := repoRoot(t)
+	runRoot := filepath.Join(t.TempDir(), "run")
+	run := func(giteaURL string) string {
+		cmd := exec.Command(
+			"python3",
+			filepath.Join(root, "scripts", "e2e-crowdrunner-freeze.py"),
+			"--run-root", runRoot,
+			"--gitea-url", giteaURL,
+			"--repo-owner", "aiops-bot",
+			"--repo-name", "crowd-runner-product",
+			"--token", token,
+			"--stop-after", "10",
+			"--timeout-seconds", "1",
+			"--poll-interval-seconds", "0.01",
+		)
+		cmd.Dir = root
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("freeze helper unexpectedly succeeded:\n%s", out)
+		}
+		return string(out)
+	}
+
+	userinfoOut := run(strings.Replace(srv.URL, "http://", "http://bot:"+proxySecret+"@", 1))
+	if strings.Contains(userinfoOut, proxySecret) || !strings.Contains(userinfoOut, "http://[redacted]@") {
+		t.Fatalf("freeze helper did not redact URL userinfo:\n%s", userinfoOut)
+	}
+
+	bodyOut := run(srv.URL)
+	for _, forbidden := range []string{token, proxySecret} {
+		if strings.Contains(bodyOut, forbidden) {
+			t.Fatalf("freeze helper leaked secret %q:\n%s", forbidden, bodyOut)
+		}
+	}
+	for _, want := range []string{"[redacted-token]", "https://[redacted]@"} {
+		if !strings.Contains(bodyOut, want) {
+			t.Fatalf("freeze helper output missing redaction marker %q:\n%s", want, bodyOut)
+		}
+	}
+}
+
 func TestCrowdRunnerCaptureSkipsOnlyDefaultScreenshotsWithoutPlaywright(t *testing.T) {
 	root := repoRoot(t)
 	script := filepath.Join(root, "scripts", "e2e-crowdrunner-capture.py")

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -1,6 +1,8 @@
 package scripts_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,6 +26,7 @@ func TestCrowdRunnerLifecycleRunbookDocumentsReusableSOP(t *testing.T) {
 	for _, want := range []string{
 		"scripts/e2e-crowdrunner-bootstrap.sh",
 		"scripts/e2e-crowdrunner-capture.py",
+		"scripts/e2e-crowdrunner-freeze.py",
 		"scripts/e2e-crowdrunner-report.py",
 		"Local binary mode intentionally reuses the operator's usual Codex setup",
 		"aiops-platform_v0.1.9_darwin_arm64.tar.gz",
@@ -36,6 +39,7 @@ func TestCrowdRunnerLifecycleRunbookDocumentsReusableSOP(t *testing.T) {
 		"add `aiops/todo` to issues 1-12",
 		`--dashboard-url "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL"`,
 		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
+		"operator milestone evidence",
 		"Do not commit `env.local`",
 	} {
 		if !strings.Contains(text, want) {
@@ -150,6 +154,7 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
 		"without\n   `aiops/*` state labels",
 		"Add `aiops/todo` to product issues 01-12",
+		"e2e-crowdrunner-freeze.py",
 	} {
 		if !strings.Contains(nextSteps, want) {
 			t.Fatalf("NEXT-STEPS.md missing %q\n%s", want, nextSteps)
@@ -160,6 +165,7 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 		`--dashboard-url "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL"`,
 		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
 		"Add `aiops/todo` to product issues 01-12",
+		"e2e-crowdrunner-freeze.py",
 	})
 
 	makerWorkflow := readFileString(t, filepath.Join(runRoot, "workflows", "maker-WORKFLOW.md"))
@@ -240,6 +246,12 @@ func TestCrowdRunnerReportGeneratesThreeVerdicts(t *testing.T) {
 	writeFileString(t, filepath.Join(runRoot, "state", "maker-final.json"), `{"counts":{"running":0,"blocked":0}}`)
 	writeFileString(t, filepath.Join(runRoot, "state", "reviewer-final.json"), `{"counts":{"running":0,"blocked":0}}`)
 	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{"counts":{"running":0,"blocked":1}}`)
+	writeFileString(t, filepath.Join(runRoot, "state", "operator-milestone-freeze-after-10.json"), `{
+		"kind":"operator_milestone_freeze",
+		"stop_after":10,
+		"completed_product_issues":10,
+		"ready_labels_removed":[{"number":11},{"number":12}]
+	}`)
 	writeFileString(t, filepath.Join(runRoot, "promo", "screenshots", "maker-dashboard.png"), "png")
 	writeFileString(t, filepath.Join(runRoot, "promo", "pages", "tui-maker-final.txt"), "maker frame")
 	writeFileString(t, filepath.Join(runRoot, "final-verify", "screenshots", "gameplay.png"), "png")
@@ -268,6 +280,8 @@ func TestCrowdRunnerReportGeneratesThreeVerdicts(t *testing.T) {
 		"Product quality",
 		"READY FOR OPERATOR PASS REVIEW",
 		"At least ten product issues reached `aiops/done`",
+		"Operator milestone freeze",
+		"ready labels removed from #11, #12",
 		"Continuation / turn-budget stress evidence",
 		"#12",
 		"final-verify/videos/gameplay.webm",
@@ -279,6 +293,70 @@ func TestCrowdRunnerReportGeneratesThreeVerdicts(t *testing.T) {
 	promo := readFileString(t, filepath.Join(runRoot, "promo", "notes", "promotion-materials.md"))
 	if !strings.Contains(promo, "fresh crowd-runner design") {
 		t.Fatalf("promo notes missing fresh product positioning:\n%s", promo)
+	}
+}
+
+func TestCrowdRunnerFreezeStopsDispatchAfterMilestone(t *testing.T) {
+	var deletes []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "token test-token" {
+			t.Fatalf("Authorization = %q; want token test-token", got)
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/aiops-bot/crowd-runner-product/issues":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fakeCrowdRunnerMilestoneIssuesJSON()))
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/repos/aiops-bot/crowd-runner-product/issues/"):
+			deletes = append(deletes, r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	root := repoRoot(t)
+	runRoot := filepath.Join(t.TempDir(), "run")
+	script := filepath.Join(root, "scripts", "e2e-crowdrunner-freeze.py")
+	cmd := exec.Command(
+		"python3",
+		script,
+		"--run-root", runRoot,
+		"--gitea-url", srv.URL,
+		"--repo-owner", "aiops-bot",
+		"--repo-name", "crowd-runner-product",
+		"--token", "test-token",
+		"--stop-after", "10",
+		"--timeout-seconds", "1",
+		"--poll-interval-seconds", "0.01",
+	)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("freeze helper failed: %v\n%s", err, out)
+	}
+
+	wantDeletes := []string{
+		"/api/v1/repos/aiops-bot/crowd-runner-product/issues/11/labels/501",
+		"/api/v1/repos/aiops-bot/crowd-runner-product/issues/12/labels/501",
+	}
+	if strings.Join(deletes, "\n") != strings.Join(wantDeletes, "\n") {
+		t.Fatalf("delete calls = %v; want %v", deletes, wantDeletes)
+	}
+	state := readFileString(t, filepath.Join(runRoot, "state", "operator-milestone-freeze-after-10.json"))
+	for _, want := range []string{
+		`"kind": "operator_milestone_freeze"`,
+		`"completed_product_issues": 10`,
+		`"number": 11`,
+		`"number": 12`,
+	} {
+		if !strings.Contains(state, want) {
+			t.Fatalf("freeze state missing %q\n%s", want, state)
+		}
+	}
+	fragment := readFileString(t, filepath.Join(runRoot, "reports", "operator-milestone-freeze-after-10.md"))
+	if !strings.Contains(fragment, "operator milestone freeze, not a worker failure") {
+		t.Fatalf("freeze report did not classify the stop as operator freeze:\n%s", fragment)
 	}
 }
 
@@ -330,5 +408,18 @@ func fakeCrowdRunnerDoneIssuesJSON() string {
 	for i := 1; i <= 12; i++ {
 		rows = append(rows, `{"number":`+itoa(i)+`,"title":"issue `+itoa(i)+`","state":"closed","labels":[{"name":"aiops/done"}]}`)
 	}
+	return "[" + strings.Join(rows, ",") + "]"
+}
+
+func fakeCrowdRunnerMilestoneIssuesJSON() string {
+	var rows []string
+	for i := 1; i <= 10; i++ {
+		rows = append(rows, `{"number":`+itoa(i)+`,"title":"issue `+itoa(i)+`","state":"closed","labels":[{"id":502,"name":"aiops/done"}]}`)
+	}
+	rows = append(rows,
+		`{"number":11,"title":"issue 11","state":"open","labels":[{"id":501,"name":"aiops/todo"}]}`,
+		`{"number":12,"title":"issue 12","state":"open","labels":[{"id":501,"name":"aiops/todo"}]}`,
+		`{"number":13,"title":"control","state":"open","labels":[{"id":501,"name":"aiops/todo"}]}`,
+	)
 	return "[" + strings.Join(rows, ",") + "]"
 }

--- a/scripts/e2e-crowdrunner-bootstrap.sh
+++ b/scripts/e2e-crowdrunner-bootstrap.sh
@@ -467,11 +467,13 @@ cat >"$run_root/NEXT-STEPS.md" <<EOF
 8. After both dashboards are listening, run maker \`worker --doctor --deploy=binary --mode=real --dashboard-url "\$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL"\`
    and reviewer \`worker --doctor --deploy=binary --mode=real --dashboard-url "\$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"\`.
 9. Add \`aiops/todo\` to product issues 01-12, then trigger a dashboard refresh.
-10. Use \`scripts/e2e-crowdrunner-capture.py\` at start, mid-run, Rework,
+10. Optional: run \`scripts/e2e-crowdrunner-freeze.py --run-root "$run_root" --gitea-url "\$AIOPS_CROWDRUNNER_GITEA_URL" --repo-owner "\$AIOPS_CROWDRUNNER_REPO_OWNER" --repo-name "\$AIOPS_CROWDRUNNER_REPO_NAME" --stop-after 10\`
+    in another terminal to record an operator milestone freeze without stopping workers.
+11. Use \`scripts/e2e-crowdrunner-capture.py\` at start, mid-run, Rework,
    cancellation, stress, and final milestones.
-11. Fresh-clone final main into \`final-verify/crowd-runner-product\` and run
+12. Fresh-clone final main into \`final-verify/crowd-runner-product\` and run
    npm verification plus Playwright smoke.
-12. Run \`scripts/e2e-crowdrunner-report.py --run-root "$run_root"\`.
+13. Run \`scripts/e2e-crowdrunner-report.py --run-root "$run_root"\`.
 
 See \`docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md\` for the full SOP.
 EOF

--- a/scripts/e2e-crowdrunner-freeze.py
+++ b/scripts/e2e-crowdrunner-freeze.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import time
 import urllib.error
 import urllib.parse
@@ -16,6 +17,7 @@ from typing import Any
 
 
 NOT_FOUND = object()
+URL_USERINFO_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s@]+@")
 
 
 def parser() -> argparse.ArgumentParser:
@@ -44,6 +46,13 @@ def api_url(args: argparse.Namespace, path: str, query: str = "") -> str:
     return url
 
 
+def redact_text(args: argparse.Namespace, text: str) -> str:
+    redacted = URL_USERINFO_RE.sub(r"\1[redacted]@", text)
+    if args.token:
+        redacted = redacted.replace(args.token, "[redacted-token]")
+    return redacted
+
+
 def request(args: argparse.Namespace, method: str, url: str, *, allow_not_found: bool = False) -> Any:
     req = urllib.request.Request(url, method=method)
     if args.token:
@@ -55,15 +64,15 @@ def request(args: argparse.Namespace, method: str, url: str, *, allow_not_found:
         if allow_not_found and exc.code == 404:
             return NOT_FOUND
         detail = exc.read().decode("utf-8", errors="replace")
-        raise SystemExit(f"{method} {url} failed: {exc.code} {detail}") from exc
+        raise SystemExit(f"{method} {redact_text(args, url)} failed: {exc.code} {redact_text(args, detail)}") from exc
     except urllib.error.URLError as exc:
-        raise SystemExit(f"{method} {url} failed: {exc.reason}") from exc
+        raise SystemExit(f"{method} {redact_text(args, url)} failed: {redact_text(args, str(exc.reason))}") from exc
     if not body:
         return None
     try:
         return json.loads(body.decode("utf-8"))
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"{method} {url} returned invalid JSON: {exc}") from exc
+        raise SystemExit(f"{method} {redact_text(args, url)} returned invalid JSON: {exc}") from exc
 
 
 def load_issues(args: argparse.Namespace) -> list[dict[str, Any]]:

--- a/scripts/e2e-crowdrunner-freeze.py
+++ b/scripts/e2e-crowdrunner-freeze.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Freeze Crowd Runner lifecycle dispatch at an operator-selected milestone."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--run-root", required=True, type=Path)
+    p.add_argument("--gitea-url", default=os.getenv("AIOPS_CROWDRUNNER_GITEA_URL", ""))
+    p.add_argument("--repo-owner", default=os.getenv("AIOPS_CROWDRUNNER_REPO_OWNER", "aiops-bot"))
+    p.add_argument("--repo-name", default=os.getenv("AIOPS_CROWDRUNNER_REPO_NAME", "crowd-runner-product"))
+    p.add_argument("--token", default=os.getenv("GITEA_TOKEN", ""))
+    p.add_argument("--stop-after", required=True, type=int)
+    p.add_argument("--product-start", type=int, default=1)
+    p.add_argument("--product-end", type=int, default=12)
+    p.add_argument("--ready-label", default="aiops/todo")
+    p.add_argument("--done-label", default="aiops/done")
+    p.add_argument("--poll-interval-seconds", type=float, default=15.0)
+    p.add_argument("--timeout-seconds", type=float, default=0.0)
+    return p
+
+
+def api_url(args: argparse.Namespace, path: str, query: str = "") -> str:
+    owner = urllib.parse.quote(args.repo_owner, safe="")
+    repo = urllib.parse.quote(args.repo_name, safe="")
+    url = f"{args.gitea_url.rstrip('/')}/api/v1/repos/{owner}/{repo}{path}"
+    if query:
+        url += "?" + query
+    return url
+
+
+def request(args: argparse.Namespace, method: str, url: str) -> Any:
+    req = urllib.request.Request(url, method=method)
+    if args.token:
+        req.add_header("Authorization", f"token {args.token}")
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"{method} {url} failed: {exc.code} {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"{method} {url} failed: {exc.reason}") from exc
+    if not body:
+        return None
+    try:
+        return json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{method} {url} returned invalid JSON: {exc}") from exc
+
+
+def load_issues(args: argparse.Namespace) -> list[dict[str, Any]]:
+    url = api_url(args, "/issues", "state=all&limit=100")
+    data = request(args, "GET", url)
+    if not isinstance(data, list):
+        raise SystemExit("Gitea issues response was not a list")
+    return data
+
+
+def label_names(issue: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for label in issue.get("labels") or []:
+        if isinstance(label, dict):
+            name = str(label.get("name", ""))
+        else:
+            name = str(label)
+        if name:
+            names.append(name)
+    return names
+
+
+def find_label(issue: dict[str, Any], name: str) -> dict[str, Any] | None:
+    for label in issue.get("labels") or []:
+        if isinstance(label, dict) and label.get("name") == name:
+            return label
+    return None
+
+
+def product_issues(args: argparse.Namespace, issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    products = []
+    for issue in issues:
+        try:
+            number = int(issue.get("number", 0))
+        except (TypeError, ValueError):
+            continue
+        if args.product_start <= number <= args.product_end:
+            products.append(issue)
+    return sorted(products, key=lambda item: int(item.get("number", 0)))
+
+
+def delete_ready_label(args: argparse.Namespace, issue: dict[str, Any], label: dict[str, Any]) -> None:
+    label_id = label.get("id")
+    if label_id is None:
+        raise SystemExit(f"issue #{issue.get('number')} has ready label without an id")
+    url = api_url(args, f"/issues/{issue.get('number')}/labels/{label_id}")
+    request(args, "DELETE", url)
+
+
+def freeze(args: argparse.Namespace, issues: list[dict[str, Any]]) -> dict[str, Any] | None:
+    products = product_issues(args, issues)
+    completed = [issue for issue in products if args.done_label in label_names(issue)]
+    if len(completed) < args.stop_after:
+        return None
+
+    removed = []
+    already_inactive = []
+    for issue in products:
+        if args.done_label in label_names(issue):
+            continue
+        ready = find_label(issue, args.ready_label)
+        if ready is None:
+            already_inactive.append(issue.get("number"))
+            continue
+        delete_ready_label(args, issue, ready)
+        removed.append({
+            "number": issue.get("number"),
+            "title": issue.get("title", ""),
+            "removed_label": args.ready_label,
+            "label_id": ready.get("id"),
+        })
+
+    return {
+        "kind": "operator_milestone_freeze",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "stop_after": args.stop_after,
+        "product_issue_range": [args.product_start, args.product_end],
+        "completed_product_issues": len(completed),
+        "ready_labels_removed": removed,
+        "already_inactive_product_issues": already_inactive,
+        "note": "Operator milestone freeze: ready labels were removed without stopping workers or dashboards.",
+    }
+
+
+def write_evidence(args: argparse.Namespace, record: dict[str, Any]) -> tuple[Path, Path]:
+    state_dir = args.run_root / "state"
+    reports_dir = args.run_root / "reports"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"operator-milestone-freeze-after-{args.stop_after}"
+    state_path = state_dir / f"{stem}.json"
+    report_path = reports_dir / f"{stem}.md"
+    state_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+    removed = ", ".join(f"#{item['number']}" for item in record["ready_labels_removed"]) or "none"
+    inactive = ", ".join(f"#{number}" for number in record["already_inactive_product_issues"]) or "none"
+    lines = [
+        "# Operator Milestone Freeze",
+        "",
+        f"- Stop after: {record['stop_after']} completed product issues",
+        f"- Completed product issues observed: {record['completed_product_issues']}",
+        f"- Ready labels removed: {removed}",
+        f"- Already inactive product issues: {inactive}",
+        "- Classification: operator milestone freeze, not a worker failure",
+        "- Workers and dashboards remain running for evidence capture.",
+    ]
+    report_path.write_text("\n".join(lines) + "\n")
+    return state_path, report_path
+
+
+def wait_for_freeze(args: argparse.Namespace) -> dict[str, Any]:
+    deadline = time.monotonic() + args.timeout_seconds if args.timeout_seconds > 0 else None
+    while True:
+        record = freeze(args, load_issues(args))
+        if record is not None:
+            return record
+        if deadline is not None and time.monotonic() >= deadline:
+            raise SystemExit(f"timed out waiting for {args.stop_after} completed product issues")
+        time.sleep(max(args.poll_interval_seconds, 0.1))
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if not args.gitea_url:
+        raise SystemExit("set --gitea-url or AIOPS_CROWDRUNNER_GITEA_URL")
+    if not args.token:
+        raise SystemExit("set --token or GITEA_TOKEN so the helper can remove ready labels")
+    if args.stop_after < 1:
+        raise SystemExit("--stop-after must be positive")
+    if args.product_start > args.product_end:
+        raise SystemExit("--product-start must be <= --product-end")
+    record = wait_for_freeze(args)
+    state_path, report_path = write_evidence(args, record)
+    print(f"operator milestone freeze recorded: {state_path}")
+    print(f"report fragment written: {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-crowdrunner-freeze.py
+++ b/scripts/e2e-crowdrunner-freeze.py
@@ -15,6 +15,9 @@ from pathlib import Path
 from typing import Any
 
 
+NOT_FOUND = object()
+
+
 def parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--run-root", required=True, type=Path)
@@ -41,7 +44,7 @@ def api_url(args: argparse.Namespace, path: str, query: str = "") -> str:
     return url
 
 
-def request(args: argparse.Namespace, method: str, url: str) -> Any:
+def request(args: argparse.Namespace, method: str, url: str, *, allow_not_found: bool = False) -> Any:
     req = urllib.request.Request(url, method=method)
     if args.token:
         req.add_header("Authorization", f"token {args.token}")
@@ -49,6 +52,8 @@ def request(args: argparse.Namespace, method: str, url: str) -> Any:
         with urllib.request.urlopen(req, timeout=20) as resp:
             body = resp.read()
     except urllib.error.HTTPError as exc:
+        if allow_not_found and exc.code == 404:
+            return NOT_FOUND
         detail = exc.read().decode("utf-8", errors="replace")
         raise SystemExit(f"{method} {url} failed: {exc.code} {detail}") from exc
     except urllib.error.URLError as exc:
@@ -100,12 +105,12 @@ def product_issues(args: argparse.Namespace, issues: list[dict[str, Any]]) -> li
     return sorted(products, key=lambda item: int(item.get("number", 0)))
 
 
-def delete_ready_label(args: argparse.Namespace, issue: dict[str, Any], label: dict[str, Any]) -> None:
+def delete_ready_label(args: argparse.Namespace, issue: dict[str, Any], label: dict[str, Any]) -> bool:
     label_id = label.get("id")
     if label_id is None:
         raise SystemExit(f"issue #{issue.get('number')} has ready label without an id")
     url = api_url(args, f"/issues/{issue.get('number')}/labels/{label_id}")
-    request(args, "DELETE", url)
+    return request(args, "DELETE", url, allow_not_found=True) is not NOT_FOUND
 
 
 def freeze(args: argparse.Namespace, issues: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -123,7 +128,9 @@ def freeze(args: argparse.Namespace, issues: list[dict[str, Any]]) -> dict[str, 
         if ready is None:
             already_inactive.append(issue.get("number"))
             continue
-        delete_ready_label(args, issue, ready)
+        if not delete_ready_label(args, issue, ready):
+            already_inactive.append(issue.get("number"))
+            continue
         removed.append({
             "number": issue.get("number"),
             "title": issue.get("title", ""),

--- a/scripts/e2e-crowdrunner-report.py
+++ b/scripts/e2e-crowdrunner-report.py
@@ -107,6 +107,36 @@ def asset_bullets(paths: list[Path], root: Path) -> list[str]:
     return [f"- `{rel(path, root)}`" for path in files] or ["- none captured"]
 
 
+def load_milestone_freezes(run_root: Path) -> list[tuple[Path, dict[str, Any]]]:
+    records = []
+    for path in sorted((run_root / "state").glob("operator-milestone-freeze-*.json")):
+        data = load_json(path, {})
+        if isinstance(data, dict) and data.get("kind") == "operator_milestone_freeze":
+            records.append((path, data))
+    return records
+
+
+def milestone_freeze_bullets(run_root: Path) -> list[str]:
+    freezes = load_milestone_freezes(run_root)
+    if not freezes:
+        return ["- none recorded"]
+    lines = []
+    for path, freeze in freezes:
+        removed = ", ".join(
+            f"#{item.get('number')}" for item in freeze.get("ready_labels_removed", [])
+        ) or "none"
+        lines.append(
+            "- operator milestone freeze after {stop_after}: "
+            "{completed} completed, ready labels removed from {removed}; evidence `{path}`".format(
+                stop_after=freeze.get("stop_after", "?"),
+                completed=freeze.get("completed_product_issues", "?"),
+                removed=removed,
+                path=rel(path, run_root),
+            )
+        )
+    return lines
+
+
 def lifecycle_verdict(product_done: list[dict[str, Any]], merged_prs: list[dict[str, Any]]) -> str:
     if len(product_done) >= 10 and len(merged_prs) >= 10:
         return "READY FOR OPERATOR PASS REVIEW"
@@ -147,6 +177,7 @@ def operator_checklist() -> list[str]:
         "- [ ] Rework was exercised and reviewer findings are linked.",
         "- [ ] Reconcile cancellation control was captured.",
         "- [ ] Continuation / turn-budget stress evidence was captured.",
+        "- [ ] Operator milestone freeze evidence was captured when used.",
         "- [ ] Fresh-clone npm verification passed.",
         "- [ ] Product screenshots include gameplay, mobile, performance, and boss/finale evidence.",
         "- [ ] Maker, reviewer, and optional stress dashboards are idle or intentionally stopped.",
@@ -204,6 +235,10 @@ def write_report(args: argparse.Namespace) -> Path:
         "## PR Results",
         "",
         *pr_rows(prs),
+        "",
+        "## Operator Milestone Freezes",
+        "",
+        *milestone_freeze_bullets(run_root),
         "",
         "## Evidence Inventory",
         "",


### PR DESCRIPTION
Closes #990

## Summary
- Add `scripts/e2e-crowdrunner-freeze.py` so an operator can freeze dispatch after N completed Crowd Runner product issues by removing remaining `aiops/todo` ready labels.
- Record the stop as operator milestone evidence under `state/` and `reports/`, and surface that evidence in the generated lifecycle report.
- Update the Crowd Runner lifecycle runbook and generated `NEXT-STEPS.md` with the optional stop-after workflow.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go test -run 'TestCrowdRunner(LifecycleRunbookDocumentsReusableSOP|BootstrapPreparesRunRoot|ReportGeneratesThreeVerdicts|FreezeStopsDispatchAfterMilestone)' -count=1 ./scripts`
- `python3 -m py_compile scripts/e2e-crowdrunner-freeze.py scripts/e2e-crowdrunner-report.py`
- Mutation verification: changed the freeze helper's default product range from 1-12 to 1-13; `TestCrowdRunnerFreezeStopsDispatchAfterMilestone` failed because it tried to remove `aiops/todo` from control issue #13; restored HEAD and reran the test successfully.

## Notes
- This is E2E harness-only; normal worker dispatch behavior is unchanged.
