### PR TITLE
fix(tui): show human-scale durations

### DIFF
--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -194,6 +194,46 @@ func TestFormatRetryRowIncludesStartupPhase(t *testing.T) {
 	}
 }
 
+func TestFormatRetryRowUsesHumanScaleForLongWaits(t *testing.T) {
+	cases := []struct {
+		name      string
+		wait      time.Duration
+		want      string
+		rawPrefix string
+	}{
+		{name: "minutes", wait: 90*time.Second + 500*time.Millisecond, want: "1m", rawPrefix: "90."},
+		{name: "hours", wait: time.Hour + 500*time.Millisecond, want: "1h", rawPrefix: "3600."},
+	}
+	for _, c := range cases {
+		due := time.Now().Add(c.wait)
+		got := formatRetryRow(stateapi.Retry{
+			IssueID:    "issue-1",
+			Identifier: "ENG-1",
+			Attempt:    1,
+			DueAt:      &due,
+		})
+		if !strings.Contains(got, " in ") || !strings.Contains(got, c.want) {
+			t.Fatalf("%s: formatRetryRow = %q; want human-scale due time containing %q", c.name, got, c.want)
+		}
+		if strings.Contains(got, c.rawPrefix) {
+			t.Fatalf("%s: formatRetryRow = %q; want no raw large second count", c.name, got)
+		}
+	}
+}
+
+func TestFormatRetryRowKeepsShortWaitPrecision(t *testing.T) {
+	due := time.Now().Add(1500 * time.Millisecond)
+	got := formatRetryRow(stateapi.Retry{
+		IssueID:    "issue-1",
+		Identifier: "ENG-1",
+		Attempt:    1,
+		DueAt:      &due,
+	})
+	if !strings.Contains(got, "1.") || !strings.Contains(got, "s") {
+		t.Fatalf("formatRetryRow = %q; want sub-minute second precision", got)
+	}
+}
+
 // ── formatRuntimeSecs ─────────────────────────────────────────────────────────
 
 func TestFormatRuntimeSecs(t *testing.T) {
@@ -201,10 +241,13 @@ func TestFormatRuntimeSecs(t *testing.T) {
 		secs float64
 		want string
 	}{
-		{0, "0m 0s"},
-		{59, "0m 59s"},
+		{0, "0s"},
+		{59, "59s"},
 		{60, "1m 0s"},
-		{3661, "61m 1s"},
+		{90, "1m 30s"},
+		{3600, "1h 0m"},
+		{3661, "1h 1m"},
+		{90000, "1d 1h"},
 	}
 	for _, c := range cases {
 		if got := formatRuntimeSecs(c.secs); got != c.want {

--- a/cmd/tui/render.go
+++ b/cmd/tui/render.go
@@ -278,13 +278,7 @@ func formatRetryRow(r stateapi.Retry) string {
 
 	dueIn := "n/a"
 	if r.DueAt != nil {
-		d := time.Until(*r.DueAt)
-		if d < 0 {
-			d = 0
-		}
-		secs := int(d.Seconds())
-		millis := int(d.Milliseconds()) % 1000
-		dueIn = fmt.Sprintf("%d.%03ds", secs, millis)
+		dueIn = formatRetryDueIn(time.Until(*r.DueAt))
 	}
 
 	errorPart := ""
@@ -427,32 +421,7 @@ func formatResetAtValue(v interface{}) string {
 }
 
 func formatRateLimitDuration(seconds int64) string {
-	if seconds < 0 {
-		seconds = 0
-	}
-	days := seconds / 86400
-	hours := (seconds % 86400) / 3600
-	mins := (seconds % 3600) / 60
-	secs := seconds % 60
-	if days > 0 {
-		if hours > 0 {
-			return fmt.Sprintf("%dd %dh", days, hours)
-		}
-		return fmt.Sprintf("%dd", days)
-	}
-	if hours > 0 {
-		if mins > 0 {
-			return fmt.Sprintf("%dh %dm", hours, mins)
-		}
-		return fmt.Sprintf("%dh", hours)
-	}
-	if mins > 0 {
-		if secs > 0 {
-			return fmt.Sprintf("%dm %ds", mins, secs)
-		}
-		return fmt.Sprintf("%dm", mins)
-	}
-	return fmt.Sprintf("%ds", secs)
+	return formatHumanDurationSeconds(seconds)
 }
 
 func formatCredits(v interface{}) string {
@@ -550,12 +519,40 @@ func formatTPS(tps float64) string {
 	return groupThousands(strconv.FormatInt(int64(math.Round(tps)), 10))
 }
 
-// formatRuntimeSecs mirrors format_runtime_seconds/1.
+func formatRetryDueIn(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		secs := int(d.Seconds())
+		millis := int(d.Milliseconds()) % 1000
+		return fmt.Sprintf("%d.%03ds", secs, millis)
+	}
+	return formatHumanDurationSeconds(int64(d.Seconds()))
+}
+
 func formatRuntimeSecs(seconds float64) string {
-	total := int(math.Max(0, math.Floor(seconds)))
-	mins := total / 60
-	secs := total % 60
-	return fmt.Sprintf("%dm %ds", mins, secs)
+	return formatHumanDurationSeconds(int64(math.Max(0, math.Floor(seconds))))
+}
+
+func formatHumanDurationSeconds(seconds int64) string {
+	if seconds < 0 {
+		seconds = 0
+	}
+	days := seconds / 86400
+	hours := (seconds % 86400) / 3600
+	mins := (seconds % 3600) / 60
+	secs := seconds % 60
+	if days > 0 {
+		return fmt.Sprintf("%dd %dh", days, hours)
+	}
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm", hours, mins)
+	}
+	if mins > 0 {
+		return fmt.Sprintf("%dm %ds", mins, secs)
+	}
+	return fmt.Sprintf("%ds", secs)
 }
 
 // formatRuntimeAndTurns mirrors format_runtime_and_turns/2.


### PR DESCRIPTION
Closes #1043

## Summary

- Render long TUI runtime values with compact human-scale units instead of total minutes.
- Render minute/hour-scale retry due times as human durations while preserving millisecond precision for short live countdowns.
- Reuse the same human-duration helper for absolute rate-limit reset durations without changing legacy `reset_in_seconds` text.

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This is a TUI display-only formatter change.

## Acceptance

- [x] Runtime displays use hour/day units for long durations.
- [x] Retry due displays avoid raw large second counts for minute/hour-scale waits.
- [x] Short retry countdowns keep sub-minute millisecond precision.
- [x] Layout-width tests continue to cover 40/80/100/120 columns.
- [x] Formatter tests cover seconds, minutes, hours, and days.

## TDD and mutation evidence

- RED: `TestFormatRetryRowUsesHumanScaleForLongWaits` failed on old `90.499s` / `3600.499s` style output.
- RED: `TestFormatRuntimeSecs` failed on old `0m 59s`, `60m 0s`, and `1500m 0s` style output.
- GREEN: added `formatRetryDueIn` and `formatHumanDurationSeconds`, with runtime and absolute reset durations using the shared human-scale path.
- Mutation: reverting runtime to total-minutes formatting made `TestFormatRuntimeSecs` fail.
- Mutation: forcing retry due to always use raw second/millisecond formatting made `TestFormatRetryRowUsesHumanScaleForLongWaits` fail.
- Mutation: disabling the sub-minute retry precision branch made `TestFormatRetryRowKeepsShortWaitPrecision` fail.

## Review fallback

- Claude / Claude Code unavailable by environment contract; no `claude` command used.
- Subagent review path is unavailable in this session, so independent review used Codex CLI plus manual diff review.
- Codex CLI review on the final committed diff reported no blocker and verified the focused formatter/rate-limit tests; its sandbox could not run the full `cmd/tui` package because of module-cache write and `httptest` port-binding restrictions, so the main session's full local gates below are the authoritative full-test evidence.
- Manual review checked sibling duration call sites in `cmd/tui` and preserved legacy `reset_in_seconds` formatting.

## PR diff size budget (AGENTS.md)

- [x] `within budget` — <=12 production files / <=300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production files changed: 1.

## Testing

- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `go test ./cmd/tui -count=1`
