### PR TITLE
fix(runner): answer server->client requests interleaved with pending RPCs

### DIFF
--- a/internal/runner/codex_app_server_request_test.go
+++ b/internal/runner/codex_app_server_request_test.go
@@ -126,6 +126,33 @@ func TestRequest_AnswersInterleavedServerRequest(t *testing.T) {
 	}
 }
 
+// TestRequest_RoutesInterleavedToolCallThroughToolHandler pins the review P2
+// on #1046: an id-bearing item/tool/call interleaved while an RPC awaits its
+// response must go through the dynamic-tool handler (here: the unsupported-
+// tool structured failure for an empty tool set), not the approval reply
+// table, which would reject an advertised tool with "Method not found"
+// solely because the call arrived before the pending response.
+func TestRequest_RoutesInterleavedToolCallThroughToolHandler(t *testing.T) {
+	c, stdin := newTurnLoopClient(t, []string{
+		`{"jsonrpc":"2.0","id":9,"method":"item/tool/call","params":{"tool":"nope","arguments":{}}}`,
+		`{"jsonrpc":"2.0","id":0,"result":{"ok":true}}`,
+	})
+	got, err := c.request(context.Background(), "turn/start", nil)
+	if err != nil {
+		t.Fatalf("request() err = %v; want nil", err)
+	}
+	if got["ok"] != true {
+		t.Errorf("request() result = %#v; want result.ok = true after answering the tool call", got)
+	}
+	wire := stdin.String()
+	if strings.Contains(wire, "Method not found") {
+		t.Errorf("stdin = %q; want the tool handler's structured reply, not a Method-not-found rejection", wire)
+	}
+	if !strings.Contains(wire, "unsupported dynamic tool") {
+		t.Errorf("stdin = %q; want the dynamic-tool handler's unsupported-tool result on the wire", wire)
+	}
+}
+
 // TestRequest_ServerRequestWithCollidingIDIsNotMistakenForResponse guards the
 // responseForID method-member check: a server->client request whose id happens
 // to equal our pending request id must be answered and skipped, not consumed

--- a/internal/runner/codex_app_server_request_test.go
+++ b/internal/runner/codex_app_server_request_test.go
@@ -10,6 +10,7 @@ package runner
 import (
 	"context"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -92,6 +93,74 @@ func TestRequest_SkipsDifferentIdMessageThenReturns(t *testing.T) {
 	}
 	if c.lastMessage != "other" {
 		t.Errorf("c.lastMessage = %q; want %q (the different-id message must be handled, then skipped)", c.lastMessage, "other")
+	}
+}
+
+// TestRequest_AnswersInterleavedServerRequest pins issue #1031: codex may
+// interleave a server->client request (id + method) while initialize /
+// thread/start / turn/start awaits its response. request() must write a
+// JSON-RPC reply to stdin — treating it as a notification leaves codex
+// blocked on the reply and the harness blocked on the response, a mutual
+// deadlock that surfaces as a misleading read timeout. Removing the
+// serverRequestMethod branch in request() fails the stdin assertion below.
+func TestRequest_AnswersInterleavedServerRequest(t *testing.T) {
+	c, stdin := newTurnLoopClient(t, []string{
+		// approvalPolicy "never" auto-approves exec approvals (matching codex
+		// AskForApproval semantics), so the reply is decision=acceptForSession.
+		`{"jsonrpc":"2.0","id":41,"method":"item/commandExecution/requestApproval","params":{"command":"go test"}}`,
+		`{"jsonrpc":"2.0","id":0,"result":{"ok":true}}`,
+	})
+	got, err := c.request(context.Background(), "turn/start", nil)
+	if err != nil {
+		t.Fatalf("request() err = %v; want nil", err)
+	}
+	if got["ok"] != true {
+		t.Errorf("request() result = %#v; want result.ok = true after answering the server request", got)
+	}
+	wire := stdin.String()
+	if !strings.Contains(wire, `"id":41`) {
+		t.Errorf("stdin = %q; want a JSON-RPC reply to the interleaved server request (id 41)", wire)
+	}
+	if !strings.Contains(wire, `"decision"`) {
+		t.Errorf("stdin = %q; want an approval decision reply for item/commandExecution/requestApproval", wire)
+	}
+}
+
+// TestRequest_ServerRequestWithCollidingIDIsNotMistakenForResponse guards the
+// responseForID method-member check: a server->client request whose id happens
+// to equal our pending request id must be answered and skipped, not consumed
+// as the (empty) response.
+func TestRequest_ServerRequestWithCollidingIDIsNotMistakenForResponse(t *testing.T) {
+	c, stdin := newTurnLoopClient(t, []string{
+		`{"jsonrpc":"2.0","id":0,"method":"item/commandExecution/requestApproval","params":{"command":"ls"}}`,
+		`{"jsonrpc":"2.0","id":0,"result":{"real":true}}`,
+	})
+	got, err := c.request(context.Background(), "thread/start", nil)
+	if err != nil {
+		t.Fatalf("request() err = %v; want nil", err)
+	}
+	if got["real"] != true {
+		t.Errorf("request() result = %#v; want the real response, not the colliding server request", got)
+	}
+	if !strings.Contains(stdin.String(), `"decision"`) {
+		t.Errorf("stdin = %q; want an approval reply for the colliding-id server request", stdin.String())
+	}
+}
+
+// TestRequest_InputRequiredServerRequestSurfacesInputRequired mirrors the turn
+// loop's SPEC §10.4 semantics on the request path: an explicit user-input
+// server request during an awaited RPC ends it with an InputRequiredError
+// (after replying on the wire) instead of silently declining and hanging on.
+func TestRequest_InputRequiredServerRequestSurfacesInputRequired(t *testing.T) {
+	c, stdin := newTurnLoopClient(t, []string{
+		`{"jsonrpc":"2.0","id":5,"method":"item/tool/requestUserInput","params":{"questions":[{"id":"q1"}]}}`,
+	})
+	_, err := c.request(context.Background(), "turn/start", nil)
+	if !IsInputRequired(err) {
+		t.Fatalf("request() err = %v; want an InputRequiredError for item/tool/requestUserInput", err)
+	}
+	if !strings.Contains(stdin.String(), `"id":5`) {
+		t.Errorf("stdin = %q; want a wire reply to the user-input request before surfacing input-required", stdin.String())
 	}
 }
 
