### PR TITLE
fix(github): do not synthesize blocker lookup failures

### DIFF
--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -39,6 +39,10 @@ type issueStateRefresherByRefs interface {
 	FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]tracker.IssueState, error)
 }
 
+type issueStateRefresherWithoutBlockersByRefs interface {
+	FetchIssueStatesWithoutBlockersByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]tracker.IssueState, error)
+}
+
 func fetchIssueStates(ctx context.Context, refresher IssueStateRefresher, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
 	if refresher == nil || len(refs) == 0 {
 		return map[string]tracker.IssueState{}, nil
@@ -51,6 +55,16 @@ func fetchIssueStates(ctx context.Context, refresher IssueStateRefresher, refs [
 		issueIDs = append(issueIDs, ref.ID)
 	}
 	return refresher.FetchIssueStatesByIDs(ctx, issueIDs)
+}
+
+func fetchIssueStatesWithoutBlockers(ctx context.Context, refresher IssueStateRefresher, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
+	if refresher == nil || len(refs) == 0 {
+		return map[string]tracker.IssueState{}, nil
+	}
+	if noBlockers, ok := refresher.(issueStateRefresherWithoutBlockersByRefs); ok {
+		return noBlockers.FetchIssueStatesWithoutBlockersByRefs(ctx, refs)
+	}
+	return fetchIssueStates(ctx, refresher, refs)
 }
 
 // ReconciliationConfig names the workflow states the poller uses to decide

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -323,7 +323,7 @@ func (d *RuntimeDispatcher) configForSnapshot(snap WorkflowSnapshot) worker.Conf
 				if stopped, ok := d.operatorTerminalStopSnapshot(ctx, issueID); ok {
 					return stopped, nil
 				}
-				statesByID, err := fetchIssueStates(ctx, refresher, []tracker.IssueRef{issueRef})
+				statesByID, err := fetchIssueStatesWithoutBlockers(ctx, refresher, []tracker.IssueRef{issueRef})
 				if err != nil {
 					return runner.IssueStateSnapshot{}, err
 				}

--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -56,6 +56,32 @@ func (s *stubRefAwareRefresher) FetchIssueStatesByRefs(_ context.Context, refs [
 	return out, nil
 }
 
+type stubNoBlockerRefAwareRefresher struct {
+	blockerRefs   [][]tracker.IssueRef
+	noBlockerRefs [][]tracker.IssueRef
+	states        map[string]string
+}
+
+func (s *stubNoBlockerRefAwareRefresher) FetchIssueStatesByIDs(context.Context, []string) (map[string]tracker.IssueState, error) {
+	return nil, errors.New("legacy ID-only refresh should not be used")
+}
+
+func (s *stubNoBlockerRefAwareRefresher) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
+	s.blockerRefs = append(s.blockerRefs, append([]tracker.IssueRef(nil), refs...))
+	return nil, errors.New("blocker-aware refresh should not be used for runner current-issue state")
+}
+
+func (s *stubNoBlockerRefAwareRefresher) FetchIssueStatesWithoutBlockersByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
+	s.noBlockerRefs = append(s.noBlockerRefs, append([]tracker.IssueRef(nil), refs...))
+	out := map[string]tracker.IssueState{}
+	for _, ref := range refs {
+		if state, ok := s.states[ref.ID]; ok {
+			out[ref.ID] = tracker.IssueState{State: state}
+		}
+	}
+	return out, nil
+}
+
 // TestRuntimeDispatcherConfigForSnapshotBuildsRefresherClosure pins the
 // SPEC §16.5 wiring: when SetIssueStateRefresher is set, the worker.Config
 // returned for a snapshot carries a factory that the worker uses to build
@@ -133,6 +159,38 @@ func TestRuntimeDispatcherConfigForSnapshotBuildsRefresherClosure(t *testing.T) 
 			t.Fatalf("err = %v, want wrapped tracker boom", err)
 		}
 	})
