### PR TITLE
fix(orchestrator): reconcile before dispatch gates

### DIFF
--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -220,27 +220,39 @@ type patchActiveClaimedTrackerIssueStatesOp struct {
 }
 
 func (p *patchActiveClaimedTrackerIssueStatesOp) apply(st *OrchestratorState) func() {
+	p.patchRunning(st)
+	p.patchRetries(st)
+	p.patchBlocked(st)
+	return func() {
+		if p.done != nil {
+			close(p.done)
+		}
+	}
+}
+
+func (p *patchActiveClaimedTrackerIssueStatesOp) patchRunning(st *OrchestratorState) {
 	for id, run := range st.Running {
 		if narrow, ok := p.activeNarrow(id); ok {
 			refreshRunningIssue(run, patchTrackerIssueState(run.Issue, narrow))
 			p.patchClaimedIssue(st, id, narrow, run.Issue)
 		}
 	}
+}
+
+func (p *patchActiveClaimedTrackerIssueStatesOp) patchRetries(st *OrchestratorState) {
 	for id, retry := range st.RetryAttempts {
 		if narrow, ok := p.activeNarrow(id); ok {
 			retry.Issue = patchTrackerIssueState(retry.Issue, narrow)
 			p.patchClaimedIssue(st, id, narrow, retry.Issue)
 		}
 	}
+}
+
+func (p *patchActiveClaimedTrackerIssueStatesOp) patchBlocked(st *OrchestratorState) {
 	for id, blocked := range st.Blocked {
 		if narrow, ok := p.activeNarrow(id); ok {
 			blocked.Issue = patchTrackerIssueState(blocked.Issue, narrow)
 			p.patchClaimedIssue(st, id, narrow, blocked.Issue)
-		}
-	}
-	return func() {
-		if p.done != nil {
-			close(p.done)
 		}
 	}
 }

--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -141,6 +141,23 @@ func (o *Orchestrator) RefreshActiveTrackerIssues(ctx context.Context, issuesByI
 	}
 }
 
