### PR TITLE
test(e2e): make continuation control deterministic

### DIFF
--- a/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
@@ -273,7 +273,11 @@ scripts/e2e-crowdrunner-capture.py \
 - **Blocked held:** confirm issue 15 remains undispatched.
 - **Continuation budget:** start the stress worker on port 4203 with
   `workflows/maker-low-turn-WORKFLOW.md`, label issue 16 `aiops/stress`, then
-  capture stress worker state and logs.
+  wait for local continuation-budget exhaustion. The bootstrap writes
+  `state/continuation-control-expected.json`; the expected machine evidence is
+  `state/stress-final.json` with `counts.blocked >= 1` and a blocked row for
+  issue 16 whose `method` is `continuation_budget`. A PR, terminal label, or
+  `Human Review` handoff for issue 16 means the control failed.
 
 ## 8. Final Verification
 
@@ -330,7 +334,7 @@ Pass when:
 - all product issues reach `aiops/done`;
 - product PRs merge through reviewer approval and CI;
 - Rework, cancellation, no-ready, blocked, and continuation-budget controls
-  behave as expected;
+  behave as expected, including the report's continuation-control assertion;
 - maker/reviewer dashboards are idle at closeout;
 - fresh-clone npm verification and Playwright smoke pass;
 - required screenshots and logs exist.

--- a/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
@@ -310,13 +310,19 @@ and `final-verify/videos/`.
 
 ## 9. Generate the Report Pack
 
