### PR TITLE
fix(runner): surface app-server startup retry phase

### DIFF
--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -179,6 +179,21 @@ func TestFormatRetryRowDefaultsKindToFailure(t *testing.T) {
 	}
 }
 
+func TestFormatRetryRowIncludesStartupPhase(t *testing.T) {
+	got := formatRetryRow(stateapi.Retry{
+		IssueID:    "issue-1",
+		Identifier: "ENG-1",
+		Attempt:    1,
+		Kind:       "failure",
+		StartupFailure: &stateapi.StartupFailure{
+			Phase: "thread/start",
+		},
+	})
+	if !strings.Contains(got, "attempt=1") || !strings.Contains(got, "startup_phase=thread/start") {
+		t.Fatalf("formatRetryRow = %q; want attempt and startup phase", got)
+	}
+}
+
 // ── formatRuntimeSecs ─────────────────────────────────────────────────────────
 
 func TestFormatRuntimeSecs(t *testing.T) {
@@ -252,7 +267,7 @@ func TestFetchState_DecodesSharedContractFields(t *testing.T) {
 	  "max_concurrent_agents": 4,
 	  "counts": {"completed_total": 12, "agent_handoff_reconcile_stopped_total": 3, "agent_handoff_reconcile_stopped": 2},
 	  "running": [{"issue_id": "i1", "issue_identifier": "ENG-1", "state": "In Progress", "session_id": "sess-1", "turn_count": 7, "last_event": "turn_completed", "last_message": "working", "started_at": "2026-05-21T09:09:55Z", "codex_app_server_pid": 12345, "tokens": {"total_tokens": 2000}}],
-	  "retrying": [{"issue_id": "i2", "attempt": 2, "due_at": "2026-05-21T09:11:00Z", "error": "retry soon", "kind": "quota_backoff"}],
+	  "retrying": [{"issue_id": "i2", "attempt": 2, "due_at": "2026-05-21T09:11:00Z", "error": "retry soon", "kind": "quota_backoff", "startup_failure": {"phase": "thread/start", "error": "codex app-server read timeout after 5000ms"}}],
 	  "codex_totals": {"total_tokens": 300, "seconds_running": 1.5},
 	  "rate_limits": {"limit_id": "lim", "primary": {"remaining": 42, "limit": 100}}
 	}`
@@ -293,6 +308,9 @@ func TestFetchState_DecodesSharedContractFields(t *testing.T) {
 	rt := state.Retrying[0]
 	if rt.Attempt != 2 || rt.Error != "retry soon" || rt.Kind != "quota_backoff" || rt.DueAt == nil {
 		t.Errorf("Retrying[0] = %+v, want attempt/error/kind/due_at decoded", rt)
+	}
+	if rt.StartupFailure == nil || rt.StartupFailure.Phase != "thread/start" {
+		t.Errorf("Retrying[0].StartupFailure = %+v, want thread/start decoded", rt.StartupFailure)
 	}
 	if state.CodexTotals.TotalTokens != 300 || state.CodexTotals.SecondsRunning != 1.5 {
 		t.Errorf("CodexTotals = %+v, want total_tokens=300 seconds_running=1.5", state.CodexTotals)

--- a/cmd/tui/render.go
+++ b/cmd/tui/render.go
@@ -293,6 +293,10 @@ func formatRetryRow(r stateapi.Retry) string {
 		}
 		errorPart = " " + colorize("error="+errStr, ansiDim)
 	}
+	startupPart := ""
+	if r.StartupFailure != nil && r.StartupFailure.Phase != "" {
+		startupPart = " " + colorize("startup_phase="+sanitize(r.StartupFailure.Phase), ansiDim)
+	}
 	return "│  " +
 		colorize("↻", ansiYellow) + " " +
 		colorize(id, ansiRed) + " " +
@@ -300,6 +304,7 @@ func formatRetryRow(r stateapi.Retry) string {
 		colorize("attempt="+attempt, ansiYellow) +
 		colorize(" in ", ansiDim) +
 		colorize(dueIn, ansiCyan) +
+		startupPart +
 		errorPart
 }
 

--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -357,12 +357,14 @@ function RetryTable({ rows }) {
           {rows.map((r) => {
             const secs = r.due_at ? (new Date(r.due_at).getTime() - Date.now()) / 1000 : NaN;
             const next = !Number.isFinite(secs) ? '—' : secs > 0 ? 'in ' + dur(secs) : 'due now';
+            const startupPhase = r.startup_failure?.phase ? `startup_phase=${r.startup_failure.phase}` : '';
+            const kindLine = [r.kind, startupPhase].filter(Boolean).join(' · ');
             return (
               <tr key={r.issue_id}>
                 <td className="issue-cell">
                   <div className="issue">
                     <IssueLink row={r} />
-                    <span className="wp">{r.kind}</span>
+                    <span className="wp" title={r.startup_failure?.error || kindLine}>{kindLine}</span>
                   </div>
                 </td>
                 <td data-label="Attempt"><span className="attempt"><span className="bd" />attempt {r.attempt}</span></td>

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -37,6 +37,7 @@ function busyState(overrides = {}) {
         issue_id: '5d3177', issue_identifier: 'MT-613', attempt: 2,
         due_at: new Date(Date.now() + 46000).toISOString(),
         error: 'context deadline exceeded', kind: 'runner_error',
+        startup_failure: { phase: 'thread/start', error: 'codex app-server read timeout after 5000ms' },
       },
     ],
     blocked: [
@@ -357,11 +358,13 @@ describe('Worker status dashboard', () => {
     expect(screen.queryByText('Stopped w/ progress')).toBeNull();
   });
 
-  it('shows the retry queue with attempt count and backoff kind', async () => {
+  it('shows the retry queue with attempt count, backoff kind, and startup phase', async () => {
     render(<App />);
     expect(await screen.findByRole('link', { name: 'MT-613' })).toBeTruthy();
     expect(screen.getByText('attempt 2')).toBeTruthy();
-    expect(screen.getByText('runner_error')).toBeTruthy();
+    const kind = screen.getByText('runner_error · startup_phase=thread/start');
+    expect(kind).toBeTruthy();
+    expect(kind.getAttribute('title')).toBe('codex app-server read timeout after 5000ms');
     // the 2-line clamp can truncate long errors; the full text stays available
     // via a hover title so it is never lost.
     const err = screen.getByText('context deadline exceeded');

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/gitea"
 	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -507,6 +508,10 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 			Identifier: "MT-649",
 			Attempt:    1,
 			Error:      "retry soon",
+			StartupFailure: &task.StartupFailure{
+				Phase: "thread/start",
+				Error: "codex app-server read timeout after 5000ms",
+			},
 		}},
 		Blocked: []orchestrator.BlockedView{{
 			IssueID:    "issue-7",
@@ -569,6 +574,10 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 			Attempt         int    `json:"attempt"`
 			Error           string `json:"error"`
 			Kind            string `json:"kind"`
+			StartupFailure  *struct {
+				Phase string `json:"phase"`
+				Error string `json:"error"`
+			} `json:"startup_failure"`
 		} `json:"retrying"`
 		Completed   []string `json:"completed"`
 		CodexTotals struct {
@@ -611,6 +620,9 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 	}
 	if payload.Retrying[0].Kind != string(orchestrator.RetryKindFailure) || payload.Retrying[1].Kind != string(orchestrator.RetryKindFailure) {
 		t.Fatalf("retrying kinds = %q/%q, want failure defaults", payload.Retrying[0].Kind, payload.Retrying[1].Kind)
+	}
+	if payload.Retrying[0].StartupFailure == nil || payload.Retrying[0].StartupFailure.Phase != "thread/start" {
+		t.Fatalf("retrying startup_failure = %+v; want thread/start", payload.Retrying[0].StartupFailure)
 	}
 	if !reflect.DeepEqual(payload.Completed, []string{"issue-3", "issue-9"}) {
 		t.Fatalf("completed = %+v, want sorted issue-3 issue-9", payload.Completed)

--- a/cmd/worker/stateapi.go
+++ b/cmd/worker/stateapi.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/orchestrator"
 	"github.com/xrf9268-hue/aiops-platform/internal/stateapi"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -397,13 +398,24 @@ func apiRetryFromView(row orchestrator.RetryView) stateapi.Retry {
 		dueAt = &v
 	}
 	return stateapi.Retry{
-		IssueID:    string(row.IssueID),
-		Identifier: row.Identifier,
-		IssueURL:   row.IssueURL,
-		Attempt:    row.Attempt,
-		DueAt:      dueAt,
-		Error:      row.Error,
-		Kind:       string(retryKindOrFailure(row.Kind)),
+		IssueID:        string(row.IssueID),
+		Identifier:     row.Identifier,
+		IssueURL:       row.IssueURL,
+		Attempt:        row.Attempt,
+		DueAt:          dueAt,
+		Error:          row.Error,
+		Kind:           string(retryKindOrFailure(row.Kind)),
+		StartupFailure: apiStartupFailure(row.StartupFailure),
+	}
+}
+
+func apiStartupFailure(in *task.StartupFailure) *stateapi.StartupFailure {
+	if in == nil {
+		return nil
+	}
+	return &stateapi.StartupFailure{
+		Phase: in.Phase,
+		Error: in.Error,
 	}
 }
 func retryKindOrFailure(kind orchestrator.RetryKind) orchestrator.RetryKind {

--- a/internal/orchestrator/actor_finalize.go
+++ b/internal/orchestrator/actor_finalize.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 )
 
@@ -313,8 +314,9 @@ func (f *finalizeRunOp) applyFailureRetry(st *OrchestratorState, elapsed time.Du
 	o := f.o
 	id := f.id
 	identifier := f.identifier
+	startupFailure := task.CopyStartupFailure(f.entry.LastStartupFailure)
 	return func() {
-		o.logRescheduleErr(o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace), id, identifier)
+		o.logRescheduleErr(o.scheduleFailureRetryWithStartupFailure(o.runCtx, issue, identifier, nextAttempt, runErr, workspace, startupFailure), id, identifier)
 	}
 }
 

--- a/internal/orchestrator/actor_retry.go
+++ b/internal/orchestrator/actor_retry.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 )
 
@@ -135,6 +136,11 @@ func (o *Orchestrator) ScheduleRetry(ctx context.Context, issue tracker.Issue, i
 func (o *Orchestrator) scheduleFailureRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string, workspace Workspace) error {
 	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindFailure, Attempt: attempt}, attempt, runErr, workspace, 0)
 }
+
+func (o *Orchestrator) scheduleFailureRetryWithStartupFailure(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string, workspace Workspace, startupFailure *task.StartupFailure) error {
+	return o.scheduleRetryWithStartupFailure(ctx, issue, identifier, RetryRequest{Kind: RetryKindFailure, Attempt: attempt}, attempt, runErr, workspace, startupFailure, 0)
+}
+
 func (o *Orchestrator) scheduleQuotaBackoffRetry(ctx context.Context, issue tracker.Issue, identifier string, attempt int, runErr string, retryAfter time.Duration, workspace Workspace) error {
 	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindQuotaBackoff, Attempt: attempt, DelayOverride: retryAfter}, attempt, runErr, workspace, 0)
 }
@@ -163,6 +169,10 @@ func (o *Orchestrator) scheduleContinuationRetry(ctx context.Context, issue trac
 	return o.scheduleRetry(ctx, issue, identifier, RetryRequest{Kind: RetryKindContinuation, Attempt: attempt}, attempt, "", workspace, continuationTurnCount)
 }
 func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, identifier string, req RetryRequest, attempt int, runErr string, workspace Workspace, continuationTurnCount int) error {
+	return o.scheduleRetryWithStartupFailure(ctx, issue, identifier, req, attempt, runErr, workspace, nil, continuationTurnCount)
+}
+
+func (o *Orchestrator) scheduleRetryWithStartupFailure(ctx context.Context, issue tracker.Issue, identifier string, req RetryRequest, attempt int, runErr string, workspace Workspace, startupFailure *task.StartupFailure, continuationTurnCount int) error {
 	op := &scheduleRetryOp{
 		o:                     o,
 		issue:                 issue,
@@ -172,6 +182,7 @@ func (o *Orchestrator) scheduleRetry(ctx context.Context, issue tracker.Issue, i
 		kind:                  req.Kind,
 		req:                   req,
 		workspace:             workspace,
+		startupFailure:        task.CopyStartupFailure(startupFailure),
 		continuationTurnCount: continuationTurnCount,
 	}
 	return o.submit(ctx, op)
@@ -190,6 +201,7 @@ type scheduleRetryOp struct {
 	kind                  RetryKind
 	req                   RetryRequest
 	workspace             Workspace
+	startupFailure        *task.StartupFailure
 	continuationTurnCount int
 }
 
@@ -212,6 +224,7 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 		DueAt:                 time.Now().Add(delay),
 		Error:                 s.runErr,
 		Kind:                  s.kind,
+		StartupFailure:        task.CopyStartupFailure(s.startupFailure),
 		ContinuationTurnCount: s.continuationTurnCount,
 		Workspace:             s.workspace,
 	}
@@ -416,12 +429,12 @@ func retryFireDispatchTail(st *OrchestratorState, entry *RetryEntry, id IssueID,
 		// reschedule through the configured backoff with attempt+1 and a
 		// typed "no available orchestrator slots" error instead of arming a
 		// short 100ms re-fire timer.
-		return capacityDeferRetry(st, id, issue, identifier, attempt, entry.Kind, entry.Workspace, o)
+		return capacityDeferRetry(st, id, issue, identifier, attempt, entry.Kind, entry.Workspace, entry.StartupFailure, o)
 	}
 	if st.StateCapacityFull(issue.State) {
 		// Retry timers must also obey per-state capacity gates. Same
 		// upstream-aligned reschedule shape as the global-cap branch.
-		return capacityDeferRetry(st, id, issue, identifier, attempt, entry.Kind, entry.Workspace, o)
+		return capacityDeferRetry(st, id, issue, identifier, attempt, entry.Kind, entry.Workspace, entry.StartupFailure, o)
 	}
 	// Consume the retry entry but keep Claimed: the re-dispatch
 	// immediately re-adds Running, and dropping Claimed in between
@@ -463,7 +476,7 @@ func suppressRetryFireAfterOperatorStop(st *OrchestratorState, entry *RetryEntry
 // 100ms re-fire loop bypassed the backoff formula, left the attempt
 // counter frozen across thousands of re-fires, and produced no runtime
 // event for the cap-pressure case.
-func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, identifier string, attempt int, kind RetryKind, workspace Workspace, o *Orchestrator) func() {
+func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, identifier string, attempt int, kind RetryKind, workspace Workspace, startupFailure *task.StartupFailure, o *Orchestrator) func() {
 	if o.runCtx.Err() != nil {
 		// Mirror retryPollFailedOp's shutdown guard (actor.go above):
 		// the followup's ScheduleRetry would fail submit anyway, so
@@ -476,6 +489,7 @@ func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, 
 	if kind == RetryKindQuotaBackoff {
 		nextAttempt = attempt
 	}
+	startupFailure = task.CopyStartupFailure(startupFailure)
 	st.RecordEvent(RuntimeEvent{
 		Kind:       RuntimeEventFailed,
 		IssueID:    id,
@@ -489,7 +503,7 @@ func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, 
 			o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, 0, workspace), id, identifier)
 			return
 		}
-		o.logRescheduleErr(o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace), id, identifier)
+		o.logRescheduleErr(o.scheduleFailureRetryWithStartupFailure(o.runCtx, issue, identifier, nextAttempt, runErr, workspace, startupFailure), id, identifier)
 	}
 }
 func findIssueByID(issues []tracker.Issue, id IssueID) *tracker.Issue {
@@ -536,6 +550,7 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 	// Carry the workspace across the reschedule so the §18.1 terminal cleanup
 	// gate still has a path on a later attempt (#341).
 	workspace := entry.Workspace
+	startupFailure := task.CopyStartupFailure(entry.StartupFailure)
 	nextAttempt := r.attempt + 1
 	if r.kind == RetryKindQuotaBackoff {
 		nextAttempt = r.attempt
@@ -555,7 +570,7 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 			o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, 0, workspace), r.id, identifier)
 			return
 		}
-		o.logRescheduleErr(o.scheduleFailureRetry(o.runCtx, issue, identifier, nextAttempt, runErr, workspace), r.id, identifier)
+		o.logRescheduleErr(o.scheduleFailureRetryWithStartupFailure(o.runCtx, issue, identifier, nextAttempt, runErr, workspace, startupFailure), r.id, identifier)
 	}
 }
 

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -1793,6 +1793,49 @@ func TestFinalize_AbnormalExitSchedulesRetry(t *testing.T) {
 	}
 }
 
+func TestFinalize_FailureRetryPreservesStartupFailurePhase(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-STARTUP", Identifier: "ENG-STARTUP", Title: "startup flakes"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	if err := o.RecordRuntimeEvent(context.Background(), iss.ID, task.RuntimeEvent{
+		Event: task.EventStartupFailed,
+		Payload: map[string]any{
+			"phase": "thread/start",
+			"error": "codex app-server read timeout after 5000ms",
+		},
+	}); err != nil {
+		t.Fatalf("RecordRuntimeEvent(startup_failed): %v", err)
+	}
+
+	disp.finishAt(0, WorkerResult{
+		Err:     errors.New("codex app-server thread/start: codex app-server read timeout after 5000ms"),
+		Elapsed: time.Millisecond,
+	})
+
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Retrying) == 1
+	}, time.Second)
+	v, _ := o.Snapshot(context.Background())
+	retry := v.Retrying[0]
+	if retry.Attempt != 1 {
+		t.Fatalf("retry Attempt = %d; want 1", retry.Attempt)
+	}
+	if retry.StartupFailure == nil || retry.StartupFailure.Phase != "thread/start" {
+		t.Fatalf("retry StartupFailure = %+v; want thread/start", retry.StartupFailure)
+	}
+}
+
 // TestFinalize_QuotaBackoffReschedulesWithRetryAfter pins that a quota-backoff
 // runner error reschedules the issue as a RetryKindQuotaBackoff entry with the
 // error's RetryAfter delay and the original attempt preserved (never Failed).
@@ -3603,7 +3646,8 @@ func TestRetryFire_GlobalCapacityFullReschedulesViaBackoff(t *testing.T) {
 	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
 
 	retryIssue := tracker.Issue{ID: "RETRY", Identifier: "RETRY", Title: "retry me"}
-	if err := o.ScheduleRetry(context.Background(), retryIssue, retryIssue.Identifier, 1, "transient"); err != nil {
+	startupFailure := &task.StartupFailure{Phase: "thread/start", Error: "codex app-server read timeout after 5000ms"}
+	if err := o.scheduleFailureRetryWithStartupFailure(context.Background(), retryIssue, retryIssue.Identifier, 1, "transient", Workspace{}, startupFailure); err != nil {
 		t.Fatalf("ScheduleRetry: %v", err)
 	}
 	waitFor(t, func() bool {
@@ -3625,7 +3669,9 @@ func TestRetryFire_GlobalCapacityFullReschedulesViaBackoff(t *testing.T) {
 		v, _ := o.Snapshot(context.Background())
 		return len(v.Retrying) == 1 &&
 			v.Retrying[0].Attempt == 2 &&
-			strings.Contains(v.Retrying[0].Error, "no available orchestrator slots")
+			strings.Contains(v.Retrying[0].Error, "no available orchestrator slots") &&
+			v.Retrying[0].StartupFailure != nil &&
+			v.Retrying[0].StartupFailure.Phase == "thread/start"
 	}, 2*time.Second)
 
 	v, _ := o.Snapshot(context.Background())
@@ -3640,6 +3686,9 @@ func TestRetryFire_GlobalCapacityFullReschedulesViaBackoff(t *testing.T) {
 	}
 	if got := v.Retrying[0].Error; !strings.Contains(got, "no available orchestrator slots") {
 		t.Fatalf("Retrying[0].Error = %q, want substring %q", got, "no available orchestrator slots")
+	}
+	if got := v.Retrying[0].StartupFailure; got == nil || got.Phase != "thread/start" {
+		t.Fatalf("Retrying[0].StartupFailure = %+v, want thread/start preserved across capacity defer", got)
 	}
 }
 
@@ -4222,7 +4271,8 @@ func TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError(t *testing.T) {
 	defer cancel()
 
 	iss := tracker.Issue{ID: "ENG-FETCH-FAIL", Identifier: "ENG-FETCH-FAIL", Title: "fetch err", State: "Todo"}
-	if err := o.ScheduleRetry(context.Background(), iss, iss.Identifier, 1, "transient"); err != nil {
+	startupFailure := &task.StartupFailure{Phase: "thread/start", Error: "codex app-server read timeout after 5000ms"}
+	if err := o.scheduleFailureRetryWithStartupFailure(context.Background(), iss, iss.Identifier, 1, "transient", Workspace{}, startupFailure); err != nil {
 		t.Fatalf("ScheduleRetry: %v", err)
 	}
 
@@ -4238,7 +4288,10 @@ func TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError(t *testing.T) {
 
 	waitFor(t, func() bool {
 		v, _ := o.Snapshot(context.Background())
-		return len(v.Retrying) == 1 && v.Retrying[0].Attempt == 2
+		return len(v.Retrying) == 1 &&
+			v.Retrying[0].Attempt == 2 &&
+			v.Retrying[0].StartupFailure != nil &&
+			v.Retrying[0].StartupFailure.Phase == "thread/start"
 	}, 2*time.Second)
 
 	v, err := o.Snapshot(context.Background())
@@ -4260,6 +4313,9 @@ func TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError(t *testing.T) {
 	}
 	if !strings.Contains(got.Error, "tracker unreachable") {
 		t.Fatalf("rescheduled error = %q, want the underlying fetch error wrapped in", got.Error)
+	}
+	if got.StartupFailure == nil || got.StartupFailure.Phase != "thread/start" {
+		t.Fatalf("rescheduled StartupFailure = %+v, want thread/start preserved across retry poll failure", got.StartupFailure)
 	}
 }
 

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 )
 
@@ -36,6 +37,9 @@ type RetryEntry struct {
 	Timer      *time.Timer
 	Error      string
 	Kind       RetryKind
+	// StartupFailure is observability-only detail for a failure retry caused by
+	// a runner startup phase. The retry policy is still owned by Kind/Attempt.
+	StartupFailure *task.StartupFailure
 	// ContinuationTurnCount carries D34's cumulative clean-turn budget across
 	// RetryKindContinuation wake/re-dispatch cycles. It is ignored for failure
 	// and quota retries.

--- a/internal/orchestrator/runtime_events.go
+++ b/internal/orchestrator/runtime_events.go
@@ -79,6 +79,7 @@ func (s *OrchestratorState) recordRuntimeEvent(run *RunningEntry, event task.Run
 		}
 	}
 	s.recordSessionFields(run, event)
+	s.recordStartupFailureFields(run, event)
 	s.recordAgentHandoffFields(run, event)
 	s.recordInputRequiredFields(run, event, now)
 	if usage, ok := tokenUsageFromEvent(event); ok {
@@ -89,6 +90,22 @@ func (s *OrchestratorState) recordRuntimeEvent(run *RunningEntry, event task.Run
 		snap := RateLimitSnapshot(limits)
 		s.RecordRateLimits(&snap)
 	}
+}
+
+func (s *OrchestratorState) recordStartupFailureFields(run *RunningEntry, event task.RuntimeEvent) {
+	if event.Event != task.EventStartupFailed {
+		return
+	}
+	payload, _ := asStringMap(event.Payload)
+	phase, ok := stringField(payload, "phase")
+	if !ok || phase == "" {
+		return
+	}
+	failure := &task.StartupFailure{Phase: phase}
+	if msg, ok := stringField(payload, "error"); ok {
+		failure.Error = msg
+	}
+	run.LastStartupFailure = failure
 }
 
 func (s *OrchestratorState) recordAgentHandoffFields(run *RunningEntry, event task.RuntimeEvent) {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
@@ -150,6 +151,10 @@ type RunningEntry struct {
 	// without a message do not clear it, so the operator-visible field keeps
 	// the last human-readable status until a new one supersedes it.
 	LastCodexMessage string
+	// LastStartupFailure is set from startup_failed runtime events and copied to
+	// failure retry rows so operators can see the failed app-server phase without
+	// parsing raw output or runner error text.
+	LastStartupFailure *task.StartupFailure
 
 	CodexInputTokens  int64
 	CodexOutputTokens int64

--- a/internal/orchestrator/state_snapshot.go
+++ b/internal/orchestrator/state_snapshot.go
@@ -8,6 +8,8 @@ package orchestrator
 
 import (
 	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
 )
 
 // StateView is the SPEC §13.3 / §13.7 shape the orchestrator publishes
@@ -173,13 +175,14 @@ func (s *OrchestratorState) Snapshot() StateView {
 	}
 	for id, r := range s.RetryAttempts {
 		view.Retrying = append(view.Retrying, RetryView{
-			IssueID:    id,
-			Identifier: r.Identifier,
-			IssueURL:   r.Issue.URL,
-			Attempt:    r.Attempt,
-			DueAt:      r.DueAt,
-			Error:      r.Error,
-			Kind:       r.Kind,
+			IssueID:        id,
+			Identifier:     r.Identifier,
+			IssueURL:       r.Issue.URL,
+			Attempt:        r.Attempt,
+			DueAt:          r.DueAt,
+			Error:          r.Error,
+			Kind:           r.Kind,
+			StartupFailure: task.CopyStartupFailure(r.StartupFailure),
 		})
 	}
 	// Iterate the FIFO order slices, not the map. The map's iteration

--- a/internal/orchestrator/views.go
+++ b/internal/orchestrator/views.go
@@ -1,6 +1,10 @@
 package orchestrator
 
-import "time"
+import (
+	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+)
 
 // This file holds the public projection types that StateView exposes for the
 // SPEC §13.7 observability surface (the /api/v1/state and /api/v1/<id>
@@ -67,13 +71,14 @@ type BlockedView struct {
 // RetryView is the per-retry-entry projection in StateView. Omits the
 // *time.Timer handle because it is not meaningful outside the process.
 type RetryView struct {
-	IssueID    IssueID
-	Identifier string
-	IssueURL   string
-	Attempt    int
-	DueAt      time.Time
-	Error      string
-	Kind       RetryKind
+	IssueID        IssueID
+	Identifier     string
+	IssueURL       string
+	Attempt        int
+	DueAt          time.Time
+	Error          string
+	Kind           RetryKind
+	StartupFailure *task.StartupFailure
 }
 
 type OperatorTerminalStopView struct {

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -778,6 +778,73 @@ for line in sys.stdin:
 	}
 }
 
+func TestCodexAppServerRunnerRecoversAfterThreadStartReadTimeout(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "attempts.txt")
+	t.Setenv("CODEX_RECOVERY_STATE", statePath)
+	installCodexStub(t, `#!/bin/sh
+printf '%s\n' "$@" > "$CODEX_ARGV_LOG"
+printf 'started\n' > "$CODEX_STARTED_LOG"
+attempt=$(cat "$CODEX_RECOVERY_STATE" 2>/dev/null || printf '0')
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$CODEX_RECOVERY_STATE"
+while IFS= read -r line; do
+    printf '%s\n' "$line" >> "$CODEX_STDIN_LOG"
+    case "$line" in
+        *'"method":"initialize"'*)
+            printf '{"jsonrpc":"2.0","id":1,"result":{}}\n'
+            ;;
+        *'"method":"thread/start"'*)
+            if [ "$attempt" -eq 1 ]; then
+                sleep 4
+                exit 0
+            fi
+            printf '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thread-1"},"model":"gpt-recovered"}}\n'
+            ;;
+        *'"method":"turn/start"'*)
+            printf '{"jsonrpc":"2.0","id":3,"result":{"turn":{"id":"turn-1"}}}\n'
+            printf '{"method":"turn/completed","params":{"turn":{"status":"completed"},"continue":false}}\n'
+            exit 0
+            ;;
+    esac
+done
+`)
+	wd := codexWorkdir(t, "recover after startup timeout")
+	in := appServerInput(wd)
+	in.Workflow.Config.Codex.EnvPassthrough = append(in.Workflow.Config.Codex.EnvPassthrough, "CODEX_RECOVERY_STATE")
+	in.Workflow.Config.Codex.ReadTimeoutMs = 2000
+	in.Workflow.Config.Codex.StallTimeoutMs = 0
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	first, err := (CodexAppServerRunner{}).Run(ctx, in)
+	if !IsReadTimeout(err) {
+		t.Fatalf("first Run error = %T %[1]v; want thread/start read timeout", err)
+	}
+	failures := runtimeEventsNamed(first.RuntimeEvents, task.EventStartupFailed)
+	if len(failures) != 1 {
+		t.Fatalf("first startup_failed events = %d; want 1; events=%#v", len(failures), first.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, failures[0], "phase"); got != "thread/start" {
+		t.Fatalf("first startup_failed phase = %#v; want thread/start", got)
+	}
+	if got := len(runtimeEventsNamed(first.RuntimeEvents, task.EventSessionStarted)); got != 0 {
+		t.Fatalf("first session_started events = %d; want no usable session", got)
+	}
+
+	in.Workflow.Config.Codex.ReadTimeoutMs = 5000
+	second, err := (CodexAppServerRunner{}).Run(ctx, in)
+	if err != nil {
+		t.Fatalf("second Run error = %v; want recovered session", err)
+	}
+	sessions := runtimeEventsNamed(second.RuntimeEvents, task.EventSessionStarted)
+	if len(sessions) != 1 {
+		t.Fatalf("second session_started events = %d; want 1; events=%#v", len(sessions), second.RuntimeEvents)
+	}
+	if got := runtimeEventField(t, sessions[0], "agent_model"); got != "gpt-recovered" {
+		t.Fatalf("second session_started agent_model = %#v; want gpt-recovered", got)
+	}
+}
+
 // TestCodexAppServerRunnerEmitsUnsupportedToolCallForUnknownTool pins SPEC
 // §10.4: when the agent invokes a tool the runtime did not advertise, the
 // orchestrator must learn about it via task.EventUnsupportedToolCall (the

--- a/internal/stateapi/types.go
+++ b/internal/stateapi/types.go
@@ -168,13 +168,21 @@ type Blocked struct {
 // Retry mirrors SPEC §13.7.2's per-retry-row object. Kind is the wire form of
 // orchestrator.RetryKind (a string enum).
 type Retry struct {
-	IssueID    string     `json:"issue_id"`
-	Identifier string     `json:"issue_identifier,omitempty"`
-	IssueURL   string     `json:"issue_url,omitempty"`
-	Attempt    int        `json:"attempt"`
-	DueAt      *time.Time `json:"due_at,omitempty"`
-	Error      string     `json:"error,omitempty"`
-	Kind       string     `json:"kind"`
+	IssueID        string          `json:"issue_id"`
+	Identifier     string          `json:"issue_identifier,omitempty"`
+	IssueURL       string          `json:"issue_url,omitempty"`
+	Attempt        int             `json:"attempt"`
+	DueAt          *time.Time      `json:"due_at,omitempty"`
+	Error          string          `json:"error,omitempty"`
+	Kind           string          `json:"kind"`
+	StartupFailure *StartupFailure `json:"startup_failure,omitempty"`
+}
+
+// StartupFailure is the wire form of the runner startup phase that failed
+// before the issue entered a usable app-server session.
+type StartupFailure struct {
+	Phase string `json:"phase"`
+	Error string `json:"error,omitempty"`
 }
 
 // OperatorTerminalStop mirrors SPEC §13.7.2's per-operator-terminal-stop row.

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -159,6 +159,21 @@ type RuntimeEvent struct {
 	Payload any    `json:"payload,omitempty"`
 }
 
+// StartupFailure is the structured subset of a startup_failed runtime event
+// that retry/status surfaces can carry without parsing runner error strings.
+type StartupFailure struct {
+	Phase string `json:"phase"`
+	Error string `json:"error,omitempty"`
+}
+
+func CopyStartupFailure(in *StartupFailure) *StartupFailure {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
 type Task struct {
 	ID            string    `json:"id"`
 	Status        Status    `json:"status"`


### PR DESCRIPTION
Closes #986

## Summary
- Preserves bounded Codex app-server startup timeouts while adding deterministic coverage for a transient `thread/start` read timeout that recovers on the next runner invocation.
- Carries the structured `startup_failed` phase/error into retry state, `/api/v1/state`, TUI retry rows, and the browser dashboard retry table so operators can see attempt count and failed startup phase without reading raw app-server JSON.
- Preserves that startup diagnostic across retry deferrals where no new runner attempt occurred, including retry-poll fetch failures and capacity deferrals.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — 12 production files / 129 added + 36 deleted production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

## Additional validation
- `go mod tidy` + `git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go build ./cmd/worker ./cmd/tui`
- Dashboard: `npm test`; `npm run build` in `cmd/worker/dashboard`
- Focused tests: `go test -run 'TestCodexAppServerRunnerRecoversAfterThreadStartReadTimeout|TestStateHTTPHandlerReturnsRuntimeStateSnapshot|TestFormatRetryRowIncludesStartupPhase|TestFinalize_FailureRetryPreservesStartupFailurePhase|TestRetryFire_(GlobalCapacityFullReschedulesViaBackoff|ReschedulesWithRetryPollFailedOnFetchError)' -count=1 ./internal/runner ./internal/orchestrator ./cmd/worker ./cmd/tui`
- Mutation-verify: removing startup failure extraction failed `TestFinalize_FailureRetryPreservesStartupFailurePhase`; dropping API mapping failed `TestStateHTTPHandlerReturnsRuntimeStateSnapshot`; dropping TUI `startup_phase` failed `TestFormatRetryRowIncludesStartupPhase`; dropping startup failure across capacity defer failed `TestRetryFire_GlobalCapacityFullReschedulesViaBackoff`; dropping startup failure across retry-poll failure failed `TestRetryFire_ReschedulesWithRetryPollFailedOnFetchError`; dropping dashboard `startup_phase` rendering failed the dashboard retry-table Vitest.
- Local review: Claude review skipped per operator quota note; self diff review plus full local gate completed. GitHub `@codex review` will be re-triggered on the pushed head.

## Acceptance criteria
- [x] Preserve bounded startup timeouts; this keeps the read-timeout path and adds deterministic delayed `thread/start` coverage.
- [x] Add deterministic runner coverage for delayed/missing `thread/start` responses: `TestCodexAppServerRunnerRecoversAfterThreadStartReadTimeout`.
- [x] Improve retry/reporting so failed startup phase and attempt count are visible without raw app-server JSON: retry state/API carries `startup_failure`; TUI and dashboard show `attempt=N` with `startup_phase=thread/start`.
- [x] Confirm the worker still recovers to a real Codex session after transient startup failure: the runner test fails first with read timeout, then succeeds with `session_started` model `gpt-recovered`.