### PR TITLE
fix(workflow): make stable-head reviewer retries idempotent

### DIFF
--- a/docs/runbooks/github-maker-reviewer-automerge-e2e.md
+++ b/docs/runbooks/github-maker-reviewer-automerge-e2e.md
@@ -23,6 +23,8 @@ repository.
   and different agent context.
 - The reviewer requests Rework on a failing head, and the maker responds with a
   new head before handing off again.
+- The reviewer records one exact head/base `COMMENTED` checkpoint after local
+  PASS; same-tuple retries reuse it and take one live external-state snapshot.
 - The reviewer approves and enables GitHub native CI-gated auto-merge only after
   review passes.
 - The reviewer confirms `state: MERGED` or non-empty `mergedAt` before adding
@@ -195,21 +197,17 @@ for label in aiops:todo aiops:rework aiops:human-review aiops:blocked aiops:done
 done
 ```
 
-`aiops:blocked` is an inactive operator-triage state for true blockers: missing
-tools/auth/permissions or issue scope that cannot continue without an operator
-decision. Codex review no-signal, NOT-CONFIRMED, usage-limit, CI pending, and
-auto-merge pending stay in `aiops:human-review`; current-head unresolved review
-threads are reviewer FAIL evidence that moves the issue to `aiops:rework`. The
-workflow examples do not use historical `CHANGES_REQUESTED` count as a stop
-condition; repeated loops are prevented by refusing unchanged-head
-handoffs/reviews. A
-`Rework response:` comment alone does not replace a new PR head. Blocked
-handoff commands remove the role's active label (`aiops:todo`, `aiops:rework`,
-or `aiops:human-review`) while adding `aiops:blocked`; adding only
-`aiops:blocked` leaves the issue eligible for the next worker tick.
-Maker handoff must include `Rework response:` in an issue comment for rework and
-must not hand off while current-head unresolved non-outdated review threads
-remain.
+`aiops:blocked` is only for true operator-owned blockers. Codex, CI, approval,
+auto-merge, and merge pending stay in `aiops:human-review`; current-head review
+threads are FAIL evidence for `aiops:rework`. Rework needs a new head plus a
+`Rework response:`; historical review counts are diagnostic only.
+
+After local PASS on an unseen `(headRefOid, baseRefOid, baseRefName)`, the
+reviewer writes one reviewer-owned `COMMENTED` checkpoint. A same-tuple retry
+skips local gates/rubric, reuses any exact-tuple Codex trigger, and takes one
+live snapshot. It never posts a second trigger or waits/polls for external
+state. A changed head/base requires full review. Blocked handoffs remove the
+role's active labels while adding `aiops:blocked`.
 
 Enable auto-merge and squash-only merges:
 
@@ -400,6 +398,7 @@ Required machine evidence:
 - worker doctor logs
 - maker and reviewer worker logs
 - `/api/v1/state` snapshots
+- reviewer checkpoint and exact-tuple trigger evidence
 - GitHub issue JSON
 - GitHub PR JSON
 - GitHub Actions/check JSON
@@ -487,6 +486,8 @@ PASS requires all of the following:
 - Dependency issue is not activated before prerequisite Done/closed evidence.
 - Maker does not approve, auto-merge, merge, close, or add `aiops:done`.
 - Reviewer does not edit, commit, or push code.
+- Same-tuple reviewer retry reuses its checkpoint, samples external state once,
+  and does not repeat verification or the semantic/security rubric.
 - Worker/orchestrator does not create PRs, merge PRs, or directly set terminal
   tracker state.
 - Issue closure occurs only after reviewer confirms GitHub merged state.

--- a/docs/runbooks/github-maker-reviewer-automerge-e2e.md
+++ b/docs/runbooks/github-maker-reviewer-automerge-e2e.md
@@ -206,8 +206,12 @@ After local PASS on an unseen `(headRefOid, baseRefOid, baseRefName)`, the
 reviewer writes one reviewer-owned `COMMENTED` checkpoint. A same-tuple retry
 skips local gates/rubric, reuses any exact-tuple Codex trigger, and takes one
 live snapshot. It never posts a second trigger or waits/polls for external
-state. A changed head/base requires full review. Blocked handoffs remove the
-role's active labels while adding `aiops:blocked`.
+state. REST records and GraphQL threads are paginated inside the snapshot. A
+changed head/base requires full review. Review commands use a detached captured
+head, a pre-write tuple-only guard, and REST `commit_id` pinning. Branch
+protection's stale approval dismissal prevents a later merge-base change from
+using the prior approval. Blocked handoffs remove active labels while adding
+`aiops:blocked`.
 
 Enable auto-merge and squash-only merges:
 

--- a/docs/runbooks/github-maker-reviewer-automerge-e2e.md
+++ b/docs/runbooks/github-maker-reviewer-automerge-e2e.md
@@ -208,10 +208,10 @@ skips local gates/rubric, reuses any exact-tuple Codex trigger, and takes one
 live snapshot. It never posts a second trigger or waits/polls for external
 state. REST records and GraphQL threads are paginated inside the snapshot. A
 changed head/base requires full review. Review commands use a detached captured
-head, a pre-write tuple-only guard, and REST `commit_id` pinning. Branch
-protection's stale approval dismissal prevents a later merge-base change from
-using the prior approval. Blocked handoffs remove active labels while adding
-`aiops:blocked`.
+head, a pre-write tuple-only guard, REST `commit_id` pinning, and a
+post-approval guard that revokes a raced approval before auto-merge. Branch
+protection's stale approval dismissal covers later merge-base changes. Blocked
+handoffs remove active labels while adding `aiops:blocked`.
 
 Enable auto-merge and squash-only merges:
 

--- a/docs/runbooks/github-maker-reviewer-automerge-e2e.md
+++ b/docs/runbooks/github-maker-reviewer-automerge-e2e.md
@@ -207,11 +207,12 @@ reviewer writes one reviewer-owned `COMMENTED` checkpoint. A same-tuple retry
 skips local gates/rubric, reuses any exact-tuple Codex trigger, and takes one
 live snapshot. It never posts a second trigger or waits/polls for external
 state. REST records and GraphQL threads are paginated inside the snapshot. A
-changed head/base requires full review. Review commands use a detached captured
-head, a pre-write tuple-only guard, REST `commit_id` pinning, and a
-post-approval guard that revokes a raced approval before auto-merge. Branch
-protection's stale approval dismissal covers later merge-base changes. Blocked
-handoffs remove active labels while adding `aiops:blocked`.
+changed head/base requires full review. Trigger, review, and auto-merge writes
+use a tuple-only guard; review commands also use a detached captured head and
+REST `commit_id` pinning. Existing auto-merge is disabled before a new approval,
+and a post-approval guard revokes a raced approval before it is re-enabled.
+Branch protection's stale approval dismissal covers later merge-base changes.
+Blocked handoffs remove active labels while adding `aiops:blocked`.
 
 Enable auto-merge and squash-only merges:
 

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -89,13 +89,13 @@ review, post a second exact-tuple Codex trigger, or wait/poll in the turn. A hea
 or base change invalidates the checkpoint. REST collections and GraphQL review
 threads are paginated to exhaustion inside that one bounded snapshot.
 
-Local review uses a detached checkout of the captured head. Before any review
-write, a tuple-only guard rejects a changed head/base without refreshing the
-asynchronous gates. Reviews use the REST API with `commit_id` pinned to the
-captured head. A post-approval tuple guard revokes a just-created approval and
-suppresses auto-merge if the tuple raced; after that guard, branch protection's
-stale approval dismissal prevents a later merge-base change from landing on
-the earlier approval.
+Local review uses a detached checkout of the captured head. Before any trigger,
+review, or auto-merge write, a tuple-only guard rejects a changed head/base
+without refreshing the asynchronous gates. Reviews use the REST API with
+`commit_id` pinned to the captured head. Existing auto-merge is disabled before
+a new approval; a post-approval tuple guard revokes a raced approval before
+auto-merge is re-enabled. Branch protection's stale approval dismissal covers
+later merge-base changes.
 
 Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending
 stay in `aiops:human-review`; absence of a reliable Codex signal is never clean.

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -92,8 +92,10 @@ threads are paginated to exhaustion inside that one bounded snapshot.
 Local review uses a detached checkout of the captured head. Before any review
 write, a tuple-only guard rejects a changed head/base without refreshing the
 asynchronous gates. Reviews use the REST API with `commit_id` pinned to the
-captured head. Branch protection must provide stale approval dismissal so a
-later merge-base change cannot land on the earlier approval.
+captured head. A post-approval tuple guard revokes a just-created approval and
+suppresses auto-merge if the tuple raced; after that guard, branch protection's
+stale approval dismissal prevents a later merge-base change from landing on
+the earlier approval.
 
 Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending
 stay in `aiops:human-review`; absence of a reliable Codex signal is never clean.

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -97,9 +97,9 @@ a new approval; a post-approval tuple guard revokes a raced approval before
 auto-merge is re-enabled. Branch protection's stale approval dismissal covers
 later merge-base changes.
 
-The reviewer body owns the `Verification (you own this)` marker so configured
-commands apply only to unseen tuples; this suppresses the worker's generic
-unconditional verify directive on same-tuple retries.
+Conditional reviewer verification commands live only in the reviewer body.
+Its `verify.commands` stays empty so the worker cannot append a generic,
+unconditional directive to same-tuple retries.
 
 Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending
 stay in `aiops:human-review`; absence of a reliable Codex signal is never clean.

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -86,7 +86,14 @@ checkpoint containing the tuple and `local-rubric=PASS`. A same-tuple retry
 reuses that checkpoint and takes one live snapshot of Codex, review threads,
 required checks, approval, auto-merge, and merge state. It does not repeat local
 review, post a second exact-tuple Codex trigger, or wait/poll in the turn. A head
-or base change invalidates the checkpoint.
+or base change invalidates the checkpoint. REST collections and GraphQL review
+threads are paginated to exhaustion inside that one bounded snapshot.
+
+Local review uses a detached checkout of the captured head. Before any review
+write, a tuple-only guard rejects a changed head/base without refreshing the
+asynchronous gates. Reviews use the REST API with `commit_id` pinned to the
+captured head. Branch protection must provide stale approval dismissal so a
+later merge-base change cannot land on the earlier approval.
 
 Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending
 stay in `aiops:human-review`; absence of a reliable Codex signal is never clean.
@@ -124,8 +131,8 @@ Configure GitHub so repository policy, not the worker, is the merge gate:
 
 - require at least one required status check, such as `build-test`;
 - require one required approving review;
-- enable stale-review dismissal or require approval of the latest push when the
-  repository policy supports it;
+- enable stale-review dismissal (including merge-base changes) and require
+  approval of the latest push when the repository policy supports it;
 - disallow force pushes and direct pushes to `main`;
 - enable squash-only merging and GitHub native auto-merge;
 - ensure the reviewer identity is different from the maker identity, because PR

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -17,9 +17,10 @@ Those operations belong to the agents and GitHub:
 - The maker agent implements the issue, verifies it, pushes a branch, opens or
   updates a PR, comments the PR URL on the issue, and hands off with
   `aiops:human-review`.
-- The reviewer agent independently reviews the PR head, requests Rework or
-  approves, enables GitHub native auto-merge, waits for GitHub to report the PR
-  merged, then marks the issue `aiops:done` and closes it.
+- The reviewer agent independently reviews each unseen head/base tuple once.
+  Later invocations sample external state once, without repeating local review
+  or waiting inside the model turn. After GitHub reports the PR merged, the
+  reviewer marks the issue `aiops:done` and closes it.
 - GitHub branch protection and Actions decide whether the approved PR can land.
 
 Do not add a worker/orchestrator phase, gate, config key, artifact, merge
@@ -77,14 +78,20 @@ also remove that role's active labels. Adding `aiops:blocked` while leaving
 `aiops:todo`, `aiops:rework`, or `aiops:human-review` in place keeps the issue
 eligible for the next worker tick.
 
-Historical `CHANGES_REQUESTED` count is diagnostic only. Do not use it as a
-hard stop while each cycle has a new head; a `Rework response:` explains the
-fix, but it does not replace a new PR head. Prevent duplicate loops by refusing
-unchanged-head handoffs or reviews.
+Historical `CHANGES_REQUESTED` count is diagnostic; Rework always needs a new
+head and a `Rework response:`. For each unseen
+`(headRefOid, baseRefOid, baseRefName)`, the reviewer runs verification and its
+semantic/security rubric once, then records a reviewer-owned `COMMENTED`
+checkpoint containing the tuple and `local-rubric=PASS`. A same-tuple retry
+reuses that checkpoint and takes one live snapshot of Codex, review threads,
+required checks, approval, auto-merge, and merge state. It does not repeat local
+review, post a second exact-tuple Codex trigger, or wait/poll in the turn. A head
+or base change invalidates the checkpoint.
+
 Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending
-stay in `aiops:human-review`; they are not `aiops:blocked` reasons. A later
-reviewer poll can re-check the same head. Current-head unresolved review threads
-are normal FAIL evidence and move the issue to `aiops:rework`.
+stay in `aiops:human-review`; absence of a reliable Codex signal is never clean.
+Current-head unresolved review threads are FAIL evidence and move the issue to
+`aiops:rework`.
 
 The normal flow is:
 
@@ -150,6 +157,8 @@ rerunning the long validation every time:
   `state`, and `mergedAt`;
 - maker handoff issue comment containing the PR URL;
 - reviewer approval or Rework review tied to the reviewed head SHA;
+- reviewer-owned `COMMENTED` checkpoint tied to the exact head/base tuple;
+- at most one reviewer-authored Codex trigger for that tuple when configured;
 - Done/close comment after merge confirmation.
 
 For release validation or a disposable proof run, use the helper scripts from
@@ -179,11 +188,11 @@ Treat governance failures as blockers, not reasons to collapse roles:
 - Failed review or missing behavior-level tests: reviewer requests changes and
   moves the issue to `aiops:rework`; maker must push a new head and include a
   `Rework response:`.
-- CI still running after approval: leave the issue in `aiops:human-review` so a
-  later reviewer continuation can re-check the same PR before marking Done.
+- CI still running after approval: leave the issue in `aiops:human-review`; the
+  next invocation reuses the exact-tuple checkpoint and samples state once.
 - Codex review no-signal, NOT-CONFIRMED, usage-limit, or asynchronous review
-  delay: comment the evidence, leave the issue in `aiops:human-review`, and let
-  a later reviewer poll re-check. Do not move it to `aiops:blocked`.
+  delay: leave `aiops:human-review` unchanged. Do not trigger the same tuple
+  again or move it to `aiops:blocked`.
 - PR already merged but approval/check evidence is missing for the merged head:
   stop and collect the missing evidence or escalate to an operator. Do not jump
   straight to Done.

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -97,6 +97,10 @@ a new approval; a post-approval tuple guard revokes a raced approval before
 auto-merge is re-enabled. Branch protection's stale approval dismissal covers
 later merge-base changes.
 
+The reviewer body owns the `Verification (you own this)` marker so configured
+commands apply only to unseen tuples; this suppresses the worker's generic
+unconditional verify directive on same-tuple retries.
+
 Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending
 stay in `aiops:human-review`; absence of a reliable Codex signal is never clean.
 Current-head unresolved review threads are FAIL evidence and move the issue to

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -77,6 +77,9 @@ When a maker or reviewer parks an issue in `aiops:blocked`, the command must
 also remove that role's active labels. Adding `aiops:blocked` while leaving
 `aiops:todo`, `aiops:rework`, or `aiops:human-review` in place keeps the issue
 eligible for the next worker tick.
+Likewise, a reviewer return to `aiops:rework` must remove
+`aiops:human-review` in the same `gh issue edit`; dual active labels can
+dispatch both roles.
 
 Historical `CHANGES_REQUESTED` count is diagnostic; Rework always needs a new
 head and a `Rework response:`. For each unseen

--- a/docs/runbooks/github-maker-reviewer-governance.md
+++ b/docs/runbooks/github-maker-reviewer-governance.md
@@ -77,9 +77,9 @@ When a maker or reviewer parks an issue in `aiops:blocked`, the command must
 also remove that role's active labels. Adding `aiops:blocked` while leaving
 `aiops:todo`, `aiops:rework`, or `aiops:human-review` in place keeps the issue
 eligible for the next worker tick.
-Likewise, a reviewer return to `aiops:rework` must remove
-`aiops:human-review` in the same `gh issue edit`; dual active labels can
-dispatch both roles.
+Likewise, after returning to `aiops:rework`, re-read labels and repair until
+`aiops:rework` is present and `aiops:human-review` absent; fail if that cannot
+converge. Dual active labels can dispatch both roles.
 
 Historical `CHANGES_REQUESTED` count is diagnostic; Rework always needs a new
 head and a `Rework response:`. For each unseen

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -35,10 +35,10 @@ Prompt bytes exclude YAML front matter.
 | Prompt | #1089 baseline | #1090 | Change |
 | --- | ---: | ---: | ---: |
 | Maker | 4,341 | 2,439 | -43.8% |
-| Reviewer | 6,892 | 5,823 | -15.5% |
-| Combined | 11,233 | 8,262 | -26.4% |
+| Reviewer | 6,892 | 5,960 | -13.5% |
+| Combined | 11,233 | 8,399 | -25.2% |
 
-The two workflows and two governance/E2E runbooks contain 979 lines, down from
+The two workflows and two governance/E2E runbooks contain 981 lines, down from
 1,015. Tests are excluded from that net-negative count.
 
 ## Replay result

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -1,0 +1,97 @@
+# Stable-head reviewer replay
+
+**Date:** 2026-07-14
+
+**Issue:** #1090
+
+**Verdict:** PASS. Exact-tuple reviewer checkpoints made merged-head
+continuations idempotent, while a changed head still forced a complete review.
+
+## Scope
+
+This replay reused the #1089 standard-profile seed, issue bodies, ordering,
+worker release, model, CI gate, and preregistered holdout. The disposable
+repository was
+<https://github.com/zjlgdx/aiops-workflow-bench-standard-20260714-1090-v1>.
+Issue 2 was activated only after issue 1 closed.
+
+| Pin | Value |
+| --- | --- |
+| Seed | `5e6264cdcfd2decb53491e37de4f825878339487` |
+| Worker | official v0.1.15 darwin/arm64 release |
+| Codex CLI | 0.144.3 |
+| Model / reasoning | `gpt-5.6-sol` / high |
+| CI | `build-test`: `go test ./...`, `go vet ./...` |
+| Holdout | #1089 preregistered real-process shell suite |
+
+The operator performed repository setup, sequential activation, and read-only
+state capture. After activation, the maker and reviewer owned code, PR,
+review, merge, and issue-state writes.
+
+## Prompt and document budgets
+
+Prompt bytes exclude YAML front matter.
+
+| Prompt | #1089 baseline | #1090 | Change |
+| --- | ---: | ---: | ---: |
+| Maker | 4,341 | 2,439 | -43.8% |
+| Reviewer | 6,892 | 4,472 | -35.1% |
+| Combined | 11,233 | 6,911 | -38.5% |
+
+The two workflows and two governance/E2E runbooks contain 948 lines, down from
+1,015. Tests are excluded from that net-negative count.
+
+## Replay result
+
+Both issues closed after their PRs merged, and a fresh clone at final main
+`7e56f3e34132042f8d812b6acb45677153c74d1a` passed the #1089 holdout.
+
+| Issue | PR / final head | Merged | Closed | Rework |
+| --- | --- | --- | --- | ---: |
+| #1 | #3 / `f14a70fd8151b38eccca720aafb6e9ddb145a2aa` | 06:16:21Z | 06:18:10Z | 1 |
+| #2 | #4 / `56fa3e45d1c2fdb9300862cc0554c66054708f53` | 06:26:33Z | 06:28:29Z | 0 |
+
+On issue 1, the first reviewer pass found two confirmed defects: missing
+`TODO_DB` changed invalid-invocation behavior, and embedded newlines violated
+the one-record-per-line contract. The maker pushed a new head; that tuple
+change invalidated the prior review and caused a complete new review. No
+operator manufactured the findings or rework.
+
+Every passing tuple received one reviewer-owned `COMMENTED` checkpoint with
+the exact `(headRefOid, baseRefOid, baseRefName)` and `local-rubric=PASS`, plus
+one exact-head approval. After GitHub merged each PR, the next invocation reused
+the checkpoint, skipped checkout/configured verification/semantic review, took
+one external snapshot, and closed the issue without another review or trigger.
+
+## Tokens, runtime, and retries
+
+Worker-observed totals include all app-server sessions, including the failed
+review, maker rework, and merged-head continuations.
+
+| Worker | Tokens | Agent runtime |
+| --- | ---: | ---: |
+| Maker | 2,967,013 | 740.8s |
+| Reviewer | 2,667,510 | 765.0s |
+| Combined | 5,634,523 | 1,505.8s |
+
+End-to-end wall time was 1,605 seconds, from issue 1 activation at 06:01:44Z to
+issue 2 closure at 06:28:29Z. There was one real rework cycle and two reviewer
+findings.
+
+The stable-tuple comparison is within this replay, so it is not confounded by
+the changed implementation:
+
+| Reviewer path | Tokens | Agent runtime |
+| --- | ---: | ---: |
+| Two full PASS reviews | 1,432,268 | 391.0s |
+| Two same-tuple merge confirmations | 702,083 | 199.2s |
+| Reduction | 51.0% | 49.0% |
+
+The full replay cost more than #1089's standard arm: +33.9% tokens, +42.2%
+agent runtime, and +37.7% wall time. The principal reason is the newly observed
+defect/rework cycle; the #1089 standard arm reported zero findings and zero
+rework. Therefore this run demonstrates retry idempotence and prompt shrinkage,
+not a claim that stronger review always reduces total delivery cost.
+
+Machine-readable values are in
+[the replay summary](assets/stable-head-reviewer-replay-20260714/summary.json).

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -35,10 +35,10 @@ Prompt bytes exclude YAML front matter.
 | Prompt | #1089 baseline | #1090 | Change |
 | --- | ---: | ---: | ---: |
 | Maker | 4,341 | 2,439 | -43.8% |
-| Reviewer | 6,892 | 6,224 | -9.7% |
-| Combined | 11,233 | 8,663 | -22.9% |
+| Reviewer | 6,892 | 6,435 | -6.6% |
+| Combined | 11,233 | 8,874 | -21.0% |
 
-The two workflows and two governance/E2E runbooks contain 982 lines, down from
+The two workflows and two governance/E2E runbooks contain 988 lines, down from
 1,015. Tests are excluded from that net-negative count.
 
 ## Replay result

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -12,7 +12,7 @@ continuations idempotent, while a changed head still forced a complete review.
 This replay reused the #1089 standard-profile seed, issue bodies, ordering,
 worker release, model, CI gate, and preregistered holdout. The disposable
 repository was
-<https://github.com/zjlgdx/aiops-workflow-bench-standard-20260714-1090-v1>.
+<https://github.com/zjlgdx/aiops-workflow-bench-standard-20260714-1090-v2>.
 Issue 2 was activated only after issue 1 closed.
 
 | Pin | Value |
@@ -35,27 +35,29 @@ Prompt bytes exclude YAML front matter.
 | Prompt | #1089 baseline | #1090 | Change |
 | --- | ---: | ---: | ---: |
 | Maker | 4,341 | 2,439 | -43.8% |
-| Reviewer | 6,892 | 5,344 | -22.5% |
-| Combined | 11,233 | 7,783 | -30.7% |
+| Reviewer | 6,892 | 5,823 | -15.5% |
+| Combined | 11,233 | 8,262 | -26.4% |
 
-The two workflows and two governance/E2E runbooks contain 970 lines, down from
+The two workflows and two governance/E2E runbooks contain 979 lines, down from
 1,015. Tests are excluded from that net-negative count.
 
 ## Replay result
 
 Both issues closed after their PRs merged, and a fresh clone at final main
-`7e56f3e34132042f8d812b6acb45677153c74d1a` passed the #1089 holdout.
+`9b1ae3e979ca386acec6bab2ab76e236af06f935` passed the #1089 holdout.
 
 | Issue | PR / final head | Merged | Closed | Rework |
 | --- | --- | --- | --- | ---: |
-| #1 | #3 / `f14a70fd8151b38eccca720aafb6e9ddb145a2aa` | 06:16:21Z | 06:18:10Z | 1 |
-| #2 | #4 / `56fa3e45d1c2fdb9300862cc0554c66054708f53` | 06:26:33Z | 06:28:29Z | 0 |
+| #1 | #3 / `6567e95d4f549402973090d7c5d13e1f8bafdc99` | 06:57:57Z | 07:00:37Z | 0 |
+| #2 | #4 / `2b75db6667cabc432a9e61946ef6633d29d8393c` | 07:09:17Z | 07:11:32Z | 0 |
 
-On issue 1, the first reviewer pass found two confirmed defects: missing
-`TODO_DB` changed invalid-invocation behavior, and embedded newlines violated
-the one-record-per-line contract. The maker pushed a new head; that tuple
-change invalidated the prior review and caused a complete new review. No
-operator manufactured the findings or rework.
+Issue 1 exposed one operational prompt failure: the reviewer delegated a review
+flow and returned its clean result without writing a checkpoint. The worker
+correctly retried the unchanged tuple, but that retry had to repeat the full
+review. The prompt was then tightened with an earned rule requiring the
+reviewer to complete the checkpoint and handoff itself. Issue 2, run with that
+final prompt from its first reviewer claim, completed the full review and
+handoff without the extra no-handoff outcome.
 
 Every passing tuple received one reviewer-owned `COMMENTED` checkpoint with
 the exact `(headRefOid, baseRefOid, baseRefName)` and `local-rubric=PASS`, plus
@@ -65,33 +67,34 @@ one external snapshot, and closed the issue without another review or trigger.
 
 ## Tokens, runtime, and retries
 
-Worker-observed totals include all app-server sessions, including the failed
-review, maker rework, and merged-head continuations.
+Worker-observed totals include all app-server sessions, including the
+no-handoff review and merged-head continuations.
 
 | Worker | Tokens | Agent runtime |
 | --- | ---: | ---: |
-| Maker | 2,967,013 | 740.8s |
-| Reviewer | 2,667,510 | 765.0s |
-| Combined | 5,634,523 | 1,505.8s |
+| Maker | 1,804,337 | 409.5s |
+| Reviewer | 2,456,281 | 884.1s |
+| Combined | 4,260,618 | 1,293.6s |
 
-End-to-end wall time was 1,605 seconds, from issue 1 activation at 06:01:44Z to
-issue 2 closure at 06:28:29Z. There was one real rework cycle and two reviewer
-findings.
+End-to-end wall time was 1,394 seconds, from issue 1 activation at 06:48:18Z to
+issue 2 closure at 07:11:32Z. There were no code rework cycles or confirmed
+review findings. Aggregate reviewer cost includes issue 1's disclosed
+pre-final-prompt no-handoff session.
 
 The stable-tuple comparison is within this replay, so it is not confounded by
 the changed implementation:
 
 | Reviewer path | Tokens | Agent runtime |
 | --- | ---: | ---: |
-| Two full PASS reviews | 1,432,268 | 391.0s |
-| Two same-tuple merge confirmations | 702,083 | 199.2s |
-| Reduction | 51.0% | 49.0% |
+| Two full PASS reviews | 1,248,550 | 442.7s |
+| Two same-tuple merge confirmations | 706,560 | 267.4s |
+| Reduction | 43.4% | 39.6% |
 
-The full replay cost more than #1089's standard arm: +33.9% tokens, +42.2%
-agent runtime, and +37.7% wall time. The principal reason is the newly observed
-defect/rework cycle; the #1089 standard arm reported zero findings and zero
-rework. Therefore this run demonstrates retry idempotence and prompt shrinkage,
-not a claim that stronger review always reduces total delivery cost.
+The full replay was close to #1089's standard arm in tokens (+1.3%) but used
+22.2% more agent runtime and 19.6% more wall time. Issue 1's extra full-review
+no-handoff is included, so this aggregate is deliberately not presented as a
+best-case final-prompt result. The within-run same-tuple comparison is the
+cleaner evidence for retry savings.
 
 Machine-readable values are in
 [the replay summary](assets/stable-head-reviewer-replay-20260714/summary.json).

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -35,10 +35,10 @@ Prompt bytes exclude YAML front matter.
 | Prompt | #1089 baseline | #1090 | Change |
 | --- | ---: | ---: | ---: |
 | Maker | 4,341 | 2,439 | -43.8% |
-| Reviewer | 6,892 | 5,960 | -13.5% |
-| Combined | 11,233 | 8,399 | -25.2% |
+| Reviewer | 6,892 | 5,961 | -13.5% |
+| Combined | 11,233 | 8,400 | -25.2% |
 
-The two workflows and two governance/E2E runbooks contain 981 lines, down from
+The two workflows and two governance/E2E runbooks contain 982 lines, down from
 1,015. Tests are excluded from that net-negative count.
 
 ## Replay result

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -35,8 +35,8 @@ Prompt bytes exclude YAML front matter.
 | Prompt | #1089 baseline | #1090 | Change |
 | --- | ---: | ---: | ---: |
 | Maker | 4,341 | 2,439 | -43.8% |
-| Reviewer | 6,892 | 6,435 | -6.6% |
-| Combined | 11,233 | 8,874 | -21.0% |
+| Reviewer | 6,892 | 6,406 | -7.1% |
+| Combined | 11,233 | 8,845 | -21.3% |
 
 The two workflows and two governance/E2E runbooks contain 988 lines, down from
 1,015. Tests are excluded from that net-negative count.

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -38,7 +38,7 @@ Prompt bytes exclude YAML front matter.
 | Reviewer | 6,892 | 6,224 | -9.7% |
 | Combined | 11,233 | 8,663 | -22.9% |
 
-The two workflows and two governance/E2E runbooks contain 989 lines, down from
+The two workflows and two governance/E2E runbooks contain 982 lines, down from
 1,015. Tests are excluded from that net-negative count.
 
 ## Replay result

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -35,10 +35,10 @@ Prompt bytes exclude YAML front matter.
 | Prompt | #1089 baseline | #1090 | Change |
 | --- | ---: | ---: | ---: |
 | Maker | 4,341 | 2,439 | -43.8% |
-| Reviewer | 6,892 | 5,961 | -13.5% |
-| Combined | 11,233 | 8,400 | -25.2% |
+| Reviewer | 6,892 | 6,224 | -9.7% |
+| Combined | 11,233 | 8,663 | -22.9% |
 
-The two workflows and two governance/E2E runbooks contain 982 lines, down from
+The two workflows and two governance/E2E runbooks contain 989 lines, down from
 1,015. Tests are excluded from that net-negative count.
 
 ## Replay result
@@ -56,8 +56,14 @@ flow and returned its clean result without writing a checkpoint. The worker
 correctly retried the unchanged tuple, but that retry had to repeat the full
 review. The prompt was then tightened with an earned rule requiring the
 reviewer to complete the checkpoint and handoff itself. Issue 2, run with that
-final prompt from its first reviewer claim, completed the full review and
+then-current prompt from its first reviewer claim, completed the full review and
 handoff without the extra no-handoff outcome.
+
+Fixed-base and exact-head review after the replay further hardened shared tuple
+guards, conditional verification, and approval/auto-merge recovery. Those
+changes are contract-tested and included in the current prompt-byte totals;
+the replay cost is evidence for the stable-tuple behavior, not a claim that the
+post-review wording itself was replayed.
 
 Every passing tuple received one reviewer-owned `COMMENTED` checkpoint with
 the exact `(headRefOid, baseRefOid, baseRefName)` and `local-rubric=PASS`, plus

--- a/docs/validation/2026-07-14-stable-head-reviewer-replay.md
+++ b/docs/validation/2026-07-14-stable-head-reviewer-replay.md
@@ -35,10 +35,10 @@ Prompt bytes exclude YAML front matter.
 | Prompt | #1089 baseline | #1090 | Change |
 | --- | ---: | ---: | ---: |
 | Maker | 4,341 | 2,439 | -43.8% |
-| Reviewer | 6,892 | 4,472 | -35.1% |
-| Combined | 11,233 | 6,911 | -38.5% |
+| Reviewer | 6,892 | 5,344 | -22.5% |
+| Combined | 11,233 | 7,783 | -30.7% |
 
-The two workflows and two governance/E2E runbooks contain 948 lines, down from
+The two workflows and two governance/E2E runbooks contain 970 lines, down from
 1,015. Tests are excluded from that net-negative count.
 
 ## Replay result

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -10,10 +10,10 @@
     "baseline_maker": 4341,
     "current_maker": 2439,
     "baseline_reviewer": 6892,
-    "current_reviewer": 6435,
+    "current_reviewer": 6406,
     "baseline_combined": 11233,
-    "current_combined": 8874,
-    "combined_reduction_percent": 21.000623
+    "current_combined": 8845,
+    "combined_reduction_percent": 21.258791
   },
   "workflow_runbook_lines": {
     "baseline": 1015,

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -10,15 +10,15 @@
     "baseline_maker": 4341,
     "current_maker": 2439,
     "baseline_reviewer": 6892,
-    "current_reviewer": 5960,
+    "current_reviewer": 5961,
     "baseline_combined": 11233,
-    "current_combined": 8399,
-    "combined_reduction_percent": 25.229235
+    "current_combined": 8400,
+    "combined_reduction_percent": 25.220333
   },
   "workflow_runbook_lines": {
     "baseline": 1015,
-    "current": 981,
-    "net": -34
+    "current": 982,
+    "net": -33
   },
   "worker_observed": {
     "maker_tokens": 1804337,

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -10,15 +10,15 @@
     "baseline_maker": 4341,
     "current_maker": 2439,
     "baseline_reviewer": 6892,
-    "current_reviewer": 6224,
+    "current_reviewer": 6435,
     "baseline_combined": 11233,
-    "current_combined": 8663,
-    "combined_reduction_percent": 22.879017
+    "current_combined": 8874,
+    "combined_reduction_percent": 21.000623
   },
   "workflow_runbook_lines": {
     "baseline": 1015,
-    "current": 982,
-    "net": -33
+    "current": 988,
+    "net": -27
   },
   "worker_observed": {
     "maker_tokens": 1804337,

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -10,15 +10,15 @@
     "baseline_maker": 4341,
     "current_maker": 2439,
     "baseline_reviewer": 6892,
-    "current_reviewer": 5823,
+    "current_reviewer": 5960,
     "baseline_combined": 11233,
-    "current_combined": 8262,
-    "combined_reduction_percent": 26.448856
+    "current_combined": 8399,
+    "combined_reduction_percent": 25.229235
   },
   "workflow_runbook_lines": {
     "baseline": 1015,
-    "current": 979,
-    "net": -36
+    "current": 981,
+    "net": -34
   },
   "worker_observed": {
     "maker_tokens": 1804337,

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -10,15 +10,15 @@
     "baseline_maker": 4341,
     "current_maker": 2439,
     "baseline_reviewer": 6892,
-    "current_reviewer": 5961,
+    "current_reviewer": 6224,
     "baseline_combined": 11233,
-    "current_combined": 8400,
-    "combined_reduction_percent": 25.220333
+    "current_combined": 8663,
+    "combined_reduction_percent": 22.879017
   },
   "workflow_runbook_lines": {
     "baseline": 1015,
-    "current": 982,
-    "net": -33
+    "current": 989,
+    "net": -26
   },
   "worker_observed": {
     "maker_tokens": 1804337,

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -10,15 +10,15 @@
     "baseline_maker": 4341,
     "current_maker": 2439,
     "baseline_reviewer": 6892,
-    "current_reviewer": 4472,
+    "current_reviewer": 5344,
     "baseline_combined": 11233,
-    "current_combined": 6911,
-    "combined_reduction_percent": 38.475919
+    "current_combined": 7783,
+    "combined_reduction_percent": 30.713078
   },
   "workflow_runbook_lines": {
     "baseline": 1015,
-    "current": 948,
-    "net": -67
+    "current": 970,
+    "net": -45
   },
   "worker_observed": {
     "maker_tokens": 2967013,

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "date": "2026-07-14",
+  "issue": 1090,
+  "repository": "zjlgdx/aiops-workflow-bench-standard-20260714-1090-v1",
+  "seed_sha": "5e6264cdcfd2decb53491e37de4f825878339487",
+  "final_main_sha": "7e56f3e34132042f8d812b6acb45677153c74d1a",
+  "holdout": "pass",
+  "prompt_bytes": {
+    "baseline_maker": 4341,
+    "current_maker": 2439,
+    "baseline_reviewer": 6892,
+    "current_reviewer": 4472,
+    "baseline_combined": 11233,
+    "current_combined": 6911,
+    "combined_reduction_percent": 38.475919
+  },
+  "workflow_runbook_lines": {
+    "baseline": 1015,
+    "current": 948,
+    "net": -67
+  },
+  "worker_observed": {
+    "maker_tokens": 2967013,
+    "maker_runtime_seconds": 740.799404667,
+    "reviewer_tokens": 2667510,
+    "reviewer_runtime_seconds": 764.95159425,
+    "total_tokens": 5634523,
+    "total_runtime_seconds": 1505.750998917,
+    "wall_seconds": 1605,
+    "rework_cycles": 1,
+    "review_findings": 2
+  },
+  "stable_tuple_comparison": {
+    "full_review_tokens": 1432268,
+    "full_review_runtime_seconds": 390.988322458,
+    "merge_confirmation_tokens": 702083,
+    "merge_confirmation_runtime_seconds": 199.231928167,
+    "token_reduction_percent": 50.981031,
+    "runtime_reduction_percent": 49.044021
+  },
+  "relative_to_1089_standard": {
+    "baseline_tokens": 4206604,
+    "baseline_runtime_seconds": 1058.739628,
+    "baseline_wall_seconds": 1166,
+    "baseline_rework_cycles": 0,
+    "tokens_change_percent": 33.944697,
+    "runtime_change_percent": 42.221086,
+    "wall_change_percent": 37.650086
+  },
+  "issues": [
+    {
+      "number": 1,
+      "pr": 3,
+      "initial_head_sha": "afc18f9986d290934d1879468374a50aa3c01254",
+      "final_head_sha": "f14a70fd8151b38eccca720aafb6e9ddb145a2aa",
+      "merged_at": "2026-07-14T06:16:21Z",
+      "closed_at": "2026-07-14T06:18:10Z",
+      "rework_cycles": 1,
+      "review_findings": 2,
+      "checkpoint_reviews": 1,
+      "approvals": 1
+    },
+    {
+      "number": 2,
+      "pr": 4,
+      "final_head_sha": "56fa3e45d1c2fdb9300862cc0554c66054708f53",
+      "merged_at": "2026-07-14T06:26:33Z",
+      "closed_at": "2026-07-14T06:28:29Z",
+      "rework_cycles": 0,
+      "review_findings": 0,
+      "checkpoint_reviews": 1,
+      "approvals": 1
+    }
+  ]
+}

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -1,74 +1,78 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "date": "2026-07-14",
   "issue": 1090,
-  "repository": "zjlgdx/aiops-workflow-bench-standard-20260714-1090-v1",
+  "repository": "zjlgdx/aiops-workflow-bench-standard-20260714-1090-v2",
   "seed_sha": "5e6264cdcfd2decb53491e37de4f825878339487",
-  "final_main_sha": "7e56f3e34132042f8d812b6acb45677153c74d1a",
+  "final_main_sha": "9b1ae3e979ca386acec6bab2ab76e236af06f935",
   "holdout": "pass",
   "prompt_bytes": {
     "baseline_maker": 4341,
     "current_maker": 2439,
     "baseline_reviewer": 6892,
-    "current_reviewer": 5344,
+    "current_reviewer": 5823,
     "baseline_combined": 11233,
-    "current_combined": 7783,
-    "combined_reduction_percent": 30.713078
+    "current_combined": 8262,
+    "combined_reduction_percent": 26.448856
   },
   "workflow_runbook_lines": {
     "baseline": 1015,
-    "current": 970,
-    "net": -45
+    "current": 979,
+    "net": -36
   },
   "worker_observed": {
-    "maker_tokens": 2967013,
-    "maker_runtime_seconds": 740.799404667,
-    "reviewer_tokens": 2667510,
-    "reviewer_runtime_seconds": 764.95159425,
-    "total_tokens": 5634523,
-    "total_runtime_seconds": 1505.750998917,
-    "wall_seconds": 1605,
-    "rework_cycles": 1,
-    "review_findings": 2
+    "maker_tokens": 1804337,
+    "maker_runtime_seconds": 409.492057875,
+    "reviewer_tokens": 2456281,
+    "reviewer_runtime_seconds": 884.145493666,
+    "total_tokens": 4260618,
+    "total_runtime_seconds": 1293.637551541,
+    "wall_seconds": 1394,
+    "rework_cycles": 0,
+    "review_findings": 0,
+    "pre_final_prompt_no_handoff_sessions": 1
   },
   "stable_tuple_comparison": {
-    "full_review_tokens": 1432268,
-    "full_review_runtime_seconds": 390.988322458,
-    "merge_confirmation_tokens": 702083,
-    "merge_confirmation_runtime_seconds": 199.231928167,
-    "token_reduction_percent": 50.981031,
-    "runtime_reduction_percent": 49.044021
+    "full_review_tokens": 1248550,
+    "full_review_runtime_seconds": 442.719735083,
+    "merge_confirmation_tokens": 706560,
+    "merge_confirmation_runtime_seconds": 267.423159083,
+    "token_reduction_percent": 43.409555,
+    "runtime_reduction_percent": 39.595383
   },
   "relative_to_1089_standard": {
     "baseline_tokens": 4206604,
     "baseline_runtime_seconds": 1058.739628,
     "baseline_wall_seconds": 1166,
     "baseline_rework_cycles": 0,
-    "tokens_change_percent": 33.944697,
-    "runtime_change_percent": 42.221086,
-    "wall_change_percent": 37.650086
+    "tokens_change_percent": 1.284029,
+    "runtime_change_percent": 22.186562,
+    "wall_change_percent": 19.554031
   },
   "issues": [
     {
       "number": 1,
       "pr": 3,
-      "initial_head_sha": "afc18f9986d290934d1879468374a50aa3c01254",
-      "final_head_sha": "f14a70fd8151b38eccca720aafb6e9ddb145a2aa",
-      "merged_at": "2026-07-14T06:16:21Z",
-      "closed_at": "2026-07-14T06:18:10Z",
-      "rework_cycles": 1,
-      "review_findings": 2,
+      "final_head_sha": "6567e95d4f549402973090d7c5d13e1f8bafdc99",
+      "base_sha": "5e6264cdcfd2decb53491e37de4f825878339487",
+      "merged_at": "2026-07-14T06:57:57Z",
+      "closed_at": "2026-07-14T07:00:37Z",
+      "rework_cycles": 0,
+      "review_findings": 0,
+      "pre_final_prompt_no_handoff_sessions": 1,
       "checkpoint_reviews": 1,
       "approvals": 1
     },
     {
       "number": 2,
       "pr": 4,
-      "final_head_sha": "56fa3e45d1c2fdb9300862cc0554c66054708f53",
-      "merged_at": "2026-07-14T06:26:33Z",
-      "closed_at": "2026-07-14T06:28:29Z",
+      "final_head_sha": "2b75db6667cabc432a9e61946ef6633d29d8393c",
+      "base_sha": "7bca40af87c8631c3fdc7d30d8d18453ec5eb22a",
+      "merged_at": "2026-07-14T07:09:17Z",
+      "closed_at": "2026-07-14T07:11:32Z",
       "rework_cycles": 0,
       "review_findings": 0,
+      "pre_final_prompt_no_handoff_sessions": 0,
       "checkpoint_reviews": 1,
       "approvals": 1
     }

--- a/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
+++ b/docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json
@@ -17,8 +17,8 @@
   },
   "workflow_runbook_lines": {
     "baseline": 1015,
-    "current": 989,
-    "net": -26
+    "current": 982,
+    "net": -33
   },
   "worker_observed": {
     "maker_tokens": 1804337,

--- a/examples/github-maker-WORKFLOW.md
+++ b/examples/github-maker-WORKFLOW.md
@@ -1,6 +1,5 @@
 ---
-# GitHub MAKER worker. Deploy with examples/github-reviewer-automerge-WORKFLOW.md
-# when validating maker/reviewer separation on GitHub branch protection.
+# GitHub MAKER worker. Pair with github-reviewer-automerge-WORKFLOW.md.
 repo:
   owner: your-github-owner
   name: your-repo
@@ -25,7 +24,7 @@ polling:
   interval_ms: 30000
 
 workspace:
-  # HARD REQUIREMENT: must differ from the reviewer worker's workspace.root.
+  # Must differ from the reviewer worker's workspace.root.
   root: ~/aiops-workspaces/github-maker
 
 agent:
@@ -39,9 +38,6 @@ agent:
 codex:
   command: codex app-server --config shell_environment_policy.inherit=all
   thread_sandbox: danger-full-access
-  # Real codex app-server startup can exceed the default 5s read timeout on
-  # release-validation machines. Keep this in the template so doctor exercises
-  # the same path the workers will use.
   read_timeout_ms: 30000
   env_passthrough:
     - GH_CONFIG_DIR
@@ -59,84 +55,49 @@ verify:
     - npm run build
     - npm run test:e2e
 ---
-You are the MAKER agent for a GitHub maker/reviewer governance run.
-
-You implement the assigned issue, open or update one PR, and hand off to an
-independent reviewer. You do NOT review, approve, auto-merge, merge, close, or
+You are the GitHub MAKER. Implement only this issue, open or update one PR, and
+hand it to the independent reviewer. Never review, approve, merge, close, or
 mark your own work done.
+Inspect your diff yourself; do not start a separate final-review workflow,
+because the independent reviewer owns that gate and handoff continues now.
 
-Issue:
-- Identifier: {{ issue.identifier }}
-- URL: {{ issue.url }}
-- Title: {{ task.title }}
+Issue: {{ issue.identifier }} — {{ task.title }} ({{ issue.url }})
+Repository: {{ repo.owner }}/{{ repo.name }}; base: {{ repo.branch }}.
 
-Repository: {{ repo.owner }}/{{ repo.name }} on base branch {{ repo.branch }}.
+Before editing:
 
-Before changing code:
-1. Run `gh api user --jq .login` and compare it with
-   `$AIOPS_EXPECTED_GITHUB_LOGIN`. If it differs, comment
-   `Blocked maker: wrong GitHub identity <login>` on the issue and stop without
-   changing labels.
-2. Let `<N>` be the numeric issue number from `{{ issue.identifier }}`.
-3. If this is a Rework return, read the newest reviewer comments and PR reviews
-   first. Treat every unresolved reviewer finding as an acceptance criterion.
-   Note the reviewed head SHA cited by the reviewer.
-4. Do not use the PR's historical `CHANGES_REQUESTED` count as a stop
-   condition. That count is diagnostic only: continue when the latest reviewer
-   finding names an actionable blocker and you can push a new commit. Stop only
-   when the blocker is not actionable after one bounded clarification pass,
-   cannot be completed within the issue scope, is blocked by missing
-   tools/auth/permissions, or would require handing off the same unchanged head
-   again.
+1. Verify `gh api user --jq .login` equals
+   `$AIOPS_EXPECTED_GITHUB_LOGIN`. On mismatch, comment
+   `Blocked maker: wrong GitHub identity <login>` and stop without labels.
+2. Let `<N>` be the numeric issue number.
+3. On `aiops:rework`, read the newest review, issue comments, and current-head
+   GraphQL `reviewThreads`. Treat every unresolved finding as required scope.
+   Record the reviewed head; an unchanged head must not be handed off again.
 
-Required implementation flow:
-1. Implement only this issue's acceptance criteria.
-2. Run the full verification gate before handoff:
-   - `npm ci`
-   - `npm test`
-   - `npm run build`
-   - `npm run test:e2e`
-3. Commit your changes on the current worker branch.
-4. Push the branch: `git push -u origin "$(git branch --show-current)"`.
-5. Open a PR against `{{ repo.branch }}` or update the existing PR for this
-   branch. The PR title and body must reference the issue with `Refs #<N>` only,
-   NOT `Issue #<N>`, `Closes #<N>`, `Fixes #<N>`, or `Resolves #<N>`. GitHub's
-   open-PR claim filter scans the PR title and body and treats `Issue #<N>` as a
-   claimed issue, which can hide the handoff from the reviewer worker. The
-   reviewer closes the issue only after GitHub confirms the PR merged.
-6. Comment the PR URL on the issue. The reviewer uses the newest PR URL comment
-   to find your handoff.
-7. Before handoff, query current-head unresolved non-outdated review threads on
-   the PR. Do not move the issue to `aiops:human-review` while any blocker
-   remains on the current head; comment the blockers and keep the issue active
-   for rework.
-8. Move the issue to reviewer state as your LAST action:
+Delivery:
+
+1. Implement only this issue and add behavior-level tests.
+2. Run the configured verification commands once before handoff.
+3. Commit and push the worker branch.
+4. Open or update its PR against `{{ repo.branch }}`. Reference only
+   `Refs #<N>`; do not use `Issue`, `Closes`, `Fixes`, or `Resolves #<N>`,
+   because the reviewer closes the issue after merge.
+5. Comment the PR URL on the issue.
+6. Query current-head unresolved, non-outdated GraphQL `reviewThreads`; any
+   blocker prevents handoff and remains maker work.
+7. For rework, push a new head and add one issue comment beginning
+   `Rework response:` with the reviewed head, new head, and every response.
+8. As the LAST action, hand off:
    `gh issue edit <N> --remove-label aiops:todo --remove-label aiops:rework --add-label aiops:human-review`.
 
