### PR TITLE
fix(worker): scrub secrets from hook output and state API error fields

### DIFF
--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -883,6 +883,70 @@ func TestApiRetryFromViewAlwaysEmitsKind(t *testing.T) {
 	}
 }
 
+func TestStateAPIProjectionRedactsCredentialedErrorFields(t *testing.T) {
+	const secret = "token-1032"
+	secretURL := "scheme://user:" + secret + "@example.com/repo.git"
+	state := apiStateFromView(orchestrator.StateView{
+		Retrying: []orchestrator.RetryView{{
+			IssueID:    "issue-1",
+			Identifier: "SEC-1",
+			Attempt:    1,
+			Error:      "retry failed: " + secretURL,
+			StartupFailure: &task.StartupFailure{
+				Phase: "thread/start",
+				Error: "startup failed: " + secretURL,
+			},
+		}},
+		Blocked: []orchestrator.BlockedView{{
+			IssueID:    "issue-2",
+			Identifier: "SEC-2",
+			Error:      "blocked: " + secretURL,
+		}},
+	})
+	assertStateAPISecretRedacted(t, "retry.error", state.Retrying[0].Error)
+	if state.Retrying[0].StartupFailure == nil {
+		t.Fatal("retry startup_failure = nil; want redacted startup failure")
+	}
+	assertStateAPISecretRedacted(t, "retry.startup_failure.error", state.Retrying[0].StartupFailure.Error)
+	assertStateAPISecretRedacted(t, "blocked.error", state.Blocked[0].Error)
+
+	retryIssue, ok := apiIssueFromView(orchestrator.StateView{
+		Retrying: []orchestrator.RetryView{{
+			IssueID:    "issue-3",
+			Identifier: "SEC-3",
+			Attempt:    2,
+			Error:      "retry issue failed: " + secretURL,
+		}},
+	}, "SEC-3")
+	if !ok || retryIssue.LastError == nil {
+		t.Fatalf("retry issue lookup = (%+v, %t), want last_error", retryIssue, ok)
+	}
+	assertStateAPISecretRedacted(t, "retry issue last_error", *retryIssue.LastError)
+
+	failedIssue, ok := apiIssueFromView(orchestrator.StateView{
+		RecentEvents: []orchestrator.RuntimeEvent{{
+			Kind:       orchestrator.RuntimeEventFailed,
+			IssueID:    "issue-4",
+			Identifier: "SEC-4",
+			Message:    "terminal failed: " + secretURL,
+		}},
+	}, "SEC-4")
+	if !ok || failedIssue.LastError == nil {
+		t.Fatalf("failed issue lookup = (%+v, %t), want last_error", failedIssue, ok)
+	}
+	assertStateAPISecretRedacted(t, "failed issue last_error", *failedIssue.LastError)
+}
+
+func assertStateAPISecretRedacted(t *testing.T, name, got string) {
+	t.Helper()
+	if strings.Contains(got, "token-1032") || strings.Contains(got, "user:token-1032@") {
+		t.Fatalf("%s leaked credential in %q", name, got)
+	}
+	if !strings.Contains(got, "<redacted>") {
+		t.Fatalf("%s = %q, want <redacted> marker", name, got)
+	}
+}
+
 func TestRootDashboardServesStateDepictingReactApp(t *testing.T) {
 	server := newStateHTTPServer("127.0.0.1", 0, func(context.Context) (orchestrator.StateView, error) {
 		return orchestrator.StateView{}, nil

--- a/cmd/worker/redact.go
+++ b/cmd/worker/redact.go
@@ -27,7 +27,11 @@ var stateAPIRedactionPatterns = []*regexp.Regexp{
 	// without the surrounding header context).
 	regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._\-+/=]+`),
 	regexp.MustCompile(`\b(?:sk|ghp|ghu|ghs|gho|github_pat|glpat|xoxb|xoxp)[_-][A-Za-z0-9_\-]{16,}`),
-	regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9+.\-]*://[^\s/@]+:[^\s/@]+@[^\s]+`),
+	// Any URL carrying userinfo — with or without a password. The bare
+	// `https://token@host` clone URL shape is still a credential, and the
+	// userinfo class is greedy up to the last @ before the authority ends so
+	// a password containing @ does not leak its tail.
+	regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9+.\-]*://[^/?#\s]*@[^\s]+`),
 }
 
 // redactStateAPILastMessage applies the SPEC §15.3 / issue #297 redaction
