### PR TITLE
fix(doctor): fail on Codex protocol drift

### DIFF
--- a/internal/doctor/doctor_codex.go
+++ b/internal/doctor/doctor_codex.go
@@ -44,7 +44,11 @@ func (r *reportBuilder) checkCodex(ctx context.Context, cfg workflow.Config) { /
 			if gotOK && codexVersionMatches(got, want) {
 				r.pass("Codex version", fmt.Sprintf("%s (matches pinned %s)", installed, runner.CodexProtocolVersion))
 			} else {
-				r.warn("Codex version",
+				status := Warn
+				if r.realMode() {
+					status = Fail
+				}
+				r.add(status, "Codex version",
 					fmt.Sprintf("%s (pinned schema is %s)", installed, runner.CodexProtocolVersion),
 					fmt.Sprintf("The vendored app-server schema is generated for codex %s exactly; any other version — older or newer — can add or rename required fields the contract test cannot see. Regenerate via scripts/refresh-codex-schema.sh after a deliberate upgrade, or align the installed codex.", runner.CodexProtocolVersion))
 			}
@@ -444,12 +448,14 @@ func usesDefaultCodexCLI(cfg workflow.Config) bool {
 	return command == "" || command == "codex app-server" || strings.HasPrefix(command, "codex app-server ")
 }
 
-// codexVersionFromOutput extracts the first `major.minor[.patch]` token from
+// codexVersionFromOutput extracts the first exact `major.minor.patch` token from
 // `codex --version` output (e.g. "codex-cli 0.142.0"), reusing parseGoVersion's
 // generic numeric parse.
 func codexVersionFromOutput(output string) (goVersion, bool) {
 	for _, field := range strings.Fields(output) {
-		if v, ok := parseGoVersion(strings.TrimPrefix(field, "v")); ok {
+		normalized := strings.TrimPrefix(field, "v")
+		v, ok := parseGoVersion(normalized)
+		if ok && v.patchSet && normalized == fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch) {
 			return v, true
 		}
 	}
@@ -461,7 +467,7 @@ func codexVersionFromOutput(output string) (goVersion, bool) {
 // CodexProtocolVersion, so any other version — older OR newer — can drift: a
 // newer release can add required fields or rename enums just as an older one
 // lacks current ones, and the contract test (pinned to the vendored schema)
-// cannot see it. Anything but an exact match warns rather than passes.
+// cannot see it. Anything but an exact match fails real-mode preflight.
 func codexVersionMatches(got, want goVersion) bool {
 	return got.major == want.major && got.minor == want.minor && got.patch == want.patch
 }

--- a/internal/doctor/doctor_codex_version_test.go
+++ b/internal/doctor/doctor_codex_version_test.go
@@ -88,7 +88,7 @@ func TestRunReturnsFailureForCodexVersionMismatch(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir())
 	want, ok := parseGoVersion(runner.CodexProtocolVersion)
 	if !ok {
-		t.Fatalf("parseGoVersion(%q) failed", runner.CodexProtocolVersion)
+		t.Fatalf("parseGoVersion(%q) ok = %v; want true", runner.CodexProtocolVersion, ok)
 	}
 	newer := formatTestVersion(goVersion{major: want.major, minor: want.minor, patch: want.patch + 1, patchSet: true})
 	path := writeWorkflowBody(t, "gitea", "token", runner.NameCodexAppServer, "")

--- a/internal/doctor/doctor_codex_version_test.go
+++ b/internal/doctor/doctor_codex_version_test.go
@@ -1,0 +1,138 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/xrf9268-hue/aiops-platform/internal/runner"
+	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+)
+
+func TestCheckCodexVersionStatusMatchesPinnedProtocol(t *testing.T) {
+	installFakeCodex(t)
+	t.Setenv("CODEX_HOME", t.TempDir())
+	want, ok := parseGoVersion(runner.CodexProtocolVersion)
+	if !ok || want.minor == 0 {
+		t.Fatalf("parseGoVersion(%q) = %+v, %v; want a version with a decrementable minor", runner.CodexProtocolVersion, want, ok)
+	}
+	customCommand := installFakeCodexWrapper(t) + " app-server"
+	tests := []struct {
+		name             string
+		mode             string
+		versionOutput    string
+		command          string
+		wantStatus       Status
+		wantVersionCheck bool
+		wantFailure      bool
+		wantVersionCall  bool
+	}{
+		{name: "exact", versionOutput: "codex-cli " + formatTestVersion(want), wantStatus: Pass, wantVersionCheck: true, wantVersionCall: true},
+		{name: "older", versionOutput: "codex-cli " + formatTestVersion(goVersion{major: want.major, minor: want.minor - 1, patch: want.patch, patchSet: true}), wantStatus: Fail, wantVersionCheck: true, wantFailure: true, wantVersionCall: true},
+		{name: "newer patch", versionOutput: "codex-cli " + formatTestVersion(goVersion{major: want.major, minor: want.minor, patch: want.patch + 1, patchSet: true}), wantStatus: Fail, wantVersionCheck: true, wantFailure: true, wantVersionCall: true},
+		{name: "newer minor", versionOutput: "codex-cli " + formatTestVersion(goVersion{major: want.major, minor: want.minor + 1, patch: 0, patchSet: true}), wantStatus: Fail, wantVersionCheck: true, wantFailure: true, wantVersionCall: true},
+		{name: "newer major", versionOutput: "codex-cli " + formatTestVersion(goVersion{major: want.major + 1, minor: 0, patch: 0, patchSet: true}), wantStatus: Fail, wantVersionCheck: true, wantFailure: true, wantVersionCall: true},
+		{name: "unparsable", versionOutput: "codex-cli unknown", wantStatus: Fail, wantVersionCheck: true, wantFailure: true, wantVersionCall: true},
+		{name: "missing patch", versionOutput: fmt.Sprintf("codex-cli %d.%d", want.major, want.minor), wantStatus: Fail, wantVersionCheck: true, wantFailure: true, wantVersionCall: true},
+		{name: "mock mode mismatch", mode: "mock", versionOutput: "codex-cli " + formatTestVersion(goVersion{major: want.major, minor: want.minor, patch: want.patch + 1, patchSet: true}), wantStatus: Warn, wantVersionCheck: true, wantVersionCall: true},
+		{name: "custom command", command: customCommand, wantStatus: Warn},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			versionCalled := false
+			cfg := workflow.DefaultConfig()
+			cfg.Agent.Default = runner.NameCodexAppServer
+			cfg.Codex.Command = tt.command
+			mode := tt.mode
+			if mode == "" {
+				mode = "real"
+			}
+			r := &reportBuilder{opts: Options{
+				Mode:   mode,
+				Runner: codexVersionRunner(tt.versionOutput, &versionCalled),
+			}}
+			r.normalize()
+			r.checkCodex(context.Background(), cfg)
+			report := Report{Checks: r.checks}
+
+			if tt.wantVersionCheck {
+				if got := findCheck(t, report, "Codex version").Status; got != tt.wantStatus {
+					t.Fatalf("Codex version status = %s; want %s", got, tt.wantStatus)
+				}
+			} else {
+				if checkExists(report, "Codex version") {
+					t.Fatalf("custom command report includes Codex version check: %+v", report.Checks)
+				}
+				if got := findCheck(t, report, "Codex CLI").Status; got != tt.wantStatus {
+					t.Fatalf("Codex CLI status = %s; want %s", got, tt.wantStatus)
+				}
+			}
+			if got := report.HasFailures(); got != tt.wantFailure {
+				t.Fatalf("Report.HasFailures() = %v; want %v", got, tt.wantFailure)
+			}
+			if got := findCheck(t, report, "Codex app-server").Status; got != Pass {
+				t.Fatalf("Codex app-server status = %s; want %s", got, Pass)
+			}
+			if versionCalled != tt.wantVersionCall {
+				t.Fatalf("codex --version called = %v; want %v", versionCalled, tt.wantVersionCall)
+			}
+		})
+	}
+}
+
+func TestRunReturnsFailureForCodexVersionMismatch(t *testing.T) {
+	installFakeCodex(t)
+	t.Setenv("CODEX_HOME", t.TempDir())
+	want, ok := parseGoVersion(runner.CodexProtocolVersion)
+	if !ok {
+		t.Fatalf("parseGoVersion(%q) failed", runner.CodexProtocolVersion)
+	}
+	newer := formatTestVersion(goVersion{major: want.major, minor: want.minor, patch: want.patch + 1, patchSet: true})
+	path := writeWorkflowBody(t, "gitea", "token", runner.NameCodexAppServer, "")
+	var out strings.Builder
+	code := Run(context.Background(), Options{
+		WorkflowPath: path,
+		Mode:         "real",
+		Deploy:       "binary",
+		Stdout:       &out,
+		Runner:       codexVersionRunner("codex-cli "+newer, nil),
+	})
+
+	if code != 1 {
+		t.Fatalf("Run(version mismatch) exit code = %d; want 1\n%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "FAIL Codex version") {
+		t.Fatalf("doctor output missing version FAIL:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "PASS Codex app-server") {
+		t.Fatalf("doctor output missing successful app-server probe:\n%s", out.String())
+	}
+}
+
+func codexVersionRunner(versionOutput string, versionCalled *bool) CommandRunner {
+	return func(_ context.Context, name string, args []string, _ []string, _ io.Reader) ([]byte, error) {
+		if name != "codex" || len(args) == 0 {
+			return nil, fmt.Errorf("unexpected command %q %v", name, args)
+		}
+		switch args[0] {
+		case "--version":
+			if versionCalled != nil {
+				*versionCalled = true
+			}
+			return []byte(versionOutput + "\n"), nil
+		case "login":
+			return []byte("Logged in\n"), nil
+		case "sandbox":
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unexpected codex args %v", args)
+		}
+	}
+}
+
+func formatTestVersion(version goVersion) string {
+	return fmt.Sprintf("%d.%d.%d", version.major, version.minor, version.patch)
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1210,6 +1210,7 @@ func TestCodexVersionFromOutput(t *testing.T) {
 		{"codex-cli line", "codex-cli 0.136.0\n", goVersion{major: 0, minor: 136, patch: 0, patchSet: true}, true},
 		{"bare version", "0.135.2", goVersion{major: 0, minor: 135, patch: 2, patchSet: true}, true},
 		{"v-prefixed", "codex v0.137.0", goVersion{major: 0, minor: 137, patch: 0, patchSet: true}, true},
+		{"missing patch", "codex-cli 0.142", goVersion{}, false},
 		{"no version token", "codex-cli unknown", goVersion{}, false},
 	}
 	for _, tc := range cases {
@@ -1228,13 +1229,13 @@ func TestCodexVersionMatches(t *testing.T) {
 		match     bool
 	}{
 		{"equal", v(0, 136, 0), v(0, 136, 0), true},
-		{"older minor warns", v(0, 135, 9), v(0, 136, 0), false},
-		// A newer codex than the vendored schema must also warn: it can add
+		{"older minor mismatches", v(0, 135, 9), v(0, 136, 0), false},
+		// A newer codex than the vendored schema must also mismatch: it can add
 		// required fields the pinned contract test cannot see (#629 P2).
-		{"newer minor warns", v(0, 137, 0), v(0, 136, 0), false},
-		{"older patch warns", v(0, 136, 0), v(0, 136, 1), false},
-		{"newer patch warns", v(0, 136, 2), v(0, 136, 1), false},
-		{"newer major warns", v(1, 0, 0), v(0, 136, 0), false},
+		{"newer minor mismatches", v(0, 137, 0), v(0, 136, 0), false},
+		{"older patch mismatches", v(0, 136, 0), v(0, 136, 1), false},
+		{"newer patch mismatches", v(0, 136, 2), v(0, 136, 1), false},
+		{"newer major mismatches", v(1, 0, 0), v(0, 136, 0), false},
 	}
 	for _, tc := range cases {
 		if got := codexVersionMatches(tc.got, tc.want); got != tc.match {


### PR DESCRIPTION
Closes #1100

## Summary
- Make the default real-mode doctor check fail closed when `codex --version` is older, newer, incomplete, or unparsable relative to the exact vendored protocol pin.
- Propagate the version mismatch into `Report.HasFailures` and the doctor CLI exit status even when the app-server launch probe succeeds.
- Preserve the custom-command warning/skip behavior and mock workflow behavior, with table-driven fake-runner coverage.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Do not collapse formatting, merge responsibilities, delete useful tests, or
reduce readability solely to check `within budget`; choose
`size-gated: justified overage` when the smallest readable change plus necessary
tests needs the space.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go test ./internal/doctor -run '^(TestCheckCodexVersionStatusMatchesPinnedProtocol|TestRunReturnsFailureForCodexVersionMismatch)$' -count=1`
- `go test -race -covermode=atomic ./internal/doctor -count=1`
- `go test -tags e2e -race -timeout 15m ./test/e2e/...`
- `go build ./cmd/worker ./cmd/tui`

## Notes
- This PR deliberately does not change `CodexProtocolVersion`, the vendored schema, Docker pins, or checksums; that upgrade is isolated in #1101.
- Custom `codex.command` configurations still skip the exact version/auth checks with an explicit warning while retaining the app-server launch probe.