-Rework convergence rules:
-- Do not re-hand-off an unchanged head. Push a new commit that addresses the
-  reviewer finding.
-- Every rework handoff MUST include an issue comment that starts with `Rework response:`,
-  naming the reviewed head, the new head, and how each
-  finding was addressed.
-- If you cannot address a concrete reviewer finding because progress is blocked
-  by a true external/operator-owned dependency, comment `Blocked rework:` with
-  the blocker and move the issue to `aiops:blocked` instead of adding
-  `aiops:human-review`:
-  `gh issue edit <N> --remove-label aiops:todo --remove-label aiops:rework --add-label aiops:blocked`.
-- Codex review uncertainty, no-signal, NOT-CONFIRMED, usage-limit, CI pending,
-  and auto-merge pending are not `aiops:blocked` reasons. If the latest
-  reviewer/Codex signal is only transient or non-actionable, comment the
-  evidence, leave the issue in its current maker-active label
-  (`aiops:todo` or `aiops:rework`), and stop without adding
-  `aiops:human-review`; the next maker poll can re-check.
-- The blocked command for that true external/operator-owned blocker is:
-  `gh issue edit <N> --remove-label aiops:todo --remove-label aiops:rework --add-label aiops:blocked`.
+Stop rules:
 
-Hard constraints:
-- Do NOT use `gh pr review`, `gh pr merge`, `gh issue close`, or
-  `gh issue edit --add-label aiops:done`.
-- Do NOT remove `aiops:human-review` except when you are actively fixing a
-  Rework issue that is already labeled `aiops:rework`.
-- Do NOT touch repository settings, branch protection, Actions secrets, or
-  workflow files unless the issue explicitly asks for them.
+- Use `aiops:blocked` only for a true external/operator-owned blocker. Comment
+  `Blocked rework:` when applicable, then remove both maker-active labels while
+  adding `aiops:blocked` as the LAST action.
+- Review uncertainty, no-signal, usage limits, CI, or merge state are not maker
+  blockers. Leave the current maker-active label unchanged and stop promptly.
+- Do not use historical review counts as a stop condition. A current actionable
+  finding permits rework; a new head is required for the next handoff.
+- Do not use `gh pr review`, `gh pr merge`, `gh issue close`, or add
+  `aiops:done`. Do not change repository settings unless this issue requires it.

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -86,6 +86,11 @@ Repository: {{ repo.owner }}/{{ repo.name }}; base: {{ repo.branch }}.
    wait, repeatedly poll, or refresh asynchronous gate state in this invocation.
    Pagination is one bounded snapshot, not repeated lifecycle polling.
 
