### PR TITLE
docs: add native agent loop positioning matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,61 @@ The goal is a practical loop, not a heavy enterprise platform: run `cmd/worker`
 as a Go-based, Gitea-friendly, locally customizable Symphony while the open
 items in [`DEVIATIONS.md`](DEVIATIONS.md) are closed systematically.
 
+## Choosing aiops-platform vs native agent loops
+
+`aiops-platform` is a local, tracker-first
+issue-to-workspace-to-agent-to-PR runtime. Claude Code dynamic workflows,
+Claude Code `/goal`, and Codex Goal mode are session/thread-local agent
+capabilities: useful around a current interactive run, but not substitutes for
+a daemon that polls tracker state, prepares deterministic workspaces, records
+state, and hands PR work back through repo-owned workflow prompts plus
+agent-owned tools.
+
+Sources checked: 2026-06-29:
+[Claude Code dynamic workflows](https://code.claude.com/docs/en/workflows),
+[Claude Code `/goal`](https://code.claude.com/docs/en/goal),
+[Codex Goal mode](https://developers.openai.com/codex/prompting#goal-mode),
+[Codex app `/goal`](https://developers.openai.com/codex/app/commands#set-or-manage-a-goal-with-goal),
+and
+[Codex CLI `/goal`](https://developers.openai.com/codex/cli/slash-commands#set-or-view-a-task-goal-with-goal).
+
+| Surface | Best fit | Lifetime and state | Not a replacement for |
+| --- | --- | --- | --- |
+| aiops-platform | Tracker-backed issue queues that should become isolated agent runs and PR handoffs | Local worker process, in-memory Symphony runtime state, deterministic Git workspaces, tracker polling, state API/dashboard | Session-local planning, ad hoc research fan-out, or a generic workflow engine |
+| Claude Code dynamic workflows | One-off audits, large migrations, cross-checked research, and manual decomposition where Claude writes and reruns a workflow script | Current Claude Code session and its generated workflow script | Worker plugin, runner mode, platform integration target, tracker poller, or PR lifecycle runtime |
+| Claude Code `/goal` | Keeping a current Claude session working across turns until a completion condition is met | Current Claude Code session | External tracker reconciliation, workspace allocation, state API, or issue-to-PR service |
+| Codex Goal mode | Giving a current Codex thread/task a persistent objective and completion criteria | Current Codex thread/task | Cross-issue scheduler, worker-owned queue, or platform-level approval/merge loop |
+
+Use aiops-platform when:
+
+- A Linear, Gitea, or GitHub queue should be polled continuously and each
+  eligible issue needs an isolated workspace/run.
+- The important unit is an external issue moving toward a branch/PR handoff,
+  not a single chat session's current task.
+- Operators need restart reconciliation, per-task state, and a dashboard/API
+  showing what the worker is doing.
+- The repeatable behavior belongs in repo-owned `WORKFLOW.md` prompts and
+  agent-side tools, so every issue gets the same harness.
+
+Prefer native workflow/goal mechanisms when:
+
+- You need a one-off codebase audit, research pass, migration sketch, or
+  decomposition before deciding what issues to file.
+- Claude dynamic workflows can be useful manual research and decomposition tools
+  for parallel checks inside the current Claude Code session.
+- Claude Code `/goal` or Codex Goal mode can keep the current session/thread
+  focused on one bounded objective with clear completion criteria.
+- A human wants interactive steering instead of daemonized tracker polling,
+  deterministic workspace setup, and PR handoff.
+
+Boundary: dynamic workflows can be useful manual research and decomposition
+tools, but they are not a worker plugin, runner mode, or platform integration
+target. Do not integrate Claude Code dynamic workflows into the worker. Do not
+add a custom worker-owned goal loop, goal-aware runner, or goal evaluator. Do
+not add worker-owned push, PR, merge, approval, or tracker-write operations. Do
+not add metrics taxonomy, pair-aware preflight, distributed state, or queue
+changes here.
+
 ## License
 
 aiops-platform is licensed under the [Apache License 2.0](LICENSE).

--- a/scripts/native_agent_loop_positioning_docs_test.go
+++ b/scripts/native_agent_loop_positioning_docs_test.go
@@ -1,0 +1,40 @@
+package scripts_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadmeDocumentsNativeAgentLoopPositioning(t *testing.T) {
+	root := repoRoot(t)
+	readme := readFileString(t, filepath.Join(root, "README.md"))
+	normalized := strings.Join(strings.Fields(readme), " ")
+
+	for _, want := range []string{
+		"## Choosing aiops-platform vs native agent loops",
+		"tracker-first issue-to-workspace-to-agent-to-PR runtime",
+		"session/thread-local agent capabilities",
+		"Claude Code dynamic workflows",
+		"Claude Code `/goal`",
+		"Codex Goal mode",
+		"Use aiops-platform when",
+		"Prefer native workflow/goal mechanisms when",
+		"Sources checked: 2026-06-29",
+		"https://code.claude.com/docs/en/workflows",
+		"https://code.claude.com/docs/en/goal",
+		"https://developers.openai.com/codex/prompting#goal-mode",
+		"https://developers.openai.com/codex/app/commands#set-or-manage-a-goal-with-goal",
+		"https://developers.openai.com/codex/cli/slash-commands#set-or-view-a-task-goal-with-goal",
+		"dynamic workflows can be useful manual research and decomposition tools",
+		"not a worker plugin, runner mode, or platform integration target",
+		"Do not integrate Claude Code dynamic workflows into the worker.",
+		"Do not add a custom worker-owned goal loop, goal-aware runner, or goal evaluator.",
+		"Do not add worker-owned push, PR, merge, approval, or tracker-write operations.",
+		"Do not add metrics taxonomy, pair-aware preflight, distributed state, or queue changes here.",
+	} {
+		if !strings.Contains(readme, want) && !strings.Contains(normalized, want) {
+			t.Fatalf("README missing positioning text %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1014

## Summary
- add a README decision matrix comparing aiops-platform with Claude Code dynamic workflows, Claude Code `/goal`, and Codex Goal mode
- document concrete use/prefer-native examples plus the worker/orchestrator non-goals from the issue
- cite official Claude and OpenAI Codex docs with `Sources checked: 2026-06-29`

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

## Notes
- Official docs checked on 2026-06-29: Claude Code dynamic workflows, Claude Code `/goal`, Codex Goal mode, Codex app `/goal`, and Codex CLI `/goal`.
- Additional local validation: `go mod tidy && git diff --exit-code -- go.mod go.sum`; `go test -count=1 ./scripts`; `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`; `go build ./cmd/worker ./cmd/tui`.
- Mutation check: temporarily removed the `not a worker plugin, runner mode, or platform integration target` sentence from README and confirmed `TestReadmeDocumentsNativeAgentLoopPositioning` failed, then restored it and re-ran the focused test.
- This docs-only PR claims no new SPEC-sensitive worker/orchestrator phase, gate, config key, or artifact.
