### PR TITLE
fix(orchestrator): preserve quota retry-after on reschedule

### DIFF
--- a/internal/orchestrator/actor_retry.go
+++ b/internal/orchestrator/actor_retry.go
@@ -212,6 +212,11 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 	attempt := s.attempt
 	kind := s.kind
 	delay := o.currentScheduler().NextDelay(s.req)
+	dueAt := time.Now().Add(delay)
+	var quotaBackoffDueAt time.Time
+	if kind == RetryKindQuotaBackoff && s.req.DelayOverride > 0 {
+		quotaBackoffDueAt = dueAt
+	}
 	// time.AfterFunc schedules immediately and is cheap (no goroutine
 	// until fire), so we can safely create the timer on the actor
 	// without blocking. ScheduleRetry needs the Timer set on the entry
@@ -221,9 +226,10 @@ func (s *scheduleRetryOp) apply(st *OrchestratorState) func() {
 		IssueID:               id,
 		Identifier:            s.identifier,
 		Attempt:               attempt,
-		DueAt:                 time.Now().Add(delay),
+		DueAt:                 dueAt,
 		Error:                 s.runErr,
 		Kind:                  s.kind,
+		QuotaBackoffDueAt:     quotaBackoffDueAt,
 		StartupFailure:        task.CopyStartupFailure(s.startupFailure),
 		ContinuationTurnCount: s.continuationTurnCount,
 		Workspace:             s.workspace,
@@ -419,7 +425,6 @@ func retryFireDispatchTail(st *OrchestratorState, entry *RetryEntry, id IssueID,
 	// state, and both the per-state capacity gate and the spawned worker
 	// must see the live state.
 	issue := entry.Issue
-	identifier := entry.Identifier
 	if suppressRetryFireAfterOperatorStop(st, entry, id) {
 		return nil
 	}
@@ -429,12 +434,12 @@ func retryFireDispatchTail(st *OrchestratorState, entry *RetryEntry, id IssueID,
 		// reschedule through the configured backoff with attempt+1 and a
 		// typed "no available orchestrator slots" error instead of arming a
 		// short 100ms re-fire timer.
-		return capacityDeferRetry(st, id, issue, identifier, attempt, entry.Kind, entry.Workspace, entry.StartupFailure, o)
+		return capacityDeferRetry(st, id, entry, attempt, o)
 	}
 	if st.StateCapacityFull(issue.State) {
 		// Retry timers must also obey per-state capacity gates. Same
 		// upstream-aligned reschedule shape as the global-cap branch.
-		return capacityDeferRetry(st, id, issue, identifier, attempt, entry.Kind, entry.Workspace, entry.StartupFailure, o)
+		return capacityDeferRetry(st, id, entry, attempt, o)
 	}
 	// Consume the retry entry but keep Claimed: the re-dispatch
 	// immediately re-adds Running, and dropping Claimed in between
@@ -476,7 +481,7 @@ func suppressRetryFireAfterOperatorStop(st *OrchestratorState, entry *RetryEntry
 // 100ms re-fire loop bypassed the backoff formula, left the attempt
 // counter frozen across thousands of re-fires, and produced no runtime
 // event for the cap-pressure case.
-func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, identifier string, attempt int, kind RetryKind, workspace Workspace, startupFailure *task.StartupFailure, o *Orchestrator) func() {
+func capacityDeferRetry(st *OrchestratorState, id IssueID, entry *RetryEntry, attempt int, o *Orchestrator) func() {
 	if o.runCtx.Err() != nil {
 		// Mirror retryPollFailedOp's shutdown guard (actor.go above):
 		// the followup's ScheduleRetry would fail submit anyway, so
@@ -484,12 +489,17 @@ func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, 
 		// leak a misleading line into shutdown logs.
 		return nil
 	}
+	issue := entry.Issue
+	identifier := entry.Identifier
+	kind := entry.Kind
+	workspace := entry.Workspace
 	const runErr = "no available orchestrator slots"
 	nextAttempt := attempt + 1
 	if kind == RetryKindQuotaBackoff {
 		nextAttempt = attempt
 	}
-	startupFailure = task.CopyStartupFailure(startupFailure)
+	startupFailure := task.CopyStartupFailure(entry.StartupFailure)
+	quotaRetryAfter := entry.quotaBackoffDelayOverride(time.Now())
 	st.RecordEvent(RuntimeEvent{
 		Kind:       RuntimeEventFailed,
 		IssueID:    id,
@@ -500,7 +510,7 @@ func capacityDeferRetry(st *OrchestratorState, id IssueID, issue tracker.Issue, 
 		// Carry the workspace across the reschedule so the §18.1 terminal
 		// cleanup gate still has a path on a later attempt (#341).
 		if kind == RetryKindQuotaBackoff {
-			o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, 0, workspace), id, identifier)
+			o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, quotaRetryAfter, workspace), id, identifier)
 			return
 		}
 		o.logRescheduleErr(o.scheduleFailureRetryWithStartupFailure(o.runCtx, issue, identifier, nextAttempt, runErr, workspace, startupFailure), id, identifier)
@@ -551,6 +561,7 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 	// gate still has a path on a later attempt (#341).
 	workspace := entry.Workspace
 	startupFailure := task.CopyStartupFailure(entry.StartupFailure)
+	quotaRetryAfter := entry.quotaBackoffDelayOverride(time.Now())
 	nextAttempt := r.attempt + 1
 	if r.kind == RetryKindQuotaBackoff {
 		nextAttempt = r.attempt
@@ -567,7 +578,7 @@ func (r *retryPollFailedOp) apply(st *OrchestratorState) func() {
 	})
 	return func() {
 		if r.kind == RetryKindQuotaBackoff {
-			o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, 0, workspace), r.id, identifier)
+			o.logRescheduleErr(o.scheduleQuotaBackoffRetry(o.runCtx, issue, identifier, nextAttempt, runErr, quotaRetryAfter, workspace), r.id, identifier)
 			return
 		}
 		o.logRescheduleErr(o.scheduleFailureRetryWithStartupFailure(o.runCtx, issue, identifier, nextAttempt, runErr, workspace, startupFailure), r.id, identifier)

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -3785,6 +3785,55 @@ func TestRetryFire_GlobalCapacityFullReschedulesViaBackoff(t *testing.T) {
 	}
 }
 
+func TestRetryFire_QuotaBackoffCapacityDeferPreservesRemainingRetryAfter(t *testing.T) {
+	disp := &fakeDispatcher{}
+	scheduler := &recordingScheduler{delay: 10 * time.Second}
+	st := NewOrchestratorState(15000, 1)
+	o := New(st, Deps{
+		Dispatcher: disp,
+		Scheduler:  scheduler,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go o.Run(ctx)
+	if err := o.WaitStarted(context.Background()); err != nil {
+		t.Fatalf("WaitStarted: %v", err)
+	}
+
+	blocker := tracker.Issue{ID: "BLOCKER", Identifier: "BLOCKER", Title: "blocker"}
+	if err := o.RequestDispatch(context.Background(), blocker, nil); err != nil {
+		t.Fatalf("dispatch blocker: %v", err)
+	}
+	waitFor(t, func() bool { return disp.count() == 1 }, time.Second)
+
+	retryIssue := tracker.Issue{ID: "RETRY-QUOTA", Identifier: "RETRY-QUOTA", Title: "quota retry"}
+	const retryAfter = time.Hour
+	if err := o.scheduleQuotaBackoffRetry(context.Background(), retryIssue, retryIssue.Identifier, 0, "quota backoff", retryAfter, Workspace{}); err != nil {
+		t.Fatalf("scheduleQuotaBackoffRetry: %v", err)
+	}
+	waitFor(t, func() bool { return len(scheduler.snapshotRequests()) == 1 }, time.Second)
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(retryIssue.ID),
+		issue:   retryIssue,
+		attempt: 0,
+		kind:    RetryKindQuotaBackoff,
+	}); err != nil {
+		t.Fatalf("submit quota retry fire: %v", err)
+	}
+	waitFor(t, func() bool { return len(scheduler.snapshotRequests()) >= 2 }, 2*time.Second)
+
+	requests := scheduler.snapshotRequests()
+	got := requests[len(requests)-1]
+	if got.Kind != RetryKindQuotaBackoff {
+		t.Fatalf("reschedule kind = %q, want %q", got.Kind, RetryKindQuotaBackoff)
+	}
+	if got.DelayOverride <= 55*time.Minute || got.DelayOverride > retryAfter {
+		t.Fatalf("reschedule DelayOverride = %s, want remaining quota RetryAfter within (55m, 1h]", got.DelayOverride)
+	}
+}
+
 // TestRetryFire_PerStateCapacityFullReschedulesViaBackoff is the symmetric
 // per-state version of the global-capacity test above: with
 // max_concurrent_agents_by_state[Rework]=1 and one running Rework issue,
@@ -4579,6 +4628,45 @@ func TestRetryFire_QuotaBackoffFetchFailureReschedulesWithoutOrphaningClaim(t *t
 	}
 	if !strings.Contains(got.Error, "tracker unavailable") {
 		t.Fatalf("rescheduled error = %q, want tracker failure reason", got.Error)
+	}
+}
+
+func TestRetryFire_QuotaBackoffFetchFailurePreservesRemainingRetryAfter(t *testing.T) {
+	disp := &fakeDispatcher{}
+	lister := &fakeCandidateLister{err: errors.New("tracker unavailable")}
+	scheduler := &recordingScheduler{delay: 10 * time.Second}
+	o, cancel := startActor(t, Deps{
+		Dispatcher:      disp,
+		Scheduler:       scheduler,
+		CandidateLister: lister,
+	})
+	defer cancel()
+
+	iss := tracker.Issue{ID: "ENG-QUOTA-POLL-WINDOW", Identifier: "ENG-QUOTA-POLL-WINDOW", Title: "quota poll", State: "Todo"}
+	const retryAfter = time.Hour
+	if err := o.scheduleQuotaBackoffRetry(context.Background(), iss, iss.Identifier, 0, "quota backoff", retryAfter, Workspace{}); err != nil {
+		t.Fatalf("scheduleQuotaBackoffRetry: %v", err)
+	}
+	waitFor(t, func() bool { return len(scheduler.snapshotRequests()) == 1 }, time.Second)
+
+	if err := o.submit(context.Background(), &retryFireOp{
+		o:       o,
+		id:      IssueID(iss.ID),
+		issue:   iss,
+		attempt: 0,
+		kind:    RetryKindQuotaBackoff,
+	}); err != nil {
+		t.Fatalf("submit quota retry fire: %v", err)
+	}
+	waitFor(t, func() bool { return len(scheduler.snapshotRequests()) >= 2 }, 2*time.Second)
+
+	requests := scheduler.snapshotRequests()
+	got := requests[len(requests)-1]
+	if got.Kind != RetryKindQuotaBackoff {
+		t.Fatalf("reschedule kind = %q, want %q", got.Kind, RetryKindQuotaBackoff)
+	}
+	if got.DelayOverride <= 55*time.Minute || got.DelayOverride > retryAfter {
+		t.Fatalf("reschedule DelayOverride = %s, want remaining quota RetryAfter within (55m, 1h]", got.DelayOverride)
 	}
 }
 

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -37,6 +37,11 @@ type RetryEntry struct {
 	Timer      *time.Timer
 	Error      string
 	Kind       RetryKind
+	// QuotaBackoffDueAt preserves the provider-requested quiet window for
+	// RetryKindQuotaBackoff. If a quota retry is requeued before this point
+	// because capacity is full or candidate fetch fails, the reschedule reuses
+	// the remaining window instead of falling through to failure backoff.
+	QuotaBackoffDueAt time.Time
 	// StartupFailure is observability-only detail for a failure retry caused by
 	// a runner startup phase. The retry policy is still owned by Kind/Attempt.
 	StartupFailure *task.StartupFailure
@@ -64,4 +69,15 @@ func (r *RetryEntry) IsDue(now time.Time) bool {
 		return false
 	}
 	return !now.Before(r.DueAt)
+}
+
+func (r *RetryEntry) quotaBackoffDelayOverride(now time.Time) time.Duration {
+	if r == nil || r.Kind != RetryKindQuotaBackoff || r.QuotaBackoffDueAt.IsZero() {
+		return 0
+	}
+	remaining := r.QuotaBackoffDueAt.Sub(now)
+	if remaining <= 0 {
+		return 0
+	}
+	return remaining
 }

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -637,6 +637,23 @@ func TestRetryEntry_IsDue(t *testing.T) {
 	}
 }
 
