### PR TITLE
fix(orchestrator): recover dispatch spawn panics

### DIFF
--- a/internal/orchestrator/actor_dispatch.go
+++ b/internal/orchestrator/actor_dispatch.go
@@ -7,6 +7,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
@@ -116,6 +117,10 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 		d.result <- ErrCapacityFull
 		return nil
 	}
+	workspace := Workspace{}
+	if consumedContinuation != nil {
+		workspace = consumedContinuation.Workspace
+	}
 	consumeContinuationRetry(st, id, consumedContinuation)
 	st.RecordEvent(RuntimeEvent{
 		Kind:       RuntimeEventCandidate,
@@ -133,8 +138,8 @@ func (d *dispatchOp) apply(st *OrchestratorState) func() {
 	attempt := d.attempt
 	result := d.result
 	return func() {
-		o.spawn(id, issue, attempt, continuationAttempt, continuationTurnCount, cleanTurnBudget)
-		result <- nil
+		defer func() { result <- nil }()
+		o.spawn(id, issue, attempt, continuationAttempt, continuationTurnCount, cleanTurnBudget, workspace)
 	}
 }
 
@@ -290,22 +295,47 @@ func (o *Orchestrator) WaitForWorkers(grace time.Duration) bool {
 //
 // spawn is invoked from a followup goroutine, never from inside an
 // apply method, so its calls into o.submit are safe.
-func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, continuationAttempt, continuationTurnCount, cleanTurnBudget int) {
+func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, continuationAttempt, continuationTurnCount, cleanTurnBudget int, workspace Workspace) {
+	workerTracked := false
+	fanoutStarted := false
+	runningRegistered := false
+	var cancel context.CancelCauseFunc
+	var startedAt time.Time
+	var workerDone chan struct{}
+	var entry *RunningEntry
+	recovery := spawnPanicRecovery{
+		o:                 o,
+		id:                id,
+		issue:             issue,
+		attempt:           attempt,
+		workspace:         workspace,
+		workerTracked:     &workerTracked,
+		fanoutStarted:     &fanoutStarted,
+		runningRegistered: &runningRegistered,
+		cancel:            &cancel,
+		startedAt:         &startedAt,
+		workerDone:        &workerDone,
+		entry:             &entry,
+	}
+	defer recovery.recover()
 	// Register with the drain group before anything that can start a worker
 	// so WaitForWorkers can never observe a live subprocess it isn't
 	// tracking; every return path below either hands the slot to the fanout
 	// goroutine or releases it.
 	o.workerWG.Add(1)
-	runCtx, cancel := context.WithCancelCause(o.runCtx)
-	startedAt := time.Now()
-	workerDone := make(chan struct{})
-	entry := &RunningEntry{
+	workerTracked = true
+	runCtx, runCancel := context.WithCancelCause(o.runCtx)
+	cancel = runCancel
+	startedAt = time.Now()
+	workerDone = make(chan struct{})
+	entry = &RunningEntry{
 		Issue:                 issue,
 		Identifier:            issue.Identifier,
 		StartedAt:             startedAt,
 		RetryAttempt:          attempt,
 		ContinuationAttempt:   continuationAttempt,
 		ContinuationTurnCount: continuationTurnCount,
+		Workspace:             workspace,
 		CancelWorker:          cancel,
 		Done:                  workerDone,
 	}
@@ -319,17 +349,26 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 		cancel(nil)
 		close(workerDone)
 		o.workerWG.Done()
+		workerTracked = false
 		return
 	}
 	select {
 	case <-registered:
+		runningRegistered = true
 	case <-o.runCtx.Done():
 		cancel(nil)
 		close(workerDone)
 		o.workerWG.Done()
+		workerTracked = false
 		return
 	}
 	resultCh := o.dispatcher.Spawn(runCtx, issue, attempt, DispatchOptions{CleanTurnBudget: cleanTurnBudget})
+	o.watchWorkerResult(id, issue, attempt, resultCh, startedAt, cancel, entry, workerDone)
+	fanoutStarted = true
+	workerTracked = false
+}
+
+func (o *Orchestrator) watchWorkerResult(id IssueID, issue tracker.Issue, attempt *int, resultCh <-chan WorkerResult, startedAt time.Time, cancel context.CancelCauseFunc, entry *RunningEntry, workerDone chan struct{}) {
 	go func() {
 		defer o.workerWG.Done()
 		defer recoverPanic("orchestrator.spawn_result_fanout")
@@ -355,6 +394,85 @@ func (o *Orchestrator) spawn(id IssueID, issue tracker.Issue, attempt *int, cont
 			close(workerDone)
 		}
 	}()
+}
+
+type spawnPanicRecovery struct {
+	o                 *Orchestrator
+	id                IssueID
+	issue             tracker.Issue
+	attempt           *int
+	workspace         Workspace
+	workerTracked     *bool
+	fanoutStarted     *bool
+	runningRegistered *bool
+	cancel            *context.CancelCauseFunc
+	startedAt         *time.Time
+	workerDone        *chan struct{}
+	entry             **RunningEntry
+}
+
+func (r spawnPanicRecovery) recover() {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+	spawnErr := fmt.Errorf("orchestrator spawn panic: %v", recovered)
+	recoverPanicValue("orchestrator.spawn", recovered)
+	if r.cancel != nil && *r.cancel != nil {
+		(*r.cancel)(spawnErr)
+	}
+	if r.fanoutStarted != nil && *r.fanoutStarted {
+		return
+	}
+	if r.canFinalizeRunning() {
+		resultCh := syntheticWorkerResult(WorkerResult{Err: spawnErr, Elapsed: time.Since(*r.startedAt)})
+		r.o.watchWorkerResult(r.id, r.issue, r.attempt, resultCh, *r.startedAt, *r.cancel, *r.entry, *r.workerDone)
+		return
+	}
+	if r.workerTracked != nil && *r.workerTracked {
+		r.o.workerWG.Done()
+		*r.workerTracked = false
+	}
+	r.o.recoverSpawnPanic(r.o.runCtx, r.id, r.issue, r.attempt, spawnErr.Error(), r.workspace)
+}
+
+func (r spawnPanicRecovery) canFinalizeRunning() bool {
+	return r.runningRegistered != nil &&
+		*r.runningRegistered &&
+		r.entry != nil &&
+		*r.entry != nil &&
+		r.workerDone != nil &&
+		*r.workerDone != nil &&
+		r.cancel != nil &&
+		*r.cancel != nil
+}
+
+func syntheticWorkerResult(result WorkerResult) <-chan WorkerResult {
+	ch := make(chan WorkerResult, 1)
+	ch <- result
+	close(ch)
+	return ch
+}
+
+func (o *Orchestrator) recoverSpawnPanic(ctx context.Context, id IssueID, issue tracker.Issue, attempt *int, runErr string, workspace Workspace) {
+	if ctx == nil {
+		return
+	}
+	identifier := issue.Identifier
+	if identifier == "" {
+		identifier = issue.ID
+	}
+	submitErr := o.submit(ctx, opFunc(func(st *OrchestratorState) func() {
+		st.RecordEvent(RuntimeEvent{Kind: RuntimeEventFailed, IssueID: id, Identifier: identifier, Message: runErr})
+		nextAttempt := 1
+		if attempt != nil {
+			nextAttempt = *attempt + 1
+		}
+		return func() {
+			o.logRescheduleErr(o.scheduleFailureRetry(ctx, issue, identifier, nextAttempt, runErr, workspace), id, identifier)
+		}
+	}))
+	o.logRescheduleErr(submitErr, id, identifier)
 }
 
 // awaitWorkerResult collects the dispatcher's single result for a spawned

--- a/internal/orchestrator/actor_dispatch_test.go
+++ b/internal/orchestrator/actor_dispatch_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,6 +97,135 @@ func (d *cancelAwareDispatcher) Spawn(ctx context.Context, _ tracker.Issue, _ *i
 		close(out)
 	}()
 	return out
+}
+
+type panicDispatcher struct{}
+
+func (panicDispatcher) Spawn(context.Context, tracker.Issue, *int, DispatchOptions) <-chan WorkerResult {
+	panic("spawn boom")
+}
+
+func TestRequestDispatchReturnsWhenSpawnPanics(t *testing.T) {
+	o, cancel := startActor(t, Deps{Dispatcher: panicDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	ctx, cancelReq := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelReq()
+	issue := tracker.Issue{ID: "ENG-PANIC", Identifier: "ENG-PANIC", State: "Todo"}
+	if err := o.RequestDispatch(ctx, issue, nil); err != nil {
+		t.Fatalf("RequestDispatch(%s) with spawn panic = %v; want nil", issue.ID, err)
+	}
+	if !o.WaitForWorkers(time.Second) {
+		t.Fatalf("WaitForWorkers(1s) = false after %s spawn panic; want true", issue.ID)
+	}
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		if err != nil {
+			return false
+		}
+		if len(view.Running) != 0 || len(view.Retrying) != 1 {
+			return false
+		}
+		retry := view.Retrying[0]
+		return retry.IssueID == IssueID(issue.ID) &&
+			retry.Kind == RetryKindFailure &&
+			strings.Contains(retry.Error, "orchestrator spawn panic")
+	}, time.Second)
+}
+
+func TestDispatchFollowupRepliesWhenSpawnRecoversBeforeDispatcher(t *testing.T) {
+	st := NewOrchestratorState(15000, 1)
+	result := make(chan error, 1)
+	op := &dispatchOp{
+		o:      &Orchestrator{},
+		issue:  tracker.Issue{ID: "ENG-PANIC-EARLY", Identifier: "ENG-PANIC-EARLY"},
+		result: result,
+	}
+	followup := op.apply(st)
+	if followup == nil {
+		t.Fatal("dispatchOp.apply returned nil followup; want spawn followup")
+	}
+	followup()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("dispatch followup reply after spawn panic = %v; want nil", err)
+		}
+	default:
+		t.Fatal("dispatch followup did not reply after spawn panic")
+	}
+}
+
+func TestSpawnPanicBeforeFanoutReleasesWorkerWait(t *testing.T) {
+	o := &Orchestrator{}
+	o.spawn("ENG-PANIC-WG", tracker.Issue{ID: "ENG-PANIC-WG", Identifier: "ENG-PANIC-WG"}, nil, 0, 0, 0, Workspace{})
+	if !o.WaitForWorkers(time.Second) {
+		t.Fatal("WaitForWorkers(1s) = false after pre-fanout spawn panic; want true")
+	}
+}
+
+func TestRecoverSpawnPanicSchedulesFailureRetryWithoutRunning(t *testing.T) {
+	o, cancel := startActor(t, Deps{Dispatcher: &fakeDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-RECOVER-CLAIM", Identifier: "ENG-RECOVER-CLAIM", State: "Todo"}
+	id := IssueID(issue.ID)
+	if err := o.submit(context.Background(), opFunc(func(st *OrchestratorState) func() {
+		st.Claimed[id] = struct{}{}
+		st.ClaimedIssues[id] = issue
+		return nil
+	})); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+	o.recoverSpawnPanic(context.Background(), id, issue, nil, "orchestrator spawn panic: boom", Workspace{})
+
+	waitFor(t, func() bool {
+		view, err := o.Snapshot(context.Background())
+		return err == nil &&
+			len(view.Running) == 0 &&
+			len(view.Retrying) == 1 &&
+			view.Retrying[0].IssueID == id &&
+			view.Retrying[0].Kind == RetryKindFailure &&
+			strings.Contains(view.Retrying[0].Error, "orchestrator spawn panic")
+	}, time.Second)
+}
+
+func TestRetryDispatchSpawnPanicPreservesWorkspace(t *testing.T) {
+	scheduler := &sequenceScheduler{delays: []time.Duration{time.Millisecond, time.Minute}}
+	o, cancel := startActor(t, Deps{Dispatcher: panicDispatcher{}, Scheduler: scheduler})
+	defer cancel()
+
+	issue := tracker.Issue{ID: "ENG-RETRY-WORKSPACE", Identifier: "ENG-RETRY-WORKSPACE", State: "Todo"}
+	id := IssueID(issue.ID)
+	workspace := Workspace{Path: "/tmp/aiops/workspaces/ENG-RETRY-WORKSPACE", Root: "/tmp/aiops/workspaces"}
+	if err := o.scheduleFailureRetry(context.Background(), issue, issue.Identifier, 1, "transient", workspace); err != nil {
+		t.Fatalf("scheduleFailureRetry: %v", err)
+	}
+	waitFor(t, func() bool {
+		path, attempt := retryWorkspace(t, o, id)
+		return attempt == 2 && path == workspace.Path
+	}, time.Second)
+}
+
+func retryWorkspace(t *testing.T, o *Orchestrator, id IssueID) (string, int) {
+	t.Helper()
+	type retryWorkspaceResult struct {
+		path    string
+		attempt int
+	}
+	reply := make(chan retryWorkspaceResult, 1)
+	if err := o.submit(context.Background(), opFunc(func(st *OrchestratorState) func() {
+		if retry := st.RetryAttempts[id]; retry != nil {
+			reply <- retryWorkspaceResult{path: retry.Workspace.Path, attempt: retry.Attempt}
+			return nil
+		}
+		reply <- retryWorkspaceResult{}
+		return nil
+	})); err != nil {
+		t.Fatalf("read retry workspace: %v", err)
+	}
+	got := <-reply
+	return got.path, got.attempt
 }
 
 // TestWaitForWorkers_DrainsInFlightWorkerOnShutdown reproduces the issue

--- a/internal/orchestrator/actor_retry.go
+++ b/internal/orchestrator/actor_retry.go
@@ -451,7 +451,7 @@ func retryFireDispatchTail(st *OrchestratorState, entry *RetryEntry, id IssueID,
 			a := attempt
 			retryAttempt = &a
 		}
-		o.spawn(id, issue, retryAttempt, 0, 0, 0)
+		o.spawn(id, issue, retryAttempt, 0, 0, 0, entry.Workspace)
 	}
 }
 