@@ -50,12 +54,20 @@ func redactStateAPILastMessage(s string) string {
 	if s == "" {
 		return ""
 	}
-	for _, p := range stateAPIRedactionPatterns {
-		s = p.ReplaceAllString(s, "<redacted>")
-	}
+	s = redactStateAPISecretText(s)
 	runes := []rune(s)
 	if len(runes) > stateAPILastMessageMaxRunes {
 		return string(runes[:stateAPILastMessageMaxRunes]) + "…"
+	}
+	return s
+}
+
+func redactStateAPISecretText(s string) string {
+	if s == "" {
+		return ""
+	}
+	for _, p := range stateAPIRedactionPatterns {
+		s = p.ReplaceAllString(s, "<redacted>")
 	}
 	return s
 }

--- a/cmd/worker/redact_test.go
+++ b/cmd/worker/redact_test.go
@@ -64,6 +64,42 @@ func TestRedactStateAPILastMessageScrubsBasicAuthURL(t *testing.T) {
 	}
 }
 
+func TestRedactStateAPISecretTextScrubsBareUserinfoURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantLeak string
+		wantKept string
+	}{
+		{
+			name:     "bare userinfo token is scrubbed",
+			in:       "fatal: unable to access 'https://oauth2supersecret@git.example.com/org/repo.git/'",
+			wantLeak: "oauth2supersecret",
+		},
+		{
+			name:     "plain URL without userinfo is preserved",
+			in:       "see https://example.com/docs for details",
+			wantKept: "https://example.com/docs",
+		},
+		{
+			name:     "email after a URL is not treated as userinfo",
+			in:       "docs at https://example.com then mail ops@example.com",
+			wantKept: "ops@example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactStateAPISecretText(tt.in)
+			if tt.wantLeak != "" && strings.Contains(got, tt.wantLeak) {
+				t.Errorf("redactStateAPISecretText(%q) = %q; leaked %q", tt.in, got, tt.wantLeak)
+			}
+			if tt.wantKept != "" && !strings.Contains(got, tt.wantKept) {
+				t.Errorf("redactStateAPISecretText(%q) = %q; want %q preserved", tt.in, got, tt.wantKept)
+			}
+		})
+	}
+}
+
 func TestRedactStateAPILastMessageTruncatesLongInput(t *testing.T) {
 	in := strings.Repeat("x", stateAPILastMessageMaxRunes+50)
 	got := redactStateAPILastMessage(in)

--- a/cmd/worker/stateapi.go
+++ b/cmd/worker/stateapi.go
@@ -251,7 +251,7 @@ func apiIssueFromView(view orchestrator.StateView, identifier string) (apiIssueR
 		payload.Attempts.CurrentRetryAttempt = &retry.Attempt
 		payload.Attempts.RestartCount = restartCountFromRetryAttempt(&retry.Attempt)
 		payload.Retry = &retry
-		payload.LastError = stringPointerIfNotEmpty(row.Error)
+		payload.LastError = redactedStringPointerIfNotEmpty(row.Error)
 		return payload, true
 	}
 	if payload, ok := apiTerminalIssueFromView(view, want); ok {
@@ -290,7 +290,7 @@ func apiTerminalIssueFromView(view orchestrator.StateView, normalizedWant string
 		payload := base(ev.IssueID, ev.Identifier, string(ev.Kind))
 		payload.RecentEvents = []map[string]any{apiRuntimeEventFromView(ev)}
 		if ev.Kind == orchestrator.RuntimeEventFailed {
-			payload.LastError = stringPointerIfNotEmpty(ev.Message)
+			payload.LastError = redactedStringPointerIfNotEmpty(ev.Message)
 		}
 		return payload, true
 	}
@@ -327,7 +327,7 @@ func apiRuntimeEventFromView(ev orchestrator.RuntimeEvent) map[string]any {
 		"kind":       ev.Kind,
 		"issue_id":   ev.IssueID,
 		"identifier": ev.Identifier,
-		"message":    ev.Message,
+		"message":    redactStateAPISecretText(ev.Message),
 		"at":         ev.At,
 	}
 	if ev.Branch != "" {
@@ -409,7 +409,7 @@ func apiRetryFromView(row orchestrator.RetryView) stateapi.Retry {
 		IssueURL:       row.IssueURL,
 		Attempt:        row.Attempt,
 		DueAt:          dueAt,
-		Error:          row.Error,
+		Error:          redactStateAPISecretText(row.Error),
 		Kind:           string(retryKindOrFailure(row.Kind)),
 		StartupFailure: apiStartupFailure(row.StartupFailure),
 	}
@@ -421,7 +421,7 @@ func apiStartupFailure(in *task.StartupFailure) *stateapi.StartupFailure {
 	}
 	return &stateapi.StartupFailure{
 		Phase: in.Phase,
-		Error: in.Error,
+		Error: redactStateAPISecretText(in.Error),
 	}
 }
 func retryKindOrFailure(kind orchestrator.RetryKind) orchestrator.RetryKind {
@@ -437,11 +437,12 @@ func copyIntPointer(in *int) *int {
 	out := *in
 	return &out
 }
-func stringPointerIfNotEmpty(value string) *string {
+func redactedStringPointerIfNotEmpty(value string) *string {
 	if value == "" {
 		return nil
 	}
-	return &value
+	redacted := redactStateAPISecretText(value)
+	return &redacted
 }
 func apiErrorCode(err error) string {
 	if category, ok := workflow.ErrorCategory(err); ok {
@@ -486,7 +487,7 @@ func apiStateFromView(view orchestrator.StateView) stateapi.StateResponse {
 				TotalTokens:  row.Tokens.TotalTokens,
 			},
 			Method:            row.Method,
-			Error:             row.Error,
+			Error:             redactStateAPISecretText(row.Error),
 			CodexAppServerPID: row.CodexAppServerPID,
 		})
 	}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -553,6 +553,7 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 	}
 	defer cancel()
 	waitDelay := workspaceHookWaitDelay(timeoutMs)
+	maskedCommand := redactCredentials(command)
 
 	// Hook commands run under `sh -c` (not `-lc`) so the user's login
 	// profile is not re-sourced per command. The PATH that a login shell
@@ -577,7 +578,9 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Start(); err != nil {
-		return HookResult{Name: name, Command: command, ExitCode: exitCode(err), Output: out.String(), Truncated: out.Truncated(), Duration: time.Since(start), Err: err}
+		truncated := out.Truncated()
+		incomplete := truncated || runCtx.Err() != nil
+		return HookResult{Name: name, Command: maskedCommand, ExitCode: exitCode(err), Output: redactHookOutput(out.String(), incomplete), Truncated: truncated, Duration: time.Since(start), Err: err}
 	}
 	done := make(chan error, 1)
 	go func() {
@@ -596,7 +599,9 @@ func runWorkspaceHookCommand(ctx context.Context, workdir string, name HookName,
 			err = fmt.Errorf("hook wait exceeded cleanup grace after timeout: %w", runCtx.Err())
 		}
 	}
-	res := HookResult{Name: name, Command: command, ExitCode: exitCode(err), Output: out.String(), Truncated: out.Truncated(), Duration: time.Since(start), Err: err}
+	truncated := out.Truncated()
+	incomplete := truncated || runCtx.Err() != nil
+	res := HookResult{Name: name, Command: maskedCommand, ExitCode: exitCode(err), Output: redactHookOutput(out.String(), incomplete), Truncated: truncated, Duration: time.Since(start), Err: err}
 	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
 		res.Err = fmt.Errorf("hook timed out after %dms: %w", timeoutMs, runCtx.Err())
 		res.ExitCode = -1

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,84 @@ func TestRunWorkspaceHookStopsOnNonZeroAndCapturesOutput(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "should-not-exist")); !os.IsNotExist(err) {
 		t.Fatalf("commands after failed hook should not run; stat err=%v", err)
+	}
+}
+
+func TestRunWorkspaceHookRedactsCredentialedURLsFromOutput(t *testing.T) {
+	const secret = "token-1032"
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{
+		"printf '%s' 'fetch scheme://user:" + secret + "@example.com/repo.git failed'",
+	}}
+
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil, workflow.Config{})
+	if err != nil {
+		t.Fatalf("RunWorkspaceHook: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	got := results[0].Output
+	if strings.Contains(got, secret) || strings.Contains(got, "user:"+secret+"@") {
+		t.Fatalf("hook output leaked credential: %q", got)
+	}
+	if !strings.Contains(got, "scheme://example.com/repo.git") {
+		t.Fatalf("hook output = %q, want redacted URL host/path preserved", got)
+	}
+	if strings.Contains(results[0].Command, secret) || strings.Contains(results[0].Command, "user:"+secret+"@") {
+		t.Fatalf("hook command leaked credential: %q", results[0].Command)
+	}
+	if !strings.Contains(results[0].Command, "scheme://example.com/repo.git") {
+		t.Fatalf("hook command = %q, want redacted URL host/path preserved", results[0].Command)
+	}
+}
+
+func TestRunWorkspaceHookRedactsBeforeOutputCap(t *testing.T) {
+	const secret = "token-1032"
+	leakingRawPrefix := "scheme://user:" + secret
+	prefixLen := VerifyOutputCap - len(leakingRawPrefix)
+	if prefixLen <= 0 {
+		t.Fatalf("VerifyOutputCap = %d, want room for boundary test", VerifyOutputCap)
+	}
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{
+		fmt.Sprintf("printf '%%*s' %d '' | tr ' ' A; printf '%%s' 'scheme://user:%s@example.com/repo.git'", prefixLen, secret),
+	}}
+
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 0, nil, workflow.Config{})
+	if err != nil {
+		t.Fatalf("RunWorkspaceHook: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if !results[0].Truncated {
+		t.Fatalf("truncated = false, want true for boundary output")
+	}
+	if strings.Contains(results[0].Output, secret) || strings.Contains(results[0].Output, "user:"+secret) {
+		t.Fatalf("truncated hook output leaked credential: %q", results[0].Output[len(results[0].Output)-64:])
+	}
+}
+
+func TestRunWorkspaceHookRedactsIncompleteTimedOutOutput(t *testing.T) {
+	const secret = "token-1032"
+	dir := t.TempDir()
+	hook := workflow.WorkspaceHook{Commands: []string{
+		"printf '%s' 'scheme://user:" + secret + "'; sleep 2",
+	}}
+
+	results, err := RunWorkspaceHook(context.Background(), dir, HookBeforeRun, hook, 50, nil, workflow.Config{})
+	if err == nil {
+		t.Fatal("RunWorkspaceHook error = nil; want timeout")
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Truncated {
+		t.Fatalf("truncated = true, want false for timeout-only incomplete output")
+	}
+	if strings.Contains(results[0].Output, secret) || strings.Contains(results[0].Output, "user:"+secret) {
+		t.Fatalf("timed-out hook output leaked credential: %q", results[0].Output)
 	}
 }
 

--- a/internal/workspace/redact.go
+++ b/internal/workspace/redact.go
@@ -27,11 +27,25 @@ import (
 // boundary, so a malformed-userinfo tail is simply outside the matched URL.
 var credentialURLRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/?#\s]*@`)
 
+// truncatedCredentialURLTailRe is a fail-closed companion for incomplete
+// free-text output. If a cap or timeout cuts `scheme://user:token@host` before
+// the `@host`, the full URL regex above cannot see userinfo; strip a trailing
+// `scheme://authority` tail only on outputs known to be incomplete.
+var truncatedCredentialURLTailRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/?#\s]*$`)
+
 // redactCredentials strips basic-auth userinfo from every URL embedded in s so a
 // clone_url's `user:token@` (the agent's push credential) never reaches a log
 // or error string — AGENTS.md secret-masking convention, #595.
 func redactCredentials(s string) string {
 	return credentialURLRe.ReplaceAllString(s, "$1")
+}
+
+func redactHookOutput(s string, incomplete bool) string {
+	s = redactCredentials(s)
+	if incomplete {
+		s = truncatedCredentialURLTailRe.ReplaceAllString(s, "$1")
+	}
+	return s
 }
 
 // credentialRedactingWriter forwards writes to w with basic-auth userinfo

--- a/internal/workspace/redact_test.go
+++ b/internal/workspace/redact_test.go
@@ -13,6 +13,47 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+func TestRedactHookOutputTruncated(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		truncated bool
+		want      string
+	}{
+		{
+			name:      "cap cut before the at-sign drops the partial authority",
+			in:        "origin https://bot:hunter2tok",
+			truncated: true,
+			want:      "origin https://",
+		},
+		{
+			name:      "cap cut inside the host after scrub drops the partial host",
+			in:        "origin https://bot:tok@git.exa",
+			truncated: true,
+			want:      "origin https://",
+		},
+		{
+			name:      "truncated tail inside a path is preserved",
+			in:        "fetch https://example.com/some/pa",
+			truncated: true,
+			want:      "fetch https://example.com/some/pa",
+		},
+		{
+			name:      "complete output keeps terminal host names",
+			in:        "origin https://bot:tok@example.com/r.git and https://example.com",
+			truncated: false,
+			want:      "origin https://example.com/r.git and https://example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactHookOutput(tt.in, tt.truncated); got != tt.want {
+				t.Errorf("redactHookOutput(%q, %v) = %q; want %q", tt.in, tt.truncated, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRedactCredentials(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Closes #1032

## Summary
- Redacts credential-shaped state API error fields before serialization: `Retry.Error`, `Retry.StartupFailure.Error`, `Blocked.Error`, per-issue `last_error`, and failed runtime-event messages now share the same state API scrub patterns as `last_message`.
- Redacts workspace hook result output and command text at `HookResult` construction, the choke point used by runtime events/log/state consumers.
- Fails closed when hook output is byte-capped or timeout-incomplete mid-URL, and covers both `scheme://user:token@host` and bare-userinfo `scheme://token@host` URL forms.

## Acceptance checklist
- [x] Hook output carrying `scheme://user:token@host` is redacted before event/state consumers see it.
- [x] `Retry.Error`, `Blocked.Error`, startup failure errors, runtime-event failed messages, and `/api/v1/<issue>` `last_error` are redacted.
- [x] No protocol-specific parser, durable cache, new worker phase/gate/artifact, or tracker write added.
- [x] Sibling sweep: hook `command`, output-cap boundary, timeout-incomplete output, and bare-userinfo URL leaks covered; raw state/hook projection grep clean.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

SPEC §15.3 requires redaction of secrets on exposed surfaces; the fix stays within existing projection/output choke points and does not add worker-side gates or state.

## Size gate
- [x] `within budget` — diff fits the ~12-file / ~300-LOC review guideline
- [ ] `size-gated: justified overage` — rationale: n/a
- [ ] `size-gated: split recommended` — rationale: n/a

Production diff: 4 files (`cmd/worker/redact.go`, `cmd/worker/stateapi.go`, `internal/workspace/manager.go`, `internal/workspace/redact.go`), about 60 production LOC.

## Verification
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (`0 issues.`)
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

## Mutation checks
Against final head `4f5d8471d6abc9ebd0858985daa48c11e4ee3b9f`:
- [x] Reverting `apiRetryFromView` to raw `row.Error` fails `TestStateAPIProjectionRedactsCredentialedErrorFields` with the token visible.
- [x] Reverting hook result `Command` to raw `command` fails `TestRunWorkspaceHookRedactsCredentialedURLsFromOutput`.
- [x] Requiring `:password@` in the state URL regex fails `TestRedactStateAPISecretTextScrubsBareUserinfoURL`.
- [x] Dropping timeout-incomplete output handling fails `TestRunWorkspaceHookRedactsIncompleteTimedOutOutput`.

## Review ledger
- Local Codex diff review fallback: first bounded review found hook cap/command issues; fixed. Second bounded review had one false positive claiming `Blocked.Error` was raw; refuted by `cmd/worker/stateapi.go` line 490 and `TestStateAPIProjectionRedactsCredentialedErrorFields`. Final bounded Codex review on this head returned `{"blocking_findings":[]}`.
- GitHub Codex review threads from earlier heads were re-audited; the timeout-incomplete hook-output thread was actionable and fixed in this head.
- Claude Code unavailable per operator instruction; no `claude` command used. Subagent review not used because the available spawn tool contract requires an explicit subagent/delegation request; compensated with bounded Codex review, manual diff/security sweep, grep sibling sweep, and full Go gates.
- Raw projection sweep: `rg` for raw `row.Error`, `ev.Message`, hook `out.String()`, and raw `Command: command` patterns returned no matches. GraphQL review-thread recheck shows all threads resolved; fresh GitHub Codex review for this head is clean.

## Remote gate
- CI/status checks: green (`Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, `Docker image build`, `Validate PR metadata`, `Validate PR title`).
- Warning audit: no `warning:` lines in the fresh CI, metadata, or title logs.
- Review threads: 0 unresolved; old Codex threads resolved after fixes.
- GitHub Codex: clean comment for reviewed commit `4f5d8471d6`.

## Current head
`4f5d8471d6abc9ebd0858985daa48c11e4ee3b9f`