+func TestRetryEntryQuotaBackoffDelayOverride(t *testing.T) {
+	now := time.Now()
+	entry := &RetryEntry{Kind: RetryKindQuotaBackoff, QuotaBackoffDueAt: now.Add(time.Hour)}
+	if got := entry.quotaBackoffDelayOverride(now); got != time.Hour {
+		t.Fatalf("quotaBackoffDelayOverride(future) = %s; want 1h", got)
+	}
+	entry.QuotaBackoffDueAt = now.Add(-time.Second)
+	if got := entry.quotaBackoffDelayOverride(now); got != 0 {
+		t.Fatalf("quotaBackoffDelayOverride(elapsed) = %s; want 0", got)
+	}
+	entry.Kind = RetryKindFailure
+	entry.QuotaBackoffDueAt = now.Add(time.Hour)
+	if got := entry.quotaBackoffDelayOverride(now); got != 0 {
+		t.Fatalf("quotaBackoffDelayOverride(non-quota) = %s; want 0", got)
+	}
+}
+
 // TestFinishRunSucceeded_CapsCompletedAndCountsCumulative pins the
 // #234 contract: the Completed map and completedOrder slice are
 // bounded by MaxRecentCompleted, evicting the oldest entry on


### PR DESCRIPTION
Closes #1034

