### PR TITLE
fix(tracker): cap success JSON decoding

### DIFF
--- a/internal/doctor/doctor_tracker.go
+++ b/internal/doctor/doctor_tracker.go
@@ -297,8 +297,8 @@ func decodeLinearProjectProbe(resp *http.Response, out any) error {
 	// Preflight mirrors the consumer: the poller decodes this response
 	// immediately, so name the non-JSON body (a login proxy answering 200
 	// HTML) instead of surfacing a bare json.SyntaxError.
-	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-		return fmt.Errorf("linear returned %s with a body that is not JSON: %w", resp.Status, err)
+	if err := tracker.DecodeJSONResponse(resp, out); err != nil {
+		return fmt.Errorf("linear returned %s with a body that is not JSON or exceeded maximum size: %w", resp.Status, err)
 	}
 	return nil
 }

--- a/internal/doctor/doctor_tracker_drain_test.go
+++ b/internal/doctor/doctor_tracker_drain_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 )
 
 // drainRecordingBody records whether the response body was read to EOF (the
@@ -86,6 +88,31 @@ func TestDecodeLinearProjectProbeDrainsResponseBodies(t *testing.T) {
 				t.Fatalf("status %d body sawEOF = %t, closed = %t; want true, true (undrained bodies break connection reuse)", tc.status, body.sawEOF, body.closed)
 			}
 		})
+	}
+}
+
+func TestDecodeLinearProjectProbeRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`{"data":{"projects":{"nodes":[]}}}`)}
+	resp := &http.Response{
+		Status:        "200 OK",
+		StatusCode:    http.StatusOK,
+		Body:          body,
+		ContentLength: 1 << 62,
+	}
+	var out struct {
+		Data struct {
+			Projects struct {
+				Nodes []struct {
+					ID string `json:"id"`
+				} `json:"nodes"`
+			} `json:"projects"`
+		} `json:"data"`
+	}
+
+	err := decodeLinearProjectProbe(resp, &out)
+
+	if !errors.Is(err, tracker.ErrJSONResponseTooLarge) {
+		t.Fatalf("decodeLinearProjectProbe() oversized success error = %v; want errors.Is(err, tracker.ErrJSONResponseTooLarge)", err)
 	}
 }
 

--- a/internal/gitea/tracker_client_drain_test.go
+++ b/internal/gitea/tracker_client_drain_test.go
@@ -36,12 +36,13 @@ func (b *drainRecordingBody) Close() error {
 // staticResponseTransport serves one canned response so per-status drain
 // coverage does not need a live server.
 type staticResponseTransport struct {
-	status int
-	body   *drainRecordingBody
+	status        int
+	body          *drainRecordingBody
+	contentLength int64
 }
 
 func (t *staticResponseTransport) RoundTrip(*http.Request) (*http.Response, error) {
-	return &http.Response{StatusCode: t.status, Header: http.Header{}, Body: t.body}, nil
+	return &http.Response{StatusCode: t.status, Header: http.Header{}, Body: t.body, ContentLength: t.contentLength}, nil
 }
 
 func newDrainTestTrackerClient(status int, body *drainRecordingBody) *TrackerClient {
@@ -92,5 +93,37 @@ func TestTrackerClientListIssuesPageDrainsErrorBody(t *testing.T) {
 	}
 	if !body.sawEOF || !body.closed {
 		t.Fatalf("body sawEOF = %t, closed = %t; want true, true (undrained bodies break connection reuse)", body.sawEOF, body.closed)
+	}
+}
+
+func TestTrackerClientListIssuesPageRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`[]`)}
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, "http://gitea.invalid", "owner", "repo")
+	client.HTTP = &http.Client{Transport: &staticResponseTransport{
+		status:        http.StatusOK,
+		body:          body,
+		contentLength: 1 << 62,
+	}}
+
+	_, _, err := client.listIssuesPage(context.Background(), "", "open", 1)
+
+	if !errors.Is(err, tracker.ErrJSONResponseTooLarge) {
+		t.Fatalf("listIssuesPage oversized success error = %v; want errors.Is(err, tracker.ErrJSONResponseTooLarge)", err)
+	}
+}
+
+func TestTrackerClientGetIssueByNumberRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`{}`)}
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, "http://gitea.invalid", "owner", "repo")
+	client.HTTP = &http.Client{Transport: &staticResponseTransport{
+		status:        http.StatusOK,
+		body:          body,
+		contentLength: 1 << 62,
+	}}
+
+	_, _, err := client.getIssueByNumber(context.Background(), 7)
+
+	if !errors.Is(err, tracker.ErrJSONResponseTooLarge) {
+		t.Fatalf("getIssueByNumber oversized success error = %v; want errors.Is(err, tracker.ErrJSONResponseTooLarge)", err)
 	}
 }

