### PR TITLE
fix: prevent dashboard running table overflow

### DIFF
--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -305,8 +305,8 @@ const IssueLink = ({ row }) => (
 function RunningTable({ rows }) {
   if (!rows.length) return <Empty title="No active sessions" sub="The worker is polling and idle — nothing is running right now." />;
   return (
-    <div className="table-wrap">
-      <table className="sessions">
+    <div className="table-wrap running-table-wrap">
+      <table className="sessions running-sessions">
         <caption className="sr-only">Running sessions</caption>
         <thead><tr>
           <th scope="col">Issue</th><th scope="col">State</th><th scope="col">Model</th><th scope="col">Runtime</th>

--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -514,7 +514,7 @@ export default function App() {
   const total = (c.running || 0) + (c.retrying || 0) + (c.blocked || 0);
   const pollSec = Math.round((s.poll_interval_ms || 0) / 1000);
   // Worker default runtime/provider (agent.default). The model is resolved
-  // per-run by the agent, so the worker-level default model is unknown (#977).
+  // per-run by the agent and rendered in the Running table.
   const agentDefault = s.agent_default || 'unknown';
   const maxConc = s.max_concurrent_agents ?? '—';
   const byState = s.max_concurrent_agents_by_state;
@@ -560,7 +560,7 @@ export default function App() {
         <div className="title-meta">
           <div className="row"><span>poll</span><b>every {pollSec}s</b></div>
           <div className="row"><span>concurrency</span><b>{maxConc} max{byStateStr}</b></div>
-          <div className="row"><span>default agent</span><b>{agentDefault} · model unknown</b></div>
+          <div className="row"><span>default agent</span><b>{agentDefault}</b></div>
         </div>
       </div>
 

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -141,8 +141,10 @@ describe('Worker status dashboard', () => {
     expect(modelCell).toBeTruthy();
     expect(modelCell.textContent).toContain('gpt-5.3-codex-spark');
     expect(modelCell.textContent).toContain('codex-app-server'); // provider sub-line
-    // worker default provider in the title meta (the model is resolved per-run).
-    expect(screen.getByText('codex-app-server · model unknown')).toBeTruthy();
+    // worker default provider in the title meta; model is resolved per-run.
+    const titleMeta = container.querySelector('.title-meta');
+    expect(titleMeta.textContent).toContain('default agentcodex-app-server');
+    expect(titleMeta.textContent).not.toContain('model unknown');
   });
 
   it('renders a missing agent model as "unknown", never blank', async () => {

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -329,6 +329,17 @@ describe('Worker status dashboard', () => {
     expect(tokHeader.querySelector('.th-sub').textContent).toBe(' in / out');
   });
 
+  it('marks the Running table with overflow-safe layout hooks', async () => {
+    const { container } = render(<App />);
+    await screen.findByRole('link', { name: 'MT-614' });
+
+    const runningPanel = [...container.querySelectorAll('.body-main .panel')]
+      .find((panel) => panel.querySelector('.panel-title')?.textContent.includes('Running'));
+    expect(runningPanel).toBeTruthy();
+    expect(runningPanel.querySelector('.running-table-wrap')).not.toBeNull();
+    expect(runningPanel.querySelector('table.running-sessions')).not.toBeNull();
+  });
+
   it('keeps reconcile-stopped details in the roll-up under the delivered KPI', async () => {
     render(<App />);
     const rollup = (await screen.findByText('Reconcile roll-up')).closest('.panel');

--- a/cmd/worker/dashboard/src/styles.css
+++ b/cmd/worker/dashboard/src/styles.css
@@ -269,9 +269,10 @@ a { color:inherit; text-decoration:none; }
 .page-title em { font-style:italic; color:var(--accent-text); font-weight:500; }
 .page-sub { color:var(--ink-mute); font-family:var(--font-prose); font-size:14px; margin-top:6px; max-width:62ch; }
 .page-sub b { color:var(--ink-soft); font-weight:600; }
-.title-meta { text-align:right; display:flex; flex-direction:column; gap:3px; flex-shrink:0; }
-.title-meta .row { display:flex; gap:7px; justify-content:flex-end; color:var(--ink-mute); font-family:var(--font-mono); font-size:11.5px; white-space:nowrap; }
+.title-meta { text-align:right; display:flex; flex-direction:column; gap:3px; flex:1 1 280px; max-width:100%; }
+.title-meta .row { display:flex; flex-wrap:wrap; gap:0 7px; justify-content:flex-end; color:var(--ink-mute); font-family:var(--font-mono); font-size:11.5px; }
 .title-meta b { color:var(--ink-soft); font-weight:500; }
+.title-meta, .title-meta .row, .title-meta b { min-width:0; overflow-wrap:anywhere; }
 
 /* ─── KPI strip ────────────────────────────────────────────── */
 .kpi-row { display:grid; grid-template-columns:repeat(4,1fr); gap:var(--gap); margin-bottom:var(--gap); }
@@ -317,10 +318,10 @@ a { color:inherit; text-decoration:none; }
   box-shadow:0 1px 0 var(--edge) inset, 0 1px 2px var(--shadow);
   padding:var(--panel-pad); margin-bottom:var(--gap);
 }
-.panel-head { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:11px; }
+.panel-head { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:11px; min-width:0; }
 .panel-title { display:flex; align-items:center; gap:9px; font-size:13px; font-weight:600; white-space:nowrap; }
 .accent-stroke { width:13px; height:2px; border-radius:2px; background:var(--accent); flex-shrink:0; }
-.panel-meta { color:var(--ink-mute); font-family:var(--font-mono); font-size:11.5px; white-space:nowrap; }
+.panel-meta { color:var(--ink-mute); font-family:var(--font-mono); font-size:11.5px; text-align:right; min-width:0; overflow-wrap:anywhere; }
 .panel-meta b { color:var(--ink-soft); font-weight:500; }
 
 /* ─── Rate limits ──────────────────────────────────────────── */
@@ -338,7 +339,7 @@ a { color:inherit; text-decoration:none; }
 .rate-bar i.bad  { background:var(--danger); }
 .rate-meta { color:var(--ink-mute); font-size:10.5px; font-family:var(--font-mono); margin-top:6px; }
 /* raw-JSON fallback when the runner reports an unrecognized rate-limit shape */
-.rate-raw { overflow:auto; margin:0; border-radius:var(--radius-md); padding:11px 12px;
+.rate-raw { overflow:auto; overflow-x:hidden; white-space:pre-wrap; overflow-wrap:anywhere; margin:0; border-radius:var(--radius-md); padding:11px 12px;
   background:var(--inset); border:1px solid var(--hairline-2);
   font-family:var(--font-mono); font-size:11.5px; line-height:1.5; color:var(--ink-soft); }
 
@@ -353,7 +354,7 @@ table.sessions th.r, table.sessions td.r { text-align:right; }
 table.sessions td { padding:var(--row-pad); padding-left:0; padding-right:12px; border-bottom:1px solid var(--hairline-2); vertical-align:top; }
 table.sessions tr:last-child td { border-bottom:0; }
 .issue { display:flex; flex-direction:column; gap:1px; }
-.issue-id { font-family:var(--font-mono); font-size:11.5px; font-weight:500; color:var(--accent-text); }
+.issue-id { font-family:var(--font-mono); font-size:11.5px; font-weight:500; color:var(--accent-text); overflow-wrap:anywhere; }
 .issue-title { color:var(--ink-soft); font-size:12px; max-width:30ch; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .wp { font-family:var(--font-mono); font-size:10.5px; color:var(--ink-mute); margin-top:1px; }
 .sess-id { font-family:var(--font-mono); font-size:11px; color:var(--ink-mute); }
@@ -414,18 +415,20 @@ table.sessions th.tok-h .th-sub { font-weight:400; color:var(--ink-faint); lette
    inset card. The window count carries the serif-numeric treatment used by the
    KPIs/meta so it reads as the value; the lifetime total stays dim. Collapses
    to flex-wrap on phones so nothing overflows the narrow viewport. */
-.rollup-grid { display:grid; grid-template-columns:auto auto 1fr; gap:8px var(--gap); }
+.rollup-grid { display:grid; grid-template-columns:auto auto minmax(0,1fr); gap:8px var(--gap); min-width:0; }
 .rollup-cell {
   display:grid; grid-template-columns:subgrid; grid-column:1 / -1; align-items:center;
   background:var(--inset); border:1px solid var(--hairline-2);
   border-radius:var(--radius-md); padding:8px 12px;
   position:relative; /* containing block for the absolutely-positioned sr-only span */
+  min-width:0;
 }
-.rollup-k { display:flex; align-items:center; gap:7px; font-size:11.5px; font-weight:600; letter-spacing:.01em; color:var(--ink-soft); white-space:nowrap; }
-.rollup-v { font-family:var(--font-mono); font-size:11px; color:var(--ink-mute); white-space:nowrap; }
+.rollup-k { display:flex; align-items:center; gap:7px; font-size:11.5px; font-weight:600; letter-spacing:.01em; color:var(--ink-soft); min-width:0; overflow-wrap:anywhere; }
+.rollup-v { font-family:var(--font-mono); font-size:11px; color:var(--ink-mute); min-width:0; overflow-wrap:anywhere; }
 .rollup-v b { font-family:var(--font-num); font-size:17px; font-weight:600; color:var(--ink); margin-right:2px; font-variant-numeric:tabular-nums; }
 .rollup-v .tot { color:var(--ink-faint); margin-left:5px; }
-.rollup-ids { display:flex; gap:5px; flex-wrap:wrap; justify-content:flex-end; }
+.rollup-ids { display:flex; gap:5px; flex-wrap:wrap; justify-content:flex-end; min-width:0; }
+.rollup-ids .tier-badge { max-width:100%; min-width:0; white-space:normal; overflow-wrap:anywhere; }
 @media (max-width:640px) {
   .rollup-grid { display:flex; flex-direction:column; }
   .rollup-cell { display:flex; flex-wrap:wrap; gap:6px 9px; grid-column:auto; }
@@ -467,9 +470,13 @@ table.sessions th.tok-h .th-sub { font-weight:400; color:var(--ink-faint); lette
   .body-main table.running-sessions th:nth-child(6) { width:10%; }
   .body-main table.running-sessions .wp,
   .body-main table.running-sessions .upd,
+  .body-main table.running-sessions .issue-id,
   .body-main table.running-sessions .mono,
   .body-main table.running-sessions .dim { overflow-wrap:anywhere; }
-  .body-main table.running-sessions .badge { max-width:100%; overflow:hidden; }
+  .body-main table.running-sessions .badge {
+    max-width:100%; height:auto; min-height:21px; line-height:1.15;
+    white-space:normal; overflow-wrap:anywhere; overflow:hidden;
+  }
   .body-main table.running-sessions th.tok-h { white-space:normal; line-height:1.15; }
   .body-main table.running-sessions th.tok-h .th-sub { display:block; }
   .body-main table.running-sessions td.tok { white-space:nowrap; }
@@ -484,7 +491,19 @@ table.sessions th.tok-h .th-sub { font-weight:400; color:var(--ink-faint); lette
    (≤640px the global card rule restores stacked layout.) */
 @media (min-width:641px) {
   .body-main .table-wrap.narrow { overflow:hidden; }
-  .body-main .table-wrap.narrow .wp, .body-main .table-wrap.narrow .upd { overflow-wrap:anywhere; }
+  .body-main .table-wrap.narrow table.sessions { table-layout:fixed; width:100%; }
+  .body-main .table-wrap.narrow table.sessions th:nth-child(1) { width:36%; }
+  .body-main .table-wrap.narrow table.sessions th:nth-child(2) { width:18%; }
+  .body-main .table-wrap.narrow table.sessions th:nth-child(3) { width:16%; }
+  .body-main .table-wrap.narrow table.sessions th:nth-child(4) { width:30%; }
+  .body-main .table-wrap.narrow .wp,
+  .body-main .table-wrap.narrow .upd,
+  .body-main .table-wrap.narrow .issue-id,
+  .body-main .table-wrap.narrow .dim { overflow-wrap:anywhere; }
+  .body-main .table-wrap.narrow .badge {
+    max-width:100%; height:auto; min-height:21px; line-height:1.15;
+    white-space:normal; overflow-wrap:anywhere; overflow:hidden;
+  }
 }
 
 /* ─── Responsive ───────────────────────────────────────────── */
@@ -524,7 +543,9 @@ table.sessions th.tok-h .th-sub { font-weight:400; color:var(--ink-faint); lette
   table.sessions td {
     display:flex; justify-content:space-between; align-items:baseline; gap:14px;
     padding:6px 0; border-bottom:1px dashed var(--hairline-2); text-align:right;
+    min-width:0; overflow-wrap:anywhere;
   }
+  table.sessions td > * { min-width:0; overflow-wrap:anywhere; }
   table.sessions td:last-child { border-bottom:0; padding-bottom:0; }
   table.sessions td[data-label]::before {
     content:attr(data-label); flex:0 0 auto; text-align:left;
@@ -536,8 +557,10 @@ table.sessions th.tok-h .th-sub { font-weight:400; color:var(--ink-faint); lette
     display:block; text-align:left; padding-top:0;
     border-bottom:1px solid var(--hairline); margin-bottom:3px; padding-bottom:8px;
   }
+  .issue { min-width:0; }
   .issue-title { white-space:normal; max-width:none; }
   .upd { -webkit-line-clamp:unset; max-width:none; text-align:right; }
+  .badge { height:auto; min-height:21px; line-height:1.15; white-space:normal; overflow-wrap:anywhere; }
   table.sessions td.tok { text-align:right; }
 }
 

--- a/cmd/worker/dashboard/src/styles.css
+++ b/cmd/worker/dashboard/src/styles.css
@@ -452,6 +452,29 @@ table.sessions th.tok-h .th-sub { font-weight:400; color:var(--ink-faint); lette
 .body-grid table.sessions { min-width:0; }
 @media (max-width:980px) { .body-grid { grid-template-columns:1fr; } }
 
+/* Running can carry very long workflow/workspace/session identifiers while it
+   is squeezed into the wider column beside Rate limits. Use a fixed table
+   layout plus breakable diagnostic text so those identifiers wrap inside their
+   cells instead of creating an inner horizontal scrollbar. */
+@media (min-width:641px) {
+  .body-main .running-table-wrap { overflow:hidden; }
+  .body-main table.running-sessions { table-layout:fixed; width:100%; }
+  .body-main table.running-sessions th:nth-child(1) { width:37%; }
+  .body-main table.running-sessions th:nth-child(2) { width:18%; }
+  .body-main table.running-sessions th:nth-child(3) { width:13%; }
+  .body-main table.running-sessions th:nth-child(4) { width:8%; }
+  .body-main table.running-sessions th:nth-child(5) { width:14%; }
+  .body-main table.running-sessions th:nth-child(6) { width:10%; }
+  .body-main table.running-sessions .wp,
+  .body-main table.running-sessions .upd,
+  .body-main table.running-sessions .mono,
+  .body-main table.running-sessions .dim { overflow-wrap:anywhere; }
+  .body-main table.running-sessions .badge { max-width:100%; overflow:hidden; }
+  .body-main table.running-sessions th.tok-h { white-space:normal; line-height:1.15; }
+  .body-main table.running-sessions th.tok-h .th-sub { display:block; }
+  .body-main table.running-sessions td.tok { white-space:nowrap; }
+}
+
 /* Retrying/Blocked tables in the main column: each fits its panel comfortably
    (the long error/detail cells wrap). Clip the wrap so the per-second retry
    countdown re-render can't flash a transient horizontal scrollbar. To keep


### PR DESCRIPTION
Closes #1018

## Summary
- keep the dashboard Running table inside its panel when workflow/workspace/session values are long
- remove the misleading top-level `model unknown` label; the header now shows only the worker default agent, while per-run model data stays in the Running table
- generalize overflow handling across dashboard meta rows, raw rate-limit JSON, roll-up chips, and Running/Retrying/Blocked tables so long unbroken operator data wraps inside its container
- add a dashboard regression test that preserves the Running table layout hooks and asserts the title meta no longer renders `model unknown`

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [ ] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [ ] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [ ] `go vet ./...`
- [ ] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

## Notes
- UI-only dashboard fix; no Go production code changed.
- Local validation: `npm test`; `npm run build`; Playwright overflow probe with long workspace/session data before/after; stress Playwright sweep with long Running, Retrying, Blocked, title-meta, raw rate-limit, and roll-up values at 1180, 980, 820, 640, and 390 px; `go test ./cmd/worker`; `git diff --check`.
- Overflow evidence: before fix, the screenshot-shaped Running wrapper measured `clientWidth=652`, `scrollWidth=736`; after fix, `clientWidth=652`, `scrollWidth=652`.
- Generalized stress evidence: every measured page/body/wrapper pair had equal `clientWidth` and `scrollWidth`, and the page text did not contain `model unknown`.
