### PR TITLE
docs: add GitHub maker/reviewer governance guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ add a bridge that imports `AGENTS.md` rather than duplicating content.
 - [Trace harness proposal follow-through](docs/runbooks/trace-harness-follow-through.md)
 - [Workspace cache and cleanup](docs/runbooks/workspace-cache.md)
 - [GitHub local automation](docs/runbooks/github-local-automation.md)
+- [GitHub maker/reviewer governance](docs/runbooks/github-maker-reviewer-governance.md)
 - [GitHub maker/reviewer auto-merge E2E](docs/runbooks/github-maker-reviewer-automerge-e2e.md)
 - [Gitea bot and branch protection](docs/runbooks/gitea-bot-and-branch-protection.md)
 - [Local Gitea Web Todo lifecycle E2E](docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md)

--- a/docs/runbooks/github-maker-reviewer-automerge-e2e.md
+++ b/docs/runbooks/github-maker-reviewer-automerge-e2e.md
@@ -3,7 +3,10 @@
 This runbook validates the production-governance shape for GitHub: a maker
 worker implements issues and opens PRs, a separate reviewer worker independently
 reviews those PRs, GitHub branch protection gates the merge, and the reviewer
-marks issues Done/closed only after GitHub reports the PR merged.
+marks issues Done/closed only after GitHub reports the PR merged. For the short
+operator setup checklist, read
+[`github-maker-reviewer-governance.md`](github-maker-reviewer-governance.md)
+first.
 
 This is a release-validation and governance test, not a CI check. It spends real
 Codex quota, needs real GitHub accounts, and should run in a disposable

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -1,0 +1,166 @@
+# GitHub maker/reviewer governance
+
+This guide is the short production setup checklist for running aiops-platform
+against GitHub with separate maker and reviewer workers. Read it before the
+long [GitHub maker/reviewer auto-merge E2E](github-maker-reviewer-automerge-e2e.md)
+runbook; the E2E runbook remains the deep release-validation script and evidence
+reference.
+
+## Worker/orchestrator boundary
+
+The worker/orchestrator schedules, prepares workspaces, runs agents, polls
+GitHub, observes state, and reconciles active runs. It does not own PR
+operations. In this topology, workers do not create PRs, approve PRs, merge PRs, close issues, or mark issues done on their own.
+
+Those operations belong to the agents and GitHub:
+
+- The maker agent implements the issue, verifies it, pushes a branch, opens or
+  updates a PR, comments the PR URL on the issue, and hands off with
+  `aiops:human-review`.
+- The reviewer agent independently reviews the PR head, requests Rework or
+  approves, enables GitHub native auto-merge, waits for GitHub to report the PR
+  merged, then marks the issue `aiops:done` and closes it.
+- GitHub branch protection and Actions decide whether the approved PR can land.
+
+Do not add a worker/orchestrator phase, gate, config key, artifact, merge
+shortcut, or issue-closing shortcut to make this topology work. The governance
+surface is the workflow prompt, credentials, branch protection, and evidence
+capture.
+
+## Production topology
+
+Use distinct GitHub identities for every role:
+
+- setup/operator: creates or configures the repository, labels, Actions, branch
+  protection, and evidence capture.
+- maker: writes branches and PRs, but never reviews, approves, merges, closes,
+  or adds `aiops:done`.
+- reviewer: reviews PRs, enables auto-merge on passed heads, confirms merge,
+  then closes issues, but never edits, commits, or pushes code.
+
+Use distinct credential homes and runtime roots:
+
+- distinct `GH_CONFIG_DIR` for setup/operator, maker, and reviewer;
+- `env -u GH_TOKEN -u GITHUB_TOKEN GH_CONFIG_DIR=<role-dir> gh ...` for
+  role-specific `gh` commands, because ambient token variables take precedence
+  over stored `GH_CONFIG_DIR` credentials;
+- distinct maker and reviewer `workspace.root` values in the selected workflow
+  files;
+- distinct maker and reviewer `AIOPS_MIRROR_ROOT` values;
+- `AIOPS_EXPECTED_GITHUB_LOGIN` set to the expected role login for each worker;
+- no `GITHUB_TOKEN` or `GH_TOKEN` passed through to the agent environment.
+
+The reusable source templates are:
+
+- [`examples/github-maker-WORKFLOW.md`](../../examples/github-maker-WORKFLOW.md)
+- [`examples/github-reviewer-automerge-WORKFLOW.md`](../../examples/github-reviewer-automerge-WORKFLOW.md)
+
+Keep those files as the source templates. Copy them into each deployment or run
+root, fill in repository values and role-specific roots, and validate the
+rendered workflows with `worker --print-config` or `worker --doctor`.
+
+## Label state machine
+
+Create and use these GitHub labels:
+
+| Label | Owner | Meaning |
+| --- | --- | --- |
+| `aiops:todo` | setup/operator | Ready for the maker to claim. |
+| `aiops:rework` | reviewer | Returned to the maker after a failed review. |
+| `aiops:human-review` | maker | Maker has handed off a PR URL for reviewer work. |
+| `aiops:done` | reviewer | PR merge has been confirmed and the issue is closing. |
+| `aiops:canceled` | setup/operator | Work should stop and active runs should reconcile away. |
+
+The normal flow is:
+
+```text
+aiops:todo or aiops:rework
+  -> maker implements, verifies, pushes, opens PR, comments PR URL
+  -> aiops:human-review
+  -> reviewer checks PR head
+       -> aiops:rework on FAIL
+       -> reviewer approval + GitHub native auto-merge on PASS
+       -> GitHub reports merged
+       -> aiops:done + issue close
+```
+
+For dependent issues, do not add `aiops:todo` until the prerequisite issues are
+`aiops:done` and closed.
+
+## Branch protection and auto-merge
+
+Configure GitHub so repository policy, not the worker, is the merge gate:
+
+- require at least one required status check, such as `build-test`;
+- require one required approving review;
+- enable stale-review dismissal or require approval of the latest push when the
+  repository policy supports it;
+- disallow force pushes and direct pushes to `main`;
+- enable squash-only merging and GitHub native auto-merge;
+- ensure the reviewer identity is different from the maker identity, because PR
+  authors cannot satisfy their own approval requirement.
+
+The reviewer should enable auto-merge with the reviewed head pinned, for
+example:
+
+```bash
+gh pr merge <PR> --auto --squash --delete-branch --match-head-commit <sha>
+```
+
+Do not use `--admin` and do not mark the issue Done until GitHub reports
+`state: MERGED` or a non-empty `mergedAt` for that PR.
+
+## Evidence checklist
+
+Capture enough evidence to prove the boundary and the merge path without
+rerunning the long validation every time:
+
+- rendered maker and reviewer workflow files;
+- `worker --print-config` or `worker --doctor` output for both roles;
+- setup, maker, and reviewer `gh api user --jq .login` output;
+- distinct `GH_CONFIG_DIR`, `workspace.root`, and `AIOPS_MIRROR_ROOT` values;
+- branch protection JSON showing required status checks and required review;
+- GitHub Actions/check JSON for the required check on the reviewed head;
+- issue JSON and timeline showing label transitions;
+- PR JSON showing author, head SHA, review state, checks, `mergeStateStatus`,
+  `state`, and `mergedAt`;
+- maker handoff issue comment containing the PR URL;
+- reviewer approval or Rework review tied to the reviewed head SHA;
+- Done/close comment after merge confirmation.
+
+For release validation or a disposable proof run, use the helper scripts from
+the E2E runbook:
+
+- [`scripts/github-maker-reviewer-release-preflight.sh`](../../scripts/github-maker-reviewer-release-preflight.sh)
+- [`scripts/github-maker-reviewer-capture.py`](../../scripts/github-maker-reviewer-capture.py)
+- [`scripts/github-maker-reviewer-final-verify.py`](../../scripts/github-maker-reviewer-final-verify.py)
+- [`scripts/github-maker-reviewer-report.py`](../../scripts/github-maker-reviewer-report.py)
+
+The full disposable-repo path is documented in
+[`docs/runbooks/github-maker-reviewer-automerge-e2e.md`](github-maker-reviewer-automerge-e2e.md).
+
+## Failure recovery
+
+Treat governance failures as blockers, not reasons to collapse roles:
+
+- Wrong GitHub identity: stop the worker or agent turn, fix `GH_CONFIG_DIR` or
+  `AIOPS_EXPECTED_GITHUB_LOGIN`, then retry. Do not continue under the wrong
+  role.
+- Shared maker/reviewer workspace or mirror root: stop both workers and restart
+  with distinct `workspace.root` and `AIOPS_MIRROR_ROOT` values.
+- Missing branch protection or required check: pause activation of new issues,
+  fix GitHub settings, then capture fresh branch-protection evidence.
+- Maker handoff without a PR URL: reviewer returns the issue to `aiops:rework`
+  with a concrete comment about what it checked.
+- Failed review or missing behavior-level tests: reviewer requests changes and
+  moves the issue to `aiops:rework`; maker must push a new head and include a
+  `Rework response:`.
+- CI still running after approval: leave the issue in `aiops:human-review` so a
+  later reviewer continuation can re-check the same PR before marking Done.
+- PR already merged but approval/check evidence is missing for the merged head:
+  stop and collect the missing evidence or escalate to an operator. Do not jump
+  straight to Done.
+
+The safe fallback for any unclear failure is to leave the issue in an active,
+reviewable state (`aiops:human-review` or `aiops:rework`) with a precise comment.
+Never downgrade to a single-agent merge, admin merge, or worker-owned merge.

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -58,6 +58,48 @@ func TestGitHubMakerReviewerRunbookDocumentsReusableHarness(t *testing.T) {
 	})
 }
 