--- a/internal/gitea/tracker_client_listing.go
+++ b/internal/gitea/tracker_client_listing.go
@@ -2,7 +2,6 @@ package gitea
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -250,8 +249,8 @@ func (c *TrackerClient) listIssuesPage(ctx context.Context, labelName string, is
 		return nil, false, fmt.Errorf("list Gitea issues failed: status %d", resp.StatusCode)
 	}
 	var issues []Issue
-	if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
-		return nil, false, err
+	if err := tracker.DecodeJSONResponse(resp, &issues); err != nil {
+		return nil, false, fmt.Errorf("decode Gitea issues response: %w", err)
 	}
 	return issues, hasNextPage(resp.Header.Values("Link")), nil
 }

--- a/internal/gitea/tracker_client_refresh.go
+++ b/internal/gitea/tracker_client_refresh.go
@@ -2,7 +2,6 @@ package gitea
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -174,8 +173,8 @@ func (c *TrackerClient) getIssueByNumber(ctx context.Context, issueNumber int) (
 		return Issue{}, false, fmt.Errorf("get Gitea issue #%d failed: status %d", issueNumber, resp.StatusCode)
 	}
 	var issue Issue
-	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
-		return Issue{}, false, err
+	if err := tracker.DecodeJSONResponse(resp, &issue); err != nil {
+		return Issue{}, false, fmt.Errorf("decode Gitea issue response: %w", err)
 	}
 	return issue, true, nil
 }

--- a/internal/runner/linear_graphql_current_issue_guard.go
+++ b/internal/runner/linear_graphql_current_issue_guard.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -345,7 +344,7 @@ func (p linearGraphQLProxy) lookupWorkflowStateIDs(ctx context.Context, stateNam
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("linear workflowStates lookup failed: %s", resp.Status)
 	}