+// PatchActiveClaimedTrackerIssueStates applies positive narrow-refresh facts to
+// claimed entries without replacing the full tracker issue stored at dispatch.
+// State and labels are authoritative when returned; BlockedBy is authoritative
+// only when non-nil because nil means the adapter supplied no blocker knowledge.
+func (o *Orchestrator) PatchActiveClaimedTrackerIssueStates(ctx context.Context, issuesByID map[string]tracker.Issue, activeStates map[string]struct{}) error {
+	done := make(chan struct{}, 1)
+	if err := o.submit(ctx, &patchActiveClaimedTrackerIssueStatesOp{issuesByID: issuesByID, activeStates: activeStates, done: done}); err != nil {
+		return err
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func waitForReconciledWorkers(ctx context.Context, canceled []*RunningEntry, wait time.Duration) error {
 	if wait <= 0 {
 		return nil
@@ -194,6 +211,67 @@ type refreshActiveTrackerIssuesOp struct {
 	issuesByID   map[string]tracker.Issue
 	activeStates map[string]struct{}
 	done         chan<- struct{}
+}
+
+type patchActiveClaimedTrackerIssueStatesOp struct {
+	issuesByID   map[string]tracker.Issue
+	activeStates map[string]struct{}
+	done         chan<- struct{}
+}
+
+func (p *patchActiveClaimedTrackerIssueStatesOp) apply(st *OrchestratorState) func() {
+	for id, run := range st.Running {
+		if narrow, ok := p.activeNarrow(id); ok {
+			refreshRunningIssue(run, patchTrackerIssueState(run.Issue, narrow))
+			p.patchClaimedIssue(st, id, narrow, run.Issue)
+		}
+	}
+	for id, retry := range st.RetryAttempts {
+		if narrow, ok := p.activeNarrow(id); ok {
+			retry.Issue = patchTrackerIssueState(retry.Issue, narrow)
+			p.patchClaimedIssue(st, id, narrow, retry.Issue)
+		}
+	}
+	for id, blocked := range st.Blocked {
+		if narrow, ok := p.activeNarrow(id); ok {
+			blocked.Issue = patchTrackerIssueState(blocked.Issue, narrow)
+			p.patchClaimedIssue(st, id, narrow, blocked.Issue)
+		}
+	}
+	return func() {
+		if p.done != nil {
+			close(p.done)
+		}
+	}
+}
+
+func (p *patchActiveClaimedTrackerIssueStatesOp) activeNarrow(id IssueID) (tracker.Issue, bool) {
+	issue, ok := p.issuesByID[string(id)]
+	return issue, ok && isActiveTrackerState(issue.State, p.activeStates)
+}
+
+func (p *patchActiveClaimedTrackerIssueStatesOp) patchClaimedIssue(st *OrchestratorState, id IssueID, narrow, fallback tracker.Issue) {
+	if claimed, ok := st.ClaimedIssues[id]; ok {
+		st.ClaimedIssues[id] = patchTrackerIssueState(claimed, narrow)
+		return
+	}
+	st.ClaimedIssues[id] = fallback
+}
+
+func patchTrackerIssueState(issue, narrow tracker.Issue) tracker.Issue {
+	if issue.ID == "" {
+		issue.ID = narrow.ID
+	}
+	if issue.Identifier == "" {
+		issue.Identifier = narrow.Identifier
+	}
+	issue.State = narrow.State
+	issue.Labels = append([]string(nil), narrow.Labels...)
+	if narrow.BlockedBy != nil {
+		issue.BlockedBy = make([]tracker.BlockerRef, len(narrow.BlockedBy))
+		copy(issue.BlockedBy, narrow.BlockedBy)
+	}
+	return issue
 }
 
 func (r *refreshActiveTrackerIssuesOp) apply(st *OrchestratorState) func() {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -136,14 +136,6 @@ func (p *Poller) PollOnce(ctx context.Context) error { //nolint:gocognit // base
 	if p.orchestrator == nil {
 		return errors.New("orchestrator poller requires orchestrator")
 	}
-	if p.preflight != nil {
-		if err := validateDispatchPreflight(*p.preflight); err != nil {
-			if recErr := p.orchestrator.recordPreflightFailed(ctx, err); recErr != nil {
-				return errors.Join(fmt.Errorf("dispatch preflight failed: %w", err), recErr)
-			}
-			return fmt.Errorf("dispatch preflight failed: %w", err)
-		}
-	}
 	var pollErr error
 	if err := p.orchestrator.ReconcileBudgetExceededRuns(ctx, p.reconcile.WorkerExitTimeout); err != nil {
 		if ctx.Err() != nil {
@@ -154,19 +146,25 @@ func (p *Poller) PollOnce(ctx context.Context) error { //nolint:gocognit // base
 	issues, activeErr := p.tracker.ListActiveIssues(ctx)
 	// Multi-tracker clients return (issues, errors.Join(...)) on partial success;
 	// keep the successful issues and join activeErr into pollErr below.
-	if activeErr != nil && len(issues) == 0 {
-		return errors.Join(pollErr, activeErr)
-	}
 	if activeErr != nil {
 		pollErr = errors.Join(pollErr, activeErr)
 	}
 	var reconciledInactive map[string]tracker.Issue
-	if p.reconcileKnown && activeErr == nil {
+	if p.reconcileKnown {
 		var err error
 		reconciledInactive, err = p.reconcileTick(ctx, issues)
 		if err != nil {
 			pollErr = errors.Join(pollErr, err)
 		}
+	}
+	if p.preflight != nil {
+		if err := validateDispatchPreflight(*p.preflight); err != nil {
+			preflightErr := fmt.Errorf("dispatch preflight failed: %w", err)
+			return errors.Join(pollErr, preflightErr, p.orchestrator.recordPreflightFailed(ctx, err))
+		}
+	}
+	if activeErr != nil && len(issues) == 0 {
+		return pollErr
 	}
 	candidates := filterEligibleCandidates(mergeOverflowCandidates(p.overflow, issues), p.reconcile.TerminalStates, p.reconcile.RequiredLabels)
 	if len(reconciledInactive) > 0 {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -143,16 +143,10 @@ func (p *Poller) PollOnce(ctx context.Context) error { //nolint:gocognit // base
 		}
 		pollErr = errors.Join(pollErr, err)
 	}
-	issues, activeErr := p.tracker.ListActiveIssues(ctx)
-	// Multi-tracker clients return (issues, errors.Join(...)) on partial success;
-	// keep the successful issues and join activeErr into pollErr below.
-	if activeErr != nil {
-		pollErr = errors.Join(pollErr, activeErr)
-	}
-	var reconciledInactive map[string]tracker.Issue
+	var reconciliation tickReconciliation
 	if p.reconcileKnown {
 		var err error
-		reconciledInactive, err = p.reconcileTick(ctx, issues)
+		reconciliation, err = p.reconcileClaimedTick(ctx, nil)
 		if err != nil {
 			pollErr = errors.Join(pollErr, err)
 		}
@@ -163,12 +157,23 @@ func (p *Poller) PollOnce(ctx context.Context) error { //nolint:gocognit // base
 			return errors.Join(pollErr, preflightErr, p.orchestrator.recordPreflightFailed(ctx, err))
 		}
 	}
+	issues, activeErr := p.tracker.ListActiveIssues(ctx)
+	// Multi-tracker clients return (issues, errors.Join(...)) on partial success;
+	// keep the successful issues and join activeErr into pollErr below.
+	if activeErr != nil {
+		pollErr = errors.Join(pollErr, activeErr)
+	}
+	if p.reconcileKnown && len(issues) > 0 {
+		if err := p.refreshListedActiveIssues(ctx, issues, reconciliation.refreshed); err != nil {
+			pollErr = errors.Join(pollErr, err)
+		}
+	}
 	if activeErr != nil && len(issues) == 0 {
 		return pollErr
 	}
 	candidates := filterEligibleCandidates(mergeOverflowCandidates(p.overflow, issues), p.reconcile.TerminalStates, p.reconcile.RequiredLabels)
-	if len(reconciledInactive) > 0 {
-		candidates = filterIssuesNotInMap(candidates, reconciledInactive)
+	if len(reconciliation.inactive) > 0 {
+		candidates = filterIssuesNotInMap(candidates, reconciliation.inactive)
 	}
 	sortCandidates(candidates)
 	p.overflow = nil
@@ -204,9 +209,20 @@ func (l activeIssueListerFromStates) ListActiveIssues(ctx context.Context) ([]tr
 	return l.tracker.ListIssuesByStates(ctx, l.states)
 }
 
+type tickReconciliation struct {
+	inactive  map[string]tracker.Issue
+	refreshed map[string]tracker.Issue
+}
+
 func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue) (map[string]tracker.Issue, error) {
+	result, err := p.reconcileClaimedTick(ctx, activeIssues)
+	return result.inactive, err
+}
+
+func (p *Poller) reconcileClaimedTick(ctx context.Context, activeIssues []tracker.Issue) (tickReconciliation, error) {
+	var result tickReconciliation
 	if p.stateTracker == nil {
-		return nil, errors.New("orchestrator poller reconciliation requires state tracker")
+		return result, errors.New("orchestrator poller reconciliation requires state tracker")
 	}
 	var fetchErr error
 	// D37 budget reconciliation already ran before the tracker-dependent active
@@ -217,15 +233,23 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 	// inactive/terminal issues in the same tick.
 	if err := p.orchestrator.ReconcileStalledRuns(ctx, p.reconcile.StallTimeoutMs, p.reconcile.WorkerExitTimeout); err != nil {
 		if ctx.Err() != nil {
-			return nil, err
+			return result, err
 		}
 		fetchErr = errors.Join(fetchErr, err)
 	}
+	issueRefs := p.orchestrator.RunningRetryingAndBlockedIssueRefs(ctx)
+	if len(issueRefs) == 0 {
+		return result, fetchErr
+	}
 	activeIssuesByID := issueMap(activeIssues)
 	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
-	refreshedIssuesByID, err := p.refreshRunningIssueStates(ctx, activeIssuesByID)
+	refreshedIssuesByID, err := p.refreshRunningIssueStates(ctx, activeIssuesByID, issueRefs)
 	if err != nil {
 		fetchErr = errors.Join(fetchErr, err)
+	}
+	result.refreshed = refreshedIssuesByID
+	if err := p.orchestrator.PatchActiveClaimedTrackerIssueStates(ctx, refreshedIssuesByID, activeStateKeys); err != nil {
+		return result, errors.Join(fetchErr, err)
 	}
 	mergeRefreshedActiveStates(activeIssuesByID, refreshedIssuesByID, activeStateKeys)
 	// The active listing may be partial (pagination caps), so absence from it
@@ -234,13 +258,29 @@ func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue
 	// state) and leave cancellation to the terminal/inactive pass below, which
 	// acts only on explicit terminal/inactive observations (SPEC §11.2 narrow
 	// refresh + §16.3) rather than treating an unlisted issue as gone.
-	if err := p.orchestrator.RefreshActiveTrackerIssues(ctx, activeIssuesByID, activeStateKeys); err != nil {
-		return nil, err
+	if len(activeIssuesByID) > 0 {
+		if err := p.orchestrator.RefreshActiveTrackerIssues(ctx, activeIssuesByID, activeStateKeys); err != nil {
+			return result, errors.Join(fetchErr, err)
+		}
 	}
-	inactiveByID, deriveErr := p.deriveInactiveIssues(ctx, activeIssuesByID, refreshedIssuesByID, activeStateKeys)
+	activeEvidenceByID := issueMap(activeIssues)
+	for id, issue := range refreshedIssuesByID {
+		if isActiveTrackerState(issue.State, activeStateKeys) {
+			activeEvidenceByID[id] = issue
+		}
+	}
+	inactiveByID, deriveErr := p.deriveInactiveIssues(ctx, activeEvidenceByID, refreshedIssuesByID, activeStateKeys)
+	result.inactive = inactiveByID
 	fetchErr = errors.Join(fetchErr, deriveErr)
 	reconcileErr := p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, inactiveByID, normalizedStates(p.reconcile.TerminalStates), p.reconcile.WorkerExitTimeout)
-	return inactiveByID, errors.Join(reconcileErr, fetchErr)
+	return result, errors.Join(reconcileErr, fetchErr)
+}
+
+func (p *Poller) refreshListedActiveIssues(ctx context.Context, issues []tracker.Issue, refreshed map[string]tracker.Issue) error {
+	issuesByID := issueMap(issues)
+	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
+	mergeRefreshedActiveStates(issuesByID, refreshed, activeStateKeys)
+	return p.orchestrator.RefreshActiveTrackerIssues(ctx, issuesByID, activeStateKeys)
 }
 
 // mergeRefreshedActiveStates folds the narrow per-issue state refresh back into
@@ -252,8 +292,7 @@ func mergeRefreshedActiveStates(activeIssuesByID, refreshedIssuesByID map[string
 	for id, issue := range refreshedIssuesByID {
 		if isActiveTrackerState(issue.State, activeStateKeys) {
 			if existing, ok := activeIssuesByID[id]; ok {
-				existing.State = issue.State
-				activeIssuesByID[id] = existing
+				activeIssuesByID[id] = patchTrackerIssueState(existing, issue)
 			}
 		} else {
 			delete(activeIssuesByID, id)
@@ -331,13 +370,9 @@ func addInactiveListedIssues(inactiveByID map[string]tracker.Issue, activeByID m
 	}
 }
 
-func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID map[string]tracker.Issue) (map[string]tracker.Issue, error) {
+func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID map[string]tracker.Issue, issueRefs []tracker.IssueRef) (map[string]tracker.Issue, error) {
 	refresher, ok := p.stateTracker.(IssueStateRefresher)
 	if !ok {
-		return nil, nil
-	}
-	issueRefs := p.orchestrator.RunningRetryingAndBlockedIssueRefs(ctx)
-	if len(issueRefs) == 0 {
 		return nil, nil
 	}
 	statesByID, err := fetchIssueStates(ctx, refresher, issueRefs)
@@ -362,6 +397,7 @@ func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID
 		// not). Only rows the tracker actually returned with a non-empty state
 		// reach here, so absence stays "no information" (never a mass-cancel).
 		issue.Labels = st.Labels
+		issue.BlockedBy = st.BlockedBy
 		refreshed[id] = issue
 	}
 	if err == nil {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -15,6 +15,8 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
 )
 
+var errDispatchPreflight = errors.New("dispatch preflight failed")
+
 // ActiveIssueLister is the tracker reader required by the SPEC poll tick.
 type ActiveIssueLister interface {
 	ListActiveIssues(ctx context.Context) ([]tracker.Issue, error)
@@ -153,7 +155,7 @@ func (p *Poller) PollOnce(ctx context.Context) error { //nolint:gocognit // base
 	}
 	if p.preflight != nil {
 		if err := validateDispatchPreflight(*p.preflight); err != nil {
-			preflightErr := fmt.Errorf("dispatch preflight failed: %w", err)
+			preflightErr := fmt.Errorf("%w: %w", errDispatchPreflight, err)
 			return errors.Join(pollErr, preflightErr, p.orchestrator.recordPreflightFailed(ctx, err))
 		}
 	}
@@ -214,6 +216,18 @@ type tickReconciliation struct {
 	refreshed map[string]tracker.Issue
 }
 
+type claimedNarrowRefresh struct {
+	activeIssuesByID    map[string]tracker.Issue
+	activeStateKeys     map[string]struct{}
+	refreshedIssuesByID map[string]tracker.Issue
+}
+
+type claimedInactiveResult struct {
+	issues       map[string]tracker.Issue
+	deriveErr    error
+	reconcileErr error
+}
+
 func (p *Poller) reconcileTick(ctx context.Context, activeIssues []tracker.Issue) (map[string]tracker.Issue, error) {
 	result, err := p.reconcileClaimedTick(ctx, activeIssues)
 	return result.inactive, err
@@ -224,56 +238,65 @@ func (p *Poller) reconcileClaimedTick(ctx context.Context, activeIssues []tracke
 	if p.stateTracker == nil {
 		return result, errors.New("orchestrator poller reconciliation requires state tracker")
 	}
-	var fetchErr error
 	// D37 budget reconciliation already ran before the tracker-dependent active
 	// listing, so SPEC §16.3 Part A can treat remaining quiet stale runs as
 	// ordinary stalls. A WorkerExitTimeout on a worker that ignores cancellation
 	// surfaces as context.DeadlineExceeded; surface that as a non-fatal poll
 	// error so one stuck run cannot block Part B from reconciling unrelated
 	// inactive/terminal issues in the same tick.
-	if err := p.orchestrator.ReconcileStalledRuns(ctx, p.reconcile.StallTimeoutMs, p.reconcile.WorkerExitTimeout); err != nil {
-		if ctx.Err() != nil {
-			return result, err
-		}
-		fetchErr = errors.Join(fetchErr, err)
+	fetchErr := p.orchestrator.ReconcileStalledRuns(ctx, p.reconcile.StallTimeoutMs, p.reconcile.WorkerExitTimeout)
+	if fetchErr != nil && ctx.Err() != nil {
+		return result, fetchErr
 	}
 	issueRefs := p.orchestrator.RunningRetryingAndBlockedIssueRefs(ctx)
 	if len(issueRefs) == 0 {
 		return result, fetchErr
 	}
-	activeIssuesByID := issueMap(activeIssues)
-	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
-	refreshedIssuesByID, err := p.refreshRunningIssueStates(ctx, activeIssuesByID, issueRefs)
-	if err != nil {
-		fetchErr = errors.Join(fetchErr, err)
-	}
-	result.refreshed = refreshedIssuesByID
-	if err := p.orchestrator.PatchActiveClaimedTrackerIssueStates(ctx, refreshedIssuesByID, activeStateKeys); err != nil {
+	narrow, narrowErr := p.refreshClaimedNarrowPhase(ctx, activeIssues, issueRefs)
+	fetchErr = errors.Join(fetchErr, narrowErr)
+	result.refreshed = narrow.refreshedIssuesByID
+	if err := p.applyClaimedNarrowPhase(ctx, narrow); err != nil {
 		return result, errors.Join(fetchErr, err)
 	}
-	mergeRefreshedActiveStates(activeIssuesByID, refreshedIssuesByID, activeStateKeys)
-	// The active listing may be partial (pagination caps), so absence from it
-	// is "no information," not inactivity: refresh stored issue metadata for the
-	// runs we DO see (so per-state capacity gates observe the latest tracker
-	// state) and leave cancellation to the terminal/inactive pass below, which
-	// acts only on explicit terminal/inactive observations (SPEC §11.2 narrow
-	// refresh + §16.3) rather than treating an unlisted issue as gone.
-	if len(activeIssuesByID) > 0 {
-		if err := p.orchestrator.RefreshActiveTrackerIssues(ctx, activeIssuesByID, activeStateKeys); err != nil {
-			return result, errors.Join(fetchErr, err)
-		}
+	inactive := p.reconcileClaimedInactivePhase(ctx, activeIssues, narrow)
+	result.inactive = inactive.issues
+	fetchErr = errors.Join(fetchErr, inactive.deriveErr)
+	return result, errors.Join(inactive.reconcileErr, fetchErr)
+}
+
+func (p *Poller) refreshClaimedNarrowPhase(ctx context.Context, activeIssues []tracker.Issue, issueRefs []tracker.IssueRef) (claimedNarrowRefresh, error) {
+	refresh := claimedNarrowRefresh{
+		activeIssuesByID: issueMap(activeIssues),
+		activeStateKeys:  normalizedStates(p.reconcile.ActiveStates),
 	}
+	var err error
+	refresh.refreshedIssuesByID, err = p.refreshRunningIssueStates(ctx, refresh.activeIssuesByID, issueRefs)
+	return refresh, err
+}
+
+func (p *Poller) applyClaimedNarrowPhase(ctx context.Context, refresh claimedNarrowRefresh) error {
+	if err := p.orchestrator.PatchActiveClaimedTrackerIssueStates(ctx, refresh.refreshedIssuesByID, refresh.activeStateKeys); err != nil {
+		return err
+	}
+	mergeRefreshedActiveStates(refresh.activeIssuesByID, refresh.refreshedIssuesByID, refresh.activeStateKeys)
+	// The active listing may be partial, so absence is "no information." Only
+	// refresh stored metadata for explicit active observations here.
+	if len(refresh.activeIssuesByID) == 0 {
+		return nil
+	}
+	return p.orchestrator.RefreshActiveTrackerIssues(ctx, refresh.activeIssuesByID, refresh.activeStateKeys)
+}
+
+func (p *Poller) reconcileClaimedInactivePhase(ctx context.Context, activeIssues []tracker.Issue, refresh claimedNarrowRefresh) claimedInactiveResult {
 	activeEvidenceByID := issueMap(activeIssues)
-	for id, issue := range refreshedIssuesByID {
-		if isActiveTrackerState(issue.State, activeStateKeys) {
+	for id, issue := range refresh.refreshedIssuesByID {
+		if isActiveTrackerState(issue.State, refresh.activeStateKeys) {
 			activeEvidenceByID[id] = issue
 		}
 	}
-	inactiveByID, deriveErr := p.deriveInactiveIssues(ctx, activeEvidenceByID, refreshedIssuesByID, activeStateKeys)
-	result.inactive = inactiveByID
-	fetchErr = errors.Join(fetchErr, deriveErr)
+	inactiveByID, deriveErr := p.deriveInactiveIssues(ctx, activeEvidenceByID, refresh.refreshedIssuesByID, refresh.activeStateKeys)
 	reconcileErr := p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, inactiveByID, normalizedStates(p.reconcile.TerminalStates), p.reconcile.WorkerExitTimeout)
-	return result, errors.Join(reconcileErr, fetchErr)
+	return claimedInactiveResult{issues: inactiveByID, deriveErr: deriveErr, reconcileErr: reconcileErr}
 }
 
 func (p *Poller) refreshListedActiveIssues(ctx context.Context, issues []tracker.Issue, refreshed map[string]tracker.Issue) error {

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -17,6 +17,12 @@ import (
 
 var errDispatchPreflight = errors.New("dispatch preflight failed")
 
+// reconciliationTrackerRequestTimeout caps each tracker read in the
+// reconcile-before-dispatch phase. PollOnce's ctx normally lives for the
+// worker process, so passing it through directly would let one unresponsive
+// tracker pin every later poll tick indefinitely.
+var reconciliationTrackerRequestTimeout = 45 * time.Second
+
 // ActiveIssueLister is the tracker reader required by the SPEC poll tick.
 type ActiveIssueLister interface {
 	ListActiveIssues(ctx context.Context) ([]tracker.Issue, error)
@@ -368,7 +374,9 @@ func (p *Poller) refreshedIssueIsInactive(issue tracker.Issue, activeStateKeys m
 func (p *Poller) appendInactiveFromStateGroups(ctx context.Context, inactiveByID map[string]tracker.Issue, activeByID map[string]struct{}) error {
 	var groupErr error
 	for _, states := range p.reconcileInactiveStateGroups() {
-		issues, err := p.stateTracker.ListIssuesByStates(ctx, states)
+		listCtx, cancel := context.WithTimeout(ctx, reconciliationTrackerRequestTimeout)
+		issues, err := p.stateTracker.ListIssuesByStates(listCtx, states)
+		cancel()
 		if err != nil {
 			groupErr = errors.Join(groupErr, err)
 			continue
@@ -398,7 +406,9 @@ func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID
 	if !ok {
 		return nil, nil
 	}
-	statesByID, err := fetchIssueStates(ctx, refresher, issueRefs)
+	fetchCtx, cancel := context.WithTimeout(ctx, reconciliationTrackerRequestTimeout)
+	statesByID, err := fetchIssueStates(fetchCtx, refresher, issueRefs)
+	cancel()
 	refsByID := make(map[string]tracker.IssueRef, len(issueRefs))
 	for _, ref := range issueRefs {
 		refsByID[ref.ID] = ref

--- a/internal/orchestrator/poller_reconciletick_test.go
+++ b/internal/orchestrator/poller_reconciletick_test.go
@@ -375,7 +375,9 @@ func TestReconcileTickSkipsEmptyIDIssueFromStateGroupFanOut(t *testing.T) {
 		},
 	}
 	dispatcher := &cancellationDispatcher{}
-	orch := New(NewOrchestratorState(30000, 1), Deps{
+	st := NewOrchestratorState(30000, 1)
+	st.Blocked[IssueID("claimed-1")] = &BlockedEntry{Identifier: "LIN-1", Issue: tracker.Issue{ID: "claimed-1", Identifier: "LIN-1", State: "In Progress"}}
+	orch := New(st, Deps{
 		Dispatcher: dispatcher,
 		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
 	})

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -190,6 +190,15 @@ type fakeIssueStateTrackerByCall struct {
 	calls     int
 }
 
+type fixedActiveIssueLister struct {
+	issues []tracker.Issue
+	err    error
+}
+
+func (f *fixedActiveIssueLister) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
+	return defaultTrackerIssueTitles(f.issues), f.err
+}
+
 func (f *fakeIssueStateTracker) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
 	return f.ListIssuesByStates(ctx, nil)
 }
@@ -342,6 +351,12 @@ func (d *cancellationDispatcher) contextAt(i int) context.Context {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.contexts[i]
+}
+
+func (d *cancellationDispatcher) issueAt(i int) tracker.Issue {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.issues[i]
 }
 
 // stuckCancellationDispatcher behaves like cancellationDispatcher but its
@@ -540,6 +555,99 @@ func TestPollOnceTrackerErrorDoesNotCancelRunningIssue(t *testing.T) {
 	case <-dispatcher.contextAt(0).Done():
 		t.Fatalf("running issue context was canceled after tracker error")
 	default:
+	}
+}
+
+func TestPollOnceZeroResultListingErrorStillReconcilesRunningIssue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Hour}})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"}, WorkerExitTimeout: time.Second,
+	})
+	preflightCfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "lin_xxxx", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	poller.preflight = &preflightCfg
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher)
+
+	listingErr := errors.New("active listing failed")
+	poller.tracker = &fixedActiveIssueLister{err: listingErr}
+	trackerClient.setIssues(nil)
+	trackerClient.resetFetchIssueStatesByIDsCalls()
+	trackerClient.setFetchIDStates(map[string]string{"issue-1": "Done"})
+
+	err := poller.PollOnce(ctx)
+	if !errors.Is(err, listingErr) {
+		t.Fatalf("listing-error poll error = %v, want %v", err, listingErr)
+	}
+	if got := trackerClient.fetchIssueStatesByRefsCalls(); len(got) != 1 {
+		t.Errorf("FetchIssueStatesByRefs calls = %d, want 1", len(got))
+	}
+	if got := dispatcher.count(); got != 1 {
+		t.Errorf("dispatcher count = %d, want 1 (no new dispatch)", got)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForNoRunningOrRetrying(t, ctx, orch)
+}
+
+func TestPollOncePartialListingErrorStillReconcilesAndDispatchesReturnedCandidates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 2), Deps{Dispatcher: dispatcher, Scheduler: RetryScheduler{MaxBackoff: time.Hour}})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"}, WorkerExitTimeout: time.Second,
+	})
+	preflightCfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "lin_xxxx", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	poller.preflight = &preflightCfg
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher)
+
+	listingErr := errors.New("one tracker failed")
+	poller.tracker = &fixedActiveIssueLister{
+		issues: []tracker.Issue{{ID: "issue-2", Identifier: "LIN-2", State: "In Progress"}},
+		err:    listingErr,
+	}
+	trackerClient.setIssues(nil)
+	trackerClient.resetFetchIssueStatesByIDsCalls()
+	trackerClient.setFetchIDStates(map[string]string{"issue-1": "Done", "issue-2": "In Progress"})
+
+	err := poller.PollOnce(ctx)
+	if !errors.Is(err, listingErr) {
+		t.Fatalf("partial-listing poll error = %v, want %v", err, listingErr)
+	}
+	calls := trackerClient.fetchIssueStatesByRefsCalls()
+	if len(calls) != 2 {
+		t.Errorf("FetchIssueStatesByRefs calls = %d, want 2 (reconcile then revalidate)", len(calls))
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForNoRunningOrRetrying(t, ctx, orch)
+	waitFor(t, func() bool { return dispatcher.count() == 2 }, time.Second)
+	if got := dispatcher.issueAt(1).ID; got != "issue-2" {
+		t.Fatalf("second dispatched issue ID = %q, want issue-2", got)
 	}
 }
 

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -177,6 +177,7 @@ type fakeIssueStateTracker struct {
 	err           error
 	fetchIDErr    error
 	fetchRefCalls [][]tracker.IssueRef
+	onFetchRefs   func([]tracker.IssueRef)
 	fetchIDStates map[string]string
 	// fetchIDIssueStates, when set, takes precedence over fetchIDStates and
 	// returns full refresh facts (state + labels + blockers) per issue ID.
@@ -191,12 +192,45 @@ type fakeIssueStateTrackerByCall struct {
 }
 
 type fixedActiveIssueLister struct {
+	mu     sync.Mutex
 	issues []tracker.Issue
 	err    error
+	calls  int
+	onList func()
 }
 
 func (f *fixedActiveIssueLister) ListActiveIssues(_ context.Context) ([]tracker.Issue, error) {
-	return defaultTrackerIssueTitles(f.issues), f.err
+	f.mu.Lock()
+	f.calls++
+	issues, err, onList := f.issues, f.err, f.onList
+	f.mu.Unlock()
+	if onList != nil {
+		onList()
+	}
+	return defaultTrackerIssueTitles(issues), err
+}
+
+func (f *fixedActiveIssueLister) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+type pollOrderSpy struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (s *pollOrderSpy) record(call string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, call)
+}
+
+func (s *pollOrderSpy) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.calls...)
 }
 
 func (f *fakeIssueStateTracker) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
@@ -227,6 +261,9 @@ func (f *fakeIssueStateTracker) FetchIssueStatesByRefs(_ context.Context, refs [
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.fetchRefCalls = append(f.fetchRefCalls, append([]tracker.IssueRef(nil), refs...))
+	if f.onFetchRefs != nil {
+		f.onFetchRefs(append([]tracker.IssueRef(nil), refs...))
+	}
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -287,6 +324,12 @@ func (f *fakeIssueStateTracker) setFetchIDErr(err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.fetchIDErr = err
+}
+
+func (f *fakeIssueStateTracker) setFetchObserver(observer func([]tracker.IssueRef)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.onFetchRefs = observer
 }
 
 func (f *fakeIssueStateTracker) resetFetchIssueStatesByIDsCalls() {
@@ -626,13 +669,26 @@ func TestPollOncePartialListingErrorStillReconcilesAndDispatchesReturnedCandidat
 	}
 	waitForCancellationDispatcherCount(t, dispatcher)
 
+	order := &pollOrderSpy{}
 	listingErr := errors.New("one tracker failed")
-	poller.tracker = &fixedActiveIssueLister{
+	candidateLister := &fixedActiveIssueLister{
 		issues: []tracker.Issue{{ID: "issue-2", Identifier: "LIN-2", State: "In Progress"}},
 		err:    listingErr,
+		onList: func() { order.record("candidate") },
 	}
+	poller.tracker = candidateLister
 	trackerClient.setIssues(nil)
 	trackerClient.resetFetchIssueStatesByIDsCalls()
+	trackerClient.setFetchObserver(func(refs []tracker.IssueRef) {
+		for _, ref := range refs {
+			switch ref.ID {
+			case "issue-1":
+				order.record("narrow")
+			case "issue-2":
+				order.record("revalidate")
+			}
+		}
+	})
 	trackerClient.setFetchIDStates(map[string]string{"issue-1": "Done", "issue-2": "In Progress"})
 
 	err := poller.PollOnce(ctx)
@@ -642,6 +698,12 @@ func TestPollOncePartialListingErrorStillReconcilesAndDispatchesReturnedCandidat
 	calls := trackerClient.fetchIssueStatesByRefsCalls()
 	if len(calls) != 2 {
 		t.Errorf("FetchIssueStatesByRefs calls = %d, want 2 (reconcile then revalidate)", len(calls))
+	}
+	if got := candidateLister.count(); got != 1 {
+		t.Errorf("candidate ListActiveIssues calls = %d, want 1", got)
+	}
+	if got := strings.Join(order.snapshot(), ","); got != "narrow,candidate,revalidate" {
+		t.Errorf("poll order = %q, want %q", got, "narrow,candidate,revalidate")
 	}
 	waitForContextCanceled(t, dispatcher.contextAt(0))
 	waitForNoRunningOrRetrying(t, ctx, orch)
@@ -657,17 +719,14 @@ func TestPollOnceCancelsTerminalIssueBeforeReturningLaterInactiveFetchError(t *t
 
 	trackerClient := &fakeIssueStateTrackerByCall{issues: [][]tracker.Issue{
 		{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}},
-		{},
-		{},
-		{},
 		{{ID: "issue-1", Identifier: "LIN-1", State: "Done"}},
+		{},
+		{},
 	}, errByCall: []error{
 		nil,
 		nil,
-		nil,
-		nil,
-		nil,
 		fmt.Errorf("inactive state fetch failed"),
+		nil,
 	}}
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -221,6 +221,58 @@ type pollOrderSpy struct {
 	calls []string
 }
 
+type blockingReconcileTracker struct {
+	mu            sync.Mutex
+	blockFetch    bool
+	blockListings bool
+	fetchCalls    int
+	listCalls     int
+	fetchDeadline []bool
+	listDeadlines []bool
+}
+
+func (b *blockingReconcileTracker) ListIssuesByStates(ctx context.Context, _ []string) ([]tracker.Issue, error) {
+	_, hasDeadline := ctx.Deadline()
+	b.mu.Lock()
+	b.listCalls++
+	b.listDeadlines = append(b.listDeadlines, hasDeadline)
+	block := b.blockListings
+	b.mu.Unlock()
+	if block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return nil, nil
+}
+
+func (b *blockingReconcileTracker) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]tracker.IssueState, error) {
+	return b.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(ids))
+}
+
+func (b *blockingReconcileTracker) FetchIssueStatesByRefs(ctx context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
+	_, hasDeadline := ctx.Deadline()
+	b.mu.Lock()
+	b.fetchCalls++
+	b.fetchDeadline = append(b.fetchDeadline, hasDeadline)
+	block := b.blockFetch
+	b.mu.Unlock()
+	if block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	states := make(map[string]tracker.IssueState, len(refs))
+	for _, ref := range refs {
+		states[ref.ID] = tracker.IssueState{State: "In Progress"}
+	}
+	return states, nil
+}
+
+func (b *blockingReconcileTracker) callSnapshot() (int, int, []bool, []bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.fetchCalls, b.listCalls, append([]bool(nil), b.fetchDeadline...), append([]bool(nil), b.listDeadlines...)
+}
+
 func (s *pollOrderSpy) record(call string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -125,7 +125,7 @@ func TestPollOncePreflightFailureSkipsDispatchAndEmitsRuntimeEvent(t *testing.T)
 	if err == nil {
 		t.Fatalf("expected preflight failure error")
 	}
-	if !strings.Contains(err.Error(), "dispatch preflight failed") {
+	if !errors.Is(err, errDispatchPreflight) {
 		t.Errorf("unexpected error shape: %v", err)
 	}
 	if dispatcher.count() != 0 {
@@ -193,7 +193,7 @@ func TestPollOncePreflightFailureStillReconcilesRunningIssue(t *testing.T) {
 	preflightCfg.Tracker.APIKey = ""
 
 	err := poller.PollOnce(ctx)
-	if err == nil || !strings.Contains(err.Error(), "dispatch preflight failed") {
+	if err == nil || !errors.Is(err, errDispatchPreflight) {
 		t.Fatalf("preflight poll error = %v, want dispatch preflight failure", err)
 	}
 	if errors.Is(err, listingErr) || !errors.Is(err, refreshErr) {
@@ -279,7 +279,7 @@ func TestPollOncePreflightFailurePatchesClaimedActiveStateWithoutWipingMetadata(
 	}
 	poller.preflight = &preflightCfg
 
-	if err := poller.PollOnce(ctx); err == nil || !strings.Contains(err.Error(), "dispatch preflight failed") {
+	if err := poller.PollOnce(ctx); err == nil || !errors.Is(err, errDispatchPreflight) {
 		t.Fatalf("preflight poll error = %v, want dispatch preflight failure", err)
 	}
 	if got := candidateLister.count(); got != 0 {
@@ -354,7 +354,7 @@ func TestPollOncePreflightSuccessProceedsToFetch(t *testing.T) {
 	if err := poller.PollOnce(ctx); err != nil && !errors.Is(err, ErrNotDispatched) {
 		// Best-effort: dispatch may or may not occur depending on test
 		// fakes; the assertion that matters is no preflight error.
-		if strings.Contains(err.Error(), "dispatch preflight failed") {
+		if errors.Is(err, errDispatchPreflight) {
 			t.Fatalf("preflight should have passed: %v", err)
 		}
 	}

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -270,7 +270,7 @@ func TestPollOncePreflightFailureBoundsReconciliationTrackerCalls(t *testing.T) 
 			poller.preflight = &preflightCfg
 
 			errCh := make(chan error, 1)
-			go func() { errCh <- poller.PollOnce(ctx) }()
+			safeGo("test.poll_once_reconciliation_timeout", func() { errCh <- poller.PollOnce(ctx) })
 			var err error
 			select {
 			case err = <-errCh:

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -226,6 +226,76 @@ func TestPollOncePreflightFailureStillReconcilesRunningIssue(t *testing.T) {
 	t.Fatalf("RecentEvents = %+v, want %s", view.RecentEvents, RuntimeEventDispatchPreflightFailed)
 }
 
+func TestPollOncePreflightFailureBoundsReconciliationTrackerCalls(t *testing.T) {
+	previousTimeout := reconciliationTrackerRequestTimeout
+	reconciliationTrackerRequestTimeout = 25 * time.Millisecond
+	defer func() { reconciliationTrackerRequestTimeout = previousTimeout }()
+
+	tests := []struct {
+		name             string
+		blockFetch       bool
+		blockListings    bool
+		wantFetchCalls   int
+		wantListingCalls int
+	}{
+		{name: "narrow refresh", blockFetch: true, wantFetchCalls: 1, wantListingCalls: 2},
+		{name: "each inactive state group", blockListings: true, wantFetchCalls: 1, wantListingCalls: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			issue := tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}
+			state := NewOrchestratorState(30000, 1)
+			state.Blocked[IssueID(issue.ID)] = &BlockedEntry{Issue: issue, Identifier: issue.Identifier}
+			state.Claimed[IssueID(issue.ID)] = struct{}{}
+			state.ClaimedIssues[IssueID(issue.ID)] = issue
+			trackerClient := &blockingReconcileTracker{blockFetch: tt.blockFetch, blockListings: tt.blockListings}
+			orch := New(state, Deps{Dispatcher: &cancellationDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Hour}})
+			go orch.Run(ctx)
+			if err := orch.WaitStarted(ctx); err != nil {
+				t.Fatalf("wait for orchestrator: %v", err)
+			}
+
+			poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+				ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"}, InactiveStates: []string{"Backlog"},
+			})
+			candidateLister := &fixedActiveIssueLister{}
+			poller.tracker = candidateLister
+			preflightCfg := workflow.Config{
+				Tracker: workflow.TrackerConfig{Kind: "linear", ProjectSlug: "team-x"},
+				Codex:   workflow.CommandConfig{Command: "codex app-server"},
+			}
+			poller.preflight = &preflightCfg
+
+			errCh := make(chan error, 1)
+			go func() { errCh <- poller.PollOnce(ctx) }()
+			var err error
+			select {
+			case err = <-errCh:
+			case <-time.After(time.Second):
+				t.Fatal("PollOnce did not return after reconciliation tracker request timeout")
+			}
+			if !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, errDispatchPreflight) {
+				t.Fatalf("PollOnce error = %v, want reconciliation deadline and preflight failure", err)
+			}
+			if got := candidateLister.count(); got != 0 {
+				t.Errorf("candidate ListActiveIssues calls = %d, want 0", got)
+			}
+			fetchCalls, listCalls, fetchDeadlines, listDeadlines := trackerClient.callSnapshot()
+			if fetchCalls != tt.wantFetchCalls || listCalls != tt.wantListingCalls {
+				t.Errorf("tracker calls = fetch:%d list:%d, want fetch:%d list:%d", fetchCalls, listCalls, tt.wantFetchCalls, tt.wantListingCalls)
+			}
+			for i, hasDeadline := range append(fetchDeadlines, listDeadlines...) {
+				if !hasDeadline {
+					t.Errorf("reconciliation tracker request %d had no deadline", i+1)
+				}
+			}
+		})
+	}
+}
+
 func TestPollOncePreflightFailurePatchesClaimedActiveStateWithoutWipingMetadata(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -148,6 +148,74 @@ func TestPollOncePreflightFailureSkipsDispatchAndEmitsRuntimeEvent(t *testing.T)
 	}
 }
 
+func TestPollOncePreflightFailureStillReconcilesRunningIssue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
+	dispatcher := &cancellationDispatcher{}
+	orch := New(NewOrchestratorState(30000, 1), Deps{
+		Dispatcher: dispatcher,
+		Scheduler:  RetryScheduler{MaxBackoff: time.Hour},
+	})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Cancelled", "Done"},
+		WorkerExitTimeout: time.Second,
+	})
+	preflightCfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", APIKey: "lin_xxxx", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	poller.preflight = &preflightCfg
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("initial poll once: %v", err)
+	}
+	waitForCancellationDispatcherCount(t, dispatcher)
+
+	listingErr := errors.New("active listing failed during preflight tick")
+	refreshErr := errors.New("narrow refresh partially failed")
+	poller.tracker = &fixedActiveIssueLister{err: listingErr}
+	trackerClient.setIssues(nil)
+	trackerClient.resetFetchIssueStatesByIDsCalls()
+	trackerClient.setFetchIDStates(map[string]string{"issue-1": "Done"})
+	trackerClient.setFetchIDErr(refreshErr)
+	preflightCfg.Tracker.APIKey = ""
+
+	err := poller.PollOnce(ctx)
+	if err == nil || !strings.Contains(err.Error(), "dispatch preflight failed") {
+		t.Fatalf("preflight poll error = %v, want dispatch preflight failure", err)
+	}
+	if !errors.Is(err, listingErr) || !errors.Is(err, refreshErr) {
+		t.Errorf("preflight poll error = %v, want joined listing and reconciliation errors", err)
+	}
+	if got := trackerClient.fetchIssueStatesByRefsCalls(); len(got) != 1 {
+		t.Errorf("FetchIssueStatesByRefs calls = %d, want 1", len(got))
+	}
+	if got := dispatcher.count(); got != 1 {
+		t.Errorf("dispatcher count = %d, want 1 (no replacement dispatch)", got)
+	}
+	waitForContextCanceled(t, dispatcher.contextAt(0))
+	waitForNoRunningOrRetrying(t, ctx, orch)
+
+	view, snapErr := orch.Snapshot(ctx)
+	if snapErr != nil {
+		t.Fatalf("snapshot: %v", snapErr)
+	}
+	for _, event := range view.RecentEvents {
+		if event.Kind == RuntimeEventDispatchPreflightFailed {
+			return
+		}
+	}
+	t.Fatalf("RecentEvents = %+v, want %s", view.RecentEvents, RuntimeEventDispatchPreflightFailed)
+}
+
 func TestPollOncePreflightSuccessProceedsToFetch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -179,11 +180,14 @@ func TestPollOncePreflightFailureStillReconcilesRunningIssue(t *testing.T) {
 	}
 	waitForCancellationDispatcherCount(t, dispatcher)
 
+	order := &pollOrderSpy{}
 	listingErr := errors.New("active listing failed during preflight tick")
 	refreshErr := errors.New("narrow refresh partially failed")
-	poller.tracker = &fixedActiveIssueLister{err: listingErr}
+	candidateLister := &fixedActiveIssueLister{err: listingErr, onList: func() { order.record("candidate") }}
+	poller.tracker = candidateLister
 	trackerClient.setIssues(nil)
 	trackerClient.resetFetchIssueStatesByIDsCalls()
+	trackerClient.setFetchObserver(func([]tracker.IssueRef) { order.record("narrow") })
 	trackerClient.setFetchIDStates(map[string]string{"issue-1": "Done"})
 	trackerClient.setFetchIDErr(refreshErr)
 	preflightCfg.Tracker.APIKey = ""
@@ -192,8 +196,14 @@ func TestPollOncePreflightFailureStillReconcilesRunningIssue(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "dispatch preflight failed") {
 		t.Fatalf("preflight poll error = %v, want dispatch preflight failure", err)
 	}
-	if !errors.Is(err, listingErr) || !errors.Is(err, refreshErr) {
-		t.Errorf("preflight poll error = %v, want joined listing and reconciliation errors", err)
+	if errors.Is(err, listingErr) || !errors.Is(err, refreshErr) {
+		t.Errorf("preflight poll error = %v, want reconciliation error without candidate-list error", err)
+	}
+	if got := candidateLister.count(); got != 0 {
+		t.Errorf("candidate ListActiveIssues calls = %d, want 0 after invalid preflight", got)
+	}
+	if got := strings.Join(order.snapshot(), ","); got != "narrow" {
+		t.Errorf("poll order = %q, want %q", got, "narrow")
 	}
 	if got := trackerClient.fetchIssueStatesByRefsCalls(); len(got) != 1 {
 		t.Errorf("FetchIssueStatesByRefs calls = %d, want 1", len(got))
@@ -214,6 +224,105 @@ func TestPollOncePreflightFailureStillReconcilesRunningIssue(t *testing.T) {
 		}
 	}
 	t.Fatalf("RecentEvents = %+v, want %s", view.RecentEvents, RuntimeEventDispatchPreflightFailed)
+}
+
+func TestPollOncePreflightFailurePatchesClaimedActiveStateWithoutWipingMetadata(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	makeIssue := func(id string, blockedBy []tracker.BlockerRef) tracker.Issue {
+		return tracker.Issue{
+			ID: id, Identifier: "LIN-" + id, Title: "title-" + id, Description: "description-" + id,
+			URL: "https://tracker.example/" + id, State: "In Progress", Labels: []string{"old"},
+			BranchName: "branch-" + id, Priority: 2, CreatedAt: time.Unix(10, 0), UpdatedAt: time.Unix(20, 0),
+			BlockedBy: blockedBy,
+		}
+	}
+	runningIssue := makeIssue("running", []tracker.BlockerRef{{ID: "old-run-blocker", State: "Todo"}})
+	retryIssue := makeIssue("retry", []tracker.BlockerRef{{ID: "old-retry-blocker", State: "Todo"}})
+	blockedIssue := makeIssue("blocked", []tracker.BlockerRef{{ID: "old-blocked-blocker", State: "Todo"}})
+
+	st := NewOrchestratorState(30000, 3)
+	st.Running[IssueID(runningIssue.ID)] = &RunningEntry{
+		Issue: runningIssue, Identifier: runningIssue.Identifier, ReconcileCleanupWorkspace: true,
+		AgentCurrentIssueHandoff: true, AgentCurrentIssueTerminalHandoff: true,
+		AgentCurrentIssueTerminalHandoffState: "Done",
+	}
+	st.RetryAttempts[IssueID(retryIssue.ID)] = &RetryEntry{Issue: retryIssue, IssueID: IssueID(retryIssue.ID), Identifier: retryIssue.Identifier}
+	st.Blocked[IssueID(blockedIssue.ID)] = &BlockedEntry{Issue: blockedIssue, Identifier: blockedIssue.Identifier}
+	for _, issue := range []tracker.Issue{runningIssue, retryIssue, blockedIssue} {
+		id := IssueID(issue.ID)
+		st.Claimed[id] = struct{}{}
+		st.ClaimedIssues[id] = issue
+	}
+
+	trackerClient := &fakeIssueStateTracker{fetchIDIssueStates: map[string]tracker.IssueState{
+		runningIssue.ID: {State: "Rework", Labels: []string{"fresh"}, BlockedBy: nil},
+		retryIssue.ID:   {State: "Rework", Labels: []string{"fresh"}, BlockedBy: []tracker.BlockerRef{}},
+		blockedIssue.ID: {State: "Rework", Labels: []string{"fresh"}, BlockedBy: []tracker.BlockerRef{{ID: "new-blocker", State: "Done"}}},
+	}}
+	orch := New(st, Deps{Dispatcher: &cancellationDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Hour}})
+	go orch.Run(ctx)
+	if err := orch.WaitStarted(ctx); err != nil {
+		t.Fatalf("wait for orchestrator: %v", err)
+	}
+	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
+		ActiveStates: []string{"In Progress", "Rework"}, TerminalStates: []string{"Done"}, WorkerExitTimeout: time.Second,
+	})
+	order := &pollOrderSpy{}
+	candidateLister := &fixedActiveIssueLister{onList: func() { order.record("candidate") }}
+	poller.tracker = candidateLister
+	trackerClient.setFetchObserver(func([]tracker.IssueRef) { order.record("narrow") })
+	preflightCfg := workflow.Config{
+		Tracker: workflow.TrackerConfig{Kind: "linear", ProjectSlug: "team-x"},
+		Codex:   workflow.CommandConfig{Command: "codex app-server"},
+	}
+	poller.preflight = &preflightCfg
+
+	if err := poller.PollOnce(ctx); err == nil || !strings.Contains(err.Error(), "dispatch preflight failed") {
+		t.Fatalf("preflight poll error = %v, want dispatch preflight failure", err)
+	}
+	if got := candidateLister.count(); got != 0 {
+		t.Errorf("candidate ListActiveIssues calls = %d, want 0", got)
+	}
+	if got := strings.Join(order.snapshot(), ","); got != "narrow" {
+		t.Errorf("poll order = %q, want %q", got, "narrow")
+	}
+
+	issues := map[string]tracker.Issue{}
+	var cleanup, handoff, terminalHandoff bool
+	orch.WithStateForTest(func(got *OrchestratorState) {
+		issues["running"] = got.Running[IssueID(runningIssue.ID)].Issue
+		issues["retry"] = got.RetryAttempts[IssueID(retryIssue.ID)].Issue
+		issues["blocked"] = got.Blocked[IssueID(blockedIssue.ID)].Issue
+		for _, id := range []string{"running", "retry", "blocked"} {
+			issues["claimed-"+id] = got.ClaimedIssues[IssueID(id)]
+		}
+		run := got.Running[IssueID(runningIssue.ID)]
+		cleanup, handoff, terminalHandoff = run.ReconcileCleanupWorkspace, run.AgentCurrentIssueHandoff, run.AgentCurrentIssueTerminalHandoff
+	})
+
+	assertPatched := func(name string, got, old tracker.Issue, wantBlockers []tracker.BlockerRef) {
+		t.Helper()
+		if got.State != "Rework" || !reflect.DeepEqual(got.Labels, []string{"fresh"}) {
+			t.Errorf("%s state/labels = %q/%v, want Rework/[fresh]", name, got.State, got.Labels)
+		}
+		if got.Title != old.Title || got.Description != old.Description || got.URL != old.URL || got.BranchName != old.BranchName || got.Priority != old.Priority || !got.CreatedAt.Equal(old.CreatedAt) || !got.UpdatedAt.Equal(old.UpdatedAt) {
+			t.Errorf("%s metadata = %+v, want preserved from %+v", name, got, old)
+		}
+		if !reflect.DeepEqual(got.BlockedBy, wantBlockers) {
+			t.Errorf("%s BlockedBy = %#v, want %#v", name, got.BlockedBy, wantBlockers)
+		}
+	}
+	assertPatched("running", issues["running"], runningIssue, runningIssue.BlockedBy)
+	assertPatched("retry", issues["retry"], retryIssue, []tracker.BlockerRef{})
+	assertPatched("blocked", issues["blocked"], blockedIssue, []tracker.BlockerRef{{ID: "new-blocker", State: "Done"}})
+	assertPatched("claimed-running", issues["claimed-running"], runningIssue, runningIssue.BlockedBy)
+	assertPatched("claimed-retry", issues["claimed-retry"], retryIssue, []tracker.BlockerRef{})
+	assertPatched("claimed-blocked", issues["claimed-blocked"], blockedIssue, []tracker.BlockerRef{{ID: "new-blocker", State: "Done"}})
+	if cleanup || handoff || terminalHandoff {
+		t.Errorf("running reconcile flags = cleanup:%v handoff:%v terminal:%v, want all false after active narrow refresh", cleanup, handoff, terminalHandoff)
+	}
 }
 
 func TestPollOncePreflightSuccessProceedsToFetch(t *testing.T) {


### PR DESCRIPTION
Closes #1112

## Summary
- run claimed-issue reconciliation before dispatch preflight and the single candidate listing, so invalid preflight or listing failures cannot suppress positive terminal/ineligible observations
- preserve partial-result semantics: explicit narrow-refresh rows update or stop claimed work, error-caused omissions remain unknown, and returned candidates still pass through the existing dispatch-time revalidation
- patch narrow state, labels, and blocker knowledge without erasing stored issue metadata, and bound every reconciliation tracker read with an independent request deadline

Ordering and error behavior follow `docs/research/SPEC.md` §6.3, §8.1, and §16.2, with the corresponding upstream control flow in `elixir/lib/symphony_elixir/orchestrator.ex`.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — 2 production files / 261 changed production LOC (test files excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- `go build ./cmd/worker ./cmd/tui`
- `go test -tags e2e -race -count=1 -timeout 15m ./test/e2e/...`
- blocking tracker doubles proved the reconciliation calls hung before the deadline fix and return both timeout and preflight errors afterward
- independent exact-head Standards and Spec reviews passed at `82f71c8957547a80c596ecf8104366b7265d2c78`

## Notes
- No tracker writes, durable queue, worker phase, or successful-refresh authoritative-absence behavior is changed; the latter remains tracked by #1113.
