### PR TITLE
test(scripts): avoid urllib userinfo hang in freeze redaction

### DIFF
--- a/scripts/crowdrunner_lifecycle_e2e_test.go
+++ b/scripts/crowdrunner_lifecycle_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -551,10 +552,12 @@ func TestCrowdRunnerFreezeRedactsFailureSecrets(t *testing.T) {
 	const token = "freeze-secret-token"
 	const proxySecret = "proxy-secret"
 
+	var authMu sync.Mutex
+	var authorization string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "token "+token {
-			t.Fatalf("Authorization = %q; want token %s", got, token)
-		}
+		authMu.Lock()
+		authorization = r.Header.Get("Authorization")
+		authMu.Unlock()
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("echoed " + token + " and https://bot:" + proxySecret + "@gitea.example.test/path"))
 	}))
@@ -562,10 +565,35 @@ func TestCrowdRunnerFreezeRedactsFailureSecrets(t *testing.T) {
 
 	root := repoRoot(t)
 	runRoot := filepath.Join(t.TempDir(), "run")
+	script := filepath.Join(root, "scripts", "e2e-crowdrunner-freeze.py")
+	redactCmd := exec.Command(
+		"python3", "-c",
+		"import argparse, runpy, sys; module = runpy.run_path(sys.argv[1]); print(module['redact_text'](argparse.Namespace(token=sys.argv[2]), sys.argv[3]))",
+		script,
+		token,
+		"GET http://bot:"+proxySecret+"@gitea.example.test failed with "+token,
+	)
+	redactCmd.Dir = root
+	userinfoOut, err := redactCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("exercise freeze redaction: %v\n%s", err, userinfoOut)
+	}
+	userinfoText := string(userinfoOut)
+	for _, forbidden := range []string{token, proxySecret} {
+		if got := strings.Contains(userinfoText, forbidden); got {
+			t.Fatalf("strings.Contains(%q, %q) = %v; want false", userinfoText, forbidden, got)
+		}
+	}
+	for _, want := range []string{"[redacted-token]", "http://[redacted]@"} {
+		if got := strings.Contains(userinfoText, want); !got {
+			t.Fatalf("strings.Contains(%q, %q) = %v; want true", userinfoText, want, got)
+		}
+	}
+
 	run := func(giteaURL string) string {
 		cmd := exec.Command(
 			"python3",
-			filepath.Join(root, "scripts", "e2e-crowdrunner-freeze.py"),
+			script,
 			"--run-root", runRoot,
 			"--gitea-url", giteaURL,
 			"--repo-owner", "aiops-bot",
@@ -583,20 +611,22 @@ func TestCrowdRunnerFreezeRedactsFailureSecrets(t *testing.T) {
 		return string(out)
 	}
 
-	userinfoOut := run(strings.Replace(srv.URL, "http://", "http://bot:"+proxySecret+"@", 1))
-	if strings.Contains(userinfoOut, proxySecret) || !strings.Contains(userinfoOut, "http://[redacted]@") {
-		t.Fatalf("freeze helper did not redact URL userinfo:\n%s", userinfoOut)
+	bodyOut := run(srv.URL)
+	authMu.Lock()
+	gotAuthorization := authorization
+	authMu.Unlock()
+	if gotAuthorization != "token "+token {
+		t.Fatalf("Authorization = %q; want token %s", gotAuthorization, token)
 	}
 
-	bodyOut := run(srv.URL)
 	for _, forbidden := range []string{token, proxySecret} {
-		if strings.Contains(bodyOut, forbidden) {
-			t.Fatalf("freeze helper leaked secret %q:\n%s", forbidden, bodyOut)
+		if got := strings.Contains(bodyOut, forbidden); got {
+			t.Fatalf("strings.Contains(%q, %q) = %v; want false", bodyOut, forbidden, got)
 		}
 	}
 	for _, want := range []string{"[redacted-token]", "https://[redacted]@"} {
-		if !strings.Contains(bodyOut, want) {
-			t.Fatalf("freeze helper output missing redaction marker %q:\n%s", want, bodyOut)
+		if got := strings.Contains(bodyOut, want); !got {
+			t.Fatalf("strings.Contains(%q, %q) = %v; want true", bodyOut, want, got)
 		}
 	}
 }


### PR DESCRIPTION
Closes #1107

## Summary
- exercise the production freeze helper's URL-userinfo redaction directly without asking `urllib` to transport a credential-bearing URL
- preserve the real HTTP 500 response-body redaction path and record the Authorization header before asserting it after the helper exits
- keep the production helper's timeout and redaction behavior unchanged

## SPEC alignment (AGENTS.md principle 6/7)
Check exactly one. When this PR changes a SPEC-sensitive path
(`internal/workflow/config.go`, a newly-added `internal/orchestrator/` or
`internal/worker/` file), the **PR Metadata** gate rejects the first option —
an extension upstream lacks must be cited or tracked, not waved through.

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
Classify the production diff into exactly one state (review discipline; this
PR size-gate is human-signed, not CI-blocked):

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Do not collapse formatting, merge responsibilities, delete useful tests, or
reduce readability solely to check `within budget`; choose
`size-gated: justified overage` when the smallest readable change plus necessary
tests needs the space.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go test -race ./scripts -run '^TestCrowdRunnerFreezeRedactsFailureSecrets$' -count=20 -timeout 30s`
- `go test -tags e2e -race -count=1 -timeout 15m ./test/e2e/...`
- mutation check: removing URL-userinfo substitution makes the target test fail immediately with input/actual/expected

## Notes
- Production diff is zero; this PR changes only `scripts/crowdrunner_lifecycle_e2e_test.go`.
- Keep all three `SPEC alignment` options present and exactly one checked, or the PR Metadata gate fails.
