### PR TITLE
fix(tui): render codex percent rate windows

### DIFF
--- a/cmd/tui/layout_test.go
+++ b/cmd/tui/layout_test.go
@@ -363,6 +363,62 @@ func TestFormatRateLimits_SanitizesUntrustedValues(t *testing.T) {
 	}
 }
 
+func TestFormatRateLimits_RendersCodexPercentWindows(t *testing.T) {
+	oldNow := rateLimitNow
+	rateLimitNow = func() time.Time { return time.Unix(1_780_000_000, 0) }
+	defer func() { rateLimitNow = oldNow }()
+
+	resetAt := rateLimitNow().Add(90 * time.Minute).Unix()
+	rl := map[string]interface{}{
+		"limitName": "codex",
+		"primary": map[string]interface{}{
+			"usedPercent":        float64(14),
+			"windowDurationMins": float64(300),
+			"resetsAt":           float64(resetAt),
+		},
+		"secondary": map[string]interface{}{
+			"used_percent":         float64(92.5),
+			"window_duration_mins": float64(10080),
+			"resets_in_seconds":    float64(30),
+		},
+	}
+	got := visibleString(formatRateLimits(rl))
+
+	for _, want := range []string{
+		"codex",
+		"primary 14% used · 5h window · resets in 1h 30m",
+		"secondary 92.5% used · 7d window · reset 30s",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatRateLimits(percent windows) = %q, want substring %q", got, want)
+		}
+	}
+	if rawEpoch := strconv.FormatInt(resetAt, 10) + "s"; strings.Contains(got, rawEpoch) {
+		t.Errorf("formatRateLimits(percent windows) rendered resets_at as relative seconds: %q", got)
+	}
+}
+
+func TestFormatRateLimits_RendersLegacyBuckets(t *testing.T) {
+	rl := map[string]interface{}{
+		"limit_id":  "legacy",
+		"primary":   map[string]interface{}{"remaining": float64(42), "limit": float64(100), "reset_in_seconds": float64(30)},
+		"secondary": map[string]interface{}{"limit": float64(200)},
+		"credits":   map[string]interface{}{"has_credits": true, "balance": float64(12.5)},
+	}
+	got := visibleString(formatRateLimits(rl))
+
+	for _, want := range []string{
+		"legacy",
+		"primary 42/100 reset 30s",
+		"secondary limit 200",
+		"credits 12.50",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatRateLimits(legacy buckets) = %q, want substring %q", got, want)
+		}
+	}
+}
+
 // ── ansiSeqLen bounds (no OOB on truncated/lone escapes) ────────────────────
 
 func TestAnsiSeqLen_Bounds(t *testing.T) {

--- a/cmd/tui/render.go
+++ b/cmd/tui/render.go
@@ -320,7 +320,7 @@ func formatRateLimits(rl map[string]interface{}) string {
 	// limit_id is the one free-form API string on this line; sanitize it so an
 	// embedded newline/control byte can't split or corrupt the row (#466). The
 	// numeric bucket/credit fields are formatted from typed values below.
-	limitID := sanitize(strMapGet(rl, "limit_id", "limit_name", ""))
+	limitID := sanitize(strMapGet(rl, "limit_id", "limit_name", "limitId", "limitName", ""))
 	if limitID == "" {
 		limitID = "unknown"
 	}
@@ -345,6 +345,9 @@ func formatRateLimitBucket(v interface{}) string {
 	if !ok {
 		return sanitize(fmt.Sprintf("%v", v))
 	}
+	if used, ok := firstNumericVal(m, "used_percent", "usedPercent"); ok {
+		return formatPercentRateLimitBucket(m, used)
+	}
 	remaining := intVal(m, "remaining")
 	limit := intVal(m, "limit")
 
@@ -360,13 +363,96 @@ func formatRateLimitBucket(v interface{}) string {
 		return "n/a"
 	}
 
-	// format_reset_value/1: integers are rendered with an "s" suffix.
-	for _, k := range []string{"reset_in_seconds", "resetInSeconds", "reset_at", "resetAt", "resets_at"} {
-		if rv, ok := m[k]; ok && rv != nil {
-			return base + " reset " + formatResetValue(rv)
-		}
+	if reset, ok := rateLimitResetText(m); ok {
+		return base + " " + reset
 	}
 	return base
+}
+
+var rateLimitNow = time.Now
+
+func formatPercentRateLimitBucket(m map[string]interface{}, used float64) string {
+	parts := []string{strconv.FormatFloat(used, 'f', -1, 64) + "% used"}
+	if mins := firstIntVal(m, "window_duration_mins", "windowDurationMins", "window_minutes", "windowMinutes"); mins != nil {
+		if window := formatRateLimitWindow(*mins); window != "" {
+			parts = append(parts, window)
+		}
+	}
+	if reset, ok := rateLimitResetText(m); ok {
+		parts = append(parts, reset)
+	}
+	return strings.Join(parts, " · ")
+}
+
+func formatRateLimitWindow(minutes int64) string {
+	if minutes <= 0 {
+		return ""
+	}
+	if minutes%1440 == 0 {
+		return strconv.FormatInt(minutes/1440, 10) + "d window"
+	}
+	if minutes%60 == 0 {
+		return strconv.FormatInt(minutes/60, 10) + "h window"
+	}
+	return strconv.FormatInt(minutes, 10) + "m window"
+}
+
+func rateLimitResetText(m map[string]interface{}) (string, bool) {
+	for _, k := range []string{"reset_in_seconds", "resetInSeconds", "resets_in_seconds", "resetsInSeconds"} {
+		if rv, ok := m[k]; ok && rv != nil {
+			return "reset " + formatResetValue(rv), true
+		}
+	}
+	for _, k := range []string{"reset_at", "resetAt", "resets_at", "resetsAt"} {
+		if rv, ok := m[k]; ok && rv != nil {
+			return formatResetAtValue(rv), true
+		}
+	}
+	return "", false
+}
+
+func formatResetAtValue(v interface{}) string {
+	switch x := v.(type) {
+	case float64:
+		return "resets in " + formatRateLimitDuration(int64(x)-rateLimitNow().Unix())
+	case int64:
+		return "resets in " + formatRateLimitDuration(x-rateLimitNow().Unix())
+	case int:
+		return "resets in " + formatRateLimitDuration(int64(x)-rateLimitNow().Unix())
+	case string:
+		return "reset " + sanitize(x)
+	default:
+		return "reset " + sanitize(fmt.Sprintf("%v", v))
+	}
+}
+
+func formatRateLimitDuration(seconds int64) string {
+	if seconds < 0 {
+		seconds = 0
+	}
+	days := seconds / 86400
+	hours := (seconds % 86400) / 3600
+	mins := (seconds % 3600) / 60
+	secs := seconds % 60
+	if days > 0 {
+		if hours > 0 {
+			return fmt.Sprintf("%dd %dh", days, hours)
+		}
+		return fmt.Sprintf("%dd", days)
+	}
+	if hours > 0 {
+		if mins > 0 {
+			return fmt.Sprintf("%dh %dm", hours, mins)
+		}
+		return fmt.Sprintf("%dh", hours)
+	}
+	if mins > 0 {
+		if secs > 0 {
+			return fmt.Sprintf("%dm %ds", mins, secs)
+		}
+		return fmt.Sprintf("%dm", mins)
+	}
+	return fmt.Sprintf("%ds", secs)
 }
 
 func formatCredits(v interface{}) string {
@@ -581,6 +667,40 @@ func intVal(m map[string]interface{}, key string) *int64 {
 		return &n
 	}
 	return nil
+}
+
+func firstIntVal(m map[string]interface{}, keys ...string) *int64 {
+	for _, key := range keys {
+		if v := intVal(m, key); v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+func numericVal(m map[string]interface{}, key string) (float64, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return 0, false
+	}
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int64:
+		return float64(x), true
+	case int:
+		return float64(x), true
+	}
+	return 0, false
+}
+
+func firstNumericVal(m map[string]interface{}, keys ...string) (float64, bool) {
+	for _, key := range keys {
+		if v, ok := numericVal(m, key); ok {
+			return v, true
+		}
+	}
+	return 0, false
 }
 
 func toFloat(v interface{}) float64 {


### PR DESCRIPTION
Closes #1042

## Summary

- Render Codex percent-window rate limit buckets in the TUI using `used_percent` / `usedPercent`.
- Show `window_duration_mins` / `windowDurationMins` as human-scale window labels.
- Treat `resets_at` / `resetsAt` as absolute Unix timestamps while preserving relative `reset_in_seconds` / `resets_in_seconds` handling for legacy payloads.

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This is a TUI display-only fix over the existing state API rate-limit snapshot.

## Acceptance

- [x] Percent-window payloads display percent used instead of `n/a`.
- [x] Window duration minutes render as human-readable windows such as `5h window` and `7d window`.
- [x] Absolute reset epochs render as relative time-to-reset, not raw seconds.
- [x] Relative reset fields remain relative.
- [x] Legacy remaining/limit buckets still render.
- [x] Existing sanitization coverage remains in place.

## TDD and mutation evidence

- RED: `TestFormatRateLimits_RendersCodexPercentWindows` initially failed against the old `n/a reset <epoch>s` rendering.
- RED: after the first fix, the same test was switched to the current Codex camelCase schema shape and failed until camelCase aliases were handled.
- Mutation: breaking `used_percent` detection made the percent-window test fail.
- Mutation: treating `resets_at` as legacy reset seconds made the raw epoch assertion fail.
- Mutation: breaking `usedPercent` alias handling made the camelCase test fail.
- Mutation: removing `resets_in_seconds` alias handling made the relative reset assertion fail.

## Review fallback

- Claude / Claude Code unavailable by environment contract; no `claude` command used.
- Subagent review path is unavailable in this session, so independent review used Codex CLI plus manual diff/schema review.
- Codex CLI first review found a real schema issue: the current vendored Codex app-server schema uses camelCase fields such as `limitName`, `usedPercent`, `windowDurationMins`, and `resetsAt`; the fix was amended to cover both camelCase and the observed snake_case payload names.
- Codex CLI second review on the final diff reported no findings.
- Manual review checked the TUI diff against state API passthrough behavior and the vendored Codex schema.

## PR diff size budget (AGENTS.md)

- [x] `within budget` — <=12 production files / <=300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production files changed: 1.

## Testing

- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,...`)
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go build ./cmd/worker ./cmd/tui`