+}
+
+func TestRuntimeDispatcherIssueStateRefresherUsesNoBlockerRefreshWhenAvailable(t *testing.T) {
+	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
+	stub := &stubNoBlockerRefAwareRefresher{states: map[string]string{"global-101": "In Progress"}}
+	d.SetIssueStateRefresher(stub)
+
+	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
+		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress"}},
+	}}}
+	cfg := d.configForSnapshot(snap)
+	fn := cfg.IssueStateRefresher(task.Task{
+		ID:          "global-101",
+		IssueRender: map[string]any{"identifier": "#7"},
+	}, snap.Workflow.Config)
+
+	snapshot, err := fn(context.Background())
+	if err != nil {
+		t.Fatalf("refresher err = %v; want nil from no-blocker current-issue refresh", err)
+	}
+	if !snapshot.Active || !snapshot.Found || snapshot.State != "In Progress" {
+		t.Fatalf("snapshot = %+v, want found active In Progress", snapshot)
+	}
+	if len(stub.blockerRefs) != 0 {
+		t.Fatalf("blocker-aware refresh calls = %#v; want none for runner current-issue state", stub.blockerRefs)
+	}
+	if len(stub.noBlockerRefs) != 1 || len(stub.noBlockerRefs[0]) != 1 {
+		t.Fatalf("no-blocker refresh calls = %#v; want one issue ref", stub.noBlockerRefs)
+	}
+	if got := stub.noBlockerRefs[0][0]; got.ID != "global-101" || got.Identifier != "#7" {
+		t.Fatalf("no-blocker refresh ref = %+v; want ID global-101 identifier #7", got)
+	}
 }
 
 // TestRuntimeDispatcherContinueGateAppliesRequiredLabels pins the SPEC §6.4