-	return decodeWorkflowStateIDs(resp.Body, stateName)
+	return decodeWorkflowStateIDs(resp, stateName)
 }
 
 func (p linearGraphQLProxy) workflowStateLookupRequest(ctx context.Context, body []byte) (*http.Request, error) {
@@ -376,7 +375,7 @@ func workflowStateLookupQuery(stateName, teamKey string) (string, map[string]any
 }`, vars
 }
 
-func decodeWorkflowStateIDs(r io.Reader, stateName string) ([]string, error) {
+func decodeWorkflowStateIDs(resp *http.Response, stateName string) ([]string, error) {
 	var out struct {
 		Data struct {
 			WorkflowStates struct {
@@ -387,7 +386,7 @@ func decodeWorkflowStateIDs(r io.Reader, stateName string) ([]string, error) {
 		} `json:"data"`
 		Errors []map[string]any `json:"errors"`
 	}
-	if err := json.NewDecoder(r).Decode(&out); err != nil {
+	if err := tracker.DecodeJSONResponse(resp, &out); err != nil {
 		return nil, fmt.Errorf("decode Linear workflowStates lookup: %w", err)
 	}
 	if len(out.Errors) > 0 {

--- a/internal/runner/linear_graphql_current_issue_guard_drain_test.go
+++ b/internal/runner/linear_graphql_current_issue_guard_drain_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 )
 
 // drainRecordingBody records whether the response body was read to EOF (the
@@ -35,16 +37,18 @@ func (b *drainRecordingBody) Close() error {
 // staticResponseTransport serves one canned response so per-status drain
 // coverage does not need a live server.
 type staticResponseTransport struct {
-	status int
-	body   *drainRecordingBody
+	status        int
+	body          *drainRecordingBody
+	contentLength int64
 }
 
 func (t *staticResponseTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	return &http.Response{
-		Status:     fmt.Sprintf("%d %s", t.status, http.StatusText(t.status)),
-		StatusCode: t.status,
-		Header:     http.Header{},
-		Body:       t.body,
+		Status:        fmt.Sprintf("%d %s", t.status, http.StatusText(t.status)),
+		StatusCode:    t.status,
+		Header:        http.Header{},
+		Body:          t.body,
+		ContentLength: t.contentLength,
 	}, nil
 }
 
@@ -97,5 +101,24 @@ func TestLookupWorkflowStateIDsDrainsResponseBodies(t *testing.T) {
 				t.Fatalf("status %d body sawEOF = %t, closed = %t; want true, true (undrained bodies break connection reuse)", tc.status, body.sawEOF, body.closed)
 			}
 		})
+	}
+}
+
+func TestLookupWorkflowStateIDsRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`{"data":{"workflowStates":{"nodes":[]}}}`)}
+	proxy := linearGraphQLProxy{
+		apiKey:  "test-key",
+		baseURL: "http://linear.invalid",
+		http: &http.Client{Transport: &staticResponseTransport{
+			status:        http.StatusOK,
+			body:          body,
+			contentLength: 1 << 62,
+		}},
+	}
+
+	ids, err := proxy.lookupWorkflowStateIDs(context.Background(), "Done", "")
+
+	if ids != nil || !errors.Is(err, tracker.ErrJSONResponseTooLarge) {
+		t.Fatalf("lookupWorkflowStateIDs(Done) oversized success = (%v, %v); want nil, errors.Is(err, tracker.ErrJSONResponseTooLarge)", ids, err)
 	}
 }

--- a/internal/tracker/drain_test.go
+++ b/internal/tracker/drain_test.go
@@ -52,9 +52,10 @@ func (b *drainRecordingBody) Close() error {
 // staticResponseTransport serves one canned response so per-status drain
 // coverage does not need a live server.
 type staticResponseTransport struct {
-	status int
-	header http.Header
-	body   *drainRecordingBody
+	status        int
+	header        http.Header
+	body          *drainRecordingBody
+	contentLength int64
 }
 
 func (t *staticResponseTransport) RoundTrip(*http.Request) (*http.Response, error) {
@@ -62,7 +63,7 @@ func (t *staticResponseTransport) RoundTrip(*http.Request) (*http.Response, erro
 	if header == nil {
 		header = http.Header{}
 	}
-	return &http.Response{StatusCode: t.status, Header: header, Body: t.body}, nil
+	return &http.Response{StatusCode: t.status, Header: header, Body: t.body, ContentLength: t.contentLength}, nil
 }
 
 func TestDrainAndCloseBoundsHugeBody(t *testing.T) {
@@ -76,6 +77,103 @@ func TestDrainAndCloseBoundsHugeBody(t *testing.T) {
 	}
 	if !body.closed {
 		t.Fatalf("DrainAndClose closed = %t; want true", body.closed)
+	}
+}
+
+func TestLinearGraphQLRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`{}`)}
+	client := NewLinearClient(workflow.TrackerConfig{APIKey: "test-key"})
+	client.BaseURL = "http://linear.invalid/graphql"
+	client.HTTP = &http.Client{Transport: &staticResponseTransport{
+		status:        http.StatusOK,
+		body:          body,
+		contentLength: 1 << 62,
+	}}
+
+	var out map[string]any
+	err := client.graphql(context.Background(), "query Probe { viewer { id } }", nil, &out)
+
+	if !errors.Is(err, ErrJSONResponseTooLarge) {
+		t.Fatalf("graphql() oversized success error = %v; want errors.Is(err, ErrJSONResponseTooLarge)", err)
+	}
+}
+
+func TestGitHubListIssuesPageRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`[]`)}
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token"}, "http://github.invalid", "acme", "api")
+	client.HTTP = &http.Client{Transport: &staticResponseTransport{
+		status:        http.StatusOK,
+		body:          body,
+		contentLength: 1 << 62,
+	}}
+
+	_, _, err := client.listIssuesPage(context.Background(), "open", "", 1)
+
+	if !errors.Is(err, ErrJSONResponseTooLarge) {
+		t.Fatalf("listIssuesPage oversized success error = %v; want errors.Is(err, ErrJSONResponseTooLarge)", err)
+	}
+}
+
+func TestGitHubListOpenPullRequestsPageRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`[]`)}
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token"}, "http://github.invalid", "acme", "api")
+	client.HTTP = &http.Client{Transport: &staticResponseTransport{
+		status:        http.StatusOK,
+		body:          body,
+		contentLength: 1 << 62,
+	}}
+
+	_, _, err := client.listOpenPullRequestsPage(context.Background(), 1)
+
+	if !errors.Is(err, ErrJSONResponseTooLarge) {
+		t.Fatalf("listOpenPullRequestsPage oversized success error = %v; want errors.Is(err, ErrJSONResponseTooLarge)", err)
+	}
+}
+
+func TestGitHubGetIssueByNumberRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`{}`)}
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token"}, "http://github.invalid", "acme", "api")
+	client.HTTP = &http.Client{Transport: &staticResponseTransport{
+		status:        http.StatusOK,
+		body:          body,
+		contentLength: 1 << 62,
+	}}
+
+	_, _, err := client.getIssueByNumber(context.Background(), 7)
+
+	if !errors.Is(err, ErrJSONResponseTooLarge) {
+		t.Fatalf("getIssueByNumber oversized success error = %v; want errors.Is(err, ErrJSONResponseTooLarge)", err)
+	}
+}
+
+func TestGitHubBlockersRejectsOversizedSuccessBody(t *testing.T) {
+	body := &drainRecordingBody{reader: strings.NewReader(`{}`)}
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token"}, "http://github.invalid", "acme", "api")
+	client.HTTP = &http.Client{Transport: &staticResponseTransport{
+		status:        http.StatusOK,
+		body:          body,
+		contentLength: 1 << 62,
+	}}
+
+	_, err := client.fetchNativeGitHubBlockers(context.Background(), []string{"I_kwDOExample"})
+
+	if !errors.Is(err, ErrJSONResponseTooLarge) {
+		t.Fatalf("fetchNativeGitHubBlockers oversized success error = %v; want errors.Is(err, ErrJSONResponseTooLarge)", err)
+	}
+}
+
+func TestDecodeJSONResponseBoundsStreamingBodyWithoutContentLength(t *testing.T) {
+	source := &infiniteReader{}
+	resp := &http.Response{Body: io.NopCloser(source), ContentLength: -1}
+
+	var out map[string]any
+	err := DecodeJSONResponse(resp, &out)
+
+	if !errors.Is(err, ErrJSONResponseTooLarge) {
+		t.Fatalf("DecodeJSONResponse streaming error = %v; want errors.Is(err, ErrJSONResponseTooLarge)", err)
+	}
+	if source.read != maxJSONResponseBytes+1 {
+		t.Fatalf("DecodeJSONResponse read %d bytes; want %d", source.read, int64(maxJSONResponseBytes+1))
 	}
 }
 

--- a/internal/tracker/github_blockers.go
+++ b/internal/tracker/github_blockers.go
@@ -261,8 +261,8 @@ func (c *GitHubClient) fetchNativeGitHubBlockers(ctx context.Context, nodeIDs []
 		return githubGraphQLBlockersResponse{}, fmt.Errorf("fetch GitHub issue blockers failed: status %d", resp.StatusCode)
 	}
 	var decoded githubGraphQLBlockersResponse
-	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
-		return githubGraphQLBlockersResponse{}, err
+	if err := DecodeJSONResponse(resp, &decoded); err != nil {
+		return githubGraphQLBlockersResponse{}, fmt.Errorf("decode GitHub blockers response: %w", err)
 	}
 	if len(decoded.Errors) > 0 {
 		return githubGraphQLBlockersResponse{}, fmt.Errorf("fetch GitHub issue blockers failed: %s", decoded.Errors[0].Message)

--- a/internal/tracker/github_listing.go
+++ b/internal/tracker/github_listing.go
@@ -2,7 +2,6 @@ package tracker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -218,8 +217,8 @@ func (c *GitHubClient) listIssuesPage(ctx context.Context, issueState, label str
 		return nil, false, fmt.Errorf("list GitHub issues failed: status %d", resp.StatusCode)
 	}
 	var issues []githubIssue
-	if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
-		return nil, false, err
+	if err := DecodeJSONResponse(resp, &issues); err != nil {
+		return nil, false, fmt.Errorf("decode GitHub issues response: %w", err)
 	}
 	return issues, githubHasNextPage(resp.Header.Values("Link")), nil
 }
@@ -291,8 +290,8 @@ func (c *GitHubClient) listOpenPullRequestsPage(ctx context.Context, page int) (
 		return nil, false, fmt.Errorf("list GitHub pull requests failed: status %d", resp.StatusCode)
 	}
 	var pulls []githubPullRequestSummary
-	if err := json.NewDecoder(resp.Body).Decode(&pulls); err != nil {
-		return nil, false, err
+	if err := DecodeJSONResponse(resp, &pulls); err != nil {
+		return nil, false, fmt.Errorf("decode GitHub pull requests response: %w", err)
 	}
 	return pulls, githubHasNextPage(resp.Header.Values("Link")), nil
 }

--- a/internal/tracker/github_refresh.go
+++ b/internal/tracker/github_refresh.go
@@ -2,7 +2,6 @@ package tracker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -248,8 +247,8 @@ func (c *GitHubClient) getIssueByNumber(ctx context.Context, issueNumber int) (g
 		return githubIssue{}, false, fmt.Errorf("get GitHub issue #%d failed: status %d", issueNumber, resp.StatusCode)
 	}
 	var issue githubIssue
-	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
-		return githubIssue{}, false, err
+	if err := DecodeJSONResponse(resp, &issue); err != nil {
+		return githubIssue{}, false, fmt.Errorf("decode GitHub issue response: %w", err)
 	}
 	return issue, true, nil
 }

--- a/internal/tracker/json_decode.go
+++ b/internal/tracker/json_decode.go
@@ -1,0 +1,34 @@
+package tracker
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const maxJSONResponseBytes = 16 << 20
+
+var ErrJSONResponseTooLarge = errors.New("tracker JSON response exceeded maximum size")
+
+// DecodeJSONResponse decodes a successful tracker response without allowing a
+// misbehaving endpoint to stream unbounded JSON into the worker.
+func DecodeJSONResponse(resp *http.Response, out any) error {
+	if resp == nil || resp.Body == nil {
+		return errors.New("tracker JSON response body is nil")
+	}
+	if resp.ContentLength > maxJSONResponseBytes {
+		return fmt.Errorf("%w: limit=%d content_length=%d", ErrJSONResponseTooLarge, maxJSONResponseBytes, resp.ContentLength)
+	}
+	var body bytes.Buffer
+	n, err := body.ReadFrom(io.LimitReader(resp.Body, maxJSONResponseBytes+1))
+	if err != nil {
+		return err
+	}
+	if n > maxJSONResponseBytes {
+		return fmt.Errorf("%w: limit=%d", ErrJSONResponseTooLarge, maxJSONResponseBytes)
+	}
+	return json.NewDecoder(bytes.NewReader(body.Bytes())).Decode(out)
+}

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -720,7 +720,7 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 	if out == nil {
 		return nil
 	}
-	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+	if err := DecodeJSONResponse(resp, out); err != nil {
 		return NewError(CategoryLinearUnknownPayload, "decode Linear GraphQL response", err)
 	}
 	return nil


### PR DESCRIPTION
Closes #1038

## Summary
- Add a shared bounded JSON decoder for successful tracker/Linear HTTP responses, returning `ErrJSONResponseTooLarge` when a declared or streamed body exceeds 16 MiB.
- Route Linear, GitHub, Gitea, runner workflow-state lookup, and doctor Linear probe success decodes through the shared helper while preserving existing status/rate-limit/drain behavior.
- Add seam tests for every replaced success decode path plus a no-`Content-Length` streaming-body test.

## Acceptance
- Linear/GitHub/Gitea success JSON decoding has a shared size cap and clear typed error.
- Misbehaving endpoints with oversized `Content-Length` fail before decoding, and chunked/unknown-length streams are bounded at `limit+1`.
- Existing response lifecycle remains intact: call sites still `DrainAndClose`/close via their pre-existing deferred cleanup.
- Sibling sweep: Codex review found runner workflow-state lookup and doctor Linear probe shared the same Linear success-response class, so they were fixed in this PR. The remaining `cmd/tui/state_client.go` decoder reads the local state API, not an external tracker/Linear/GitHub/Gitea boundary, so it is out of scope.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

SPEC/Elixir evidence:
- SPEC §11.1/§11.2 define tracker read operations, Linear GraphQL transport, pagination, and the 30s network timeout; this PR keeps those operations and transport semantics unchanged.
- SPEC §11.4 says tracker errors are logged/skipped/kept running by callers; this PR only classifies an oversized success body as a decode/payload error at the existing boundary.
- SPEC §17 says implementations should not assume tracker data or other inputs are fully trustworthy; this is Go-side input-boundary hardening, not a new Symphony phase.
- `elixir/lib/symphony_elixir/linear/client.ex:164-172` returns the decoded successful Linear body from `Req.post`, and `elixir/lib/symphony_elixir/linear/client.ex:398-405` issues the JSON request with a 30s connect timeout. The Go port still follows the same request/decode flow, with an explicit response-size cap because Go streams `resp.Body` directly.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded). Production files changed: 9.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Do not collapse formatting, merge responsibilities, delete useful tests, or
reduce readability solely to check `within budget`; choose
`size-gated: justified overage` when the smallest readable change plus necessary
tests needs the space.

## TDD and mutation
- RED: oversized success-body seam tests failed for Linear, GitHub, Gitea, runner workflow-state lookup, and doctor Linear probe before each path was wired to the shared decoder.
- Mutation 1: removed the `ContentLength > maxJSONResponseBytes` guard; all oversized `Content-Length` seam tests failed across tracker/gitea/runner/doctor.
- Mutation 2: changed the streaming read from `maxJSONResponseBytes+1` to `maxJSONResponseBytes`; `TestDecodeJSONResponseBoundsStreamingBodyWithoutContentLength` failed with a normal JSON error instead of `ErrJSONResponseTooLarge`.
- Restored mutations from `HEAD`, reran focused tests, and confirmed `internal/tracker/json_decode.go` was clean against `HEAD`.

## Review fallback
- Claude Code is unavailable in this environment, so no Claude/Claude Code command was run.
- Fallback review used Codex CLI on the PR diff, manual SPEC/Elixir comparison, local diff review, sibling sweep, and the full Go gate below.
- Codex CLI review pass 1 found two P2 gaps: runner workflow-state lookup and doctor Linear probe still decoded successful Linear responses directly. Both were fixed.
- Codex CLI review pass 2 result: PASS, findings none.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- `go build ./cmd/worker ./cmd/tui`
- `go test ./internal/tracker ./internal/gitea ./internal/runner ./internal/doctor -run 'Test(LinearGraphQLRejectsOversizedSuccessBody|GitHub.*RejectsOversizedSuccessBody|DecodeJSONResponseBoundsStreamingBodyWithoutContentLength|TrackerClient.*RejectsOversizedSuccessBody|LookupWorkflowStateIDsRejectsOversizedSuccessBody|DecodeLinearProjectProbeRejectsOversizedSuccessBody)' -count=1`
- `go test ./internal/tracker ./internal/gitea -count=1`
- `go test ./internal/runner ./internal/doctor -run 'Test(LookupWorkflowStateIDsRejectsOversizedSuccessBody|LookupWorkflowStateIDsDrainsResponseBodies|DecodeLinearProjectProbeRejectsOversizedSuccessBody|DecodeLinearProjectProbeDrainsResponseBodies|ProbeLinearProjectSlugMasksEndpointUserinfoInErrors)' -count=1`

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