@@ -202,6 +271,13 @@ func TestResponseForID(t *testing.T) {
 			msg:         map[string]any{"id": 1.5, "result": map[string]any{"stray": true}},
 			wantMatched: true,
 			wantErrCat:  CategoryResponseError,
+		},
+		{
+			// A response never carries a method member: a matching id plus a
+			// method is a server->client request the caller must answer (#1031).
+			name:        "server request with colliding id is not a response",
+			msg:         map[string]any{"id": float64(7), "method": "item/tool/requestUserInput"},
+			wantMatched: false,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/runner/codex_app_server_response.go
+++ b/internal/runner/codex_app_server_response.go
@@ -11,6 +11,13 @@ import (
 // member. A non-matching msg (matched=false) is an interleaved notification the
 // caller must dispatch and keep reading past.
 func responseForID(msg map[string]any, id int) (result map[string]any, matched bool, err error) {
+	// A JSON-RPC response never carries a method member: a message with both
+	// id and method is a server->client *request* (approval prompt, tool
+	// call, elicitation) the caller must answer — even when the server's id
+	// numerically collides with our pending request id or is not an integer.
+	if _, hasMethod := msg["method"]; hasMethod {
+		return nil, false, nil
+	}
 	gotID, ok := numberID(msg["id"])
 	if !ok {
 		// A present-but-non-integer id is a malformed response: numberID will not

--- a/internal/runner/codex_app_server_transport.go
+++ b/internal/runner/codex_app_server_transport.go
@@ -43,7 +43,7 @@ func (c *appServerClient) request(ctx context.Context, method string, params any
 		if result, matched, rpcErr := responseForID(msg, id); matched {
 			return result, rpcErr
 		}
-		if done, reqErr := c.dispatchInterleavedMessage(msg); done {
+		if done, reqErr := c.dispatchInterleavedMessage(ctx, msg); done {
 			return nil, reqErr
 		}
 	}
@@ -51,19 +51,30 @@ func (c *appServerClient) request(ctx context.Context, method string, params any
 
 // dispatchInterleavedMessage handles a message read while an RPC awaits its
 // response. Codex may interleave a server->client request (approval prompt,
-// tool call, elicitation — carries both id and method); it must be answered
-// through the same machinery the turn loop uses, because treating it as a
-// notification leaves codex blocked on the reply and the request loop blocked
-// on the response — a mutual deadlock surfacing as a misleading read
-// timeout/stall (#1031). True notifications keep flowing to
-// handleNotification. done=true aborts the pending RPC with reqErr (an
-// InputRequiredError or a wire-write failure).
-func (c *appServerClient) dispatchInterleavedMessage(msg map[string]any) (done bool, reqErr error) {
-	if method, ok := serverRequestMethod(msg); ok {
-		return c.handleServerRequest(msg, method)
+// dynamic tool call, user input, elicitation — carries both id and method);
+// it must be answered through the same machinery the turn loop uses, because
+// treating it as a notification leaves codex blocked on the reply and the
+// request loop blocked on the response — a mutual deadlock surfacing as a
+// misleading read timeout/stall (#1031). item/tool/call routes through the
+// dynamic-tool handler (not the approval table, which would reply "Method
+// not found" and reject an advertised linear_graphql/gitea_issue_labels call
+// solely for arriving early); everything else follows handleServerRequest.
+// True notifications keep flowing to handleNotification. done=true aborts
+// the pending RPC with reqErr (an InputRequiredError or a wire-write
+// failure).
+func (c *appServerClient) dispatchInterleavedMessage(ctx context.Context, msg map[string]any) (done bool, reqErr error) {
+	method, ok := serverRequestMethod(msg)
+	if !ok {
+		c.handleNotification(msg)
+		return false, nil
 	}
-	c.handleNotification(msg)
-	return false, nil
+	if method == "item/tool/call" {
+		if err := c.handleDynamicToolCall(ctx, msg); err != nil {
+			return true, err
+		}
+		return false, nil
+	}
+	return c.handleServerRequest(msg, method)
 }
 
 // serverRequestMethod reports whether msg is a server->client JSON-RPC request

--- a/internal/runner/codex_app_server_transport.go
+++ b/internal/runner/codex_app_server_transport.go
@@ -43,8 +43,40 @@ func (c *appServerClient) request(ctx context.Context, method string, params any
 		if result, matched, rpcErr := responseForID(msg, id); matched {
 			return result, rpcErr
 		}
-		c.handleNotification(msg)
+		if done, reqErr := c.dispatchInterleavedMessage(msg); done {
+			return nil, reqErr
+		}
 	}
+}
+
+// dispatchInterleavedMessage handles a message read while an RPC awaits its
+// response. Codex may interleave a server->client request (approval prompt,
+// tool call, elicitation — carries both id and method); it must be answered
+// through the same machinery the turn loop uses, because treating it as a
+// notification leaves codex blocked on the reply and the request loop blocked
+// on the response — a mutual deadlock surfacing as a misleading read
+// timeout/stall (#1031). True notifications keep flowing to
+// handleNotification. done=true aborts the pending RPC with reqErr (an
+// InputRequiredError or a wire-write failure).
+func (c *appServerClient) dispatchInterleavedMessage(msg map[string]any) (done bool, reqErr error) {
+	if method, ok := serverRequestMethod(msg); ok {
+		return c.handleServerRequest(msg, method)
+	}
+	c.handleNotification(msg)
+	return false, nil
+}
+
+// serverRequestMethod reports whether msg is a server->client JSON-RPC request
+// (id and method both present) and returns its method name.
+func serverRequestMethod(msg map[string]any) (string, bool) {
+	if _, hasID := msg["id"]; !hasID {
+		return "", false
+	}
+	method, _ := msg["method"].(string)
+	if method == "" {
+		return "", false
+	}
+	return method, true
 }
 func (c *appServerClient) notify(method string, params map[string]any) error {
 	return c.send(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})


### PR DESCRIPTION
Closes #1031

## Summary
- `request()` (used by `initialize`, `thread/start`, `turn/start`) treated every non-response message as a notification, so a server->client request codex interleaved while the RPC awaited its response (approval prompt, user-input request, elicitation) was never replied to: codex blocked on the reply, the harness blocked on the response, and the run died on a misleading read-timeout/stall classification.
- The turn loop already classifies messages by method (`id` + `method` => `handleServerRequest`); `request()` now routes interleaved server requests through the same machinery (replying per approval policy, surfacing SPEC §10.4 input-required), and `responseForID` no longer mistakes a method-carrying message with a colliding id for the response.
- Same failure class as the earlier turn-loop fix ("classify RPC messages by method"); this sweeps the sibling `request()` path per clean-code rule 10.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

No new phase/gate/artifact: extends the existing server-request reply machinery (SPEC §10.4) to the sibling request path.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: 2 files (`codex_app_server_transport.go`, `codex_app_server_response.go`), ~40 LOC.

## Testing
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.trellis/scripts python3 -m unittest discover -s .trellis/scripts/tests -p 'test_*.py'`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Mutation-verified per clean-code rule 6 against the committed artifact:
- deleting the server-request branch in the request loop fails `TestRequest_AnswersInterleavedServerRequest` (no reply on stdin) and `TestRequest_InputRequiredServerRequestSurfacesInputRequired` (EOF instead of InputRequiredError);
- deleting the method-member check in `responseForID` fails `TestResponseForID/server_request_with_colliding_id_is_not_a_response`;
- tree restored to HEAD after each mutation.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.

Made with [Cursor](https://cursor.com)