### PR TITLE
fix(runner): preserve inherited codex environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ govern *how* we evaluate components inside the SPEC-aligned envelope.
 
 ## Cross-cutting checklist when porting from the Elixir reference
 
-The SPEC-alignment rules above govern *protocol contract*. Three
+The SPEC-alignment rules above govern *protocol contract*. Four
 classes of failure have shown up in shipped PRs anyway, because the
 SPEC text does not surface them. Use this checklist in addition to
 reading SPEC and the reference module — every item is tied to a
@@ -250,7 +250,22 @@ specific observed failure per the "Earned rules" principle.
    export strips — a non-experimental bundle silently drops them and falsely
    flags a working field as removed. ([provenance](docs/engineering-rules-rationale.md#cross-cutting-checklist))
 
-4. **Run an adversarial pass on your own diff before asking a human
+4. **Preserve local Codex environment inheritance for binary deployments.**
+   The upstream Elixir app-server starts `codex.command` from the issue
+   workspace and naturally inherits the user environment of the running
+   orchestrator. A local aiops-platform binary should preserve that expectation:
+   when the worker and `codex app-server` run as the same user, Codex may reuse
+   the same `HOME` / `CODEX_HOME`, repo/user/admin/system skills, MCP config,
+   operator-enabled Apps/connectors, plugin-provided capability, and shell-tool
+   environment according to Codex's own discovery/config rules. Do not disable
+   host-local skills/MCP/Apps/connectors by default or drop `CODEX_HOME` from the
+   agent subprocess baseline. Repo-owned required skill/MCP declarations are
+   portability and diagnostics hardening for containers, remote hosts, or
+   explicitly declared dependencies — not a replacement for the local binary's
+   inherited Codex environment.
+   ([provenance](docs/engineering-rules-rationale.md#cross-cutting-checklist))
+
+5. **Run an adversarial pass on your own diff before asking a human
    to look.** `@codex review` reads SPEC + the Elixir reference +
    this file, and surfaces precisely the gaps that human review
    tends to miss. Trigger it on the head commit before marking the

--- a/README.md
+++ b/README.md
@@ -374,8 +374,8 @@ key with type, default, behavior, and validation rule) is
 | `agent.max_turns` | `20` per-session turn budget — the codex app-server runner's in-session loop (SPEC §5.3.5) | SPEC §6.4 |
 | `agent.max_continuation_turns` | `agent.max_turns` (default `20`) issue-level clean-turn budget across fresh and continuation dispatches. Each dispatch receives the remaining clean-turn budget, capped again by `agent.max_turns`; reaching the budget parks the issue in local `blocked` state (`continuation_budget`) instead of looping forever. Raising the value later does not automatically redrive existing blocked claims. | implementation (accepted deviation D34 / #621) |
 | `agent.timeout` | `30m` | implementation (#215) |
-| `codex.command` | `codex app-server` | SPEC §6.4 |
-| `codex.env_passthrough` / `claude.env_passthrough` | none beyond runner baseline (`PATH`, `HOME`, `USER`, locale, `TZ`, `TERM`); use for model CLI auth/proxy/CA vars, not tracker/repo API tokens | implementation (#384) |
+| `codex.command` | `codex app-server` | SPEC §6.4; real-Codex workflow templates add `--config shell_environment_policy.inherit=all` for upstream-style shell environment inheritance |
+| `codex.env_passthrough` / `claude.env_passthrough` | none beyond runner baseline (`PATH`, `HOME`, `CODEX_HOME`, `USER`, locale, `TZ`, `TERM`); use for model CLI auth/proxy/CA vars, not tracker/repo API tokens | implementation (#384, #1049) |
 | `server.port` | `4000` (`-1` disables the HTTP state server + dashboard) | implementation |
 | `policy.mode` | `draft_pr` (or `analysis_only`) | implementation |
 | `tracker.kind` | none — REQUIRED per SPEC §6.4; the loader rejects an empty value with an error that names the field and the allowed set (`gitea`, `github`, `linear`) | SPEC §6.4 |

--- a/docs/engineering-rules-rationale.md
+++ b/docs/engineering-rules-rationale.md
@@ -137,7 +137,30 @@ non-`--experimental` regen made `dynamicTools` look removed in 0.136 when the
 upstream `ThreadStartParams` struct was byte-identical and merely
 experimental-gated.
 
-### Item 4 — run an adversarial pass on your own diff before a human looks
+### Item 4 — preserve local Codex environment inheritance for binary deployments
+The upstream Elixir app-server launches `codex.command` from the issue workspace
+with `bash -lc` or SSH command execution and does not sanitize away the
+orchestrator user's environment; its README also says operators may copy
+repository-local skills and that agents can use either Linear MCP or the
+injected `linear_graphql` tool. Codex itself discovers skills and MCP
+configuration through `HOME` / `CODEX_HOME`, repository skills, user skills,
+admin/system skills, and `config.toml`; Codex's `shell_environment_policy`
+controls what its own shell tools inherit after app-server startup.
+
+**Earned by:** #1049 initially framed repo-owned skill dependencies as a fix
+that should avoid inheriting the operator's current desktop/session skills. That
+wording is reasonable for portable/containerized contracts but too broad for
+local binary deployments: a direct binary worker running under the same user as
+`codex app-server` should preserve the upstream behavior and naturally reuse the
+same Codex home. The portability hardening is to validate explicit repo-owned
+or workflow-declared dependencies when they are declared, not to amputate
+host-local skills/MCP/Apps/connectors/plugin capability from the local binary
+path. The same audit found two sibling regressions: the runner baseline omitted
+`CODEX_HOME`, breaking non-default Codex homes, and the default workflow command
+lacked upstream's `shell_environment_policy.inherit=all`, narrowing the
+environment seen by Codex-launched shell tools.
+
+### Item 5 — run an adversarial pass on your own diff before a human looks
 `@codex review` reads SPEC + the Elixir reference + `AGENTS.md`, and surfaces
 precisely the gaps that human review tends to miss. Trigger it on the head commit
 before marking the PR ready, and for each finding either fix it or document in

--- a/docs/runbooks/codex-app-server-docker.md
+++ b/docs/runbooks/codex-app-server-docker.md
@@ -129,6 +129,9 @@ Two modes are supported. Pick one per deployment; do not mix them.
    workflow opts in: add `OPENAI_API_KEY` to `codex.env_passthrough` in
    `WORKFLOW.md`. Source the value from a Docker secret / secret file and let the
    entrypoint export it; never put it on a command line or in a git-tracked file.
+   If the workflow command uses `shell_environment_policy.inherit=all`,
+   Codex-launched shell tools also see intentionally passed model-runtime
+   credentials.
    Tracker/repo tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`, …) stay denied from
    passthrough by policy — only the model key is opt-in.
 
@@ -155,9 +158,8 @@ CODEX_HOME=/home/aiops/.codex
 ```
 
 Codex resolves its home from `CODEX_HOME` if set, otherwise `$HOME/.codex`. The
-worker passes `HOME` to the agent subprocess but **not** `CODEX_HOME`; if you
-point `CODEX_HOME` somewhere other than `$HOME/.codex`, also add `CODEX_HOME` to
-`codex.env_passthrough` so the agent sees the same home the preflight checked.
+worker passes both `HOME` and `CODEX_HOME` to the agent subprocess by default so
+the app-server sees the same Codex home the preflight checked.
 
 ### Declarative model configuration
 

--- a/docs/runbooks/first-run-docker-linear-codex.md
+++ b/docs/runbooks/first-run-docker-linear-codex.md
@@ -68,8 +68,9 @@ Edit `.aiops/WORKFLOW.md`:
 - set `tracker.project_slug` to the Linear project slug;
 - keep `agent.default: mock` for the first smoke;
 - switch to `agent.default: codex-app-server` only for the real Codex smoke;
-- in Docker real mode, set `codex.command: codex app-server` and make the
-  sandbox choice explicit.
+- in Docker real mode, use a real-Codex workflow template whose `codex.command`
+  adds `--config shell_environment_policy.inherit=all`, or set an explicit
+  equivalent, and make the sandbox choice explicit.
 
 ## 2. Configure Compose
 

--- a/docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md
+++ b/docs/runbooks/local-gitea-webtodo-lifecycle-e2e.md
@@ -187,7 +187,8 @@ AIOPS_MIRROR_ROOT="$AIOPS_WEBTODO_REVIEWER_MIRROR_ROOT" \
 
 For a local desktop binary run, `CODEX_HOME` normally stays unset so Codex uses
 the operator's usual `~/.codex`. For a reproducible production-style run, set a
-dedicated `CODEX_HOME` and include it in `codex.env_passthrough`.
+dedicated `CODEX_HOME`; the worker passes it through to `codex app-server` by
+default.
 
 ## 4. Run Maker and Reviewer
 

--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -120,7 +120,7 @@ Use when:
 agent:
   default: codex-app-server
 codex:
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
 ```
 
 The agent's sandbox/approval posture is set by `codex.thread_sandbox` (per-session) and `codex.turn_sandbox_policy` (per-turn; derived from `thread_sandbox` when unset — see DEVIATIONS.md D32). Use `workspace-write` on shared hosts and `danger-full-access` only on already-isolated workers (container, dedicated VM).

--- a/docs/runbooks/workflow-frontmatter-reference.md
+++ b/docs/runbooks/workflow-frontmatter-reference.md
@@ -111,8 +111,8 @@ over stdio).
 
 | Key | Type | Default | Behavior | Validation |
 |-----|------|---------|----------|------------|
-| `codex.command` | string | `codex app-server` | Launch command for the app-server subprocess | `$VAR`; a `codex exec` argv is rejected (#541) |
-| `codex.env_passthrough` | string list | `[]` | Env vars the agent subprocess inherits beyond the runner baseline — for model CLI auth/proxy/CA vars. Tracker/repo tokens (`GITHUB_TOKEN`, `GITEA_TOKEN`, `LINEAR_API_KEY`, …) and the `tracker.api_key` variable/value are denied | denied names rejected at load |
+| `codex.command` | string | `codex app-server` | Launch command for the app-server subprocess; real-Codex workflow templates add `--config shell_environment_policy.inherit=all` for upstream-style shell-environment inheritance | `$VAR`; a `codex exec` argv is rejected (#541) |
+| `codex.env_passthrough` | string list | `[]` | Env vars the agent subprocess inherits beyond the runner baseline (`PATH`, `HOME`, `CODEX_HOME`, `USER`, locale, `TZ`, `TERM`) — for model CLI auth/proxy/CA vars. Tracker/repo tokens (`GITHUB_TOKEN`, `GITEA_TOKEN`, `LINEAR_API_KEY`, …) and the `tracker.api_key` variable/value are denied | denied names rejected at load |
 | `codex.approval_policy` | map | `granular` with every flag `false` (auto-reject all approval prompts) | Sent as the app-server approval policy | — |
 | `codex.thread_sandbox` | string | `workspace-write` | `thread/start` sandbox string; also the single knob the per-turn policy derives from (DEVIATIONS D32) | — |
 | `codex.turn_sandbox_policy` | typed map | derived from `thread_sandbox` | Explicit per-turn `sandboxPolicy` override; `type` is required (`dangerFullAccess`, `readOnly`, `externalSandbox`, `workspaceWrite`), with per-type required fields (`writableRoots`, `networkAccess`, …) | strict per-type field checking; legacy `mode:`-style shapes rejected |

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -130,15 +130,18 @@ The current Go implementation provides these safety controls:
   retries silently;
 - allow-listed environment for agent and hook subprocesses: by
   default these children run with only a small POSIX baseline env (`PATH`,
-  `HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TZ`, `TERM`). Tracker/repo
-  tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`, `GITEA_TOKEN`) and any other secret
-  in the worker's `.env` are excluded — a malicious or buggy WORKFLOW.md cannot
-  `env > /tmp/dump` and exfiltrate them. Operators opt non-tracker vars back in
-  per workflow with `codex.env_passthrough`, `claude.env_passthrough`, or
-  `hooks.env_passthrough`; agent and hook passthrough reject tracker/repo API
-  token names, the configured `tracker.api_key` env-var name, and env vars
-  whose current value equals the configured `tracker.api_key`, so those
-  credentials stay behind orchestrator-owned tools. See
+  `HOME`, `CODEX_HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TZ`, `TERM`).
+  Tracker/repo tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`, `GITEA_TOKEN`) and any
+  other secret in the worker's `.env` are excluded — a malicious or buggy
+  WORKFLOW.md cannot `env > /tmp/dump` and exfiltrate them. Operators opt
+  non-tracker vars back in per workflow with `codex.env_passthrough`,
+  `claude.env_passthrough`, or `hooks.env_passthrough`; real-Codex workflow
+  templates that set `shell_environment_policy.inherit=all` also make those
+  intentionally passed variables visible to Codex-launched shell tools. Agent
+  and hook passthrough reject tracker/repo API token names, the configured
+  `tracker.api_key` env-var name, and env vars whose current value equals the
+  configured `tracker.api_key`, so those credentials stay behind
+  orchestrator-owned tools. See
   [`docs/design/hook-verify-env-allowlist.md`](design/hook-verify-env-allowlist.md);
 - allow-listed redaction of Codex `turn/failed`, `turn/cancelled`, and failed
   `turn/completed` protocol payloads: returned error strings and

--- a/docs/superpowers/specs/2026-07-03-preserve-codex-app-environment-design.md
+++ b/docs/superpowers/specs/2026-07-03-preserve-codex-app-environment-design.md
@@ -1,0 +1,212 @@
+# Preserve Codex App Environment Inheritance
+
+**Date:** 2026-07-03
+**Issue:** [#1049](https://github.com/xrf9268-hue/aiops-platform/issues/1049)
+**Status:** Draft for rollback implementation
+
+## Problem
+
+`codex app-server` threads currently receive a runner-owned `config` object that
+forces Codex Apps/connectors off:
+
+```json
+{
+  "apps": {
+    "_default": {
+      "enabled": false,
+      "open_world_enabled": false,
+      "destructive_enabled": false
+    }
+  },
+  "features": {
+    "apps": false,
+    "connectors": false
+  }
+}
+```
+
+That behavior was introduced by #635 to avoid an unattended GitHub run stalling
+on an interactive Codex App approval dialog. The fix was broader than the
+failure: it disables host-configured Apps/connectors for every local
+`codex app-server` thread, even when the operator intentionally enabled them in
+the Codex environment that runs the worker.
+
+For direct local binary deployments, this is the wrong boundary. The upstream
+Elixir app-server launches `codex.command` from the issue workspace without
+injecting a thread config that disables Apps/connectors. It naturally inherits
+the environment of the user running the orchestrator. `aiops-platform` should
+preserve that same expectation when the worker and `codex app-server` run as the
+same user.
+
+## Decision
+
+Rollback the default thread-scoped Apps/connectors disablement. By default, the
+runner should omit the `config` field from `thread/start`, allowing Codex to use
+its normal effective configuration for Apps/connectors, skills, plugins, and MCP
+discovery.
+
+Preserve Codex home inheritance explicitly. `CODEX_HOME` is part of Codex's
+documented environment surface and points at config, auth, logs, sessions,
+skills, and standalone package metadata; the runner baseline should pass it to
+the app-server when the worker has it set.
+
+Preserve Codex shell-tool environment inheritance in real-Codex workflow
+templates. The core `codex.command` default remains the SPEC §6.4 value
+`codex app-server`, while shipped real-Codex templates should launch app-server
+with `--config shell_environment_policy.inherit=all`, matching the upstream
+WORKFLOW's local-binary posture while still keeping tracker/repo tokens out of
+the app-server environment through aiops-platform's existing deny filter.
+
+The runner still advertises explicit Symphony dynamic tools such as
+`linear_graphql`. Those tools are additive and remain the portable contract for
+tracker-specific workflow actions.
+
+## Scope
+
+### In scope
+
+- Remove the default `thread/start.config` payload that forces
+  `features.apps=false`, `features.connectors=false`, and
+  `apps._default.enabled=false`.
+- Add `CODEX_HOME` to the agent subprocess baseline environment.
+- Update workflow examples and runbooks that explicitly pin
+  `command: codex app-server` so real-Codex templates use the upstream-style
+  inherited shell environment when real Codex is intended.
+- Replace tests that pin disabled Apps/connectors with tests that assert the
+  runner does not override the host Codex Apps/connectors configuration by
+  default.
+- Keep explicit runner-owned `dynamicTools` unchanged.
+- Keep approval and elicitation handling unchanged so unattended sessions still
+  fail closed when Codex asks the operator for input the worker cannot provide.
+- Update #1049 wording so it distinguishes:
+  - inherited same-user local Codex environment capability,
+  - repo-owned required skill dependencies for portability/diagnostics,
+  - open-world/destructive app access policy.
+
+### Out of scope
+
+- Do not change `multiAgentMode: none` in this rollback. That setting was added
+  separately by #999 and controls injected multi-agent mode instructions, not the
+  Apps/connectors inheritance bug. Follow-up issue #1056 owns the separate audit.
+- Do not add a new workflow front-matter key in this rollback.
+- Do not add worker-side PR, review, merge, or tracker-write shortcuts.
+- Do not disable ordinary user skills or MCP configuration for same-user local
+  binary deployments.
+- Do not silently enable open-world or destructive app behavior beyond whatever
+  the operator's effective Codex configuration already enables.
+
+## Design
+
+`buildThreadStartParams` should build the minimal upstream-aligned
+`thread/start` payload:
+
+```go
+map[string]any{
+    "approvalPolicy": approvalPolicy,
+    "sandbox":        in.Workflow.Config.Codex.ThreadSandbox,
+    "cwd":            in.Workdir,
+    "dynamicTools":   appServerDynamicToolSpecs(in.Workflow.Config),
+    "multiAgentMode": "none",
+}
+```
+
+There should be no `config` key unless a future, explicit workflow/operator
+policy requires one. Omitting the key lets Codex resolve its own configuration
+from the process environment and Codex config files.
+
+The schema contract test for `ThreadStartParams` remains valuable and should
+continue validating the actual payload. The standalone `Config` schema test for
+`appServerThreadConfig` should be removed because the runner no longer builds a
+thread config by default.
+
+`agentEnv` should include `CODEX_HOME` in its baseline next to `HOME`. Existing
+tracker-token deny logic still applies to both baseline and passthrough names, so
+this does not expose `GITHUB_TOKEN`, `GITEA_TOKEN`, `LINEAR_API_KEY`, or the
+configured tracker token value.
+
+Real-Codex workflow templates should use the upstream-style command:
+
+```text
+codex app-server --config shell_environment_policy.inherit=all
+```
+
+The core `workflow.DefaultConfig().Codex.Command` and empty-command fallback in
+`NewCodexAppServerCommand` stay `codex app-server` to preserve SPEC §6.4. When a
+workflow sets the upstream-style command above, the argument order keeps
+`app-server` as the direct subcommand so the runner's direct-exec path remains
+active; it does not need a shell wrapper.
+
+## Tests
+
+- Update `TestBuildThreadStartParamsDisablesInheritedCodexAppTools` into a
+  positive inheritance-preservation test:
+  - build the payload,
+  - assert `payload["config"]` is absent,
+  - assert `dynamicTools` is still present when tracker config requires it.
+- Keep `TestBuildThreadStartParamsPinsMultiAgentMode` unchanged for this
+  rollback.
+- Remove `TestCodexAppServerThreadConfigMatchesSchema`; the config helper should
+  no longer exist.
+- Add/adjust tests proving `CODEX_HOME` is part of the runner baseline and the
+  app-server subprocess environment.
+- Keep SPEC-default tests for `codex app-server`; use template/doc checks for
+  the explicit real-Codex workflow command posture.
+- Run:
+
+```bash
+go test ./internal/runner
+go test ./internal/workflow
+go test ./scripts
+git diff --check
+```
+
+## Acceptance Criteria
+
+- `thread/start` no longer sends `config.features.apps=false` or
+  `config.features.connectors=false` by default.
+- `thread/start` no longer sends `apps._default.enabled=false` by default.
+- `CODEX_HOME` is inherited by the app-server subprocess without requiring
+  `codex.env_passthrough`.
+- Shipped real-Codex workflow templates include
+  `shell_environment_policy.inherit=all`.
+- Explicit `dynamicTools` continue to be advertised.
+- `multiAgentMode: none` remains unchanged.
+- Existing approval/input-required handling remains unchanged.
+- #1049 no longer frames host-local Apps/connectors inheritance as something the
+  runner should disable by default.
+
+## Cross-Check Verdict
+
+Treat these as inheritance regressions and handle them in this rollback:
+
+- Default `thread/start.config` disabled Apps/connectors.
+- Agent subprocess baseline omitted `CODEX_HOME`.
+- Real-Codex workflow templates pinned the narrower `codex app-server` command
+  instead of the upstream-style
+  `codex app-server --config shell_environment_policy.inherit=all`.
+
+Reviewed but keep separate from this rollback:
+
+- `multiAgentMode: none`: schema says it leaves multi-agent tools available and
+  only suppresses injected delegation instructions. Follow-up #1056 owns the
+  separate schema/app-server evidence audit.
+- `codex.approval_policy` granular all-false: this is the current-schema
+  definite fail-closed posture for unattended input/approval requests. #624
+  remains the right place to audit approval kinds that slip past granular flags;
+  do not "fix" it by disabling entire capability surfaces.
+- `linear_graphql.allow_mutations: false`: this is a token-isolated dynamic-tool
+  mutation gate, not a host Codex environment inheritance issue. Workflows that
+  need agent-owned Linear writes should opt into allowed mutations explicitly.
+- Tracker/repo token env deny-list: this preserves the SPEC token boundary and
+  should not be relaxed as part of local Codex environment inheritance.
+- Optional worker sandbox `env_allowlist`: only applies when the operator opts
+  into the external sandbox wrapper; it is not part of the default local binary
+  app-server path.
+
+## Follow-up Reflection
+
+#635 solved a real unattended-approval stall by turning off an entire Codex
+surface. The narrower failure was approval handling for a specific interactive
+tool path. Future hardening should first identify the failed behavior and then
+constrain that behavior directly; broad session-level disablement needs an
+explicit SPEC/upstream justification before it becomes the default.

--- a/docs/workflows/company-cautious-WORKFLOW.md
+++ b/docs/workflows/company-cautious-WORKFLOW.md
@@ -44,7 +44,7 @@ agent:
   max_turns: 6
 
 codex:
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
 
 claude:
   command: claude

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -47,7 +47,7 @@ agent:
 codex:
   # The SPEC §10 runner is `codex app-server` — a long-running JSON-RPC 2.0
   # session over stdio. Set agent.default: codex-app-server to use it.
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
   # linear_graphql narrows the agent-visible Linear GraphQL tool to the
   # operator-chosen surface (SPEC §15.5 harness hardening / #298). The
   # zero value (omit the block) keeps the safest posture: queries are

--- a/examples/gitea-WORKFLOW.md
+++ b/examples/gitea-WORKFLOW.md
@@ -38,7 +38,7 @@ agent:
   max_turns: 8
 
 codex:
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
 
 claude:
   command: claude

--- a/examples/github-local-WORKFLOW.md
+++ b/examples/github-local-WORKFLOW.md
@@ -41,7 +41,7 @@ agent:
 
 codex:
   # The SPEC §10 runner is the long-running `codex app-server` JSON-RPC session.
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
   # thread_sandbox: danger-full-access is intended for a trusted local Mac or an
   # already-isolated Docker worker. Use workspace-write on shared hosts.
   thread_sandbox: danger-full-access

--- a/examples/github-maker-WORKFLOW.md
+++ b/examples/github-maker-WORKFLOW.md
@@ -37,7 +37,7 @@ agent:
   timeout: 2h
 
 codex:
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
   thread_sandbox: danger-full-access
   # Real codex app-server startup can exceed the default 5s read timeout on
   # release-validation machines. Keep this in the template so doctor exercises

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -39,7 +39,7 @@ agent:
   timeout: 2h
 
 codex:
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
   thread_sandbox: danger-full-access
   read_timeout_ms: 30000
   env_passthrough:

--- a/examples/maker-WORKFLOW.md
+++ b/examples/maker-WORKFLOW.md
@@ -49,7 +49,7 @@ agent:
   max_turns: 30
 
 codex:
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
   # workspace-write lets the agent build/test before pushing. networkAccess:true
   # is required for `git push` and the Gitea PR API (typed policies default to
   # networkAccess:false, which would block both).

--- a/examples/reviewer-WORKFLOW.md
+++ b/examples/reviewer-WORKFLOW.md
@@ -52,7 +52,7 @@ agent:
   max_turns: 8
 
 codex:
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
   # Two tiers (pick one); BOTH need networkAccess: true — the typed sandbox
   # policies derive networkAccess: false by default, which blocks the
   # git fetch / Gitea API calls the review depends on. The verdict label

--- a/examples/reviewer-automerge-WORKFLOW.md
+++ b/examples/reviewer-automerge-WORKFLOW.md
@@ -50,7 +50,7 @@ agent:
   max_continuation_turns: 36
 
 codex:
-  command: codex app-server
+  command: codex app-server --config shell_environment_policy.inherit=all
   # workspace-write so the reviewer can fetch the head branch and run build/test.
   # networkAccess:true is REQUIRED — git fetch + Gitea API + the auto-merge call
   # all need network; typed policies default it to false.

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -524,32 +524,10 @@ func buildInitializeParams() map[string]any {
 func buildThreadStartParams(in RunInput, approvalPolicy any) map[string]any {
 	return map[string]any{
 		"approvalPolicy": approvalPolicy,
-		"config":         appServerThreadConfig(),
 		"sandbox":        in.Workflow.Config.Codex.ThreadSandbox,
 		"cwd":            in.Workdir,
 		"dynamicTools":   appServerDynamicToolSpecs(in.Workflow.Config),
 		"multiAgentMode": "none",
-	}
-}
-
-func appServerThreadConfig() map[string]any {
-	return map[string]any{
-		"apps": map[string]any{
-			"_default": map[string]any{
-				// Unattended worker sessions own PR/tracker handoff through
-				// WORKFLOW-prescribed CLI commands plus explicit dynamicTools.
-				"enabled":             false,
-				"open_world_enabled":  false,
-				"destructive_enabled": false,
-			},
-		},
-		"features": map[string]any{
-			// The app default does not override host config that explicitly
-			// enables a connector, so disable the app feature for the session.
-			// Codex also accepts `connectors` as the legacy alias for Apps.
-			"apps":       false,
-			"connectors": false,
-		},
 	}
 }
 

--- a/internal/runner/codex_app_server_cmd.go
+++ b/internal/runner/codex_app_server_cmd.go
@@ -31,7 +31,7 @@ func buildCodexAppServerCmd(ctx context.Context, in RunInput, env []string) (*ex
 func NewCodexAppServerCommand(ctx context.Context, cfg workflow.Config, env []string) (*exec.Cmd, bool, error) {
 	command := strings.TrimSpace(cfg.Codex.Command)
 	if command == "" {
-		command = "codex app-server"
+		command = workflow.DefaultCodexCommand
 	}
 	// A codex-prefixed command with no shell syntax execs the codex binary
 	// directly. This keeps the common case (including args like

--- a/internal/runner/codex_app_server_schema_test.go
+++ b/internal/runner/codex_app_server_schema_test.go
@@ -99,13 +99,6 @@ func TestCodexAppServerThreadStartPayloadMatchesSchema(t *testing.T) {
 	}
 }
 
-func TestCodexAppServerThreadConfigMatchesSchema(t *testing.T) {
-	sch := compileCodexDef(t, codexSchemaCompiler(t), "Config")
-	if err := validateWire(t, sch, appServerThreadConfig()); err != nil {
-		t.Errorf("appServerThreadConfig() failed Config schema: %v", err)
-	}
-}
-
 func TestCodexAppServerTurnStartPayloadMatchesSchema(t *testing.T) {
 	in := codexSchemaTestInput(t)
 	approval := in.Workflow.Config.Codex.ApprovalPolicy

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -129,7 +129,7 @@ func codexAppServerEnvStubScript(t *testing.T, body string) string {
 	header := `#!/usr/bin/env python3
 import os, sys
 with open("env.txt", "w") as f:
-    for name in ("LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN", "PATH"):
+    for name in ("LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN", "PATH", "CODEX_HOME"):
         if name in os.environ:
             f.write(f"{name}={os.environ[name]}\n")
 `
@@ -278,42 +278,14 @@ for line in sys.stdin:
 	}
 }
 
-func TestBuildThreadStartParamsDisablesInheritedCodexAppTools(t *testing.T) {
-	in := appServerInput(codexWorkdir(t, "disable app tools"))
+func TestBuildThreadStartParamsPreservesInheritedCodexAppConfig(t *testing.T) {
+	in := appServerInput(codexWorkdir(t, "preserve app config"))
 	in.Workflow.Config.Tracker.Kind = "linear"
 	in.Workflow.Config.Tracker.APIKey = "linear-secret"
 	payload := buildThreadStartParams(in, in.Workflow.Config.Codex.ApprovalPolicy)
 
-	config, ok := payload["config"].(map[string]any)
-	if !ok {
-		t.Fatalf("thread/start config = %#v; want object disabling inherited app tools", payload["config"])
-	}
-	apps, ok := config["apps"].(map[string]any)
-	if !ok {
-		t.Fatalf("thread/start config.apps = %#v; want object", config["apps"])
-	}
-	features, ok := config["features"].(map[string]any)
-	if !ok {
-		t.Fatalf("thread/start config.features = %#v; want object", config["features"])
-	}
-	if features["apps"] != false {
-		t.Fatalf("thread/start config.features.apps = %#v; want false", features["apps"])
-	}
-	if features["connectors"] != false {
-		t.Fatalf("thread/start config.features.connectors = %#v; want false", features["connectors"])
-	}
-	defaultApp, ok := apps["_default"].(map[string]any)
-	if !ok {
-		t.Fatalf("thread/start config.apps._default = %#v; want object", apps["_default"])
-	}
-	if defaultApp["enabled"] != false {
-		t.Fatalf("thread/start config.apps._default.enabled = %#v; want false", defaultApp["enabled"])
-	}
-	if defaultApp["open_world_enabled"] != false {
-		t.Fatalf("thread/start config.apps._default.open_world_enabled = %#v; want false", defaultApp["open_world_enabled"])
-	}
-	if defaultApp["destructive_enabled"] != false {
-		t.Fatalf("thread/start config.apps._default.destructive_enabled = %#v; want false", defaultApp["destructive_enabled"])
+	if _, ok := payload["config"]; ok {
+		t.Fatalf("thread/start config = %#v; want absent so Codex uses inherited host config", payload["config"])
 	}
 	if tools, _ := payload["dynamicTools"].([]map[string]any); len(tools) == 0 {
 		t.Fatalf("thread/start dynamicTools = %#v; want explicit runner tools still advertised", payload["dynamicTools"])
@@ -350,6 +322,7 @@ for line in sys.stdin:
 	t.Setenv("LINEAR_API_KEY", "linear-secret")
 	t.Setenv("GITEA_TOKEN", "gitea-secret")
 	t.Setenv("GITHUB_TOKEN", "github-secret")
+	t.Setenv("CODEX_HOME", filepath.Join(wd, "codex-home"))
 
 	if _, err := (CodexAppServerRunner{}).Run(context.Background(), appServerInput(wd)); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -366,6 +339,9 @@ for line in sys.stdin:
 	}
 	if !strings.Contains(string(body), "PATH=") {
 		t.Fatalf("codex app-server env lost baseline PATH:\n%s", body)
+	}
+	if !strings.Contains(string(body), "CODEX_HOME="+filepath.Join(wd, "codex-home")) {
+		t.Fatalf("codex app-server env lost baseline CODEX_HOME:\n%s", body)
 	}
 }
 

--- a/internal/runner/env.go
+++ b/internal/runner/env.go
@@ -11,6 +11,7 @@ import (
 var baselineAgentEnvAllowlist = []string{
 	"PATH",
 	"HOME",
+	"CODEX_HOME",
 	"USER",
 	"LANG",
 	"LC_ALL",

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -441,6 +441,7 @@ func TestAgentEnvWithLookupBoundaryTable(t *testing.T) {
 	lookupValues := map[string]string{
 		"PATH":                       "/worker/path",
 		"HOME":                       "/home/agent",
+		"CODEX_HOME":                 "/home/agent/.codex-alt",
 		"USER":                       "agent-user",
 		"AIOPS_ALLOWED":              "allowed-value",
 		"AIOPS_DUPLICATE":            "duplicate-value",
@@ -479,6 +480,7 @@ func TestAgentEnvWithLookupBoundaryTable(t *testing.T) {
 	}{
 		{name: "PATH", wantValue: "/login/path"},
 		{name: "HOME", wantValue: "/home/agent"},
+		{name: "CODEX_HOME", wantValue: "/home/agent/.codex-alt"},
 		{name: "USER", wantValue: "agent-user"},
 		{name: "AIOPS_ALLOWED", wantValue: "allowed-value"},
 		{name: "AIOPS_DUPLICATE", wantValue: "duplicate-value"},

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -396,6 +396,8 @@ type VerifyConfig struct {
 	Commands []string `yaml:"commands" json:"commands"`
 }
 
+const DefaultCodexCommand = "codex app-server"
+
 func DefaultConfig() Config {
 	return Config{
 		Server: ServerConfig{Host: "127.0.0.1", Port: 4000},
@@ -426,7 +428,7 @@ func DefaultConfig() Config {
 			Timeout:              30 * time.Minute,
 		},
 		Codex: CommandConfig{
-			Command: "codex app-server",
+			Command: DefaultCodexCommand,
 			// See loader.go for why this is `granular:` with all flags
 			// false instead of the obsolete `reject:` shape (#329).
 			ApprovalPolicy: map[string]any{"granular": map[string]any{


### PR DESCRIPTION
Closes #1057

Part of #1049. Follow-up #1056 owns the separate `multiAgentMode: none` audit.

## Summary
- Remove the runner-owned `thread/start.config` override that disabled Codex Apps/connectors by default, so same-user local binary app-server runs preserve the operator's effective Codex config.
- Add `CODEX_HOME` to the agent subprocess baseline and update tests/docs so non-default Codex homes keep skills, MCP config, auth, sessions, and plugin/package metadata available.
- Update shipped real-Codex workflow templates to use `codex app-server --config shell_environment_policy.inherit=all` while keeping the core SPEC default as `codex app-server`.

Root cause: the prior unattended App-approval fix disabled an entire Codex capability surface for every local app-server thread instead of only failing closed on approval/input paths the worker cannot satisfy.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [ ] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [x] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Upstream reference checked: `elixir/lib/symphony_elixir/codex/app_server.ex:189` launches `codex.command` from the issue workspace without a runner-injected environment override, and `elixir/lib/symphony_elixir/codex/app_server.ex:280` starts `thread/start` with approval policy, sandbox, cwd, and dynamic tools rather than an Apps/connectors-disabling `config` payload. Upstream's real-Codex workflow also uses `elixir/WORKFLOW.md:33` with `shell_environment_policy.inherit=all`.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts` (covered by `go test -count=1 ./scripts`)
- [ ] `go vet ./...`
- [ ] `go test -race -covermode=atomic ./...`
- [ ] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation run:

```bash
go test -count=1 ./internal/runner ./internal/workflow ./scripts ./cmd/worker ./internal/doctor
gofmt -l $(git ls-files '*.go')
git diff --check
```

Not run: full `go vet ./...`, full race suite, and golangci gate.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
- `multiAgentMode: none` remains unchanged in this PR because it is not the Apps/connectors inheritance regression; #1056 tracks the follow-up evidence audit.