### PR TITLE
fix(runner): decouple codex stdout draining from the busy consumer and bound stdin writes

### DIFF
--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -277,8 +277,13 @@ type appServerClient struct {
 	// consumer. readCh carries lines and is closed only by the reader; readErr is
 	// the sticky terminal scan error, published before close(readCh) so the close
 	// is the happens-before edge that lets the consumer read it race-free.
-	readCh            chan []byte
-	readErr           error
+	readCh  chan []byte
+	readErr error
+	// stdoutBufferBytes / stdinWriteTimeout override the transport's stdio
+	// bounds (maxAppServerBufferedBytes / appServerStdinWriteTimeout) in
+	// tests; zero means the production default.
+	stdoutBufferBytes int
+	stdinWriteTimeout time.Duration
 	out               io.Writer
 	nextID            int
 	codexAppServerPID int

--- a/internal/runner/codex_app_server_classify_test.go
+++ b/internal/runner/codex_app_server_classify_test.go
@@ -189,6 +189,21 @@ func TestClassifyAppServerOutcome_CategorizedBeatsPortExit(t *testing.T) {
 	}
 }
 
+func TestClassifyAppServerOutcome_StdoutBacklogOverflowBeatsPortExit(t *testing.T) {
+	runErr := error(&stdoutBacklogOverflowError{capBytes: 8})
+	waitErr := errors.New("signal: killed")
+	_, err := classifyAppServerOutcome(context.Background(), Result{}, runErr, waitErr, 1000, time.Now(), time.Second)
+	if !isStdoutBacklogOverflow(err) {
+		t.Fatalf("classifyAppServerOutcome(stdout backlog overflow, waitErr) err = %v; want stdout-backlog overflow", err)
+	}
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryResponseError {
+		t.Fatalf("ErrorCategory(%v) = %q, %v; want %q, true", err, cat, ok, CategoryResponseError)
+	}
+	if errors.Is(err, waitErr) {
+		t.Fatalf("classifyAppServerOutcome(stdout backlog overflow, waitErr) err = %v; must not wrap waitErr as port exit", err)
+	}
+}
+
 // TestClassifyAppServerOutcome_TurnTimeoutUnderDeadlineIsTimeout pins the #507
 // item-3 wontfix: when the outer run deadline has fired, a coinciding
 // *TurnTimeoutError is reported as a *TimeoutError (the outer-deadline branch

