### PR TITLE
ci: restore Go security and golangci contract gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,13 +173,10 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
 
-      # Build the govulncheck toolchain from the go.mod floor (now 1.25.11, the
-      # patched release for GO-2026-5037/5039) so the scan evaluates the same
-      # standard library the release/docker builds ship. The previous "latest
-      # 1.25.x via check-latest" posture broke when the actions version manifest
-      # lagged the 1.25.11 security release: check-latest still resolved a
-      # vulnerable 1.25.10, so the gate failed repo-wide while shipped artifacts
-      # stayed on the unpatched floor. Pinning scan == ship via go.mod fixes both.
+      # Build govulncheck with the exact go.mod security floor so the scan
+      # evaluates the same standard library the release and Docker builds ship.
+      # Resolving a floating minor through check-latest previously lagged a Go
+      # security release and left both the gate and shipped artifacts vulnerable.
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25.11
+ARG GO_VERSION=1.25.12
 FROM node:22-bookworm AS dashboard
 WORKDIR /src/cmd/worker/dashboard
 COPY cmd/worker/dashboard/package.json cmd/worker/dashboard/package-lock.json ./

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -33,7 +33,7 @@ needs Postgres, it is stale — file an issue.
 
 ## Prerequisites
 
-- Go 1.25.11 or newer (the exact patch floor pinned in `go.mod` and the
+- Go 1.25.12 or newer (the exact patch floor pinned in `go.mod` and the
   Dockerfile).
 - `git` and `curl`.
 - Tracker credentials matching the workflow you're running:
@@ -69,8 +69,8 @@ container runtime.
 
 Keep `GOTOOLCHAIN=auto` enabled unless you have already installed the pinned Go
 toolchain locally. With `GOTOOLCHAIN=auto`, modern Go can download the required
-toolchain when the checkout asks for Go 1.25.11. If the machine is offline or
-the download is blocked, install Go 1.25.11 first (or pre-seed the toolchain)
+toolchain when the checkout asks for Go 1.25.12. If the machine is offline or
+the download is blocked, install Go 1.25.12 first (or pre-seed the toolchain)
 and re-run `./scripts/dev-test.sh`.
 
 ## 1. Configure the workflow and environment

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xrf9268-hue/aiops-platform
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -42,12 +42,24 @@ func TestCIGolangCILintHasBlockingCorrectnessGate(t *testing.T) {
 	}
 
 	text := string(body)
-	blockingStep := regexp.MustCompile(`(?s)- name: Run golangci-lint blocking gate.*?(?:\n\n|$)`).FindString(text)
-	if blockingStep == "" {
-		t.Fatal("CI workflow missing blocking golangci-lint gate")
+	lintSteps := regexp.MustCompile(
+		`(?s)- name: Run golangci-lint blocking gate(?: \(e2e build tag\))?.*?(?:\n\n|$)`,
+	).FindAllString(text, -1)
+	if got, want := len(lintSteps), 2; got != want {
+		t.Fatalf("golangci-lint blocking gate count = %d; want %d", got, want)
 	}
+	actionPattern := regexp.MustCompile(`golangci/golangci-lint-action@[0-9a-f]{40}`)
+	actionRef := actionPattern.FindString(lintSteps[0])
+	if actionRef == "" {
+		t.Fatalf("blocking golangci-lint step action is not pinned to a commit SHA:\n%s", lintSteps[0])
+	}
+	for i, step := range lintSteps[1:] {
+		if got := actionPattern.FindString(step); got != actionRef {
+			t.Fatalf("golangci-lint gate %d action = %q; want %q", i+2, got, actionRef)
+		}
+	}
+	blockingStep := lintSteps[0]
 	for _, want := range []string{
-		"golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee",
 		"version: v2.12.2",
 		// funlen+gocognit are part of the single blocking gate (#504); the
 		// baseline is grandfathered in-line via //nolint, not report-only.


### PR DESCRIPTION
Closes #1085
Closes #1086

## Summary
- make the golangci workflow contract update-safe by removing its duplicated action revision
- require both blocking lint gates to use the same immutable 40-character commit SHA
- raise the Go security floor and shipped Docker toolchain from 1.25.11 to 1.25.12
- keep govulncheck on the exact `go.mod` floor and refresh the current local-development runbook

## Root cause
Two required checks on `main` formed a merge deadlock. Dependabot PR #1075 updated both action references in `.github/workflows/ci.yml`, while the contract test retained a third copy of the old SHA. Independently, GO-2026-5856 affects the Go 1.25.11 standard library and is fixed in 1.25.12. A PR containing only either repair still fails the other required check, so both narrow fixes must enter `main` atomically; they remain separate commits.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] explicit RED: Go 1.25.11 `govulncheck ./...` reports GO-2026-5856 and exits 3
- [x] explicit GREEN: Go 1.25.12 `govulncheck ./...` reports no vulnerabilities
- [x] mutation: mismatched lint-gate SHAs fail with actual and expected refs
- [x] mutation: Docker 1.25.11 vs go.mod 1.25.12 fails the alignment check
- [x] `gofmt -l $(git ls-files '*.go')`
- [x] `go mod tidy && git diff --exit-code -- go.sum`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0`
- [x] `go test -run '^(TestCIGolangCILintHasBlockingCorrectnessGate|TestProductionGoFilesStayWithinSizeBudget)$' -count=1 ./scripts`
- [x] `go test -race -covermode=atomic ./...`
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] `docker manifest inspect golang:1.25.12-bookworm`

## Notes
- Official Go vulnerability record: https://pkg.go.dev/vuln/GO-2026-5856
- Go 1.25.12 is the first fixed 1.25 release for this advisory.