## Summary
- Persist the quota-backoff quiet window on `RetryEntry` as an absolute `QuotaBackoffDueAt` timestamp when a provider `RetryAfter` schedules a quota retry.
- Reapply the remaining quota window when a quota retry is requeued through capacity-defer or retry-poll-failed.
- Let reschedules fall back to the ordinary failure formula only after the stored quota window has elapsed.

Root cause: the initial quota-backoff path passed `RetryAfter` as `RetryRequest.DelayOverride`, but `RetryEntry` did not retain the provider window. The two reschedule paths therefore called `scheduleQuotaBackoffRetry(..., 0, ...)`, dropping the override.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

Upstream checked:
- `docs/research/SPEC.md:775`-`786` defines retry entry storage and the ordinary failure backoff formula.
- `docs/research/SPEC.md:1923`-`1946` defines retry timer handling: candidate fetch, retry-poll-failed reschedule, capacity reschedule, dispatch.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/orchestrator.ex:1023`-`1060` stores retry metadata and due time when scheduling retries.
- `/tmp/symphony-upstream/elixir/lib/symphony_elixir/orchestrator.ex:1082`-`1098` and `:1162`-`:1179` reschedule retry-poll-failed and capacity-full retries through the same retry metadata path.

`RetryAfter`/quota backoff is an aiops-platform runner-classification extension, so the SPEC/Elixir boundary is to preserve normal retry semantics while carrying the local provider quiet-window metadata through existing retry reschedules. No new worker-side gate, tracker write, durable cache, or state machine phase is added.

## Acceptance
- [x] Initial quota retry still schedules with `RetryAfter` as `DelayOverride`.
- [x] Capacity-deferred quota retry reuses the remaining provider quiet window.
- [x] Retry-poll-failed quota retry reuses the remaining provider quiet window.
- [x] When the stored quota window is elapsed, the override returns 0 so existing failure backoff applies.
- [x] Ordinary failure and continuation retry behavior is unchanged.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — production diff is 2 files and well under 300 production LOC.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
Head: `e80892cd032a21e41e9682ac5198e92156dc109a`

- [x] `go test ./internal/orchestrator -run 'TestRetryFire_QuotaBackoff(CapacityDefer|FetchFailure)PreservesRemainingRetryAfter$'` (red before implementation: both saw `DelayOverride = 0s`)
- [x] `go test ./internal/orchestrator -run 'Test(Finalize_QuotaBackoffReschedulesWithRetryAfter|Finalize_QuotaBackoffDoesNotBumpNextFailureRetryAttempt|RetryFire_GlobalCapacityFullReschedulesViaBackoff|RetryFire_PerStateCapacityFullReschedulesViaBackoff|RetryFire_ReschedulesWithRetryPollFailedOnFetchError|RetryFire_QuotaBackoffFetchFailureReschedulesWithoutOrphaningClaim|RetryFire_QuotaBackoff(CapacityDefer|FetchFailure)PreservesRemainingRetryAfter)$'`
- [x] `go test ./internal/orchestrator -run 'Test(RetryEntryQuotaBackoffDelayOverride|RetryFire_QuotaBackoff(CapacityDefer|FetchFailure)PreservesRemainingRetryAfter)$'`
- [x] `go test ./internal/orchestrator`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

Mutation proof:
- Temporarily cleared `QuotaBackoffDueAt` during retry scheduling; both quota reschedule regression tests failed with `DelayOverride = 0s`.

## Reviews and remote gates
- [x] Local Codex diff review fallback: `MERGE-READY` for head `e80892cd032a21e41e9682ac5198e92156dc109a`.
- [x] GitHub `@codex review` attempted from active account `zjlgdx`; connector replied that this repo has no Codex environment configured, so no GitHub Codex code review was available. Fallback used: local read-only Codex diff review, SPEC/Elixir comparison, manual source review, full local Go gates, and CI.
- [x] GraphQL review-thread audit: no review threads on PR #1066.
- [x] CI for head `e80892cd032a21e41e9682ac5198e92156dc109a`: Go build/test, E2E Gitea mock loop, Security and supply-chain, Docker image build, PR Metadata, and PR Title Lint passed.
- [x] Warning annotation audit: zero warning/failure annotations on CI run `28654933055`, PR Metadata run `28655210238`, and PR Title Lint run `28655210243`.