+Before any trigger, verdict, checkpoint, or approval write—and before changing
+auto-merge—run a tuple-only guard. If the current tuple differs from the
+snapshot, write nothing and end; the next invocation reviews the new tuple.
+This guard does not refresh Codex, checks, threads, or merge state.
+
 ## Exact-tuple checkpoint
 
 The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
@@ -110,10 +115,6 @@ The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
 2. Run the configured verification commands once.
 3. Review the complete diff against the issue, including behavior-level tests,
    security, failure paths, and unrelated scope.
-Before any trigger, verdict, checkpoint, or approval write—and before changing
-auto-merge—run a tuple-only guard. If the current tuple differs from the
-snapshot, write nothing and end; the next invocation reviews the new tuple.
-This guard does not refresh Codex, checks, threads, or merge state.
 4. Treat unresolved, non-outdated current-head blockers from any author,
    failed required checks, or an unmet acceptance criterion as FAIL. Submit one
    consolidated `CHANGES_REQUESTED` through the REST review API with

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -1,7 +1,5 @@
 ---
-# GitHub REVIEWER worker. Claims aiops:human-review, independently reviews the
-# maker PR, approves only on PASS, enables GitHub native CI-gated auto-merge,
-# and closes the issue only after GitHub confirms the PR merged.
+# GitHub REVIEWER worker. Independently reviews and enables native auto-merge.
 repo:
   owner: your-github-owner
   name: your-repo