--- a/internal/runner/codex_app_server_reader_test.go
+++ b/internal/runner/codex_app_server_reader_test.go
@@ -10,9 +10,12 @@ package runner
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -130,6 +133,164 @@ func TestStdoutReader_HoldsLineAcrossTimeoutThenDelivers(t *testing.T) {
 	}
 	if got, want := string(line), "late-line"; got != want {
 		t.Fatalf("second readLine() = %q; want %q (a line held across the first read's timeout must be delivered intact)", got, want)
+	}
+}
+
+// TestStdoutReader_DrainsFloodWhileConsumerBusy pins the #1033 deadlock
+// scenario: codex keeps streaming stdout while the consumer is parked in a
+// synchronous dynamic-tool call and reads nothing. Every producer write must
+// still complete (the pump queues in memory, keeping the pipe drained); with
+// a direct scan→consumer handoff the scan goroutine parks on the second line
+// and the producer stalls — exactly the OS-pipe backpressure that deadlocks
+// the real subprocess. Order must survive the queueing.
+func TestStdoutReader_DrainsFloodWhileConsumerBusy(t *testing.T) {
+	c, pw := newPipeReaderClient(t)
+	const n = 200
+	wrote := make(chan error, 1)
+	go func() {
+		for i := 0; i < n; i++ {
+			if _, err := fmt.Fprintf(pw, "line-%d\n", i); err != nil {
+				wrote <- err
+				return
+			}
+		}
+		wrote <- nil
+	}()
+	// The consumer stays busy: nothing reads readCh until the flood is fully
+	// written.
+	select {
+	case err := <-wrote:
+		if err != nil {
+			t.Fatalf("producer write err = %v; want all %d lines written with no consumer", err, n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("producer blocked with the consumer busy — stdout is not being drained (#1033)")
+	}
+	for i := 0; i < n; i++ {
+		line, err := c.readLine(context.Background())
+		if err != nil {
+			t.Fatalf("readLine(%d) err = %v; want buffered line", i, err)
+		}
+		if got, want := string(line), fmt.Sprintf("line-%d", i); got != want {
+			t.Fatalf("readLine(%d) = %q; want %q (queueing must preserve order)", i, got, want)
+		}
+	}
+}
+
+// TestStdoutReader_BacklogOverflowFailsTypedNotOOM pins the pump's memory
+// bound: when the scanned-but-unconsumed backlog exceeds the cap, the
+// consumer observes a typed backlog error through the closed readCh instead
+// of the worker growing without bound, and the producer still completes (the
+// pump keeps discarding to EOF so neither the scan goroutine nor the
+// subprocess blocks).
+func TestStdoutReader_BacklogOverflowFailsTypedNotOOM(t *testing.T) {
+	c, pw := newPipeReaderClient(t, func(c *appServerClient) { c.stdoutBufferBytes = 256 })
+	wrote := make(chan error, 1)
+	go func() {
+		for i := 0; i < 100; i++ {
+			if _, err := fmt.Fprintf(pw, "%064d\n", i); err != nil {
+				wrote <- err
+				return
+			}
+		}
+		wrote <- nil
+	}()
+	select {
+	case err := <-wrote:
+		if err != nil {
+			t.Fatalf("producer write err = %v; want the overflow path to keep draining the pipe", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("producer blocked after backlog overflow — pump must discard to EOF")
+	}
+	_, err := c.readLine(context.Background())
+	if !isStdoutBacklogOverflow(err) {
+		t.Fatalf("readLine() err = %v; want the typed stdout-backlog overflow error", err)
+	}
+	if cat, ok := ErrorCategory(err); !ok || cat != CategoryResponseError {
+		t.Fatalf("ErrorCategory(%v) = %q, %v; want %q, true", err, cat, ok, CategoryResponseError)
+	}
+}
+
+// TestStdoutReader_BacklogOverflowCountsEmptyLines pins the second half of the
+// backlog cap: each queued message must carry a per-item charge, not just
+// len(line), so blank-line floods cannot grow q.items forever while q.bytes
+// stays at zero.
+func TestStdoutReader_BacklogOverflowCountsEmptyLines(t *testing.T) {
+	c, pw := newPipeReaderClient(t, func(c *appServerClient) { c.stdoutBufferBytes = 1 })
+	wrote := make(chan error, 1)
+	go func() {
+		for i := 0; i < 100; i++ {
+			if _, err := fmt.Fprintln(pw); err != nil {
+				wrote <- err
+				return
+			}
+		}
+		if err := pw.Close(); err != nil {
+			wrote <- err
+			return
+		}
+		wrote <- nil
+	}()
+	select {
+	case err := <-wrote:
+		if err != nil {
+			t.Fatalf("producer write err = %v; want empty-line overflow path to keep draining the pipe", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("producer blocked after empty-line backlog overflow — pump must count items and keep draining")
+	}
+	_, err := c.readLine(context.Background())
+	if !isStdoutBacklogOverflow(err) {
+		t.Fatalf("readLine() err = %v; want stdout-backlog overflow for queued empty lines", err)
+	}
+}
+
+// TestSend_StdinWriteTimeoutFailsInsteadOfHanging pins the write half of the
+// #1033 stdio deadlock over a real OS pipe (the production stdin is an
+// *os.File from cmd.StdinPipe): once the pipe's kernel buffer is full and the
+// reader side stops draining — codex blocked mid-write on its own stdout —
+// send must fail with os.ErrDeadlineExceeded after the write timeout instead
+// of parking the consumer goroutine until the run's outer deadline.
+func TestSend_StdinWriteTimeoutFailsInsteadOfHanging(t *testing.T) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() err = %v", err)
+	}
+	defer func() { _ = pr.Close() }()
+	defer func() { _ = pw.Close() }()
+
+	// Fill the kernel buffer with bounded writes until one times out; nobody
+	// reads pr, modeling a codex that stopped draining stdin.
+	junk := bytes.Repeat([]byte("x"), 32<<10)
+	for {
+		if err := pw.SetWriteDeadline(time.Now().Add(50 * time.Millisecond)); err != nil {
+			t.Skipf("pipe write deadlines unsupported on this platform: %v", err)
+		}
+		if _, err := pw.Write(junk); err != nil {
+			if !errors.Is(err, os.ErrDeadlineExceeded) {
+				t.Fatalf("filling pipe: write err = %v; want os.ErrDeadlineExceeded", err)
+			}
+			break
+		}
+	}
+
+	// Clear the fill loop's leftover deadline: send must arm its own, or a
+	// stale expired deadline would mask a send() that sets none.
+	if err := pw.SetWriteDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear write deadline: %v", err)
+	}
+
+	c := &appServerClient{stdin: pw, out: io.Discard, stdinWriteTimeout: 100 * time.Millisecond}
+	sent := make(chan error, 1)
+	go func() { sent <- c.send(map[string]any{"jsonrpc": "2.0", "method": "turn/start"}) }()
+	select {
+	case err := <-sent:
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("send() on a full undrained stdin pipe err = %v; want os.ErrDeadlineExceeded", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("send() still blocked after 5s — the stdin write timeout must bound it (#1033)")
 	}
 }
 

--- a/internal/runner/codex_app_server_transport.go
+++ b/internal/runner/codex_app_server_transport.go
@@ -27,6 +27,24 @@ const (
 	// ("Max line size: 10 MB"). Lines exceeding this surface as bufio.ErrTooLong
 	// instead of growing the buffer unbounded and OOMing the worker.
 	maxAppServerLineBytes = 10 * 1024 * 1024
+	// maxAppServerBufferedBytes caps how many bytes of scanned-but-unconsumed
+	// stdout lines the reader pump may hold while the consumer is busy (e.g. a
+	// synchronous dynamic-tool HTTP call, bounded by its own 30s timeout). The
+	// Elixir reference gets this buffering for free — Port output queues into
+	// the process mailbox — and the pump is the explicit Go compensation
+	// (AGENTS.md cross-cutting checklist item 2); the cap keeps the
+	// compensation memory-bounded and turns a pathological flood into a typed
+	// error instead of an OOM or a stdio deadlock.
+	maxAppServerBufferedBytes = 64 << 20
+	// lineQueueItemOverheadBytes is a conservative charge for each queued stdout
+	// item in addition to payload bytes. The cap is a safety budget, not exact
+	// heap accounting; charging per item keeps blank/tiny-line floods bounded.
+	lineQueueItemOverheadBytes = 64
+	// appServerStdinWriteTimeout bounds a single write to codex stdin. The read
+	// path has read_timeout_ms; without a write bound the symmetric half of a
+	// stdio deadlock (codex blocked writing stdout, harness blocked writing
+	// stdin) hangs until the run's outer deadline instead of failing fast.
+	appServerStdinWriteTimeout = 30 * time.Second
 )
 
 func (c *appServerClient) request(ctx context.Context, method string, params any) (map[string]any, error) {
@@ -98,8 +116,24 @@ func (c *appServerClient) send(msg map[string]any) error {
 		return err
 	}
 	b = append(b, '\n')
-	_, err = c.stdin.Write(b)
-	return err
+	// Bound the write when stdin supports deadlines (the real subprocess pipe
+	// is an *os.File; test buffers are not and skip this). If codex stops
+	// draining its stdin while we still owe it a reply, the write fails with
+	// os.ErrDeadlineExceeded instead of hanging the consumer goroutine — the
+	// write-side twin of read_timeout_ms.
+	timeout := c.stdinWriteTimeout
+	if timeout <= 0 {
+		timeout = appServerStdinWriteTimeout
+	}
+	if d, ok := c.stdin.(interface{ SetWriteDeadline(time.Time) error }); ok {
+		if derr := d.SetWriteDeadline(time.Now().Add(timeout)); derr == nil {
+			defer func() { _ = d.SetWriteDeadline(time.Time{}) }()
+		}
+	}
+	if _, err = c.stdin.Write(b); err != nil {
+		return fmt.Errorf("write codex app-server stdin: %w", err)
+	}
+	return nil
 }
 func (c *appServerClient) readMessage(ctx context.Context) (map[string]any, error) {
 	msg, raw, err := c.readProtocolMessage(ctx)
@@ -132,48 +166,170 @@ func (c *appServerClient) readProtocolMessage(ctx context.Context) (map[string]a
 	return msg, line, nil
 }
 
-// startStdoutReader launches the single long-lived stdout reader. It is the
-// source stage of https://go.dev/blog/pipelines: one goroutine owns the
-// bufio.Scanner (which is not safe for concurrent use) and continuously scans
-// lines, handing each to the request/response consumer over readCh. Its lifetime
-// is the app-server process: it exits when scanner.Scan returns false (stdout
-// EOF or error — the process closed stdout on exit), recording a sticky readErr.
+// startStdoutReader launches the long-lived stdout reader as a two-stage
+// pipeline (https://go.dev/blog/pipelines): a scan goroutine that owns the
+// bufio.Scanner (not safe for concurrent use) and keeps the OS pipe drained,
+// and a pump goroutine that queues scanned lines in memory and feeds the
+// request/response consumer over readCh.
 //
-// The reader has no separate stop signal: the consumer never abandons readCh, it
-// drains to EOF at shutdown (RunCodexAppServer drains before cmd.Wait), so the
-// reader always keeps the pipe flowing and reaches EOF rather than parking on a
-// send forever (Go Code Review Comments, "Goroutine Lifetimes"). `defer
-// close(readCh)` runs on every exit path, so a consumer waiting on readCh is
-// always released and the close is the happens-before edge that publishes
-// readErr. readCh is created here so the goroutine and its channel have one owner.
+// The pump exists because the consumer can be busy for tens of seconds — a
+// dynamic-tool HTTP call runs synchronously on the consumer goroutine — while
+// codex keeps streaming stdout without waiting for the tool reply. With a
+// direct unbuffered handoff the scan goroutine parks on the send, nobody
+// drains the OS pipe (~64 KiB), codex blocks writing stdout, and the tool
+// reply written to codex stdin can then deadlock against codex's blocked
+// write (#1033). The Elixir reference never sees this because Port output
+// queues into the process mailbox; the pump is the explicit Go compensation
+// (AGENTS.md cross-cutting checklist item 2), memory-bounded by
+// maxAppServerBufferedBytes so a pathological flood fails typed instead of
+// OOMing.
+//
+// Lifetimes: the scan goroutine exits at stdout EOF/error (the process closed
+// stdout), publishing its terminal error through scanErr (buffered 1) before
+// closing lines. The pump exits after lines closes and the queue drains — the
+// consumer never abandons readCh, it drains to EOF at shutdown
+// (RunCodexAppServer drains before cmd.Wait) — or on queue overflow, where it
+// keeps discarding scanned lines to EOF so neither the scan goroutine nor
+// codex ever blocks. Only the pump writes c.readErr, and `defer close(readCh)`
+// on its every exit path is the happens-before edge that publishes it.
 func (c *appServerClient) startStdoutReader() {
 	c.readCh = make(chan []byte)
+	lines := make(chan []byte)
+	scanErr := make(chan error, 1)
 	go func() {
-		defer close(c.readCh)
-		defer c.recoverReaderPanic()
+		defer close(lines)
+		defer c.recoverReaderPanic(scanErr)
 		for c.scanner.Scan() {
 			// Scanner.Bytes() is invalidated by the next Scan (bufio docs); copy
 			// before handing the line across the goroutine boundary.
 			line := append([]byte(nil), c.scanner.Bytes()...)
-			c.readCh <- line
+			lines <- line
 		}
-		c.readErr = scanTerminalError(c.scanner)
+		scanErr <- scanTerminalError(c.scanner)
 	}()
+	go c.pumpStdoutLines(lines, scanErr)
 }
 
-// recoverReaderPanic is the stdout reader's deferred recovery: a panic in the
-// scan loop is published as readErr (so the consumer sees an error rather than
-// hanging on a never-closed readCh) and logged with a stack, not swallowed —
-// matching the orchestrator's recoverPanicValue convention (recover.go).
-func (c *appServerClient) recoverReaderPanic() {
+// pumpStdoutLines is the buffering stage between the scan goroutine and the
+// consumer: it queues lines while the consumer is busy and forwards them in
+// order. On overflow it records the typed error and switches to discarding
+// the rest of the stream so the scan goroutine still reaches EOF (a parked
+// scan goroutine would leak and re-create the very pipe stall this stage
+// removes).
+func (c *appServerClient) pumpStdoutLines(lines <-chan []byte, scanErr <-chan error) {
+	defer close(c.readCh)
+	defer recoverPanicValue("runner.app_server_stdout_pump")
+	q := lineQueue{capBytes: c.stdoutBufferBytes}
+	if q.capBytes <= 0 {
+		q.capBytes = maxAppServerBufferedBytes
+	}
+	for lines != nil || q.len() > 0 {
+		out, head := q.sendArm(c.readCh)
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				lines = nil
+			} else if !q.push(line) {
+				c.readErr = &stdoutBacklogOverflowError{capBytes: q.capBytes}
+				// Fail the consumer immediately (deferred close(readCh) runs on
+				// return) while a detached drain keeps the scan goroutine and the
+				// subprocess unblocked until stdout EOFs — the failing run tears
+				// the process down, so the drain's lifetime is bounded by it.
+				go drainLines(lines)
+				return
+			}
+		case out <- head:
+			q.pop()
+		}
+	}
+	c.readErr = <-scanErr
+}
+
+// lineQueue is the pump's in-order, byte-bounded backlog of scanned lines.
+type lineQueue struct {
+	capBytes int
+	items    [][]byte
+	// bytes tracks the cap charge, including per-item overhead, rather than
+	// only len(line); otherwise blank-line floods never hit the limit.
+	bytes int
+}
+
+func (q *lineQueue) len() int { return len(q.items) }
+
+// push appends line and reports whether the backlog is still within capBytes.
+func (q *lineQueue) push(line []byte) bool {
+	q.items = append(q.items, line)
+	q.bytes += queuedLineBytes(line)
+	return q.bytes <= q.capBytes
+}
+
+func (q *lineQueue) pop() {
+	q.bytes -= queuedLineBytes(q.items[0])
+	q.items[0] = nil
+	q.items = q.items[1:]
+}
+
+func queuedLineBytes(line []byte) int {
+	return len(line) + lineQueueItemOverheadBytes
+}
+
+// sendArm returns the select arm for forwarding the head line: a nil channel
+// (never ready) when the queue is empty, so the select blocks on receive only.
+func (q *lineQueue) sendArm(readCh chan []byte) (chan<- []byte, []byte) {
+	if len(q.items) == 0 {
+		return nil, nil
+	}
+	return readCh, q.items[0]
+}
+
+// drainLines consumes a line channel to close, discarding content, so the
+// producing goroutine can always finish its sends and exit.
+func drainLines(lines <-chan []byte) {
+	defer recoverPanicValue("runner.app_server_stdout_overflow_drain")
+	for range lines {
+	}
+}
+
+type stdoutBacklogOverflowError struct {
+	capBytes int
+}
+
+func (e *stdoutBacklogOverflowError) Error() string {
+	return fmt.Sprintf("codex app-server stdout backlog exceeded %d bytes with the consumer busy", e.capBytes)
+}
+
+func (e *stdoutBacklogOverflowError) category() RunnerErrorCategory {
+	return CategoryResponseError
+}
+
+func isStdoutBacklogOverflow(err error) bool {
+	var overflow *stdoutBacklogOverflowError
+	return errors.As(err, &overflow)
+}
+
+// recoverPanicValue logs a recovered panic with a stack instead of letting it
+// kill the worker — the runner-local twin of the orchestrator's recoverPanic
+// convention (internal/orchestrator/recover.go).
+func recoverPanicValue(site string) {
+	if r := recover(); r != nil {
+		log.Printf("event=runner_goroutine_panic site=%s panic=%v stack=%q", site, r, debug.Stack())
+	}
+}
+
+// recoverReaderPanic is the scan goroutine's deferred recovery: a panic in the
+// scan loop is published through scanErr (so the pump forwards it as readErr
+// and the consumer sees an error rather than hanging) and logged with a
+// stack, not swallowed — matching the orchestrator's recoverPanic convention
+// (recover.go).
+func (c *appServerClient) recoverReaderPanic(scanErr chan<- error) {
 	r := recover()
 	if r == nil {
 		return
 	}
 	if err, ok := r.(error); ok {
-		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %w", err)
+		scanErr <- fmt.Errorf("codex app-server stdout reader panic: %w", err)
 	} else {
-		c.readErr = fmt.Errorf("codex app-server stdout reader panic: %v", r)
+		scanErr <- fmt.Errorf("codex app-server stdout reader panic: %v", r)
 	}
 	log.Printf("event=codex_app_server_reader_panic panic=%v stack=%q", r, debug.Stack())
 }


### PR DESCRIPTION
Closes #1033

## Summary
- Keep the Codex app-server stdout pipe drained while the consumer is busy in a synchronous dynamic-tool call by inserting a bounded pump between the scanner goroutine and the request/turn consumer.
- Bound stdin writes with a 30s write deadline when the stdin pipe supports deadlines, so a blocked Codex subprocess cannot park the consumer goroutine indefinitely.
- Tighten the stdout backlog cap so empty/tiny-message floods count per queued item, and make backlog overflow a typed `response_error` so it is not masked as `port_exit` when the subprocess is terminated afterward.

Root cause: the previous reader handed stdout lines to the consumer over an unbuffered channel. During a slow dynamic-tool HTTP call the consumer was not reading, so the stdout scanner could park, the OS pipe could fill, Codex could block writing stdout, and the harness could then block writing the tool reply to stdin.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Upstream checked:
- `docs/research/SPEC.md:948`-`965` defines the app-server launch/stdio transport contract and the 10 MB max-line safety setting.
- `docs/research/SPEC.md:995`-`1019` requires processing app-server updates until turn termination and keeping stdio protocol handling separate from diagnostic stderr.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/codex/app_server.ex:195`-`204` launches the Codex command as an Elixir `Port`; Elixir queues port output into the receiving process mailbox.
- `docs/engineering-rules-rationale.md:99`-`104` records the Go-port compensation: an `exec.Cmd` owner must keep stdout/stderr drained to EOF before `Wait`.

## Rework response
- Reviewed head: `baef1eaaaf3ede11153ae7633f1106fc011b3070`.
- New head: `f599e3289ca4706c26254d07ef3dd483deee7e11`.
- Blocker 1, "Count queued messages in the stdout backlog cap": fixed by charging each queued line as `len(line)+lineQueueItemOverheadBytes` through `queuedLineBytes`; `TestStdoutReader_BacklogOverflowCountsEmptyLines` covers blank-line floods.
- Blocker 2, "Return a categorized error for stdout backlog overflow": fixed by `stdoutBacklogOverflowError` implementing the runner category interface as `CategoryResponseError`; `TestClassifyAppServerOutcome_StdoutBacklogOverflowBeatsPortExit` pins that this beats the `waitErr`/`CategoryPortExit` branch.
- Current-thread audit after rework: both prior Codex review threads were replied to and resolved through GraphQL; no unresolved current-head review thread remained on `f599e3289ca4706c26254d07ef3dd483deee7e11` at the body update.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded). Production diff: 2 files (`internal/runner/codex_app_server.go`, `internal/runner/codex_app_server_transport.go`), under the guideline.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

Focused validation:
```bash
go test ./internal/runner -run 'Test(StdoutReader_BacklogOverflowFailsTypedNotOOM|StdoutReader_BacklogOverflowCountsEmptyLines|ClassifyAppServerOutcome_StdoutBacklogOverflowBeatsPortExit)$'
go test ./internal/runner
```

Mutation proof for this rework:
- Temporarily changed `queuedLineBytes` back to `len(line)`; `TestStdoutReader_BacklogOverflowCountsEmptyLines` failed because blank-line overflow disappeared.
- Temporarily removed the overflow error category; `TestClassifyAppServerOutcome_StdoutBacklogOverflowBeatsPortExit` failed with `port_exit`, proving the classifier mask is covered.

Remote follow-through before this body refresh:
- CI on `f599e3289ca4706c26254d07ef3dd483deee7e11`: `Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, and `Docker image build` passed in run `28652072193`.
- Governance checks passed before this body refresh: `Validate PR metadata` run `28652072148`, `Validate PR title (Conventional Commits)` run `28652072153`. The body edit may trigger fresh metadata/title checks.

Review fallback:
- Claude Code unavailable per batch instructions; not invoked.
- GitHub Codex review on `baef1eaaaf` produced the two blockers above; both were fixed, replied to, and resolved.
- Local Codex diff review on `f599e3289ca4706c26254d07ef3dd483deee7e11`: `MERGE-READY`; residual risk was no full real `codex app-server` subprocess reproduction of the stdio interlock.
- Local manual diff review: `MERGE-READY`; checked backlog accounting, typed/category overflow classification, classifier precedence, SPEC/Elixir boundary, and sibling queue/classifier paths.
