### PR TITLE
fix(orchestrator): avoid duplicate stall cancels

### DIFF
--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -257,12 +257,13 @@ type reconcileStalledRunsOp struct {
 func (r *reconcileStalledRunsOp) apply(st *OrchestratorState) func() {
 	var canceled []*RunningEntry
 	for id, run := range st.Running {
-		if run.BudgetExceeded {
+		if run.BudgetExceeded || run.StallCanceled {
 			continue
 		}
 		if !r.isStalled(run) {
 			continue
 		}
+		run.StallCanceled = true
 		canceled = append(canceled, run)
 		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: id, Identifier: run.Identifier, Message: "stalled"})
 	}

--- a/internal/orchestrator/actor_reconcile_ops_test.go
+++ b/internal/orchestrator/actor_reconcile_ops_test.go
@@ -99,6 +99,49 @@ func TestReconcileStalledRunsOpTimingReference(t *testing.T) {
 	}
 }
 
+func TestReconcileStalledRunsOpCancelsStalledRunOnceUntilFinalize(t *testing.T) {
+	now := time.Now()
+	st := NewOrchestratorState(15000, 10)
+	cancelCount := 0
+	run := &RunningEntry{
+		Identifier:  "S",
+		LastEventAt: now.Add(-time.Hour),
+		StartedAt:   now.Add(-2 * time.Hour),
+		CancelWorker: func(error) {
+			cancelCount++
+		},
+	}
+	st.Running[IssueID("S")] = run
+
+	firstResult := make(chan []*RunningEntry, 1)
+	first := &reconcileStalledRunsOp{timeout: time.Minute, now: now, result: firstResult}
+	first.apply(st)()
+	firstCanceled := <-firstResult
+	if len(firstCanceled) != 1 || firstCanceled[0] != run {
+		t.Fatalf("first stalled reconcile canceled = %+v, want the running entry", firstCanceled)
+	}
+
+	secondResult := make(chan []*RunningEntry, 1)
+	second := &reconcileStalledRunsOp{timeout: time.Minute, now: now.Add(time.Second), result: secondResult}
+	second.apply(st)()
+	secondCanceled := <-secondResult
+	if len(secondCanceled) != 0 {
+		t.Fatalf("second stalled reconcile canceled = %+v, want no duplicate cancel before finalize", secondCanceled)
+	}
+	if cancelCount != 1 {
+		t.Fatalf("cancelCount = %d, want 1", cancelCount)
+	}
+	failed := 0
+	for _, ev := range st.RecentEvents {
+		if ev.Kind == RuntimeEventFailed && ev.IssueID == IssueID("S") && ev.Message == "stalled" {
+			failed++
+		}
+	}
+	if failed != 1 {
+		t.Fatalf("stalled failed events = %d, want 1 (events=%+v)", failed, st.RecentEvents)
+	}
+}
+
 func TestReconcileBudgetExceededRunsOpRetriesMarkedRunningCancel(t *testing.T) {
 	st := NewOrchestratorState(15000, 10)
 	cancelCount := 0

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -156,16 +156,17 @@ type RunningEntry struct {
 	// parsing raw output or runner error text.
 	LastStartupFailure *task.StartupFailure
 
-	CodexInputTokens  int64
-	CodexOutputTokens int64
-	CodexTotalTokens  int64
-
+	CodexInputTokens         int64
+	CodexOutputTokens        int64
+	CodexTotalTokens         int64
 	LastReportedInputTokens  int64
 	LastReportedOutputTokens int64
 	LastReportedTotalTokens  int64
-	BudgetExceeded           bool
-	BudgetExceededAt         time.Time
-	BudgetExceededError      string
+	// StallCanceled suppresses duplicate stall reconcile work before finalize.
+	StallCanceled       bool
+	BudgetExceeded      bool
+	BudgetExceededAt    time.Time
+	BudgetExceededError string
 
 	InputRequired       bool
 	InputRequiredAt     time.Time


### PR DESCRIPTION
Closes #1039

## Summary
- Make stall reconciliation cancel and record the `Failed`/`stalled` event only once for a running entry before `finalizeRunOp` removes it.
- Preserve retry behavior by keeping the latch on the live `RunningEntry`, so a later retry starts with a fresh unstalled entry.

## Acceptance
- A stalled run queues exactly one cancel while it remains in `state.running`.
- A stalled run records exactly one `RuntimeEventFailed` event with message `stalled` before finalize.
- Active/non-stalled runs and existing stall timeout behavior remain unchanged.
- Sibling sweep: budget-exceeded reconciliation already has one-shot event semantics and intentionally retries cancel for marked budget entries via existing tests, so that independent policy was left out of scope.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

SPEC/Elixir evidence:
- SPEC §8.5 says stall reconciliation terminates the worker and queues retry when elapsed time exceeds `codex.stall_timeout_ms`.
- SPEC §16.3 runs stall reconciliation as part of `reconcile_running_issues`.
- `elixir/lib/symphony_elixir/orchestrator.ex:601-627` restarts a stalled issue by terminating the running issue and scheduling retry.
- `elixir/lib/symphony_elixir/orchestrator.ex:546-568` removes the issue from `state.running` during termination, so the same stalled run cannot be re-processed on later ticks. The Go latch preserves that one-shot behavior while cancellation/finalize is off-actor.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded). Production files changed: 2.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Do not collapse formatting, merge responsibilities, delete useful tests, or
reduce readability solely to check `within budget`; choose
`size-gated: justified overage` when the smallest readable change plus necessary
tests needs the space.

## TDD and mutation
- RED: added `TestReconcileStalledRunsOpCancelsStalledRunOnceUntilFinalize`; before the fix it failed because the second reconcile queued a duplicate cancel.
- Mutation 1: removed `|| run.StallCanceled`; the new test failed on the duplicate second cancel.
- Mutation 2: removed `run.StallCanceled = true`; the new test failed on the duplicate second cancel.
- Restored both changes, reran focused tests, and confirmed touched-file diff clean against `HEAD` after mutation restore.

## Review fallback
- Claude Code is unavailable in this environment, so no Claude/Claude Code command was run.
- Fallback review used Codex CLI on the PR diff, manual SPEC/Elixir comparison, local diff review, and the full Go gate below.
- Codex CLI independent review result: findings none. It ran the targeted orchestrator stall tests and `gofmt -l` on touched files.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go build ./cmd/worker ./cmd/tui`
- `go test ./internal/orchestrator -run 'TestReconcileStalledRuns(Op|Cancels|Leaves|Skips)' -count=1`
- `go test ./internal/orchestrator -count=1`

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