-Save final state:
+Save final state. The final capture writes `state/maker-final.json`,
+`state/reviewer-final.json`, and `state/stress-final.json` from the dashboard
+state APIs before the report reads them:
 
 ```bash
-curl -fsS "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL/api/v1/state" \
-  > "$AIOPS_CROWDRUNNER_RUN_ROOT/state/maker-final.json"
-curl -fsS "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL/api/v1/state" \
-  > "$AIOPS_CROWDRUNNER_RUN_ROOT/state/reviewer-final.json"
+scripts/e2e-crowdrunner-capture.py \
+  --run-root "$AIOPS_CROWDRUNNER_RUN_ROOT" \
+  --maker-url "$AIOPS_CROWDRUNNER_MAKER_DASHBOARD_URL" \
+  --reviewer-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL" \
+  --stress-url "$AIOPS_CROWDRUNNER_STRESS_DASHBOARD_URL" \
+  --tui-bin "$AIOPS_CROWDRUNNER_TUI_BIN" \
+  --tag final \
+  --no-default-screenshots
 curl -fsS -H "Authorization: token $GITEA_TOKEN" \
   "$AIOPS_CROWDRUNNER_GITEA_URL/api/v1/repos/$AIOPS_CROWDRUNNER_REPO_OWNER/$AIOPS_CROWDRUNNER_REPO_NAME/issues?state=all" \
   > "$AIOPS_CROWDRUNNER_RUN_ROOT/state/issues-final.json"

--- a/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
@@ -129,7 +129,8 @@ Required labels:
 - `aiops/rework`
 - `aiops/done`
 - `aiops/canceled`
-- `aiops/stress`
+- `aiops/stress` (auxiliary routing label for issue 16; pair it with
+  `aiops/todo` so Gitea derives the mapped `Todo` state)
 
 Create issues from `issues/*.md` without `aiops/*` state labels. Keep product
 issues inactive until the dashboard doctor passes; after that gate, activate
@@ -138,7 +139,8 @@ issues 1-12 by adding `aiops/todo`. Keep control issues staged:
 - Issue 13: no `aiops/*` label.
 - Issue 14: add `aiops/todo` only when testing cancellation.
 - Issue 15: leave unlabeled or blocked.
-- Issue 16: run only with the low-turn stress workflow and `aiops/stress`.
+- Issue 16: run only with the low-turn stress workflow; add both `aiops/todo`
+  and `aiops/stress` when starting the continuation-budget control.
 
 Save the created issue list:
 
@@ -272,7 +274,8 @@ scripts/e2e-crowdrunner-capture.py \
   after state.
 - **Blocked held:** confirm issue 15 remains undispatched.
 - **Continuation budget:** start the stress worker on port 4203 with
-  `workflows/maker-low-turn-WORKFLOW.md`, label issue 16 `aiops/stress`, then
+  `workflows/maker-low-turn-WORKFLOW.md`, label issue 16 with both `aiops/todo`
+  and `aiops/stress`, then
   wait for local continuation-budget exhaustion. The bootstrap writes
   `state/continuation-control-expected.json`; the expected machine evidence is
   `state/stress-final.json` with `counts.blocked >= 1` and a blocked row for

--- a/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-crowdrunner-lifecycle-e2e.md
@@ -130,7 +130,8 @@ Required labels:
 - `aiops/done`
 - `aiops/canceled`
 - `aiops/stress` (auxiliary routing label for issue 16; pair it with
-  `aiops/todo` so Gitea derives the mapped `Todo` state)
+  `aiops/in-progress` so Gitea derives a mapped state that the main maker
+  workflow treats as inactive)
 
 Create issues from `issues/*.md` without `aiops/*` state labels. Keep product
 issues inactive until the dashboard doctor passes; after that gate, activate
@@ -139,8 +140,9 @@ issues 1-12 by adding `aiops/todo`. Keep control issues staged:
 - Issue 13: no `aiops/*` label.
 - Issue 14: add `aiops/todo` only when testing cancellation.
 - Issue 15: leave unlabeled or blocked.
-- Issue 16: run only with the low-turn stress workflow; add both `aiops/todo`
-  and `aiops/stress` when starting the continuation-budget control.
+- Issue 16: run only with the low-turn stress workflow; add both
+  `aiops/in-progress` and `aiops/stress` when starting the continuation-budget
+  control.
 
 Save the created issue list:
 
@@ -274,8 +276,8 @@ scripts/e2e-crowdrunner-capture.py \
   after state.
 - **Blocked held:** confirm issue 15 remains undispatched.
 - **Continuation budget:** start the stress worker on port 4203 with
-  `workflows/maker-low-turn-WORKFLOW.md`, label issue 16 with both `aiops/todo`
-  and `aiops/stress`, then
+  `workflows/maker-low-turn-WORKFLOW.md`, label issue 16 with both
+  `aiops/in-progress` and `aiops/stress`, then
   wait for local continuation-budget exhaustion. The bootstrap writes
   `state/continuation-control-expected.json`; the expected machine evidence is
   `state/stress-final.json` with `counts.blocked >= 1` and a blocked row for

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -89,6 +89,7 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 		"issues/12-release-polish-pwa.md",
 		"issues/16-control-continuation-budget.md",
 		"state",
+		"state/continuation-control-expected.json",
 		"artifacts",
 		"logs",
 		"downloads",
@@ -145,6 +146,30 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 	} {
 		if !strings.Contains(issue, want) {
 			t.Fatalf("issue 07 missing %q\n%s", want, issue)
+		}
+	}
+
+	controlIssue := readFileString(t, filepath.Join(runRoot, "issues", "16-control-continuation-budget.md"))
+	for _, want := range []string{
+		"CONTINUATION_BUDGET_CANARY",
+		".aiops/operator-continuation-release",
+		"must not edit files, commit, push, open a PR",
+		`method of continuation_budget for issue #16`,
+	} {
+		if !strings.Contains(controlIssue, want) {
+			t.Fatalf("issue 16 missing %q\n%s", want, controlIssue)
+		}
+	}
+
+	expectation := readFileString(t, filepath.Join(runRoot, "state", "continuation-control-expected.json"))
+	for _, want := range []string{
+		`"kind": "continuation_budget_control_expectation"`,
+		`"issue_number": 16`,
+		`"expected_blocked_method": "continuation_budget"`,
+		`"forbidden_pr_issue_reference": "#16"`,
+	} {
+		if !strings.Contains(expectation, want) {
+			t.Fatalf("continuation expectation missing %q\n%s", want, expectation)
 		}
 	}
 
@@ -209,6 +234,9 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 				"  max_continuation_turns: 2",
 				"    - Stress",
 				"  root: " + filepath.Join(runRoot, "workspaces", "stress"),
+				"deterministic continuation-budget stress-control agent",
+				"Do not edit files, create branches, commit, push, open a pull request",
+				`method: "continuation_budget"`,
 			},
 		},
 	} {
@@ -225,6 +253,9 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 	}
 	if strings.Contains(stressWorkflow, "    - Todo") || strings.Contains(stressWorkflow, "    - Rework") {
 		t.Fatalf("stress workflow should not claim Todo/Rework states:\n%s", stressWorkflow)
+	}
+	if strings.Contains(stressWorkflow, "You are an autonomous MAKER agent") {
+		t.Fatalf("stress workflow should not inherit the maker PR prompt:\n%s", stressWorkflow)
 	}
 }
 
@@ -245,7 +276,16 @@ func TestCrowdRunnerReportGeneratesThreeVerdicts(t *testing.T) {
 	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), fakeMergedPRsJSON())
 	writeFileString(t, filepath.Join(runRoot, "state", "maker-final.json"), `{"counts":{"running":0,"blocked":0}}`)
 	writeFileString(t, filepath.Join(runRoot, "state", "reviewer-final.json"), `{"counts":{"running":0,"blocked":0}}`)
-	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{"counts":{"running":0,"blocked":1}}`)
+	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{
+		"counts":{"running":0,"blocked":1},
+		"blocked":[{"issue_identifier":"#16","issue_url":"http://gitea.local/aiops-bot/crowd-runner-product/issues/16","method":"continuation_budget"}]
+	}`)
+	writeFileString(t, filepath.Join(runRoot, "state", "continuation-control-expected.json"), `{
+		"kind":"continuation_budget_control_expectation",
+		"issue_number":16,
+		"expected_blocked_method":"continuation_budget",
+		"forbidden_pr_issue_reference":"#16"
+	}`)
 	writeFileString(t, filepath.Join(runRoot, "state", "operator-milestone-freeze-after-10.json"), `{
 		"kind":"operator_milestone_freeze",
 		"stop_after":10,
@@ -283,6 +323,8 @@ func TestCrowdRunnerReportGeneratesThreeVerdicts(t *testing.T) {
 		"Operator milestone freeze",
 		"ready labels removed from #11, #12",
 		"Continuation / turn-budget stress evidence",
+		"Continuation control: PASS",
+		"issue #16 blocked via `continuation_budget`",
 		"#12",
 		"final-verify/videos/gameplay.webm",
 	} {
@@ -293,6 +335,37 @@ func TestCrowdRunnerReportGeneratesThreeVerdicts(t *testing.T) {
 	promo := readFileString(t, filepath.Join(runRoot, "promo", "notes", "promotion-materials.md"))
 	if !strings.Contains(promo, "fresh crowd-runner design") {
 		t.Fatalf("promo notes missing fresh product positioning:\n%s", promo)
+	}
+}
+
+func TestCrowdRunnerReportRejectsContinuationControlPR(t *testing.T) {
+	root := repoRoot(t)
+	runRoot := filepath.Join(t.TempDir(), "run")
+	mkdirAll(t, filepath.Join(runRoot, "state"), filepath.Join(runRoot, "reports"), filepath.Join(runRoot, "promo", "notes"))
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesJSON())
+	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), `[
+		{"number":22,"title":"test: finish continuation control","body":"Refs #16","state":"closed","merged":true,"head":{"ref":"ai/16-control-continuation-budget"}}
+	]`)
+	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{
+		"counts":{"running":0,"blocked":1},
+		"blocked":[{"issue_identifier":"#16","method":"continuation_budget"}]
+	}`)
+	writeFileString(t, filepath.Join(runRoot, "state", "continuation-control-expected.json"), `{
+		"kind":"continuation_budget_control_expectation",
+		"issue_number":16,
+		"expected_blocked_method":"continuation_budget",
+		"forbidden_pr_issue_reference":"#16"
+	}`)
+
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "e2e-crowdrunner-report.py"), "--run-root", runRoot)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("report failed: %v\n%s", err, out)
+	}
+	report := readFileString(t, filepath.Join(runRoot, "reports", "report.md"))
+	if !strings.Contains(report, "Continuation control: FAIL: control issue #16 produced PR(s) #22") {
+		t.Fatalf("report did not reject the control PR:\n%s", report)
 	}
 }
 

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -153,7 +153,7 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 	for _, want := range []string{
 		"CONTINUATION_BUDGET_CANARY",
 		".aiops/operator-continuation-release",
-		"both aiops/todo and aiops/stress",
+		"both aiops/in-progress and aiops/stress",
 		"must not edit files, commit, push, open a PR",
 		`method of continuation_budget for issue #16`,
 	} {
@@ -166,7 +166,7 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 	for _, want := range []string{
 		`"kind": "continuation_budget_control_expectation"`,
 		`"issue_number": 16`,
-		`"active_label": "aiops/todo"`,
+		`"active_label": "aiops/in-progress"`,
 		`"routing_label": "aiops/stress"`,
 		`"expected_blocked_method": "continuation_budget"`,
 		`"forbidden_pr_issue_reference": "#16"`,
@@ -236,7 +236,7 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 			want: []string{
 				"  max_turns: 1",
 				"  max_continuation_turns: 2",
-				"    - Todo",
+				"    - In Progress",
 				"  required_labels:",
 				"    - aiops/stress",
 				"  root: " + filepath.Join(runRoot, "workspaces", "stress"),
@@ -257,8 +257,10 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 			}
 		}
 	}
-	if strings.Contains(stressWorkflow, "    - Stress") || strings.Contains(stressWorkflow, "    - Rework") {
-		t.Fatalf("stress workflow should use mapped Todo plus required labels, not Stress/Rework states:\n%s", stressWorkflow)
+	if strings.Contains(stressWorkflow, "    - Todo") ||
+		strings.Contains(stressWorkflow, "    - Stress") ||
+		strings.Contains(stressWorkflow, "    - Rework") {
+		t.Fatalf("stress workflow should use mapped In Progress plus required labels, not maker/stress states:\n%s", stressWorkflow)
 	}
 	if strings.Contains(stressWorkflow, "You are an autonomous MAKER agent") {
 		t.Fatalf("stress workflow should not inherit the maker PR prompt:\n%s", stressWorkflow)

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -290,7 +290,7 @@ func TestCrowdRunnerReportGeneratesThreeVerdicts(t *testing.T) {
 		filepath.Join(runRoot, "final-verify", "playwright-report"),
 		filepath.Join(runRoot, "logs"),
 	)
-	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithControlJSON("open"))
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithOpenControlJSON())
 	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), fakeMergedPRsJSON())
 	writeFileString(t, filepath.Join(runRoot, "state", "maker-final.json"), `{"counts":{"running":0,"blocked":0}}`)
 	writeFileString(t, filepath.Join(runRoot, "state", "reviewer-final.json"), `{"counts":{"running":0,"blocked":0}}`)
@@ -360,7 +360,7 @@ func TestCrowdRunnerReportRejectsContinuationControlPR(t *testing.T) {
 	root := repoRoot(t)
 	runRoot := filepath.Join(t.TempDir(), "run")
 	mkdirAll(t, filepath.Join(runRoot, "state"), filepath.Join(runRoot, "reports"), filepath.Join(runRoot, "promo", "notes"))
-	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithControlJSON("open"))
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithOpenControlJSON())
 	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), `[
 		{"number":22,"title":"test: finish control","body":"","state":"closed","merged":true,"head":{"ref":"ai/16"}}
 	]`)
@@ -391,7 +391,7 @@ func TestCrowdRunnerReportRejectsContinuationControlTerminalLabel(t *testing.T) 
 	root := repoRoot(t)
 	runRoot := filepath.Join(t.TempDir(), "run")
 	mkdirAll(t, filepath.Join(runRoot, "state"), filepath.Join(runRoot, "reports"), filepath.Join(runRoot, "promo", "notes"))
-	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithControlJSON("open", "aiops/human-review"))
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithOpenControlJSON("aiops/human-review"))
 	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), `[]`)
 	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{
 		"counts":{"running":0,"blocked":1},
@@ -413,6 +413,35 @@ func TestCrowdRunnerReportRejectsContinuationControlTerminalLabel(t *testing.T) 
 	report := readFileString(t, filepath.Join(runRoot, "reports", "report.md"))
 	if !strings.Contains(report, "Continuation control: FAIL: control issue #16 has forbidden label(s) aiops/human-review.") {
 		t.Fatalf("report did not reject the control terminal label:\n%s", report)
+	}
+}
+
+func TestCrowdRunnerReportRejectsAnonymousContinuationControlRow(t *testing.T) {
+	root := repoRoot(t)
+	runRoot := filepath.Join(t.TempDir(), "run")
+	mkdirAll(t, filepath.Join(runRoot, "state"), filepath.Join(runRoot, "reports"), filepath.Join(runRoot, "promo", "notes"))
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithOpenControlJSON())
+	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), `[]`)
+	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{
+		"counts":{"running":0,"blocked":1},
+		"blocked":[{"method":"continuation_budget"}]
+	}`)
+	writeFileString(t, filepath.Join(runRoot, "state", "continuation-control-expected.json"), `{
+		"kind":"continuation_budget_control_expectation",
+		"issue_number":16,
+		"expected_blocked_method":"continuation_budget"
+	}`)
+
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "e2e-crowdrunner-report.py"), "--run-root", runRoot)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("report failed: %v\n%s", err, out)
+	}
+	report := readFileString(t, filepath.Join(runRoot, "reports", "report.md"))
+	want := "Continuation control: FAIL: stress worker blocked, but no issue #16 `continuation_budget` row was captured."
+	if !strings.Contains(report, want) {
+		t.Fatalf("report accepted anonymous continuation row; missing %q\n%s", want, report)
 	}
 }
 
@@ -591,13 +620,13 @@ func fakeCrowdRunnerDoneIssuesJSON() string {
 	return "[" + strings.Join(rows, ",") + "]"
 }
 
-func fakeCrowdRunnerDoneIssuesWithControlJSON(state string, labels ...string) string {
+func fakeCrowdRunnerDoneIssuesWithOpenControlJSON(labels ...string) string {
 	body := strings.TrimSuffix(strings.TrimPrefix(fakeCrowdRunnerDoneIssuesJSON(), "["), "]")
 	var labelRows []string
 	for _, label := range labels {
 		labelRows = append(labelRows, `{"name":"`+label+`"}`)
 	}
-	control := `{"number":16,"title":"control","state":"` + state + `","labels":[` + strings.Join(labelRows, ",") + `]}`
+	control := `{"number":16,"title":"control","state":"open","labels":[` + strings.Join(labelRows, ",") + `]}`
 	return "[" + body + "," + control + "]"
 }
 

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -153,6 +153,7 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 	for _, want := range []string{
 		"CONTINUATION_BUDGET_CANARY",
 		".aiops/operator-continuation-release",
+		"both aiops/todo and aiops/stress",
 		"must not edit files, commit, push, open a PR",
 		`method of continuation_budget for issue #16`,
 	} {
@@ -165,8 +166,11 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 	for _, want := range []string{
 		`"kind": "continuation_budget_control_expectation"`,
 		`"issue_number": 16`,
+		`"active_label": "aiops/todo"`,
+		`"routing_label": "aiops/stress"`,
 		`"expected_blocked_method": "continuation_budget"`,
 		`"forbidden_pr_issue_reference": "#16"`,
+		`"aiops/human-review"`,
 	} {
 		if !strings.Contains(expectation, want) {
 			t.Fatalf("continuation expectation missing %q\n%s", want, expectation)
@@ -232,7 +236,9 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 			want: []string{
 				"  max_turns: 1",
 				"  max_continuation_turns: 2",
-				"    - Stress",
+				"    - Todo",
+				"  required_labels:",
+				"    - aiops/stress",
 				"  root: " + filepath.Join(runRoot, "workspaces", "stress"),
 				"deterministic continuation-budget stress-control agent",
 				"Do not edit files, create branches, commit, push, open a pull request",
@@ -251,8 +257,8 @@ func TestCrowdRunnerBootstrapPreparesRunRoot(t *testing.T) {
 			}
 		}
 	}
-	if strings.Contains(stressWorkflow, "    - Todo") || strings.Contains(stressWorkflow, "    - Rework") {
-		t.Fatalf("stress workflow should not claim Todo/Rework states:\n%s", stressWorkflow)
+	if strings.Contains(stressWorkflow, "    - Stress") || strings.Contains(stressWorkflow, "    - Rework") {
+		t.Fatalf("stress workflow should use mapped Todo plus required labels, not Stress/Rework states:\n%s", stressWorkflow)
 	}
 	if strings.Contains(stressWorkflow, "You are an autonomous MAKER agent") {
 		t.Fatalf("stress workflow should not inherit the maker PR prompt:\n%s", stressWorkflow)
@@ -373,7 +379,7 @@ func TestCrowdRunnerReportRejectsContinuationControlTerminalLabel(t *testing.T) 
 	root := repoRoot(t)
 	runRoot := filepath.Join(t.TempDir(), "run")
 	mkdirAll(t, filepath.Join(runRoot, "state"), filepath.Join(runRoot, "reports"), filepath.Join(runRoot, "promo", "notes"))
-	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithControlJSON("open", "Human Review"))
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithControlJSON("open", "aiops/human-review"))
 	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), `[]`)
 	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{
 		"counts":{"running":0,"blocked":1},
@@ -383,7 +389,7 @@ func TestCrowdRunnerReportRejectsContinuationControlTerminalLabel(t *testing.T) 
 		"kind":"continuation_budget_control_expectation",
 		"issue_number":16,
 		"expected_blocked_method":"continuation_budget",
-		"forbidden_terminal_labels":["aiops/done","aiops/canceled","Human Review"]
+		"forbidden_terminal_labels":["aiops/done","aiops/canceled","aiops/human-review"]
 	}`)
 
 	cmd := exec.Command("python3", filepath.Join(root, "scripts", "e2e-crowdrunner-report.py"), "--run-root", runRoot)
@@ -393,7 +399,7 @@ func TestCrowdRunnerReportRejectsContinuationControlTerminalLabel(t *testing.T) 
 		t.Fatalf("report failed: %v\n%s", err, out)
 	}
 	report := readFileString(t, filepath.Join(runRoot, "reports", "report.md"))
-	if !strings.Contains(report, "Continuation control: FAIL: control issue #16 has forbidden label(s) Human Review.") {
+	if !strings.Contains(report, "Continuation control: FAIL: control issue #16 has forbidden label(s) aiops/human-review.") {
 		t.Fatalf("report did not reject the control terminal label:\n%s", report)
 	}
 }

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -387,6 +387,38 @@ func TestCrowdRunnerReportRejectsContinuationControlPR(t *testing.T) {
 	}
 }
 
+func TestCrowdRunnerReportRejectsContinuationControlPRByTrackerID(t *testing.T) {
+	root := repoRoot(t)
+	runRoot := filepath.Join(t.TempDir(), "run")
+	mkdirAll(t, filepath.Join(runRoot, "state"), filepath.Join(runRoot, "reports"), filepath.Join(runRoot, "promo", "notes"))
+	doneIssues := strings.TrimSuffix(strings.TrimPrefix(fakeCrowdRunnerDoneIssuesJSON(), "["), "]")
+	controlIssue := `{"id":1601,"number":16,"title":"control","state":"open","labels":[]}`
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), "["+doneIssues+","+controlIssue+"]")
+	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), `[
+		{"number":23,"title":"test: finish unrelated","body":"","state":"closed","merged":true,"head":{"ref":"ai/1601"}}
+	]`)
+	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{
+		"counts":{"running":0,"blocked":1},
+		"blocked":[{"issue_identifier":"#16","method":"continuation_budget"}]
+	}`)
+	writeFileString(t, filepath.Join(runRoot, "state", "continuation-control-expected.json"), `{
+		"kind":"continuation_budget_control_expectation",
+		"issue_number":16,
+		"expected_blocked_method":"continuation_budget"
+	}`)
+
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "e2e-crowdrunner-report.py"), "--run-root", runRoot)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("report failed: %v\n%s", err, out)
+	}
+	report := readFileString(t, filepath.Join(runRoot, "reports", "report.md"))
+	if !strings.Contains(report, "Continuation control: FAIL: control issue #16 produced PR(s) #23") {
+		t.Fatalf("report did not reject the tracker-id control PR:\n%s", report)
+	}
+}
+
 func TestCrowdRunnerReportRejectsContinuationControlTerminalLabel(t *testing.T) {
 	root := repoRoot(t)
 	runRoot := filepath.Join(t.TempDir(), "run")

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -41,6 +41,9 @@ func TestCrowdRunnerLifecycleRunbookDocumentsReusableSOP(t *testing.T) {
 		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
 		"operator milestone evidence",
 		"Do not commit `env.local`",
+		"`state/stress-final.json`",
+		`--tag final`,
+		`--stress-url "$AIOPS_CROWDRUNNER_STRESS_DASHBOARD_URL"`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("runbook missing %q", want)
@@ -53,6 +56,13 @@ func TestCrowdRunnerLifecycleRunbookDocumentsReusableSOP(t *testing.T) {
 		`--dashboard-url "$AIOPS_CROWDRUNNER_REVIEWER_DASHBOARD_URL"`,
 		"add `aiops/todo` to issues 1-12",
 		"trigger a work poll:",
+	})
+	assertInOrder(t, text, []string{
+		"## 9. Generate the Report Pack",
+		"state/stress-final.json",
+		"scripts/e2e-crowdrunner-capture.py",
+		`--tag final`,
+		"scripts/e2e-crowdrunner-report.py",
 	})
 }
 

--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -272,7 +272,7 @@ func TestCrowdRunnerReportGeneratesThreeVerdicts(t *testing.T) {
 		filepath.Join(runRoot, "final-verify", "playwright-report"),
 		filepath.Join(runRoot, "logs"),
 	)
-	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesJSON())
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithControlJSON("open"))
 	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), fakeMergedPRsJSON())
 	writeFileString(t, filepath.Join(runRoot, "state", "maker-final.json"), `{"counts":{"running":0,"blocked":0}}`)
 	writeFileString(t, filepath.Join(runRoot, "state", "reviewer-final.json"), `{"counts":{"running":0,"blocked":0}}`)
@@ -342,9 +342,9 @@ func TestCrowdRunnerReportRejectsContinuationControlPR(t *testing.T) {
 	root := repoRoot(t)
 	runRoot := filepath.Join(t.TempDir(), "run")
 	mkdirAll(t, filepath.Join(runRoot, "state"), filepath.Join(runRoot, "reports"), filepath.Join(runRoot, "promo", "notes"))
-	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesJSON())
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithControlJSON("open"))
 	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), `[
-		{"number":22,"title":"test: finish continuation control","body":"Refs #16","state":"closed","merged":true,"head":{"ref":"ai/16-control-continuation-budget"}}
+		{"number":22,"title":"test: finish control","body":"","state":"closed","merged":true,"head":{"ref":"ai/16"}}
 	]`)
 	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{
 		"counts":{"running":0,"blocked":1},
@@ -366,6 +366,35 @@ func TestCrowdRunnerReportRejectsContinuationControlPR(t *testing.T) {
 	report := readFileString(t, filepath.Join(runRoot, "reports", "report.md"))
 	if !strings.Contains(report, "Continuation control: FAIL: control issue #16 produced PR(s) #22") {
 		t.Fatalf("report did not reject the control PR:\n%s", report)
+	}
+}
+
+func TestCrowdRunnerReportRejectsContinuationControlTerminalLabel(t *testing.T) {
+	root := repoRoot(t)
+	runRoot := filepath.Join(t.TempDir(), "run")
+	mkdirAll(t, filepath.Join(runRoot, "state"), filepath.Join(runRoot, "reports"), filepath.Join(runRoot, "promo", "notes"))
+	writeFileString(t, filepath.Join(runRoot, "state", "issues-final.json"), fakeCrowdRunnerDoneIssuesWithControlJSON("open", "Human Review"))
+	writeFileString(t, filepath.Join(runRoot, "state", "prs-final.json"), `[]`)
+	writeFileString(t, filepath.Join(runRoot, "state", "stress-final.json"), `{
+		"counts":{"running":0,"blocked":1},
+		"blocked":[{"issue_identifier":"#16","method":"continuation_budget"}]
+	}`)
+	writeFileString(t, filepath.Join(runRoot, "state", "continuation-control-expected.json"), `{
+		"kind":"continuation_budget_control_expectation",
+		"issue_number":16,
+		"expected_blocked_method":"continuation_budget",
+		"forbidden_terminal_labels":["aiops/done","aiops/canceled","Human Review"]
+	}`)
+
+	cmd := exec.Command("python3", filepath.Join(root, "scripts", "e2e-crowdrunner-report.py"), "--run-root", runRoot)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("report failed: %v\n%s", err, out)
+	}
+	report := readFileString(t, filepath.Join(runRoot, "reports", "report.md"))
+	if !strings.Contains(report, "Continuation control: FAIL: control issue #16 has forbidden label(s) Human Review.") {
+		t.Fatalf("report did not reject the control terminal label:\n%s", report)
 	}
 }
 
@@ -542,6 +571,16 @@ func fakeCrowdRunnerDoneIssuesJSON() string {
 		rows = append(rows, `{"number":`+itoa(i)+`,"title":"issue `+itoa(i)+`","state":"closed","labels":[{"name":"aiops/done"}]}`)
 	}
 	return "[" + strings.Join(rows, ",") + "]"
+}
+
+func fakeCrowdRunnerDoneIssuesWithControlJSON(state string, labels ...string) string {
+	body := strings.TrimSuffix(strings.TrimPrefix(fakeCrowdRunnerDoneIssuesJSON(), "["), "]")
+	var labelRows []string
+	for _, label := range labels {
+		labelRows = append(labelRows, `{"name":"`+label+`"}`)
+	}
+	control := `{"number":16,"title":"control","state":"` + state + `","labels":[` + strings.Join(labelRows, ",") + `]}`
+	return "[" + body + "," + control + "]"
 }
 
 func fakeCrowdRunnerMilestoneIssuesJSON() string {

--- a/scripts/e2e-crowdrunner-bootstrap.sh
+++ b/scripts/e2e-crowdrunner-bootstrap.sh
@@ -122,8 +122,9 @@ For issue #16:
 - On every turn, inspect whether the sentinel exists. If it is absent, report
   that the control remains intentionally active and stop the turn cleanly
   without tracker handoff.
-- Leave the Gitea issue in `aiops/stress` so the worker performs continuation
-  retries until `agent.max_continuation_turns` is exhausted.
+- Leave the Gitea issue with both `aiops/todo` and `aiops/stress` so the
+  mapped `Todo` state dispatches only through this stress worker's required
+  routing label until `agent.max_continuation_turns` is exhausted.
 
 Expected harness result: `/api/v1/state` shows issue #16 in `blocked` with
 `method: "continuation_budget"`. Any PR, terminal label, or Human Review handoff
@@ -168,7 +169,7 @@ STRESS_PROMPT
         fi ;;
       "    - Todo")
         if [ "$mode" = "stress" ]; then
-          printf '    - Stress\n'
+          printf '%s\n' "$line"
         else
           printf '%s\n' "$line"
         fi ;;
@@ -178,6 +179,12 @@ STRESS_PROMPT
         else
           printf '%s\n' "$line"
         fi ;;
+      "  inactive_states:")
+        if [ "$mode" = "stress" ]; then
+          printf '  required_labels:\n'
+          printf '    - aiops/stress\n'
+        fi
+        printf '%s\n' "$line" ;;
       *)
         line="${line//go build .\/.../npm ci, npm run lint, npm run test -- --run, and npm run build}"
         line="${line//go test .\/.../npm run test -- --run}"
@@ -195,14 +202,15 @@ cat >"$run_root/state/continuation-control-expected.json" <<'EOF'
   "kind": "continuation_budget_control_expectation",
   "issue_number": 16,
   "worker": "stress",
-  "active_label": "aiops/stress",
+  "active_label": "aiops/todo",
+  "routing_label": "aiops/stress",
   "expected_state_file": "state/stress-final.json",
   "expected_blocked_method": "continuation_budget",
   "expected_counts": {
     "blocked_at_least": 1
   },
   "forbidden_pr_issue_reference": "#16",
-  "forbidden_terminal_labels": ["aiops/done", "aiops/canceled", "Human Review"]
+  "forbidden_terminal_labels": ["aiops/done", "aiops/canceled", "aiops/human-review"]
 }
 EOF
 
@@ -458,12 +466,12 @@ write_issue 15 control-blocked-held "CONTROL blocked issue held out of ready gat
 write_issue 16 control-continuation-budget "CONTROL continuation budget stress worker" \
 "Control scenario:
 - This is CONTINUATION_BUDGET_CANARY and must not produce product code.
-- Run only with workflows/maker-low-turn-WORKFLOW.md on the Stress state.
-- Label this issue aiops/stress, not aiops/todo.
+- Run only with workflows/maker-low-turn-WORKFLOW.md on Todo plus the aiops/stress routing label.
+- Label this issue with both aiops/todo and aiops/stress when starting the control.
 - The required sentinel .aiops/operator-continuation-release is intentionally absent and may only be created by the operator.
 - The stress agent must not edit files, commit, push, open a PR, move labels, or hand off to Human Review.
 - Expected terminal evidence is state/stress-final.json with counts.blocked >= 1 and a blocked row method of continuation_budget for issue #16.
-- A PR, aiops/done, aiops/canceled, Human Review handoff, or normal one-turn completion is a failed control.
+- A PR, aiops/done, aiops/canceled, aiops/human-review handoff, or normal one-turn completion is a failed control.
 - Capture stress worker state and logs after the continuation budget blocks locally.
 - Do not mix this worker with the main maker/reviewer evidence."
 

--- a/scripts/e2e-crowdrunner-bootstrap.sh
+++ b/scripts/e2e-crowdrunner-bootstrap.sh
@@ -122,9 +122,9 @@ For issue #16:
 - On every turn, inspect whether the sentinel exists. If it is absent, report
   that the control remains intentionally active and stop the turn cleanly
   without tracker handoff.
-- Leave the Gitea issue with both `aiops/todo` and `aiops/stress` so the
-  mapped `Todo` state dispatches only through this stress worker's required
-  routing label until `agent.max_continuation_turns` is exhausted.
+- Leave the Gitea issue with both `aiops/in-progress` and `aiops/stress` so the
+  mapped `In Progress` state dispatches only through this stress worker's
+  required routing label until `agent.max_continuation_turns` is exhausted.
 
 Expected harness result: `/api/v1/state` shows issue #16 in `blocked` with
 `method: "continuation_budget"`. Any PR, terminal label, or Human Review handoff
@@ -169,7 +169,7 @@ STRESS_PROMPT
         fi ;;
       "    - Todo")
         if [ "$mode" = "stress" ]; then
-          printf '%s\n' "$line"
+          printf '    - In Progress\n'
         else
           printf '%s\n' "$line"
         fi ;;
@@ -202,7 +202,7 @@ cat >"$run_root/state/continuation-control-expected.json" <<'EOF'
   "kind": "continuation_budget_control_expectation",
   "issue_number": 16,
   "worker": "stress",
-  "active_label": "aiops/todo",
+  "active_label": "aiops/in-progress",
   "routing_label": "aiops/stress",
   "expected_state_file": "state/stress-final.json",
   "expected_blocked_method": "continuation_budget",
@@ -466,8 +466,8 @@ write_issue 15 control-blocked-held "CONTROL blocked issue held out of ready gat
 write_issue 16 control-continuation-budget "CONTROL continuation budget stress worker" \
 "Control scenario:
 - This is CONTINUATION_BUDGET_CANARY and must not produce product code.
-- Run only with workflows/maker-low-turn-WORKFLOW.md on Todo plus the aiops/stress routing label.
-- Label this issue with both aiops/todo and aiops/stress when starting the control.
+- Run only with workflows/maker-low-turn-WORKFLOW.md on In Progress plus the aiops/stress routing label.
+- Label this issue with both aiops/in-progress and aiops/stress when starting the control.
 - The required sentinel .aiops/operator-continuation-release is intentionally absent and may only be created by the operator.
 - The stress agent must not edit files, commit, push, open a PR, move labels, or hand off to Human Review.
 - Expected terminal evidence is state/stress-final.json with counts.blocked >= 1 and a blocked row method of continuation_budget for issue #16.

--- a/scripts/e2e-crowdrunner-bootstrap.sh
+++ b/scripts/e2e-crowdrunner-bootstrap.sh
@@ -102,7 +102,37 @@ render_workflow() {
   local workspace_root="$3"
   local mode="${4:-normal}"
   local skip_next_go_test=0
+  local frontmatter_delims=0
   while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$mode" = "stress" ] && [ "$line" = "---" ]; then
+      frontmatter_delims=$((frontmatter_delims + 1))
+      printf '%s\n' "$line"
+      if [ "$frontmatter_delims" -eq 2 ]; then
+        cat <<'STRESS_PROMPT'
+You are a deterministic continuation-budget stress-control agent.
+
+This workflow only exercises aiops-platform's continuation-budget boundary. It
+is not a product maker workflow.
+
+For issue #16:
+- Do not edit files, create branches, commit, push, open a pull request, comment
+  a PR URL, or change labels.
+- The required sentinel `.aiops/operator-continuation-release` is operator-only,
+  intentionally absent, and must not be created by the agent.
+- On every turn, inspect whether the sentinel exists. If it is absent, report
+  that the control remains intentionally active and stop the turn cleanly
+  without tracker handoff.
+- Leave the Gitea issue in `aiops/stress` so the worker performs continuation
+  retries until `agent.max_continuation_turns` is exhausted.
+
+Expected harness result: `/api/v1/state` shows issue #16 in `blocked` with
+`method: "continuation_budget"`. Any PR, terminal label, or Human Review handoff
+is a failed control.
+STRESS_PROMPT
+        break
+      fi
+      continue
+    fi
     if [ "$skip_next_go_test" -eq 1 ]; then
       skip_next_go_test=0
       case "$line" in
@@ -159,6 +189,22 @@ render_workflow() {
 render_workflow "$repo_root/examples/maker-WORKFLOW.md" "$run_root/workflows/maker-WORKFLOW.md" "$run_root/workspaces/maker" normal
 render_workflow "$repo_root/examples/reviewer-automerge-WORKFLOW.md" "$run_root/workflows/reviewer-automerge-WORKFLOW.md" "$run_root/workspaces/reviewer" normal
 render_workflow "$repo_root/examples/maker-WORKFLOW.md" "$run_root/workflows/maker-low-turn-WORKFLOW.md" "$run_root/workspaces/stress" stress
+
+cat >"$run_root/state/continuation-control-expected.json" <<'EOF'
+{
+  "kind": "continuation_budget_control_expectation",
+  "issue_number": 16,
+  "worker": "stress",
+  "active_label": "aiops/stress",
+  "expected_state_file": "state/stress-final.json",
+  "expected_blocked_method": "continuation_budget",
+  "expected_counts": {
+    "blocked_at_least": 1
+  },
+  "forbidden_pr_issue_reference": "#16",
+  "forbidden_terminal_labels": ["aiops/done", "aiops/canceled", "Human Review"]
+}
+EOF
 
 cat >"$run_root/seed-repo/package.json" <<'EOF'
 {
@@ -411,10 +457,14 @@ write_issue 15 control-blocked-held "CONTROL blocked issue held out of ready gat
 
 write_issue 16 control-continuation-budget "CONTROL continuation budget stress worker" \
 "Control scenario:
+- This is CONTINUATION_BUDGET_CANARY and must not produce product code.
 - Run only with workflows/maker-low-turn-WORKFLOW.md on the Stress state.
 - Label this issue aiops/stress, not aiops/todo.
-- The task intentionally asks for broad product analysis plus implementation so one turn is unlikely to complete.
-- Capture runner timeout, continuation, clean-turn budget, or local blocked state evidence from the stress worker.
+- The required sentinel .aiops/operator-continuation-release is intentionally absent and may only be created by the operator.
+- The stress agent must not edit files, commit, push, open a PR, move labels, or hand off to Human Review.
+- Expected terminal evidence is state/stress-final.json with counts.blocked >= 1 and a blocked row method of continuation_budget for issue #16.
+- A PR, aiops/done, aiops/canceled, Human Review handoff, or normal one-turn completion is a failed control.
+- Capture stress worker state and logs after the continuation budget blocks locally.
 - Do not mix this worker with the main maker/reviewer evidence."
 
 cat >"$run_root/env.example" <<EOF

--- a/scripts/e2e-crowdrunner-report.py
+++ b/scripts/e2e-crowdrunner-report.py
@@ -82,6 +82,71 @@ def counts_line(name: str, state: dict[str, Any]) -> str:
     return f"- {name}: `{interesting}`"
 
 
+def control_issue_number(expectation: dict[str, Any]) -> int:
+    try:
+        return int(expectation.get("issue_number", 16))
+    except (TypeError, ValueError):
+        return 16
+
+
+def control_pr_refs(prs: list[dict[str, Any]], issue_number: int) -> list[str]:
+    needle = f"#{issue_number}"
+    slug = "control-continuation-budget"
+    refs = []
+    for pr in prs:
+        head = pr.get("head") or {}
+        text = " ".join(
+            str(value)
+            for value in [
+                pr.get("title", ""),
+                pr.get("body", ""),
+                head.get("ref", ""),
+            ]
+        )
+        if needle in text or slug in text.lower():
+            refs.append(f"#{pr.get('number', '?')}")
+    return refs
+
+
+def continuation_budget_rows(stress: dict[str, Any], method: str, issue_number: int) -> list[dict[str, Any]]:
+    rows = stress.get("blocked") or []
+    if not isinstance(rows, list):
+        return []
+    matches = []
+    for row in rows:
+        if not isinstance(row, dict) or row.get("method") != method:
+            continue
+        identifier = str(row.get("issue_identifier", ""))
+        issue_id = str(row.get("issue_id", ""))
+        issue_url = str(row.get("issue_url", "")).rstrip("/")
+        if (
+            identifier == f"#{issue_number}"
+            or issue_id == str(issue_number)
+            or issue_url.endswith(f"/issues/{issue_number}")
+            or not (identifier or issue_id or issue_url)
+        ):
+            matches.append(row)
+    return matches
+
+
+def continuation_control_verdict(
+    stress: dict[str, Any],
+    prs: list[dict[str, Any]],
+    expectation: dict[str, Any],
+) -> str:
+    issue_number = control_issue_number(expectation)
+    method = str(expectation.get("expected_blocked_method", "continuation_budget"))
+    pr_refs = control_pr_refs(prs, issue_number)
+    if pr_refs:
+        return f"FAIL: control issue #{issue_number} produced PR(s) {', '.join(pr_refs)}."
+    rows = continuation_budget_rows(stress, method, issue_number)
+    if rows:
+        return f"PASS: issue #{issue_number} blocked via `{method}` in stress worker state."
+    if (stress.get("counts") or {}).get("blocked", 0):
+        return f"FAIL: stress worker blocked, but no issue #{issue_number} `{method}` row was captured."
+    return f"FAIL: stress worker did not capture issue #{issue_number} `{method}` exhaustion."
+
+
 def collect_assets(run_root: Path) -> dict[str, list[Path]]:
     return {
         "promo_screenshots": sorted((run_root / "promo" / "screenshots").glob("**/*.png")),