--- a/internal/orchestrator/workflow_runtime.go
+++ b/internal/orchestrator/workflow_runtime.go
@@ -365,10 +365,12 @@ func RunWorkflowReloadLoop(ctx context.Context, runtime *WorkflowRuntime, opts W
 }
 
 func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(d):
+	case <-timer.C:
 		return nil
 	}
 }

--- a/internal/orchestrator/workflow_runtime_test.go
+++ b/internal/orchestrator/workflow_runtime_test.go
@@ -1,0 +1,67 @@
+package orchestrator
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestSleepContextUsesStoppableTimer(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "workflow_runtime.go", nil, 0)
+	if err != nil {
+		t.Fatalf("ParseFile(workflow_runtime.go) = %v; want nil", err)
+	}
+	fn := findFunc(file, "sleepContext")
+	if fn == nil {
+		t.Fatal("sleepContext function not found")
+	}
+	if callsSelector(fn, "time", "After") {
+		t.Fatal("sleepContext uses time.After; want time.NewTimer plus Stop")
+	}
+	if !callsSelector(fn, "time", "NewTimer") {
+		t.Fatal("sleepContext does not call time.NewTimer")
+	}
+	if !callsStop(fn) {
+		t.Fatal("sleepContext does not stop its timer")
+	}
+}
+
+func findFunc(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
+func callsSelector(fn *ast.FuncDecl, receiver, selector string) bool {
+	found := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != selector {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if ok && ident.Name == receiver {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+func callsStop(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if ok && sel.Sel.Name == "Stop" {
+			found = true
+		}
+		return true
+	})
+	return found
+}


### PR DESCRIPTION
Closes #1037

## Summary
- Replace `sleepContext`'s `time.After` wait with a stoppable `time.NewTimer` so interrupted poll/reload sleeps do not leave timers alive until the full interval elapses.
- Harden dispatch spawn panics so `RequestDispatch` always receives its reply, `WaitForWorkers` is not stranded, and recovered spawn failures flow into the existing failure-retry state path while preserving retry workspaces.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

SPEC / upstream notes:
- This is Go runtime-guarantee compensation, not a new Symphony phase or deviation.
- SPEC describes retry timers as cancelable handles and dispatch failures as retryable; upstream Elixir cancels existing timers in `elixir/lib/symphony_elixir/orchestrator.ex` (`schedule_tick`, `schedule_issue_retry`) and routes spawn child errors back into retry handling.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: 3 files, ~129 added / 9 removed production LOC.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` → `0 issues.`
- `go test ./internal/orchestrator -count=1`
- `go build ./cmd/worker ./cmd/tui`

Mutation checks:
- Disabled dispatch followup reply while keeping the code compiling; `TestRequestDispatchReturnsWhenSpawnPanics` failed with `context deadline exceeded`.
- Disabled `spawnPanicRecovery`; `TestRequestDispatchReturnsWhenSpawnPanics` failed because `WaitForWorkers` did not drain.
- Disabled claim-level spawn-panic retry scheduling; `TestRecoverSpawnPanicSchedulesFailureRetryWithoutRunning` failed waiting for the failure retry.
- Dropped retry workspace threading on retry redispatch; `TestRetryDispatchSpawnPanicPreservesWorkspace` failed because the recovered retry lost its workspace path.
- Reverted `sleepContext` to `time.After`; `TestSleepContextUsesStoppableTimer` failed.

Review fallback:
- Claude Code is unavailable in this environment, so the double-review fallback used Codex CLI diff review, manual local diff review, SPEC/Elixir comparison, GitHub `@codex review`, and the Go gates above.
- Local Codex CLI diff review final pass on head `2226a24d`: `PASS` with no source-confirmed correctness, race, leak, or test-quality findings.
- GitHub `@codex review` on the previous head found a retry-workspace preservation gap; the final head threads the workspace through dispatch spawn recovery and retry redispatch. GitHub `@codex review` on head `2226a24d28` then reported no major issues.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
