### PR TITLE
fix(dashboard): show days for long resets

### DIFF
--- a/cmd/worker/dashboard/src/App.jsx
+++ b/cmd/worker/dashboard/src/App.jsx
@@ -28,9 +28,14 @@ const compact = (n) => {
 
 function dur(sec) {
   const total = Math.max(0, Math.round(Number(sec) || 0));
+  const d = Math.floor(total / 86400);
   const h = Math.floor(total / 3600);
   const m = Math.floor((total % 3600) / 60);
   const s = total % 60;
+  if (d) {
+    const dayHours = Math.floor((total % 86400) / 3600);
+    return dayHours ? `${d}d ${dayHours}h` : `${d}d`;
+  }
   if (h) return `${h}h ${m}m`;
   if (m) return `${m}m ${s}s`;
   return `${s}s`;

--- a/cmd/worker/dashboard/src/App.test.jsx
+++ b/cmd/worker/dashboard/src/App.test.jsx
@@ -248,6 +248,26 @@ describe('Worker status dashboard', () => {
     expect(screen.getByText(/7-day window/)).toBeTruthy();
   });
 
+  it('formats long rate-limit reset countdowns with day units', async () => {
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(Date.UTC(2026, 0, 2, 3, 4, 5));
+    try {
+      current = busyState({
+        rate_limits: {
+          limit_name: 'codex', plan_type: 'pro',
+          primary: { used_percent: 31, window_minutes: 300, resets_at: unixIn(3 * 3600 + 51 * 60) },
+          secondary: { used_percent: 12, window_minutes: 10080, resets_at: unixIn(49 * 3600 + 10 * 60) },
+        },
+      });
+      render(<App />);
+      await screen.findByText('Primary window');
+
+      expect(screen.getByText(/5-hour window · resets in 3h 51m/)).toBeTruthy();
+      expect(screen.getByText(/7-day window · resets in 2d 1h/)).toBeTruthy();
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it('falls back to a raw JSON dump for an unrecognized rate-limit shape', async () => {
     // No used_percent windows → keep the data visible rather than mis-rendering it.
     current = busyState({ rate_limits: { limit_name: 'codex', primary: { remaining: 450, limit: 500 } } });


### PR DESCRIPTION
Closes #1040

## Summary
- Format dashboard durations of at least 24 hours with day units, so long rate-limit resets render as `2d 1h` instead of `49h 10m`.
- Keep existing sub-day dashboard duration text compact (`3h 51m`, `12m 04s`, `41s`).
- Add a rendered rate-limit panel regression test covering both short and multi-day reset countdowns.

## Acceptance
- [x] Dashboard rate-limit reset text uses days for durations of at least 24 hours.
- [x] Existing short-duration displays stay compact.
- [x] Dashboard tests cover a secondary window reset longer than 24 hours.
- [x] Scope decision: changed the shared dashboard `dur(sec)` formatter because the same human-scale output is appropriate for dashboard runtimes, retry due text, budget labels, and process runtime; TUI duration readability remains separate in #1043.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## Review fallback
- Subagent reviewer path: contract-blocked because the available Codex subagent tool requires explicit current-turn user authorization for subagents.
- Claude Code reviewer: unavailable by user instruction; no `claude` / Claude Code command was invoked.
- Codex-family independent review: `codex exec` diff review found no source-confirmed findings; it also ran `npm --prefix cmd/worker/dashboard test -- --run` successfully.
- Local manual diff review: inspected the committed dashboard diff and found no source-confirmed blocking issues.
- GitHub `@codex review`: first review on `a59d6f60ea` found one flaky-test P2; fixed in `1acacc3eb8`; second review reported no major issues on `1acacc3eb8`.

## Rework response
- Reviewed head: `a59d6f60eaad4689e8c88b76ef2e0cdb6d29fb94`.
- New head: `1acacc3eb895d9b1a6a7f41d5e0f4359bf9c8387`.
- Finding addressed: stabilized the long-reset countdown test by freezing `Date.now` around the rendered `RateWindow` assertion and restoring the spy in `finally`.
- Current thread result: GraphQL review thread `PRRT_kwDOSN-Foc6OMBSA` resolved after it became outdated on the fixed head.

## Remote follow-through
- [x] Required checks on `1acacc3eb895d9b1a6a7f41d5e0f4359bf9c8387`: CI, PR Metadata, and PR Title Lint all passed.
- [x] GraphQL reviewThreads audit: resolved/outdated only after rework; no current-head unresolved thread.
- [x] Warning audit: only existing/tooling noise observed (`git checkout` hints, Vite `--disable-warning` command text, tar `--warning=no-unknown-keyword`, and Trivy vendor severity informational WARN); no issue-specific warning.

## Mutation / TDD evidence
- RED: after adding `formats long rate-limit reset countdowns with day units`, `npm test -- -t "formats long rate-limit reset countdowns"` failed because the secondary window still rendered hour-only text.
- GREEN: the same focused test passed after adding the day branch to `dur(sec)`.
- Mutation check: temporarily changed the day divisor from `86400` to `864000`; the focused test failed on the missing `2d 1h`; restored the implementation and reran the focused test successfully.
- Rework mutation check: repeated the same divisor mutation after stabilizing the test with fixed `Date.now`; the focused test still failed as expected, then passed after restore.

## Verification
- [x] `npm test`
- [x] `npm run build`
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`

## Size gate
- [x] `within budget` — diff fits the ~12-file / ~300-LOC review guideline
- [ ] `size-gated: justified overage` — rationale: n/a
- [ ] `size-gated: split recommended` — rationale: n/a