--- a/internal/tracker/github_blockers.go
+++ b/internal/tracker/github_blockers.go
@@ -21,6 +21,7 @@ var githubBlockedByIssueRE = regexp.MustCompile(`(?i)\b(?:blocked by|depends on)
 type githubBlockerSource struct {
 	IssueID    string
 	Identifier string
+	State      string
 	NodeID     string
 	Number     int
 	Body       string
@@ -70,9 +71,9 @@ type githubBodyBlockerResolution struct {
 	Found bool
 }
 
-func (c *GitHubClient) attachGitHubBlockersToIssues(ctx context.Context, issues []Issue) {
+func (c *GitHubClient) attachGitHubBlockersToIssues(ctx context.Context, issues []Issue) error {
 	if len(issues) == 0 {
-		return
+		return nil
 	}
 	sources := make([]githubBlockerSource, 0, len(issues))
 	for i := range issues {
@@ -84,12 +85,16 @@ func (c *GitHubClient) attachGitHubBlockersToIssues(ctx context.Context, issues 
 		sources = append(sources, githubBlockerSource{
 			IssueID:    issues[i].ID,
 			Identifier: issues[i].Identifier,
+			State:      issues[i].State,
 			NodeID:     meta.NodeID,
 			Number:     meta.Number,
 			Body:       meta.Body,
 		})
 	}
-	blockers := c.blockersForGitHubSources(ctx, sources, githubConfiguredStates(c.Config))
+	blockers, err := c.blockersForGitHubSources(ctx, sources, githubConfiguredStates(c.Config))
+	if err != nil {
+		return err
+	}
 	for i := range issues {
 		if blockedBy, ok := blockers[issues[i].ID]; ok {
 			issues[i].BlockedBy = blockedBy
@@ -99,43 +104,78 @@ func (c *GitHubClient) attachGitHubBlockersToIssues(ctx context.Context, issues 
 			issues[i].BlockedBy = []BlockerRef{}
 		}
 	}
+	return nil
 }
 
-func (c *GitHubClient) blockersForGitHubSources(ctx context.Context, sources []githubBlockerSource, configuredStates []string) map[string][]BlockerRef {
+func (c *GitHubClient) blockersForGitHubSources(ctx context.Context, sources []githubBlockerSource, configuredStates []string) (map[string][]BlockerRef, error) {
 	out := make(map[string][]BlockerRef, len(sources))
-	native, nativeErr := c.nativeGitHubBlockers(ctx, sources, configuredStates)
-	for _, source := range sources {
-		blockedBy := nativeGitHubBlockersForSource(source, native, nativeErr)
-		for _, blocker := range c.bodyGitHubBlockers(ctx, source.Body, configuredStates, githubBlockerNumbers(blockedBy)) {
-			blockedBy = appendGitHubBlocker(blockedBy, blocker)
+	hydrationSources := githubBlockerHydrationSources(sources)
+	native, nativeErr := c.nativeGitHubBlockers(ctx, hydrationSources, configuredStates)
+	if nativeErr != nil {
+		if c.Logf != nil {
+			c.Logf("github blockedBy lookup failed; skipping unverified blocker state for this tick: %v", nativeErr)
 		}
-		if blockedBy == nil {
-			blockedBy = []BlockerRef{}
+		return nil, nativeErr
+	}
+	for _, source := range sources {
+		blockedBy, err := c.blockersForGitHubSource(ctx, source, native, configuredStates)
+		if err != nil {
+			return nil, err
 		}
 		out[source.IssueID] = blockedBy
 	}
-	if nativeErr != nil && c.Logf != nil {
-		c.Logf("github blockedBy lookup failed; failing closed for issues with native node IDs: %v", nativeErr)
-	}
-	return out
+	return out, nil
 }
 
-func nativeGitHubBlockersForSource(source githubBlockerSource, native map[string]githubNativeBlockers, nativeErr error) []BlockerRef {
-	if source.NodeID == "" {
-		return []BlockerRef{}
+func (c *GitHubClient) blockersForGitHubSource(ctx context.Context, source githubBlockerSource, native map[string]githubNativeBlockers, configuredStates []string) ([]BlockerRef, error) {
+	if !githubBlockerSourceNeedsHydration(source) {
+		return []BlockerRef{}, nil
 	}
-	if nativeErr != nil {
-		return []BlockerRef{unknownGitHubBlocker(source, "native lookup failed")}
+	blockedBy, err := nativeGitHubBlockersForSource(source, native)
+	if err != nil {
+		return nil, err
+	}
+	for _, blocker := range c.bodyGitHubBlockers(ctx, source.Body, configuredStates, githubBlockerNumbers(blockedBy)) {
+		blockedBy = appendGitHubBlocker(blockedBy, blocker)
+	}
+	if blockedBy == nil {
+		return []BlockerRef{}, nil
+	}
+	return blockedBy, nil
+}
+
+func githubBlockerHydrationSources(sources []githubBlockerSource) []githubBlockerSource {
+	hydrationSources := make([]githubBlockerSource, 0, len(sources))
+	for _, source := range sources {
+		if githubBlockerSourceNeedsHydration(source) {
+			hydrationSources = append(hydrationSources, source)
+		}
+	}
+	return hydrationSources
+}
+
+func githubBlockerSourceNeedsHydration(source githubBlockerSource) bool {
+	return githubTodoWorkflowState(source.State)
+}
+
+func githubTodoWorkflowState(state string) bool {
+	state = strings.ToLower(strings.TrimSpace(state))
+	return state == "todo" || strings.HasSuffix(state, ":todo") || strings.HasSuffix(state, "/todo")
+}
+
+func nativeGitHubBlockersForSource(source githubBlockerSource, native map[string]githubNativeBlockers) ([]BlockerRef, error) {
+	if source.NodeID == "" {
+		return []BlockerRef{}, nil
 	}
 	got, ok := native[source.NodeID]
 	if !ok {
-		return []BlockerRef{unknownGitHubBlocker(source, "native lookup missing issue")}
+		return nil, fmt.Errorf("github blockedBy lookup missing issue node %q for %s", source.NodeID, source.Identifier)
 	}
 	blockedBy := append([]BlockerRef(nil), got.Blockers...)
 	if got.Incomplete {
 		blockedBy = appendGitHubBlocker(blockedBy, unknownGitHubBlocker(source, "native blocker pagination incomplete"))
 	}
-	return blockedBy
+	return blockedBy, nil
 }
 
 func (c *GitHubClient) nativeGitHubBlockers(ctx context.Context, sources []githubBlockerSource, configuredStates []string) (map[string]githubNativeBlockers, error) {
@@ -282,9 +322,9 @@ func (c *GitHubClient) resolveBodyGitHubBlocker(ctx context.Context, issueNumber
 	issue, found, err := c.getIssueByNumber(ctx, issueNumber)
 	if err != nil {
 		if c.Logf != nil {
-			c.Logf("github body blocker lookup for #%d failed; failing closed: %v", issueNumber, err)
+			c.Logf("github body blocker lookup for #%d failed; omitting unverified fallback blocker this tick: %v", issueNumber, err)
 		}
-		return githubBodyBlockerResolution{Ref: BlockerRef{Identifier: fmt.Sprintf("#%d", issueNumber)}, Found: true}
+		return githubBodyBlockerResolution{}
 	}
 	if !found {
 		return githubBodyBlockerResolution{}

--- a/internal/tracker/github_listing.go
+++ b/internal/tracker/github_listing.go
@@ -78,7 +78,9 @@ func (c *GitHubClient) ListIssuesByStates(ctx context.Context, states []string) 
 			nil,
 		)
 	}
-	c.attachGitHubBlockersToIssues(ctx, out)
+	if err := c.attachGitHubBlockersToIssues(ctx, out); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 

--- a/internal/tracker/github_refresh.go
+++ b/internal/tracker/github_refresh.go
@@ -30,12 +30,22 @@ import (
 // matches the GitHub convention where workflow position is encoded as labels.
 //
 // BlockedBy carries GitHub dependency data from the native GraphQL
-// Issue.blockedBy relation when available, plus the in-repo body fallback
-// ("Blocked by #N" / "Depends on #N"). A non-nil empty slice means the refresh
-// confirmed no blockers; unknown or incomplete dependency knowledge is surfaced
-// as an empty-state placeholder so the Todo blocker gate fails closed.
+// Issue.blockedBy relation for Todo-like states when available, plus the
+// in-repo body fallback ("Blocked by #N" / "Depends on #N"). A non-nil empty
+// slice means the refresh confirmed no blockers or the state does not need
+// blocker hydration; native lookup failure aborts Todo-like refresh so dispatch
+// skips this tick, while incomplete native pagination is surfaced as an
+// empty-state placeholder so the Todo blocker gate fails closed.
 func (c *GitHubClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]IssueState, error) {
 	return c.FetchIssueStatesByRefs(ctx, IssueRefsFromIDs(issueIDs))
+}
+
+// FetchIssueStatesWithoutBlockersByRefs fetches the state/labels needed by the
+// runner's per-turn current-issue gate without optional dependency hydration.
+// Dispatch-time revalidation still uses FetchIssueStatesByRefs so Todo blocker
+// checks remain authoritative before starting new work.
+func (c *GitHubClient) FetchIssueStatesWithoutBlockersByRefs(ctx context.Context, issueRefs []IssueRef) (map[string]IssueState, error) {
+	return c.fetchIssueStatesByRefs(ctx, issueRefs, false)
 }
 
 type githubFetchedIssueState struct {
@@ -46,6 +56,10 @@ type githubFetchedIssueState struct {
 }
 
 func (c *GitHubClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef) (map[string]IssueState, error) { //nolint:gocognit // baseline (#521)
+	return c.fetchIssueStatesByRefs(ctx, issueRefs, true)
+}
+
+func (c *GitHubClient) fetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef, includeBlockers bool) (map[string]IssueState, error) { //nolint:gocognit // baseline (#521)
 	if strings.TrimSpace(c.Token) == "" {
 		return nil, fmt.Errorf("GitHub tracker api_key is required")
 	}
@@ -100,25 +114,42 @@ func (c *GitHubClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []I
 		})
 	}
 	states := make(map[string]IssueState, len(fetched))
-	blockersByID := c.blockersForRefreshedGitHubIssues(ctx, fetched, configuredStates)
+	blockersByID, err := c.blockerRefsForFetchedGitHubIssueStates(ctx, fetched, configuredStates, includeBlockers)
+	if err != nil {
+		return nil, err
+	}
 	for _, row := range fetched {
-		blockedBy := blockersByID[row.issueID]
-		if blockedBy == nil {
-			blockedBy = []BlockerRef{}
-		}
 		// Carry the full label set (SPEC §6.4 required_labels gate) alongside the
 		// resolved state so label removal can stop/release already-claimed work.
-		states[row.issueID] = IssueState{State: row.state, Labels: row.labels, BlockedBy: blockedBy}
+		states[row.issueID] = IssueState{State: row.state, Labels: row.labels, BlockedBy: githubIssueStateBlockers(blockersByID, row.issueID, includeBlockers)}
 	}
 	return states, nil
 }
 
-func (c *GitHubClient) blockersForRefreshedGitHubIssues(ctx context.Context, rows []githubFetchedIssueState, configuredStates []string) map[string][]BlockerRef {
+func (c *GitHubClient) blockerRefsForFetchedGitHubIssueStates(ctx context.Context, fetched []githubFetchedIssueState, configuredStates []string, includeBlockers bool) (map[string][]BlockerRef, error) {
+	if !includeBlockers {
+		return nil, nil
+	}
+	return c.blockersForRefreshedGitHubIssues(ctx, fetched, configuredStates)
+}
+
+func githubIssueStateBlockers(blockersByID map[string][]BlockerRef, issueID string, includeBlockers bool) []BlockerRef {
+	if !includeBlockers {
+		return nil
+	}
+	if blockedBy := blockersByID[issueID]; blockedBy != nil {
+		return blockedBy
+	}
+	return []BlockerRef{}
+}
+
+func (c *GitHubClient) blockersForRefreshedGitHubIssues(ctx context.Context, rows []githubFetchedIssueState, configuredStates []string) (map[string][]BlockerRef, error) {
 	sources := make([]githubBlockerSource, 0, len(rows))
 	for _, row := range rows {
 		sources = append(sources, githubBlockerSource{
 			IssueID:    row.issueID,
 			Identifier: fmt.Sprintf("#%d", row.issue.Number),
+			State:      row.state,
 			NodeID:     row.issue.NodeID,
 			Number:     row.issue.Number,
 			Body:       row.issue.Body,

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -15,6 +15,23 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
+type githubPathErrorTransport struct {
+	base http.RoundTripper
+	path string
+	err  error
+}
+
+func (t githubPathErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path == t.path {
+		return nil, t.err
+	}
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
 func TestGitHubClientListIssuesByStatesMapsRepositoryIssues(t *testing.T) {
 	var requestedPath string
 	var requestedQuery string
@@ -288,6 +305,160 @@ func TestGitHubClientListIssuesByStatesFailsClosedWhenNativeBlockersAreIncomplet
 	}
 	if got := issues[0].BlockedBy; len(got) != 1 || got[0].State != "" {
 		t.Fatalf("blocked_by = %+v, want one unknown-state blocker so Todo dispatch fails closed", got)
+	}
+}
+
+func TestGitHubClientListIssuesByStatesSkipsBlockerLookupForNonTodoStates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case "/repos/acme/api/issues":
+			_ = json.NewEncoder(w).Encode([]githubIssue{{
+				ID:        100,
+				NodeID:    "I_100",
+				Number:    10,
+				Title:     "terminal issue",
+				Body:      "Blocked by #13",
+				HTMLURL:   "https://github.com/acme/api/issues/10",
+				State:     "closed",
+				CreatedAt: "2026-05-20T01:02:03Z",
+				UpdatedAt: "2026-05-20T02:03:04Z",
+				Labels:    []githubLabel{{Name: "done"}},
+			}})
+		case "/graphql", "/repos/acme/api/issues/13":
+			t.Fatalf("ListIssuesByStates(done) must not hydrate blockers via %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{
+		APIKey:         "test-token",
+		TerminalStates: []string{"done"},
+	}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"done"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates(done): %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %+v, want 1", issues)
+	}
+	if got := issues[0].BlockedBy; got == nil || len(got) != 0 {
+		t.Fatalf("done issue BlockedBy = %#v; want non-nil empty blockers without lookup", got)
+	}
+}
+
+func TestGitHubClientListIssuesByStatesReturnsErrorWhenNativeBlockerLookupIsRateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case "/repos/acme/api/issues":
+			_ = json.NewEncoder(w).Encode([]githubIssue{{
+				ID:        100,
+				NodeID:    "I_100",
+				Number:    10,
+				Title:     "unknown native dependency state",
+				HTMLURL:   "https://github.com/acme/api/issues/10",
+				State:     "open",
+				CreatedAt: "2026-05-20T01:02:03Z",
+				UpdatedAt: "2026-05-20T02:03:04Z",
+				Labels:    []githubLabel{{Name: "aiops:todo"}},
+			}})
+		case "/graphql":
+			w.Header().Set("Retry-After", "30")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"message":"rate limited"}`)
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{
+		APIKey:       "test-token",
+		ActiveStates: []string{"aiops:todo"},
+	}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	issues, err := client.ListActiveIssues(context.Background())
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("ListActiveIssues error = %v; want errors.Is ErrRateLimited from native blockedBy lookup", err)
+	}
+	if issues != nil {
+		t.Fatalf("ListActiveIssues issues = %#v; want nil when native blockedBy lookup is not authoritative", issues)
+	}
+}
+
+func TestGitHubClientListIssuesByStatesOmitsBodyFallbackWhenLookupTransportFails(t *testing.T) {
+	var fallbackRequested bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/pulls":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case "/repos/acme/api/issues":
+			_ = json.NewEncoder(w).Encode([]githubIssue{{
+				ID:        100,
+				NodeID:    "I_100",
+				Number:    10,
+				Title:     "best effort body dependency",
+				Body:      "Blocked by #13",
+				HTMLURL:   "https://github.com/acme/api/issues/10",
+				State:     "open",
+				CreatedAt: "2026-05-20T01:02:03Z",
+				UpdatedAt: "2026-05-20T02:03:04Z",
+				Labels:    []githubLabel{{Name: "aiops:todo"}},
+			}})
+		case "/graphql":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+				map[string]any{
+					"id":     "I_100",
+					"number": float64(10),
+					"blockedBy": map[string]any{
+						"nodes":    []any{},
+						"pageInfo": map[string]any{"hasNextPage": false},
+					},
+				},
+			}}})
+		case "/repos/acme/api/issues/13":
+			fallbackRequested = true
+			t.Fatalf("transport should fail before handler receives %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{
+		APIKey:       "test-token",
+		ActiveStates: []string{"aiops:todo"},
+	}, srv.URL, "acme", "api")
+	base := srv.Client().Transport
+	client.HTTP = &http.Client{Transport: githubPathErrorTransport{
+		base: base,
+		path: "/repos/acme/api/issues/13",
+		err:  errors.New("body fallback transport failed"),
+	}}
+
+	issues, err := client.ListActiveIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListActiveIssues: %v", err)
+	}
+	if fallbackRequested {
+		t.Fatal("body fallback handler was reached; want injected transport failure")
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %+v, want 1", issues)
+	}
+	if got := issues[0].BlockedBy; got == nil || len(got) != 0 {
+		t.Fatalf("blocked_by = %+v, want no synthetic body fallback blocker after transport failure", got)
 	}
 }
 