@@ -26,7 +24,7 @@ polling:
   interval_ms: 30000
 
 workspace:
-  # HARD REQUIREMENT: must differ from the maker worker's workspace.root.
+  # Must differ from the maker worker's workspace.root.
   root: ~/aiops-workspaces/github-reviewer
 
 agent:
@@ -50,131 +48,95 @@ codex:
 
 policy:
   mode: draft_pr
+
+verify:
+  commands:
+    - npm ci
+    - npm test
+    - npm run build
+    - npm run test:e2e
 ---
-You are the independent REVIEWER agent for a GitHub maker/reviewer governance
-run. You did not write the code. You review the maker's PR, approve and enable
-GitHub native CI-gated auto-merge only on PASS, then close the issue only after
-GitHub confirms the PR merged.
+You are the independent GitHub REVIEWER. You do not edit, commit, or push code.
+Approve and enable native auto-merge only after PASS; close the issue only
+after GitHub confirms the PR merged.
 
-You do NOT write, commit, or push code.
+Issue: {{ issue.identifier }} — {{ task.title }} ({{ issue.url }})
+Repository: {{ repo.owner }}/{{ repo.name }}; base: {{ repo.branch }}.
 
-Issue:
-- Identifier: {{ issue.identifier }}
-- URL: {{ issue.url }}
-- Title: {{ task.title }}
+## Identity, PR, and one snapshot
 
