### PR TITLE
feat(observability): classify active success without handoff

### DIFF
--- a/cmd/tui/layout_test.go
+++ b/cmd/tui/layout_test.go
@@ -130,6 +130,7 @@ func representativeState(now time.Time) *stateapi.StateResponse {
 			CompletedTotal:                    12,
 			AgentHandoffReconcileStoppedTotal: 3,
 			AgentHandoffReconcileStopped:      2,
+			ActiveSuccessNoHandoffTotal:       5,
 		},
 		CodexTotals: stateapi.CodexTotals{InputTokens: 123456, OutputTokens: 654321, TotalTokens: 1_000_000_000, SecondsRunning: 3600},
 		Running: []stateapi.Running{{
@@ -226,7 +227,7 @@ func TestRenderFrame_ShowsAgentHandoffCount(t *testing.T) {
 	now := time.Now()
 	frame := visibleString(renderFrame(representativeState(now), nil, now, 0, "http://127.0.0.1:4001", 5*time.Second))
 
-	if !strings.Contains(frame, "Handoffs: completed 12 | agent 3 (recent 2)") {
+	if !strings.Contains(frame, "Handoffs: completed 12 | agent 3 (recent 2) | no handoff 5") {
 		t.Fatalf("renderFrame missing agent handoff count: %q", frame)
 	}
 }

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -265,7 +265,7 @@ func TestFetchState_DecodesSharedContractFields(t *testing.T) {
 	body := `{
 	  "poll_interval_ms": 5000,
 	  "max_concurrent_agents": 4,
-	  "counts": {"completed_total": 12, "agent_handoff_reconcile_stopped_total": 3, "agent_handoff_reconcile_stopped": 2},
+	  "counts": {"completed_total": 12, "agent_handoff_reconcile_stopped_total": 3, "agent_handoff_reconcile_stopped": 2, "active_success_no_handoff_total": 5, "active_success_no_handoff": 1},
 	  "running": [{"issue_id": "i1", "issue_identifier": "ENG-1", "state": "In Progress", "session_id": "sess-1", "turn_count": 7, "last_event": "turn_completed", "last_message": "working", "started_at": "2026-05-21T09:09:55Z", "codex_app_server_pid": 12345, "tokens": {"total_tokens": 2000}}],
 	  "retrying": [{"issue_id": "i2", "attempt": 2, "due_at": "2026-05-21T09:11:00Z", "error": "retry soon", "kind": "quota_backoff", "startup_failure": {"phase": "thread/start", "error": "codex app-server read timeout after 5000ms"}}],
 	  "codex_totals": {"total_tokens": 300, "seconds_running": 1.5},
@@ -286,6 +286,12 @@ func TestFetchState_DecodesSharedContractFields(t *testing.T) {
 	}
 	if got := state.Counts.CompletedTotal; got != 12 {
 		t.Errorf("Counts.CompletedTotal = %d, want 12 (completed_total tag)", got)
+	}
+	if got := state.Counts.ActiveSuccessNoHandoffTotal; got != 5 {
+		t.Errorf("Counts.ActiveSuccessNoHandoffTotal = %d, want 5 (active_success_no_handoff_total tag)", got)
+	}
+	if got := state.Counts.ActiveSuccessNoHandoff; got != 1 {
+		t.Errorf("Counts.ActiveSuccessNoHandoff = %d, want 1 (active_success_no_handoff tag)", got)
 	}
 	// Pin every running-row field the dashboard renders (render.go formatRunningRow)
 	// so a tag typo on any of them fails here rather than blanking a column.

--- a/cmd/tui/render.go
+++ b/cmd/tui/render.go
@@ -94,7 +94,9 @@ func renderFrame(state *stateapi.StateResponse, fetchErr error, now time.Time, t
 			colorize("completed "+formatCount(state.Counts.CompletedTotal), ansiGreen) +
 			colorize(" | ", ansiGray) +
 			colorize("agent "+formatCount(state.Counts.AgentHandoffReconcileStoppedTotal), ansiGreen) +
-			colorize(" (recent "+formatCount(int64(state.Counts.AgentHandoffReconcileStopped))+")", ansiGray),
+			colorize(" (recent "+formatCount(int64(state.Counts.AgentHandoffReconcileStopped))+")", ansiGray) +
+			colorize(" | ", ansiGray) +
+			colorize("no handoff "+formatCount(state.Counts.ActiveSuccessNoHandoffTotal), ansiYellow),
 		colorize("│ Throughput: ", ansiBold) + colorize(formatTPS(tps)+" tps", ansiCyan),
 		colorize("│ Runtime:    ", ansiBold) + colorize(formatRuntimeSecs(state.CodexTotals.SecondsRunning), ansiMagenta),
 		colorize("│ Tokens:     ", ansiBold) +

--- a/cmd/worker/dashboard/fallback.html
+++ b/cmd/worker/dashboard/fallback.html
@@ -82,6 +82,7 @@
           <div class="tile"><span class="label">Retrying</span><span class="value" id="retrying">-</span></div>
           <div class="tile"><span class="label">Blocked</span><span class="value" id="blocked">-</span></div>
           <div class="tile"><span class="label">Delivered</span><span class="value" id="delivered">-</span></div>
+          <div class="tile"><span class="label">No handoff</span><span class="value" id="no-handoff">-</span></div>
         </section>
         <pre id="state">Loading...</pre>
       </main>
@@ -95,6 +96,7 @@
           document.getElementById('retrying').textContent = counts.retrying ?? 0;
           document.getElementById('blocked').textContent = counts.blocked ?? 0;
           document.getElementById('delivered').textContent = counts.agent_handoff_reconcile_stopped ?? 0;
+          document.getElementById('no-handoff').textContent = counts.active_success_no_handoff ?? 0;
           document.getElementById('state').textContent = JSON.stringify(state, null, 2);
         })
         .catch(function (err) {

--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -437,6 +437,7 @@ function Topbar({ status, generatedAt, version, onRefresh, settings }) {
 // these explain why each bucket is informational vs worth inspecting.
 const STOPPED_DESC = 'Runs reaped by reconcile after making progress — worth inspecting, not a guaranteed success.';
 const HANDOFF_DESC = 'Runs the reconcile loop stopped after the agent had already completed its handoff (opened its PR / wrote back to the tracker) — finished before being reaped; informational, not an error.';
+const NO_HANDOFF_DESC = 'Clean runner exits that left the issue active with no guarded handoff — the worker will continue normally, but the run did not deliver tracker progress.';
 
 // ── main app ─────────────────────────────────────────────────────────────────
 export default function App() {
@@ -522,8 +523,13 @@ export default function App() {
     : '';
   const stopped = s.reconcile_stopped_with_progress || [];
   const handoff = s.agent_handoff_reconcile_stopped || [];
+  const noHandoff = s.active_success_no_handoff || [];
   const deliveredRecent = c.agent_handoff_reconcile_stopped || 0;
   const deliveredTotal = c.agent_handoff_reconcile_stopped_total || 0;
+  const deliveredFlag = [
+    c.reconcile_stopped_with_progress > 0 ? `${c.reconcile_stopped_with_progress} stopped w/ progress` : '',
+    c.active_success_no_handoff > 0 ? `${c.active_success_no_handoff} no handoff` : '',
+  ].filter(Boolean).join(' · ') || null;
   const online = status === 'live';
 
   return (
@@ -566,8 +572,8 @@ export default function App() {
         <Kpi
           label="Delivered"
           value={deliveredRecent}
-          sub={`${compact(deliveredTotal)} state handoffs lifetime · ${compact(c.completed_total)} clean exits`}
-          flag={c.reconcile_stopped_with_progress > 0 ? `${c.reconcile_stopped_with_progress} stopped w/ progress` : null}
+          sub={`${compact(deliveredTotal)} state handoffs lifetime · ${compact(c.completed_total)} completed exits`}
+          flag={deliveredFlag}
           status="done"
         />
       </div>
@@ -627,18 +633,26 @@ export default function App() {
             <RateLimits rl={rl} />
           </div>
 
-          {/* Reconcile roll-up — Stopped-with-progress (#557) + Agent-handoff
-              (#617) folded from two full panels into one compact strip; each
+          {/* Reconcile roll-up — Stopped-with-progress (#557), Agent-handoff
+              (#617), and active-success/no-handoff (#988) folded into one compact strip; each
               bucket's explanatory prose is exposed via a hover title + an
-              sr-only span (STOPPED_DESC / HANDOFF_DESC) so it costs no visible
-              vertical budget. Hidden when both buckets are empty. */}
-          {(stopped.length > 0 || handoff.length > 0) ? (
+              sr-only span so it costs no visible vertical budget. Hidden when
+              all buckets are empty. */}
+          {(stopped.length > 0 || handoff.length > 0 || noHandoff.length > 0) ? (
             <div className="panel">
               <div className="panel-head">
                 <div className="panel-title"><span className="accent-stroke" />Reconcile roll-up</div>
-                <div className="panel-meta">reaped by the reconcile loop</div>
+                <div className="panel-meta">handoff and continuation outcomes</div>
               </div>
               <div className="rollup-grid">
+                {noHandoff.length > 0 ? (
+                  <div className="rollup-cell" title={NO_HANDOFF_DESC}>
+                    <span className="rollup-k"><span className="kpi-dot retry" />No handoff</span>
+                    <span className="rollup-v"><b>{c.active_success_no_handoff}</b> this window<span className="tot">· {c.active_success_no_handoff_total} total</span></span>
+                    <span className="rollup-ids">{noHandoff.map((id) => <span key={id} className="tier-badge">{id}</span>)}</span>
+                    <span className="sr-only">{NO_HANDOFF_DESC}</span>
+                  </div>
+                ) : null}
                 {stopped.length > 0 ? (
                   <div className="rollup-cell" title={STOPPED_DESC}>
                     <span className="rollup-k"><span className="kpi-dot retry" />Stopped w/ progress</span>

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -18,6 +18,7 @@ function busyState(overrides = {}) {
       completed: 14, completed_total: 137,
       reconcile_stopped_with_progress: 1, reconcile_stopped_with_progress_total: 4,
       agent_handoff_reconcile_stopped: 1, agent_handoff_reconcile_stopped_total: 9,
+      active_success_no_handoff: 1, active_success_no_handoff_total: 6,
     },
     running: [
       {
@@ -51,6 +52,7 @@ function busyState(overrides = {}) {
     completed: ['aa0112', 'aa0245', 'aa0388'],
     reconcile_stopped_with_progress: ['bb0190'],
     agent_handoff_reconcile_stopped: ['cc0271'],
+    active_success_no_handoff: ['dd0442'],
     codex_totals: { input_tokens: 4812000, output_tokens: 631400, total_tokens: 5443400, seconds_running: 7338 },
     rate_limits: {
       limit_name: 'codex',
@@ -70,9 +72,10 @@ const idleState = {
     running: 0, retrying: 0, blocked: 0, completed: 9, completed_total: 132,
     reconcile_stopped_with_progress: 0, reconcile_stopped_with_progress_total: 3,
     agent_handoff_reconcile_stopped: 0, agent_handoff_reconcile_stopped_total: 8,
+    active_success_no_handoff: 0, active_success_no_handoff_total: 5,
   },
   running: [], retrying: [], blocked: [],
-  completed: [], reconcile_stopped_with_progress: [], agent_handoff_reconcile_stopped: [],
+  completed: [], reconcile_stopped_with_progress: [], agent_handoff_reconcile_stopped: [], active_success_no_handoff: [],
   codex_totals: { input_tokens: 2140000, output_tokens: 288900, total_tokens: 2428900, seconds_running: 4292 },
   rate_limits: null,
 };
@@ -115,7 +118,8 @@ describe('Worker status dashboard', () => {
     const delivered = screen.getByText('Delivered').closest('.kpi');
     expect(within(delivered).getByText('1')).toBeTruthy();
     expect(within(delivered).getByText(/9 state handoffs lifetime/)).toBeTruthy();
-    expect(within(delivered).getByText(/137 clean exits/)).toBeTruthy();
+    expect(within(delivered).getByText(/137 completed exits/)).toBeTruthy();
+    expect(within(delivered).getByText(/1 no handoff/)).toBeTruthy();
     expect(screen.queryByText(/^Completed$/)).toBeNull();
 
     // codex token totals strip (5,443,400 → 5.4M) and a compacted running token cell.
@@ -329,7 +333,13 @@ describe('Worker status dashboard', () => {
     render(<App />);
     const rollup = (await screen.findByText('Reconcile roll-up')).closest('.panel');
 
-    // both buckets render as compact rows inside the single roll-up panel
+    const noHandoffCell = within(rollup).getByText('No handoff').closest('.rollup-cell');
+    expect(within(noHandoffCell).getByText('dd0442')).toBeTruthy();
+    expect(noHandoffCell.querySelector('.rollup-v b').textContent).toBe('1');
+    expect(noHandoffCell.querySelector('.rollup-v .tot').textContent).toBe('· 6 total');
+    expect(noHandoffCell.textContent).toContain('no guarded handoff');
+
+    // all outcome buckets render as compact rows inside the single roll-up panel
     const stoppedCell = within(rollup).getByText('Stopped w/ progress').closest('.rollup-cell');
     expect(within(stoppedCell).getByText('bb0190')).toBeTruthy();
     // v2: the window count is the serif-numeric anchor (<b>), the lifetime
@@ -349,13 +359,14 @@ describe('Worker status dashboard', () => {
     expect(screen.getAllByText('Agent handoff')).toHaveLength(1);
   });
 
-  it('hides the reconcile roll-up when both buckets are empty', async () => {
+  it('hides the reconcile roll-up when all buckets are empty', async () => {
     current = idleState;
     render(<App />);
     await screen.findByRole('heading', { name: /Worker status/i });
     expect(screen.queryByText('Reconcile roll-up')).toBeNull();
     expect(screen.queryByText('Agent handoff')).toBeNull();
     expect(screen.queryByText('Stopped w/ progress')).toBeNull();
+    expect(screen.queryByText('No handoff')).toBeNull();
   });
 
   it('shows the retry queue with attempt count, backoff kind, and startup phase', async () => {

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -356,6 +356,39 @@ func TestApiIssueFromViewResolvesAgentHandoffReconcileStoppedFromBucketWhenEvent
 	}
 }
 
+func TestApiIssueFromViewFindsActiveSuccessNoHandoffByIdentifierAndID(t *testing.T) {
+	view := orchestrator.StateView{
+		ActiveSuccessNoHandoff: []orchestrator.IssueID{"gitea-issue-12"},
+		RecentEvents: []orchestrator.RuntimeEvent{{
+			Kind:       orchestrator.RuntimeEventActiveSuccessNoHandoff,
+			IssueID:    "gitea-issue-12",
+			Identifier: "#12",
+			Message:    "worker exited cleanly while issue remained active with no agent handoff",
+			At:         time.Unix(1700000000, 0).UTC(),
+		}},
+	}
+	for _, want := range []string{"#12", "gitea-issue-12"} {
+		got, ok := apiIssueFromView(view, want)
+		if !ok {
+			t.Fatalf("apiIssueFromView(%q) ok = false; want true", want)
+		}
+		if got.Status != "active_success_no_handoff" || got.IssueID != "gitea-issue-12" {
+			t.Fatalf("apiIssueFromView(%q) = (%s, %s); want (active_success_no_handoff, gitea-issue-12)", want, got.Status, got.IssueID)
+		}
+	}
+}
+
+func TestApiIssueFromViewResolvesActiveSuccessNoHandoffFromBucketWhenEventAgedOut(t *testing.T) {
+	view := orchestrator.StateView{
+		Completed:              []orchestrator.IssueID{"gitea-issue-12"},
+		ActiveSuccessNoHandoff: []orchestrator.IssueID{"gitea-issue-12"},
+	}
+	got, ok := apiIssueFromView(view, "gitea-issue-12")
+	if !ok || got.Status != "active_success_no_handoff" {
+		t.Fatalf("apiIssueFromView(gitea-issue-12) = (%v, %s); want (true, active_success_no_handoff)", ok, got.Status)
+	}
+}
+
 func TestApiIssueFromViewPrefersAgentHandoffWhenBucketsOverlap(t *testing.T) {
 	view := orchestrator.StateView{
 		ReconcileStoppedWithProgress: []orchestrator.IssueID{"linear-uuid-63"},
@@ -526,7 +559,9 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 			Method:     "mcpServer/elicitation/request",
 			Error:      "input required",
 		}},
-		Completed: []orchestrator.IssueID{"issue-9", "issue-3"},
+		Completed:                             []orchestrator.IssueID{"issue-9", "issue-3"},
+		ActiveSuccessNoHandoff:                []orchestrator.IssueID{"issue-12"},
+		CumulativeActiveSuccessNoHandoffTotal: 6,
 		CodexTotals: orchestrator.CodexTotals{
 			InputTokens:    10,
 			OutputTokens:   20,
@@ -553,9 +588,11 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 		PollIntervalMs      int64  `json:"poll_interval_ms"`
 		MaxConcurrentAgents int    `json:"max_concurrent_agents"`
 		Counts              struct {
-			Running  int `json:"running"`
-			Retrying int `json:"retrying"`
-			Blocked  int `json:"blocked"`
+			Running                     int   `json:"running"`
+			Retrying                    int   `json:"retrying"`
+			Blocked                     int   `json:"blocked"`
+			ActiveSuccessNoHandoff      int   `json:"active_success_no_handoff"`
+			ActiveSuccessNoHandoffTotal int64 `json:"active_success_no_handoff_total"`
 		} `json:"counts"`
 		Running []struct {
 			IssueID         string `json:"issue_id"`
@@ -579,8 +616,9 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 				Error string `json:"error"`
 			} `json:"startup_failure"`
 		} `json:"retrying"`
-		Completed   []string `json:"completed"`
-		CodexTotals struct {
+		Completed              []string `json:"completed"`
+		ActiveSuccessNoHandoff []string `json:"active_success_no_handoff"`
+		CodexTotals            struct {
 			InputTokens    int64   `json:"input_tokens"`
 			OutputTokens   int64   `json:"output_tokens"`
 			TotalTokens    int64   `json:"total_tokens"`
@@ -606,6 +644,9 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 	if payload.Counts.Running != 2 || payload.Counts.Retrying != 2 || payload.Counts.Blocked != 2 {
 		t.Fatalf("counts = %+v, want running=2 retrying=2 blocked=2", payload.Counts)
 	}
+	if payload.Counts.ActiveSuccessNoHandoff != 1 || payload.Counts.ActiveSuccessNoHandoffTotal != 6 {
+		t.Fatalf("active no-handoff counts = %+v, want active_success_no_handoff=1 total=6", payload.Counts)
+	}
 	if len(payload.Running) != 2 || payload.Running[0].IssueID != "issue-1" || payload.Running[1].IssueID != "issue-2" {
 		t.Fatalf("running = %+v, want sorted issue-1 then issue-2", payload.Running)
 	}
@@ -626,6 +667,9 @@ func TestStateHTTPHandlerReturnsRuntimeStateSnapshot(t *testing.T) {
 	}
 	if !reflect.DeepEqual(payload.Completed, []string{"issue-3", "issue-9"}) {
 		t.Fatalf("completed = %+v, want sorted issue-3 issue-9", payload.Completed)
+	}
+	if !reflect.DeepEqual(payload.ActiveSuccessNoHandoff, []string{"issue-12"}) {
+		t.Fatalf("active_success_no_handoff = %+v, want [issue-12]", payload.ActiveSuccessNoHandoff)
 	}
 	// SPEC §8.4: failures retry rather than being parked in a suppression set,
 	// so the state surface no longer emits a `failed` array (#584, D29 closed).
@@ -791,14 +835,15 @@ func TestRootDashboardServesStateDepictingReactApp(t *testing.T) {
 			t.Fatalf("asset %s status code = %d, want %d; body=%s", assetPath, assetW.Code, http.StatusOK, assetW.Body.String())
 		}
 		asset := assetW.Body.String()
-		for _, want := range []string{"/api/v1/state", "Running sessions", "Retrying sessions", "Blocked claims", "Total tokens", "Rate limits", "Delivered", "agent_handoff_reconcile_stopped", "reconcile_stopped_with_progress"} {
+		for _, want := range []string{"/api/v1/state", "Running sessions", "Retrying sessions", "Blocked claims", "Total tokens", "Rate limits", "Delivered", "agent_handoff_reconcile_stopped", "reconcile_stopped_with_progress", "active_success_no_handoff"} {
 			if !strings.Contains(asset, want) {
 				t.Fatalf("dashboard asset missing state surface label %q", want)
 			}
 		}
 	} else {
 		if !strings.Contains(html, "Delivered") ||
-			!strings.Contains(html, "agent_handoff_reconcile_stopped") {
+			!strings.Contains(html, "agent_handoff_reconcile_stopped") ||
+			!strings.Contains(html, "active_success_no_handoff") {
 			t.Fatalf("dashboard fallback missing delivered handoff KPI wiring:\n%s", html)
 		}
 		if strings.Contains(html, "reconcile_stopped_with_progress") {

--- a/cmd/worker/runbook_drift_test.go
+++ b/cmd/worker/runbook_drift_test.go
@@ -105,6 +105,8 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 			ReconcileStoppedWithProgressTotal: 2,
 			AgentHandoffReconcileStopped:      3,
 			AgentHandoffReconcileStoppedTotal: 4,
+			ActiveSuccessNoHandoff:            1,
+			ActiveSuccessNoHandoffTotal:       5,
 		},
 		Running: []stateapi.Running{{
 			IssueID:       "issue-1",
@@ -153,6 +155,8 @@ func fullyPopulatedAPIStateResponseJSON(t *testing.T) []byte {
 		}},
 		Completed:                    []string{"issue-4"},
 		ReconcileStoppedWithProgress: []string{"issue-6"},
+		AgentHandoffReconcileStopped: []string{"issue-7"},
+		ActiveSuccessNoHandoff:       []string{"issue-8"},
 		CodexTotals: stateapi.CodexTotals{
 			InputTokens:    100,
 			OutputTokens:   200,

--- a/cmd/worker/stateapi.go
+++ b/cmd/worker/stateapi.go
@@ -280,6 +280,7 @@ func apiTerminalIssueFromView(view orchestrator.StateView, normalizedWant string
 			ev.Kind != orchestrator.RuntimeEventFailed &&
 			ev.Kind != orchestrator.RuntimeEventReconcileStopped &&
 			ev.Kind != orchestrator.RuntimeEventAgentHandoffReconcileStopped &&
+			ev.Kind != orchestrator.RuntimeEventActiveSuccessNoHandoff &&
 			ev.Kind != orchestrator.RuntimeEventOperatorTerminalStop {
 			continue
 		}
@@ -293,23 +294,27 @@ func apiTerminalIssueFromView(view orchestrator.StateView, normalizedWant string
 		}
 		return payload, true
 	}
-	for _, issueID := range view.Completed {
-		if matchesIssueLookup(issueID, "", normalizedWant) {
-			return base(issueID, string(issueID), "completed"), true
-		}
-	}
 	for _, issueID := range view.AgentHandoffReconcileStopped {
 		if matchesIssueLookup(issueID, "", normalizedWant) {
 			return base(issueID, string(issueID), "agent_handoff_reconcile_stopped"), true
 		}
 	}
+	for _, issueID := range view.ActiveSuccessNoHandoff {
+		if matchesIssueLookup(issueID, "", normalizedWant) {
+			return base(issueID, string(issueID), "active_success_no_handoff"), true
+		}
+	}
+	for _, issueID := range view.Completed {
+		if matchesIssueLookup(issueID, "", normalizedWant) {
+			return base(issueID, string(issueID), "completed"), true
+		}
+	}
 	// Keep the per-issue lookup consistent with the aggregate: an ID surfaced in
 	// reconcile_stopped_with_progress must be drillable here instead of returning
-	// issue_not_found (#557). Checked after completed and agent handoff so a later
-	// clean exit or a more-specific delivery signal for the same id takes
-	// precedence. A failed run is surfaced by the RuntimeEventFailed scan above
-	// (failures now retry per SPEC §8.4 rather than being parked in a suppression
-	// set).
+	// issue_not_found (#557). Checked after the more-specific buckets and
+	// completed so those newer signals take precedence for overlapping IDs. A
+	// failed run is surfaced by the RuntimeEventFailed scan above (failures now
+	// retry per SPEC §8.4 rather than being parked in a suppression set).
 	for _, issueID := range view.ReconcileStoppedWithProgress {
 		if matchesIssueLookup(issueID, "", normalizedWant) {
 			return base(issueID, string(issueID), "reconcile_stopped_with_progress"), true
@@ -497,6 +502,7 @@ func apiStateFromView(view orchestrator.StateView) stateapi.StateResponse {
 		Completed:                    sortedIssueIDStrings(view.Completed),
 		ReconcileStoppedWithProgress: sortedIssueIDStrings(view.ReconcileStoppedWithProgress),
 		AgentHandoffReconcileStopped: sortedIssueIDStrings(view.AgentHandoffReconcileStopped),
+		ActiveSuccessNoHandoff:       sortedIssueIDStrings(view.ActiveSuccessNoHandoff),
 		OperatorTerminalStops:        operatorStops,
 		CodexTotals: stateapi.CodexTotals{
 			InputTokens:    view.CodexTotals.InputTokens,
@@ -554,6 +560,8 @@ func apiCountsFromView(view orchestrator.StateView) stateapi.Counts {
 		ReconcileStoppedWithProgressTotal: view.CumulativeReconcileStoppedWithProgressTotal,
 		AgentHandoffReconcileStopped:      len(view.AgentHandoffReconcileStopped),
 		AgentHandoffReconcileStoppedTotal: view.CumulativeAgentHandoffReconcileStoppedTotal,
+		ActiveSuccessNoHandoff:            len(view.ActiveSuccessNoHandoff),
+		ActiveSuccessNoHandoffTotal:       view.CumulativeActiveSuccessNoHandoffTotal,
 		OperatorTerminalStops:             len(view.OperatorTerminalStops),
 		OperatorTerminalStopsTotal:        view.CumulativeOperatorTerminalStopsTotal,
 	}

--- a/docs/runbooks/runtime-status.md
+++ b/docs/runbooks/runtime-status.md
@@ -147,6 +147,8 @@ the shape here without updating the handler — or vice versa — fails the buil
     "reconcile_stopped_with_progress_total": 2,
     "agent_handoff_reconcile_stopped": 3,
     "agent_handoff_reconcile_stopped_total": 4,
+    "active_success_no_handoff": 1,
+    "active_success_no_handoff_total": 5,
     "operator_terminal_stops": 1,
     "operator_terminal_stops_total": 1
   },
@@ -205,6 +207,7 @@ the shape here without updating the handler — or vice versa — fails the buil
   "completed": [],
   "reconcile_stopped_with_progress": [],
   "agent_handoff_reconcile_stopped": [],
+  "active_success_no_handoff": [],
   "operator_terminal_stops": [
     {
       "issue_id": "issue-4",
@@ -235,11 +238,13 @@ the shape here without updating the handler — or vice versa — fails the buil
 | `blocked`         | Live count of input-blocked rows (Codex elicitation / approval pending).      |
 | `retrying`        | Current retry-backoff queue depth.                                            |
 | `completed`       | Size of the FIFO-bounded recent-completed set published as `completed`.       |
-| `completed_total` | Monotonic counter of Succeeded transitions since process start (#234).        |
+| `completed_total` | Monotonic counter of clean worker exits since process start (#234); active clean exits with no handoff are included here and also classified in `active_success_no_handoff_total`. |
 | `reconcile_stopped_with_progress` | Size of the FIFO-bounded recent set of reconcile-stopped runs that had completed ≥1 agent turn (made progress) before the per-tick reconcile reaped them mid-finalization. Usually the agent's own handoff, but `turn_completed` fires after every turn, so it can also be a run stopped after an intermediate turn — treat it as "reaped after progress, worth inspecting," not a guaranteed success. Surfaced so such a run is visible rather than absent from `completed` (#557). Does not overlap `completed`: a reconcile-stopped run is not a clean exit, so `completed` is unchanged. |
 | `reconcile_stopped_with_progress_total` | Monotonic counter of reconcile-stopped-with-progress transitions since process start. |
 | `agent_handoff_reconcile_stopped` | Size of the FIFO-bounded recent set of reconcile-stopped runs that observed the guarded `linear_graphql` current issue move to a non-active state before reconcile made the issue ineligible. This covers the successful delivery visibility gap where the agent moved the issue and the worker was stopped instead of exiting cleanly; generic Linear comments, workpad writes, and unrelated mutations do not count as delivery. It does not overlap `completed`, but it may overlap `reconcile_stopped_with_progress` when the handoff also completed a turn before reconcile reaped it. |
 | `agent_handoff_reconcile_stopped_total` | Monotonic counter of agent-handoff reconcile-stop transitions since process start. |
+| `active_success_no_handoff` | Size of the FIFO-bounded recent set of clean runner exits where the issue remained in the active tracker state last observed by the orchestrator and no guarded current-issue handoff event was seen. These entries overlap `completed` because they are normal worker exits; the worker still queues the normal continuation retry, so this is an observability signal for "no tracker progress yet," not a scheduler stop or tracker mutation. |
+| `active_success_no_handoff_total` | Monotonic counter of active-success-without-handoff transitions since process start. |
 | `operator_terminal_stops` | Size of the FIFO-bounded recent set of process-local Operator Terminal Stop latches (capped by `MaxRecentOperatorTerminalStops`, default 1000, #667). A latch is recorded when this worker observes terminal tracker state for an issue without a structured agent-owned current-issue handoff fact; a latched issue is not re-dispatched by this process even if the tracker later reads active. |
 | `operator_terminal_stops_total` | Monotonic counter of distinct Operator Terminal Stop latches since process start, surviving the #667 cap eviction. Use this, not `operator_terminal_stops`, for a lifetime number once a long-running worker has rotated past the bound; the difference between the two is the count evicted from the bounded set. |
 
@@ -247,12 +252,12 @@ There is no `failed` set: per SPEC §8.4/§16.6 a failed run is retried with
 backoff (visible under `retrying`), not parked in a suppression bucket — the
 former deterministic-non-retryable suppression was removed in #584 (D29).
 
-`completed`, `reconcile_stopped_with_progress`, and
-`agent_handoff_reconcile_stopped` arrays at the top level publish the recent N
-issue IDs in those sets; for lifetime totals across FIFO eviction use the
-`_total` counters. `operator_terminal_stops` publishes full rows instead of
-only IDs so operators can see the terminal state, stop time, and first
-suppressed active-candidate evidence.
+`completed`, `reconcile_stopped_with_progress`,
+`agent_handoff_reconcile_stopped`, and `active_success_no_handoff` arrays at the
+top level publish the recent N issue IDs in those sets; for lifetime totals
+across FIFO eviction use the `_total` counters. `operator_terminal_stops`
+publishes full rows instead of only IDs so operators can see the terminal state,
+stop time, and first suppressed active-candidate evidence.
 
 ### `codex_totals.seconds_running` semantics
 

--- a/internal/orchestrator/actor_finalize.go
+++ b/internal/orchestrator/actor_finalize.go
@@ -115,11 +115,10 @@ func (f *finalizeRunOp) applyCleanExit(st *OrchestratorState, elapsed time.Durat
 	// issue keeps getting fresh sessions until tracker state changes (reconcile /
 	// §16.5 self-stop). D34 keeps that loop bounded locally by carrying
 	// nextContinuationTurnCount through the retry entry.
-	if !st.FinishRunSucceeded(f.id, f.entry, elapsed) {
+	if !f.finishCleanContinuation(st, elapsed) {
 		close(f.done)
 		return nil
 	}
-	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
 	// Use f.entry.Issue, not f.issue: reconciliation may have refreshed
 	// the tracker state mid-run, and per-state capacity gates must see
 	// the live state, not the dispatch-time snapshot.
@@ -145,6 +144,28 @@ func (f *finalizeRunOp) applyCleanExit(st *OrchestratorState, elapsed time.Durat
 	return func() {
 		o.logRescheduleErr(o.scheduleContinuationRetry(o.runCtx, issue, identifier, nextAttempt, nextContinuationTurnCount, workspace), id, identifier)
 	}
+}
+
+func (f *finalizeRunOp) finishCleanContinuation(st *OrchestratorState, elapsed time.Duration) bool {
+	if f.shouldRecordActiveSuccessNoHandoff() {
+		if !st.FinishRunActiveSuccessNoHandoff(f.id, f.entry, elapsed) {
+			return false
+		}
+		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
+		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventActiveSuccessNoHandoff, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly while issue remained active with no agent handoff"})
+		return true
+	}
+	if !st.FinishRunSucceeded(f.id, f.entry, elapsed) {
+		return false
+	}
+	st.RecordEvent(RuntimeEvent{Kind: RuntimeEventCompleted, IssueID: f.id, Identifier: f.identifier, Message: "worker exited cleanly"})
+	return true
+}
+
+func (f *finalizeRunOp) shouldRecordActiveSuccessNoHandoff() bool {
+	return f.result.IssueExitState == nil &&
+		!runHasCurrentIssueHandoff(f.entry) &&
+		strings.TrimSpace(f.entry.Issue.State) != ""
 }
 
 func (f *finalizeRunOp) shouldBlockContinuationBudget(st *OrchestratorState, turnCount int) bool {

--- a/internal/orchestrator/actor_reconcile_stopped_with_progress_test.go
+++ b/internal/orchestrator/actor_reconcile_stopped_with_progress_test.go
@@ -575,3 +575,66 @@ func TestReconcileCancelAfterUnclassifiedGiteaMutationDoesNotRecordAgentHandoff(
 		t.Fatalf("ReconcileStoppedWithProgress = %v; want [%s] (progress is still recorded)", v.ReconcileStoppedWithProgress, iss.ID)
 	}
 }
+
+func TestCleanGiteaActiveExitRecordsNoHandoffAndStillRedispatches(t *testing.T) {
+	disp := &fakeDispatcher{}
+	o, cancel := startActor(t, Deps{
+		Dispatcher: disp,
+		Scheduler:  &sequenceScheduler{delays: []time.Duration{time.Millisecond}},
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "8842", Identifier: "#12", State: "Todo"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	disp.finishAt(0, WorkerResult{Err: nil, Elapsed: time.Millisecond})
+	waitFor(t, func() bool {
+		v, _ := o.Snapshot(context.Background())
+		return len(v.Running) == 0 && len(v.ActiveSuccessNoHandoff) == 1 && len(v.Retrying) == 1
+	}, time.Second)
+
+	v, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(v.ActiveSuccessNoHandoff) != 1 || v.ActiveSuccessNoHandoff[0] != IssueID(iss.ID) {
+		t.Fatalf("ActiveSuccessNoHandoff = %v; want [%s]", v.ActiveSuccessNoHandoff, iss.ID)
+	}
+	if v.CumulativeActiveSuccessNoHandoffTotal != 1 {
+		t.Fatalf("CumulativeActiveSuccessNoHandoffTotal = %d; want 1", v.CumulativeActiveSuccessNoHandoffTotal)
+	}
+	if len(v.Completed) != 1 || v.Completed[0] != IssueID(iss.ID) || v.CumulativeCompletedTotal != 1 {
+		t.Fatalf("Completed = %v total=%d; want [%s]/1 for active success without handoff", v.Completed, v.CumulativeCompletedTotal, iss.ID)
+	}
+	if len(v.Retrying) != 1 || v.Retrying[0].Kind != RetryKindContinuation {
+		t.Fatalf("Retrying = %+v; want one continuation retry", v.Retrying)
+	}
+	if !recentEventKind(v.RecentEvents, IssueID(iss.ID), RuntimeEventActiveSuccessNoHandoff) {
+		t.Fatalf("RecentEvents = %+v; want active_success_no_handoff for %s", v.RecentEvents, iss.ID)
+	}
+	if !recentEventKind(v.RecentEvents, IssueID(iss.ID), RuntimeEventCompleted) {
+		t.Fatalf("RecentEvents = %+v; want completed for %s", v.RecentEvents, iss.ID)
+	}
+
+	select {
+	case <-o.retryWakeCh():
+	case <-time.After(time.Second):
+		t.Fatal("continuation retry did not wake poll loop")
+	}
+	if err := o.RequestDispatchAfterTrackerRecheck(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatchAfterTrackerRecheck: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 2 }, time.Second)
+}
+
+func recentEventKind(events []RuntimeEvent, issueID IssueID, kind RuntimeEventKind) bool {
+	for _, ev := range events {
+		if ev.IssueID == issueID && ev.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -1463,7 +1463,7 @@ func TestPollOnceRedispatchesIssueAfterPriorRunCompleted(t *testing.T) {
 		t.Fatalf("initial poll once: %v", err)
 	}
 	waitForDispatcherCount(t, dispatcher, 1)
-	waitForCompleted(t, ctx, orch, "issue-1")
+	waitForActiveSuccessNoHandoff(t, ctx, orch, "issue-1")
 
 	waitForRetryDue(t, ctx, orch, "issue-1")
 	if err := poller.PollOnce(ctx); err != nil {
@@ -1498,7 +1498,7 @@ func TestPollOnceKeepsDueContinuationRetryMissingFromActiveListing(t *testing.T)
 		t.Fatalf("initial poll once: %v", err)
 	}
 	waitForDispatcherCount(t, dispatcher, 1)
-	waitForCompleted(t, ctx, orch, IssueID(issue.ID))
+	waitForActiveSuccessNoHandoff(t, ctx, orch, IssueID(issue.ID))
 	waitForRetryDue(t, ctx, orch, IssueID(issue.ID))
 
 	poller.tracker = &fakeIssueTracker{}
@@ -1700,7 +1700,7 @@ func TestPollOnceDispatchesOverflowIssueAfterCapacityFrees(t *testing.T) {
 	}
 
 	close(firstRunBlocked)
-	waitForCompleted(t, ctx, orch, "issue-1")
+	waitForActiveSuccessNoHandoff(t, ctx, orch, "issue-1")
 
 	secondRunBlocked := make(chan struct{})
 	dispatcher.mu.Lock()
@@ -1741,7 +1741,7 @@ func TestPollOnceDropsOverflowIssueThatIsNoLongerActive(t *testing.T) {
 	waitForDispatcherCount(t, dispatcher, 1)
 
 	close(dispatcher.releaseCh)
-	waitForCompleted(t, ctx, orch, "issue-1")
+	waitForActiveSuccessNoHandoff(t, ctx, orch, "issue-1")
 	dispatcher.releaseCh = nil
 	trackerClient.issues = []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "Todo"}}
 	waitForRetryDue(t, ctx, orch, "issue-1")
@@ -1812,7 +1812,7 @@ func waitForBlockingDispatcherCount(t *testing.T, dispatcher *blockingDispatcher
 	t.Fatalf("dispatcher issues = %d, want %d", dispatcher.count(), want)
 }
 
-func waitForCompleted(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
+func waitForActiveSuccessNoHandoff(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
@@ -1820,14 +1820,14 @@ func waitForCompleted(t *testing.T, ctx context.Context, orch *Orchestrator, id 
 		if err != nil {
 			t.Fatalf("snapshot: %v", err)
 		}
-		for _, completed := range view.Completed {
-			if completed == id {
+		for _, noHandoff := range view.ActiveSuccessNoHandoff {
+			if noHandoff == id {
 				return
 			}
 		}
 		time.Sleep(time.Millisecond)
 	}
-	t.Fatalf("issue %s was not marked completed", id)
+	t.Fatalf("issue %s was not marked active_success_no_handoff", id)
 }
 
 func waitForRetryDue(t *testing.T, ctx context.Context, orch *Orchestrator, id IssueID) {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -262,10 +262,11 @@ type OrchestratorState struct {
 	// behavior is the default.
 	MaxRecentCompleted int
 
-	// CumulativeCompletedTotal is a monotonic counter of every Completed
-	// transition observed since process start. It survives cap-eviction, so
-	// operators can read a true lifetime total from /api/v1/state even when
-	// the per-id slice has been trimmed.
+	// CumulativeCompletedTotal is a monotonic counter of every clean worker
+	// exit observed since process start. Active clean exits with no handoff
+	// are also classified in CumulativeActiveSuccessNoHandoffTotal.
+	// It survives cap-eviction, so operators can read a true lifetime total from
+	// /api/v1/state even when the per-id slice has been trimmed.
 	CumulativeCompletedTotal int64
 
 	// ReconcileStoppedWithProgress records reconcile-stopped runs that had completed
@@ -289,6 +290,15 @@ type OrchestratorState struct {
 	AgentHandoffReconcileStopped                map[IssueID]struct{}
 	agentHandoffReconcileStoppedOrder           []IssueID
 	CumulativeAgentHandoffReconcileStoppedTotal int64
+
+	// ActiveSuccessNoHandoff records clean worker exits where the tracker issue
+	// stayed in the active state last observed by the orchestrator and no
+	// guarded current-issue handoff event was seen. The continuation retry still
+	// owns re-dispatch; this bucket is an additional classification on top of
+	// normal Completed accounting so operators can inspect "no handoff yet" loops.
+	ActiveSuccessNoHandoff                map[IssueID]struct{}
+	activeSuccessNoHandoffOrder           []IssueID
+	CumulativeActiveSuccessNoHandoffTotal int64
 
 	OperatorTerminalStops     map[IssueID]*OperatorTerminalStopEntry
 	operatorTerminalStopOrder []IssueID
@@ -369,6 +379,7 @@ func NewOrchestratorState(pollIntervalMs int64, maxConcurrentAgents int) *Orches
 		Completed:                      map[IssueID]struct{}{},
 		ReconcileStoppedWithProgress:   map[IssueID]struct{}{},
 		AgentHandoffReconcileStopped:   map[IssueID]struct{}{},
+		ActiveSuccessNoHandoff:         map[IssueID]struct{}{},
 		OperatorTerminalStops:          map[IssueID]*OperatorTerminalStopEntry{},
 		cleaningWorkspaces:             map[IssueID]struct{}{},
 		MaxRecentCompleted:             DefaultMaxRecentCompleted,
@@ -431,7 +442,7 @@ func (s *OrchestratorState) IsClaimed(id IssueID) bool {
 // MaxRecentCompleted by evicting the oldest entry. A repeat call for
 // the same id is a no-op for the slice (FIFO position is preserved
 // from the first transition) but still increments the cumulative
-// counter — every observed succeeded transition is a real event.
+// counter — every observed Completed transition is a real event.
 func (s *OrchestratorState) recordCompleted(id IssueID) {
 	s.CumulativeCompletedTotal++
 	if _, ok := s.Completed[id]; ok {
@@ -480,6 +491,20 @@ func (s *OrchestratorState) recordAgentHandoffReconcileStopped(id IssueID) {
 		oldest := s.agentHandoffReconcileStoppedOrder[0]
 		s.agentHandoffReconcileStoppedOrder = s.agentHandoffReconcileStoppedOrder[1:]
 		delete(s.AgentHandoffReconcileStopped, oldest)
+	}
+}
+
+func (s *OrchestratorState) recordActiveSuccessNoHandoff(id IssueID) {
+	s.CumulativeActiveSuccessNoHandoffTotal++
+	if _, ok := s.ActiveSuccessNoHandoff[id]; ok {
+		return
+	}
+	s.ActiveSuccessNoHandoff[id] = struct{}{}
+	s.activeSuccessNoHandoffOrder = append(s.activeSuccessNoHandoffOrder, id)
+	if s.MaxRecentCompleted > 0 && len(s.activeSuccessNoHandoffOrder) > s.MaxRecentCompleted {
+		oldest := s.activeSuccessNoHandoffOrder[0]
+		s.activeSuccessNoHandoffOrder = s.activeSuccessNoHandoffOrder[1:]
+		delete(s.ActiveSuccessNoHandoff, oldest)
 	}
 }
 
@@ -599,6 +624,22 @@ func (s *OrchestratorState) FinishRunSucceeded(id IssueID, run *RunningEntry, el
 	delete(s.Claimed, id)
 	delete(s.ClaimedIssues, id)
 	s.recordCompleted(id)
+	s.CodexTotals.AddSeconds(elapsed)
+	return true
+}
+
+// FinishRunActiveSuccessNoHandoff releases a clean worker exit that did not
+// hand off its issue. It preserves the SPEC §16.6 completed bookkeeping and
+// also records the distinct no-handoff observability bucket.
+func (s *OrchestratorState) FinishRunActiveSuccessNoHandoff(id IssueID, run *RunningEntry, elapsed time.Duration) bool {
+	if current, ok := s.Running[id]; !ok || current != run {
+		return false
+	}
+	delete(s.Running, id)
+	delete(s.Claimed, id)
+	delete(s.ClaimedIssues, id)
+	s.recordCompleted(id)
+	s.recordActiveSuccessNoHandoff(id)
 	s.CodexTotals.AddSeconds(elapsed)
 	return true
 }

--- a/internal/orchestrator/state_snapshot.go
+++ b/internal/orchestrator/state_snapshot.go
@@ -47,6 +47,11 @@ type StateView struct {
 	// handoff. It may overlap ReconcileStoppedWithProgress when the handoff also
 	// completed a turn before reconcile reaped it.
 	AgentHandoffReconcileStopped []IssueID
+	// ActiveSuccessNoHandoff is the FIFO-bounded recent set of clean exits that
+	// left the issue active with no guarded handoff signal. These exits still
+	// re-dispatch through the normal continuation retry and also remain in
+	// Completed per SPEC §16.6.
+	ActiveSuccessNoHandoff []IssueID
 	// OperatorTerminalStops is the FIFO-bounded recent set of D35 latches (oldest
 	// first), capped by MaxRecentOperatorTerminalStops. For the lifetime total that
 	// survives eviction, read CumulativeOperatorTerminalStopsTotal.
@@ -54,6 +59,7 @@ type StateView struct {
 	CumulativeCompletedTotal                    int64
 	CumulativeReconcileStoppedWithProgressTotal int64
 	CumulativeAgentHandoffReconcileStoppedTotal int64
+	CumulativeActiveSuccessNoHandoffTotal       int64
 	CumulativeOperatorTerminalStopsTotal        int64
 	CodexTotals                                 CodexTotals
 	CodexRateLimits                             *RateLimitSnapshot
@@ -108,6 +114,64 @@ func (s *OrchestratorState) snapshotRunningViews() []RunningView {
 	return rows
 }
 
+func (s *OrchestratorState) snapshotBlockedViews() []BlockedView {
+	rows := make([]BlockedView, 0, len(s.Blocked))
+	for id, b := range s.Blocked {
+		rows = append(rows, BlockedView{
+			IssueID:           id,
+			Identifier:        b.Identifier,
+			IssueURL:          b.Issue.URL,
+			State:             b.Issue.State,
+			BlockedAt:         b.BlockedAt,
+			WorkspacePath:     b.Workspace.Path,
+			SessionID:         b.Session.SessionID,
+			LastEventAt:       b.LastEventAt,
+			Method:            b.Method,
+			Error:             b.Error,
+			CodexAppServerPID: b.Session.CodexAppServerPID,
+		})
+	}
+	return rows
+}
+
+func (s *OrchestratorState) snapshotRetryViews() []RetryView {
+	rows := make([]RetryView, 0, len(s.RetryAttempts))
+	for id, r := range s.RetryAttempts {
+		rows = append(rows, RetryView{
+			IssueID:        id,
+			Identifier:     r.Identifier,
+			IssueURL:       r.Issue.URL,
+			Attempt:        r.Attempt,
+			DueAt:          r.DueAt,
+			Error:          r.Error,
+			Kind:           r.Kind,
+			StartupFailure: task.CopyStartupFailure(r.StartupFailure),
+		})
+	}
+	return rows
+}
+
+func (s *OrchestratorState) snapshotOperatorTerminalStopViews() []OperatorTerminalStopView {
+	rows := make([]OperatorTerminalStopView, 0, len(s.operatorTerminalStopOrder))
+	for _, id := range s.operatorTerminalStopOrder {
+		entry, ok := s.LookupOperatorTerminalStop(id)
+		if !ok {
+			continue
+		}
+		rows = append(rows, OperatorTerminalStopView{
+			IssueID:               id,
+			Identifier:            entry.Identifier,
+			State:                 entry.State,
+			StoppedAt:             entry.StoppedAt,
+			SuppressedDispatches:  entry.SuppressedDispatches,
+			FirstSuppressedAt:     entry.FirstSuppressedAt,
+			FirstSuppressedState:  entry.FirstSuppressedState,
+			FirstSuppressedReason: entry.FirstSuppressedReason,
+		})
+	}
+	return rows
+}
+
 func (s *OrchestratorState) Snapshot() StateView {
 	// Keep the live-aggregate math on the monotonic clock: `time.Now()`
 	// carries a monotonic component that `time.Time.Sub` uses for elapsed
@@ -143,48 +207,23 @@ func (s *OrchestratorState) Snapshot() StateView {
 		MaxConcurrentAgents:          s.MaxConcurrentAgents,
 		MaxConcurrentAgentsByState:   copyStateConcurrencyLimits(s.MaxConcurrentAgentsByState),
 		AgentDefault:                 s.AgentDefault,
-		Blocked:                      make([]BlockedView, 0, len(s.Blocked)),
-		Retrying:                     make([]RetryView, 0, len(s.RetryAttempts)),
+		Blocked:                      s.snapshotBlockedViews(),
+		Retrying:                     s.snapshotRetryViews(),
 		Completed:                    make([]IssueID, 0, len(s.completedOrder)),
 		ReconcileStoppedWithProgress: make([]IssueID, 0, len(s.reconcileStoppedWithProgressOrder)),
 		AgentHandoffReconcileStopped: make([]IssueID, 0, len(s.agentHandoffReconcileStoppedOrder)),
-		OperatorTerminalStops:        make([]OperatorTerminalStopView, 0, len(s.operatorTerminalStopOrder)),
+		ActiveSuccessNoHandoff:       make([]IssueID, 0, len(s.activeSuccessNoHandoffOrder)),
+		OperatorTerminalStops:        s.snapshotOperatorTerminalStopViews(),
 		CumulativeCompletedTotal:     s.CumulativeCompletedTotal,
 		CumulativeReconcileStoppedWithProgressTotal: s.CumulativeReconcileStoppedWithProgressTotal,
 		CumulativeAgentHandoffReconcileStoppedTotal: s.CumulativeAgentHandoffReconcileStoppedTotal,
+		CumulativeActiveSuccessNoHandoffTotal:       s.CumulativeActiveSuccessNoHandoffTotal,
 		CumulativeOperatorTerminalStopsTotal:        s.CumulativeOperatorTerminalStopsTotal,
 		CodexTotals:                                 totals,
 		CodexRateLimits:                             copyRateLimitSnapshot(s.CodexRateLimits),
 		RecentEvents:                                append([]RuntimeEvent(nil), s.RecentEvents...),
 	}
 	view.Running = s.snapshotRunningViews()
-	for id, b := range s.Blocked {
-		view.Blocked = append(view.Blocked, BlockedView{
-			IssueID:           id,
-			Identifier:        b.Identifier,
-			IssueURL:          b.Issue.URL,
-			State:             b.Issue.State,
-			BlockedAt:         b.BlockedAt,
-			WorkspacePath:     b.Workspace.Path,
-			SessionID:         b.Session.SessionID,
-			LastEventAt:       b.LastEventAt,
-			Method:            b.Method,
-			Error:             b.Error,
-			CodexAppServerPID: b.Session.CodexAppServerPID,
-		})
-	}
-	for id, r := range s.RetryAttempts {
-		view.Retrying = append(view.Retrying, RetryView{
-			IssueID:        id,
-			Identifier:     r.Identifier,
-			IssueURL:       r.Issue.URL,
-			Attempt:        r.Attempt,
-			DueAt:          r.DueAt,
-			Error:          r.Error,
-			Kind:           r.Kind,
-			StartupFailure: task.CopyStartupFailure(r.StartupFailure),
-		})
-	}
 	// Iterate the FIFO order slices, not the map. The map's iteration
 	// order is undefined in Go; using the slices preserves observed
 	// insertion order so /api/v1/state consumers see "oldest first"
@@ -192,22 +231,7 @@ func (s *OrchestratorState) Snapshot() StateView {
 	view.Completed = append(view.Completed, s.completedOrder...)
 	view.ReconcileStoppedWithProgress = append(view.ReconcileStoppedWithProgress, s.reconcileStoppedWithProgressOrder...)
 	view.AgentHandoffReconcileStopped = append(view.AgentHandoffReconcileStopped, s.agentHandoffReconcileStoppedOrder...)
-	for _, id := range s.operatorTerminalStopOrder {
-		entry, ok := s.LookupOperatorTerminalStop(id)
-		if !ok {
-			continue
-		}
-		view.OperatorTerminalStops = append(view.OperatorTerminalStops, OperatorTerminalStopView{
-			IssueID:               id,
-			Identifier:            entry.Identifier,
-			State:                 entry.State,
-			StoppedAt:             entry.StoppedAt,
-			SuppressedDispatches:  entry.SuppressedDispatches,
-			FirstSuppressedAt:     entry.FirstSuppressedAt,
-			FirstSuppressedState:  entry.FirstSuppressedState,
-			FirstSuppressedReason: entry.FirstSuppressedReason,
-		})
-	}
+	view.ActiveSuccessNoHandoff = append(view.ActiveSuccessNoHandoff, s.activeSuccessNoHandoffOrder...)
 	return view
 }
 

--- a/internal/orchestrator/status.go
+++ b/internal/orchestrator/status.go
@@ -31,10 +31,16 @@ const (
 	// that observed a current-issue state handoff through an agent-visible
 	// tracker mutation tool (linear_graphql, linear_ai_workpad,
 	// gitea_issue_labels — #748) before the tracker made the issue inactive.
-	// This is a scheduler/reader observability signal only: completed
-	// accounting stays limited to clean worker exits, and tracker writes
-	// remain agent-owned.
+	// This is a scheduler/reader observability signal only: completed accounting
+	// stays separate from reconcile-stopped handoffs, and tracker writes remain
+	// agent-owned.
 	RuntimeEventAgentHandoffReconcileStopped RuntimeEventKind = "agent_handoff_reconcile_stopped"
+	// RuntimeEventActiveSuccessNoHandoff marks a clean worker exit whose issue
+	// still has the active tracker state last observed by the orchestrator, with
+	// no guarded current-issue handoff event. The scheduler still queues the
+	// normal continuation; this is an operator-visible "no handoff yet" outcome,
+	// not a tracker write.
+	RuntimeEventActiveSuccessNoHandoff RuntimeEventKind = "active_success_no_handoff"
 	// RuntimeEventDispatchPreflightFailed flags SPEC §8.1 step 2 failures:
 	// the per-tick dispatch preflight could not validate the workflow's
 	// tracker / agent / API-key config, so the orchestrator skipped

--- a/internal/stateapi/types.go
+++ b/internal/stateapi/types.go
@@ -47,10 +47,15 @@ type StateResponse struct {
 	// rather than absent from completed (#557). It does not overlap
 	// completed: a reconcile-stopped run is not a clean §16.5 exit, matching
 	// upstream's accounting, so completed stays unchanged.
-	ReconcileStoppedWithProgress []string               `json:"reconcile_stopped_with_progress"`
-	AgentHandoffReconcileStopped []string               `json:"agent_handoff_reconcile_stopped"`
-	OperatorTerminalStops        []OperatorTerminalStop `json:"operator_terminal_stops"`
-	CodexTotals                  CodexTotals            `json:"codex_totals"`
+	ReconcileStoppedWithProgress []string `json:"reconcile_stopped_with_progress"`
+	AgentHandoffReconcileStopped []string `json:"agent_handoff_reconcile_stopped"`
+	// ActiveSuccessNoHandoff lists clean runner exits that left the issue in the
+	// active tracker state last observed by the orchestrator, with no guarded
+	// current-issue handoff event. These still re-dispatch through the normal
+	// continuation path and also remain in Completed per SPEC §16.6.
+	ActiveSuccessNoHandoff []string               `json:"active_success_no_handoff"`
+	OperatorTerminalStops  []OperatorTerminalStop `json:"operator_terminal_stops"`
+	CodexTotals            CodexTotals            `json:"codex_totals"`
 	// RateLimits is the latest Codex rate-limit payload (SPEC §13.7.2). It
 	// is emitted unconditionally — `null` until a `rate_limit_updated`
 	// notification is observed — so operators can rely on the key always
@@ -78,10 +83,9 @@ type Counts struct {
 	// totals across worker restarts and FIFO evictions, use
 	// completed_total. SPEC §13.7 §4.1.8.
 	Completed int `json:"completed"`
-	// CompletedTotal is a monotonic counter of every observed Succeeded
-	// transition since process start, independent of FIFO eviction. Added
-	// for #234 so long-running deployments still expose a true lifetime
-	// number when the bounded set has rotated.
+	// CompletedTotal is a monotonic counter of every clean worker exit observed
+	// since process start, independent of FIFO eviction. Active clean exits with
+	// no handoff are also classified in active_success_no_handoff_total.
 	CompletedTotal int64 `json:"completed_total"`
 	// ReconcileStoppedWithProgress is the size of the FIFO-bounded recent set of
 	// reconcile-stopped runs that had made progress (≥1 completed turn; the same set
@@ -92,6 +96,8 @@ type Counts struct {
 	ReconcileStoppedWithProgressTotal int64 `json:"reconcile_stopped_with_progress_total"`
 	AgentHandoffReconcileStopped      int   `json:"agent_handoff_reconcile_stopped"`
 	AgentHandoffReconcileStoppedTotal int64 `json:"agent_handoff_reconcile_stopped_total"`
+	ActiveSuccessNoHandoff            int   `json:"active_success_no_handoff"`
+	ActiveSuccessNoHandoffTotal       int64 `json:"active_success_no_handoff_total"`
 	// OperatorTerminalStops is the size of the FIFO-bounded recent D35 latch set
 	// (the same set published as `state.operator_terminal_stops`).
 	// OperatorTerminalStopsTotal is the lifetime monotonic counter that survives


### PR DESCRIPTION
Closes #988

## Summary
- Add an `active_success_no_handoff` runtime bucket for clean runner exits that leave the issue in the active tracker state with no guarded current-issue handoff event.
- Preserve normal `completed` bookkeeping for those clean exits while also surfacing the more specific no-handoff outcome.
- Keep normal continuation retry/re-dispatch behavior unchanged; the worker remains a scheduler/reader and does not create PRs or mutate tracker state.
- Surface the bucket through `/api/v1/state`, `/api/v1/<issue>`, TUI, dashboard, fallback HTML, and `docs/runbooks/runtime-status.md`.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy` + `git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `npm test` and `npm run build` in `cmd/worker/dashboard`

Focused validation:
- `go test ./internal/orchestrator -run '^TestCleanGiteaActiveExitRecordsNoHandoffAndStillRedispatches$' -count=1`
- `go test ./cmd/worker -run 'TestApiIssueFromViewFindsActiveSuccessNoHandoffByIdentifierAndID|TestApiIssueFromViewResolvesActiveSuccessNoHandoffFromBucketWhenEventAgedOut|TestStateHTTPHandlerReturnsRuntimeStateSnapshot' -count=1`
- `go test ./cmd/tui -run 'TestRenderFrame_ShowsAgentHandoffCount|TestParseState' -count=1`

Mutation verification against final commit `f973abd`:
- Disabling the finalize predicate failed `TestCleanGiteaActiveExitRecordsNoHandoffAndStillRedispatches`.
- Removing the API projection failed `TestStateHTTPHandlerReturnsRuntimeStateSnapshot`.
- Hiding the dashboard roll-up failed `App.test.jsx` on the missing `No handoff` row.
- Removing the TUI suffix failed `TestRenderFrame_ShowsAgentHandoffCount`.
- Removing `recordCompleted` from the no-handoff clean-exit transition failed `TestCleanGiteaActiveExitRecordsNoHandoffAndStillRedispatches` on missing `Completed`/`completed_total`.
- Removing the paired `completed` runtime event failed `TestCleanGiteaActiveExitRecordsNoHandoffAndStillRedispatches` on missing `RuntimeEventCompleted`.
- Moving the `completed` fallback before `active_success_no_handoff` failed `TestApiIssueFromViewResolvesActiveSuccessNoHandoffFromBucketWhenEventAgedOut` with status `completed` instead of `active_success_no_handoff`.

## Notes
- The new bucket is observability only. It does not affect tracker writes, PR creation, or the continuation retry path.
