### PR TITLE
fix(runner): scope CODEX_HOME to codex app-server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,10 +259,10 @@ specific observed failure per the "Earned rules" principle.
    operator-enabled Apps/connectors, plugin-provided capability, and shell-tool
    environment according to Codex's own discovery/config rules. Do not disable
    host-local skills/MCP/Apps/connectors by default or drop `CODEX_HOME` from the
-   agent subprocess baseline. Repo-owned required skill/MCP declarations are
-   portability and diagnostics hardening for containers, remote hosts, or
-   explicitly declared dependencies — not a replacement for the local binary's
-   inherited Codex environment.
+   Codex app-server subprocess environment. Repo-owned required skill/MCP
+   declarations are portability and diagnostics hardening for containers, remote
+   hosts, or explicitly declared dependencies — not a replacement for the local
+   binary's inherited Codex environment.
    ([provenance](docs/engineering-rules-rationale.md#cross-cutting-checklist))
 
 5. **Run an adversarial pass on your own diff before asking a human

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ key with type, default, behavior, and validation rule) is
 | `agent.max_continuation_turns` | `agent.max_turns` (default `20`) issue-level clean-turn budget across fresh and continuation dispatches. Each dispatch receives the remaining clean-turn budget, capped again by `agent.max_turns`; reaching the budget parks the issue in local `blocked` state (`continuation_budget`) instead of looping forever. Raising the value later does not automatically redrive existing blocked claims. | implementation (accepted deviation D34 / #621) |
 | `agent.timeout` | `30m` | implementation (#215) |
 | `codex.command` | `codex app-server` | SPEC §6.4; real-Codex workflow templates add `--config shell_environment_policy.inherit=all` for upstream-style shell environment inheritance |
-| `codex.env_passthrough` / `claude.env_passthrough` | none beyond runner baseline (`PATH`, `HOME`, `CODEX_HOME`, `USER`, locale, `TZ`, `TERM`); use for model CLI auth/proxy/CA vars, not tracker/repo API tokens | implementation (#384, #1049) |
+| `codex.env_passthrough` / `claude.env_passthrough` | none beyond the selected runner baseline (`PATH`, `HOME`, `USER`, locale, `TZ`, `TERM`; Codex app-server also receives `CODEX_HOME`); use for model CLI auth/proxy/CA vars, not tracker/repo API tokens | implementation (#384, #1049, #1062) |
 | `server.port` | `4000` (`-1` disables the HTTP state server + dashboard) | implementation |
 | `policy.mode` | `draft_pr` (or `analysis_only`) | implementation |
 | `tracker.kind` | none — REQUIRED per SPEC §6.4; the loader rejects an empty value with an error that names the field and the allowed set (`gitea`, `github`, `linear`) | SPEC §6.4 |

--- a/docs/engineering-rules-rationale.md
+++ b/docs/engineering-rules-rationale.md
@@ -155,10 +155,10 @@ local binary deployments: a direct binary worker running under the same user as
 same Codex home. The portability hardening is to validate explicit repo-owned
 or workflow-declared dependencies when they are declared, not to amputate
 host-local skills/MCP/Apps/connectors/plugin capability from the local binary
-path. The same audit found two sibling regressions: the runner baseline omitted
-`CODEX_HOME`, breaking non-default Codex homes, and the default workflow command
-lacked upstream's `shell_environment_policy.inherit=all`, narrowing the
-environment seen by Codex-launched shell tools.
+path. The same audit found two sibling regressions: the Codex app-server
+environment omitted `CODEX_HOME`, breaking non-default Codex homes, and the
+default workflow command lacked upstream's `shell_environment_policy.inherit=all`,
+narrowing the environment seen by Codex-launched shell tools.
 
 ### Item 5 — run an adversarial pass on your own diff before a human looks
 `@codex review` reads SPEC + the Elixir reference + `AGENTS.md`, and surfaces

--- a/docs/runbooks/workflow-frontmatter-reference.md
+++ b/docs/runbooks/workflow-frontmatter-reference.md
@@ -112,7 +112,7 @@ over stdio).
 | Key | Type | Default | Behavior | Validation |
 |-----|------|---------|----------|------------|
 | `codex.command` | string | `codex app-server` | Launch command for the app-server subprocess; real-Codex workflow templates add `--config shell_environment_policy.inherit=all` for upstream-style shell-environment inheritance | `$VAR`; a `codex exec` argv is rejected (#541) |
-| `codex.env_passthrough` | string list | `[]` | Env vars the agent subprocess inherits beyond the runner baseline (`PATH`, `HOME`, `CODEX_HOME`, `USER`, locale, `TZ`, `TERM`) — for model CLI auth/proxy/CA vars. Tracker/repo tokens (`GITHUB_TOKEN`, `GITEA_TOKEN`, `LINEAR_API_KEY`, …) and the `tracker.api_key` variable/value are denied | denied names rejected at load |
+| `codex.env_passthrough` | string list | `[]` | Env vars the Codex app-server subprocess inherits beyond its baseline (`PATH`, `HOME`, `CODEX_HOME`, `USER`, locale, `TZ`, `TERM`) — for model CLI auth/proxy/CA vars. Tracker/repo tokens (`GITHUB_TOKEN`, `GITEA_TOKEN`, `LINEAR_API_KEY`, …) and the `tracker.api_key` variable/value are denied | denied names rejected at load |
 | `codex.approval_policy` | map | `granular` with every flag `false` (auto-reject all approval prompts) | Sent as the app-server approval policy | — |
 | `codex.thread_sandbox` | string | `workspace-write` | `thread/start` sandbox string; also the single knob the per-turn policy derives from (DEVIATIONS D32) | — |
 | `codex.turn_sandbox_policy` | typed map | derived from `thread_sandbox` | Explicit per-turn `sandboxPolicy` override; `type` is required (`dangerFullAccess`, `readOnly`, `externalSandbox`, `workspaceWrite`), with per-type required fields (`writableRoots`, `networkAccess`, …) | strict per-type field checking; legacy `mode:`-style shapes rejected |
@@ -127,7 +127,7 @@ over stdio).
 | Key | Type | Default | Behavior | Validation |
 |-----|------|---------|----------|------------|
 | `claude.command` | string | `claude` | Launch command for the Claude runner | `$VAR` |
-| `claude.env_passthrough` | string list | `[]` | Same semantics and deny-list as `codex.env_passthrough` | denied names rejected at load |
+| `claude.env_passthrough` | string list | `[]` | Same deny-list as `codex.env_passthrough`, but the default Claude/generic baseline excludes `CODEX_HOME`; opt in explicitly only when that runner intentionally needs it | denied names rejected at load |
 
 `claude:` shares the `codex:` schema shape, but the app-server fields
 (`approval_policy`, `thread_sandbox`, `turn_sandbox_policy`, the `*_timeout_ms`

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -130,17 +130,19 @@ The current Go implementation provides these safety controls:
   retries silently;
 - allow-listed environment for agent and hook subprocesses: by
   default these children run with only a small POSIX baseline env (`PATH`,
-  `HOME`, `CODEX_HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TZ`, `TERM`).
-  Tracker/repo tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`, `GITEA_TOKEN`) and any
-  other secret in the worker's `.env` are excluded — a malicious or buggy
-  WORKFLOW.md cannot `env > /tmp/dump` and exfiltrate them. Operators opt
-  non-tracker vars back in per workflow with `codex.env_passthrough`,
-  `claude.env_passthrough`, or `hooks.env_passthrough`; real-Codex workflow
-  templates that set `shell_environment_policy.inherit=all` also make those
-  intentionally passed variables visible to Codex-launched shell tools. Agent
-  and hook passthrough reject tracker/repo API token names, the configured
-  `tracker.api_key` env-var name, and env vars whose current value equals the
-  configured `tracker.api_key`, so those credentials stay behind
+  `HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TZ`, `TERM`); the Codex
+  app-server runner additionally receives `CODEX_HOME` so Codex can resolve its
+  configured home without giving that credential directory to non-Codex agents
+  by default. Tracker/repo tokens (`LINEAR_API_KEY`, `GITHUB_TOKEN`,
+  `GITEA_TOKEN`) and any other secret in the worker's `.env` are excluded — a
+  malicious or buggy WORKFLOW.md cannot `env > /tmp/dump` and exfiltrate them.
+  Operators opt non-tracker vars back in per workflow with
+  `codex.env_passthrough`, `claude.env_passthrough`, or `hooks.env_passthrough`;
+  real-Codex workflow templates that set `shell_environment_policy.inherit=all`
+  also make those intentionally passed variables visible to Codex-launched shell
+  tools. Agent and hook passthrough reject tracker/repo API token names, the
+  configured `tracker.api_key` env-var name, and env vars whose current value
+  equals the configured `tracker.api_key`, so those credentials stay behind
   orchestrator-owned tools. See
   [`docs/design/hook-verify-env-allowlist.md`](design/hook-verify-env-allowlist.md);
 - allow-listed redaction of Codex `turn/failed`, `turn/cancelled`, and failed

--- a/docs/superpowers/specs/2026-07-03-preserve-codex-app-environment-design.md
+++ b/docs/superpowers/specs/2026-07-03-preserve-codex-app-environment-design.md
@@ -47,8 +47,8 @@ discovery.
 
 Preserve Codex home inheritance explicitly. `CODEX_HOME` is part of Codex's
 documented environment surface and points at config, auth, logs, sessions,
-skills, and standalone package metadata; the runner baseline should pass it to
-the app-server when the worker has it set.
+skills, and standalone package metadata; the Codex app-server environment should
+pass it to the app-server when the worker has it set.
 
 Preserve Codex shell-tool environment inheritance in real-Codex workflow
 templates. The core `codex.command` default remains the SPEC §6.4 value
@@ -68,7 +68,7 @@ tracker-specific workflow actions.
 - Remove the default `thread/start.config` payload that forces
   `features.apps=false`, `features.connectors=false`, and
   `apps._default.enabled=false`.
-- Add `CODEX_HOME` to the agent subprocess baseline environment.
+- Add `CODEX_HOME` to the Codex app-server subprocess environment.
 - Update workflow examples and runbooks that explicitly pin
   `command: codex app-server` so real-Codex templates use the upstream-style
   inherited shell environment when real Codex is intended.
@@ -119,10 +119,12 @@ continue validating the actual payload. The standalone `Config` schema test for
 `appServerThreadConfig` should be removed because the runner no longer builds a
 thread config by default.
 
-`agentEnv` should include `CODEX_HOME` in its baseline next to `HOME`. Existing
-tracker-token deny logic still applies to both baseline and passthrough names, so
-this does not expose `GITHUB_TOKEN`, `GITEA_TOKEN`, `LINEAR_API_KEY`, or the
-configured tracker token value.
+The Codex app-server environment should include `CODEX_HOME` next to `HOME`.
+Existing tracker-token deny logic still applies to both baseline and passthrough
+names, so this does not expose `GITHUB_TOKEN`, `GITEA_TOKEN`, `LINEAR_API_KEY`,
+or the configured tracker token value. Non-Codex runners should keep
+`CODEX_HOME` out of their default baseline unless a workflow explicitly opts in
+through that runner's `env_passthrough`.
 
 Real-Codex workflow templates should use the upstream-style command:
 
@@ -147,8 +149,8 @@ active; it does not need a shell wrapper.
   rollback.
 - Remove `TestCodexAppServerThreadConfigMatchesSchema`; the config helper should
   no longer exist.
-- Add/adjust tests proving `CODEX_HOME` is part of the runner baseline and the
-  app-server subprocess environment.
+- Add/adjust tests proving `CODEX_HOME` is part of the app-server subprocess
+  environment and absent from non-Codex runner defaults.
 - Keep SPEC-default tests for `codex app-server`; use template/doc checks for
   the explicit real-Codex workflow command posture.
 - Run:
@@ -180,7 +182,7 @@ git diff --check
 Treat these as inheritance regressions and handle them in this rollback:
 
 - Default `thread/start.config` disabled Apps/connectors.
-- Agent subprocess baseline omitted `CODEX_HOME`.
+- Codex app-server environment omitted `CODEX_HOME`.
 - Real-Codex workflow templates pinned the narrower `codex app-server` command
   instead of the upstream-style
   `codex app-server --config shell_environment_policy.inherit=all`.

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -126,7 +126,7 @@ func (CodexAppServerRunner) Run(ctx context.Context, in RunInput) (Result, error
 // launches codex directly (vs a shell wrapper) and sandboxEnabled whether the
 // sandbox wraps it — both feed appServerProcessPID's PID-emission guard.
 func setupAppServerCommand(ctx context.Context, in RunInput) (cmd *exec.Cmd, directCodexExec, sandboxEnabled bool, err error) {
-	env := agentEnv(in.Workflow.Config.Codex.EnvPassthrough, in.Workflow.Config)
+	env := codexAppServerEnv(in.Workflow.Config.Codex.EnvPassthrough, in.Workflow.Config)
 	// Pin the agent's Go toolchain caches to a sandbox-writable, per-workspace
 	// path so its first `go test` does not fail on the default $HOME-based
 	// caches that lie outside codex's workspace-write sandbox (#544).

--- a/internal/runner/env.go
+++ b/internal/runner/env.go
@@ -11,7 +11,6 @@ import (
 var baselineAgentEnvAllowlist = []string{
 	"PATH",
 	"HOME",
-	"CODEX_HOME",
 	"USER",
 	"LANG",
 	"LC_ALL",
@@ -20,10 +19,16 @@ var baselineAgentEnvAllowlist = []string{
 	"TERM",
 }
 
+var codexAppServerEnvAllowlist = append(append([]string{}, baselineAgentEnvAllowlist...), "CODEX_HOME")
+
 var agentLoginPATH = workspace.LoginPATH
 
 func agentEnv(passthrough []string, cfg workflow.Config) []string {
 	return agentEnvWithLookup(passthrough, cfg, os.LookupEnv, agentLoginPATH)
+}
+
+func codexAppServerEnv(passthrough []string, cfg workflow.Config) []string {
+	return codexAppServerEnvWithLookup(passthrough, cfg, os.LookupEnv, agentLoginPATH)
 }
 
 // AgentEnvForPreflight returns the same sanitized environment used by the
@@ -32,7 +37,7 @@ func agentEnv(passthrough []string, cfg workflow.Config) []string {
 func AgentEnvForPreflight(agent string, cfg workflow.Config) []string {
 	switch agent {
 	case NameCodexAppServer:
-		return agentEnv(cfg.Codex.EnvPassthrough, cfg)
+		return codexAppServerEnv(cfg.Codex.EnvPassthrough, cfg)
 	case "claude":
 		return agentEnv(cfg.Claude.EnvPassthrough, cfg)
 	default:
@@ -42,4 +47,8 @@ func AgentEnvForPreflight(agent string, cfg workflow.Config) []string {
 
 func agentEnvWithLookup(passthrough []string, cfg workflow.Config, lookup func(string) (string, bool), loginPath func() string) []string {
 	return envpolicy.BuildSanitizedEnv(baselineAgentEnvAllowlist, passthrough, cfg, lookup, loginPath)
+}
+
+func codexAppServerEnvWithLookup(passthrough []string, cfg workflow.Config, lookup func(string) (string, bool), loginPath func() string) []string {
+	return envpolicy.BuildSanitizedEnv(codexAppServerEnvAllowlist, passthrough, cfg, lookup, loginPath)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -251,6 +251,7 @@ func TestShellRunnerDoesNotInheritWorkerSecretsByDefault(t *testing.T) {
 	t.Setenv("LINEAR_API_KEY", "linear-secret")
 	t.Setenv("GITEA_TOKEN", "gitea-secret")
 	t.Setenv("GITHUB_TOKEN", "github-secret")
+	t.Setenv("CODEX_HOME", filepath.Join(workdir, "codex-home"))
 
 	wf := workflow.Workflow{Config: workflow.Config{
 		Workspace: workflow.WorkspaceConfig{Root: filepath.Dir(workdir)},
@@ -275,6 +276,9 @@ func TestShellRunnerDoesNotInheritWorkerSecretsByDefault(t *testing.T) {
 		if strings.Contains(string(body), secretName+"=") {
 			t.Fatalf("runner env leaked %s:\n%s", secretName, body)
 		}
+	}
+	if strings.Contains(string(body), "CODEX_HOME=") {
+		t.Fatalf("shell runner inherited Codex credential home by default:\n%s", body)
 	}
 	if !strings.Contains(string(body), "PATH=") {
 		t.Fatalf("runner env lost baseline PATH:\n%s", body)
@@ -434,6 +438,27 @@ func TestAgentEnvUsesLoginShellPATHSnapshot(t *testing.T) {
 	}
 }
 
+func TestAgentEnvForPreflightScopesCodexHomeToCodexAppServer(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	t.Setenv("CODEX_HOME", codexHome)
+
+	cfg := workflow.Config{}
+	codexEnv := strings.Join(AgentEnvForPreflight(NameCodexAppServer, cfg), "\n")
+	if !strings.Contains(codexEnv, "CODEX_HOME="+codexHome) {
+		t.Fatalf("codex preflight env missing CODEX_HOME=%q:\n%s", codexHome, codexEnv)
+	}
+
+	claudeEnv := strings.Join(AgentEnvForPreflight("claude", cfg), "\n")
+	if strings.Contains(claudeEnv, "CODEX_HOME=") {
+		t.Fatalf("claude preflight env inherited Codex credential home:\n%s", claudeEnv)
+	}
+
+	genericEnv := strings.Join(AgentEnvForPreflight("mock", cfg), "\n")
+	if strings.Contains(genericEnv, "CODEX_HOME=") {
+		t.Fatalf("generic preflight env inherited Codex credential home:\n%s", genericEnv)
+	}
+}
+
 func TestAgentEnvWithLookupBoundaryTable(t *testing.T) {
 	cfg := workflow.Config{
 		Tracker: workflow.TrackerConfig{APIKey: "configured-tracker-secret"},
@@ -480,7 +505,6 @@ func TestAgentEnvWithLookupBoundaryTable(t *testing.T) {
 	}{
 		{name: "PATH", wantValue: "/login/path"},
 		{name: "HOME", wantValue: "/home/agent"},
-		{name: "CODEX_HOME", wantValue: "/home/agent/.codex-alt"},
 		{name: "USER", wantValue: "agent-user"},
 		{name: "AIOPS_ALLOWED", wantValue: "allowed-value"},
 		{name: "AIOPS_DUPLICATE", wantValue: "duplicate-value"},
@@ -492,6 +516,9 @@ func TestAgentEnvWithLookupBoundaryTable(t *testing.T) {
 		if counts[tc.name] != 1 {
 			t.Fatalf("%s appeared %d times, want 1 in env %#v", tc.name, counts[tc.name], env)
 		}
+	}
+	if counts["CODEX_HOME"] != 0 {
+		t.Fatalf("generic agent env included CODEX_HOME %d times; want 0 in env %#v", counts["CODEX_HOME"], env)
 	}
 	for _, denied := range []string{"LINEAR_API_KEY", "GITEA_TOKEN", "GITHUB_TOKEN", "AIOPS_CONFIGURED_TRACKER", "BAD"} {
 		if counts[denied] != 0 {


### PR DESCRIPTION
Closes #1062

## Summary
- Split runner environment baselines so `CODEX_HOME` is only added for the Codex app-server runner and Codex preflight, not Claude or generic shell runner defaults.
- Keep Codex app-server `CODEX_HOME` inheritance intact for non-default Codex homes.
- Update stale docs from PR #1058 that described `CODEX_HOME` as part of every agent baseline.

Root cause: PR #1058 fixed non-default Codex homes by adding `CODEX_HOME` to the shared `agentEnv` baseline; `ShellRunner` also uses that helper for Claude/generic agents, so non-Codex workflows inherited the Codex credential/config home by default.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Upstream checked:
- `docs/research/SPEC.md:450`-`465` defines `codex.command` as the Codex app-server command launched in the workspace.
- `docs/research/SPEC.md:948`-`959` defines the launch contract for the Codex app-server subprocess.
- `elixir/lib/symphony_elixir/codex/app_server.ex:195`-`204` starts `codex.command` via `bash -lc` with workspace `cd`, scoped to the app-server path.
- `elixir/lib/symphony_elixir/config/schema.ex:165`-`167` keeps the default command as `codex app-server`.

## Acceptance / review-thread ledger
- [x] Non-Codex `ShellRunner` no longer inherits `CODEX_HOME` by default.
- [x] Generic preflight env no longer inherits `CODEX_HOME` by default.
- [x] Claude preflight env no longer inherits `CODEX_HOME` by default.
- [x] Codex app-server run env still inherits `CODEX_HOME` by default.
- [x] Codex app-server preflight env still matches the app-server run env.
- [x] Stale docs now distinguish selected runner baseline from Codex app-server baseline.
- [x] Current-head GraphQL review thread audit on `4feefa059193045978a1d21fd37546ef7564a7a5`: no threads.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded). Production diff: `internal/runner/env.go`, `internal/runner/codex_app_server.go`, about +12/-3 production LOC.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
```bash
go test ./internal/runner -run 'Test(ShellRunnerDoesNotInheritWorkerSecretsByDefault|AgentEnvForPreflightScopesCodexHomeToCodexAppServer|AgentEnvWithLookupBoundaryTable|CodexAppServerRunnerDoesNotInheritWorkerSecretsByDefault)$'
go test ./internal/runner ./internal/doctor
go mod tidy && git diff --exit-code -- go.mod go.sum
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0
go build ./cmd/worker ./cmd/tui
```

Remote follow-through:
- CI on head `4feefa059193045978a1d21fd37546ef7564a7a5`: `Go build and test`, `Security and supply-chain`, `E2E Gitea mock loop`, and `Docker image build` passed in run `28651117821`.
- Governance checks passed: `Validate PR metadata` run `28651117810`, `Validate PR title (Conventional Commits)` run `28651117848`.
- Warning audit: no `::warning`, `warning:`, `Warning:`, or `WARNING` annotations in logs for runs `28651117821`, `28651117810`, or `28651117848`; broad text scan only found checkout hint text and command flags containing the word `warning`.

Red/green and mutation proof:
- Initial focused tests failed before production changes on the shell leak, Claude preflight leak, and generic baseline table.
- Mutation 1: temporarily routing `setupAppServerCommand` back through `agentEnv` made `TestCodexAppServerRunnerDoesNotInheritWorkerSecretsByDefault` fail because Codex app-server lost `CODEX_HOME`.
- Mutation 2: temporarily adding `CODEX_HOME` back to `baselineAgentEnvAllowlist` made the shell/preflight/boundary tests fail because non-Codex envs inherited the Codex home again.

Review fallback:
- Claude Code unavailable per batch instructions; not invoked.
- `multi_agent_v1.spawn_agent` was discovered but its tool contract requires explicit current-request subagent/delegation authorization, so it was not used.
- GitHub Codex review app could not review this head because it posted a usage-limit comment on 2026-07-03; no unresolved GitHub review threads were present after that comment.
- Codex-family diff review via `codex exec` on `origin/main...HEAD`: `MERGE-READY`, no source-confirmed defects; reviewer did not run tests.
- Local manual diff review: `MERGE-READY`, no source-confirmed defects. Checked `agentEnv`/`codexAppServerEnv`, `setupAppServerCommand`, `ShellRunner`, `AgentEnvForPreflight`, docs, and test coverage.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
- This does not change `codex.env_passthrough` / `claude.env_passthrough` deny-list behavior; a workflow can still explicitly opt a non-Codex runner into `CODEX_HOME`, but it is no longer inherited by default.