-Repository: {{ repo.owner }}/{{ repo.name }} on base branch {{ repo.branch }}.
+1. Verify `gh api user --jq .login` equals
+   `$AIOPS_EXPECTED_GITHUB_LOGIN`; otherwise comment
+   `Blocked reviewer: wrong GitHub identity <login>` and stop without labels.
+   Let `<N>` be the numeric issue number.
+2. Use the newest maker PR URL in issue comments. If absent, comment what was
+   checked, then return to `aiops:rework` as the LAST action.
+3. Take one live snapshot for this invocation:
+   - PR metadata including number, state, author, `headRefOid`, `baseRefOid`,
+     `baseRefName`, `mergedAt`, checks, merge state, and auto-merge state;
+   - REST review records and PR comments, preserving author, state, body,
+     `commit_id`, and time;
+   - GraphQL `reviewThreads(first:100)` with resolution and outdated state.
+   Set `<PR_NUMBER>`, `<HEAD>`, `<BASE_OID>`, and `<BASE_NAME>` from it. Do not
+   wait, repeatedly poll, or refresh any external state in this invocation.
 
-Step 0 - identity and issue number:
-1. Run `gh api user --jq .login` and compare it with
-   `$AIOPS_EXPECTED_GITHUB_LOGIN`. If it differs, comment
-   `Blocked reviewer: wrong GitHub identity <login>` on the issue and stop
-   without changing labels.
-2. Let `<N>` be the numeric issue number from `{{ issue.identifier }}`.
+## Exact-tuple checkpoint
 
-Step 1 - find the PR:
-1. Read issue comments and take the newest PR URL commented by the maker as
-   `<PR_URL>`.
-2. If no PR URL exists, comment what you looked for, then move the issue back to
-   Rework with:
-   `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework`.
-   Stop.
-3. Read PR metadata with `gh pr view <PR_URL> --json number,state,author,headRefName,headRefOid,baseRefName,body,mergeStateStatus,isDraft,mergedAt,statusCheckRollup`.
-   Let `<PR_NUMBER>` be the returned numeric `number`; use `<PR_NUMBER>` in
-   later `gh pr ...` commands and REST API paths.
-4. Read PR review records with commit IDs:
-   `gh api --paginate --slurp "repos/{{ repo.owner }}/{{ repo.name }}/pulls/<PR_NUMBER>/reviews?per_page=100"`.
-   Flatten the returned page arrays, then use each record's `state`,
-   `user.login`, `commit_id`, and `submitted_at` when identifying the newest
-   reviewer-owned reviews.
-5. If `state` is `MERGED` or `mergedAt` is already present, do not jump straight
-   to Done. First confirm from the review records that the merged PR head still
-   has a reviewer-owned `APPROVED` review whose `commit_id` equals the current
-   `headRefOid`, plus a successful `build-test` status/check in
-   `statusCheckRollup`; only then continue to Step 3 PASS item 5. If either
-   proof is missing, comment the missing evidence and stop without changing
-   labels.
-6. Do not use the PR's historical `CHANGES_REQUESTED` count as a stop
-   condition. That count is diagnostic only. Compare the newest reviewer-owned
-   `CHANGES_REQUESTED` review's `commit_id` with the current `headRefOid`.
-   Continue reviewing only when the current head differs from that `commit_id`,
-   or when no reviewer-owned `CHANGES_REQUESTED` review exists. A
-   `Rework response:` comment explains the change, but does not replace a new
-   PR head. If the newest reviewer-owned `CHANGES_REQUESTED` review already
-   targets the current `headRefOid`, do not post a duplicate review or continue
-   based on a `Rework response:` comment alone. First comment
-   `Reviewer re-queued unchanged head <headRefOid>; waiting for maker rework`.
-   Then move the issue back to Rework as your LAST action and stop:
-   `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework`.
+The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
+`baseRefName=<BASE_NAME>`). A reusable checkpoint is a reviewer-owned
+`COMMENTED` review whose body contains exactly:
 
-Step 2 - review the current head:
-1. Ensure the PR author is not the reviewer login.
-2. Checkout/fetch the PR head locally for inspection. You may change local
-   checkout state, but you must not edit, commit, or push files.
-3. Run the full gate on the PR head:
-   - `npm ci`
-   - `npm test`
-   - `npm run build`
-   - `npm run test:e2e`
-4. Review every changed behavior against the issue acceptance criteria.
-5. Tests must be behavior-level. Static source-string or markup checks are not
-   enough for client behavior; require executable DOM/browser/JS tests or an
-   equivalent refactor into executable code.
-6. Reject unrelated scope changes, missing tests, unsafe behavior, failing
-   gates, or claims that are not proved by code/tests.
+`Reviewer checkpoint: headRefOid=<HEAD> baseRefOid=<BASE_OID> baseRefName=<BASE_NAME> local-rubric=PASS`
 
-Step 3 - verdict:
-FAIL:
-- Before failing, gather all current-head blocker evidence: current-head unresolved non-outdated review threads,
-  failed required checks, and each issue acceptance criterion not met. Summarize
-  all current-head blocker items in one review so the maker does not fix them
-  one at a time.
-- Post a concrete review finding with file/path context where possible, the PR
-  head SHA reviewed, and the exact acceptance criterion not met.
-- Use `gh pr review <PR_NUMBER> --request-changes --body "<findings>"` when possible.
-- Move the issue back to Rework:
-  `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework`.
-- This is your LAST action.
+- For the same exact tuple, reuse that checkpoint: skip checkout, configured
+  verification, and semantic/security review. Use only the one live snapshot
+  to resolve external state, then end promptly.
+- Any head or base changes invalidate it and require the full review below.
+- A current-head reviewer-owned `CHANGES_REQUESTED` without a newer head is not
+  a checkpoint. Comment the unchanged head, return to `aiops:rework` as the
+  LAST action, and do not duplicate the review.
 
-BLOCKED:
-- Codex NOT-CONFIRMED, no-signal, usage-limit, CI pending, and auto-merge
-  pending are not `aiops:blocked` reasons. Comment the evidence, leave the issue
-  in `aiops:human-review`, and stop so a later reviewer poll can re-check.
-- unresolved non-outdated current-head review threads are FAIL inputs, not
-  blockers; collect them in the review body and move the issue back to Rework.
-- Use `aiops:blocked` only for a true external/operator-owned blocker that
-  prevents reviewer progress outside the normal review/retry loop:
-  `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:blocked`.
+## Full review for an unseen tuple
 
-PASS:
-1. Post a short issue comment summarizing the passed rubric and the reviewed
-   head SHA.
-2. Approve the PR:
-   `gh pr review <PR_NUMBER> --approve --body "Rubric passed for head <sha>."`
-3. Enable GitHub native CI-gated auto-merge:
-   `gh pr merge <PR_NUMBER> --auto --squash --delete-branch --match-head-commit <sha>`.
-   Do not use `--admin`.
-4. Poll `gh pr view <PR_NUMBER> --json state,mergedAt,headRefOid,mergeStateStatus`
-   until GitHub reports `state: MERGED` or a non-empty `mergedAt`. Poll with a
-   short bounded wait, not a busy loop. If it has not merged within your turn
-   budget, leave the issue in `aiops:human-review` and stop so the next reviewer
-   continuation can re-check. Do not mark Done before merge confirmation.
-5. After merge confirmation only, mark Done, then close in one retry-safe block:
-   `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:done`
+1. Confirm the maker and reviewer identities differ. Fetch and inspect the PR
+   head without editing it.
+2. Run the configured verification commands once.
+3. Review the complete diff against the issue, including behavior-level tests,
+   security, failure paths, and unrelated scope.
+4. Treat unresolved, non-outdated current-head blockers from any author,
+   failed required checks, or an unmet acceptance criterion as FAIL. Submit one
+   consolidated `CHANGES_REQUESTED` review tied to `<HEAD>`, then move to
+   `aiops:rework` as the LAST action.
+5. On local PASS, post the exact reviewer-owned `COMMENTED` checkpoint once.
+   It records local evidence and is not approval.
+
+## External gates and landing
+
+If repository policy requires GitHub Codex review, its trigger must be authored
+by the expected reviewer identity and carry the exact tuple. Reuse an existing
+exact-tuple trigger; post at most one `@codex review` trigger per tuple. Accept
+only the repository-documented reliable completion signal bound to `<HEAD>`.
+The absence of a reliable Codex signal is not clean. Findings join the FAIL
+evidence; no-signal, usage-limit, and pending results leave
+`aiops:human-review` unchanged and end promptly.
+
+Using only this invocation's snapshot:
+
+1. If the PR is merged, require a reviewer-owned `APPROVED` review with
+   `commit_id=<HEAD>` and a successful required check on `<HEAD>`. Then mark
+   `aiops:done` and close. If close fails, restore `aiops:human-review`
+   immediately and fail non-zero.
+2. If required Codex or checks are pending, leave `aiops:human-review`
+   unchanged and end promptly.
+3. When local and external gates are clean, use the snapshot to approve only if
+   exact-head approval is absent, and enable auto-merge only if it is absent:
+   `gh pr review <PR_NUMBER> --approve --body "Rubric passed for head <HEAD>."`
    then
-   `gh issue close <N> --comment "Done after PR <PR_NUMBER> merged at <mergedAt>."`
-   If close fails, immediately restore the active reviewer label with
-   `gh issue edit <N> --remove-label aiops:done --add-label aiops:human-review`
-   and stop with a non-zero failure. Do not leave an open issue labeled
-   `aiops:done`.
-   This is your LAST action.
+   `gh pr merge <PR_NUMBER> --auto --squash --delete-branch --match-head-commit <HEAD>`.
+   Do not use `--admin`. If approval and auto-merge already exist but merge is
+   pending, make no duplicate write. Do not re-read state afterward; a later
+   invocation confirms merge from its one snapshot.
 
-Hard constraints:
-- Do NOT edit, commit, or push code.
-- Do NOT close an issue before GitHub confirms the PR is merged.
-- Do NOT approve an unreviewed new head. If the head changed after your prior
-  review, run the rubric again.
-- Do NOT mark Done for an already merged PR unless the merged `headRefOid` still
-  has reviewer-owned approval and successful `build-test` evidence.
-- Do NOT use worker/orchestrator shortcuts, repository admin bypasses, or
-  worker-side merge helpers.
+Use `aiops:blocked` only for a true external/operator-owned blocker. Never use
+it for Codex, CI, approval, auto-merge, merge, or review-thread state. Never
+close before non-empty `mergedAt`, and never approve an unreviewed tuple.

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -48,13 +48,6 @@ codex:
 
 policy:
   mode: draft_pr
-
-verify:
-  commands:
-    - npm ci
-    - npm test
-    - npm run build
-    - npm run test:e2e
 ---
 You are the independent GitHub REVIEWER. You do not edit, commit, or push code.
 Approve and enable native auto-merge only after PASS; close the issue only

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -74,11 +74,15 @@ Repository: {{ repo.owner }}/{{ repo.name }}; base: {{ repo.branch }}.
 3. Take one live snapshot for this invocation:
    - PR metadata including number, state, author, `headRefOid`, `baseRefOid`,
      `baseRefName`, `mergedAt`, checks, merge state, and auto-merge state;
-   - REST review records and PR comments, preserving author, state, body,
-     `commit_id`, and time;
-   - GraphQL `reviewThreads(first:100)` with resolution and outdated state.
+   - all REST review records and PR comments via `--paginate --slurp`, flattened
+     while preserving author, state, body, `commit_id`, and time;
+   - all GraphQL `reviewThreads` by following `pageInfo` / `endCursor` while
+     `hasNextPage`; preserve resolution and outdated state;
+   - branch-protection proof that approvals become stale when head or merge
+     base changes.
    Set `<PR_NUMBER>`, `<HEAD>`, `<BASE_OID>`, and `<BASE_NAME>` from it. Do not
-   wait, repeatedly poll, or refresh any external state in this invocation.
+   wait, repeatedly poll, or refresh asynchronous gate state in this invocation.
+   Pagination is one bounded snapshot, not repeated lifecycle polling.
 
 ## Exact-tuple checkpoint
 
@@ -98,17 +102,19 @@ The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
 
 ## Full review for an unseen tuple
 
-1. Confirm the maker and reviewer identities differ. Fetch and inspect the PR
-   head without editing it.
+1. Confirm the maker and reviewer identities differ. Fetch, then use a detached
+   checkout of `<HEAD>` for every inspection and configured command; do not
+   review a moving branch name or edit files.
 2. Run the configured verification commands once.
 3. Review the complete diff against the issue, including behavior-level tests,
    security, failure paths, and unrelated scope.
 4. Treat unresolved, non-outdated current-head blockers from any author,
    failed required checks, or an unmet acceptance criterion as FAIL. Submit one
-   consolidated `CHANGES_REQUESTED` review tied to `<HEAD>`, then move to
-   `aiops:rework` as the LAST action.
+   consolidated `CHANGES_REQUESTED` through the REST review API with
+   `commit_id=<HEAD>`, then move to `aiops:rework` as the LAST action.
 5. On local PASS, post the exact reviewer-owned `COMMENTED` checkpoint once.
-   It records local evidence and is not approval.
+   Use the REST review API with `commit_id=<HEAD>` and event `COMMENT`; it
+   records local evidence and is not approval.
 
 ## External gates and landing
 
@@ -122,20 +128,25 @@ evidence; no-signal, usage-limit, and pending results leave
 
 Using only this invocation's snapshot:
 
+Before any verdict/checkpoint/approval write, perform one tuple-only guard. If
+the current `(headRefOid, baseRefOid, baseRefName)` differs from the snapshot,
+write no review or checkpoint and end; the next invocation reviews the new
+tuple. This guard does not refresh Codex, checks, threads, or merge state.
+
 1. If the PR is merged, require a reviewer-owned `APPROVED` review with
    `commit_id=<HEAD>` and a successful required check on `<HEAD>`. Then mark
    `aiops:done` and close. If close fails, restore `aiops:human-review`
    immediately and fail non-zero.
 2. If required Codex or checks are pending, leave `aiops:human-review`
    unchanged and end promptly.