@@ -194,6 +259,7 @@ def write_report(args: argparse.Namespace) -> Path:
     maker = load_json(run_root / "state" / "maker-final.json", {})
     reviewer = load_json(run_root / "state" / "reviewer-final.json", {})
     stress = load_json(run_root / "state" / "stress-final.json", {})
+    control_expectation = load_json(run_root / "state" / "continuation-control-expected.json", {})
     assets = collect_assets(run_root)
 
     product_done = [
@@ -214,6 +280,7 @@ def write_report(args: argparse.Namespace) -> Path:
         f"- aiops-platform lifecycle: **{verdict}**",
         f"- Codex product delivery: {codex_delivery_verdict(product_done)}",
         f"- Product quality: {product_quality_verdict(run_root)}",
+        f"- Continuation control: {continuation_control_verdict(stress, prs, control_expectation)}",
         "",
         "The helper does not self-certify a full pass. Mark the checklist below",
         "against the live evidence before promoting or committing the report.",
@@ -227,6 +294,10 @@ def write_report(args: argparse.Namespace) -> Path:
         counts_line("Maker", maker),
         counts_line("Reviewer", reviewer),
         counts_line("Stress", stress),
+        "",
+        "## Control Scenario Assertions",
+        "",
+        f"- Continuation budget: {continuation_control_verdict(stress, prs, control_expectation)}",
         "",
         "## Issue Results",
         "",

--- a/scripts/e2e-crowdrunner-report.py
+++ b/scripts/e2e-crowdrunner-report.py
@@ -27,7 +27,7 @@ def load_json(path: Path, default: Any) -> Any:
         return default
 
 
-def label_names(issue: dict[str, Any]) -> str:
+def issue_label_names(issue: dict[str, Any]) -> list[str]:
     labels = issue.get("labels") or []
     names = []
     for label in labels:
@@ -35,7 +35,11 @@ def label_names(issue: dict[str, Any]) -> str:
             names.append(str(label.get("name", "")))
         else:
             names.append(str(label))
-    return ", ".join(name for name in names if name) or "-"
+    return [name for name in names if name]
+
+
+def label_names(issue: dict[str, Any]) -> str:
+    return ", ".join(issue_label_names(issue)) or "-"
 
 
 def issue_rows(issues: list[dict[str, Any]]) -> list[str]:
@@ -91,21 +95,60 @@ def control_issue_number(expectation: dict[str, Any]) -> int:
 
 def control_pr_refs(prs: list[dict[str, Any]], issue_number: int) -> list[str]:
     needle = f"#{issue_number}"
+    branch = f"ai/{issue_number}"
     slug = "control-continuation-budget"
     refs = []
     for pr in prs:
         head = pr.get("head") or {}
+        head_ref = str(head.get("ref", ""))
         text = " ".join(
             str(value)
             for value in [
                 pr.get("title", ""),
                 pr.get("body", ""),
-                head.get("ref", ""),
+                head_ref,
             ]
         )
-        if needle in text or slug in text.lower():
+        if (
+            needle in text
+            or slug in text.lower()
+            or head_ref == branch
+            or head_ref.startswith(f"{branch}-")
+        ):
             refs.append(f"#{pr.get('number', '?')}")
     return refs
+
+
+def control_issue_status_failure(
+    issues: list[dict[str, Any]],
+    expectation: dict[str, Any],
+    issue_number: int,
+) -> str:
+    forbidden_labels = expectation.get("forbidden_terminal_labels") or [
+        "aiops/done",
+        "aiops/canceled",
+        "Human Review",
+    ]
+    forbidden = [str(label) for label in forbidden_labels]
+    for issue in issues:
+        try:
+            number = int(issue.get("number", 0))
+        except (TypeError, ValueError):
+            continue
+        if number != issue_number:
+            continue
+        labels = issue_label_names(issue)
+        forbidden_found = [label for label in forbidden if label in labels]
+        if forbidden_found:
+            return (
+                f"FAIL: control issue #{issue_number} has forbidden label(s) "
+                f"{', '.join(forbidden_found)}."
+            )
+        state = str(issue.get("state", "")).lower()
+        if state and state != "open":
+            return f"FAIL: control issue #{issue_number} reached terminal state `{state}`."
+        return ""
+    return f"FAIL: control issue #{issue_number} missing from issues-final evidence."
 
 
 def continuation_budget_rows(stress: dict[str, Any], method: str, issue_number: int) -> list[dict[str, Any]]:
@@ -132,6 +175,7 @@ def continuation_budget_rows(stress: dict[str, Any], method: str, issue_number: 
 def continuation_control_verdict(
     stress: dict[str, Any],
     prs: list[dict[str, Any]],
+    issues: list[dict[str, Any]],
     expectation: dict[str, Any],
 ) -> str:
     issue_number = control_issue_number(expectation)
@@ -139,6 +183,9 @@ def continuation_control_verdict(
     pr_refs = control_pr_refs(prs, issue_number)
     if pr_refs:
         return f"FAIL: control issue #{issue_number} produced PR(s) {', '.join(pr_refs)}."
+    status_failure = control_issue_status_failure(issues, expectation, issue_number)
+    if status_failure:
+        return status_failure
     rows = continuation_budget_rows(stress, method, issue_number)
     if rows:
         return f"PASS: issue #{issue_number} blocked via `{method}` in stress worker state."
@@ -280,7 +327,7 @@ def write_report(args: argparse.Namespace) -> Path:
         f"- aiops-platform lifecycle: **{verdict}**",
         f"- Codex product delivery: {codex_delivery_verdict(product_done)}",
         f"- Product quality: {product_quality_verdict(run_root)}",
-        f"- Continuation control: {continuation_control_verdict(stress, prs, control_expectation)}",
+        f"- Continuation control: {continuation_control_verdict(stress, prs, issues, control_expectation)}",
         "",
         "The helper does not self-certify a full pass. Mark the checklist below",
         "against the live evidence before promoting or committing the report.",
@@ -297,7 +344,7 @@ def write_report(args: argparse.Namespace) -> Path:
         "",
         "## Control Scenario Assertions",
         "",
-        f"- Continuation budget: {continuation_control_verdict(stress, prs, control_expectation)}",
+        f"- Continuation budget: {continuation_control_verdict(stress, prs, issues, control_expectation)}",
         "",
         "## Issue Results",
         "",

--- a/scripts/e2e-crowdrunner-report.py
+++ b/scripts/e2e-crowdrunner-report.py
@@ -166,7 +166,6 @@ def continuation_budget_rows(stress: dict[str, Any], method: str, issue_number: 
             identifier == f"#{issue_number}"
             or issue_id == str(issue_number)
             or issue_url.endswith(f"/issues/{issue_number}")
-            or not (identifier or issue_id or issue_url)
         ):
             matches.append(row)
     return matches

--- a/scripts/e2e-crowdrunner-report.py
+++ b/scripts/e2e-crowdrunner-report.py
@@ -127,7 +127,7 @@ def control_issue_status_failure(
     forbidden_labels = expectation.get("forbidden_terminal_labels") or [
         "aiops/done",
         "aiops/canceled",
-        "Human Review",
+        "aiops/human-review",
     ]
     forbidden = [str(label) for label in forbidden_labels]
     for issue in issues:

--- a/scripts/e2e-crowdrunner-report.py
+++ b/scripts/e2e-crowdrunner-report.py
@@ -93,9 +93,28 @@ def control_issue_number(expectation: dict[str, Any]) -> int:
         return 16
 
 
-def control_pr_refs(prs: list[dict[str, Any]], issue_number: int) -> list[str]:
+def control_issue_branch_ids(issues: list[dict[str, Any]], issue_number: int) -> list[str]:
+    ids = {str(issue_number)}
+    for issue in issues:
+        try:
+            number = int(issue.get("number", 0))
+        except (TypeError, ValueError):
+            continue
+        if number != issue_number:
+            continue
+        issue_id = str(issue.get("id", "")).strip()
+        if issue_id:
+            ids.add(issue_id)
+    return sorted(ids)
+
+
+def control_pr_refs(
+    prs: list[dict[str, Any]],
+    issue_number: int,
+    issues: list[dict[str, Any]],
+) -> list[str]:
     needle = f"#{issue_number}"
-    branch = f"ai/{issue_number}"
+    branches = [f"ai/{issue_id}" for issue_id in control_issue_branch_ids(issues, issue_number)]
     slug = "control-continuation-budget"
     refs = []
     for pr in prs:
@@ -112,8 +131,7 @@ def control_pr_refs(prs: list[dict[str, Any]], issue_number: int) -> list[str]:
         if (
             needle in text
             or slug in text.lower()
-            or head_ref == branch
-            or head_ref.startswith(f"{branch}-")
+            or any(head_ref == branch or head_ref.startswith(f"{branch}-") for branch in branches)
         ):
             refs.append(f"#{pr.get('number', '?')}")
     return refs
@@ -179,7 +197,7 @@ def continuation_control_verdict(
 ) -> str:
     issue_number = control_issue_number(expectation)
     method = str(expectation.get("expected_blocked_method", "continuation_budget"))
-    pr_refs = control_pr_refs(prs, issue_number)
+    pr_refs = control_pr_refs(prs, issue_number, issues)
     if pr_refs:
         return f"FAIL: control issue #{issue_number} produced PR(s) {', '.join(pr_refs)}."
     status_failure = control_issue_status_failure(issues, expectation, issue_number)


### PR DESCRIPTION
Closes #989

## Summary

- Replace the stress workflow body with a deterministic continuation-budget canary instead of inheriting the maker PR/handoff prompt.
- Generate machine-readable `state/continuation-control-expected.json` and tighten issue 16/runbook instructions around the expected blocked state.
- Route the continuation control through mapped `In Progress` plus required `aiops/stress`, so Gitea can dispatch it deterministically while the normal maker treats it as inactive.
- Make the report assert `continuation_budget` blocked evidence for issue 16 and fail if the control produced a PR, including deterministic worker branch forms.
- Reject continuation-control PASS when issue 16 carries forbidden terminal labels or reaches a terminal state, using Gitea's raw `aiops/human-review` label.
- Persist final stress worker state through the documented final capture flow before the report reads `state/stress-final.json`.
- Require a matched issue identity on continuation-budget blocked rows; anonymous blocked rows cannot certify issue 16.
- Match control PR worker branches by both visible issue number fallback (`ai/16`) and the tracker issue API `id` from `issues-final.json`.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

SPEC §1 boundary is preserved: the worker remains scheduler/reader, while this PR only changes operator-run test fixtures and evidence interpretation.

## Acceptance Criteria

- [x] The stress/control scenario no longer inherits the maker workflow path that can complete by opening a PR; it is a deterministic canary that leaves issue 16 active until the continuation budget blocks locally.
- [x] The expected terminal state is machine-readable in `state/continuation-control-expected.json` and asserted from `state/stress-final.json` plus the issue snapshot's forbidden terminal labels/state; the blocked row must identify issue 16 by `issue_identifier`, `issue_id`, or `issue_url`.
- [x] The report fails the control if a PR references issue 16, uses the deterministic visible-number branch `ai/16`, or uses the tracker-id branch `ai/<issue.id>`, so it cannot pass by completing all work in one normal turn.

## PR diff size budget (AGENTS.md)

- [x] `within budget` — 4 files, E2E harness/docs/tests only, production diff under the guideline.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing

- [x] `go test -run 'TestCrowdRunner(BootstrapPreparesRunRoot|ReportGeneratesThreeVerdicts|ReportRejectsContinuationControlPR|ReportRejectsContinuationControlTerminalLabel)' -count=1 ./scripts`
- [x] `go test -run 'TestCrowdRunnerLifecycleRunbookDocumentsReusableSOP' -count=1 ./scripts`
- [x] `go test -run 'TestCrowdRunner(ReportGeneratesThreeVerdicts|ReportRejectsContinuationControlPR|ReportRejectsContinuationControlTerminalLabel|ReportRejectsAnonymousContinuationControlRow)' -count=1 ./scripts`
- [x] `go test -run 'TestCrowdRunner(ReportGeneratesThreeVerdicts|ReportRejectsContinuationControlPR|ReportRejectsContinuationControlPRByTrackerID|ReportRejectsContinuationControlTerminalLabel|ReportRejectsAnonymousContinuationControlRow)' -count=1 ./scripts`
- [x] Full local gate: `gofmt -l $(git ls-files '*.go')`, `go mod tidy && git diff --exit-code -- go.mod go.sum`, `go vet ./...`, Trellis unittest discovery, `bash -n scripts/e2e-crowdrunner-bootstrap.sh`, `python3 -m py_compile scripts/e2e-crowdrunner-report.py scripts/e2e-crowdrunner-freeze.py scripts/e2e-crowdrunner-capture.py`, golangci-lint v2.12.2 (`0 issues`), file-size budget test, `go test -race -covermode=atomic ./...`, `go build ./cmd/worker ./cmd/tui`.

## Mutation Verification

- Mutated the report to ignore `pr_refs`; `TestCrowdRunnerReportRejectsContinuationControlPR` failed because a #16 PR was incorrectly accepted.
- Mutated the stress workflow frontmatter delimiter check so it inherited the maker prompt; `TestCrowdRunnerBootstrapPreparesRunRoot` failed on the missing deterministic control prompt.
- Mutated away the exact `ai/<issue>` branch match; `TestCrowdRunnerReportRejectsContinuationControlPR` failed because `ai/16` was incorrectly accepted.
- Mutated away the forbidden-label/state status check; `TestCrowdRunnerReportRejectsContinuationControlTerminalLabel` failed because `aiops/human-review` was incorrectly accepted.
- Mutated the stress workflow back to an unmapped `Stress` state; `TestCrowdRunnerBootstrapPreparesRunRoot` failed because the generated workflow no longer used a mapped state.
- Mutated generated `forbidden_terminal_labels` back to `Human Review`; `TestCrowdRunnerBootstrapPreparesRunRoot` failed because the expectation no longer contained raw `aiops/human-review`.
- Mutated the stress workflow back to maker-owned `Todo`; `TestCrowdRunnerBootstrapPreparesRunRoot` failed because the generated workflow no longer used isolated `In Progress`.
- Mutated final report-pack capture from `--tag final` to `--tag midrun`; `TestCrowdRunnerLifecycleRunbookDocumentsReusableSOP` failed because the final stress-state capture contract was broken.
- Mutated anonymous continuation-budget rows back to accepted matches; `TestCrowdRunnerReportRejectsAnonymousContinuationControlRow` failed because anonymous evidence incorrectly passed.
- Mutated tracker issue `id` branch matching away; `TestCrowdRunnerReportRejectsContinuationControlPRByTrackerID` failed because `ai/<issue.id>` was incorrectly accepted.