@@ -984,6 +1155,102 @@ func TestGitHubClientFetchIssueStatesByRefsPopulatesBlockedByAndDropsDeletedFall
 	}
 	if got := states["230"].BlockedBy; got == nil || len(got) != 0 {
 		t.Fatalf("FetchIssueStatesByRefs(#23).BlockedBy = %#v, want non-nil empty slice for confirmed no blockers", got)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesWithoutBlockersByRefsSkipsBlockerHydration(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/20":
+			_ = json.NewEncoder(w).Encode(githubIssue{
+				ID:        200,
+				NodeID:    "I_200",
+				Number:    20,
+				Title:     "runner refresh",
+				Body:      "Blocked by #21",
+				State:     "open",
+				CreatedAt: "2026-05-20T01:02:03Z",
+				UpdatedAt: "2026-05-20T02:03:04Z",
+				Labels:    []githubLabel{{Name: "aiops:todo"}, {Name: "backend"}},
+			})
+		case "/graphql":
+			t.Fatal("FetchIssueStatesWithoutBlockersByRefs must not hydrate GitHub blockers")
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{
+		APIKey:       "test-token",
+		ActiveStates: []string{"aiops:todo"},
+	}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesWithoutBlockersByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesWithoutBlockersByRefs: %v", err)
+	}
+	got, ok := states["200"]
+	if !ok {
+		t.Fatalf("states = %#v; want row 200", states)
+	}
+	if got.State != "aiops:todo" {
+		t.Fatalf("states[200].State = %q; want aiops:todo", got.State)
+	}
+	if len(got.Labels) != 2 || got.Labels[0] != "aiops:todo" || got.Labels[1] != "backend" {
+		t.Fatalf("states[200].Labels = %#v; want aiops:todo/backend", got.Labels)
+	}
+	if got.BlockedBy != nil {
+		t.Fatalf("states[200].BlockedBy = %#v; want nil no-blocker knowledge for runner current-issue refresh", got.BlockedBy)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByRefsSkipsBlockerLookupForNonTodoStates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/20":
+			_ = json.NewEncoder(w).Encode(githubIssue{
+				ID:        200,
+				NodeID:    "I_200",
+				Number:    20,
+				Title:     "done issue",
+				Body:      "Depends on #21",
+				HTMLURL:   "https://github.com/acme/api/issues/20",
+				State:     "closed",
+				CreatedAt: "2026-05-20T01:02:03Z",
+				UpdatedAt: "2026-05-20T02:03:04Z",
+				Labels:    []githubLabel{{Name: "done"}},
+			})
+		case "/graphql", "/repos/acme/api/issues/21":
+			t.Fatalf("FetchIssueStatesByRefs(done) must not hydrate blockers via %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewGitHubClient(workflow.TrackerConfig{
+		APIKey:         "test-token",
+		TerminalStates: []string{"done"},
+	}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs: %v", err)
+	}
+	got, ok := states["200"]
+	if !ok {
+		t.Fatalf("FetchIssueStatesByRefs missing issue 200: %+v", states)
+	}
+	if got.State != "done" {
+		t.Fatalf("FetchIssueStatesByRefs state = %q, want done", got.State)
+	}
+	if got.BlockedBy == nil || len(got.BlockedBy) != 0 {
+		t.Fatalf("FetchIssueStatesByRefs BlockedBy = %#v; want non-nil empty blockers without lookup", got.BlockedBy)
 	}
 }
 

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -36,15 +36,17 @@ type IssueState struct {
 	// (#750). nil means the adapter supplied no blocker knowledge for this
 	// issue and the consumer must keep its listing-time verdict; a non-nil
 	// empty slice is a positive "no blockers" answer. Unresolvable blocker
-	// knowledge fails closed as an empty-state placeholder the gate treats
+	// knowledge may fail closed as an empty-state placeholder the gate treats
 	// as open — never as nil, which would read as "safe". Linear resolves
 	// blockers only for refreshed Todo-state issues (the only state the gate
 	// applies to), placeholding the whole Todo batch when the
 	// inverse-relations query fails; Gitea derives them from the issue
 	// body's `Depends on #N` references, placeholding
 	// transiently-unresolvable references and skipping definitively-deleted
-	// blockers; GitHub prefers the native GraphQL `Issue.blockedBy` relation
-	// and supplements it with `Blocked by #N` / `Depends on #N` body references.
+	// blockers; GitHub hydrates Todo-like states from the native GraphQL
+	// `Issue.blockedBy` relation, returns a tracker error when that
+	// authoritative lookup fails, and treats `Blocked by #N` / `Depends on #N`
+	// body references as best-effort fallback.
 	BlockedBy []BlockerRef
 }
 