-3. When local and external gates are clean, use the snapshot to approve only if
-   exact-head approval is absent, and enable auto-merge only if it is absent:
-   `gh pr review <PR_NUMBER> --approve --body "Rubric passed for head <HEAD>."`
-   then
+3. When local and external gates are clean, require stale approval dismissal.
+   Approve only if exact-head approval is absent, using the REST review API with
+   `commit_id=<HEAD>` and event `APPROVE`; then, if auto-merge is absent, run
    `gh pr merge <PR_NUMBER> --auto --squash --delete-branch --match-head-commit <HEAD>`.
-   Do not use `--admin`. If approval and auto-merge already exist but merge is
-   pending, make no duplicate write. Do not re-read state afterward; a later
-   invocation confirms merge from its one snapshot.
+   Do not use `--admin`. GitHub stale approval dismissal protects a base change
+   after the guard; a later invocation must review its new tuple. If approval
+   and auto-merge already exist but merge is pending, make no duplicate write.
+   Do not re-read state afterward; a later invocation confirms merge.
 
 Use `aiops:blocked` only for a true external/operator-owned blocker. Never use
 it for Codex, CI, approval, auto-merge, merge, or review-thread state. Never

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -112,7 +112,9 @@ The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
 1. Confirm the maker and reviewer identities differ. Fetch, then use a detached
    checkout of `<HEAD>` for every inspection and configured command; do not
    review a moving branch name or edit files.
-2. Run the configured verification commands once.
+2. **Verification (you own this):** only for an unseen tuple, run the configured
+   commands once: `npm ci`; `npm test`; `npm run build`; `npm run test:e2e`.
+   The same-tuple checkpoint path skips them.
 3. Review the complete diff against the issue, including behavior-level tests,
    security, failure paths, and unrelated scope.
 4. Treat unresolved, non-outdated current-head blockers from any author,
@@ -148,8 +150,9 @@ Using only this invocation's snapshot:
    `commit_id=<HEAD>` and event `APPROVE`; retain its review ID. Immediately run
    a post-approval tuple guard. If the tuple changed, dismiss that approval (or
    replace it with commit-pinned `REQUEST_CHANGES` if dismissal is unavailable),
-   require successful revocation, do not enable auto-merge, and end. If the
-   tuple still matches and auto-merge is absent, run
+   require successful revocation, do not enable auto-merge, and end. With an
+   exact-head approval already present, whether from this or a prior invocation,
+   run the tuple-only guard; if auto-merge is absent and the tuple matches, run
    `gh pr merge <PR_NUMBER> --auto --squash --delete-branch --match-head-commit <HEAD>`.
    Do not use `--admin`. GitHub stale approval dismissal protects a base change
    after the post-approval guard; a later invocation must review its new tuple.

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -52,14 +52,15 @@ policy:
 You are the independent GitHub REVIEWER. You do not edit, commit, or push code.
 Approve and enable native auto-merge only after PASS; close the issue only
 after GitHub confirms the PR merged.
-Do not start a separate review skill/workflow or delegate the verdict. Complete
-the checkpoint and handoff yourself in this turn so the lifecycle advances.
+Do not start a separate review skill or delegate. Complete the checkpoint and
+handoff yourself this turn.
 
 Issue: {{ issue.identifier }} — {{ task.title }} ({{ issue.url }})
 Repository: {{ repo.owner }}/{{ repo.name }}; base: {{ repo.branch }}.
-Whenever this workflow says return/move to `aiops:rework`, make this the LAST
-action: `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework`.
-Never leave both active labels on the issue.
+Whenever this workflow says return/move to `aiops:rework`, finish with this
+transition: `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework`.
+Re-read labels; require `aiops:rework` present and `aiops:human-review` absent.
+Repair and recheck before exit; fail non-zero if it cannot converge.
 
 ## Identity, PR, and one snapshot
 
@@ -79,8 +80,7 @@ Never leave both active labels on the issue.
    - branch-protection proof that approvals become stale when head or merge
      base changes.
    Set `<PR_NUMBER>`, `<HEAD>`, `<BASE_OID>`, and `<BASE_NAME>` from it. Do not
-   wait, repeatedly poll, or refresh asynchronous gate state in this invocation.
-   Pagination is one bounded snapshot, not repeated lifecycle polling.
+   wait/poll or refresh asynchronous gates. Pagination is one bounded snapshot.
 
 Before any trigger, verdict, checkpoint, or approval write—and before changing
 auto-merge—run a tuple-only guard. If the current tuple differs from the
@@ -95,7 +95,7 @@ The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
 
 `Reviewer checkpoint: headRefOid=<HEAD> baseRefOid=<BASE_OID> baseRefName=<BASE_NAME> local-rubric=PASS`
 
-- For the same exact tuple, reuse that checkpoint: skip checkout, configured
+- For the same exact tuple, reuse that checkpoint: skip checkout,
   verification, and semantic/security review. Use only the one live snapshot
   to resolve external state, then end promptly.
 - Any head or base changes invalidate it and require the full review below.
@@ -105,11 +105,10 @@ The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
 
 ## Full review for an unseen tuple
 
-1. Confirm the maker and reviewer identities differ. Fetch, then use a detached
-   checkout of `<HEAD>` for every inspection and configured command; do not
-   review a moving branch name or edit files.
-2. **Verification (you own this):** only for an unseen tuple, run the configured
-   commands once: `npm ci`; `npm test`; `npm run build`; `npm run test:e2e`.
+1. Confirm the maker and reviewer identities differ. Inspect a detached checkout
+   of `<HEAD>`; do not review a moving branch name or edit files.
+2. **Verification (you own this):** only for an unseen tuple, run these commands
+   once: `npm ci`; `npm test`; `npm run build`; `npm run test:e2e`.
    The same-tuple checkpoint path skips them.
 3. Review the complete diff against the issue, including behavior-level tests,
    security, failure paths, and unrelated scope.
@@ -123,13 +122,14 @@ The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
 
 ## External gates and landing
 
-If repository policy requires GitHub Codex review, its trigger must be authored
-by the expected reviewer identity and carry the exact tuple. Reuse an existing
-exact-tuple trigger; post at most one `@codex review` trigger per tuple. Accept
-only the repository-documented reliable completion signal bound to `<HEAD>`.
-The absence of a reliable Codex signal is not clean. Findings join the FAIL
-evidence; no-signal, usage-limit, and pending results leave
-`aiops:human-review` unchanged and end promptly.
+If policy requires GitHub Codex review, its trigger needs the expected identity
+and exact tuple. Reuse an existing exact-tuple trigger; post at most one
+`@codex review` trigger per tuple. Accept
+only the documented reliable completion signal bound to `<HEAD>`. The absence
+of a reliable Codex signal is not clean. Findings join the FAIL
+evidence: submit one consolidated commit-pinned `CHANGES_REQUESTED`, then use
+the `aiops:rework` transition above as the LAST action. No-signal,
+usage-limit, or pending leaves `aiops:human-review` unchanged and ends promptly.
 
 Using only this invocation's snapshot:
 

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -57,6 +57,9 @@ the checkpoint and handoff yourself in this turn so the lifecycle advances.
 
 Issue: {{ issue.identifier }} — {{ task.title }} ({{ issue.url }})
 Repository: {{ repo.owner }}/{{ repo.name }}; base: {{ repo.branch }}.
+Whenever this workflow says return/move to `aiops:rework`, make this the LAST
+action: `gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework`.
+Never leave both active labels on the issue.
 
 ## Identity, PR, and one snapshot
 

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -59,6 +59,8 @@ verify:
 You are the independent GitHub REVIEWER. You do not edit, commit, or push code.
 Approve and enable native auto-merge only after PASS; close the issue only
 after GitHub confirms the PR merged.
+Do not start a separate review skill/workflow or delegate the verdict. Complete
+the checkpoint and handoff yourself in this turn so the lifecycle advances.
 
 Issue: {{ issue.identifier }} — {{ task.title }} ({{ issue.url }})
 Repository: {{ repo.owner }}/{{ repo.name }}; base: {{ repo.branch }}.
@@ -141,12 +143,17 @@ tuple. This guard does not refresh Codex, checks, threads, or merge state.
    unchanged and end promptly.
 3. When local and external gates are clean, require stale approval dismissal.
    Approve only if exact-head approval is absent, using the REST review API with
-   `commit_id=<HEAD>` and event `APPROVE`; then, if auto-merge is absent, run
+   `commit_id=<HEAD>` and event `APPROVE`; retain its review ID. Immediately run
+   a post-approval tuple guard. If the tuple changed, dismiss that approval (or
+   replace it with commit-pinned `REQUEST_CHANGES` if dismissal is unavailable),
+   require successful revocation, do not enable auto-merge, and end. If the
+   tuple still matches and auto-merge is absent, run
    `gh pr merge <PR_NUMBER> --auto --squash --delete-branch --match-head-commit <HEAD>`.
    Do not use `--admin`. GitHub stale approval dismissal protects a base change
-   after the guard; a later invocation must review its new tuple. If approval
-   and auto-merge already exist but merge is pending, make no duplicate write.
-   Do not re-read state afterward; a later invocation confirms merge.
+   after the post-approval guard; a later invocation must review its new tuple.
+   If approval and auto-merge already exist but merge is pending, make no
+   duplicate write. Do not refresh asynchronous gates afterward; a later
+   invocation confirms merge.
 
 Use `aiops:blocked` only for a true external/operator-owned blocker. Never use
 it for Codex, CI, approval, auto-merge, merge, or review-thread state. Never

--- a/examples/github-reviewer-automerge-WORKFLOW.md
+++ b/examples/github-reviewer-automerge-WORKFLOW.md
@@ -110,6 +110,10 @@ The tuple is (`headRefOid=<HEAD>`, `baseRefOid=<BASE_OID>`,
 2. Run the configured verification commands once.
 3. Review the complete diff against the issue, including behavior-level tests,
    security, failure paths, and unrelated scope.
+Before any trigger, verdict, checkpoint, or approval write—and before changing
+auto-merge—run a tuple-only guard. If the current tuple differs from the
+snapshot, write nothing and end; the next invocation reviews the new tuple.
+This guard does not refresh Codex, checks, threads, or merge state.
 4. Treat unresolved, non-outdated current-head blockers from any author,
    failed required checks, or an unmet acceptance criterion as FAIL. Submit one
    consolidated `CHANGES_REQUESTED` through the REST review API with
@@ -130,11 +134,6 @@ evidence; no-signal, usage-limit, and pending results leave
 
 Using only this invocation's snapshot:
 
-Before any verdict/checkpoint/approval write, perform one tuple-only guard. If
-the current `(headRefOid, baseRefOid, baseRefName)` differs from the snapshot,
-write no review or checkpoint and end; the next invocation reviews the new
-tuple. This guard does not refresh Codex, checks, threads, or merge state.
-
 1. If the PR is merged, require a reviewer-owned `APPROVED` review with
    `commit_id=<HEAD>` and a successful required check on `<HEAD>`. Then mark
    `aiops:done` and close. If close fails, restore `aiops:human-review`
@@ -142,7 +141,9 @@ tuple. This guard does not refresh Codex, checks, threads, or merge state.
 2. If required Codex or checks are pending, leave `aiops:human-review`
    unchanged and end promptly.
 3. When local and external gates are clean, require stale approval dismissal.
-   Approve only if exact-head approval is absent, using the REST review API with
+   If exact-head approval is absent, disable auto-merge and confirm it is absent
+   before approval; if that fails, leave `aiops:human-review` and end. Run the
+   tuple-only guard, then approve through the REST review API with
    `commit_id=<HEAD>` and event `APPROVE`; retain its review ID. Immediately run
    a post-approval tuple guard. If the tuple changed, dismiss that approval (or
    replace it with commit-pinned `REQUEST_CHANGES` if dismissal is unavailable),

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -257,9 +257,11 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 			"disable auto-merge and confirm it is absent before approval",
 			"With an exact-head approval already present",
 			"at most one `@codex review`", "absence of a reliable Codex signal is not clean",
+			"use the `aiops:rework` transition above as the LAST action",
 			"head or base changes", "reviewThreads", "current-head blockers from any author",
 			"REST review API", "event `APPROVE`", "--match-head-commit <HEAD>",
 			"gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework",
+			"Re-read labels", "Repair and recheck before exit", "fail non-zero if it cannot converge",
 			"Do not use `--admin`", "mergedAt", "restore `aiops:human-review`", "aiops:blocked",
 		}
 	default:
@@ -276,8 +278,11 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 			t.Fatalf("reviewer rework command count = %d; want 1", strings.Count(text, normalizedWorkflowText(reworkCommand)))
 		}
 		assertWorkflowInvariantOrder(t, text,
+			"gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework",
+			"Re-read labels", "Repair and recheck before exit",
 			"Pagination is one bounded snapshot", "Before any trigger, verdict, checkpoint, or approval write",
 			"## Exact-tuple checkpoint", "event `COMMENT`", "at most one `@codex review`",
+			"Findings join the FAIL evidence", "use the `aiops:rework` transition above",
 			"disable auto-merge and confirm it is absent before approval", "event `APPROVE`",
 			"post-approval tuple guard",
 			"dismiss that approval", "With an exact-head approval already present",
@@ -423,7 +428,7 @@ func TestGitHubMakerReviewerWorkflowPromptsKeepTransientReviewGatesOutOfBlocked(
 		body := readFileString(t, filepath.Join(root, path))
 		bodyText := normalizedWorkflowText(body)
 		for _, want := range []string{
-			"no-signal, usage-limit, and pending results leave `aiops:human-review` unchanged",
+			"No-signal", "usage-limit", "pending leaves `aiops:human-review` unchanged",
 			"current-head blockers from any author",
 			"move to `aiops:rework`",
 		} {

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
 
@@ -203,6 +204,26 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 			}
 		}
 		assertGitHubRolePromptContract(t, tc.role, loaded.PromptTemplate)
+		if tc.role == "reviewer" {
+			assertReviewerEffectiveVerifyContract(t, loaded.PromptTemplate, cfg.Verify.Commands)
+		}
+	}
+}
+
+func assertReviewerEffectiveVerifyContract(t *testing.T, prompt string, commands []string) {
+	t.Helper()
+	effective := worker.AppendVerifyDirective(prompt, commands)
+	const marker = "**Verification (you own this):**"
+	if strings.Count(effective, marker) != 1 {
+		t.Fatalf("reviewer effective prompt marker count = %d; want 1", strings.Count(effective, marker))
+	}
+	if strings.Contains(effective, "before you hand off — i.e. before opening a PR") {
+		t.Fatalf("reviewer effective prompt contains unconditional worker verify directive")
+	}
+	for _, command := range commands {
+		if !strings.Contains(effective, "`"+command+"`") {
+			t.Fatalf("reviewer effective prompt missing scoped command %q", command)
+		}
 	}
 }
 
