### PR TITLE
fix(linear): fail closed when listing blocker lookup fails

### DIFF
--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -313,7 +313,17 @@ func (c *LinearClient) fetchLinearIssuesPage(ctx context.Context, vars map[strin
 		issues = append(issues, iss)
 	}
 	if err := c.attachLinearBlockers(ctx, issues); err != nil {
-		return nil, linearPageInfo{}, err
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, linearPageInfo{}, errors.Join(err, ctxErr)
+		}
+		if errors.Is(err, ErrRateLimited) {
+			return nil, linearPageInfo{}, err
+		}
+		// Blocker data only gates Todo candidate dispatch. If the auxiliary
+		// inverse-relations query fails, keep the primary page and fail Todo
+		// candidates closed for this tick; non-Todo consumers ignore BlockedBy.
+		log.Printf("event=linear_blocker_listing_failed error=%q detail=\"listing Todo issues fail closed with a placeholder blocker this page\"", err.Error())
+		failClosedTodoIssueBlockers(issues)
 	}
 	pageInfo := linearPageInfo{
 		HasNextPage: out.Data.Issues.PageInfo.HasNextPage,
@@ -450,6 +460,14 @@ func failClosedTodoBlockers(states map[string]IssueState) {
 		}
 		state.BlockedBy = []BlockerRef{{}}
 		states[id] = state
+	}
+}
+
+func failClosedTodoIssueBlockers(issues []Issue) {
+	for i := range issues {
+		if isTodoState(issues[i].State) {
+			issues[i].BlockedBy = []BlockerRef{{}}
+		}
 	}
 }
 

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -535,6 +535,110 @@ func TestListIssuesByStatesPaginatesLinearInverseRelationsBeforeMappingBlockers(
 	}
 }
 
+// A failed listing-time blocker resolution must not fail the whole poll page:
+// blocker data only gates Todo dispatch. Todo issues fail closed with the same
+// empty-state placeholder used by FetchIssueStatesByIDs, while non-Todo issues
+// remain usable for state/reconcile consumers.
+func TestListIssuesByStatesSurvivesBlockerResolutionFailure(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		if opNameFromQuery(payload.Query) == "ListIssuesInverseRelations" {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[`+
+			`{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}},`+
+			`{"id":"issue-2","identifier":"LIN-2","title":"Two","description":"","url":"https://linear.app/acme/issue/LIN-2","priority":2,"createdAt":"2026-05-15T00:01:00Z","updatedAt":"2026-05-16T00:01:00Z","state":{"name":"In Progress"}}`+
+			`],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo", "In Progress"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates = error %v; want success despite blocker resolution failure", err)
+	}
+	if got := len(issues); got != 2 {
+		t.Fatalf("issues = %d, want 2", got)
+	}
+	if got := issues[0].BlockedBy; len(got) != 1 || got[0].State != "" {
+		t.Fatalf("Todo issue BlockedBy = %#v; want one empty-state placeholder after blocker resolution failure", got)
+	}
+	if got := issues[1].BlockedBy; got != nil {
+		t.Fatalf("non-Todo issue BlockedBy = %#v; want nil after blocker resolution failure", got)
+	}
+}
+
+func TestListIssuesByStatesPropagatesCallerTimeoutDuringBlockerResolution(t *testing.T) {
+	blockerStarted := make(chan struct{})
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		if opNameFromQuery(payload.Query) == "ListIssuesInverseRelations" {
+			close(blockerStarted)
+			<-r.Context().Done()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[`+
+			`{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}}`+
+			`],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+	client.RequestTimeout = time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	issues, err := client.ListIssuesByStates(ctx, []string{"Todo"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ListIssuesByStates caller-timeout err = %v, issues = %#v; want context.DeadlineExceeded", err, issues)
+	}
+	select {
+	case <-blockerStarted:
+	default:
+		t.Fatal("blocker resolution request was not attempted")
+	}
+}
+
+func TestListIssuesByStatesPropagatesRateLimitDuringBlockerResolution(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		if opNameFromQuery(payload.Query) == "ListIssuesInverseRelations" {
+			w.Header().Set("Retry-After", "30")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[`+
+			`{"id":"issue-1","identifier":"LIN-1","title":"One","description":"","url":"https://linear.app/acme/issue/LIN-1","priority":1,"createdAt":"2026-05-15T00:00:00Z","updatedAt":"2026-05-16T00:00:00Z","state":{"name":"Todo"}}`+
+			`],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("ListIssuesByStates rate-limit err = %v, issues = %#v; want errors.Is ErrRateLimited", err, issues)
+	}
+	var rateLimited *RateLimitedError
+	if !errors.As(err, &rateLimited) || rateLimited.RetryAfter != 30*time.Second {
+		t.Fatalf("rate limit details = %#v; want RetryAfter 30s (err = %v)", rateLimited, err)
+	}
+}
+
 // TestListIssuesByStatesBatchesBlockerLookupsForManyTodoIssues pins #672: three
 // Todo issues on one page resolve their blockers in a single batched query
 // (2 requests total) rather than one query per issue (the prior N+1 = 4
@@ -721,7 +825,7 @@ func TestListIssuesByStatesUsesConfiguredPaginationMaxPages(t *testing.T) {
 	}
 }
 
