### PR TITLE
test(scripts): isolate npm timeout from clone latency

### DIFF
--- a/scripts/github_maker_reviewer_e2e_test.go
+++ b/scripts/github_maker_reviewer_e2e_test.go
@@ -1302,11 +1302,12 @@ func TestGitHubMakerReviewerCaptureStripsAmbientGitHubTokens(t *testing.T) {
 }
 
 func TestGitHubMakerReviewerFinalVerifyTimesOutStalledCommands(t *testing.T) {
+	const timeoutSeconds = "3"
 	root := repoRoot(t)
 	runRoot := filepath.Join(t.TempDir(), "run")
 	fakeBin := filepath.Join(t.TempDir(), "fakebin")
 	mkdirAll(t, fakeBin)
-	writeFileString(t, filepath.Join(fakeBin, "gh"), fakeGhForFinalVerify())
+	writeFileString(t, filepath.Join(fakeBin, "gh"), fakeGhForFinalVerifyWithCloneDelay())
 	writeFileString(t, filepath.Join(fakeBin, "npm"), "#!/usr/bin/env bash\nsleep 5\n")
 	for _, name := range []string{"gh", "npm"} {
 		if err := os.Chmod(filepath.Join(fakeBin, name), 0o755); err != nil {
@@ -1321,7 +1322,7 @@ func TestGitHubMakerReviewerFinalVerifyTimesOutStalledCommands(t *testing.T) {
 		"--run-root", runRoot,
 		"--repo", "octo-org/octo-todo",
 		"--skip-screenshots",
-		"--command-timeout-seconds", "1",
+		"--command-timeout-seconds", timeoutSeconds,
 	)
 	cmd.Dir = root
 	cmd.Env = append(os.Environ(),
@@ -1333,12 +1334,23 @@ func TestGitHubMakerReviewerFinalVerifyTimesOutStalledCommands(t *testing.T) {
 	if err == nil {
 		t.Fatalf("final verify succeeded; want npm timeout\n%s", out)
 	}
-	if !strings.Contains(string(out), "npm ci timed out after 1s; see") {
-		t.Fatalf("final verify output missing timeout and log path\n%s", out)
+	wantDiagnostic := "npm ci timed out after " + timeoutSeconds + "s; see"
+	if got := strings.Contains(string(out), wantDiagnostic); !got {
+		t.Fatalf("strings.Contains(output, %q) = %v; want true\noutput:\n%s", wantDiagnostic, got, out)
+	}
+	cloneLog := readFileString(t, filepath.Join(runRoot, "final-verify", "logs", "gh-clone.log"))
+	wantCloneMarker := "AIOPS_FINAL_VERIFY_EXIT_STATUS: 0"
+	if got := strings.Contains(cloneLog, wantCloneMarker); !got {
+		t.Fatalf("strings.Contains(cloneLog, %q) = %v; want true\ncloneLog:\n%s", wantCloneMarker, got, cloneLog)
 	}
 	log := readFileString(t, filepath.Join(runRoot, "final-verify", "logs", "npm-ci.log"))
-	if !strings.Contains(log, "TIMEOUT after 1s") {
-		t.Fatalf("npm log missing timeout marker\n%s", log)
+	for _, want := range []string{
+		"TIMEOUT after " + timeoutSeconds + "s",
+		"AIOPS_FINAL_VERIFY_EXIT_STATUS: timeout",
+	} {
+		if got := strings.Contains(log, want); !got {
+			t.Fatalf("strings.Contains(npmLog, %q) = %v; want true\nnpmLog:\n%s", want, got, log)
+		}
 	}
 }
 
@@ -1828,4 +1840,8 @@ fi
 echo "unexpected gh args: $*" >&2
 exit 42
 `
+}
+
+func fakeGhForFinalVerifyWithCloneDelay() string {
+	return strings.Replace(fakeGhForFinalVerify(), `  mkdir -p "$dest"`, "  sleep 1.5\n  mkdir -p \"$dest\"", 1)
 }


### PR DESCRIPTION
Closes #1105

## Summary
- Give the timeout test a deliberate 1.5-second fake-clone prerequisite and a 3-second command budget, so the fixture proves clone completion before the stalled `npm ci` timeout.
- Keep `github-maker-reviewer-final-verify.py`, its 900-second production default, fresh-clone behavior, and real command timeout enforcement unchanged.
- Require command-specific output plus clone success, npm `TIMEOUT`, and timeout exit-status evidence.

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Do not collapse formatting, merge responsibilities, delete useful tests, or
reduce readability solely to check `within budget`; choose
`size-gated: justified overage` when the smallest readable change plus necessary
tests needs the space.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

- `go test -race ./scripts -run '^TestGitHubMakerReviewerFinalVerifyTimesOutStalledCommands$' -count=20` (PASS, 97.8s)
- `go test ./scripts -count=1`
- `go test ./scripts ./internal/tracker -count=1`
- `go vet ./...`
- blocking golangci gate (0 issues)
- `go test -race -covermode=atomic ./...`
- `go test -tags e2e -race -count=1 -timeout 15m ./test/e2e/...`
- `go build ./cmd/worker ./cmd/tui`
- Red proof: with the delayed clone and the old 1-second budget, the test fails on `gh repo clone ... timed out after 1s`; the committed 3-second budget reaches and asserts the intended npm timeout.

## Notes
- Production final-verify code and defaults are unchanged.