@@ -233,6 +254,7 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 			"post-approval tuple guard", "dismiss that approval", "do not enable auto-merge",
 			"Before any trigger, verdict, checkpoint, or approval write",
 			"disable auto-merge and confirm it is absent before approval",
+			"With an exact-head approval already present",
 			"at most one `@codex review`", "absence of a reliable Codex signal is not clean",
 			"head or base changes", "reviewThreads", "current-head blockers from any author",
 			"REST review API", "event `APPROVE`", "--match-head-commit <HEAD>",
@@ -252,7 +274,8 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 			"## Exact-tuple checkpoint", "event `COMMENT`", "at most one `@codex review`",
 			"disable auto-merge and confirm it is absent before approval", "event `APPROVE`",
 			"post-approval tuple guard",
-			"dismiss that approval", "--match-head-commit <HEAD>")
+			"dismiss that approval", "With an exact-head approval already present",
+			"--match-head-commit <HEAD>")
 	}
 }
 

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -30,12 +30,14 @@ func TestGitHubMakerReviewerRunbookDocumentsReusableHarness(t *testing.T) {
 		"required job named `build-test`",
 		"required_approving_review_count",
 		"aiops:blocked",
-		"true blockers",
-		"Blocked\nhandoff commands remove the role's active label",
-		"historical `CHANGES_REQUESTED` count",
-		"unchanged-head\nhandoffs/reviews",
-		"comment alone does not replace a new PR head",
-		"current-head unresolved non-outdated review threads",
+		"true operator-owned blockers",
+		"Rework response:",
+		"(headRefOid, baseRefOid, baseRefName)",
+		"reviewer-owned `COMMENTED` checkpoint",
+		"same-tuple retry",
+		"one live snapshot",
+		"never posts a second trigger",
+		"changed head/base requires full review",
 		"worker --doctor --deploy=binary --mode=real",
 		"If `gh release view`, checksum, attestation",
 		"git push --dry-run",
@@ -46,7 +48,7 @@ func TestGitHubMakerReviewerRunbookDocumentsReusableHarness(t *testing.T) {
 		"Do not downgrade the scenario into\nsingle-agent merge",
 		"`gh pr merge <PR> --auto --squash --delete-branch --match-head-commit <sha>`",
 	} {
-		if !strings.Contains(body, want) {
+		if !strings.Contains(normalizedWorkflowText(body), normalizedWorkflowText(want)) {
 			t.Fatalf("runbook missing %q", want)
 		}
 	}
@@ -89,11 +91,13 @@ func TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology(t *testin
 		"`aiops:done`",
 		"`aiops:canceled`",
 		"`Rework response:`",
-		"current-head unresolved non-outdated review threads",
-		"diagnostic only",
-		"unchanged-head",
-		"does not replace a new PR head",
-		"Codex no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending\nstay in `aiops:human-review`",
+		"(headRefOid, baseRefOid, baseRefName)",
+		"reviewer-owned `COMMENTED` checkpoint",
+		"same-tuple retry",
+		"one live snapshot",
+		"does not repeat local review",
+		"A head or base change invalidates the checkpoint",
+		"absence of a reliable Codex signal is never clean",
 		"branch protection",
 		"required status check",
 		"required approving review",
@@ -109,7 +113,7 @@ func TestGitHubMakerReviewerGovernanceGuideDocumentsProductionTopology(t *testin
 		"scripts/github-maker-reviewer-capture.py",
 		"scripts/github-maker-reviewer-report.py",
 	} {
-		if !strings.Contains(body, want) {
+		if !strings.Contains(normalizedWorkflowText(body), normalizedWorkflowText(want)) {
 			t.Fatalf("governance guide missing %q", want)
 		}
 	}
@@ -121,6 +125,7 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 	t.Setenv("AIOPS_GITHUB_REPO_CLONE_URL", "https://github.com/octo-org/octo-todo.git")
 
 	for _, tc := range []struct {
+		role            string
 		path            string
 		active          []string
 		inactive        []string
@@ -128,34 +133,20 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 		maxContTurns    int
 		maxClaimTokens  int64
 		maxClaimSeconds int64
-		mustContain     []string
-		mustNotContain  []string
+		verifyCommands  []string
 	}{
 		{
+			role:            "maker",
 			path:            "examples/github-maker-WORKFLOW.md",
 			active:          []string{"aiops:todo", "aiops:rework"},
 			inactive:        []string{"aiops:human-review", "aiops:blocked", "aiops:done", "aiops:canceled"},
 			maxTurns:        30,
 			maxClaimTokens:  20000000,
 			maxClaimSeconds: 7200,
-			mustContain: []string{
-				"Do NOT use `gh pr review`, `gh pr merge`, `gh issue close`, or",
-				"PR title and body must reference the issue with `Refs #<N>` only",
-				"open-PR claim filter scans the PR title and body",
-				"issue comment that starts with `Rework response:`",
-				"current-head unresolved non-outdated review threads",
-				"historical `CHANGES_REQUESTED` count as a stop\n   condition",
-				"would require handing off the same unchanged head\n   again",
-				"aiops:blocked",
-				"gh issue edit <N> --remove-label aiops:todo --remove-label aiops:rework --add-label aiops:blocked",
-				"Codex review uncertainty, no-signal, NOT-CONFIRMED, usage-limit, CI pending",
-				"leave the issue in its current maker-active label",
-				"true external/operator-owned blocker",
-				"LAST action",
-			},
-			mustNotContain: []string{"gitea_issue_labels", "AIOPS_MAKER_MAX_REWORK_CYCLES", "max rework cycle budget", "Codex reports a usage-limit/input-required result"},
+			verifyCommands:  []string{"npm ci", "npm test", "npm run build", "npm run test:e2e"},
 		},
 		{
+			role:            "reviewer",
 			path:            "examples/github-reviewer-automerge-WORKFLOW.md",
 			active:          []string{"aiops:human-review"},
 			inactive:        []string{"aiops:todo", "aiops:rework", "aiops:blocked", "aiops:done", "aiops:canceled"},
@@ -163,34 +154,7 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 			maxContTurns:    48,
 			maxClaimTokens:  12000000,
 			maxClaimSeconds: 7200,
-			mustContain: []string{
-				"gh pr review <PR_NUMBER> --approve",
-				"gh pr merge <PR_NUMBER> --auto --squash --delete-branch --match-head-commit <sha>",
-				"gh pr view <PR_URL>",
-				"gh pr view <PR_NUMBER> --json state,mergedAt,headRefOid,mergeStateStatus",
-				"<PR_NUMBER>",
-				"Do not use `--admin`",
-				"Do NOT close an issue before GitHub confirms the PR is merged",
-				"Do NOT edit, commit, or push code",
-				"do not jump straight\n   to Done",
-				"reviewer-owned `APPROVED` review whose `commit_id`",
-				"pulls/<PR_NUMBER>/reviews?per_page=100",
-				"--paginate --slurp",
-				"`commit_id`",
-				"successful `build-test`",
-				"retry-safe",
-				"current-head unresolved non-outdated review threads",
-				"all current-head blocker",
-				"historical `CHANGES_REQUESTED` count as a stop\n   condition",
-				"does not replace a new\n   PR head",
-				"Reviewer re-queued unchanged head <headRefOid>; waiting for maker rework",
-				"Then move the issue back to Rework as your LAST action and stop",
-				"aiops:blocked",
-				"Codex NOT-CONFIRMED, no-signal, usage-limit, CI pending",
-				"leave the issue in `aiops:human-review`",
-				"true external/operator-owned blocker",
-			},
-			mustNotContain: []string{"gitea_issue_labels", "--json merged,", "AIOPS_REVIEWER_MAX_REWORK_CYCLES", "max rework cycle budget", "Codex usage-limit/input-required stops the review"},
+			verifyCommands:  []string{"npm ci", "npm test", "npm run build", "npm run test:e2e"},
 		},
 	} {
 		full := filepath.Join(root, tc.path)
@@ -223,6 +187,9 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 		if cfg.Agent.MaxRuntimeSecondsPerClaim != tc.maxClaimSeconds {
 			t.Fatalf("%s max_runtime_seconds_per_claim = %d; want %d", tc.path, cfg.Agent.MaxRuntimeSecondsPerClaim, tc.maxClaimSeconds)
 		}
+		if strings.Join(cfg.Verify.Commands, "\n") != strings.Join(tc.verifyCommands, "\n") {
+			t.Fatalf("%s verify.commands = %v; want %v", tc.path, cfg.Verify.Commands, tc.verifyCommands)
+		}
 		if cfg.Codex.ReadTimeoutMs != 30000 {
 			t.Fatalf("%s codex.read_timeout_ms = %d; want 30000", tc.path, cfg.Codex.ReadTimeoutMs)
 		}
@@ -234,18 +201,91 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 				t.Fatalf("%s env_passthrough missing %q: %v", tc.path, want, cfg.Codex.EnvPassthrough)
 			}
 		}
-		text := readFileString(t, full)
-		for _, want := range tc.mustContain {
-			if !strings.Contains(text, want) {
-				t.Fatalf("%s missing %q", tc.path, want)
-			}
-		}
-		for _, forbidden := range tc.mustNotContain {
-			if strings.Contains(text, forbidden) {
-				t.Fatalf("%s contains forbidden %q", tc.path, forbidden)
-			}
+		assertGitHubRolePromptContract(t, tc.role, loaded.PromptTemplate)
+	}
+}
+
+func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
+	t.Helper()
+	text := normalizedWorkflowText(prompt)
+	commonForbidden := []string{"gitea_issue_labels", "--watch", "sleep "}
+	for _, forbidden := range commonForbidden {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("%s prompt contains forbidden %q", role, forbidden)
 		}
 	}
+	var required []string
+	switch role {
+	case "maker":
+		required = []string{
+			"Implement only this issue", "configured verification", "Refs #<N>",
+			"Rework response:", "new head", "reviewThreads", "aiops:human-review",
+			"true external/operator-owned blocker", "aiops:blocked", "LAST action",
+		}
+	case "reviewer":
+		required = []string{
+			"headRefOid", "baseRefOid", "baseRefName", "reviewer-owned `COMMENTED`",
+			"local-rubric=PASS", "same exact tuple", "skip checkout", "one live snapshot",
+			"at most one `@codex review`", "absence of a reliable Codex signal is not clean",
+			"head or base changes", "reviewThreads", "current-head blockers from any author",
+			"gh pr review <PR_NUMBER> --approve", "--match-head-commit <HEAD>",
+			"Do not use `--admin`", "mergedAt", "restore `aiops:human-review`", "aiops:blocked",
+		}
+	default:
+		t.Fatalf("unknown role %q", role)
+	}
+	for _, want := range required {
+		if !strings.Contains(text, normalizedWorkflowText(want)) {
+			t.Fatalf("%s prompt missing invariant %q", role, want)
+		}
+	}
+}
+
+func TestGitHubMakerReviewerPromptBudgetsAndNetNegativeDocs(t *testing.T) {
+	root := repoRoot(t)
+	paths := []string{
+		"examples/github-maker-WORKFLOW.md",
+		"examples/github-reviewer-automerge-WORKFLOW.md",
+	}
+	wantMax := []int{4341, 6892}
+	total := 0
+	for i, path := range paths {
+		body := readFileString(t, filepath.Join(root, path))
+		size := len([]byte(githubWorkflowPromptBody(t, path, body)))
+		if size > wantMax[i] {
+			t.Fatalf("%s prompt bytes = %d; want <= %d", path, size, wantMax[i])
+		}
+		total += size
+	}
+	if total > 8986 {
+		t.Fatalf("combined prompt bytes = %d; want <= 8986", total)
+	}
+
+	tracked := []string{
+		paths[0], paths[1],
+		"docs/runbooks/github-maker-reviewer-governance.md",
+		"docs/runbooks/github-maker-reviewer-automerge-e2e.md",
+	}
+	lines := 0
+	for _, path := range tracked {
+		lines += strings.Count(readFileString(t, filepath.Join(root, path)), "\n")
+	}
+	if lines >= 1015 {
+		t.Fatalf("tracked workflow/runbook lines = %d; want < 1015", lines)
+	}
+}
+
+func githubWorkflowPromptBody(t *testing.T, path, body string) string {
+	t.Helper()
+	if !strings.HasPrefix(body, "---\n") {
+		return body
+	}
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---\n")
+	if end < 0 {
+		t.Fatalf("%s front matter is not terminated", path)
+	}
+	return rest[end+len("\n---\n"):]
 }
 
 func TestGitHubMakerReviewerWorkflowPromptsKeepTransientReviewGatesOutOfBlocked(t *testing.T) {
@@ -276,8 +316,8 @@ func TestGitHubMakerReviewerWorkflowPromptsKeepTransientReviewGatesOutOfBlocked(
 		body := readFileString(t, filepath.Join(root, path))
 		bodyText := normalizedWorkflowText(body)
 		for _, want := range []string{
-			"Codex review uncertainty, no-signal, NOT-CONFIRMED, usage-limit, CI pending, and auto-merge pending are not `aiops:blocked` reasons",
-			"leave the issue in its current maker-active label",
+			"Review uncertainty, no-signal, usage limits, CI, or merge state are not maker blockers",
+			"Leave the current maker-active label unchanged",
 			"true external/operator-owned blocker",
 		} {
 			if !strings.Contains(bodyText, normalizedWorkflowText(want)) {
@@ -289,10 +329,9 @@ func TestGitHubMakerReviewerWorkflowPromptsKeepTransientReviewGatesOutOfBlocked(
 		body := readFileString(t, filepath.Join(root, path))
 		bodyText := normalizedWorkflowText(body)
 		for _, want := range []string{
-			"Codex NOT-CONFIRMED, no-signal, usage-limit, CI pending, and auto-merge pending are not `aiops:blocked` reasons",
-			"leave the issue in `aiops:human-review`",
-			"unresolved non-outdated current-head review threads",
-			"move the issue back to Rework",
+			"no-signal, usage-limit, and pending results leave `aiops:human-review` unchanged",
+			"current-head blockers from any author",
+			"move to `aiops:rework`",
 		} {
 			if !strings.Contains(bodyText, normalizedWorkflowText(want)) {
 				t.Fatalf("%s missing reviewer transient-review guidance %q", path, want)

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -259,6 +259,7 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 			"at most one `@codex review`", "absence of a reliable Codex signal is not clean",
 			"head or base changes", "reviewThreads", "current-head blockers from any author",
 			"REST review API", "event `APPROVE`", "--match-head-commit <HEAD>",
+			"gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework",
 			"Do not use `--admin`", "mergedAt", "restore `aiops:human-review`", "aiops:blocked",
 		}
 	default:
@@ -270,6 +271,10 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 		}
 	}
 	if role == "reviewer" {
+		const reworkCommand = "gh issue edit <N> --remove-label aiops:human-review --add-label aiops:rework"
+		if strings.Count(text, normalizedWorkflowText(reworkCommand)) != 1 {
+			t.Fatalf("reviewer rework command count = %d; want 1", strings.Count(text, normalizedWorkflowText(reworkCommand)))
+		}
 		assertWorkflowInvariantOrder(t, text,
 			"Pagination is one bounded snapshot", "Before any trigger, verdict, checkpoint, or approval write",
 			"## Exact-tuple checkpoint", "event `COMMENT`", "at most one `@codex review`",

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -136,6 +136,7 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 		maxClaimTokens  int64
 		maxClaimSeconds int64
 		verifyCommands  []string
+		promptCommands  []string
 	}{
 		{
 			role:            "maker",
@@ -156,7 +157,7 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 			maxContTurns:    48,
 			maxClaimTokens:  12000000,
 			maxClaimSeconds: 7200,
-			verifyCommands:  []string{"npm ci", "npm test", "npm run build", "npm run test:e2e"},
+			promptCommands:  []string{"npm ci", "npm test", "npm run build", "npm run test:e2e"},
 		},
 	} {
 		full := filepath.Join(root, tc.path)
@@ -205,14 +206,14 @@ func TestGitHubMakerReviewerWorkflowExamplesLoadAndPinBoundaries(t *testing.T) {
 		}
 		assertGitHubRolePromptContract(t, tc.role, loaded.PromptTemplate)
 		if tc.role == "reviewer" {
-			assertReviewerEffectiveVerifyContract(t, loaded.PromptTemplate, cfg.Verify.Commands)
+			assertReviewerEffectiveVerifyContract(t, loaded.PromptTemplate, cfg.Verify.Commands, tc.promptCommands)
 		}
 	}
 }
 
-func assertReviewerEffectiveVerifyContract(t *testing.T, prompt string, commands []string) {
+func assertReviewerEffectiveVerifyContract(t *testing.T, prompt string, configured, expected []string) {
 	t.Helper()
-	effective := worker.AppendVerifyDirective(prompt, commands)
+	effective := worker.AppendVerifyDirective(prompt, configured)
 	const marker = "**Verification (you own this):**"
 	if strings.Count(effective, marker) != 1 {
 		t.Fatalf("reviewer effective prompt marker count = %d; want 1", strings.Count(effective, marker))
@@ -220,7 +221,7 @@ func assertReviewerEffectiveVerifyContract(t *testing.T, prompt string, commands
 	if strings.Contains(effective, "before you hand off — i.e. before opening a PR") {
 		t.Fatalf("reviewer effective prompt contains unconditional worker verify directive")
 	}
-	for _, command := range commands {
+	for _, command := range expected {
 		if !strings.Contains(effective, "`"+command+"`") {
 			t.Fatalf("reviewer effective prompt missing scoped command %q", command)
 		}

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -230,6 +230,8 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 			"`--paginate --slurp`", "`pageInfo`", "`hasNextPage`", "tuple-only guard",
 			"detached checkout of `<HEAD>`", "`commit_id=<HEAD>`", "stale approval dismissal",
 			"post-approval tuple guard", "dismiss that approval", "do not enable auto-merge",
+			"Before any trigger, verdict, checkpoint, or approval write",
+			"disable auto-merge and confirm it is absent before approval",
 			"at most one `@codex review`", "absence of a reliable Codex signal is not clean",
 			"head or base changes", "reviewThreads", "current-head blockers from any author",
 			"REST review API", "event `APPROVE`", "--match-head-commit <HEAD>",
@@ -245,7 +247,9 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 	}
 	if role == "reviewer" {
 		assertWorkflowInvariantOrder(t, text,
-			"tuple-only guard", "event `APPROVE`", "post-approval tuple guard",
+			"tuple-only guard", "event `COMMENT`", "at most one `@codex review`",
+			"disable auto-merge and confirm it is absent before approval", "event `APPROVE`",
+			"post-approval tuple guard",
 			"dismiss that approval", "--match-head-commit <HEAD>")
 	}
 }

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -247,7 +247,8 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 	}
 	if role == "reviewer" {
 		assertWorkflowInvariantOrder(t, text,
-			"tuple-only guard", "event `COMMENT`", "at most one `@codex review`",
+			"Pagination is one bounded snapshot", "Before any trigger, verdict, checkpoint, or approval write",
+			"## Exact-tuple checkpoint", "event `COMMENT`", "at most one `@codex review`",
 			"disable auto-merge and confirm it is absent before approval", "event `APPROVE`",
 			"post-approval tuple guard",
 			"dismiss that approval", "--match-head-commit <HEAD>")

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -224,10 +224,12 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 		}
 	case "reviewer":
 		required = []string{
+			"Do not start a separate review skill", "Complete the checkpoint and handoff yourself",
 			"headRefOid", "baseRefOid", "baseRefName", "reviewer-owned `COMMENTED`",
 			"local-rubric=PASS", "same exact tuple", "skip checkout", "one live snapshot",
 			"`--paginate --slurp`", "`pageInfo`", "`hasNextPage`", "tuple-only guard",
 			"detached checkout of `<HEAD>`", "`commit_id=<HEAD>`", "stale approval dismissal",
+			"post-approval tuple guard", "dismiss that approval", "do not enable auto-merge",
 			"at most one `@codex review`", "absence of a reliable Codex signal is not clean",
 			"head or base changes", "reviewThreads", "current-head blockers from any author",
 			"REST review API", "event `APPROVE`", "--match-head-commit <HEAD>",
@@ -240,6 +242,23 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 		if !strings.Contains(text, normalizedWorkflowText(want)) {
 			t.Fatalf("%s prompt missing invariant %q", role, want)
 		}
+	}
+	if role == "reviewer" {
+		assertWorkflowInvariantOrder(t, text,
+			"tuple-only guard", "event `APPROVE`", "post-approval tuple guard",
+			"dismiss that approval", "--match-head-commit <HEAD>")
+	}
+}
+
+func assertWorkflowInvariantOrder(t *testing.T, text string, ordered ...string) {
+	t.Helper()
+	last := -1
+	for _, marker := range ordered {
+		at := strings.Index(text, normalizedWorkflowText(marker))
+		if at <= last {
+			t.Fatalf("workflow invariant %q appears at %d after %d", marker, at, last)
+		}
+		last = at
 	}
 }
 

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -226,9 +226,11 @@ func assertGitHubRolePromptContract(t *testing.T, role, prompt string) {
 		required = []string{
 			"headRefOid", "baseRefOid", "baseRefName", "reviewer-owned `COMMENTED`",
 			"local-rubric=PASS", "same exact tuple", "skip checkout", "one live snapshot",
+			"`--paginate --slurp`", "`pageInfo`", "`hasNextPage`", "tuple-only guard",
+			"detached checkout of `<HEAD>`", "`commit_id=<HEAD>`", "stale approval dismissal",
 			"at most one `@codex review`", "absence of a reliable Codex signal is not clean",
 			"head or base changes", "reviewThreads", "current-head blockers from any author",
-			"gh pr review <PR_NUMBER> --approve", "--match-head-commit <HEAD>",
+			"REST review API", "event `APPROVE`", "--match-head-commit <HEAD>",
 			"Do not use `--admin`", "mergedAt", "restore `aiops:human-review`", "aiops:blocked",
 		}
 	default:

--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -1,6 +1,7 @@
 package scripts_test
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -298,6 +299,44 @@ func TestGitHubMakerReviewerPromptBudgetsAndNetNegativeDocs(t *testing.T) {
 	}
 	if lines >= 1015 {
 		t.Fatalf("tracked workflow/runbook lines = %d; want < 1015", lines)
+	}
+}
+
+func TestGitHubMakerReviewerReplaySummaryMatchesTrackedArtifacts(t *testing.T) {
+	root := repoRoot(t)
+	var summary struct {
+		PromptBytes struct {
+			Maker    int `json:"current_maker"`
+			Reviewer int `json:"current_reviewer"`
+			Combined int `json:"current_combined"`
+		} `json:"prompt_bytes"`
+		TrackedLines struct {
+			Current int `json:"current"`
+		} `json:"workflow_runbook_lines"`
+	}
+	path := filepath.Join(root, "docs/validation/assets/stable-head-reviewer-replay-20260714/summary.json")
+	if err := json.Unmarshal([]byte(readFileString(t, path)), &summary); err != nil {
+		t.Fatalf("parse replay summary: %v", err)
+	}
+
+	maker := len(githubWorkflowPromptBody(t, "maker", readFileString(t, filepath.Join(root, "examples/github-maker-WORKFLOW.md"))))
+	reviewer := len(githubWorkflowPromptBody(t, "reviewer", readFileString(t, filepath.Join(root, "examples/github-reviewer-automerge-WORKFLOW.md"))))
+	if summary.PromptBytes.Maker != maker || summary.PromptBytes.Reviewer != reviewer || summary.PromptBytes.Combined != maker+reviewer {
+		t.Fatalf("summary prompt bytes = %d/%d/%d; want %d/%d/%d", summary.PromptBytes.Maker, summary.PromptBytes.Reviewer, summary.PromptBytes.Combined, maker, reviewer, maker+reviewer)
+	}
+
+	tracked := []string{
+		"examples/github-maker-WORKFLOW.md",
+		"examples/github-reviewer-automerge-WORKFLOW.md",
+		"docs/runbooks/github-maker-reviewer-governance.md",
+		"docs/runbooks/github-maker-reviewer-automerge-e2e.md",
+	}
+	lines := 0
+	for _, trackedPath := range tracked {
+		lines += strings.Count(readFileString(t, filepath.Join(root, trackedPath)), "\n")
+	}
+	if summary.TrackedLines.Current != lines {
+		t.Fatalf("summary tracked lines = %d; want %d", summary.TrackedLines.Current, lines)
 	}
 }
 


### PR DESCRIPTION
Closes #1090

## Summary
- shrink the maker/reviewer prompt bodies from 11,233 to 8,845 bytes (-21.3%) while preserving issue scope, verification, rework, exact-head review, Codex, CI, approval, merge, and close gates
- add an exact `(headRefOid, baseRefOid, baseRefName)` reviewer checkpoint so unchanged tuples skip local verification and semantic review, reuse at most one Codex trigger, and take one bounded external snapshot
- guard trigger/review/auto-merge writes against tuple races, pin REST reviews to the captured head, and keep auto-merge absent until a new approval survives its post-approval guard
- publish the fixed-holdout replay and machine-readable token/runtime/rework evidence

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 2 production workflow files and 151 added production lines; tests, runbooks, and validation evidence are excluded.
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -count=1 -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] `go mod tidy` left `go.mod` / `go.sum` clean
- [x] `go build ./cmd/worker ./cmd/tui`
- [x] fixed-base Standards and Spec review against `865503f873f80f3e1b88ce402dfcadd80deebc0c`
- [x] #1089 fixed holdout against two serial issues in the disposable replay repository

## Validation
- prompt bodies: maker 4,341 -> 2,439 bytes (-43.8%); reviewer 6,892 -> 6,406 bytes (-7.1%); combined 11,233 -> 8,845 bytes (-21.3%)
- tracked workflow/runbook lines: 1,015 -> 988 (net -27)
- both replay PRs merged and both issues closed; fresh-clone holdout passed at `9b1ae3e979ca386acec6bab2ab76e236af06f935`
- worker-observed replay totals: 4,260,618 tokens, 1,293.6s agent runtime, 1,394s wall time, 0 rework cycles, 0 confirmed review findings
- same-tuple merge confirmations used 43.4% fewer tokens and 39.6% less runtime than the two successful full reviews in the same replay
- the disclosed first-issue no-handoff session led to an earned prompt rule that keeps checkpoint and handoff ownership in the current reviewer turn
- post-replay review hardening is contract-tested and reflected in current prompt sizes; replay costs describe the stable-tuple behavior rather than the final wording byte-for-byte

## Notes
- No worker/orchestrator production code, machine-local `.aiops/**`, or `scripts/local-pr-follow-through.sh` changes.
- The replay repository is `zjlgdx/aiops-workflow-bench-standard-20260714-1090-v2`; committed evidence is in `docs/validation/2026-07-14-stable-head-reviewer-replay.md` and its adjacent summary JSON.