+func TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology(t *testing.T) {
+	root := repoRoot(t)
+	readme := readFileString(t, filepath.Join(root, "README.md"))
+	guidePath := "docs/runbooks/github-maker-reviewer-governance.md"
+	if !strings.Contains(readme, guidePath) {
+		t.Fatalf("README does not link the GitHub maker/reviewer governance guide")
+	}
+
+	body := readFileString(t, filepath.Join(root, "docs", "runbooks", "github-maker-reviewer-governance.md"))
+	for _, want := range []string{
+		"distinct GitHub identities",
+		"distinct `GH_CONFIG_DIR`",
+		"env -u GH_TOKEN -u GITHUB_TOKEN",
+		"distinct maker and reviewer `workspace.root`",
+		"distinct maker and reviewer `AIOPS_MIRROR_ROOT`",
+		"`AIOPS_EXPECTED_GITHUB_LOGIN`",
+		"`aiops:todo`",
+		"`aiops:rework`",
+		"`aiops:human-review`",
+		"`aiops:done`",
+		"`aiops:canceled`",
+		"branch protection",
+		"required status check",
+		"required approving review",
+		"GitHub native auto-merge",
+		"Evidence checklist",
+		"Failure recovery",
+		"Worker/orchestrator boundary",
+		"do not create PRs, approve PRs, merge PRs, close issues",
+		"examples/github-maker-WORKFLOW.md",
+		"examples/github-reviewer-automerge-WORKFLOW.md",
+		"docs/runbooks/github-maker-reviewer-automerge-e2e.md",
+		"scripts/github-maker-reviewer-release-preflight.sh",
+		"scripts/github-maker-reviewer-capture.py",
+		"scripts/github-maker-reviewer-report.py",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("governance guide missing %q", want)
+		}
+	}
+}
+
 func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 	root := repoRoot(t)
 	t.Setenv("GITHUB_TOKEN", "github-token")