-func TestListIssuesByStatesErrorsWhenInverseRelationMaxPagesExceeded(t *testing.T) {
+func TestListIssuesByStatesFailsClosedWhenInverseRelationMaxPagesExceeded(t *testing.T) {
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var payload struct {
@@ -743,13 +847,16 @@ func TestListIssuesByStatesErrorsWhenInverseRelationMaxPagesExceeded(t *testing.
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
 
-	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
-	if !errors.Is(err, ErrIssueListingCapped) {
-		t.Fatalf("ListIssuesByStates error = %v, want ErrIssueListingCapped from inverse relation cap", err)
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates = error %v; want success with Todo fail-closed after inverse relation cap", err)
+	}
+	if got := issues[0].BlockedBy; len(got) != 1 || got[0].State != "" {
+		t.Fatalf("Todo issue BlockedBy = %#v; want one empty-state placeholder after inverse relation cap", got)
 	}
 }
 
-func TestListIssuesByStatesUsesConfiguredInverseRelationPaginationMaxPages(t *testing.T) {
+func TestListIssuesByStatesConfiguredInverseRelationPaginationCapFailsClosed(t *testing.T) {
 	var perIssueRelationRequests atomic.Int32
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -774,9 +881,12 @@ func TestListIssuesByStatesUsesConfiguredInverseRelationPaginationMaxPages(t *te
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops", PaginationMaxPages: 1})
 
-	_, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
-	if !errors.Is(err, ErrIssueListingCapped) {
-		t.Fatalf("ListIssuesByStates error = %v, want ErrIssueListingCapped after configured inverse-relation cap", err)
+	issues, err := client.ListIssuesByStates(context.Background(), []string{"Todo"})
+	if err != nil {
+		t.Fatalf("ListIssuesByStates = error %v; want success with Todo fail-closed after configured inverse-relation cap", err)
+	}
+	if got := issues[0].BlockedBy; len(got) != 1 || got[0].State != "" {
+		t.Fatalf("Todo issue BlockedBy = %#v; want one empty-state placeholder after configured inverse-relation cap", got)
 	}
 	if got := perIssueRelationRequests.Load(); got != 0 {
 		t.Fatalf("per-issue inverse relation requests = %d, want 0 because the batched relation page counts toward pagination_max_pages", got)


### PR DESCRIPTION
Closes #1035

## Summary
- Align Linear listing-time blocker hydration with the refresh path: ordinary auxiliary `inverseRelations` failures keep the primary issue page and fail Todo candidates closed with an empty-state placeholder blocker.
- Preserve non-Todo issues unchanged because SPEC applies the blocker gate only to Todo dispatch/revalidation.
- Preserve control-flow/backpressure errors from auxiliary blocker hydration: caller context cancellation/deadline and `ErrRateLimited`/`RetryAfter` now propagate instead of being converted to a healthy degraded page.

Root cause: `fetchLinearIssuesPage` returned `attachLinearBlockers` errors directly. The first fix degraded all auxiliary lookup failures; Codex review then caught that retry-fetch timeouts and rate limits must remain observable. Final head `f89ed2265b6c86cd452f7b5de098c951eddbed39` keeps fail-closed only for safe blocker-data degradation.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Upstream checked:
- `docs/research/SPEC.md:729`-`739` keeps candidate fetch as one poll-loop step; tracker errors skip dispatch for the tick, but this change avoids treating ordinary degraded auxiliary blocker data as a primary candidate-fetch failure.
- `docs/research/SPEC.md:741`-`755` scopes the blocker rule to Todo candidate selection.
- `docs/research/SPEC.md:1201`-`1209` defines `blocked_by` as normalized candidate data derived from inverse relations.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/orchestrator.ex:804`-`812` and `:864`-`:879` apply `todo_issue_blocked_by_non_terminal?` only during dispatch eligibility.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/orchestrator.ex:1602`-`1604` applies the same Todo blocker gate during retry/revalidation.

## Acceptance
- [x] Listing-time blocker attach failure no longer aborts the page for ordinary blocker-data failures.
- [x] Todo issues on that page fail closed with one empty-state placeholder blocker.
- [x] Non-Todo issues on that page keep their blocker data nil/unaffected.
- [x] Existing refresh-path fail-closed behavior is unchanged.
- [x] Inverse-relation pagination-cap failures from blocker hydration now follow the same listing fail-closed behavior.
- [x] Caller cancellation/deadline during blocker hydration propagates as an error.
- [x] Linear rate-limit responses during blocker hydration propagate with `ErrRateLimited` and `RetryAfter`.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff is 1 file (`internal/tracker/linear.go`), well under 300 production LOC.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
Final head: `f89ed2265b6c86cd452f7b5de098c951eddbed39`

- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

Focused validation:
```bash
go test ./internal/tracker -run 'TestListIssuesByStates(SurvivesBlockerResolutionFailure|PropagatesCallerTimeoutDuringBlockerResolution|PropagatesRateLimitDuringBlockerResolution|FailsClosedWhenInverseRelationMaxPagesExceeded|ConfiguredInverseRelationPaginationCapFailsClosed)$'
go test ./internal/tracker
```

Mutation proof:
- Temporarily restored the old `return nil, linearPageInfo{}, err` path; `TestListIssuesByStatesSurvivesBlockerResolutionFailure` failed on the returned blocker lookup error.
- Temporarily made the fail-closed helper mark every issue, not only Todo; `TestListIssuesByStatesSurvivesBlockerResolutionFailure` failed because the non-Todo issue gained a placeholder blocker.
- Temporarily removed the `ctx.Err()` guard; `TestListIssuesByStatesPropagatesCallerTimeoutDuringBlockerResolution` failed because the caller deadline was swallowed into a placeholder blocker.
- Temporarily removed the `ErrRateLimited` guard; `TestListIssuesByStatesPropagatesRateLimitDuringBlockerResolution` failed because `ErrRateLimited`/`RetryAfter` were swallowed into a placeholder blocker.

## Reviews and remote gates
- [x] Resolved Codex review threads `PRRT_kwDOSN-Foc6OKEzc` and `PRRT_kwDOSN-Foc6OKH3v` with replies on head `f89ed2265b6c86cd452f7b5de098c951eddbed39`.
- [x] Local Codex diff review fallback: `MERGE-READY`; residual risk was that the read-only review sandbox could not run Go tests, covered by local full gates above.
- [x] GitHub `@codex review` on `f89ed2265b`: "Didn't find any major issues" (`https://github.com/xrf9268-hue/aiops-platform/pull/1065#issuecomment-4875194360`).
- [x] CI run `28654037379` passed for head `f89ed2265b6c86cd452f7b5de098c951eddbed39`.
- [x] PR Metadata run `28654037373` passed before this final body update; final metadata run to be rechecked after this edit.
- [x] PR Title Lint run `28654037376` passed.
- [x] Warning annotation audit: no annotations on check runs `84978719745`, `84978719746`, `84978719752`, `84979257463`, `84978677546`, or `84978677544`.
