### PR TITLE
fix(orchestrator): make token usage folding exact

### DIFF
--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -1326,7 +1326,7 @@ func TestRecordRuntimeEventTracksLastEventAndMessage(t *testing.T) {
 	}
 }
 
-func TestRecordRuntimeEventTreatsGenericUsageAsEventDelta(t *testing.T) {
+func TestRecordRuntimeEventTreatsTurnCompletedUsageAsAbsolute(t *testing.T) {
 	o, issueID, cancel := startRuntimeEventActor(t, "ENG-USAGE")
 	defer cancel()
 
@@ -1342,8 +1342,8 @@ func TestRecordRuntimeEventTreatsGenericUsageAsEventDelta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
-	if view.CodexTotals.TotalTokens != 10 {
-		t.Fatalf("CodexTotals.TotalTokens = %d, want generic usage counted as per-event delta", view.CodexTotals.TotalTokens)
+	if view.CodexTotals.TotalTokens != 5 {
+		t.Fatalf("CodexTotals.TotalTokens = %d, want repeated absolute turn usage folded once", view.CodexTotals.TotalTokens)
 	}
 }
 

--- a/internal/orchestrator/runtime_events.go
+++ b/internal/orchestrator/runtime_events.go
@@ -263,7 +263,6 @@ type tokenUsage struct {
 	input, output, total int64
 	hasInput, hasOutput  bool
 	hasTotal             bool
-	absolute             bool
 }
 
 func tokenUsageFromEvent(event task.RuntimeEvent) (tokenUsage, bool) {
@@ -280,15 +279,13 @@ func tokenUsageFromEvent(event task.RuntimeEvent) (tokenUsage, bool) {
 	}
 	for _, path := range absolutePaths {
 		if usage, ok := tokenUsageFromMap(mapAtPath(payload, path)); ok {
-			usage.absolute = true
 			return usage, true
 		}
 	}
-	paths := [][]string{{"usage"}, {"turn", "usage"}}
-	if event.Event == task.EventTurnCompleted {
-		paths = append(paths, nil)
+	if event.Event != task.EventTurnCompleted {
+		return tokenUsage{}, false
 	}
-	for _, path := range paths {
+	for _, path := range [][]string{{"usage"}, {"turn", "usage"}, nil} {
 		if usage, ok := tokenUsageFromMap(mapAtPath(payload, path)); ok {
 			return usage, true
 		}
@@ -315,31 +312,23 @@ func tokenUsageFromMap(m map[string]any) (tokenUsage, bool) {
 
 func applyTokenUsage(run *RunningEntry, usage tokenUsage) (inputDelta, outputDelta, totalDelta int64) {
 	if usage.hasInput {
-		inputDelta = usage.input
-		if usage.absolute {
-			inputDelta = positiveDelta(usage.input, run.CodexInputTokens)
-			run.LastReportedInputTokens += inputDelta
-		}
+		inputDelta = positiveDelta(usage.input, run.LastReportedInputTokens)
+		run.LastReportedInputTokens = max(run.LastReportedInputTokens, usage.input)
+		run.CodexInputTokens = run.LastReportedInputTokens
 	}
 	if usage.hasOutput {
-		outputDelta = usage.output
-		if usage.absolute {
-			outputDelta = positiveDelta(usage.output, run.CodexOutputTokens)
-			run.LastReportedOutputTokens += outputDelta
-		}
+		outputDelta = positiveDelta(usage.output, run.LastReportedOutputTokens)
+		run.LastReportedOutputTokens = max(run.LastReportedOutputTokens, usage.output)
+		run.CodexOutputTokens = run.LastReportedOutputTokens
 	}
 	if usage.hasTotal {
-		totalDelta = usage.total
-		if usage.absolute {
-			totalDelta = positiveDelta(usage.total, run.CodexTotalTokens)
-			run.LastReportedTotalTokens += totalDelta
-		}
+		totalDelta = positiveDelta(usage.total, run.LastReportedTotalTokens)
+		run.LastReportedTotalTokens = max(run.LastReportedTotalTokens, usage.total)
+		run.CodexTotalTokens = run.LastReportedTotalTokens
 	} else {
 		totalDelta = inputDelta + outputDelta
+		run.CodexTotalTokens += totalDelta
 	}
-	run.CodexInputTokens += inputDelta
-	run.CodexOutputTokens += outputDelta
-	run.CodexTotalTokens += totalDelta
 	return inputDelta, outputDelta, totalDelta
 }
 

--- a/internal/orchestrator/runtime_events.go
+++ b/internal/orchestrator/runtime_events.go
@@ -304,9 +304,6 @@ func tokenUsageFromMap(m map[string]any) (tokenUsage, bool) {
 	if v, ok := numberField(m, "total_tokens", "total", "totalTokens"); ok {
 		usage.total, usage.hasTotal = v, true
 	}
-	if !usage.hasTotal && (usage.hasInput || usage.hasOutput) {
-		usage.total, usage.hasTotal = usage.input+usage.output, true
-	}
 	return usage, usage.hasInput || usage.hasOutput || usage.hasTotal
 }
 
@@ -325,9 +322,6 @@ func applyTokenUsage(run *RunningEntry, usage tokenUsage) (inputDelta, outputDel
 		totalDelta = positiveDelta(usage.total, run.LastReportedTotalTokens)
 		run.LastReportedTotalTokens = max(run.LastReportedTotalTokens, usage.total)
 		run.CodexTotalTokens = run.LastReportedTotalTokens
-	} else {
-		totalDelta = inputDelta + outputDelta
-		run.CodexTotalTokens += totalDelta
 	}
 	return inputDelta, outputDelta, totalDelta
 }

--- a/internal/orchestrator/runtime_events_token_test.go
+++ b/internal/orchestrator/runtime_events_token_test.go
@@ -66,6 +66,38 @@ func TestRecordRuntimeEventAbsoluteUsageAddsOnlyMonotonicIncrease(t *testing.T) 
 	}
 }
 
+func TestRecordRuntimeEventDoesNotDeriveMissingProviderTotal(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-EXPLICIT-TOTAL")
+	defer cancel()
+
+	events := []task.RuntimeEvent{
+		absoluteUsageEvent(100, 20, 120),
+		{
+			Event: task.EventNotification,
+			Payload: map[string]any{"token_usage": map[string]any{
+				"total": map[string]any{"input_tokens": 110, "output_tokens": 30},
+			}},
+		},
+	}
+	for _, event := range events {
+		if err := o.RecordRuntimeEvent(context.Background(), issueID, event); err != nil {
+			t.Fatalf("RecordRuntimeEvent(%q) = %v; want nil", event.Event, err)
+		}
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() = %v; want nil", err)
+	}
+	want := TokensView{InputTokens: 110, OutputTokens: 30, TotalTokens: 120}
+	if got := view.Running[0].Tokens; got != want {
+		t.Fatalf("Running tokens = %+v; want explicit provider totals %+v", got, want)
+	}
+	if got := view.CodexTotals; got.InputTokens != 110 || got.OutputTokens != 30 || got.TotalTokens != 120 {
+		t.Fatalf("CodexTotals = %+v; want input=110 output=30 explicit total=120", got)
+	}
+}
+
 func TestRecordRuntimeEventIgnoresLastTokenUsage(t *testing.T) {
 	o, issueID, cancel := startRuntimeEventActor(t, "ENG-LAST-USAGE")
 	defer cancel()

--- a/internal/orchestrator/runtime_events_token_test.go
+++ b/internal/orchestrator/runtime_events_token_test.go
@@ -1,0 +1,140 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/task"
+)
+
+func TestRecordRuntimeEventAbsoluteUsageIgnoresGenericNotification(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-ABSOLUTE-USAGE")
+	defer cancel()
+
+	events := []task.RuntimeEvent{
+		absoluteUsageEvent(100, 20, 120),
+		{
+			Event: task.EventNotification,
+			Payload: map[string]any{
+				"usage": map[string]any{"input_tokens": 5, "output_tokens": 1, "total_tokens": 6},
+			},
+		},
+		absoluteUsageEvent(100, 20, 120),
+	}
+	for _, event := range events {
+		if err := o.RecordRuntimeEvent(context.Background(), issueID, event); err != nil {
+			t.Fatalf("RecordRuntimeEvent(%q) = %v; want nil", event.Event, err)
+		}
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() = %v; want nil", err)
+	}
+	if len(view.Running) != 1 {
+		t.Fatalf("Running rows = %d; want 1", len(view.Running))
+	}
+	want := TokensView{InputTokens: 100, OutputTokens: 20, TotalTokens: 120}
+	if got := view.Running[0].Tokens; got != want {
+		t.Fatalf("Running tokens = %+v; want %+v", got, want)
+	}
+	if got := view.CodexTotals; got.InputTokens != 100 || got.OutputTokens != 20 || got.TotalTokens != 120 {
+		t.Fatalf("CodexTotals = %+v; want input=100 output=20 total=120", got)
+	}
+}
+
+func TestRecordRuntimeEventAbsoluteUsageAddsOnlyMonotonicIncrease(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-MONOTONIC-USAGE")
+	defer cancel()
+
+	for _, event := range []task.RuntimeEvent{
+		absoluteUsageEvent(8, 3, 11),
+		absoluteUsageEvent(8, 3, 11),
+		absoluteUsageEvent(10, 4, 14),
+	} {
+		if err := o.RecordRuntimeEvent(context.Background(), issueID, event); err != nil {
+			t.Fatalf("RecordRuntimeEvent(%q) = %v; want nil", event.Event, err)
+		}
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() = %v; want nil", err)
+	}
+	if got := view.CodexTotals; got.InputTokens != 10 || got.OutputTokens != 4 || got.TotalTokens != 14 {
+		t.Fatalf("CodexTotals = %+v; want input=10 output=4 total=14", got)
+	}
+}
+
+func TestRecordRuntimeEventIgnoresLastTokenUsage(t *testing.T) {
+	o, issueID, cancel := startRuntimeEventActor(t, "ENG-LAST-USAGE")
+	defer cancel()
+
+	events := []task.RuntimeEvent{
+		{
+			Event: task.EventNotification,
+			Payload: map[string]any{"token_usage": map[string]any{
+				"last":  map[string]any{"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+				"total": map[string]any{"input_tokens": 200, "output_tokens": 100, "total_tokens": 300},
+			}},
+		},
+		{
+			Event: task.EventNotification,
+			Payload: map[string]any{"token_usage": map[string]any{
+				"last": map[string]any{"input_tokens": 8, "output_tokens": 3, "total_tokens": 11},
+			}},
+		},
+	}
+	for _, event := range events {
+		if err := o.RecordRuntimeEvent(context.Background(), issueID, event); err != nil {
+			t.Fatalf("RecordRuntimeEvent(%q) = %v; want nil", event.Event, err)
+		}
+	}
+
+	view, err := o.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() = %v; want nil", err)
+	}
+	if got := view.CodexTotals; got.InputTokens != 200 || got.OutputTokens != 100 || got.TotalTokens != 300 {
+		t.Fatalf("CodexTotals = %+v; want input=200 output=100 total=300", got)
+	}
+}
+
+func TestApplyTokenUsageUsesLastReportedAbsoluteBaseline(t *testing.T) {
+	run := &RunningEntry{
+		CodexInputTokens:         105,
+		CodexOutputTokens:        21,
+		CodexTotalTokens:         126,
+		LastReportedInputTokens:  100,
+		LastReportedOutputTokens: 20,
+		LastReportedTotalTokens:  120,
+	}
+	usage := tokenUsage{
+		input: 110, output: 22, total: 132,
+		hasInput: true, hasOutput: true, hasTotal: true,
+	}
+
+	inputDelta, outputDelta, totalDelta := applyTokenUsage(run, usage)
+	if inputDelta != 10 || outputDelta != 2 || totalDelta != 12 {
+		t.Fatalf("applyTokenUsage deltas = %d/%d/%d; want 10/2/12 from last absolute report", inputDelta, outputDelta, totalDelta)
+	}
+	if run.CodexInputTokens != 110 || run.CodexOutputTokens != 22 || run.CodexTotalTokens != 132 {
+		t.Fatalf("running tokens = %d/%d/%d; want authoritative 110/22/132", run.CodexInputTokens, run.CodexOutputTokens, run.CodexTotalTokens)
+	}
+	if run.LastReportedInputTokens != 110 || run.LastReportedOutputTokens != 22 || run.LastReportedTotalTokens != 132 {
+		t.Fatalf("last reported tokens = %d/%d/%d; want 110/22/132", run.LastReportedInputTokens, run.LastReportedOutputTokens, run.LastReportedTotalTokens)
+	}
+}
+
+func absoluteUsageEvent(input, output, total int64) task.RuntimeEvent {
+	return task.RuntimeEvent{
+		Event: task.EventNotification,
+		Payload: map[string]any{
+			"token_usage": map[string]any{
+				"total": map[string]any{
+					"input_tokens": input, "output_tokens": output, "total_tokens": total,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Closes #1098

## Summary
- Treat supported Codex thread token totals as authoritative absolute snapshots and fold only monotonic increases.
- Ignore generic usage carried by unrelated runtime events and never count `last_token_usage`.
- Preserve an explicitly reported provider `total_tokens`; input/output-only snapshots no longer invent a total.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] `go test ./internal/orchestrator -run 'TestRecordRuntimeEvent.*(Token|Usage)|TestApplyTokenUsage' -count=1`
- [x] `go build ./cmd/worker ./cmd/tui`

## Notes
- The new missing-total regression failed before the fix with an invented total of 140 instead of the provider baseline 120.
- Independent Standards and Spec review passed after the provider-total correction.