### PR DESCRIPTION
Closes #1015

## Summary
- Add `docs/runbooks/github-maker-reviewer-governance.md` as the concise production topology checklist for GitHub maker/reviewer operation.
- Link the existing maker/reviewer workflow templates, E2E validation runbook, and evidence helper scripts instead of duplicating their full contents.
- Add README discoverability and a pointer from the long E2E runbook back to the short guide.

## Acceptance criteria
- [x] A concise governance guide exists and can be read before the long E2E runbook.
- [x] The guide contains identity, credential, workspace, mirror, label, branch-protection, auto-merge, evidence, and recovery checklists.
- [x] The guide explicitly states that worker/orchestrator do not create PRs, approve PRs, merge PRs, close issues, or mark issues done.
- [x] README links the guide from the architecture/runbook list.
- [x] Existing GitHub maker/reviewer workflow examples remain the linked source templates.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Docs only. Boundary wording follows SPEC §1: Symphony is a scheduler/runner and tracker reader; ticket writes live in workflow/runtime agent tooling.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- RED: `go test -run '^TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology$' -count=1 ./scripts` failed before the README link/guide existed.
- GREEN: `go test -run '^TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology$' -count=1 ./scripts`
- Codex review P2 on `7f89ab1`: guide needed to clear ambient GitHub token vars for role-specific `gh` commands.
- RED for review fix: `go test -run '^TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology$' -count=1 ./scripts` failed until the guide included `env -u GH_TOKEN -u GITHUB_TOKEN`.
- GREEN after review fix: `go test -run '^TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology$' -count=1 ./scripts`
- `go test -run 'TestGitHubMakerReviewer' -count=1 ./scripts`
- `go test -count=1 ./scripts`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go build ./cmd/worker ./cmd/tui`
- `go test -race -covermode=atomic ./...`
- Mutation check: removed the README governance-guide link, confirmed the new docs test failed on discoverability, restored the link, and confirmed `git diff --exit-code -- README.md`.
- Fresh Codex review on `b952f2a18b` from the `zjlgdx` trigger reported no major issues; GraphQL reviewThreads has no unresolved, non-outdated threads.

CI:
- [x] Go build and test
- [x] Security and supply-chain
- [x] E2E Gitea mock loop
- [x] Docker image build
- [x] Validate PR metadata
- [x] Validate PR title (Conventional Commits)

## Notes
- Long GitHub maker/reviewer E2E was not rerun; issue #1015 explicitly scopes this as docs extraction from the validated harness.
- Initial `@codex review` from `xrf9268-hue` hit Codex usage limits; fresh review was re-triggered from `zjlgdx` per operator instruction.