### PR DESCRIPTION
Closes #1053

## Summary
- Stop turning GitHub `Issue.blockedBy` lookup failures into synthetic unknown blockers; Todo-like native lookup failures now surface as tracker errors so the current listing/revalidation tick can retry later.
- Treat body `Blocked by #N` / `Depends on #N` lookup failures as best-effort omissions instead of manufacturing `#N` blockers, while preserving successful native/body blocker behavior and native pagination fail-closed behavior.
- Keep non-Todo listings/refreshes state-only for blocker hydration so terminal/in-progress reconciliation is not blocked by optional GitHub dependency lookup.
- Keep runner per-turn current-issue refresh on state/labels only via a GitHub no-blocker refresh path, so optional blocker GraphQL outages do not fail already-running Codex turns.

## Acceptance checklist
- [x] Native GitHub `Issue.blockedBy` lookup failures no longer create synthetic unknown `BlockedBy` refs.
- [x] Body fallback lookup failures no longer create synthetic `Identifier: #N` blocker refs.
- [x] Native failure behavior returns a tracker error only for Todo-like candidate fetch / dispatch revalidation where the blocker gate applies; non-Todo listing/refresh paths skip hydration.
- [x] Rate-limit and transport-error regressions prove lookup failures do not create permanent/non-terminal blockers.
- [x] Existing real blocker behavior remains covered: successful native blockers, successful body fallback blockers, terminal blockers, absent blockers, chunked native lookup, and native pagination fail-closed behavior.
- [x] No persistent cache, new labels, queue concepts, or worker-side tracker writes.

