### PR TITLE
fix(orchestrator): drain in-flight agent workers on shutdown

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -30,6 +30,13 @@ import (
 // hence the explicit build ARG there).
 var version = "devel"
 
+// workerShutdownDrainGrace bounds how long run() waits for in-flight agent
+// workers after the poll loop exits on SIGTERM/SIGINT. It matches the
+// reconcile WorkerExitTimeout (workflow_runtime.go): workers that ignore
+// cancellation longer than this are abandoned to process exit, and a second
+// signal always terminates immediately.
+const workerShutdownDrainGrace = 30 * time.Second
+
 func resolveVersion() string { return buildinfo.Resolve(version) }
 
 func main() { //nolint:gocognit // baseline (#521)
@@ -447,7 +454,18 @@ func run(ctx context.Context, args []string) error { //nolint:gocognit,funlen //
 			log.Printf("workflow reload loop exited: %v", err)
 		}
 	}()
-	return orchestrator.RunPollLoopWithRuntime(ctx, poller, runtime, orchestrator.PollLoopRuntimeOptions{})
+	pollErr := orchestrator.RunPollLoopWithRuntime(ctx, poller, runtime, orchestrator.PollLoopRuntimeOptions{})
+	// SIGTERM/SIGINT lands here with in-flight agents still running. Drain
+	// them before returning from run(): a bare return exits the process,
+	// racing the runners' subprocess kill and skipping result collection
+	// (issue #1030). Workers see the canceled root context and exit on
+	// their own; the grace period only bounds the wait. A second signal
+	// still kills the process immediately (signal.NotifyContext stops
+	// relaying once canceled).
+	if !orch.WaitForWorkers(workerShutdownDrainGrace) {
+		log.Printf("event=shutdown_drain_timeout grace=%s note=%q", workerShutdownDrainGrace, "exiting with agent workers still running")
+	}
+	return pollErr
 }
 func reconciliationConfigForWorkflow(cfg workflow.Config) orchestrator.ReconciliationConfig {
 	// Single source of truth for the field list lives in

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -64,6 +64,12 @@ func main() { //nolint:gocognit // baseline (#521)
 		os.Exit(doctor.Run(context.Background(), opts))
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	// Restore default signal disposition the moment the first signal cancels
+	// ctx: run() drains in-flight agent workers for up to
+	// workerShutdownDrainGrace before returning, and NotifyContext keeps
+	// swallowing signals until stop() — without this a second SIGTERM/SIGINT
+	// during the drain would be ignored instead of terminating immediately.
+	context.AfterFunc(ctx, stop)
 	if err := normalizeRunError(run(ctx, os.Args[1:]), ctx.Err()); err != nil {
 		stop()
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/orchestrator/actor.go
+++ b/internal/orchestrator/actor.go
@@ -145,6 +145,14 @@ type Orchestrator struct {
 	// via the started channel close.
 	runCtx  context.Context
 	started chan struct{}
+
+	// workerWG tracks every spawn until its dispatcher result is consumed.
+	// WaitForWorkers waits on it so a SIGTERM shutdown drains in-flight
+	// agent subprocesses instead of orphaning them when main returns —
+	// the explicit Go replacement for the ordered child termination a BEAM
+	// supervision tree performs on shutdown (AGENTS.md cross-cutting
+	// checklist item 2).
+	workerWG sync.WaitGroup
 }
 
 // New constructs an Orchestrator over an existing state value. Callers

--- a/internal/orchestrator/actor_dispatch.go
+++ b/internal/orchestrator/actor_dispatch.go
@@ -256,6 +256,32 @@ func cleanTurnBudgetForContinuationBudget(maxContinuationTurns, continuationTurn
 	return remaining
 }
 
+// WaitForWorkers blocks until every spawned worker goroutine has consumed its
+// dispatcher result (the worker subprocess has exited and its outcome is
+// collected) or grace elapses, and reports whether the drain completed. main
+// calls it after the poll loop returns on SIGTERM/SIGINT: without the wait the
+// process exits mid-run, racing the runner's subprocess kill and skipping
+// after_run/workspace teardown (BEAM gets the ordered child shutdown for free
+// from the supervision tree; a Go main return provides no such guarantee —
+// AGENTS.md cross-cutting checklist item 2). Workers observe the canceled run
+// context and exit on their own; grace only bounds how long shutdown waits for
+// that to happen.
+func (o *Orchestrator) WaitForWorkers(grace time.Duration) bool {
+	drained := make(chan struct{})
+	safeGo("orchestrator.worker_drain_wait", func() {
+		o.workerWG.Wait()
+		close(drained)
+	})
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-drained:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
 // spawn asks the dispatcher for a worker, records the Running entry
 // through the actor, and starts the watcher goroutine that submits
 // finalizeRunOp on worker exit. The caller must already hold the
@@ -265,6 +291,11 @@ func cleanTurnBudgetForContinuationBudget(maxContinuationTurns, continuationTurn
 // spawn is invoked from a followup goroutine, never from inside an
 // apply method, so its calls into o.submit are safe.
 func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, continuationAttempt, continuationTurnCount, cleanTurnBudget int) {
+	// Register with the drain group before anything that can start a worker
+	// so WaitForWorkers can never observe a live subprocess it isn't
+	// tracking; every return path below either hands the slot to the fanout
+	// goroutine or releases it.
+	o.workerWG.Add(1)
 	runCtx, cancel := context.WithCancelCause(o.runCtx)
 	startedAt := time.Now()
 	workerDone := make(chan struct{})
@@ -287,6 +318,7 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 	})); err != nil {
 		cancel(nil)
 		close(workerDone)
+		o.workerWG.Done()
 		return
 	}
 	select {
@@ -294,10 +326,12 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 	case <-o.runCtx.Done():
 		cancel(nil)
 		close(workerDone)
+		o.workerWG.Done()
 		return
 	}
 	resultCh := o.dispatcher.Spawn(runCtx, issue, attempt, DispatchOptions{CleanTurnBudget: cleanTurnBudget})
 	go func() {
+		defer o.workerWG.Done()
 		defer recoverPanic("orchestrator.spawn_result_fanout")
 		var res WorkerResult
 		select {
@@ -312,9 +346,19 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 				res = WorkerResult{Err: context.Canceled, Elapsed: time.Since(startedAt)}
 			}
 		case <-o.runCtx.Done():
+			// Shutdown: cancel the worker, then keep waiting for its
+			// result instead of abandoning it. The dispatcher contract
+			// yields exactly one result (or a close) once the worker
+			// observes the canceled context, so this converges; returning
+			// here instead would strand the still-running subprocess for
+			// WaitForWorkers and skip result collection entirely.
 			cancel(nil)
-			close(workerDone)
-			return
+			r, ok := <-resultCh
+			if ok {
+				res = r
+			} else {
+				res = WorkerResult{Err: context.Canceled, Elapsed: time.Since(startedAt)}
+			}
 		}
 		// workerDone is closed in exactly one path: either by
 		// finalizeRunOp.apply once the actor accepts this submit, or by this

--- a/internal/orchestrator/actor_dispatch.go
+++ b/internal/orchestrator/actor_dispatch.go
@@ -333,33 +333,7 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 	go func() {
 		defer o.workerWG.Done()
 		defer recoverPanic("orchestrator.spawn_result_fanout")
-		var res WorkerResult
-		select {
-		case r, ok := <-resultCh:
-			cancel(nil)
-			if ok {
-				res = r
-			} else {
-				// Dispatcher closed without yielding a result: treat
-				// as a cancellation, which becomes an abnormal exit
-				// and triggers a retry per SPEC §7.3.
-				res = WorkerResult{Err: context.Canceled, Elapsed: time.Since(startedAt)}
-			}
-		case <-o.runCtx.Done():
-			// Shutdown: cancel the worker, then keep waiting for its
-			// result instead of abandoning it. The dispatcher contract
-			// yields exactly one result (or a close) once the worker
-			// observes the canceled context, so this converges; returning
-			// here instead would strand the still-running subprocess for
-			// WaitForWorkers and skip result collection entirely.
-			cancel(nil)
-			r, ok := <-resultCh
-			if ok {
-				res = r
-			} else {
-				res = WorkerResult{Err: context.Canceled, Elapsed: time.Since(startedAt)}
-			}
-		}
+		res := o.awaitWorkerResult(resultCh, startedAt, cancel)
 		// workerDone is closed in exactly one path: either by
 		// finalizeRunOp.apply once the actor accepts this submit, or by this
 		// goroutine when submit fails because o.runCtx was canceled before
@@ -381,4 +355,28 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 			close(workerDone)
 		}
 	}()
+}
+
+// awaitWorkerResult collects the dispatcher's single result for a spawned
+// worker. On shutdown (runCtx canceled) it cancels the worker and then keeps
+// waiting instead of abandoning it: the Dispatcher contract yields exactly one
+// result (or a close) once the worker observes the canceled context, so this
+// converges — returning early would strand the still-running subprocess for
+// WaitForWorkers and skip result collection entirely (#1030). A dispatcher
+// close without a result is a cancellation, which becomes an abnormal exit and
+// triggers a retry per SPEC §7.3.
+func (o *Orchestrator) awaitWorkerResult(resultCh <-chan WorkerResult, startedAt time.Time, cancel context.CancelCauseFunc) WorkerResult {
+	var r WorkerResult
+	ok := false
+	select {
+	case r, ok = <-resultCh:
+		cancel(nil)
+	case <-o.runCtx.Done():
+		cancel(nil)
+		r, ok = <-resultCh
+	}
+	if !ok {
+		return WorkerResult{Err: context.Canceled, Elapsed: time.Since(startedAt)}
+	}
+	return r
 }

