### PR TITLE
fix(workflow): keep transient review gates out of blocked

### DIFF
--- a/docs/runbooks/github-maker-reviewer-automerge-e2e.md
+++ b/docs/runbooks/github-maker-reviewer-automerge-e2e.md
@@ -196,10 +196,13 @@ done
 ```
 
 `aiops:blocked` is an inactive operator-triage state for true blockers: missing
-tools/auth/permissions, explicit Codex usage/input-required stops, or issue
-scope that cannot continue without an operator decision. The workflow examples
-do not use historical `CHANGES_REQUESTED` count as a stop condition; repeated
-loops are prevented by refusing unchanged-head handoffs/reviews. A
+tools/auth/permissions or issue scope that cannot continue without an operator
+decision. Codex review no-signal, NOT-CONFIRMED, usage-limit, CI pending, and
+auto-merge pending stay in `aiops:human-review`; current-head unresolved review
+threads are reviewer FAIL evidence that moves the issue to `aiops:rework`. The
+workflow examples do not use historical `CHANGES_REQUESTED` count as a stop
+condition; repeated loops are prevented by refusing unchanged-head
+handoffs/reviews. A
 `Rework response:` comment alone does not replace a new PR head. Blocked
 handoff commands remove the role's active label (`aiops:todo`, `aiops:rework`,
 or `aiops:human-review`) while adding `aiops:blocked`; adding only

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -81,8 +81,10 @@ Historical `CHANGES_REQUESTED` count is diagnostic only. Do not use it as a
 hard stop while each cycle has a new head; a `Rework response:` explains the
 fix, but it does not replace a new PR head. Prevent duplicate loops by refusing
 unchanged-head handoffs or reviews.
-Explicit Codex usage-limit/input-required results count as true blockers because
-another automatic reviewer turn would repeat the same non-actionable stop.
+Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending
+stay in `aiops:human-review`; they are not `aiops:blocked` reasons. A later
+reviewer poll can re-check the same head. Current-head unresolved review threads
+are normal FAIL evidence and move the issue to `aiops:rework`.
 
 The normal flow is:
 
@@ -179,6 +181,9 @@ Treat governance failures as blockers, not reasons to collapse roles:
   `Rework response:`.
 - CI still running after approval: leave the issue in `aiops:human-review` so a
   later reviewer continuation can re-check the same PR before marking Done.
+- Codex review no-signal, NOT-CONFIRMED, usage-limit, or asynchronous review
+  delay: comment the evidence, leave the issue in `aiops:human-review`, and let
+  a later reviewer poll re-check. Do not move it to `aiops:blocked`.
 - PR already merged but approval/check evidence is missing for the merged head:
   stop and collect the missing evidence or escalate to an operator. Do not jump
   straight to Done.

--- a/examples/github-maker-WORKFLOW.md
+++ b/examples/github-maker-WORKFLOW.md
@@ -119,13 +119,18 @@ Rework convergence rules:
 - Every rework handoff MUST include an issue comment that starts with `Rework response:`,
   naming the reviewed head, the new head, and how each
   finding was addressed.
-- If you cannot address the finding, comment `Blocked rework:` with the blocker
-  and move the issue to `aiops:blocked` instead of adding `aiops:human-review`:
+- If you cannot address a concrete reviewer finding because progress is blocked
+  by a true external/operator-owned dependency, comment `Blocked rework:` with
+  the blocker and move the issue to `aiops:blocked` instead of adding
+  `aiops:human-review`:
   `gh issue edit <N> --remove-label aiops:todo --remove-label aiops:rework --add-label aiops:blocked`.
-- If Codex reports a usage-limit/input-required result, or the latest finding is
-  still not actionable after one bounded clarification pass, comment the bounded
-  result and move the issue to `aiops:blocked` so an operator can decide whether
-  to redrive or split it:
+- Codex review uncertainty, no-signal, NOT-CONFIRMED, usage-limit, CI pending,
+  and auto-merge pending are not `aiops:blocked` reasons. If the latest
+  reviewer/Codex signal is only transient or non-actionable, comment the
+  evidence, leave the issue in its current maker-active label
+  (`aiops:todo` or `aiops:rework`), and stop without adding
+  `aiops:human-review`; the next maker poll can re-check.
+- The blocked command for that true external/operator-owned blocker is:
   `gh issue edit <N> --remove-label aiops:todo --remove-label aiops:rework --add-label aiops:blocked`.
 
 Hard constraints:

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -137,11 +137,13 @@ FAIL:
 - This is your LAST action.
 
 BLOCKED:
-- If Codex usage-limit/input-required stops the review, or the review cannot
-  produce an actionable PASS/FAIL after one bounded clarification pass, comment
-  the bounded reason and move the issue to `aiops:blocked` instead of FAIL/PASS.
-  Do not leave an open issue labeled `aiops:human-review` when the next reviewer
-  would only repeat the same non-actionable turn:
+- Codex NOT-CONFIRMED, no-signal, usage-limit, CI pending, and auto-merge
+  pending are not `aiops:blocked` reasons. Comment the evidence, leave the issue
+  in `aiops:human-review`, and stop so a later reviewer poll can re-check.
+- unresolved non-outdated current-head review threads are FAIL inputs, not
+  blockers; collect them in the review body and move the issue back to Rework.
+- Use `aiops:blocked` only for a true external/operator-owned blocker that
+  prevents reviewer progress outside the normal review/retry loop:
   `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:blocked`.
 
 PASS:

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -33,7 +33,7 @@ func TestGitHubMakerReviewerRunbookDocumentsReusableHarness(t *testing.T) {
 		"true blockers",
 		"Blocked\nhandoff commands remove the role's active label",
 		"historical `CHANGES_REQUESTED` count",
-		"unchanged-head handoffs/reviews",
+		"unchanged-head\nhandoffs/reviews",
 		"comment alone does not replace a new PR head",
 		"current-head unresolved non-outdated review threads",
 		"worker --doctor --deploy=binary --mode=real",
@@ -93,7 +93,7 @@ func TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology(t *testin
 		"diagnostic only",
 		"unchanged-head",
 		"does not replace a new PR head",
-		"usage-limit/input-required",
+		"Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending\nstay in `aiops:human-review`",
 		"branch protection",
 		"required status check",
 		"required approving review",
@@ -148,10 +148,12 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 				"would require handing off the same unchanged head\n   again",
 				"aiops:blocked",
 				"gh issue edit <N> --remove-label aiops:todo --remove-label aiops:rework --add-label aiops:blocked",
-				"Codex reports a usage-limit/input-required result",
+				"Codex review uncertainty, no-signal, NOT-CONFIRMED, usage-limit, CI pending",
+				"leave the issue in its current maker-active label",
+				"true external/operator-owned blocker",
 				"LAST action",
 			},
-			mustNotContain: []string{"gitea_issue_labels", "AIOPS_MAKER_MAX_REWORK_CYCLES", "max rework cycle budget"},
+			mustNotContain: []string{"gitea_issue_labels", "AIOPS_MAKER_MAX_REWORK_CYCLES", "max rework cycle budget", "Codex reports a usage-limit/input-required result"},
 		},
 		{
 			path:            "examples/github-reviewer-automerge-WORKFLOW.md",
@@ -184,11 +186,11 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 				"Reviewer re-queued unchanged head <headRefOid>; waiting for maker rework",
 				"Then move the issue back to Rework as your LAST action and stop",
 				"aiops:blocked",
-				"gh issue edit <N> --remove-label aiops:human-review --add-label aiops:blocked",
-				"Codex usage-limit/input-required",
-				"Do not leave an open issue labeled",
+				"Codex NOT-CONFIRMED, no-signal, usage-limit, CI pending",
+				"leave the issue in `aiops:human-review`",
+				"true external/operator-owned blocker",
 			},
-			mustNotContain: []string{"gitea_issue_labels", "--json merged,", "AIOPS_REVIEWER_MAX_REWORK_CYCLES", "max rework cycle budget"},
+			mustNotContain: []string{"gitea_issue_labels", "--json merged,", "AIOPS_REVIEWER_MAX_REWORK_CYCLES", "max rework cycle budget", "Codex usage-limit/input-required stops the review"},
 		},
 	} {
 		full := filepath.Join(root, tc.path)
@@ -244,6 +246,63 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGitHubMakerReviewerWorkflowPromptsKeepTransientReviewGatesOutOfBlocked(t *testing.T) {
+	root := repoRoot(t)
+	makerPaths := []string{
+		"examples/github-maker-WORKFLOW.md",
+	}
+	reviewerPaths := []string{
+		"examples/github-reviewer-automerge-WORKFLOW.md",
+	}
+	for _, path := range append(append([]string{}, makerPaths...), reviewerPaths...) {
+		body := readFileString(t, filepath.Join(root, path))
+		bodyText := normalizedWorkflowText(body)
+		for _, forbidden := range []string{
+			"Codex reports a usage-limit result",
+			"Codex reports a usage-limit/input-required result",
+			"Codex usage-limit stops the review",
+			"Codex usage-limit/input-required stops the review",
+			"GitHub Codex review not confirmed for head <sha>` and move\n   the issue to `aiops:blocked`",
+			"Do not leave an open issue labeled `aiops:human-review` when the next reviewer would only repeat",
+		} {
+			if strings.Contains(bodyText, normalizedWorkflowText(forbidden)) {
+				t.Fatalf("%s still routes transient Codex review state to blocked via %q", path, forbidden)
+			}
+		}
+	}
+	for _, path := range makerPaths {
+		body := readFileString(t, filepath.Join(root, path))
+		bodyText := normalizedWorkflowText(body)
+		for _, want := range []string{
+			"Codex review uncertainty, no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending are not `aiops:blocked` reasons",
+			"leave the issue in its current maker-active label",
+			"true external/operator-owned blocker",
+		} {
+			if !strings.Contains(bodyText, normalizedWorkflowText(want)) {
+				t.Fatalf("%s missing maker transient-review guidance %q", path, want)
+			}
+		}
+	}
+	for _, path := range reviewerPaths {
+		body := readFileString(t, filepath.Join(root, path))
+		bodyText := normalizedWorkflowText(body)
+		for _, want := range []string{
+			"Codex NOT-CONFIRMED, no-signal, usage-limit, CI pending, and auto-merge pending are not `aiops:blocked` reasons",
+			"leave the issue in `aiops:human-review`",
+			"unresolved non-outdated current-head review threads",
+			"move the issue back to Rework",
+		} {
+			if !strings.Contains(bodyText, normalizedWorkflowText(want)) {
+				t.Fatalf("%s missing reviewer transient-review guidance %q", path, want)
+			}
+		}
+	}
+}
+
+func normalizedWorkflowText(text string) string {
+	return strings.Join(strings.Fields(text), " ")
 }
 
 func TestGitHubMakerReviewerBootstrapPreparesRunRoot(t *testing.T) {


### PR DESCRIPTION
Closes #1052

## Summary
- Update GitHub maker/reviewer workflow guidance so Codex no-signal / NOT-CONFIRMED / usage-limit, CI pending, and auto-merge pending stay in active review states instead of moving to `aiops:blocked`.
- Make reviewer behavior explicit: unresolved non-outdated current-head review threads are FAIL inputs that move `aiops:human-review` to `aiops:rework`.
- Update the reusable workflow examples and GitHub maker/reviewer runbooks, plus doc tests that prevent reintroducing the old blocked-label rule.

## Acceptance checklist
- [x] Examples keep transient Codex review uncertainty, CI pending, and auto-merge pending out of `aiops:blocked`.
- [x] Reviewer prompt says Codex NOT-CONFIRMED/no-signal/usage-limit leaves the issue in `aiops:human-review`; no merge/approval/block.
- [x] Reviewer prompt says unresolved current-head review threads are FAIL/rework, not blocked.
- [x] Maker prompt says Codex review uncertainty leaves the issue in the current maker-active label; `aiops:blocked` is only for a true external/operator-owned blocker on a concrete finding.
- [x] Governance and E2E runbooks describe the same semantics.
- [x] Workflow docs tests pin the simplified semantics and reject the old usage-limit -> blocked wording.
- [x] No new tracker labels, durable blocked state, worker-owned PR/review gate, or auto-merge broadening.

## Upstream / SPEC evidence
- `docs/research/SPEC.md:54-60`: Symphony is a scheduler/runner and tracker reader; handoff states such as Human Review are workflow-defined.
- `docs/research/SPEC.md:781-796`: normal continuation/failures use retry/backoff semantics.
- `docs/research/SPEC.md:1225-1239`: tracker errors skip/continue; ticket writes remain workflow/agent-side.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/orchestrator.ex:200-245`: ordinary agent exits retry/backoff unless they are input-required blockers.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/orchestrator.ex:652-657`: blocked state is tied to input/approval/elicitation-style operator blockers.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 0 production Go files changed; tracked diff is workflow docs/examples plus scripts tests.
- [ ] `size-gated: justified overage` — over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run 'TestGitHubMakerReviewerWorkflow(PromptsKeepTransientReviewGatesOutOfBlocked|ExamplesLoadAndPinBoundaries)|TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology|TestGitHubMakerReviewerRunbookDocumentsReusableHarness' -count=1 ./scripts`
- [x] `go test ./scripts -count=1`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` (`0 issues`)
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

## Mutation check
- [x] Reintroduced the old tracked reviewer-example rule (`Codex usage-limit/input-required stops the review` -> `aiops:blocked`); `TestGitHubMakerReviewerWorkflowPromptsKeepTransientReviewGatesOutOfBlocked` failed as expected.

## Review ledger
- Claude fallback: Claude Code / `claude` intentionally not invoked per operator instruction.
- Subagent fallback: not used; this was a focused docs/workflow prompt change and the operator explicitly disallowed Claude Code.
- Local diff review: no worker/orchestrator code changes, no new labels/state machines/cache/gates, and no auto-merge broadening.

## Notes
- The local ignored deployment copies under `.aiops/bwu/workflows/` were updated in this workspace, but `.aiops/` is excluded by this checkout and is not part of the PR diff. The tracked reusable sources are `examples/github-maker-WORKFLOW.md` and `examples/github-reviewer-automerge-WORKFLOW.md`.
- Deferrals / follow-up issues: none.
