### PR TITLE
fix(gitea): reuse default tracker HTTP client

### DIFF
--- a/internal/gitea/tracker_client.go
+++ b/internal/gitea/tracker_client.go
@@ -52,6 +52,9 @@ type TrackerClient struct {
 
 	issueNumbers sync.Map
 
+	defaultHTTPOnce sync.Once
+	defaultHTTP     *http.Client
+
 	paginationCapHits atomic.Int64
 }
 
@@ -76,7 +79,13 @@ func (c *TrackerClient) httpClient() *http.Client {
 	if c != nil && c.HTTP != nil {
 		return c.HTTP
 	}
-	return &http.Client{Timeout: c.requestTimeout()}
+	if c == nil {
+		return &http.Client{Timeout: defaultGiteaRequestTimeout}
+	}
+	c.defaultHTTPOnce.Do(func() {
+		c.defaultHTTP = &http.Client{Timeout: c.requestTimeout()}
+	})
+	return c.defaultHTTP
 }
 
 // PaginationCapHits returns how often this client observed more than

--- a/internal/gitea/tracker_client_timeout_test.go
+++ b/internal/gitea/tracker_client_timeout_test.go
@@ -38,6 +38,33 @@ func TestTrackerClientFallbackHTTPClientUsesRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestTrackerClientDefaultHTTPClientIsReused(t *testing.T) {
+	c := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, "https://gitea.example", "owner", "repo")
+
+	first := c.httpClient()
+	second := c.httpClient()
+
+	if first == nil || second == nil {
+		t.Fatalf("default HTTP clients = %p, %p; want non-nil", first, second)
+	}
+	if first != second {
+		t.Fatalf("default HTTP client pointers = %p, %p; want reuse", first, second)
+	}
+	if got := first.Timeout; got != defaultGiteaRequestTimeout {
+		t.Fatalf("default HTTP.Timeout = %v, want %v", got, defaultGiteaRequestTimeout)
+	}
+}
+
+func TestTrackerClientInjectedHTTPClientWins(t *testing.T) {
+	injected := &http.Client{Timeout: 750 * time.Millisecond}
+	c := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, "https://gitea.example", "owner", "repo")
+	c.HTTP = injected
+
+	if got := c.httpClient(); got != injected {
+		t.Fatalf("httpClient() = %p, want injected %p", got, injected)
+	}
+}
+
 func TestTrackerClientListIssuesAbortsHungServer(t *testing.T) {
 	srv := hungGiteaServer(t)
 	client := NewTrackerClient(workflow.TrackerConfig{


### PR DESCRIPTION
Closes #1036

## Summary
- Cache the default Gitea tracker `*http.Client` behind `sync.Once` so production requests reuse one client instead of allocating a fresh client per API call.
- Keep explicit `TrackerClient.HTTP` injection as the highest-priority path, and keep the default client timeout wired through `requestTimeout()`.

## Technical conclusion
- Problem: `TrackerClient.HTTP == nil` caused `httpClient()` to allocate a new `http.Client` for each Gitea request.
- Boundary: this is tracker adapter transport hygiene, not a new tracker operation, worker/orchestrator phase, cache, state machine, or tracker write.
- Minimum fix: reuse one default client per `TrackerClient`; keep explicit test/caller injection unchanged.
- Non-goals: no changes to Gitea pagination, blocker lookup semantics, tracker API shape, or request timeout policy.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

SPEC / upstream notes:
- SPEC §11 requires tracker reader operations and normalized outputs; it does not require per-request HTTP client allocation.
- Upstream Elixir's Linear client issues requests through the shared `Req` stack (`elixir/lib/symphony_elixir/linear/client.ex`), so this change keeps Gitea adapter transport behavior inside the existing tracker boundary.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: 1 file, ~10 added / 1 removed production LOC.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0` → `0 issues.`
- `go test ./internal/gitea -count=1`
- `go test ./internal/gitea -run 'TestTrackerClient(DefaultHTTPClientIsReused|InjectedHTTPClientWins|FallbackHTTPClientUsesRequestTimeout)' -count=1`
- `go build ./cmd/worker ./cmd/tui`

Mutation checks:
- Replaced the cached default client return with a fresh `&http.Client{Timeout: c.requestTimeout()}`; `TestTrackerClientDefaultHTTPClientIsReused` failed on pointer mismatch.
- Disabled the explicit `HTTP` injection branch; `TestTrackerClientInjectedHTTPClientWins` failed because `httpClient()` did not return the injected client.

Review fallback:
- Claude Code is unavailable in this environment, so the double-review fallback used Codex CLI diff review, manual local diff review, SPEC/Elixir comparison, sibling sweep, GitHub `@codex review`, and the Go gates above.
- Local Codex CLI diff review on head `7c20c22`: `PASS` with no source-confirmed correctness, race, leak, or test-quality findings. Its read-only sandbox could not run live `gh`/Go cache checks, so the main session performed those gates directly.
- GitHub `@codex review` on head `7c20c22372` reported no major issues.

## Notes
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