--- a/internal/orchestrator/actor_dispatch_test.go
+++ b/internal/orchestrator/actor_dispatch_test.go
@@ -1,8 +1,11 @@
 package orchestrator
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 )
 
 // TestResolveDispatchClaim_Table characterizes every branch of the dispatch
@@ -69,6 +72,81 @@ func TestResolveDispatchClaim_Table(t *testing.T) {
 				t.Fatalf("resolveDispatchClaim continuationTurnCount = %d; want %d", contTurnCount, tc.wantContTurnCount)
 			}
 		})
+	}
+}
+
+// cancelAwareDispatcher yields its worker result only after the spawn
+// context is canceled, modeling a real agent run that exits in response to
+// shutdown cancellation rather than instantly.
+type cancelAwareDispatcher struct {
+	released chan struct{} // closed when the worker goroutine has delivered its result
+}
+
+func (d *cancelAwareDispatcher) Spawn(ctx context.Context, _ tracker.Issue, _ *int, _ DispatchOptions) <-chan WorkerResult {
+	out := make(chan WorkerResult, 1)
+	go func() {
+		<-ctx.Done()
+		out <- WorkerResult{Err: context.Canceled}
+		close(out)
+		close(d.released)
+	}()
+	return out
+}
+
+// TestWaitForWorkers_DrainsInFlightWorkerOnShutdown reproduces the issue
+// #1030 SIGTERM path: the actor context is canceled while a worker is
+// mid-run. WaitForWorkers must block until the worker observes the
+// cancellation and its result is collected — deleting the workerWG handoff
+// in spawn (or restoring the old early return in the runCtx.Done fanout
+// branch) makes WaitForWorkers return before the dispatcher delivered the
+// result, failing the released-channel assertion below.
+func TestWaitForWorkers_DrainsInFlightWorkerOnShutdown(t *testing.T) {
+	disp := &cancelAwareDispatcher{released: make(chan struct{})}
+	st := NewOrchestratorState(15000, 100)
+	o := New(st, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	ctx, cancel := context.WithCancel(context.Background())
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	iss := tracker.Issue{ID: "ENG-drain", Identifier: "ENG-drain", Title: "shutdown drain"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch(%s) = %v; want nil", iss.ID, err)
+	}
+
+	// Worker is running (blocked on ctx.Done). Simulate SIGTERM.
+	cancel()
+
+	if !o.WaitForWorkers(5 * time.Second) {
+		t.Fatalf("WaitForWorkers(5s) = false; want true (worker exits on cancel)")
+	}
+	select {
+	case <-disp.released:
+	default:
+		t.Fatalf("WaitForWorkers returned before the dispatcher delivered the worker result")
+	}
+}
+
+// TestWaitForWorkers_TimesOutOnStuckWorker pins the bounded-grace contract:
+// a worker that ignores cancellation must not wedge shutdown forever.
+func TestWaitForWorkers_TimesOutOnStuckWorker(t *testing.T) {
+	disp := &fakeDispatcher{} // never delivers a result
+	st := NewOrchestratorState(15000, 100)
+	o := New(st, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	ctx, cancel := context.WithCancel(context.Background())
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-stuck", Identifier: "ENG-stuck", Title: "stuck worker"}
+	if err := o.RequestDispatch(context.Background(), iss, nil); err != nil {
+		t.Fatalf("RequestDispatch(%s) = %v; want nil", iss.ID, err)
+	}
+	if o.WaitForWorkers(50 * time.Millisecond) {
+		t.Fatalf("WaitForWorkers(50ms) = true; want false (worker never exits)")
 	}
 }
 

--- a/internal/orchestrator/actor_dispatch_test.go
+++ b/internal/orchestrator/actor_dispatch_test.go
@@ -76,32 +76,37 @@ func TestResolveDispatchClaim_Table(t *testing.T) {
 }
 
 // cancelAwareDispatcher yields its worker result only after the spawn
-// context is canceled, modeling a real agent run that exits in response to
-// shutdown cancellation rather than instantly.
+// context is canceled plus a teardown delay, modeling a real agent run that
+// needs time to wind down (subprocess kill, artifact write) after shutdown
+// cancellation. released is closed strictly before the result is delivered,
+// so a drain that returned without consuming the result observes it still
+// open.
 type cancelAwareDispatcher struct {
-	released chan struct{} // closed when the worker goroutine has delivered its result
+	teardown time.Duration
+	released chan struct{}
 }
 
 func (d *cancelAwareDispatcher) Spawn(ctx context.Context, _ tracker.Issue, _ *int, _ DispatchOptions) <-chan WorkerResult {
 	out := make(chan WorkerResult, 1)
 	go func() {
 		<-ctx.Done()
+		time.Sleep(d.teardown)
+		close(d.released)
 		out <- WorkerResult{Err: context.Canceled}
 		close(out)
-		close(d.released)
 	}()
 	return out
 }
 
 // TestWaitForWorkers_DrainsInFlightWorkerOnShutdown reproduces the issue
 // #1030 SIGTERM path: the actor context is canceled while a worker is
-// mid-run. WaitForWorkers must block until the worker observes the
-// cancellation and its result is collected — deleting the workerWG handoff
-// in spawn (or restoring the old early return in the runCtx.Done fanout
-// branch) makes WaitForWorkers return before the dispatcher delivered the
-// result, failing the released-channel assertion below.
+// mid-run and the worker needs teardown time after observing the
+// cancellation. WaitForWorkers must block until the worker's result is
+// collected — deleting the workerWG handoff in spawn (or restoring the old
+// early return in the runCtx.Done fanout branch) makes WaitForWorkers return
+// during the teardown window, failing the released-channel assertion below.
 func TestWaitForWorkers_DrainsInFlightWorkerOnShutdown(t *testing.T) {
-	disp := &cancelAwareDispatcher{released: make(chan struct{})}
+	disp := &cancelAwareDispatcher{teardown: 300 * time.Millisecond, released: make(chan struct{})}
 	st := NewOrchestratorState(15000, 100)
 	o := New(st, Deps{Dispatcher: disp, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Closes #1030

## Summary
- SIGTERM/SIGINT previously returned from `run()` the instant the poll loop exited; the process died racing the runner's subprocess kill, orphaning codex subprocesses and skipping worker result collection.
- `spawn` now registers every worker with a drain `WaitGroup`; the result fanout goroutine, on `runCtx` cancellation, cancels the worker and **keeps waiting for its result** (per the Dispatcher one-result contract) instead of returning early.
- `cmd/worker` calls the new `Orchestrator.WaitForWorkers(30s)` after the poll loop returns: shutdown now waits for in-flight agents to exit (bounded by the same 30 s the reconcile `WorkerExitTimeout` uses); a second signal still terminates immediately.
- This is the explicit Go replacement for the ordered child shutdown a BEAM supervision tree provides implicitly (AGENTS.md cross-cutting checklist item 2).

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

No new phase/gate/artifact: this only changes process-exit ordering. Upstream BEAM gets ordered child termination from the supervision tree (`elixir/lib/symphony_elixir/application.ex` children shutdown semantics); a Go `main` return provides no equivalent, which AGENTS.md cross-cutting checklist item 2 classifies as an implicit runtime guarantee the port must replicate explicitly.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: 3 files (`actor.go`, `actor_dispatch.go`, `cmd/worker/main.go`), ~60 LOC.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Mutation-verified per clean-code rule 6: restoring the old `runCtx.Done()` early-return in the fanout goroutine fails `TestWaitForWorkers_DrainsInFlightWorkerOnShutdown` (`WaitForWorkers returned before the dispatcher delivered the worker result`); tree restored to HEAD afterwards. `TestWaitForWorkers_TimesOutOnStuckWorker` pins the bounded-grace contract.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.

Made with [Cursor](https://cursor.com)