## Upstream / SPEC evidence
- `docs/research/SPEC.md:54-60`: Symphony is a scheduler/runner and tracker reader; tracker writes stay agent/workflow-side.
- `docs/research/SPEC.md:1225-1229`: candidate-fetch failures skip dispatch for the tick; running-state refresh failures keep active workers running.
- `docs/research/SPEC.md:1586-1603`: tracker candidate-fetch failures retry on the next tick; reconciliation refresh failures retry later.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/orchestrator.ex:248-299`: upstream logs tracker fetch errors and keeps state rather than inventing business state.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/orchestrator.ex:909-926`: upstream dispatch refresh failure skips the stale dispatch.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff is 6 files / ~167 production LOC changed; tests excluded.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test ./internal/tracker -run 'TestGitHubClient(ListIssuesByStatesSkipsBlockerLookupForNonTodoStates|FetchIssueStatesByRefsSkipsBlockerLookupForNonTodoStates|ListIssuesByStatesReturnsErrorWhenNativeBlockerLookupIsRateLimited|ListIssuesByStatesOmitsBodyFallbackWhenLookupTransportFails|FetchIssueStatesWithoutBlockersByRefsSkipsBlockerHydration)' -count=1`
- [x] `go test ./internal/orchestrator -run TestRuntimeDispatcherIssueStateRefresherUsesNoBlockerRefreshWhenAvailable -count=1`
- [x] `go test ./internal/tracker -count=1`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (`0 issues`)
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

## Mutation check
- [x] Native lookup failure mutation: changed `return nil, nativeErr` to `return out, nil`; `TestGitHubClientListIssuesByStatesReturnsErrorWhenNativeBlockerLookupIsRateLimited` failed as expected.
- [x] Body fallback mutation: restored synthetic fallback blocker on lookup error; `TestGitHubClientListIssuesByStatesOmitsBodyFallbackWhenLookupTransportFails` failed as expected.
- [x] Runner no-blocker refresh mutation: changed per-turn refresh back to blocker-aware `fetchIssueStates`; `TestRuntimeDispatcherIssueStateRefresherUsesNoBlockerRefreshWhenAvailable` failed as expected.
- [x] Non-Todo hydration mutation: made every source require hydration; `TestGitHubClientListIssuesByStatesSkipsBlockerLookupForNonTodoStates` and `TestGitHubClientFetchIssueStatesByRefsSkipsBlockerLookupForNonTodoStates` failed as expected.

## Review ledger
- Official `@codex review` on `9eb4f659`: P2 requested scoping GitHub blocker errors to Todo listings; fixed by passing source state into blocker hydration, hydrating only Todo-like states, and adding listing + refresh regressions for terminal `done` issues.
- Official `@codex review` on `fbb09ece`: "Didn't find any major issues."
- Subagent review fallback: `spawn_agent` was discovered but contract requires explicit subagent/delegation request; not used.
- Claude fallback: Claude Code / `claude` intentionally not invoked per operator instruction.
- Codex CLI fallback review round 1: `NEEDS-CHANGES`; fixed the runner per-turn blocker-hydration regression, and refuted the body-fallback finding because #1053 explicitly allows best-effort omission for body phrase lookup failure.
- Codex CLI fallback review round 2: `MERGE-READY`, no severity-tagged findings.
- Local diff review: `MERGE-READY`; no SPEC boundary expansion, no tracker writes, no cache/queue/label changes.

## Notes
- Final head: `fbb09ece7d5729383434c5ba86889806e45a134a`.
- CI / PR Metadata / PR Title: green on final head; warning audit clean.
- Review threads: previous P2 thread replied to and resolved; no unresolved current-head threads.
- Deferrals / follow-up issues: none.
