### PR TITLE
docs(runner): audit codex app-server multi-agent mode

### DIFF
--- a/docs/validation/2026-07-03-codex-multi-agent-mode-audit.md
+++ b/docs/validation/2026-07-03-codex-multi-agent-mode-audit.md
@@ -1,0 +1,105 @@
+# Codex app-server multiAgentMode audit
+
+**Date:** 2026-07-03
+**Issue:** #1056
+
+## Verdict
+
+Keep `thread/start.multiAgentMode: "none"` in the Codex app-server runner.
+
+This is a Codex protocol compatibility pin, not a host-local capability gate.
+For the vendored 0.142.0 target schema, `none` preserves the pre-0.142 prompt
+contract by avoiding injected multi-agent delegation instructions. It does not
+disable multi-agent tools, runner-advertised `dynamicTools`, host MCP discovery,
+skills, Apps/connectors, plugin-provided capability, or Codex config inheritance.
+
+No SPEC deviation is needed. Upstream Symphony does not send this field because
+it tracks an older Codex protocol shape, but SPEC allows implementations to use
+the targeted protocol to advertise client-side tools and set supported runner
+policy. The aiops-platform runner keeps advertising `dynamicTools` in the same
+`thread/start` payload.
+
+## Evidence
+
+### Vendored target schema: Codex 0.142.0
+
+`internal/runner/testdata/codex_app_server_protocol_v0_142_0.v2.schemas.json`
+was generated with `codex app-server generate-json-schema --experimental` and
+is the runner's checked-in contract for `CodexProtocolVersion = "0.142.0"`.
+
+Relevant schema facts:
+
+- `MultiAgentMode` says it controls whether the model receives multi-agent
+  delegation instructions, and that `none` leaves multi-agent tools available
+  without injecting delegation instructions.
+- `ThreadStartParams.multiAgentMode` says omitted defaults to
+  `explicitRequestOnly`.
+- `ThreadStartParams.dynamicTools` is a separate property on the same request
+  object.
+
+That is the reason PR #999 pinned `multiAgentMode` to `none`: omitting the field
+would have opted aiops-platform into `explicitRequestOnly` instruction injection
+after the Codex 0.142 schema bump.
+
+### Current local Codex schema: Codex 0.142.5
+
+Checked locally in this workspace:
+
+```bash
+codex --version
+tmp=$(mktemp -d)
+codex app-server generate-json-schema --out "$tmp" --experimental
+```
+
+The local binary reports `codex-cli 0.142.5`. Its generated schema still defines
+`MultiAgentMode` as delegation-instruction control and says `none` leaves the
+multi-agent tools available. The request property is now described as
+deprecated/ignored, while `dynamicTools` remains a separate `ThreadStartParams`
+property.
+
+That current schema is compatible with keeping the 0.142.0 pin: at worst the
+newer app-server ignores it, and it still is not a capability disablement.
+
+### Runner payload and tests
+
+The runner's `buildThreadStartParams` sends:
+
+- `approvalPolicy`
+- `sandbox`
+- `cwd`
+- `dynamicTools`
+- `multiAgentMode: "none"`
+
+It does not send a `config` object. That keeps host-local Codex config discovery
+in Codex's own hands and avoids the Apps/connectors disablement class covered by
+#1049.
+
+The regression tests now cover the important wiring seam:
+
+- `TestBuildThreadStartParamsPinsMultiAgentModeWithoutSuppressingDynamicTools`
+  fails if the field is omitted/changed or if runner dynamic tools stop being
+  advertised under `multiAgentMode: "none"`.
+- `TestBuildThreadStartParamsPreservesInheritedCodexAppConfig` fails if the
+  runner reintroduces a `thread/start.config` override that could suppress
+  host-local Apps/connectors or other Codex config.
+- `TestCodexAppServerThreadStartPayloadMatchesSchema` validates the actual
+  `thread/start` payload against the vendored experimental schema and exercises
+  a non-empty `DynamicToolSpec`.
+
+## Upstream and SPEC comparison
+
+Upstream Symphony's Elixir app-server sends `approvalPolicy`, `sandbox`, `cwd`,
+and `dynamicTools` in `thread/start`; it does not send `multiAgentMode`.
+
+SPEC says the runner should advertise implemented client-side tools using the
+targeted app-server protocol. For aiops-platform's targeted 0.142.0 protocol,
+the compatibility pin and explicit `dynamicTools` advertisement are both part
+of that request shape. No worker-side tracker write, verification phase, gate,
+cache, or artifact is introduced here.
+
+## Non-goals
+
+- Do not change #1049's Apps/connectors, `CODEX_HOME`, shell environment, or
+  repo-owned skill dependency work.
+- Do not add a workflow config key.
+- Do not add a worker/orchestrator phase, gate, artifact, or tracker mutation.

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -520,7 +520,9 @@ func buildInitializeParams() map[string]any {
 // buildThreadStartParams is the thread/start payload. dynamicTools is an
 // experimental field gated by the experimentalApi capability set in
 // buildInitializeParams; it advertises the SPEC §10.5 client-side tool surface
-// (e.g. linear_graphql) to the agent.
+// (e.g. linear_graphql) to the agent. multiAgentMode is intentionally separate:
+// Codex 0.142.0 used it to control delegation instruction injection, not host
+// config, MCP, skills, Apps/connectors, plugins, or dynamic tool availability.
 func buildThreadStartParams(in RunInput, approvalPolicy any) map[string]any {
 	return map[string]any{
 		"approvalPolicy": approvalPolicy,

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -292,12 +292,17 @@ func TestBuildThreadStartParamsPreservesInheritedCodexAppConfig(t *testing.T) {
 	}
 }
 
-func TestBuildThreadStartParamsPinsMultiAgentMode(t *testing.T) {
+func TestBuildThreadStartParamsPinsMultiAgentModeWithoutSuppressingDynamicTools(t *testing.T) {
 	in := appServerInput(codexWorkdir(t, "pin multi-agent mode"))
+	in.Workflow.Config.Tracker.Kind = "linear"
+	in.Workflow.Config.Tracker.APIKey = "linear-secret"
 	payload := buildThreadStartParams(in, in.Workflow.Config.Codex.ApprovalPolicy)
 
 	if got := payload["multiAgentMode"]; got != "none" {
 		t.Fatalf("thread/start multiAgentMode = %#v; want none to preserve WORKFLOW-only instructions", got)
+	}
+	if tools, _ := payload["dynamicTools"].([]map[string]any); len(tools) == 0 {
+		t.Fatalf("thread/start dynamicTools = %#v; want tools still advertised because multiAgentMode is not a capability gate", payload["dynamicTools"])
 	}
 }
 


### PR DESCRIPTION
Closes #1056

## Summary
- Keep `thread/start.multiAgentMode: none` and document why it is an instruction-injection compatibility pin, not a host-local capability disablement.
- Add a durable validation note for the vendored Codex 0.142.0 schema, current local Codex 0.142.5 generated schema, SPEC §10, and upstream Elixir app-server comparison.
- Strengthen the runner test so the same seam proves `multiAgentMode: none` does not suppress runner-advertised `dynamicTools`.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

## Acceptance
- [x] Live/current schema check documented: local `codex-cli 0.142.5` generated schema keeps `MultiAgentMode` instruction-only semantics and marks the request field deprecated/ignored, with `dynamicTools` still separate.
- [x] Vendored target schema check documented: 0.142.0 says `none` leaves multi-agent tools available and omitted defaults to `explicitRequestOnly`.
- [x] Tests cover unattended-run behavior: pinned `multiAgentMode: none`, non-empty runner `dynamicTools`, no `thread/start.config` override, and schema validation of the actual request payload.
- [x] Code comments/docs explain why this is not host-local MCP/skills/Apps/connectors/plugin disablement.
- [x] #1049 remains separate; this PR does not touch Apps/connectors, `CODEX_HOME`, shell environment inheritance, or repo-owned skill dependency work.

## Upstream evidence
- SPEC §10 says the targeted Codex app-server protocol/schema controls request shape and client-side tools should be advertised via that protocol.
- Upstream Elixir `codex/app_server.ex` sends `approvalPolicy`, `sandbox`, `cwd`, and `dynamicTools`, but does not send `multiAgentMode`.
- aiops-platform keeps upstream's tool advertisement and adds only the current Codex-protocol compatibility pin introduced by #999.

## Verification
- `codex --version` -> `codex-cli 0.142.5`
- `codex app-server generate-json-schema --out "$tmp" --experimental` and inspected `MultiAgentMode`, `ThreadStartParams.multiAgentMode`, and `ThreadStartParams.dynamicTools`.
- `go test ./internal/runner -run 'TestBuildThreadStartParams(PreservesInheritedCodexAppConfig|PinsMultiAgentModeWithoutSuppressingDynamicTools)|TestCodexAppServerThreadStartPayloadMatchesSchema' -count=1`
- Mutation check: changed committed `multiAgentMode` from `none` to `explicitRequestOnly`; `TestBuildThreadStartParamsPinsMultiAgentModeWithoutSuppressingDynamicTools` failed, then restored.
- Mutation check: changed committed `dynamicTools` to an empty slice; `TestBuildThreadStartParamsPinsMultiAgentModeWithoutSuppressingDynamicTools` failed, then restored.
- `go test ./internal/runner -count=1`
- `gofmt -l $(git ls-files '*.go')`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go test -race -covermode=atomic ./...`
- `go build ./cmd/worker ./cmd/tui`

## Review fallback
Claude Code is unavailable per operator instruction. I used a bounded read-only Codex local diff review plus manual SPEC/schema/Elixir review instead; Codex local review result: `No blocking findings`.