### PR TITLE
fix(orchestrator): classify issue refresh outcomes

### DIFF
--- a/docs/superpowers/plans/2026-07-15-issue-state-refresh-outcomes.md
+++ b/docs/superpowers/plans/2026-07-15-issue-state-refresh-outcomes.md
@@ -1,0 +1,364 @@
+# Issue State Refresh Outcomes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every narrow tracker refresh classify each requested issue reference as current, confirmed absent, or unknown so reconciliation releases only authoritative disappearances.
+
+**Architecture:** Add a zero-safe outcome to the existing narrow `tracker.IssueState` fact, normalize every request to an explicit map row, and make Linear, GitHub, and Gitea assign authoritative outcomes at their adapter boundaries. The poller will pass only `Current` rows into existing state reconciliation and send only `ConfirmedAbsent` refs to a dedicated actor operation; `Unknown` rows and failed requests preserve claims. Retry timers retain ownership of failure and capacity retries, while cleanup rechecks distinguish absence from terminal state.
+
+**Tech Stack:** Go 1.25, standard library HTTP/GraphQL clients, actor-style orchestrator, `testing`, Docker-backed Gitea E2E.
+
+## Global Constraints
+
+- Base all work and final review on `054bab42ca9b477e6b93d6c0b94aa7fd2d2cf34d` (`origin/main` when this plan was written).
+- Keep the adapter-contract and orchestrator-consumer change atomic on branch `codex/issue-1113-refresh-outcomes`; do not add a compatibility path that interprets a missing map key as absence.
+- `IssueStateOutcomeUnknown` must be the zero value. Every non-empty requested ID must appear in the returned map, including configuration, transport, partial-response, malformed-reference, and repository-mismatch failures.
+- Only a successful authoritative lookup may emit `IssueStateOutcomeAbsent`. A malformed/partial issue payload is `Unknown`; a successfully fetched Gitea issue that definitively has no recognized aiops workflow-state label is absent from this adapter's workflow domain and is `Absent`, preserving the existing #740 continuation-unwedge behavior.
+- Preserve results from earlier clean batches and independent successful REST references when another batch/reference fails, and return the joined error for diagnostics. A GraphQL `data + errors` chunk is partial as a whole and must remain `Unknown` unless error paths prove individual fields complete.
+- Treat a decodable response with missing required structural fields as a typed incomplete-response error and `Unknown`; distinguish an omitted field from a valid empty collection.
+- Stop issuing later per-reference/chunk requests after a typed rate-limit or canceled/deadline context, leaving all unattempted rows `Unknown` while preserving earlier authoritative outcomes.
+- Confirmed absence is not terminal: never delete its workspace and never set terminal-cleanup or operator-stop latches.
+- Do not release failure, quota, or capacity retry entries during poll-tick reconciliation. SPEC section 8.4 retry timers remain their owner.
+- Bound all added tracker I/O with existing request contexts and route asynchronous test/runtime work through the repository's panic-safe helpers.
+- Use `apply_patch` for edits, run red tests before implementation, create the single atomic implementation commit after Tasks 1-3, and review the final three-dot diff against the fixed base.
+
+---
+
+### Task 1: Define and enforce the per-reference adapter contract
+
+**Files:**
+
+- Modify: `internal/tracker/tracker.go`
+- Modify: `internal/tracker/linear.go`
+- Create: `internal/tracker/linear_refresh.go`
+- Modify: `internal/tracker/linear_test.go`
+- Modify: `internal/tracker/github_refresh.go`
+- Modify: `internal/tracker/github_blockers.go`
+- Modify: `internal/tracker/github_test.go`
+- Modify: `internal/gitea/tracker_client_refresh.go`
+- Modify: `internal/gitea/tracker_client_test.go`
+
+- [ ] **Step 1: Add failing contract tests for the zero-safe outcome model**
+
+  Add table tests around `IssueState` that require these exact outcomes:
+
+  ```go
+  const (
+      IssueStateOutcomeUnknown IssueStateOutcome = iota
+      IssueStateOutcomeCurrent
+      IssueStateOutcomeAbsent
+  )
+  ```
+
+  Test that the zero value is `Unknown`, current rows retain state/labels/blockers, and absent rows carry no fabricated state. Run:
+
+  ```bash
+  go test ./internal/tracker -run 'TestIssueStateOutcome' -count=1
+  ```
+
+  Expected: FAIL because the outcome type and constants do not exist.
+
+- [ ] **Step 2: Add failing Linear adapter outcome tests**
+
+  Extend `internal/tracker/linear_test.go` with cases proving:
+
+  - a clean exact-ID response marks returned nodes `Current` and omitted requested IDs `Absent`;
+  - a GraphQL `data + errors` response marks the entire affected chunk `Unknown` and returns an error, even when partial nodes are present;
+  - missing `data.issues.nodes`, node ID/state, or labels structure leaves the entire affected chunk `Unknown` with a typed incomplete-response error, while an explicit empty `nodes: []` is a clean authoritative absence;
+  - a failed chunk leaves that chunk `Unknown` while preserving authoritative results from earlier chunks;
+  - a rate-limited/canceled chunk prevents later chunk I/O and leaves unattempted IDs unknown, including Linear's documented HTTP 400 GraphQL shape with `errors[].extensions.code == "RATELIMITED"`;
+  - API-key or transport failure returns an explicit `Unknown` row for each requested non-empty ID.
+
+  Run:
+
+  ```bash
+  go test ./internal/tracker -run 'TestFetchIssueStatesByIDs.*(Outcome|Partial|Unknown|Absent)' -count=1
+  ```
+
+  Expected: FAIL because clean omissions are sparse and failures currently discard the result map.
+
+- [ ] **Step 3: Add failing GitHub and Gitea adapter outcome tests**
+
+  Add table cases proving for each REST adapter:
+
+  - a resolved issue with a valid workflow state is `Current`;
+  - a reference resolved through this client's current-repository ID-to-number cache and returning 404 (and GitHub 410) is `Absent`;
+  - an uncached identifier fallback returning 404/410, unresolvable ref, malformed identifier, cache/identifier mismatch, or fetched-ID/repository mismatch is `Unknown`;
+  - a successfully fetched Gitea issue with no recognized aiops state label is `Absent`, while a malformed/partial state payload is `Unknown`;
+  - a cached issue number that conflicts with the ref's valid identifier remains `Unknown` even when the cached number's lookup returns 404; the adapter must validate reference consistency before treating not-found as authoritative;
+  - a decoded REST issue whose returned number differs from the requested endpoint remains `Unknown` and cannot rewrite the ID-to-number cache;
+  - a REST payload that omits required ID/number/state/labels structure remains `Unknown` with a typed incomplete-response error; explicit `labels: []` remains valid;
+  - one HTTP/JSON failure produces an error and an `Unknown` row without erasing other authoritative rows;
+  - a rate-limited/canceled reference prevents later reference I/O and leaves unattempted refs unknown;
+  - a GitHub blocker-hydration failure leaves Todo-like rows `Unknown` but preserves authoritative non-Todo/terminal rows as `Current`;
+  - Todo blocker subqueries fail closed on structurally partial data: Linear missing `data.issues.nodes`/requested rows produces the existing placeholder blocker path, while GitHub missing `node_id`/`blockedBy` produces an error and leaves only the affected Todo row unknown;
+  - when blocker hydration succeeds, both blocker and no-blocker GitHub refresh entrypoints assign the same state outcome; the separate failure case may leave only Todo-like blocker-dependent rows unknown.
+
+  Run:
+
+  ```bash
+  go test ./internal/tracker ./internal/gitea -run 'Test.*FetchIssueStates.*(Outcome|Partial|Unknown|Absent)' -count=1
+  ```
+
+  Expected: FAIL because the adapters currently skip ambiguous rows and abort with a nil map on per-reference failure.
+
+- [ ] **Step 4: Implement the minimal adapter contract**
+
+  In `internal/tracker/tracker.go`, add `IssueStateOutcome` and an `Outcome` field to `IssueState`, documenting that missing keys and the zero value are unknown. Add small predicates only if they remove repeated status comparisons.
+
+  Keep the narrow Linear refresh implementation in `internal/tracker/linear_refresh.go` rather than pushing `linear.go` beyond the repository's 800-line production-file budget.
+
+  In every adapter, prefill a deduplicated map entry for each non-empty requested ID with `Outcome: IssueStateOutcomeUnknown`. Then:
+
+  - Linear: represent required GraphQL response fields with presence-aware pointers; only after validating a complete chunk mark missing IDs `Absent` and decoded nodes `Current`; on `data + errors` or incomplete structure, leave the entire chunk unknown, join a typed error, and preserve only earlier clean chunks. Classify both HTTP 429 and the documented HTTP 400 `RATELIMITED` GraphQL error code as `ErrRateLimited`, then break before later chunks; also stop after context cancellation/deadline.
+  - GitHub/Gitea: distinguish current-repository cache resolution from identifier-only fallback; validate any cached issue number against a supplied valid identifier (and any `#N` ID) before network I/O; require the returned payload number to equal the requested endpoint number before caching; use presence-aware decode for required fields; mark a successful matching state lookup current; mark not-found absent only when a consistent current-client cache makes repository identity authoritative; leave fallback 404/410, malformed, unresolved, mismatched, partial, and failed rows unknown; continue independent references and return `errors.Join` of per-ref errors, except stop on rate-limit or context cancellation/deadline. A successful complete Gitea response with explicit `labels: []` and no recognized aiops state label is the `Absent` out-of-workflow case.
+  - If GitHub's batch blocker hydration fails, leave Todo-like rows unknown and return the error; non-Todo/terminal rows do not consume blocker data and remain current. The no-blocker path may mark every successful state row current.
+  - Validate nested label names and blocker-query structural fields, not only their containing arrays. Explicit empty arrays are authoritative empty sets; missing/null/empty required scalars are partial responses.
+
+- [ ] **Step 5: Run adapter tests and the package baseline**
+
+  ```bash
+  gofmt -w internal/tracker/tracker.go internal/tracker/linear.go internal/tracker/linear_refresh.go internal/tracker/linear_test.go internal/tracker/github_refresh.go internal/tracker/github_test.go internal/gitea/tracker_client_refresh.go internal/gitea/tracker_client_test.go
+  go test ./internal/tracker ./internal/gitea -count=1
+  go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 6: Record the adapter mutation cases for the post-commit seam check**
+
+  Record these post-commit mutations without applying them yet: change one authoritative not-found assignment from `Absent` to `Unknown`; change one failed Linear chunk from `Unknown` to `Current`; bypass one REST cache/identifier consistency check. Task 3 performs the mutations only after the complete atomic artifact is committed, so each test proves behavior rather than merely encountering the intentionally incomplete intermediate tree.
+
+- [ ] **Step 7: Hold the adapter contract uncommitted for the atomic consumer switch**
+
+  ```bash
+  git diff --check
+  git status --short
+  ```
+
+  Do not commit yet. Until Task 2 removes omission inference, the old `releaseVanishedContinuations` path would misclassify a new explicit `Unknown` row with an empty state as vanished. The adapter contract and every destructive consumer must first become safe in the same commit.
+
+---
+
+### Task 2: Reconcile confirmed absence without inferring it from omission
+
+**Files:**
+
+- Modify: `internal/orchestrator/poller.go`
+- Modify: `internal/orchestrator/actor_reconcile.go`
+- Modify: `internal/orchestrator/poller_reconciletick_test.go`
+- Modify: `internal/orchestrator/actor_reconcile_inactive_test.go`
+- Modify: test refresh fakes in `internal/orchestrator/poller_test.go`
+
+- [ ] **Step 1: Add a failing real poller-to-actor state-matrix test**
+
+  Build one poll tick with explicit outcome rows covering:
+
+  - running + absent: cancel worker, release claim, preserve workspace, do not set terminal-cleanup/operator-stop state;
+  - blocked + absent: release claim without cleanup;
+  - continuation retry + absent: stop timer and release claim;
+  - failure and quota/capacity retry + absent: preserve the retry and claim;
+  - current active: retain claim and refresh stored state;
+  - current terminal: use the existing cancel-and-cleanup path;
+  - unknown row and a missing fake row: preserve all associated claims;
+  - a mixed refresh error: still apply authoritative current/absent rows while preserving unknown rows, and surface the error.
+  - a confirmed-absent running issue that also appears in the same tick's stale terminal/inactive group listing: the narrow absent verdict wins, no operator-terminal stop is recorded, and a pre-seeded `ReconcileCleanupWorkspace=true` flag is cleared before cancellation.
+
+  Drive `Poller.reconcileClaimedTick` through the actual actor; do not unit-test only a leaf predicate. Run:
+
+  ```bash
+  go test ./internal/orchestrator -run 'TestPollerReconcileClaimedTick.*RefreshOutcome' -count=1
+  ```
+
+  Expected: FAIL because running/blocked absence has no actor transition and continuation still derives disappearance from omission.
+
+- [ ] **Step 2: Add failing actor-operation tests**
+
+  Add focused tests for a new `ReconcileAbsentTrackerIssuesAndWait` operation. Assert it releases only running, blocked, and `RetryKindContinuation` entries, waits for a running worker's `Done`, leaves workspace cleanup false, and leaves failure/quota/capacity retry timers untouched.
+
+  Run:
+
+  ```bash
+  go test ./internal/orchestrator -run 'TestReconcileAbsentTrackerIssues' -count=1
+  ```
+
+  Expected: FAIL because the operation does not exist.
+
+- [ ] **Step 3: Implement outcome normalization at the poller boundary**
+
+  Update `fetchIssueStates` and `fetchIssueStatesWithoutBlockers` to prefill every non-empty requested ID as `Unknown` and overlay adapter results. This protects the orchestrator from non-compliant fakes or future adapters without converting missing rows to absent.
+
+  Change `refreshRunningIssueStates` to return both current `tracker.Issue` rows and a set of explicitly absent refs. Remove `releaseVanishedContinuations` and all map-omission inference. Apply current rows through the existing patch/active/inactive flows, then pass only confirmed-absent refs to the new actor operation even when the adapter also returned a partial error.
+
+  Treat the narrow per-reference result as stronger than a potentially stale terminal/inactive group listing from the same tick: remove explicitly absent IDs from the later `inactiveByID` set before invoking inactive reconciliation. Otherwise a still-exiting absent run could be reclassified as terminal and incorrectly gain workspace cleanup/operator-stop state after the absence operation.
+
+- [ ] **Step 4: Implement the dedicated actor transition**
+
+  Add one actor command that handles confirmed absence in a single serialized state mutation:
+
+  - running: clear the claim, set reconcile cancellation without cleanup, invoke cancellation, and wait up to `WorkerExitTimeout`;
+  - blocked: release the claim without cleanup;
+  - retry: release only when `Kind == RetryKindContinuation`; retain failure/quota/capacity entries and timers.
+
+  Do not reuse `ReconcileInactiveTrackerIssuesAndWait`, because that path deliberately releases all retry kinds and may drive terminal cleanup.
+
+- [ ] **Step 5: Update existing refresh fakes to emit explicit current outcomes**
+
+  Every test fake that intends to represent an observed state must set `Outcome: tracker.IssueStateOutcomeCurrent`. Tests intentionally exercising ambiguity should emit `Unknown` or omit the key and assert claim preservation.
+
+- [ ] **Step 6: Run reconciliation tests**
+
+  ```bash
+  gofmt -w internal/orchestrator/poller.go internal/orchestrator/actor_reconcile.go internal/orchestrator/poller_reconciletick_test.go internal/orchestrator/actor_reconcile_inactive_test.go internal/orchestrator/poller_test.go
+  go test ./internal/orchestrator -run 'Test(PollerReconcileClaimedTick|ReconcileAbsentTrackerIssues|Poller.*Reconcile)' -count=1
+  ```
+
+- [ ] **Step 7: Hold the reconciliation transition for the remaining consumer sweep**
+
+  ```bash
+  git diff --check
+  go test ./internal/orchestrator ./internal/tracker ./internal/gitea -count=1
+  ```
+
+  Do not commit until Task 3 proves every secondary consumer is outcome-aware.
+
+---
+
+### Task 3: Make every secondary consumer outcome-aware
+
+**Files:**
+
+- Modify: `internal/orchestrator/poller_candidates.go`
+- Modify: `internal/orchestrator/poller_candidates_test.go`
+- Modify: `internal/orchestrator/runtime_poller.go`
+- Modify: `internal/orchestrator/runtime_poller_test.go`
+- Modify: `internal/orchestrator/actor_cleanup.go`
+- Modify: `internal/orchestrator/actor_retry.go`
+- Modify: `internal/orchestrator/actor_test.go`
+- Modify: any remaining `IssueState`-producing orchestrator test fakes found by `rg`
+
+- [ ] **Step 1: Add failing candidate and per-turn gate tests**
+
+  Require dispatch revalidation to consume only `Current`: absent and unknown both skip dispatch, while a partial error preserves usable current rows for unrelated candidates. For the runner's per-turn gate, require current to set `Found:true`; absent and unknown-without-error to produce `Found:false, Active:true` with the prior issue fallback; and an actual adapter error to be surfaced.
+
+  ```bash
+  go test ./internal/orchestrator -run 'Test.*(Revalidate|CurrentIssue).*(Outcome|Absent|Unknown|Partial)' -count=1
+  ```
+
+  Expected: FAIL because these consumers currently equate map presence with current state.
+
+- [ ] **Step 2: Add failing cleanup and retry ownership tests**
+
+  Extend cleanup recheck tests so:
+
+  - explicit current terminal still deletes the workspace;
+  - explicit current nonterminal still resumes a continuation;
+  - unknown/error continues the existing bounded recheck;
+  - confirmed absent neither deletes nor retries nor resumes a continuation.
+
+  Extend retry-timer tests to pin §8.4 ownership: a successful candidate lookup miss still releases failure/capacity claims; a candidate lookup error requeues; narrow refresh absence does not release them early; only an explicit current terminal result may request terminal cleanup.
+
+  ```bash
+  go test ./internal/orchestrator -run 'Test.*(CleanupRecheck|Retry).*(Absent|Unknown|Terminal|Missing)' -count=1
+  ```
+
+  Expected: FAIL on the new absent cleanup verdict and explicit outcome assertions.
+
+- [ ] **Step 3: Implement outcome-aware secondary consumers**
+
+  - Candidate revalidation: only `Current` may rebuild and gate a candidate; absent/unknown skip it without releasing any claim.
+  - Runtime current-issue refresh: only `Current` is found; absent and unknown-without-error return the existing SPEC section 16.5 prior-issue fallback (`Found:false`, `Active:true`, nil error), while an actual adapter error is returned verbatim. The mutation tool guard still fails closed on `Found:false` without turning a benign unknown into a failed worker attempt.
+  - Cleanup recheck: introduce a small verdict that distinguishes current-terminal, current-nonterminal, absent, and unknown/error. Absent exits without deletion or continuation; unknown/error uses the bounded retry.
+  - Retry terminal resolution: only `Current` terminal state selects cleanup. Absent/unknown remain release-only at the timer-owned candidate decision; do not change successful candidate-miss behavior.
+
+- [ ] **Step 4: Sweep every producer and consumer**
+
+  ```bash
+  rg -n 'IssueState\s*\{' --glob '*.go'
+  rg -n 'statesByID\[|FetchIssueStates' internal/orchestrator internal/tracker internal/gitea --glob '*.go'
+  ```
+
+  Classify each occurrence. Set explicit `Current` in fakes/fixtures that mean a real observation, and verify no production consumer treats key presence or empty state as confirmed absence.
+
+- [ ] **Step 5: Run package tests**
+
+  ```bash
+  gofmt -w internal/orchestrator/poller_candidates.go internal/orchestrator/poller_candidates_test.go internal/orchestrator/runtime_poller.go internal/orchestrator/runtime_poller_test.go internal/orchestrator/actor_cleanup.go internal/orchestrator/actor_retry.go internal/orchestrator/actor_test.go
+  go test ./internal/orchestrator ./internal/tracker ./internal/gitea -count=1
+  ```
+
+- [ ] **Step 6: Commit the complete atomic contract and consumer switch**
+
+  ```bash
+  git add docs/superpowers/plans/2026-07-15-issue-state-refresh-outcomes.md internal/tracker internal/gitea internal/orchestrator
+  git commit -m "fix(orchestrator): classify issue refresh outcomes" -m "Closes #1113"
+  ```
+
+  Inspect the committed tree and confirm there is no parent-to-child revision in the PR history where explicit unknown rows can reach the old omission-based release path.
+
+- [ ] **Step 7: Mutation-check the committed wiring seams**
+
+  Starting from a clean committed tree, use `apply_patch` for one compiling mutation at a time, run its focused test, require an assertion failure, then reverse the same patch and require `git diff --exit-code HEAD` before the next mutation:
+
+  - tracker seam: authoritative cached not-found `Absent` → `Unknown`;
+  - Linear partial-response seam: failed-chunk `Unknown` → `Current` for a returned partial node;
+  - REST authority seam: bypass the cache/identifier consistency check before a not-found verdict;
+  - poller/actor seam: allow `RetryKindFailure` through the confirmed-absence release condition;
+  - stale-list precedence seam: stop excluding an explicitly absent ID from same-tick inactive listings;
+  - cleanup seam: classify confirmed absent as terminal.
+
+  The tests must fail on behavior assertions (outcome, retained retry/timer, cleanup/operator-stop call count), not compilation.
+
+---
+
+### Task 4: Run the repository gate, review the exact head, and deliver #1113
+
+**Files:**
+
+- Review: all changes since `054bab42ca9b477e6b93d6c0b94aa7fd2d2cf34d`
+- Modify only files required to fix source-confirmed review findings
+
+- [ ] **Step 1: Run focused race tests and inspect the diff budget**
+
+  ```bash
+  go test -race ./internal/tracker ./internal/gitea ./internal/orchestrator -count=1
+  git diff --stat 054bab42ca9b477e6b93d6c0b94aa7fd2d2cf34d...HEAD
+  git diff --check 054bab42ca9b477e6b93d6c0b94aa7fd2d2cf34d...HEAD
+  ```
+
+  Expected: PASS; classify the PR as `within budget` unless the production diff genuinely exceeds the repository guideline.
+
+- [ ] **Step 2: Run every required local gate freshly**
+
+  ```bash
+  test -z "$(gofmt -l $(git ls-files '*.go'))"
+  go mod tidy
+  git diff --exit-code -- go.mod go.sum
+  go vet ./...
+  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config=.golangci.yml --issues-exit-code=0
+  go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts
+  go test -race -covermode=atomic ./...
+  go build ./cmd/worker ./cmd/tui
+  go test -tags e2e -race -timeout 15m -count=1 ./test/e2e/...
+  ```
+
+  Expected: every command exits zero. CI quota is not a local blocker, but no failed local gate may be ignored.
+
+- [ ] **Step 3: Run independent Standards and Spec reviews against the fixed base**
+
+  Give separate reviewers the exact `BASE_SHA` and `HEAD_SHA`. Standards review checks `AGENTS.md`, clean-code rules, timeouts, goroutine safety, error classification, file/function budgets, and test quality. Spec review checks issue #1113, SPEC sections 8.4/8.5/11.2/11.4/16.3/16.5, the Elixir reference, adapter authority boundaries, and every acceptance criterion.
+
+  Fix only source-confirmed findings, commit them, rerun the affected tests and full required gates, then re-run both reviews against the same base until both return PASS on the same head.
+
+- [ ] **Step 4: Push and open the ready PR**
+
+  ```bash
+  git push -u origin codex/issue-1113-refresh-outcomes
+  gh pr create --repo xrf9268-hue/aiops-platform --base main --head codex/issue-1113-refresh-outcomes --title 'fix(orchestrator): classify issue refresh outcomes' --body-file /tmp/aiops-pr-1113.md
+  ```
+
+  The PR body must include `Closes #1113`, `within budget` or an accurately justified size-gate classification, the SPEC-alignment evidence, and the exact local verification commands. Do not include memory citations.
+
+- [ ] **Step 5: Follow the live PR to merge-confirmed closure**
+
+  Re-read the current head SHA, checks, reviews, and unresolved threads. CI quota exhaustion may be documented and ignored only because the complete local gate passed; a real failed check or actionable current-head review must be fixed. Squash-merge only the exact reviewed head with head matching enabled, then verify GitHub reports `state: MERGED`, a non-null `mergedAt`, and issue #1113 closed before moving to #1114.

--- a/internal/gitea/tracker_client_blocker.go
+++ b/internal/gitea/tracker_client_blocker.go
@@ -2,6 +2,7 @@ package gitea
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -22,6 +23,15 @@ var dependsOnRegexp = regexp.MustCompile(`(?i)depends on #(\d+)`)
 type giteaTrackerContextKey int
 
 const blockerCacheContextKey giteaTrackerContextKey = iota
+
+// blockerLookupPolicy keeps candidate listing best-effort while letting the
+// narrow refresh preserve rate-limit and deadline signals for its batch halt.
+type blockerLookupPolicy int
+
+const (
+	blockerLookupBestEffort blockerLookupPolicy = iota
+	blockerLookupHaltRefresh
+)
 
 // blockerCacheEntry memoizes one getIssueByNumber result so a `Depends on #N`
 // blocker referenced by multiple source issues is fetched at most once per poll
@@ -52,23 +62,27 @@ func blockerCacheFrom(ctx context.Context) map[int]blockerCacheEntry {
 // per poll tick. A successful fetch and a definitive 404 are memoized; a
 // transient error returns resolved=false without caching so a later source
 // issue can retry. resolved distinguishes "the lookup answered" (found tells
-// whether the issue exists) from "the lookup failed" — callers must not treat
-// a transient failure as a definitive absence. When no per-tick cache is
-// installed (non-poll callers), it falls back to a direct fetch.
-func (c *TrackerClient) cachedIssueByNumber(ctx context.Context, cache map[int]blockerCacheEntry, n int) (issue Issue, found, resolved bool) {
+// whether the issue exists) from "the lookup failed"; err preserves the lookup
+// failure so callers can propagate global halt signals while ordinary failures
+// still become fail-closed placeholders. When no per-tick cache is installed
+// (non-poll callers), it falls back to a direct fetch.
+func (c *TrackerClient) cachedIssueByNumber(ctx context.Context, cache map[int]blockerCacheEntry, n int) (issue Issue, found, resolved bool, err error) {
 	if cache != nil {
 		if entry, ok := cache[n]; ok {
-			return entry.issue, entry.found, true
+			return entry.issue, entry.found, true, nil
 		}
 	}
 	fetched, found, err := c.getIssueByNumber(ctx, n)
 	if err != nil {
-		return Issue{}, false, false
+		return Issue{}, false, false, err
+	}
+	if found && fetched.Number != n {
+		return Issue{}, false, false, fmt.Errorf("%w: Gitea blocker request #%d returned issue #%d", tracker.ErrIssueStateRefreshIncomplete, n, fetched.Number)
 	}
 	if cache != nil {
 		cache[n] = blockerCacheEntry{issue: fetched, found: found}
 	}
-	return fetched, found, true
+	return fetched, found, true, nil
 }
 
 // buildBlockedBy parses `Depends on #N` references from issue.Body and looks
@@ -87,28 +101,40 @@ func (c *TrackerClient) cachedIssueByNumber(ctx context.Context, cache map[int]b
 // failure is deliberately not cached). A definitive 404 is a DELETED blocker:
 // it can never become terminal, so blocking on it would starve the candidate
 // forever — it drops out of the list instead.
-func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string) []tracker.BlockerRef {
+func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string, policy blockerLookupPolicy) ([]tracker.BlockerRef, error) {
 	matches := dependsOnRegexp.FindAllStringSubmatch(body, -1)
 	if len(matches) == 0 {
-		return nil
+		return nil, nil
 	}
 	cache := blockerCacheFrom(ctx)
 	seen := map[int]struct{}{}
 	var refs []tracker.BlockerRef
 	for _, m := range matches {
-		n, err := strconv.Atoi(m[1])
-		if err != nil || n <= 0 {
+		n, ok := parseUnseenBlockerNumber(m[1], seen)
+		if !ok {
 			continue
 		}
-		if _, ok := seen[n]; ok {
-			continue
+		ref, ok, err := c.blockerRefForNumber(ctx, cache, n, policy)
+		if err != nil {
+			return nil, err
 		}
-		seen[n] = struct{}{}
-		if ref, ok := c.blockerRefForNumber(ctx, cache, n); ok {
+		if ok {
 			refs = append(refs, ref)
 		}
 	}
-	return refs
+	return refs, nil
+}
+
+func parseUnseenBlockerNumber(raw string, seen map[int]struct{}) (int, bool) {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	if _, ok := seen[n]; ok {
+		return 0, false
+	}
+	seen[n] = struct{}{}
+	return n, true
 }
 
 // blockerRefForNumber resolves one `Depends on #N` reference: a resolved
@@ -116,21 +142,27 @@ func (c *TrackerClient) buildBlockedBy(ctx context.Context, body string) []track
 // as an empty-state placeholder (logged — without that a persistently failing
 // lookup would starve the candidate indistinguishably from a genuine open
 // blocker), and a definitively deleted blocker reports ok=false to drop out.
-func (c *TrackerClient) blockerRefForNumber(ctx context.Context, cache map[int]blockerCacheEntry, n int) (tracker.BlockerRef, bool) {
-	issue, found, resolved := c.cachedIssueByNumber(ctx, cache, n)
+func (c *TrackerClient) blockerRefForNumber(ctx context.Context, cache map[int]blockerCacheEntry, n int, policy blockerLookupPolicy) (tracker.BlockerRef, bool, error) {
+	issue, found, resolved, lookupErr := c.cachedIssueByNumber(ctx, cache, n)
+	if policy == blockerLookupHaltRefresh && lookupErr != nil && tracker.ShouldStopIssueStateRefresh(ctx, lookupErr) {
+		if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(lookupErr, ctxErr) {
+			lookupErr = errors.Join(lookupErr, ctxErr)
+		}
+		return tracker.BlockerRef{}, false, lookupErr
+	}
 	if !resolved {
 		if c.Logf != nil {
 			c.Logf("gitea blocker lookup failed transiently for #%d; failing closed as an open placeholder", n)
 		}
-		return tracker.BlockerRef{Identifier: fmt.Sprintf("#%d", n)}, true
+		return tracker.BlockerRef{Identifier: fmt.Sprintf("#%d", n)}, true, nil
 	}
 	if !found {
-		return tracker.BlockerRef{}, false
+		return tracker.BlockerRef{}, false, nil
 	}
 	state, _ := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
 	return tracker.BlockerRef{
 		ID:         giteaIssueID(issue),
 		Identifier: fmt.Sprintf("#%d", issue.Number),
 		State:      state,
-	}, true
+	}, true, nil
 }

--- a/internal/gitea/tracker_client_listing.go
+++ b/internal/gitea/tracker_client_listing.go
@@ -187,6 +187,10 @@ func (c *TrackerClient) scopeIssue(ctx context.Context, issue Issue, wantedState
 	if err != nil {
 		return tracker.Issue{}, false, err
 	}
+	blockedBy, err := c.buildBlockedBy(ctx, issue.Body, blockerLookupBestEffort)
+	if err != nil {
+		return tracker.Issue{}, false, err
+	}
 	return tracker.Issue{
 		ID:          giteaIssueID(issue),
 		Identifier:  fmt.Sprintf("#%d", issue.Number),
@@ -197,7 +201,7 @@ func (c *TrackerClient) scopeIssue(ctx context.Context, issue Issue, wantedState
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 		Labels:      extractGiteaLabels(issue.Labels),
-		BlockedBy:   c.buildBlockedBy(ctx, issue.Body),
+		BlockedBy:   blockedBy,
 		// Priority: Gitea has no native priority field — see
 		// dependsOnRegexp comment / SPEC §4.1.1 note. Left at the zero
 		// value; dispatch sort treats every Gitea issue as equal priority

--- a/internal/gitea/tracker_client_refresh.go
+++ b/internal/gitea/tracker_client_refresh.go
@@ -70,7 +70,7 @@ func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []
 		c.cacheIssueNumber(issue)
 		state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
 		c.logDiagnostics(issue, diagnostics)
-		if strings.EqualFold(strings.TrimSpace(state), "Todo") && !bodyPresent {
+		if giteaTodoWorkflowState(state) && !bodyPresent {
 			refreshErrs = append(refreshErrs, fmt.Errorf("%w: Gitea Todo issue response missing body", tracker.ErrIssueStateRefreshIncomplete))
 			continue
 		}
@@ -96,12 +96,21 @@ func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []
 	return states, errors.Join(refreshErrs...)
 }
 
-// buildRefreshedIssueState carries the full normalized label set and refreshed
-// blockers onto an authoritative Current row. The issue body is authoritative
-// for this adapter, so no `Depends on #N` references becomes a positive non-nil
-// "no blockers" result; transient resolution failures become open placeholders
-// inside buildBlockedBy.
+// buildRefreshedIssueState carries the full normalized label set onto an
+// authoritative Current row. Only Todo needs blocker knowledge for the dispatch
+// gate; other states avoid irrelevant dependency I/O and keep BlockedBy nil.
+// For Todo, the issue body is authoritative, so no `Depends on #N` references
+// becomes a positive non-nil "no blockers" result; transient resolution
+// failures become open placeholders inside buildBlockedBy.
 func (c *TrackerClient) buildRefreshedIssueState(ctx context.Context, issue Issue, state string) (tracker.IssueState, error) {
+	refreshed := tracker.IssueState{
+		Outcome: tracker.IssueStateOutcomeCurrent,
+		State:   state,
+		Labels:  extractGiteaLabels(issue.Labels),
+	}
+	if !giteaTodoWorkflowState(state) {
+		return refreshed, nil
+	}
 	blockedBy, err := c.buildBlockedBy(ctx, issue.Body, blockerLookupHaltRefresh)
 	if err != nil {
 		return tracker.IssueState{}, err
@@ -109,12 +118,12 @@ func (c *TrackerClient) buildRefreshedIssueState(ctx context.Context, issue Issu
 	if blockedBy == nil {
 		blockedBy = []tracker.BlockerRef{}
 	}
-	return tracker.IssueState{
-		Outcome:   tracker.IssueStateOutcomeCurrent,
-		State:     state,
-		Labels:    extractGiteaLabels(issue.Labels),
-		BlockedBy: blockedBy,
-	}, nil
+	refreshed.BlockedBy = blockedBy
+	return refreshed, nil
+}
+
+func giteaTodoWorkflowState(state string) bool {
+	return strings.EqualFold(strings.TrimSpace(state), "Todo")
 }
 
 func stateDiagnosticsContain(diagnostics []StateDiagnostic, code string) bool {

--- a/internal/gitea/tracker_client_refresh.go
+++ b/internal/gitea/tracker_client_refresh.go
@@ -2,6 +2,8 @@ package gitea
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,82 +17,143 @@ func (c *TrackerClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []st
 	return c.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(issueIDs))
 }
 
+// FetchIssueStatesByRefs classifies every non-empty requested ID. A 404 is
+// confirmed absence only when this client previously cached the ID-to-number
+// mapping for the current repository; fallback-only not-found responses stay
+// unknown because the human identifier alone does not prove repository scope.
 func (c *TrackerClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []tracker.IssueRef) (map[string]tracker.IssueState, error) { //nolint:gocognit // baseline (#521)
+	states, refs := tracker.UnknownIssueStatesByRefs(issueRefs)
 	if c.BaseURL == "" || c.Token == "" {
-		return nil, fmt.Errorf("GITEA_BASE_URL and Gitea tracker api_key are required")
+		return states, fmt.Errorf("GITEA_BASE_URL and Gitea tracker api_key are required")
 	}
 	if c.Owner == "" || c.Repo == "" {
-		return nil, fmt.Errorf("repo.owner and repo.name are required for Gitea tracker polling")
+		return states, fmt.Errorf("repo.owner and repo.name are required for Gitea tracker polling")
 	}
-	if len(issueRefs) == 0 {
-		return map[string]tracker.IssueState{}, nil
+	if len(refs) == 0 {
+		return states, nil
 	}
 	// Install a per-refresh blocker cache so buildBlockedBy fetches each
 	// `Depends on #N` blocker at most once across the batch, mirroring the
 	// listing path (#677).
 	ctx = withBlockerCache(ctx)
-	states := make(map[string]tracker.IssueState, len(issueRefs))
-	seen := map[string]struct{}{}
-	for _, issueRef := range issueRefs {
-		issueID := strings.TrimSpace(issueRef.ID)
-		if issueID == "" {
-			continue
-		}
-		if _, ok := seen[issueID]; ok {
-			continue
-		}
-		seen[issueID] = struct{}{}
-		issueNumber, ok := c.issueNumberForStateRefresh(issueRef)
+	var refreshErrs []error
+	for _, issueRef := range refs {
+		issueID := issueRef.ID
+		issueNumber, ok, cached := c.issueNumberForStateRefresh(issueRef)
 		if !ok {
 			c.logStateRefreshCacheMiss(issueRef)
 			continue
 		}
-		issue, found, err := c.getIssueByNumber(ctx, issueNumber)
+		if !giteaIssueRefMatchesNumber(issueRef, issueNumber) {
+			continue
+		}
+		issue, found, bodyPresent, err := c.getIssueStateByNumber(ctx, issueNumber)
 		if err != nil {
-			return nil, err
+			refreshErrs = append(refreshErrs, err)
+			if tracker.ShouldStopIssueStateRefresh(ctx, err) {
+				break
+			}
+			continue
 		}
 		if !found {
+			if cached {
+				states[issueID] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeAbsent}
+			}
+			continue
+		}
+		if issue.Number != issueNumber {
 			continue
 		}
 		if !giteaIssueMatchesRef(issueID, issueRef.Identifier, issue) {
-			c.cacheIssueNumber(issue)
 			continue
 		}
 		c.cacheIssueNumber(issue)
 		state, diagnostics := IssueStateFromLabels(issue.Labels, DefaultStateLabelMappings())
 		c.logDiagnostics(issue, diagnostics)
-		if state == "" {
+		if strings.EqualFold(strings.TrimSpace(state), "Todo") && !bodyPresent {
+			refreshErrs = append(refreshErrs, fmt.Errorf("%w: Gitea Todo issue response missing body", tracker.ErrIssueStateRefreshIncomplete))
 			continue
 		}
-		// Carry the full label set (SPEC §6.4 required_labels gate) alongside the
-		// derived state; extractGiteaLabels lowercases/trims to match the gate.
-		// BlockedBy is re-derived from the refreshed body so dispatch-time
-		// revalidation can re-apply the SPEC §8.2 Todo blocker gate (#750);
-		// the body is authoritative for this adapter, so an absence of
-		// `Depends on #N` references is a positive non-nil "no blockers" and
-		// transiently-unresolvable references fail closed as open
-		// placeholders inside buildBlockedBy.
-		blockedBy := c.buildBlockedBy(ctx, issue.Body)
-		if blockedBy == nil {
-			blockedBy = []tracker.BlockerRef{}
+		if state == "" {
+			if stateDiagnosticsContain(diagnostics, "unknown_aiops_label") {
+				continue
+			}
+			// A matching issue with no aiops/* workflow label is authoritatively
+			// outside this adapter's workflow and must release continuations.
+			states[issueID] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeAbsent}
+			continue
 		}
-		states[issueID] = tracker.IssueState{State: state, Labels: extractGiteaLabels(issue.Labels), BlockedBy: blockedBy}
+		refreshed, err := c.buildRefreshedIssueState(ctx, issue, state)
+		if err != nil {
+			refreshErrs = append(refreshErrs, err)
+			if tracker.ShouldStopIssueStateRefresh(ctx, err) {
+				break
+			}
+			continue
+		}
+		states[issueID] = refreshed
 	}
-	return states, nil
+	return states, errors.Join(refreshErrs...)
+}
+
+// buildRefreshedIssueState carries the full normalized label set and refreshed
+// blockers onto an authoritative Current row. The issue body is authoritative
+// for this adapter, so no `Depends on #N` references becomes a positive non-nil
+// "no blockers" result; transient resolution failures become open placeholders
+// inside buildBlockedBy.
+func (c *TrackerClient) buildRefreshedIssueState(ctx context.Context, issue Issue, state string) (tracker.IssueState, error) {
+	blockedBy, err := c.buildBlockedBy(ctx, issue.Body, blockerLookupHaltRefresh)
+	if err != nil {
+		return tracker.IssueState{}, err
+	}
+	if blockedBy == nil {
+		blockedBy = []tracker.BlockerRef{}
+	}
+	return tracker.IssueState{
+		Outcome:   tracker.IssueStateOutcomeCurrent,
+		State:     state,
+		Labels:    extractGiteaLabels(issue.Labels),
+		BlockedBy: blockedBy,
+	}, nil
+}
+
+func stateDiagnosticsContain(diagnostics []StateDiagnostic, code string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func giteaIssueMatchesRef(issueID, identifier string, issue Issue) bool {
 	issueID = strings.TrimSpace(issueID)
-	if issueID == giteaIssueID(issue) {
-		return true
-	}
 	if !giteaIdentifierMatchesIssueNumber(identifier, issue.Number) {
 		return false
+	}
+	if issueID == giteaIssueID(issue) {
+		return true
 	}
 	if strings.HasPrefix(issueID, "#") {
 		return issueID == fmt.Sprintf("#%d", issue.Number)
 	}
 	return issueID == giteaIssueNumberID(issue.Number)
+}
+
+func giteaIssueRefMatchesNumber(ref tracker.IssueRef, issueNumber int) bool {
+	identifier := strings.TrimSpace(ref.Identifier)
+	if identifier != "" {
+		got, ok := giteaIssueNumberFromIdentifier(identifier)
+		if !ok || got != issueNumber {
+			return false
+		}
+	}
+	id := strings.TrimSpace(ref.ID)
+	if !strings.HasPrefix(id, "#") {
+		return true
+	}
+	got, ok := giteaIssueNumberFromIdentifier(id)
+	return ok && got == issueNumber
 }
 
 func giteaIdentifierMatchesIssueNumber(identifier string, issueNumber int) bool {
@@ -107,11 +170,12 @@ func giteaIssueNumberID(issueNumber int) string {
 	return strconv.Itoa(issueNumber)
 }
 
-func (c *TrackerClient) issueNumberForStateRefresh(ref tracker.IssueRef) (int, bool) {
+func (c *TrackerClient) issueNumberForStateRefresh(ref tracker.IssueRef) (int, bool, bool) {
 	if issueNumber, ok := c.cachedIssueNumber(ref.ID); ok {
-		return issueNumber, true
+		return issueNumber, true, true
 	}
-	return IssueNumberFromRef(ref.ID, ref.Identifier)
+	issueNumber, ok := IssueNumberFromRef(ref.ID, ref.Identifier)
+	return issueNumber, ok, false
 }
 
 // IssueNumberFromRef derives a Gitea issue number from a tracker issue
@@ -149,32 +213,72 @@ func giteaIssueNumberFromIdentifier(identifier string) (int, bool) {
 }
 
 func (c *TrackerClient) getIssueByNumber(ctx context.Context, issueNumber int) (Issue, bool, error) {
+	issue, found, _, err := c.getIssueByNumberWithMetadata(ctx, issueNumber)
+	return issue, found, err
+}
+
+func (c *TrackerClient) getIssueStateByNumber(ctx context.Context, issueNumber int) (Issue, bool, bool, error) {
+	return c.getIssueByNumberWithMetadata(ctx, issueNumber)
+}
+
+func (c *TrackerClient) getIssueByNumberWithMetadata(ctx context.Context, issueNumber int) (Issue, bool, bool, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/repos/%s/%s/issues/%d", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo), issueNumber)
 	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return Issue{}, false, err
+		return Issue{}, false, false, err
 	}
 	req.Header.Set("Authorization", "token "+c.Token)
 	client := c.httpClient()
 	resp, err := client.Do(req)
 	if err != nil {
-		return Issue{}, false, err
+		return Issue{}, false, false, err
 	}
 	defer tracker.DrainAndClose(resp)
 	if resp.StatusCode == http.StatusNotFound {
-		return Issue{}, false, nil
+		return Issue{}, false, false, nil
 	}
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return Issue{}, false, tracker.NewRateLimitedError(fmt.Sprintf("get Gitea issue #%d", issueNumber), resp.StatusCode, resp.Header)
+		return Issue{}, false, false, tracker.NewRateLimitedError(fmt.Sprintf("get Gitea issue #%d", issueNumber), resp.StatusCode, resp.Header)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return Issue{}, false, fmt.Errorf("get Gitea issue #%d failed: status %d", issueNumber, resp.StatusCode)
+		return Issue{}, false, false, fmt.Errorf("get Gitea issue #%d failed: status %d", issueNumber, resp.StatusCode)
 	}
-	var issue Issue
-	if err := tracker.DecodeJSONResponse(resp, &issue); err != nil {
+	issue, bodyPresent, err := decodeGiteaIssueStateResponse(resp)
+	if err != nil {
+		return Issue{}, false, false, err
+	}
+	return issue, true, bodyPresent, nil
+}
+
+func decodeGiteaIssueStateResponse(resp *http.Response) (Issue, bool, error) {
+	var raw json.RawMessage
+	if err := tracker.DecodeJSONResponse(resp, &raw); err != nil {
 		return Issue{}, false, fmt.Errorf("decode Gitea issue response: %w", err)
 	}
-	return issue, true, nil
+	var presence struct {
+		ID     *int64  `json:"id"`
+		Number *int    `json:"number"`
+		Body   *string `json:"body"`
+		Labels *[]struct {
+			Name *string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal(raw, &presence); err != nil {
+		return Issue{}, false, fmt.Errorf("decode Gitea issue response: %w", err)
+	}
+	if presence.ID == nil || *presence.ID <= 0 || presence.Number == nil || *presence.Number <= 0 || presence.Labels == nil {
+		return Issue{}, false, fmt.Errorf("%w: Gitea issue response has incomplete id, number, or labels", tracker.ErrIssueStateRefreshIncomplete)
+	}
+	for _, label := range *presence.Labels {
+		if label.Name == nil || strings.TrimSpace(*label.Name) == "" {
+			return Issue{}, false, fmt.Errorf("%w: Gitea issue label missing non-empty name", tracker.ErrIssueStateRefreshIncomplete)
+		}
+	}
+	var issue Issue
+	if err := json.Unmarshal(raw, &issue); err != nil {
+		return Issue{}, false, fmt.Errorf("decode Gitea issue response: %w", err)
+	}
+	return issue, presence.Body != nil, nil
 }

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -16,6 +17,19 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
 )
+
+type giteaPathErrorTransport struct {
+	base http.RoundTripper
+	path string
+	err  error
+}
+
+func (t giteaPathErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path == t.path {
+		return nil, t.err
+	}
+	return t.base.RoundTrip(req)
+}
 
 func TestTrackerClientSatisfiesIssueStateRefresher(t *testing.T) {
 	var _ tracker.IssueStateRefresher = (*TrackerClient)(nil)
@@ -143,14 +157,320 @@ func TestTrackerClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIDs: %v", err)
 	}
-	if got, want := states, map[string]string{"101": "Done"}; len(got) != len(want) || got["101"].State != want["101"] {
-		t.Fatalf("states = %#v, want %#v", got, want)
+	if len(states) != 2 || states["101"].Outcome != tracker.IssueStateOutcomeCurrent || states["101"].State != "Done" || states["202"].Outcome != tracker.IssueStateOutcomeAbsent {
+		t.Fatalf("states = %#v; want current 101 and absent 202", states)
 	}
 	if got, want := states["101"].Labels, []string{"aiops/done", "aiops-ready"}; !slices.Equal(got, want) {
 		t.Fatalf("FetchIssueStatesByIDs(101).Labels = %v; want %v", got, want)
 	}
 	if got, want := strings.Join(requestedPaths, ","), "/api/v1/repos/owner/repo/issues,/api/v1/repos/owner/repo/issues/1,/api/v1/repos/owner/repo/issues/2"; got != want {
 		t.Fatalf("requested paths = %s, want %s", got, want)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesByRefsOutcomeMatrixAndPartialError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/1":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 101, Number: 1, Labels: []Label{{Name: "aiops/done"}}})
+		case "/api/v1/repos/owner/repo/issues/2":
+			http.NotFound(w, r)
+		case "/api/v1/repos/owner/repo/issues/3":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 999, Number: 3, Labels: []Label{{Name: "aiops/todo"}}})
+		case "/api/v1/repos/owner/repo/issues/4":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 404, Number: 4, Labels: []Label{{Name: "ready"}}})
+		case "/api/v1/repos/owner/repo/issues/5":
+			http.Error(w, "boom", http.StatusInternalServerError)
+		case "/api/v1/repos/owner/repo/issues/6":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 606, Number: 6, Labels: []Label{{Name: "aiops/done"}}})
+		case "/api/v1/repos/owner/repo/issues/7":
+			http.NotFound(w, r)
+		default:
+			t.Fatalf("request path = %q; want one of issue endpoints #1 through #7", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	client.issueNumbers.Store("202", 2)
+	refs := []tracker.IssueRef{
+		{ID: "101", Identifier: "#1"},
+		{ID: "202", Identifier: "#2"},
+		{ID: "opaque"},
+		{ID: "#bad"},
+		{ID: "303", Identifier: "#3"},
+		{ID: "404", Identifier: "#4"},
+		{ID: "505", Identifier: "#5"},
+		{ID: "606", Identifier: "#6"},
+		{ID: "707", Identifier: "#7"},
+		{ID: "101", Identifier: "#1"},
+		{},
+	}
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), refs)
+	if err == nil {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want HTTP 500", err)
+	}
+	want := map[string]tracker.IssueStateOutcome{
+		"101":    tracker.IssueStateOutcomeCurrent,
+		"202":    tracker.IssueStateOutcomeAbsent,
+		"opaque": tracker.IssueStateOutcomeUnknown,
+		"#bad":   tracker.IssueStateOutcomeUnknown,
+		"303":    tracker.IssueStateOutcomeUnknown,
+		"404":    tracker.IssueStateOutcomeAbsent,
+		"505":    tracker.IssueStateOutcomeUnknown,
+		"606":    tracker.IssueStateOutcomeCurrent,
+		"707":    tracker.IssueStateOutcomeUnknown,
+	}
+	if len(states) != len(want) {
+		t.Fatalf("states len = %d; want %d: %#v", len(states), len(want), states)
+	}
+	for id, outcome := range want {
+		if got := states[id].Outcome; got != outcome {
+			t.Fatalf("states[%q].Outcome = %v; want %v (row=%#v)", id, got, outcome, states[id])
+		}
+	}
+}
+
+func TestTrackerClientFetchIssueStatesPayloadNumberMismatchStaysUnknown(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Issue{ID: 101, Number: 2, Labels: []Label{{Name: "aiops/done"}}})
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	client.issueNumbers.Store("101", 1)
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "101", Identifier: "#1"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil", err)
+	}
+	if got := states["101"].Outcome; got != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("outcome = %v; want unknown for payload number mismatch", got)
+	}
+	if number, ok := client.cachedIssueNumber("101"); !ok || number != 1 {
+		t.Fatalf("cached issue number = %d, %v; want original 1 preserved", number, ok)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesPartialPayloadAndEmptyLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     string
+		wantOutcome tracker.IssueStateOutcome
+		wantErr     bool
+	}{
+		{name: "missing id", payload: `{"number":1,"body":"","labels":[]}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "zero id", payload: `{"id":0,"number":1,"body":"","labels":[]}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "missing number", payload: `{"id":101,"body":"","labels":[]}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "zero number", payload: `{"id":101,"number":0,"body":"","labels":[]}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "missing labels", payload: `{"id":101,"number":1,"body":""}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "null labels", payload: `{"id":101,"number":1,"body":"","labels":null}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "label missing name", payload: `{"id":101,"number":1,"body":"","labels":[{}]}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "label null name", payload: `{"id":101,"number":1,"body":"","labels":[{"name":null}]}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "label empty name", payload: `{"id":101,"number":1,"body":"","labels":[{"name":"  "}]}`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "empty labels", payload: `{"id":101,"number":1,"body":"","labels":[]}`, wantOutcome: tracker.IssueStateOutcomeAbsent},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.payload)
+			}))
+			defer server.Close()
+			client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+			client.HTTP = server.Client()
+			client.issueNumbers.Store("101", 1)
+
+			states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"101"})
+			if tc.wantErr && !errors.Is(err, tracker.ErrIssueStateRefreshIncomplete) {
+				t.Fatalf("FetchIssueStatesByIDs error = %v; want typed incomplete response", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("FetchIssueStatesByIDs() error = %v; want nil", err)
+			}
+			if got := states["101"].Outcome; got != tc.wantOutcome {
+				t.Fatalf("outcome = %v; want %v", got, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+func TestTrackerClientFetchIssueStatesTodoRequiresBodyKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantOutcome tracker.IssueStateOutcome
+		wantErr     bool
+	}{
+		{name: "missing body", body: ``, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "null body", body: `,"body":null`, wantOutcome: tracker.IssueStateOutcomeUnknown, wantErr: true},
+		{name: "empty body", body: `,"body":""`, wantOutcome: tracker.IssueStateOutcomeCurrent},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"id":101,"number":1,"labels":[{"name":"aiops/todo"}]`+tc.body+`}`)
+			}))
+			defer server.Close()
+			client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+			client.HTTP = server.Client()
+
+			states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "101", Identifier: "#1"}})
+			if tc.wantErr && !errors.Is(err, tracker.ErrIssueStateRefreshIncomplete) {
+				t.Fatalf("FetchIssueStatesByRefs error = %v; want typed incomplete body", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil", err)
+			}
+			if got := states["101"].Outcome; got != tc.wantOutcome {
+				t.Fatalf("outcome = %v; want %v", got, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+func TestTrackerClientFetchIssueStatesIncompletePayloadPreservesLaterCurrent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/1":
+			_, _ = io.WriteString(w, `{"id":101,"number":1}`)
+		case "/api/v1/repos/owner/repo/issues/2":
+			_, _ = io.WriteString(w, `{"id":202,"number":2,"labels":[{"name":"aiops/done"}]}`)
+		default:
+			t.Fatalf("request path = %q; want issue endpoint #1 or #2", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "101", Identifier: "#1"}, {ID: "202", Identifier: "#2"}})
+	if !errors.Is(err, tracker.ErrIssueStateRefreshIncomplete) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want typed incomplete response", err)
+	}
+	if states["101"].Outcome != tracker.IssueStateOutcomeUnknown || states["202"].Outcome != tracker.IssueStateOutcomeCurrent {
+		t.Fatalf("states = %#v; want incomplete row unknown and later clean row current", states)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesRateLimitStopsLaterRefs(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "101", Identifier: "#1"}, {ID: "202", Identifier: "#2"}})
+	if !errors.Is(err, tracker.ErrRateLimited) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want typed rate limit", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d; want stop after first rate limit", requests)
+	}
+	if states["101"].Outcome != tracker.IssueStateOutcomeUnknown || states["202"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want both refs unknown", states)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesRequestDeadlineStopsLaterRefs(t *testing.T) {
+	serverRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		serverRequests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":202,"number":2,"labels":[{"name":"aiops/done"}]}`)
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = &http.Client{Transport: giteaPathErrorTransport{
+		base: server.Client().Transport,
+		path: "/api/v1/repos/owner/repo/issues/1",
+		err:  context.DeadlineExceeded,
+	}}
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "101", Identifier: "#1"}, {ID: "202", Identifier: "#2"}})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want request deadline", err)
+	}
+	if serverRequests != 0 {
+		t.Fatalf("server requests = %d; want no second lookup after request deadline", serverRequests)
+	}
+	if states["101"].Outcome != tracker.IssueStateOutcomeUnknown || states["202"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want both refs unknown", states)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesUnknownForUnknownAiopsLabel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/owner/repo/issues/8" {
+			t.Fatalf("request path = %q; want issue 8", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Issue{ID: 808, Number: 8, Labels: []Label{{Name: "aiops/future-state"}}})
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "808", Identifier: "#8"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil", err)
+	}
+	if got := states["808"].Outcome; got != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("outcome = %v; want unknown for unrecognized aiops/* workflow label", got)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesUnknownForInconsistentCachedRefOutcome(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+	tests := []struct {
+		name string
+		ref  tracker.IssueRef
+	}{
+		{name: "conflicting identifier", ref: tracker.IssueRef{ID: "101", Identifier: "#2"}},
+		{name: "malformed identifier", ref: tracker.IssueRef{ID: "101", Identifier: "not-a-number"}},
+		{name: "number id conflicts with identifier", ref: tracker.IssueRef{ID: "#1", Identifier: "#2"}},
+		{name: "number id conflicts with cache", ref: tracker.IssueRef{ID: "#2"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client.issueNumbers.Store(tc.ref.ID, 1)
+			states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{tc.ref})
+			if err != nil {
+				t.Fatalf("FetchIssueStatesByRefs(%+v) error = %v; want nil", tc.ref, err)
+			}
+			if got := states[tc.ref.ID].Outcome; got != tracker.IssueStateOutcomeUnknown {
+				t.Fatalf("outcome = %v; want unknown for inconsistent cached ref", got)
+			}
+		})
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d; want inconsistent refs rejected before network lookup", requests)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesUnknownOnConfigurationFailure(t *testing.T) {
+	client := NewTrackerClient(workflow.TrackerConfig{}, "", "", "")
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"1", "2", "1", ""})
+	if err == nil {
+		t.Fatal("FetchIssueStatesByIDs error = nil; want configuration error")
+	}
+	if len(states) != 2 || states["1"].Outcome != tracker.IssueStateOutcomeUnknown || states["2"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want explicit unknown rows for configuration failure", states)
 	}
 }
 
@@ -213,8 +533,8 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs wrong ID: %v", err)
 	}
-	if len(states) != 0 {
-		t.Fatalf("states for mismatched issue id = %#v, want empty", states)
+	if len(states) != 1 || states["other-global-id"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states for mismatched issue id = %#v; want explicit unknown", states)
 	}
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "#7"}})
 	if err != nil {
@@ -227,8 +547,8 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs mismatched #number ID: %v", err)
 	}
-	if len(states) != 0 {
-		t.Fatalf("states for mismatched #number ID = %#v, want empty", states)
+	if len(states) != 1 || states["#8"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states for mismatched #number ID = %#v; want explicit unknown", states)
 	}
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "7", Identifier: "#7"}})
 	if err != nil {
@@ -241,24 +561,24 @@ func TestTrackerClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs mismatched numeric fallback ID: %v", err)
 	}
-	if len(states) != 0 {
-		t.Fatalf("states for mismatched numeric fallback ID = %#v, want empty", states)
+	if len(states) != 1 || states["5"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states for mismatched numeric fallback ID = %#v; want explicit unknown", states)
 	}
 	client.cacheIssueNumber(Issue{ID: 5, Number: 5})
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "5", Identifier: "#7"}})
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs cached mismatched numeric fallback ID: %v", err)
 	}
-	if len(states) != 0 {
-		t.Fatalf("states for cached mismatched numeric fallback ID = %#v, want empty", states)
+	if len(states) != 1 || states["5"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states for cached mismatched numeric fallback ID = %#v; want explicit unknown", states)
 	}
 	client.cacheIssueNumber(Issue{ID: 555, Number: 5})
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{{ID: "555", Identifier: "#7"}})
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs cached global ID with stale identifier: %v", err)
 	}
-	if got := states["555"].State; got != "Done" {
-		t.Fatalf("cached global ID state = %q, want Done", got)
+	if got := states["555"].Outcome; got != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("cached global ID outcome = %v; want unknown for stale identifier", got)
 	}
 	states, err = client.FetchIssueStatesByIDs(context.Background(), []string{"987654"})
 	if err != nil {
@@ -937,11 +1257,14 @@ func TestCachedIssueByNumberNilCacheFallsBackToDirectFetch(t *testing.T) {
 	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
 	client.HTTP = server.Client()
 
-	issue, found, resolved := client.cachedIssueByNumber(context.Background(), nil, 3)
+	issue, found, resolved, err := client.cachedIssueByNumber(context.Background(), nil, 3)
+	if err != nil {
+		t.Fatalf("cachedIssueByNumber(nil cache, 3) error = %v; want nil", err)
+	}
 	if !found || !resolved || issue.Number != 3 {
 		t.Fatalf("cachedIssueByNumber(nil cache, 3) = (%#v, %v, %v); want issue #3, true, true", issue, found, resolved)
 	}
-	if _, found, _ = client.cachedIssueByNumber(context.Background(), nil, 3); !found {
+	if _, found, _, err = client.cachedIssueByNumber(context.Background(), nil, 3); err != nil || !found {
 		t.Fatalf("cachedIssueByNumber(nil cache, 3) second call found = false; want true")
 	}
 	if blockerFetches != 2 {
@@ -999,6 +1322,59 @@ func TestTrackerClientListIssuesByStatesRetriesBlockerAfterTransientError(t *tes
 	}
 	if placeholders != 1 || resolved != 1 {
 		t.Fatalf("blocker #3 carried as placeholder=%d resolved=%d; want 1 fail-closed placeholder (errored source) and 1 resolved (retried source)", placeholders, resolved)
+	}
+}
+
+func TestTrackerClientListActiveIssuesKeepsIssueOnBlockerGlobalFailure(t *testing.T) {
+	tests := []struct {
+		name           string
+		blockerStatus  int
+		blockerRequest error
+	}{
+		{name: "rate limit", blockerStatus: http.StatusTooManyRequests},
+		{name: "request deadline", blockerRequest: context.DeadlineExceeded},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v1/repos/owner/repo/issues":
+					_ = json.NewEncoder(w).Encode([]Issue{{
+						ID: 101, Number: 1, Title: "blocked todo", Body: "Depends on #9",
+						HTMLURL: "https://gitea.local/owner/repo/issues/1",
+						Labels:  []Label{{Name: "aiops/todo"}},
+					}})
+				case "/api/v1/repos/owner/repo/issues/9":
+					w.WriteHeader(tc.blockerStatus)
+				default:
+					t.Fatalf("request path for %q = %q; want listing or blocker endpoint", tc.name, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret", ActiveStates: []string{"Todo"}}, server.URL, "owner", "repo")
+			client.HTTP = server.Client()
+			if tc.blockerRequest != nil {
+				client.HTTP = &http.Client{Transport: giteaPathErrorTransport{
+					base: server.Client().Transport,
+					path: "/api/v1/repos/owner/repo/issues/9",
+					err:  tc.blockerRequest,
+				}}
+			}
+
+			issues, err := client.ListActiveIssues(context.Background())
+			if err != nil {
+				t.Fatalf("ListActiveIssues(%q) error = %v; want nil", tc.name, err)
+			}
+			if len(issues) != 1 {
+				t.Fatalf("ListActiveIssues(%q) issue count = %d; want 1", tc.name, len(issues))
+			}
+			want := []tracker.BlockerRef{{Identifier: "#9"}}
+			if !slices.Equal(issues[0].BlockedBy, want) {
+				t.Fatalf("ListActiveIssues(%q) BlockedBy = %#v; want %#v", tc.name, issues[0].BlockedBy, want)
+			}
+		})
 	}
 }
 
@@ -1072,7 +1448,7 @@ func TestTrackerClientFetchIssueStatesByRefsCarriesRefreshedBlockers(t *testing.
 		{ID: "444", Identifier: "#4"},
 	})
 	if err != nil {
-		t.Fatalf("FetchIssueStatesByRefs: %v", err)
+		t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil", err)
 	}
 	blocked := states["555"].BlockedBy
 	if len(blocked) != 1 || blocked[0].ID != "999" || blocked[0].Identifier != "#9" || blocked[0].State != "In Progress" {
@@ -1102,6 +1478,116 @@ func TestTrackerClientFetchIssueStatesByRefsCarriesRefreshedBlockers(t *testing.
 	terminalMixed := states["444"].BlockedBy
 	if len(terminalMixed) != 2 || terminalMixed[0].Identifier != "#10" || terminalMixed[0].State != "Done" || terminalMixed[1].Identifier != "#99" || terminalMixed[1].State != "" {
 		t.Fatalf("FetchIssueStatesByRefs(444).BlockedBy = %#v; want resolved #10 (Done) plus the #99 placeholder", terminalMixed)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesBlockerRateLimitStopsLaterRefs(t *testing.T) {
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/5":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 555, Number: 5, Body: "Depends on #9", Labels: []Label{{Name: "aiops/todo"}}})
+		case "/api/v1/repos/owner/repo/issues/9":
+			w.WriteHeader(http.StatusTooManyRequests)
+		case "/api/v1/repos/owner/repo/issues/6":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 666, Number: 6, Labels: []Label{{Name: "aiops/done"}}})
+		default:
+			t.Fatalf("request path = %q; want issue endpoint #5, #6, or blocker #9", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{
+		{ID: "555", Identifier: "#5"},
+		{ID: "666", Identifier: "#6"},
+	})
+	if !errors.Is(err, tracker.ErrRateLimited) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want blocker rate limit", err)
+	}
+	if slices.Contains(requestedPaths, "/api/v1/repos/owner/repo/issues/6") {
+		t.Fatalf("requested paths = %v; want later source #6 skipped after blocker rate limit", requestedPaths)
+	}
+	if states["555"].Outcome != tracker.IssueStateOutcomeUnknown || states["666"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want current and later refs unknown after blocker rate limit", states)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesBlockerDeadlineStopsLaterRefs(t *testing.T) {
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/5":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 555, Number: 5, Body: "Depends on #9", Labels: []Label{{Name: "aiops/todo"}}})
+		case "/api/v1/repos/owner/repo/issues/6":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 666, Number: 6, Labels: []Label{{Name: "aiops/done"}}})
+		default:
+			t.Fatalf("request path = %q; want source issue endpoint #5 or #6", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = &http.Client{Transport: giteaPathErrorTransport{
+		base: server.Client().Transport,
+		path: "/api/v1/repos/owner/repo/issues/9",
+		err:  context.DeadlineExceeded,
+	}}
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{
+		{ID: "555", Identifier: "#5"},
+		{ID: "666", Identifier: "#6"},
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want blocker request deadline", err)
+	}
+	if len(requestedPaths) != 1 || requestedPaths[0] != "/api/v1/repos/owner/repo/issues/5" {
+		t.Fatalf("requested paths = %v; want only source #5 before blocker deadline", requestedPaths)
+	}
+	if states["555"].Outcome != tracker.IssueStateOutcomeUnknown || states["666"].Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want current and later refs unknown after blocker deadline", states)
+	}
+}
+
+func TestTrackerClientFetchIssueStatesBlockerNumberMismatchFailsClosedWithoutCaching(t *testing.T) {
+	blockerFetches := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/5":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 555, Number: 5, Body: "Depends on #9", Labels: []Label{{Name: "aiops/todo"}}})
+		case "/api/v1/repos/owner/repo/issues/6":
+			_ = json.NewEncoder(w).Encode(Issue{ID: 666, Number: 6, Body: "Depends on #9", Labels: []Label{{Name: "aiops/todo"}}})
+		case "/api/v1/repos/owner/repo/issues/9":
+			blockerFetches++
+			_ = json.NewEncoder(w).Encode(Issue{ID: 999, Number: 99, Labels: []Label{{Name: "aiops/done"}}})
+		default:
+			t.Fatalf("request path = %q; want issue endpoint #5, #6, or blocker #9", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+	client.HTTP = server.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{
+		{ID: "555", Identifier: "#5"},
+		{ID: "666", Identifier: "#6"},
+	})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil", err)
+	}
+	if blockerFetches != 2 {
+		t.Fatalf("blocker #9 fetches = %d; want 2 because mismatched #99 payload must not be cached", blockerFetches)
+	}
+	for _, id := range []string{"555", "666"} {
+		got := states[id]
+		if got.Outcome != tracker.IssueStateOutcomeCurrent || len(got.BlockedBy) != 1 || got.BlockedBy[0].Identifier != "#9" || got.BlockedBy[0].State != "" {
+			t.Fatalf("states[%s] = %#v; want current Todo with fail-closed #9 placeholder", id, got)
+		}
 	}
 }
 

--- a/internal/gitea/tracker_client_test.go
+++ b/internal/gitea/tracker_client_test.go
@@ -1481,6 +1481,63 @@ func TestTrackerClientFetchIssueStatesByRefsCarriesRefreshedBlockers(t *testing.
 	}
 }
 
+func TestTrackerClientFetchIssueStatesNonTodoSkipsBlockerLookupFailure(t *testing.T) {
+	tests := []struct {
+		name           string
+		blockerStatus  int
+		blockerRequest error
+	}{
+		{name: "rate limit", blockerStatus: http.StatusTooManyRequests},
+		{name: "request deadline", blockerRequest: context.DeadlineExceeded},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestedPaths []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestedPaths = append(requestedPaths, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v1/repos/owner/repo/issues/5":
+					_ = json.NewEncoder(w).Encode(Issue{ID: 555, Number: 5, Body: "Depends on #9", Labels: []Label{{Name: "aiops/in-progress"}}})
+				case "/api/v1/repos/owner/repo/issues/9":
+					w.WriteHeader(tc.blockerStatus)
+				case "/api/v1/repos/owner/repo/issues/6":
+					_ = json.NewEncoder(w).Encode(Issue{ID: 666, Number: 6, Labels: []Label{{Name: "aiops/done"}}})
+				default:
+					t.Fatalf("request path = %q; want source issue #5/#6 or blocker #9", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+			client := NewTrackerClient(workflow.TrackerConfig{APIKey: "secret"}, server.URL, "owner", "repo")
+			client.HTTP = server.Client()
+			if tc.blockerRequest != nil {
+				client.HTTP = &http.Client{Transport: giteaPathErrorTransport{
+					base: server.Client().Transport,
+					path: "/api/v1/repos/owner/repo/issues/9",
+					err:  tc.blockerRequest,
+				}}
+			}
+
+			states, err := client.FetchIssueStatesByRefs(context.Background(), []tracker.IssueRef{
+				{ID: "555", Identifier: "#5"},
+				{ID: "666", Identifier: "#6"},
+			})
+			if err != nil {
+				t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil without non-Todo blocker lookup", err)
+			}
+			if slices.Contains(requestedPaths, "/api/v1/repos/owner/repo/issues/9") {
+				t.Fatalf("requested paths = %v; want no blocker lookup for non-Todo source", requestedPaths)
+			}
+			if got := states["555"]; got.Outcome != tracker.IssueStateOutcomeCurrent || got.State != "In Progress" || got.BlockedBy != nil {
+				t.Fatalf("states[555] = %#v; want current In Progress with nil blocker knowledge", got)
+			}
+			if got := states["666"]; got.Outcome != tracker.IssueStateOutcomeCurrent || got.State != "Done" {
+				t.Fatalf("states[666] = %#v; want later Done row current", got)
+			}
+		})
+	}
+}
+
 func TestTrackerClientFetchIssueStatesBlockerRateLimitStopsLaterRefs(t *testing.T) {
 	var requestedPaths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/orchestrator/actor_cleanup.go
+++ b/internal/orchestrator/actor_cleanup.go
@@ -176,7 +176,7 @@ func (o *Orchestrator) runReconciledWorkspaceCleanup(w ReconciledWorkspace, cont
 
 // runReconciledWorkspaceCleanupAttempt is one pass of the deletion-time recheck.
 // attempt is 0 for the initial pass and N for the Nth backed-off retry after a
-// failed or absent tracker state refresh; on an unknown refresh it schedules the
+// failed or unknown tracker state refresh; on an unknown refresh it schedules the
 // next attempt through retryReconciledWorkspaceCleanup (exponential backoff +
 // give-up bound) instead of re-probing on a fixed interval forever (#675).
 func (o *Orchestrator) runReconciledWorkspaceCleanupAttempt(w ReconciledWorkspace, continuation *continuationAfterSkippedCleanup, attempt int) {
@@ -192,16 +192,22 @@ func (o *Orchestrator) runReconciledWorkspaceCleanupAttempt(w ReconciledWorkspac
 		return
 	}
 	defer o.endReconcileWorkspaceCleanup(w.IssueID)
-	currentState, terminal, known := o.verifyReconciledWorkspaceStillTerminal(w)
-	if !known {
+	currentState, verdict := o.verifyReconciledWorkspaceStillTerminal(w)
+	switch verdict {
+	case reconciledWorkspaceStateUnknown:
 		o.retryReconciledWorkspaceCleanup(w, continuation, attempt+1)
 		return
-	}
-	if !terminal {
+	case reconciledWorkspaceStateAbsent:
+		return
+	case reconciledWorkspaceStateCurrentNonTerminal:
 		if o.hasOperatorTerminalStop(w.IssueID) {
 			return
 		}
 		o.continueAfterSkippedTerminalCleanup(continuation)
+		return
+	case reconciledWorkspaceStateCurrentTerminal:
+	default:
+		o.retryReconciledWorkspaceCleanup(w, continuation, attempt+1)
 		return
 	}
 	if strings.TrimSpace(currentState) != "" {
@@ -229,7 +235,7 @@ func (o *Orchestrator) continueAfterSkippedTerminalCleanup(continuation *continu
 }
 
 // retryReconciledWorkspaceCleanup reschedules the deletion-time state recheck
-// after a failed or absent tracker refresh. It uses the same exponential
+// after a failed or unknown tracker refresh. It uses the same exponential
 // backoff as the failure-retry path (RetryScheduler.NextDelay with
 // RetryKindFailure) so a persistently unavailable tracker is probed on a growing
 // interval rather than every fixed second, and it gives up after
@@ -266,26 +272,52 @@ func (o *Orchestrator) retryReconciledWorkspaceCleanup(w ReconciledWorkspace, co
 		}
 	})
 }
-func (o *Orchestrator) verifyReconciledWorkspaceStillTerminal(w ReconciledWorkspace) (string, bool, bool) {
+
+type reconciledWorkspaceStateVerdict uint8
+
+const (
+	reconciledWorkspaceStateUnknown reconciledWorkspaceStateVerdict = iota
+	reconciledWorkspaceStateCurrentTerminal
+	reconciledWorkspaceStateCurrentNonTerminal
+	reconciledWorkspaceStateAbsent
+)
+
+func (o *Orchestrator) verifyReconciledWorkspaceStillTerminal(w ReconciledWorkspace) (string, reconciledWorkspaceStateVerdict) {
 	resolver, terminalStates := o.currentRetryTerminalResolver()
 	if resolver == nil || len(terminalStates) == 0 {
-		return w.State, true, true
+		return w.State, reconciledWorkspaceStateCurrentTerminal
 	}
 	ctx, cancel := context.WithTimeout(o.runCtx, terminalCleanupStateFetchTimeout)
 	defer cancel()
 	states, err := fetchIssueStates(ctx, resolver, []tracker.IssueRef{{ID: string(w.IssueID), Identifier: w.Identifier}})
 	if err != nil {
 		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_refresh_failed error=%q", w.IssueID, w.Identifier, err.Error())
-		return "", false, false
+		return "", reconciledWorkspaceStateUnknown
 	}
 	st, ok := states[string(w.IssueID)]
 	if !ok {
 		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_missing", w.IssueID, w.Identifier)
-		return "", false, false
+		return "", reconciledWorkspaceStateUnknown
+	}
+	switch st.Outcome {
+	case tracker.IssueStateOutcomeUnknown:
+		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_unknown", w.IssueID, w.Identifier)
+		return "", reconciledWorkspaceStateUnknown
+	case tracker.IssueStateOutcomeAbsent:
+		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=issue_absent", w.IssueID, w.Identifier)
+		return "", reconciledWorkspaceStateAbsent
+	case tracker.IssueStateOutcomeCurrent:
+	default:
+		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_outcome_invalid outcome=%d", w.IssueID, w.Identifier, st.Outcome)
+		return "", reconciledWorkspaceStateUnknown
+	}
+	if strings.TrimSpace(st.State) == "" {
+		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_missing", w.IssueID, w.Identifier)
+		return "", reconciledWorkspaceStateUnknown
 	}
 	if !isTerminalTrackerState(st.State, terminalStates) {
 		log.Printf("event=reconcile_workspace_skip issue_id=%s issue_identifier=%s reason=state_not_terminal state=%q", w.IssueID, w.Identifier, st.State)
-		return st.State, false, true
+		return st.State, reconciledWorkspaceStateCurrentNonTerminal
 	}
-	return st.State, true, true
+	return st.State, reconciledWorkspaceStateCurrentTerminal
 }

--- a/internal/orchestrator/actor_reconcile.go
+++ b/internal/orchestrator/actor_reconcile.go
@@ -202,6 +202,29 @@ func (o *Orchestrator) ReconcileInactiveTrackerIssuesAndWait(ctx context.Context
 	return waitForReconciledWorkers(ctx, canceled, workerExitTimeout)
 }
 
+// ReconcileAbsentTrackerIssuesAndWait releases claims only for issue refs the
+// narrow tracker refresh explicitly classified Absent. Absence is not a
+// terminal observation: running work is canceled without workspace cleanup,
+// blocked work is released, and only continuation retries are released here.
+// Failure and quota retries remain owned by their SPEC section 8.4 timers.
+func (o *Orchestrator) ReconcileAbsentTrackerIssuesAndWait(ctx context.Context, absentIDs map[string]struct{}, workerExitTimeout time.Duration) error {
+	if len(absentIDs) == 0 {
+		return nil
+	}
+	reply := make(chan []*RunningEntry, 1)
+	op := &reconcileAbsentTrackerIssuesOp{o: o, absentIDs: absentIDs, result: reply}
+	if err := o.submit(ctx, op); err != nil {
+		return err
+	}
+	var canceled []*RunningEntry
+	select {
+	case canceled = <-reply:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return waitForReconciledWorkers(ctx, canceled, workerExitTimeout)
+}
+
 // refreshActiveTrackerIssuesOp refreshes RunningEntry.Issue and the matching
 // ClaimedIssues snapshot for every in-process issue observed in the active set,
 // without canceling anything. It is safe to call when the active listing may be
@@ -429,6 +452,38 @@ type reconcileInactiveTrackerIssuesOp struct {
 	result         chan<- []*RunningEntry
 }
 
+type reconcileAbsentTrackerIssuesOp struct {
+	o         *Orchestrator
+	absentIDs map[string]struct{}
+	result    chan<- []*RunningEntry
+}
+
+func (r *reconcileAbsentTrackerIssuesOp) apply(st *OrchestratorState) func() {
+	var canceled []*RunningEntry
+	for id, run := range st.Running {
+		if _, absent := r.absentIDs[string(id)]; !absent {
+			continue
+		}
+		st.ReleaseClaim(id)
+		run.ReconcileCancel = true
+		run.ReconcileCleanupWorkspace = false
+		run.AgentCurrentIssueHandoff = false
+		clearAgentCurrentIssueTerminalHandoff(run)
+		canceled = append(canceled, run)
+	}
+	for id := range st.Blocked {
+		if _, absent := r.absentIDs[string(id)]; absent {
+			st.ReleaseClaim(id)
+		}
+	}
+	for id, retry := range st.RetryAttempts {
+		if _, absent := r.absentIDs[string(id)]; absent && retry.Kind == RetryKindContinuation {
+			st.ReleaseClaim(id)
+		}
+	}
+	return r.o.reconcileCancelFollowup(canceled, nil, r.result)
+}
+
 // apply releases every in-process entry whose issue is observed in the inactive
 // listing, gating SPEC §18.1 workspace cleanup on a terminal transition. Each
 // per-collection helper returns what to collect: running entries are cancelled
@@ -608,47 +663,4 @@ func refreshRunningIssue(run *RunningEntry, issue tracker.Issue) {
 	// not settle; a later inactive observation must prove a fresh handoff.
 	run.AgentCurrentIssueHandoff = false
 	clearAgentCurrentIssueTerminalHandoff(run)
-}
-
-// ReleaseVanishedContinuations drops queued continuation retries whose issue a
-// clean narrow refresh was asked about but did not return (deleted, or a Gitea
-// issue whose aiops/* state labels were stripped so no state can be derived).
-// Such an issue is invisible to every listing and refresh from then on — the
-// no-information-on-absence invariant keeps the reconcile cancel paths away
-// from it by design — so without this release the continuation sits in
-// RetryAttempts/Claimed forever and the issue wedges in retrying (#740
-// review). Release-only, mirroring retryFireAfterFetchOp's absence branch
-// (#341): absence is not a terminal observation, so no workspace action.
-// Failure/quota retries are deliberately not touched — their fire path runs
-// its own candidate fetch and releases on absence — and running/blocked
-// issues are not in RetryAttempts, so a vanished ref for them is a no-op
-// here; the destructive paths keep requiring positive observations.
-func (o *Orchestrator) ReleaseVanishedContinuations(ctx context.Context, refs []tracker.IssueRef) error {
-	return o.submit(ctx, &releaseVanishedContinuationsOp{refs: refs})
-}
-
-type releaseVanishedContinuationsOp struct {
-	refs []tracker.IssueRef
-}
-
-func (r *releaseVanishedContinuationsOp) apply(st *OrchestratorState) func() {
-	for _, ref := range r.refs {
-		id := IssueID(ref.ID)
-		entry, ok := st.RetryAttempts[id]
-		if !ok || entry.Kind != RetryKindContinuation {
-			continue
-		}
-		identifier := entry.Identifier
-		if identifier == "" {
-			identifier = ref.Identifier
-		}
-		st.ReleaseClaim(id)
-		st.RecordEvent(RuntimeEvent{
-			Kind:       RuntimeEventFailed,
-			IssueID:    id,
-			Identifier: identifier,
-			Message:    "continuation released: issue vanished from tracker refresh",
-		})
-	}
-	return nil
 }

--- a/internal/orchestrator/actor_reconcile_inactive_test.go
+++ b/internal/orchestrator/actor_reconcile_inactive_test.go
@@ -1,8 +1,7 @@
 package orchestrator
 
-// actor_reconcile_inactive_test.go pins reconcileInactiveTrackerIssuesOp release
-// behaviors the existing reconcile suite left unpinned, before #499 decomposes
-// the op's three per-collection loops into helpers. Two classes are covered:
+// actor_reconcile_inactive_test.go pins tracker-reconciliation release behavior
+// across partial inactive listings and explicit narrow-refresh absence:
 //
 //   - Partial-listing safety: an in-process entry whose issue is ABSENT from a
 //     (possibly pagination-truncated) inactive listing is "unknown", not
@@ -18,6 +17,9 @@ package orchestrator
 //     not, so gating the release behind the terminal check would slip past the
 //     suite (the helper releases via `defer st.ReleaseClaim`, which must run on
 //     the non-terminal path too).
+//
+//   - Confirmed absence: running and blocked entries plus continuation retries
+//     release without terminal cleanup; failure/quota retries remain timer-owned.
 
 import (
 	"context"
@@ -27,7 +29,156 @@ import (
 
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 )
+
+func TestReconcileAbsentTrackerIssuesWaitsForRunningWorkerDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	id := IssueID("ENG-ABSENT-RUN")
+	workerDone := make(chan struct{})
+	cancelCause := make(chan error, 1)
+	st := NewOrchestratorState(15000, 4)
+	st.BeginDispatch(id, &RunningEntry{
+		Issue:                                 tracker.Issue{ID: string(id), Identifier: "ENG-1", State: "In Progress"},
+		Identifier:                            "ENG-1",
+		Done:                                  workerDone,
+		CancelWorker:                          func(err error) { cancelCause <- err },
+		ReconcileCleanupWorkspace:             true,
+		AgentCurrentIssueHandoff:              true,
+		AgentCurrentIssueTerminalHandoff:      true,
+		AgentCurrentIssueTerminalHandoffState: "Done",
+	})
+	cleaner := &recordingWorkspaceCleaner{}
+	o := New(st, Deps{Dispatcher: &fakeDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Minute}, WorkspaceCleaner: cleaner})
+	safeGo("test.reconcile_absent_wait", func() { o.Run(ctx) })
+	if err := o.WaitStarted(ctx); err != nil {
+		t.Fatalf("WaitStarted() error = %v; want nil", err)
+	}
+
+	result := make(chan error, 1)
+	safeGo("test.reconcile_absent_call", func() {
+		result <- o.ReconcileAbsentTrackerIssuesAndWait(ctx, map[string]struct{}{string(id): {}}, time.Second)
+	})
+
+	select {
+	case got := <-cancelCause:
+		if !errors.Is(got, worker.ErrReconcileCancel) {
+			t.Fatalf("cancel cause = %v; want %v", got, worker.ErrReconcileCancel)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancel cause received = false after 1s; want true")
+	}
+	select {
+	case err := <-result:
+		t.Fatalf("ReconcileAbsentTrackerIssuesAndWait returned before Done closed with error = %v; want call blocked", err)
+	default:
+	}
+
+	close(workerDone)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("ReconcileAbsentTrackerIssuesAndWait() error = %v; want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ReconcileAbsentTrackerIssuesAndWait returned after Done closed = false after 1s; want true")
+	}
+
+	var run RunningEntry
+	var found, claimed bool
+	o.WithStateForTest(func(got *OrchestratorState) {
+		if entry := got.Running[id]; entry != nil {
+			run = *entry
+			found = true
+		}
+		_, claimed = got.Claimed[id]
+	})
+	if !found {
+		t.Fatalf("Running[%s] = nil; want non-nil until test worker finalizes", id)
+	}
+	if claimed {
+		t.Errorf("Claimed[%s] present = true; want released after confirmed absence", id)
+	}
+	if !run.ReconcileCancel || run.ReconcileCleanupWorkspace || run.AgentCurrentIssueHandoff || run.AgentCurrentIssueTerminalHandoff || run.AgentCurrentIssueTerminalHandoffState != "" {
+		t.Errorf("running reconcile flags = cancel:%v cleanup:%v handoff:%v terminal:%v state:%q; want true,false,false,false,empty",
+			run.ReconcileCancel, run.ReconcileCleanupWorkspace, run.AgentCurrentIssueHandoff,
+			run.AgentCurrentIssueTerminalHandoff, run.AgentCurrentIssueTerminalHandoffState)
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Fatalf("workspace cleanups = %+v; want none for confirmed absence", calls)
+	}
+}
+
+func TestReconcileAbsentTrackerIssuesReleasesOnlyAbsenceOwnedClaims(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	st := NewOrchestratorState(15000, 8)
+	issueFor := func(id IssueID) tracker.Issue {
+		return tracker.Issue{ID: string(id), Identifier: string(id), State: "In Progress"}
+	}
+	blockedID := IssueID("ABSENT-BLOCKED")
+	st.Blocked[blockedID] = &BlockedEntry{Issue: issueFor(blockedID), Identifier: string(blockedID)}
+	st.Claimed[blockedID] = struct{}{}
+	st.ClaimedIssues[blockedID] = issueFor(blockedID)
+
+	continuationID := IssueID("ABSENT-CONTINUATION")
+	continuationTimer := time.NewTimer(time.Hour)
+	st.ScheduleRetry(&RetryEntry{
+		Issue: issueFor(continuationID), IssueID: continuationID, Identifier: string(continuationID),
+		Kind: RetryKindContinuation, Timer: continuationTimer,
+	})
+	retainedTimers := make(map[IssueID]*time.Timer)
+	for _, tc := range []struct {
+		id   IssueID
+		kind RetryKind
+	}{
+		{id: "ABSENT-FAILURE", kind: RetryKindFailure},
+		{id: "ABSENT-CAPACITY-DEFERRED", kind: RetryKindFailure},
+		{id: "ABSENT-QUOTA", kind: RetryKindQuotaBackoff},
+		{id: "UNKNOWN-CONTINUATION", kind: RetryKindContinuation},
+	} {
+		timer := time.NewTimer(time.Hour)
+		retainedTimers[tc.id] = timer
+		st.ScheduleRetry(&RetryEntry{Issue: issueFor(tc.id), IssueID: tc.id, Identifier: string(tc.id), Kind: tc.kind, Timer: timer})
+	}
+
+	o := New(st, Deps{Dispatcher: &fakeDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Minute}})
+	safeGo("test.reconcile_absent_owned_claims", func() { o.Run(ctx) })
+	if err := o.WaitStarted(ctx); err != nil {
+		t.Fatalf("WaitStarted() error = %v; want nil", err)
+	}
+	absent := map[string]struct{}{
+		string(blockedID): {}, string(continuationID): {},
+		"ABSENT-FAILURE": {}, "ABSENT-CAPACITY-DEFERRED": {}, "ABSENT-QUOTA": {},
+	}
+	if err := o.ReconcileAbsentTrackerIssuesAndWait(ctx, absent, time.Second); err != nil {
+		t.Fatalf("ReconcileAbsentTrackerIssuesAndWait() error = %v; want nil", err)
+	}
+
+	o.WithStateForTest(func(got *OrchestratorState) {
+		for _, id := range []IssueID{blockedID, continuationID} {
+			if got.IsClaimed(id) {
+				t.Errorf("IsClaimed(%s) = true; want released", id)
+			}
+		}
+		for _, id := range []IssueID{"ABSENT-FAILURE", "ABSENT-CAPACITY-DEFERRED", "ABSENT-QUOTA", "UNKNOWN-CONTINUATION"} {
+			if !got.IsClaimed(id) || got.RetryAttempts[id] == nil {
+				t.Errorf("retry %s retained = %v claimed = %v; want both true", id, got.RetryAttempts[id] != nil, got.IsClaimed(id))
+			}
+		}
+	})
+	if continuationTimer.Stop() {
+		t.Fatal("released continuation timer active = true; want false after ReleaseClaim")
+	}
+	for id, timer := range retainedTimers {
+		if !timer.Stop() {
+			t.Errorf("retained retry timer %s was stopped; want timer ownership preserved", id)
+		}
+	}
+}
 
 // blockIssue dispatches issue and drives it to the Blocked state via an
 // input-required runtime event, returning once the actor reports it blocked.

--- a/internal/orchestrator/actor_retry.go
+++ b/internal/orchestrator/actor_retry.go
@@ -385,9 +385,10 @@ func (r *retryFireOp) fireWithCandidateFetch(entry *RetryEntry, lister ActiveIss
 // classification for a fired failure-retry whose issue is absent from the active
 // candidate set, recovering upstream handle_retry_issue_lookup's terminal branch
 // that the active-only fetch collapses into plain absence (#341). It returns
-// (true, state) only when a resolver is wired and reports a terminal state;
-// every other outcome (no resolver, fetch error, empty/non-terminal state)
-// returns (false, "") so the caller keeps the release-only default. Runs
+// (true, state) only when a resolver is wired and reports a Current terminal
+// state; every other outcome (no resolver, fetch error, Unknown, Absent,
+// empty/non-terminal state) returns (false, "") so the caller keeps the
+// release-only default. Runs
 // off-actor; the lookup gets its OWN timeout budget rather than reusing the
 // already-consumed candidate-fetch ctx, because a slow-but-successful fetch near
 // the deadline would otherwise fail this call immediately with
@@ -408,7 +409,11 @@ func resolveRetryTerminalState(o *Orchestrator, id IssueID, identifier string) (
 	if rerr != nil {
 		return false, ""
 	}
-	s := strings.TrimSpace(statesByID[string(id)].State)
+	state := statesByID[string(id)]
+	if state.Outcome != tracker.IssueStateOutcomeCurrent {
+		return false, ""
+	}
+	s := strings.TrimSpace(state.State)
 	if s == "" || !isTerminalTrackerState(s, terminalStates) {
 		return false, ""
 	}

--- a/internal/orchestrator/actor_test.go
+++ b/internal/orchestrator/actor_test.go
@@ -2682,6 +2682,25 @@ type flakyStateRefresher struct {
 	calls  int
 }
 
+type explicitOutcomeStateRefresher struct {
+	states map[string]tracker.IssueState
+	err    error
+}
+
+func (r *explicitOutcomeStateRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]tracker.IssueState, error) {
+	return r.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(ids))
+}
+
+func (r *explicitOutcomeStateRefresher) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
+	out := make(map[string]tracker.IssueState, len(refs))
+	for _, ref := range refs {
+		if state, ok := r.states[ref.ID]; ok {
+			out[ref.ID] = state
+		}
+	}
+	return out, r.err
+}
+
 func (f *flakyStateRefresher) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]tracker.IssueState, error) {
 	f.calls++
 	if f.calls == 1 {
@@ -2698,9 +2717,102 @@ func (r *redispatchDuringCleanupRefresher) FetchIssueStatesByRefs(ctx context.Co
 	r.attempted <- r.orch.RequestDispatch(ctx, r.issue, nil)
 	out := make(map[string]tracker.IssueState, len(refs))
 	for _, ref := range refs {
-		out[ref.ID] = tracker.IssueState{State: r.state}
+		out[ref.ID] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: r.state}
 	}
 	return out, nil
+}
+
+func TestReconcileWorkspaceCleanupRecheckUsesExplicitOutcome(t *testing.T) {
+	tests := []struct {
+		name        string
+		states      map[string]tracker.IssueState
+		wantRequest RetryKind
+		wantCleanup bool
+		wantRetry   bool
+	}{
+		{
+			name: "current terminal cleans",
+			states: map[string]tracker.IssueState{
+				"ENG-OUTCOME": {Outcome: tracker.IssueStateOutcomeCurrent, State: "Done"},
+			},
+			wantCleanup: true,
+		},
+		{
+			name: "current nonterminal resumes continuation",
+			states: map[string]tracker.IssueState{
+				"ENG-OUTCOME": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress"},
+			},
+			wantRequest: RetryKindContinuation,
+			wantRetry:   true,
+		},
+		{
+			name: "state-bearing unknown retries recheck",
+			states: map[string]tracker.IssueState{
+				"ENG-OUTCOME": {Outcome: tracker.IssueStateOutcomeUnknown, State: "Done"},
+			},
+			wantRequest: RetryKindFailure,
+		},
+		{
+			name: "terminal-looking invalid outcome retries recheck",
+			states: map[string]tracker.IssueState{
+				"ENG-OUTCOME": {Outcome: tracker.IssueStateOutcome(99), State: "Done"},
+			},
+			wantRequest: RetryKindFailure,
+		},
+		{
+			name:        "missing row retries recheck",
+			states:      map[string]tracker.IssueState{},
+			wantRequest: RetryKindFailure,
+		},
+		{
+			name: "state-bearing absent stops without cleanup or continuation",
+			states: map[string]tracker.IssueState{
+				"ENG-OUTCOME": {Outcome: tracker.IssueStateOutcomeAbsent, State: "Done"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheduler := &recordingScheduler{delay: time.Hour}
+			cleaner := &recordingWorkspaceCleaner{}
+			o, cancel := startActor(t, Deps{
+				Dispatcher: &fakeDispatcher{}, Scheduler: scheduler, WorkspaceCleaner: cleaner,
+			})
+			defer cancel()
+			o.SetRetryTerminalStateResolver(&explicitOutcomeStateRefresher{states: tt.states}, []string{"Done"})
+
+			issue := tracker.Issue{ID: "ENG-OUTCOME", Identifier: "ENG-OUTCOME", State: "In Progress"}
+			workspace := Workspace{Path: "/var/aiops/workspaces/acme/repo/linear_issue/ENG-OUTCOME", Root: testWorkspaceRoot}
+			continuation := &continuationAfterSkippedCleanup{
+				issue: issue, identifier: issue.Identifier, attempt: 2, continuationTurnCount: 3, workspace: workspace,
+			}
+			o.runReconciledWorkspaceCleanup(ReconciledWorkspace{
+				IssueID: IssueID(issue.ID), Identifier: issue.Identifier, Path: workspace.Path, Root: workspace.Root, State: "Done", Reason: "terminal",
+			}, continuation)
+
+			if tt.wantRequest != "" {
+				waitFor(t, func() bool { return len(scheduler.snapshotRequests()) > 0 }, time.Second)
+			}
+			requests := scheduler.snapshotRequests()
+			if tt.wantRequest == "" {
+				if len(requests) != 0 {
+					t.Fatalf("scheduler requests = %+v; want none", requests)
+				}
+			} else if len(requests) != 1 || requests[0].Kind != tt.wantRequest {
+				t.Fatalf("scheduler requests = %+v; want one %s", requests, tt.wantRequest)
+			}
+			if got := len(cleaner.snapshot()); (got == 1) != tt.wantCleanup {
+				t.Fatalf("workspace cleanup count = %d; want cleanup=%v", got, tt.wantCleanup)
+			}
+			view, err := o.Snapshot(context.Background())
+			if err != nil {
+				t.Fatalf("Snapshot() error = %v; want nil", err)
+			}
+			if got := len(view.Retrying) == 1; got != tt.wantRetry {
+				t.Fatalf("retry entry present = %v; want %v (view=%+v)", got, tt.wantRetry, view.Retrying)
+			}
+		})
+	}
 }
 
 func TestReconcileWorkspaceCleanupRechecksStateUnderReservation(t *testing.T) {
@@ -4220,6 +4332,67 @@ func TestRetryFire_ReleasesClaimWhenIssueAbsentFromCandidates(t *testing.T) {
 	}
 }
 
+func TestRetryFire_CandidateMissReleasesEveryRetryOwnershipKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    RetryKind
+		attempt int
+		runErr  string
+	}{
+		{name: "failure", kind: RetryKindFailure, attempt: 2, runErr: "transient"},
+		{name: "quota backoff", kind: RetryKindQuotaBackoff, runErr: "quota backoff"},
+		{name: "capacity-deferred failure", kind: RetryKindFailure, attempt: 3, runErr: "no available orchestrator slots"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			disp := &fakeDispatcher{}
+			lister := &fakeCandidateLister{}
+			o, cancel := startActor(t, Deps{
+				Dispatcher:      disp,
+				Scheduler:       &sequenceScheduler{delays: []time.Duration{time.Hour}},
+				CandidateLister: lister,
+			})
+			defer cancel()
+
+			issue := tracker.Issue{ID: "ENG-MISS", Identifier: "ENG-MISS", State: "Todo"}
+			req := RetryRequest{Kind: tt.kind, Attempt: tt.attempt}
+			if tt.kind == RetryKindQuotaBackoff {
+				req.DelayOverride = time.Hour
+			}
+			if err := o.scheduleRetry(context.Background(), issue, issue.Identifier, req, tt.attempt, tt.runErr, Workspace{}, 0); err != nil {
+				t.Fatalf("scheduleRetry(%s) error = %v; want nil", tt.kind, err)
+			}
+			waitFor(t, func() bool {
+				view, err := o.Snapshot(context.Background())
+				return err == nil && len(view.Retrying) == 1
+			}, time.Second)
+			if err := o.submit(context.Background(), &retryFireOp{
+				o: o, id: IssueID(issue.ID), issue: issue, attempt: tt.attempt, kind: tt.kind,
+			}); err != nil {
+				t.Fatalf("submit retry fire for %s error = %v; want nil", tt.kind, err)
+			}
+
+			waitFor(t, func() bool {
+				view, err := o.Snapshot(context.Background())
+				return err == nil && len(view.Retrying) == 0
+			}, 2*time.Second)
+			var claimed bool
+			o.WithStateForTest(func(st *OrchestratorState) {
+				claimed = st.IsClaimed(IssueID(issue.ID))
+			})
+			if claimed {
+				t.Fatalf("IsClaimed(%s) = true after successful candidate miss; want released", issue.ID)
+			}
+			if got := disp.count(); got != 0 {
+				t.Fatalf("Dispatcher.Spawn calls = %d, want 0", got)
+			}
+			if got := lister.callCount(); got != 1 {
+				t.Fatalf("candidate lister calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
 // staticStateRefresher is a read-only IssueStateRefresher for the §16.6
 // retry-fire terminal-resolution tests (#341). Concurrent reads of the
 // underlying map from multiple followup goroutines are safe because nothing
@@ -4230,7 +4403,7 @@ func (s staticStateRefresher) FetchIssueStatesByIDs(_ context.Context, ids []str
 	out := make(map[string]tracker.IssueState, len(ids))
 	for _, id := range ids {
 		if state, ok := s[id]; ok {
-			out[id] = tracker.IssueState{State: state}
+			out[id] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: state}
 		}
 	}
 	return out, nil
@@ -4250,10 +4423,64 @@ func (r *recordingRefStateRefresher) FetchIssueStatesByRefs(_ context.Context, r
 	out := make(map[string]tracker.IssueState, len(refs))
 	for _, ref := range refs {
 		if state, ok := r.states[ref.ID]; ok {
-			out[ref.ID] = tracker.IssueState{State: state}
+			out[ref.ID] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: state}
 		}
 	}
 	return out, nil
+}
+
+func TestResolveRetryTerminalStateRequiresCurrentOutcome(t *testing.T) {
+	tests := []struct {
+		name      string
+		refresher *explicitOutcomeStateRefresher
+		want      bool
+		wantState string
+	}{
+		{
+			name: "current terminal",
+			refresher: &explicitOutcomeStateRefresher{states: map[string]tracker.IssueState{
+				"ENG-RETRY-OUTCOME": {Outcome: tracker.IssueStateOutcomeCurrent, State: "Done"},
+			}},
+			want: true, wantState: "Done",
+		},
+		{
+			name: "current nonterminal",
+			refresher: &explicitOutcomeStateRefresher{states: map[string]tracker.IssueState{
+				"ENG-RETRY-OUTCOME": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress"},
+			}},
+		},
+		{
+			name: "state-bearing unknown",
+			refresher: &explicitOutcomeStateRefresher{states: map[string]tracker.IssueState{
+				"ENG-RETRY-OUTCOME": {Outcome: tracker.IssueStateOutcomeUnknown, State: "Done"},
+			}},
+		},
+		{
+			name: "state-bearing absent",
+			refresher: &explicitOutcomeStateRefresher{states: map[string]tracker.IssueState{
+				"ENG-RETRY-OUTCOME": {Outcome: tracker.IssueStateOutcomeAbsent, State: "Done"},
+			}},
+		},
+		{
+			name: "terminal-looking invalid outcome",
+			refresher: &explicitOutcomeStateRefresher{states: map[string]tracker.IssueState{
+				"ENG-RETRY-OUTCOME": {Outcome: tracker.IssueStateOutcome(99), State: "Done"},
+			}},
+		},
+		{name: "missing row", refresher: &explicitOutcomeStateRefresher{states: map[string]tracker.IssueState{}}},
+		{name: "refresh error", refresher: &explicitOutcomeStateRefresher{err: errors.New("tracker down")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, cancel := startActor(t, Deps{Dispatcher: &fakeDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Hour}})
+			defer cancel()
+			o.SetRetryTerminalStateResolver(tt.refresher, []string{"Done"})
+			terminal, state := resolveRetryTerminalState(o, "ENG-RETRY-OUTCOME", "ENG-RETRY-OUTCOME")
+			if terminal != tt.want || state != tt.wantState {
+				t.Fatalf("resolveRetryTerminalState = (%v, %q); want (%v, %q)", terminal, state, tt.want, tt.wantState)
+			}
+		})
+	}
 }
 
 // TestRetryFire_TerminalIssueFiresWorkspaceCleanup is the failure-retry half of

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -52,27 +52,44 @@ type issueStateRefresherWithoutBlockersByRefs interface {
 }
 
 func fetchIssueStates(ctx context.Context, refresher IssueStateRefresher, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
-	if refresher == nil || len(refs) == 0 {
-		return map[string]tracker.IssueState{}, nil
+	states, normalizedRefs := tracker.UnknownIssueStatesByRefs(refs)
+	if refresher == nil || len(normalizedRefs) == 0 {
+		return states, nil
 	}
+	var fetched map[string]tracker.IssueState
+	var err error
 	if refRefresher, ok := refresher.(issueStateRefresherByRefs); ok {
-		return refRefresher.FetchIssueStatesByRefs(ctx, refs)
+		fetched, err = refRefresher.FetchIssueStatesByRefs(ctx, normalizedRefs)
+	} else {
+		issueIDs := make([]string, 0, len(normalizedRefs))
+		for _, ref := range normalizedRefs {
+			issueIDs = append(issueIDs, ref.ID)
+		}
+		fetched, err = refresher.FetchIssueStatesByIDs(ctx, issueIDs)
 	}
-	issueIDs := make([]string, 0, len(refs))
-	for _, ref := range refs {
-		issueIDs = append(issueIDs, ref.ID)
-	}
-	return refresher.FetchIssueStatesByIDs(ctx, issueIDs)
+	mergeRequestedIssueStates(states, fetched)
+	return states, err
 }
 
 func fetchIssueStatesWithoutBlockers(ctx context.Context, refresher IssueStateRefresher, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
-	if refresher == nil || len(refs) == 0 {
-		return map[string]tracker.IssueState{}, nil
+	states, normalizedRefs := tracker.UnknownIssueStatesByRefs(refs)
+	if refresher == nil || len(normalizedRefs) == 0 {
+		return states, nil
 	}
 	if noBlockers, ok := refresher.(issueStateRefresherWithoutBlockersByRefs); ok {
-		return noBlockers.FetchIssueStatesWithoutBlockersByRefs(ctx, refs)
+		fetched, err := noBlockers.FetchIssueStatesWithoutBlockersByRefs(ctx, normalizedRefs)
+		mergeRequestedIssueStates(states, fetched)
+		return states, err
 	}
-	return fetchIssueStates(ctx, refresher, refs)
+	return fetchIssueStates(ctx, refresher, normalizedRefs)
+}
+
+func mergeRequestedIssueStates(states, fetched map[string]tracker.IssueState) {
+	for id, state := range fetched {
+		if _, requested := states[id]; requested {
+			states[id] = state
+		}
+	}
 }
 
 // ReconciliationConfig names the workflow states the poller uses to decide
@@ -226,6 +243,7 @@ type claimedNarrowRefresh struct {
 	activeIssuesByID    map[string]tracker.Issue
 	activeStateKeys     map[string]struct{}
 	refreshedIssuesByID map[string]tracker.Issue
+	absentIssueIDs      map[string]struct{}
 }
 
 type claimedInactiveResult struct {
@@ -276,13 +294,16 @@ func (p *Poller) refreshClaimedNarrowPhase(ctx context.Context, activeIssues []t
 		activeStateKeys:  normalizedStates(p.reconcile.ActiveStates),
 	}
 	var err error
-	refresh.refreshedIssuesByID, err = p.refreshRunningIssueStates(ctx, refresh.activeIssuesByID, issueRefs)
+	refresh.refreshedIssuesByID, refresh.absentIssueIDs, err = p.refreshRunningIssueStates(ctx, refresh.activeIssuesByID, issueRefs)
 	return refresh, err
 }
 
 func (p *Poller) applyClaimedNarrowPhase(ctx context.Context, refresh claimedNarrowRefresh) error {
 	if err := p.orchestrator.PatchActiveClaimedTrackerIssueStates(ctx, refresh.refreshedIssuesByID, refresh.activeStateKeys); err != nil {
 		return err
+	}
+	for id := range refresh.absentIssueIDs {
+		delete(refresh.activeIssuesByID, id)
 	}
 	mergeRefreshedActiveStates(refresh.activeIssuesByID, refresh.refreshedIssuesByID, refresh.activeStateKeys)
 	// The active listing may be partial, so absence is "no information." Only
@@ -301,7 +322,12 @@ func (p *Poller) reconcileClaimedInactivePhase(ctx context.Context, activeIssues
 		}
 	}
 	inactiveByID, deriveErr := p.deriveInactiveIssues(ctx, activeEvidenceByID, refresh.refreshedIssuesByID, refresh.activeStateKeys)
+	for id := range refresh.absentIssueIDs {
+		delete(inactiveByID, id)
+	}
 	reconcileErr := p.orchestrator.ReconcileInactiveTrackerIssuesAndWait(ctx, inactiveByID, normalizedStates(p.reconcile.TerminalStates), p.reconcile.WorkerExitTimeout)
+	absentErr := p.orchestrator.ReconcileAbsentTrackerIssuesAndWait(ctx, refresh.absentIssueIDs, p.reconcile.WorkerExitTimeout)
+	reconcileErr = errors.Join(reconcileErr, absentErr)
 	return claimedInactiveResult{issues: inactiveByID, deriveErr: deriveErr, reconcileErr: reconcileErr}
 }
 
@@ -401,65 +427,46 @@ func addInactiveListedIssues(inactiveByID map[string]tracker.Issue, activeByID m
 	}
 }
 
-func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID map[string]tracker.Issue, issueRefs []tracker.IssueRef) (map[string]tracker.Issue, error) {
+func (p *Poller) refreshRunningIssueStates(ctx context.Context, activeIssuesByID map[string]tracker.Issue, issueRefs []tracker.IssueRef) (map[string]tracker.Issue, map[string]struct{}, error) {
 	refresher, ok := p.stateTracker.(IssueStateRefresher)
 	if !ok {
-		return nil, nil
+		return nil, nil, nil
 	}
 	fetchCtx, cancel := context.WithTimeout(ctx, reconciliationTrackerRequestTimeout)
 	statesByID, err := fetchIssueStates(fetchCtx, refresher, issueRefs)
 	cancel()
-	refsByID := make(map[string]tracker.IssueRef, len(issueRefs))
-	for _, ref := range issueRefs {
-		refsByID[ref.ID] = ref
-	}
 	refreshed := make(map[string]tracker.Issue, len(statesByID))
-	for id, st := range statesByID {
-		if strings.TrimSpace(id) == "" || strings.TrimSpace(st.State) == "" {
-			continue
-		}
-		issue, ok := activeIssuesByID[id]
-		if !ok {
-			issue = tracker.Issue{ID: id, Identifier: refsByID[id].Identifier}
-		}
-		issue.ID = id
-		issue.State = st.State
-		// Carry refreshed labels so deriveInactiveIssues can observe SPEC §6.4
-		// label removal on in-flight issues that sit beyond the active-listing
-		// page (the narrow refresh queries them by claimed ref, the listing may
-		// not). Only rows the tracker actually returned with a non-empty state
-		// reach here, so absence stays "no information" (never a mass-cancel).
-		issue.Labels = st.Labels
-		issue.BlockedBy = st.BlockedBy
-		refreshed[id] = issue
+	absent := make(map[string]struct{})
+	for _, ref := range issueRefs {
+		collectClaimedRefreshOutcome(ref, statesByID[strings.TrimSpace(ref.ID)], activeIssuesByID, refreshed, absent)
 	}
-	if err == nil {
-		err = p.releaseVanishedContinuations(ctx, issueRefs, statesByID)
-	}
-	return refreshed, err
+	return refreshed, absent, err
 }
 
-// releaseVanishedContinuations releases queued continuation entries whose
-// issue a CLEAN narrow refresh was asked about but did not return with a
-// usable state (deleted, or a Gitea issue whose aiops/* state labels were
-// stripped). Reconcile's cancel paths deliberately treat absence as
-// no-information, so without this sweep such a continuation wedges in
-// RetryAttempts/Claimed forever — the poll loop never lists the issue again
-// and nothing else releases it (#740 review). Gated on err == nil: with a
-// failed fetch a missing row is indistinguishable from tracker downtime.
-// Kind filtering (continuations only, release-only) happens actor-side in
-// ReleaseVanishedContinuations.
-func (p *Poller) releaseVanishedContinuations(ctx context.Context, queried []tracker.IssueRef, statesByID map[string]tracker.IssueState) error {
-	vanished := make([]tracker.IssueRef, 0, len(queried))
-	for _, ref := range queried {
-		if st, ok := statesByID[ref.ID]; !ok || strings.TrimSpace(st.State) == "" {
-			vanished = append(vanished, ref)
-		}
+func collectClaimedRefreshOutcome(ref tracker.IssueRef, state tracker.IssueState, activeIssuesByID, refreshed map[string]tracker.Issue, absent map[string]struct{}) {
+	id := strings.TrimSpace(ref.ID)
+	if id == "" {
+		return
 	}
-	if len(vanished) == 0 {
-		return nil
+	if state.Outcome == tracker.IssueStateOutcomeAbsent {
+		absent[id] = struct{}{}
+		return
 	}
-	return p.orchestrator.ReleaseVanishedContinuations(ctx, vanished)
+	if state.Outcome != tracker.IssueStateOutcomeCurrent || strings.TrimSpace(state.State) == "" {
+		return
+	}
+	issue, ok := activeIssuesByID[id]
+	if !ok {
+		issue = tracker.Issue{ID: id, Identifier: ref.Identifier}
+	}
+	issue.ID = id
+	issue.State = state.State
+	// Labels and blockers are authoritative only on Current rows. Carrying
+	// them here lets out-of-page claimed issues re-run the required-label and
+	// Todo blocker gates without treating Unknown as fresh evidence.
+	issue.Labels = state.Labels
+	issue.BlockedBy = state.BlockedBy
+	refreshed[id] = issue
 }
 
 func (p *Poller) reconcileInactiveStateGroups() [][]string {

--- a/internal/orchestrator/poller_candidates.go
+++ b/internal/orchestrator/poller_candidates.go
@@ -36,9 +36,9 @@ var dispatchRevalidationTimeout = 45 * time.Second
 // the same trim upstream gets from should_dispatch_issue? running before
 // revalidate_issue_for_dispatch — so the refresh cost stays proportional to
 // what can spawn, not to the active listing. A refreshed candidate is dropped
-// when the refresh omits it (upstream {:skip, :missing}; the Gitea adapter
-// also omits issues whose aiops/* state labels were stripped), when its
-// refreshed state left the configured active set, or when its refreshed
+// unless the adapter returned an authoritative Current row (missing, Unknown,
+// and confirmed Absent all skip), when its refreshed state left the configured
+// active set, or when its refreshed
 // labels no longer satisfy the SPEC §6.4 required-labels gate, or when it is
 // a Todo issue whose refreshed blockers are not all terminal (upstream
 // retry_candidate_issue?'s !todo_issue_blocked_by_non_terminal?,
@@ -94,11 +94,10 @@ func (p *Poller) claimableDispatchRefs(ctx context.Context, candidates []tracker
 
 // filterRevalidatedCandidates keeps the claimable candidates whose refreshed
 // tracker row still passes the dispatch gates, carrying the refreshed state
-// and labels onto each survivor. Dropping is skip-only: a dropped candidate's
-// queued continuation (if any) is released by the reconcile pass's
-// vanished-continuation sweep when the row is missing, or by the inactive
-// reconcile when the row is present but ineligible — never here, so the
-// release stays single-sourced.
+// and labels onto each survivor. Dropping is skip-only: the claimed reconcile
+// path owns releases for explicit Absent or inactive observations, while
+// missing and Unknown rows preserve claim ownership. This pre-dispatch filter
+// never mutates claim state.
 func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimable map[IssueID]struct{}, statesByID map[string]tracker.IssueState) []tracker.Issue {
 	activeStateKeys := normalizedStates(p.reconcile.ActiveStates)
 	terminalStateKeys := normalizedStates(p.reconcile.TerminalStates)
@@ -114,11 +113,11 @@ func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimab
 	return kept
 }
 
-// revalidatedCandidate applies the per-issue revalidation verdict: missing
-// from the refresh (upstream {:skip, :missing}), refreshed out of the active
-// set, refreshed past the SPEC §6.4 required-labels gate, or a refreshed Todo
-// issue whose blockers reopened all drop the candidate; otherwise the
-// refreshed state, labels, and blocker data are carried onto it. The blocker
+// revalidatedCandidate applies the per-issue revalidation verdict: only a
+// Current refresh row may dispatch. Missing, Unknown, and Absent rows skip;
+// Current rows outside the active set, past the SPEC §6.4 required-labels gate,
+// or carrying a reopened Todo blocker also skip. Otherwise the refreshed
+// state, labels, and blocker data are carried onto the candidate. The blocker
 // recheck matches upstream retry_candidate_issue?'s
 // !todo_issue_blocked_by_non_terminal? on the refreshed issue
 // (orchestrator.ex:1602-1604, #750); when the refresh supplies no blocker
@@ -127,8 +126,24 @@ func (p *Poller) filterRevalidatedCandidates(candidates []tracker.Issue, claimab
 // passed, so it cannot newly drop the candidate.
 func revalidatedCandidate(issue tracker.Issue, statesByID map[string]tracker.IssueState, activeStateKeys, terminalStateKeys map[string]struct{}, requiredLabels []string) (tracker.Issue, bool) {
 	refreshed, ok := statesByID[issue.ID]
-	if !ok || strings.TrimSpace(refreshed.State) == "" {
+	if !ok {
 		logStaleDispatchSkipped(issue, "", "missing_from_refresh")
+		return tracker.Issue{}, false
+	}
+	switch refreshed.Outcome {
+	case tracker.IssueStateOutcomeUnknown:
+		logStaleDispatchSkipped(issue, "", "refresh_unknown")
+		return tracker.Issue{}, false
+	case tracker.IssueStateOutcomeAbsent:
+		logStaleDispatchSkipped(issue, "", "confirmed_absent")
+		return tracker.Issue{}, false
+	case tracker.IssueStateOutcomeCurrent:
+	default:
+		logStaleDispatchSkipped(issue, "", "invalid_refresh_outcome")
+		return tracker.Issue{}, false
+	}
+	if strings.TrimSpace(refreshed.State) == "" {
+		logStaleDispatchSkipped(issue, "", "current_state_missing")
 		return tracker.Issue{}, false
 	}
 	issue.State = refreshed.State

--- a/internal/orchestrator/poller_candidates_test.go
+++ b/internal/orchestrator/poller_candidates_test.go
@@ -56,9 +56,8 @@ func TestPollOnceSkipsDispatchWhenRevalidationOmitsIssue(t *testing.T) {
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
 	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
 
-	// An empty refresh result is upstream's {:skip, :missing}: the issue was
-	// deleted, or (Gitea) its aiops/* state labels were stripped so no state
-	// can be derived.
+	// An omitted result normalizes to Unknown. Dispatch fails closed, but the
+	// omission is not treated as confirmed tracker absence.
 	trackerClient.setFetchIDStates(map[string]string{})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce() = %v; want nil", err)
@@ -84,6 +83,50 @@ func TestPollOnceDispatchesRevalidatedCandidateWithRefreshedState(t *testing.T) 
 	}
 	if got := dispatcher.issueAt(0).State; got != "Rework" {
 		t.Fatalf("dispatched issue state = %q; want refreshed state %q", got, "Rework")
+	}
+}
+
+func TestRevalidatedCandidateRequiresCurrentOutcome(t *testing.T) {
+	issue := tracker.Issue{ID: "issue-1", Identifier: "LIN-1", Title: "work", State: "In Progress"}
+	active := normalizedStates([]string{"In Progress", "Rework"})
+	terminal := normalizedStates([]string{"Done"})
+	tests := []struct {
+		name    string
+		states  map[string]tracker.IssueState
+		want    bool
+		wantOut string
+	}{
+		{
+			name: "current active",
+			states: map[string]tracker.IssueState{
+				issue.ID: {Outcome: tracker.IssueStateOutcomeCurrent, State: "Rework"},
+			},
+			want: true, wantOut: "Rework",
+		},
+		{
+			name: "state-bearing unknown",
+			states: map[string]tracker.IssueState{
+				issue.ID: {Outcome: tracker.IssueStateOutcomeUnknown, State: "Rework"},
+			},
+		},
+		{
+			name: "state-bearing absent",
+			states: map[string]tracker.IssueState{
+				issue.ID: {Outcome: tracker.IssueStateOutcomeAbsent, State: "Rework"},
+			},
+		},
+		{name: "missing row", states: map[string]tracker.IssueState{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, keep := revalidatedCandidate(issue, tt.states, active, terminal, nil)
+			if keep != tt.want {
+				t.Fatalf("revalidatedCandidate keep = %v; want %v (got=%+v)", keep, tt.want, got)
+			}
+			if keep && got.State != tt.wantOut {
+				t.Fatalf("revalidatedCandidate state = %q; want %q", got.State, tt.wantOut)
+			}
+		})
 	}
 }
 
@@ -161,16 +204,16 @@ func continuationClaimState(t *testing.T, ctx context.Context, poller *Poller, i
 	return retained, claimed
 }
 
-func TestPollOnceReleasesDueContinuationWhenRevalidationOmitsIssue(t *testing.T) {
+func TestPollOnceReleasesDueContinuationWhenRefreshConfirmsAbsent(t *testing.T) {
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}}
 	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
 	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
 
-	// The refresh omits the issue entirely (deleted / Gitea aiops/* labels
-	// stripped). Reconcile's cancel paths treat absence as no-information
-	// forever, so the vanished-continuation sweep must release the queued
-	// continuation or the issue wedges in retrying (#740 review P2).
-	trackerClient.setFetchIDStates(map[string]string{})
+	// Only the explicit per-ref Absent outcome proves deletion / removal from
+	// the tracker workflow. A missing or Unknown row remains no-information.
+	trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
+		"issue-1": {Outcome: tracker.IssueStateOutcomeAbsent},
+	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce() = %v; want nil", err)
 	}
@@ -179,20 +222,22 @@ func TestPollOnceReleasesDueContinuationWhenRevalidationOmitsIssue(t *testing.T)
 	}
 	retained, claimed := continuationClaimState(t, ctx, poller, "issue-1")
 	if retained || claimed {
-		t.Fatalf("continuation after missing revalidation: retained=%v claimed=%v; want released", retained, claimed)
+		t.Fatalf("continuation after confirmed absence: retained=%v claimed=%v; want released", retained, claimed)
 	}
 }
 
-func TestPollOnceReleasesDueContinuationAbsentFromActiveListing(t *testing.T) {
+func TestPollOnceReleasesDueContinuationConfirmedAbsentFromActiveListing(t *testing.T) {
 	// The between-tick variant: the issue vanished BEFORE this tick's listing,
 	// so it is never a dispatch candidate at all. The reconcile pass still
-	// narrow-refreshes it as a claimed (retrying) ref; a clean refresh that
-	// does not return it must release the continuation (#740 review HIGH).
+	// narrow-refreshes it as a claimed (retrying) ref; an explicit Absent
+	// outcome must release the continuation (#740 review HIGH).
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{}}
 	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
 	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
 
-	trackerClient.setFetchIDStates(map[string]string{})
+	trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
+		"issue-1": {Outcome: tracker.IssueStateOutcomeAbsent},
+	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce() = %v; want nil", err)
 	}
@@ -205,11 +250,11 @@ func TestPollOnceReleasesDueContinuationAbsentFromActiveListing(t *testing.T) {
 	}
 }
 
-func TestPollOnceRetainsVanishedFailureRetry(t *testing.T) {
-	// A failure retry whose issue vanished is NOT released by the sweep: its
-	// own fire path runs the SPEC §16.6 candidate fetch and releases on
-	// absence with terminal-state resolution (#341). Releasing it here would
-	// double-own that contract.
+func TestPollOnceRetainsAbsentFailureRetry(t *testing.T) {
+	// A failure retry whose narrow refresh confirms absence is NOT released by
+	// reconciliation: its own timer fire path runs the SPEC §16.6 candidate
+	// fetch and releases on absence with terminal-state resolution (#341).
+	// Releasing it here would double-own that contract.
 	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{}}
 	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
 	id := IssueID("issue-1")
@@ -235,7 +280,9 @@ func TestPollOnceRetainsVanishedFailureRetry(t *testing.T) {
 		t.Fatalf("seed failure retry: %v", ctx.Err())
 	}
 
-	trackerClient.setFetchIDStates(map[string]string{})
+	trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
+		"issue-1": {Outcome: tracker.IssueStateOutcomeAbsent},
+	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce() = %v; want nil", err)
 	}
@@ -244,7 +291,27 @@ func TestPollOnceRetainsVanishedFailureRetry(t *testing.T) {
 	}
 	retained, claimed := continuationClaimState(t, ctx, poller, id)
 	if !retained || !claimed {
-		t.Fatalf("failure retry after vanished refresh: retained=%v claimed=%v; want retained", retained, claimed)
+		t.Fatalf("failure retry after absent refresh: retained=%v claimed=%v; want retained", retained, claimed)
+	}
+}
+
+func TestPollOnceRetainsDueContinuationWhenRefreshOmitsOutcome(t *testing.T) {
+	trackerClient := &fakeIssueStateTracker{issues: []tracker.Issue{}}
+	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, revalidationReconcileConfig())
+	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
+
+	// A non-compliant or partial adapter may omit a requested row. The poller
+	// boundary totalizes that omission to Unknown; it must never infer absence.
+	trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{})
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce() = %v; want nil", err)
+	}
+	if got := dispatcher.count(); got != 0 {
+		t.Fatalf("dispatched %d issues (%v); want 0", got, dispatcher.issueIDs())
+	}
+	retained, claimed := continuationClaimState(t, ctx, poller, "issue-1")
+	if !retained || !claimed {
+		t.Fatalf("continuation after omitted refresh outcome: retained=%v claimed=%v; want retained", retained, claimed)
 	}
 }
 
@@ -254,8 +321,8 @@ func TestPollOnceRetainsDueContinuationWhenRevalidationFetchFails(t *testing.T) 
 	seedDueContinuation(t, ctx, poller, tracker.Issue{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"})
 
 	// With the fetch failing, a missing row is indistinguishable from tracker
-	// downtime — the vanished-continuation sweep must not run and the
-	// continuation must survive (upstream {:error} leaves state untouched).
+	// downtime. The normalized Unknown outcome must preserve the continuation
+	// (upstream {:error} leaves state untouched).
 	trackerClient.setFetchIDStates(map[string]string{})
 	trackerClient.setFetchIDErr(errors.New("tracker briefly down"))
 	if err := poller.PollOnce(ctx); err == nil || !strings.Contains(err.Error(), "revalidate dispatch candidates") {
@@ -316,7 +383,7 @@ func TestPollOnceSkipsDispatchWhenRevalidationShowsReopenedBlocker(t *testing.T)
 	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, todoBlockerRevalidationConfig())
 
 	trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
-		"issue-1": {State: "Todo", BlockedBy: []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "In Progress"}}},
+		"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "Todo", BlockedBy: []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "In Progress"}}},
 	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce() = %v; want nil", err)
@@ -340,7 +407,7 @@ func TestPollOnceBlockerRevalidationHonorsNilVersusEmptyContract(t *testing.T) {
 		poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, todoBlockerRevalidationConfig())
 
 		trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
-			"issue-1": {State: "Todo", BlockedBy: []tracker.BlockerRef{}},
+			"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "Todo", BlockedBy: []tracker.BlockerRef{}},
 		})
 		if err := poller.PollOnce(ctx); err != nil {
 			t.Fatalf("PollOnce() = %v; want nil", err)
@@ -363,7 +430,7 @@ func TestPollOnceBlockerRevalidationHonorsNilVersusEmptyContract(t *testing.T) {
 		poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, todoBlockerRevalidationConfig())
 
 		trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
-			"issue-1": {State: "Todo"},
+			"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "Todo"},
 		})
 		if err := poller.PollOnce(ctx); err != nil {
 			t.Fatalf("PollOnce() = %v; want nil", err)
@@ -388,7 +455,7 @@ func TestPollOnceBlockerRevalidationGatesTodoOnly(t *testing.T) {
 	poller, dispatcher, ctx := startRevalidationHarness(t, trackerClient, todoBlockerRevalidationConfig())
 
 	trackerClient.setFetchIDIssueStates(map[string]tracker.IssueState{
-		"issue-1": {State: "In Progress", BlockedBy: []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "In Progress"}}},
+		"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress", BlockedBy: []tracker.BlockerRef{{ID: "blocker-1", Identifier: "GT-9", State: "In Progress"}}},
 	})
 	if err := poller.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce() = %v; want nil", err)

--- a/internal/orchestrator/poller_github_loop_test.go
+++ b/internal/orchestrator/poller_github_loop_test.go
@@ -36,6 +36,15 @@ func githubLoopServer(t *testing.T, listBody, refreshBody func() any) *httptest.
 			_ = json.NewEncoder(w).Encode(listBody())
 		case "/repos/acme/api/issues/159":
 			_ = json.NewEncoder(w).Encode(refreshBody())
+		case "/graphql":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+				map[string]any{
+					"id": "I_159", "number": 159,
+					"blockedBy": map[string]any{
+						"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false},
+					},
+				},
+			}}})
 		default:
 			t.Errorf("unexpected GitHub request path %q", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -45,7 +54,7 @@ func githubLoopServer(t *testing.T, listBody, refreshBody func() any) *httptest.
 
 func githubIssueJSON(label string) map[string]any {
 	return map[string]any{
-		"id": 159, "number": 159, "title": "loop integration", "state": "open",
+		"id": 159, "node_id": "I_159", "number": 159, "title": "loop integration", "body": "", "state": "open",
 		"created_at": "2026-05-20T01:02:03Z", "updated_at": "2026-05-20T02:03:04Z",
 		"labels": []map[string]any{{"name": label}},
 	}

--- a/internal/orchestrator/poller_reconciletick_test.go
+++ b/internal/orchestrator/poller_reconciletick_test.go
@@ -2,12 +2,14 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
+	"github.com/xrf9268-hue/aiops-platform/internal/worker"
 )
 
 // fixedStateTracker is a minimal IssueStateLister/IssueStateRefresher that
@@ -23,6 +25,8 @@ type fixedStateTracker struct {
 	fixedListIssues []tracker.Issue
 
 	fetchStates map[string]tracker.IssueState
+	fetchErr    error
+	listErr     error
 }
 
 func (f *fixedStateTracker) ListActiveIssues(ctx context.Context) ([]tracker.Issue, error) {
@@ -37,7 +41,7 @@ func (f *fixedStateTracker) ListIssuesByStates(_ context.Context, _ []string) ([
 	}
 	out := make([]tracker.Issue, len(f.fixedListIssues))
 	copy(out, f.fixedListIssues)
-	return out, nil
+	return out, f.listErr
 }
 
 func (f *fixedStateTracker) FetchIssueStatesByRefs(_ context.Context, refs []tracker.IssueRef) (map[string]tracker.IssueState, error) {
@@ -53,11 +57,35 @@ func (f *fixedStateTracker) FetchIssueStatesByRefs(_ context.Context, refs []tra
 			out[id] = st
 		}
 	}
-	return out, nil
+	return out, f.fetchErr
 }
 
 func (f *fixedStateTracker) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]tracker.IssueState, error) {
 	return f.FetchIssueStatesByRefs(ctx, tracker.IssueRefsFromIDs(ids))
+}
+
+func TestFetchIssueStatesNormalizesMissingRowsToUnknown(t *testing.T) {
+	refresher := &fixedStateTracker{fetchStates: map[string]tracker.IssueState{
+		"current": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress"},
+		"extra":   {Outcome: tracker.IssueStateOutcomeAbsent},
+	}}
+	states, err := fetchIssueStates(context.Background(), refresher, []tracker.IssueRef{
+		{ID: "current", Identifier: "LIN-1"},
+		{ID: "missing", Identifier: "LIN-2"},
+	})
+	if err != nil {
+		t.Fatalf("fetchIssueStates() error = %v; want nil", err)
+	}
+	if got := states["current"].Outcome; got != tracker.IssueStateOutcomeCurrent {
+		t.Errorf("states[current].Outcome = %v; want Current", got)
+	}
+	missing, ok := states["missing"]
+	if !ok || missing.Outcome != tracker.IssueStateOutcomeUnknown {
+		t.Errorf("states[missing] = %+v present=%v; want explicit Unknown", missing, ok)
+	}
+	if _, ok := states["extra"]; ok {
+		t.Errorf("states[extra] present = true; want false for unrequested adapter row")
+	}
 }
 
 // TestReconcileTickPartACancelledContextReturnsFatally pins the load-bearing
@@ -123,7 +151,7 @@ func TestReconcileTickDropsNonActiveNonInactiveRefreshedIssueFromInactiveSet(t *
 	defer cancel()
 
 	trackerClient := &fixedStateTracker{
-		fetchStates: map[string]tracker.IssueState{"issue-1": {State: "Triage"}},
+		fetchStates: map[string]tracker.IssueState{"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "Triage"}},
 	}
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
@@ -174,7 +202,7 @@ func TestReconcileTickTreatsActiveIssueMissingRequiredLabelAsInactive(t *testing
 	// WITHOUT the required label (label removed mid-run). The §6.4 gate now reads
 	// labels from the refresh, so only label removal (not a state change) makes it
 	// ineligible here.
-	trackerClient := &fixedStateTracker{fetchStates: map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"backend"}}}}
+	trackerClient := &fixedStateTracker{fetchStates: map[string]tracker.IssueState{"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress", Labels: []string{"backend"}}}}
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
@@ -219,7 +247,7 @@ func TestReconcileTickKeepsActiveIssueRetainingRequiredLabel(t *testing.T) {
 
 	// Narrow refresh shows issue-1 still In Progress and STILL carrying the
 	// required label, so it must NOT be reconciled inactive.
-	trackerClient := &fixedStateTracker{fetchStates: map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"aiops-ready", "backend"}}}}
+	trackerClient := &fixedStateTracker{fetchStates: map[string]tracker.IssueState{"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress", Labels: []string{"aiops-ready", "backend"}}}}
 	dispatcher := &cancellationDispatcher{}
 	orch := New(NewOrchestratorState(30000, 1), Deps{
 		Dispatcher: dispatcher,
@@ -290,7 +318,7 @@ func newRunningLabelReconcilePoller(t *testing.T, refresh map[string]tracker.Iss
 // could not observe.
 func TestReconcileTickCancelsOutOfPageRunningIssueMissingRequiredLabel(t *testing.T) {
 	poller, ctx := newRunningLabelReconcilePoller(t,
-		map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"backend"}}},
+		map[string]tracker.IssueState{"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress", Labels: []string{"backend"}}},
 		[]string{"aiops-ready"})
 
 	// Active listing is EMPTY (issue-1 is out of page); only the refresh carries it.
@@ -312,7 +340,7 @@ func TestReconcileTickCancelsOutOfPageRunningIssueMissingRequiredLabel(t *testin
 // wrongly cancelled (false cancel).
 func TestReconcileTickKeepsOutOfPageRunningIssueRetainingRequiredLabel(t *testing.T) {
 	poller, ctx := newRunningLabelReconcilePoller(t,
-		map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"aiops-ready", "backend"}}},
+		map[string]tracker.IssueState{"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress", Labels: []string{"aiops-ready", "backend"}}},
 		[]string{"aiops-ready"})
 
 	got, err := poller.reconcileTick(ctx, nil) // issue-1 out of page; only refresh has it
@@ -342,12 +370,166 @@ func TestReconcileTickKeepsRunningIssueAbsentFromRefresh(t *testing.T) {
 	}
 }
 
+func TestPollerReconcileClaimedTickAppliesAuthoritativeRefreshOutcomesDespiteError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const (
+		runningAbsent       = IssueID("running-absent")
+		runningAbsentListed = IssueID("running-absent-listed")
+		runningActive       = IssueID("running-active")
+		runningTerminal     = IssueID("running-terminal")
+		blockedAbsent       = IssueID("blocked-absent")
+		blockedUnknown      = IssueID("blocked-unknown")
+		continuation        = IssueID("continuation-absent")
+		failure             = IssueID("failure-absent")
+		quota               = IssueID("quota-absent")
+		missing             = IssueID("continuation-missing")
+	)
+	issue := func(id IssueID) tracker.Issue {
+		return tracker.Issue{ID: string(id), Identifier: strings.ToUpper(string(id)), State: "In Progress"}
+	}
+	closedDone := make(chan struct{})
+	close(closedDone)
+	cancelCauses := make(map[IssueID]error)
+	st := NewOrchestratorState(30000, 16)
+	seedRun := func(id IssueID) *RunningEntry {
+		run := &RunningEntry{
+			Issue: issue(id), Identifier: issue(id).Identifier, Done: closedDone,
+			CancelWorker: func(err error) { cancelCauses[id] = err },
+		}
+		st.BeginDispatch(id, run)
+		return run
+	}
+	absentRun := seedRun(runningAbsent)
+	absentRun.ReconcileCleanupWorkspace = true
+	absentRun.AgentCurrentIssueHandoff = true
+	absentRun.AgentCurrentIssueTerminalHandoff = true
+	absentRun.AgentCurrentIssueTerminalHandoffState = "Done"
+	seedRun(runningAbsentListed)
+	seedRun(runningActive)
+	seedRun(runningTerminal)
+	for _, id := range []IssueID{blockedAbsent, blockedUnknown} {
+		st.Blocked[id] = &BlockedEntry{Issue: issue(id), Identifier: issue(id).Identifier}
+		st.Claimed[id] = struct{}{}
+		st.ClaimedIssues[id] = issue(id)
+	}
+	for _, retry := range []struct {
+		id   IssueID
+		kind RetryKind
+	}{
+		{id: continuation, kind: RetryKindContinuation},
+		{id: failure, kind: RetryKindFailure},
+		{id: quota, kind: RetryKindQuotaBackoff},
+		{id: missing, kind: RetryKindContinuation},
+	} {
+		st.ScheduleRetry(&RetryEntry{Issue: issue(retry.id), IssueID: retry.id, Identifier: issue(retry.id).Identifier, Kind: retry.kind})
+	}
+
+	refreshErr := errors.New("one refresh chunk failed")
+	trackerClient := &fixedStateTracker{
+		fixedListIssues: []tracker.Issue{
+			{ID: string(runningAbsent), Identifier: issue(runningAbsent).Identifier, State: "Done"},
+			{ID: string(runningTerminal), Identifier: issue(runningTerminal).Identifier, State: "Done"},
+		},
+		fetchStates: map[string]tracker.IssueState{
+			string(runningAbsent):       {Outcome: tracker.IssueStateOutcomeAbsent},
+			string(runningAbsentListed): {Outcome: tracker.IssueStateOutcomeAbsent},
+			string(runningActive):       {Outcome: tracker.IssueStateOutcomeCurrent, State: "Rework", Labels: []string{"fresh"}},
+			string(runningTerminal):     {Outcome: tracker.IssueStateOutcomeCurrent, State: "Done"},
+			string(blockedAbsent):       {Outcome: tracker.IssueStateOutcomeAbsent},
+			string(blockedUnknown):      {Outcome: tracker.IssueStateOutcomeUnknown},
+			string(continuation):        {Outcome: tracker.IssueStateOutcomeAbsent},
+			string(failure):             {Outcome: tracker.IssueStateOutcomeAbsent},
+			string(quota):               {Outcome: tracker.IssueStateOutcomeAbsent},
+		},
+		fetchErr: refreshErr,
+	}
+	cleaner := &recordingWorkspaceCleaner{}
+	o := New(st, Deps{Dispatcher: &cancellationDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Hour}, WorkspaceCleaner: cleaner})
+	safeGo("test.refresh_outcome_matrix_actor", func() { o.Run(ctx) })
+	if err := o.WaitStarted(ctx); err != nil {
+		t.Fatalf("WaitStarted() error = %v; want nil", err)
+	}
+	poller := NewPollerWithReconciliation(trackerClient, o, ReconciliationConfig{
+		ActiveStates: []string{"In Progress", "Rework"}, TerminalStates: []string{"Done"}, WorkerExitTimeout: time.Second,
+	})
+
+	result, err := poller.reconcileClaimedTick(ctx, []tracker.Issue{issue(runningAbsentListed)})
+	if !errors.Is(err, refreshErr) {
+		t.Fatalf("reconcileClaimedTick error = %v; want mixed refresh error %v", err, refreshErr)
+	}
+	for _, id := range []IssueID{runningActive, runningTerminal} {
+		if _, ok := result.refreshed[string(id)]; !ok {
+			t.Errorf("refreshed[%s] missing; want authoritative Current row applied", id)
+		}
+	}
+	if _, ok := result.refreshed[string(runningAbsent)]; ok {
+		t.Errorf("refreshed[%s] present = true; want false for Absent", runningAbsent)
+	}
+	if _, ok := result.inactive[string(runningAbsent)]; ok {
+		t.Errorf("inactive[%s] present from stale listing = true; want false because explicit Absent wins", runningAbsent)
+	}
+	if _, ok := result.inactive[string(runningTerminal)]; !ok {
+		t.Errorf("inactive[%s] missing; want Current terminal row reconciled", runningTerminal)
+	}
+
+	o.WithStateForTest(func(got *OrchestratorState) {
+		active := got.Running[runningActive]
+		if active == nil || active.Issue.State != "Rework" || active.ReconcileCancel {
+			t.Errorf("active run = %+v; want refreshed Rework run retained", active)
+		}
+		absent := got.Running[runningAbsent]
+		if absent == nil || !absent.ReconcileCancel || absent.ReconcileCleanupWorkspace || absent.AgentCurrentIssueHandoff || absent.AgentCurrentIssueTerminalHandoff {
+			t.Errorf("absent run flags = %+v; want cancel without cleanup/handoff", absent)
+		}
+		terminal := got.Running[runningTerminal]
+		if terminal == nil || !terminal.ReconcileCancel || !terminal.ReconcileCleanupWorkspace {
+			t.Errorf("terminal run flags = %+v; want terminal cancel with cleanup", terminal)
+		}
+		if _, ok := got.Blocked[blockedAbsent]; ok {
+			t.Errorf("Blocked[%s] retained; want released on explicit Absent", blockedAbsent)
+		}
+		if _, ok := got.Blocked[blockedUnknown]; !ok {
+			t.Errorf("Blocked[%s] missing; want retained on Unknown", blockedUnknown)
+		}
+		if _, ok := got.RetryAttempts[continuation]; ok {
+			t.Errorf("RetryAttempts[%s] retained; want continuation released on Absent", continuation)
+		}
+		for _, id := range []IssueID{failure, quota, missing} {
+			if got.RetryAttempts[id] == nil {
+				t.Errorf("RetryAttempts[%s] = nil; want retained for timer-owned or unknown outcome", id)
+			}
+		}
+		if _, ok := got.LookupOperatorTerminalStop(runningAbsent); ok {
+			t.Errorf("operator terminal stop[%s] present = true; want false because absence is not terminal", runningAbsent)
+		}
+		if _, ok := got.ClaimedIssues[runningAbsentListed]; ok {
+			t.Errorf("ClaimedIssues[%s] present after stale active listing = true; want false because explicit Absent wins", runningAbsentListed)
+		}
+		if _, ok := got.LookupOperatorTerminalStop(runningTerminal); !ok {
+			t.Errorf("operator terminal stop[%s] present = false; want true for Current terminal", runningTerminal)
+		}
+	})
+	for _, id := range []IssueID{runningAbsent, runningAbsentListed, runningTerminal} {
+		if !errors.Is(cancelCauses[id], worker.ErrReconcileCancel) {
+			t.Errorf("cancel cause[%s] = %v; want %v", id, cancelCauses[id], worker.ErrReconcileCancel)
+		}
+	}
+	if _, canceled := cancelCauses[runningActive]; canceled {
+		t.Errorf("active run %s canceled = true; want false", runningActive)
+	}
+	if calls := cleaner.snapshot(); len(calls) != 0 {
+		t.Errorf("workspace cleanups = %+v; want none before running workers finalize and for Absent", calls)
+	}
+}
+
 // TestReconcileTickEmptyRequiredLabelsKeepsLabellessRunningIssue pins the
 // gate-off default: with no required_labels, a running issue carrying no matching
 // label must NOT be reconciled inactive on label grounds.
 func TestReconcileTickEmptyRequiredLabelsKeepsLabellessRunningIssue(t *testing.T) {
 	poller, ctx := newRunningLabelReconcilePoller(t,
-		map[string]tracker.IssueState{"issue-1": {State: "In Progress", Labels: []string{"backend"}}},
+		map[string]tracker.IssueState{"issue-1": {Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress", Labels: []string{"backend"}}},
 		nil) // gate off
 
 	got, err := poller.reconcileTick(ctx, nil)

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -262,7 +262,7 @@ func (b *blockingReconcileTracker) FetchIssueStatesByRefs(ctx context.Context, r
 	}
 	states := make(map[string]tracker.IssueState, len(refs))
 	for _, ref := range refs {
-		states[ref.ID] = tracker.IssueState{State: "In Progress"}
+		states[ref.ID] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: "In Progress"}
 	}
 	return states, nil
 }
@@ -335,7 +335,7 @@ func (f *fakeIssueStateTracker) FetchIssueStatesByRefs(_ context.Context, refs [
 	if f.fetchIDStates != nil {
 		for id, state := range f.fetchIDStates {
 			if _, ok := wanted[id]; ok {
-				out[id] = tracker.IssueState{State: state}
+				out[id] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: state}
 			}
 		}
 		return out, f.fetchIDErr
@@ -344,7 +344,7 @@ func (f *fakeIssueStateTracker) FetchIssueStatesByRefs(_ context.Context, refs [
 	// same labels the real narrow refresh surfaces (SPEC §6.4 gate).
 	for _, issue := range f.issues {
 		if _, ok := wanted[issue.ID]; ok {
-			out[issue.ID] = tracker.IssueState{State: issue.State, Labels: issue.Labels}
+			out[issue.ID] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: issue.State, Labels: issue.Labels}
 		}
 	}
 	return out, nil

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -327,9 +327,9 @@ func TestPollOncePreflightFailurePatchesClaimedActiveStateWithoutWipingMetadata(
 	}
 
 	trackerClient := &fakeIssueStateTracker{fetchIDIssueStates: map[string]tracker.IssueState{
-		runningIssue.ID: {State: "Rework", Labels: []string{"fresh"}, BlockedBy: nil},
-		retryIssue.ID:   {State: "Rework", Labels: []string{"fresh"}, BlockedBy: []tracker.BlockerRef{}},
-		blockedIssue.ID: {State: "Rework", Labels: []string{"fresh"}, BlockedBy: []tracker.BlockerRef{{ID: "new-blocker", State: "Done"}}},
+		runningIssue.ID: {Outcome: tracker.IssueStateOutcomeCurrent, State: "Rework", Labels: []string{"fresh"}, BlockedBy: nil},
+		retryIssue.ID:   {Outcome: tracker.IssueStateOutcomeCurrent, State: "Rework", Labels: []string{"fresh"}, BlockedBy: []tracker.BlockerRef{}},
+		blockedIssue.ID: {Outcome: tracker.IssueStateOutcomeCurrent, State: "Rework", Labels: []string{"fresh"}, BlockedBy: []tracker.BlockerRef{{ID: "new-blocker", State: "Done"}}},
 	}}
 	orch := New(st, Deps{Dispatcher: &cancellationDispatcher{}, Scheduler: RetryScheduler{MaxBackoff: time.Hour}})
 	go orch.Run(ctx)

--- a/internal/orchestrator/runtime_poller.go
+++ b/internal/orchestrator/runtime_poller.go
@@ -328,13 +328,14 @@ func (d *RuntimeDispatcher) configForSnapshot(snap WorkflowSnapshot) worker.Conf
 					return runner.IssueStateSnapshot{}, err
 				}
 				state, ok := statesByID[issueID]
-				if !ok || strings.TrimSpace(state.State) == "" {
+				if !ok || state.Outcome != tracker.IssueStateOutcomeCurrent || strings.TrimSpace(state.State) == "" {
 					// SPEC §16.5 "issue = refreshed_issue[0] or
-					// issue": no row means we treat the issue as
-					// still in its prior (active) state rather
-					// than aborting on a benign absence. Leave this
-					// branch label-blind so a transient empty refresh
-					// never self-stops a healthy run.
+					// issue": only an authoritative Current row may
+					// replace the prior snapshot. Missing, Unknown, and
+					// Absent therefore keep this per-turn check active;
+					// reconciliation owns confirmed-absence cancellation.
+					// Leave this branch label-blind so an inconclusive
+					// refresh never self-stops a healthy run.
 					return runner.IssueStateSnapshot{Found: false, Active: true}, nil
 				}
 				normalized := strings.ToLower(strings.TrimSpace(state.State))
@@ -343,7 +344,8 @@ func (d *RuntimeDispatcher) configForSnapshot(snap WorkflowSnapshot) worker.Conf
 				// SPEC §6.4 "continue" gate: an issue still in an active state
 				// but no longer carrying every required label is not routable,
 				// so the runner must self-stop (it stops on !Active). Applied
-				// only on a present row, so absence stays no-information above.
+				// only on an authoritative Current row; every other outcome
+				// stays no-information for this per-turn check above.
 				routable := active && labelsSatisfyRequired(state.Labels, requiredLabels)
 				return runner.IssueStateSnapshot{Found: true, State: state.State, Active: routable, Terminal: terminal}, nil
 			}

--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -16,10 +16,11 @@ import (
 )
 
 type stubRefresher struct {
-	calls   [][]string
-	states  map[string]string
-	labels  map[string][]string
-	fetchEr error
+	calls       [][]string
+	states      map[string]string
+	labels      map[string][]string
+	issueStates map[string]tracker.IssueState
+	fetchEr     error
 }
 
 func (s *stubRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]tracker.IssueState, error) {
@@ -29,8 +30,12 @@ func (s *stubRefresher) FetchIssueStatesByIDs(_ context.Context, ids []string) (
 	}
 	out := map[string]tracker.IssueState{}
 	for _, id := range ids {
+		if state, ok := s.issueStates[id]; ok {
+			out[id] = state
+			continue
+		}
 		if state, ok := s.states[id]; ok {
-			out[id] = tracker.IssueState{State: state, Labels: s.labels[id]}
+			out[id] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: state, Labels: s.labels[id]}
 		}
 	}
 	return out, nil
@@ -50,7 +55,7 @@ func (s *stubRefAwareRefresher) FetchIssueStatesByRefs(_ context.Context, refs [
 	out := map[string]tracker.IssueState{}
 	for _, ref := range refs {
 		if state, ok := s.states[ref.ID]; ok {
-			out[ref.ID] = tracker.IssueState{State: state}
+			out[ref.ID] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: state}
 		}
 	}
 	return out, nil
@@ -76,7 +81,7 @@ func (s *stubNoBlockerRefAwareRefresher) FetchIssueStatesWithoutBlockersByRefs(_
 	out := map[string]tracker.IssueState{}
 	for _, ref := range refs {
 		if state, ok := s.states[ref.ID]; ok {
-			out[ref.ID] = tracker.IssueState{State: state}
+			out[ref.ID] = tracker.IssueState{Outcome: tracker.IssueStateOutcomeCurrent, State: state}
 		}
 	}
 	return out, nil
@@ -159,6 +164,45 @@ func TestRuntimeDispatcherConfigForSnapshotBuildsRefresherClosure(t *testing.T) 
 			t.Fatalf("err = %v, want wrapped tracker boom", err)
 		}
 	})
+}
+
+func TestRuntimeDispatcherCurrentIssueRefreshRequiresCurrentOutcome(t *testing.T) {
+	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
+	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
+		Tracker: workflow.TrackerConfig{ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"}},
+	}}}
+	tests := []struct {
+		name   string
+		states map[string]tracker.IssueState
+	}{
+		{
+			name: "state-bearing unknown",
+			states: map[string]tracker.IssueState{
+				"issue-1": {Outcome: tracker.IssueStateOutcomeUnknown, State: "In Progress"},
+			},
+		},
+		{
+			name: "state-bearing absent",
+			states: map[string]tracker.IssueState{
+				"issue-1": {Outcome: tracker.IssueStateOutcomeAbsent, State: "Done"},
+			},
+		},
+		{name: "missing row", states: map[string]tracker.IssueState{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d.SetIssueStateRefresher(&stubRefresher{issueStates: tt.states})
+			cfg := d.configForSnapshot(snap)
+			fn := cfg.IssueStateRefresher(task.Task{ID: "issue-1"}, snap.Workflow.Config)
+			got, err := fn(context.Background())
+			if err != nil {
+				t.Fatalf("current issue refresh error = %v; want nil", err)
+			}
+			if got.Found || !got.Active || got.Terminal || got.State != "" {
+				t.Fatalf("current issue snapshot = %+v; want Found=false Active=true fallback", got)
+			}
+		})
+	}
 }
 
 func TestRuntimeDispatcherIssueStateRefresherUsesNoBlockerRefreshWhenAvailable(t *testing.T) {

--- a/internal/tracker/github_blockers.go
+++ b/internal/tracker/github_blockers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -33,8 +34,8 @@ type githubNativeBlockers struct {
 }
 
 type githubGraphQLBlockersResponse struct {
-	Data struct {
-		Nodes []githubGraphQLIssueNode `json:"nodes"`
+	Data *struct {
+		Nodes *[]githubGraphQLIssueNode `json:"nodes"`
 	} `json:"data"`
 	Errors []struct {
 		Message string `json:"message"`
@@ -42,34 +43,43 @@ type githubGraphQLBlockersResponse struct {
 }
 
 type githubGraphQLIssueNode struct {
-	ID        string `json:"id"`
-	Number    int    `json:"number"`
-	BlockedBy struct {
-		Nodes    []githubGraphQLBlockerNode `json:"nodes"`
-		PageInfo struct {
-			HasNextPage bool `json:"hasNextPage"`
-		} `json:"pageInfo"`
-	} `json:"blockedBy"`
+	ID        *string                 `json:"id"`
+	Number    *int                    `json:"number"`
+	BlockedBy *githubGraphQLBlockedBy `json:"blockedBy"`
+}
+
+type githubGraphQLBlockedBy struct {
+	Nodes    *[]githubGraphQLBlockerNode `json:"nodes"`
+	PageInfo *struct {
+		HasNextPage *bool `json:"hasNextPage"`
+	} `json:"pageInfo"`
 }
 
 type githubGraphQLBlockerNode struct {
-	ID         string `json:"id"`
-	DatabaseID int64  `json:"databaseId"`
-	Number     int    `json:"number"`
-	State      string `json:"state"`
-	Labels     struct {
-		Nodes []githubGraphQLLabel `json:"nodes"`
+	ID         *string `json:"id"`
+	DatabaseID *int64  `json:"databaseId"`
+	Number     *int    `json:"number"`
+	State      *string `json:"state"`
+	Labels     *struct {
+		Nodes *[]githubGraphQLLabel `json:"nodes"`
 	} `json:"labels"`
 }
 
 type githubGraphQLLabel struct {
-	Name string `json:"name"`
+	Name *string `json:"name"`
 }
 
 type githubBodyBlockerResolution struct {
 	Ref   BlockerRef
 	Found bool
 }
+
+type githubBodyBlockerLookupPolicy uint8
+
+const (
+	githubBodyBlockerBestEffort githubBodyBlockerLookupPolicy = iota
+	githubBodyBlockerRefresh
+)
 
 func (c *GitHubClient) attachGitHubBlockersToIssues(ctx context.Context, issues []Issue) error {
 	if len(issues) == 0 {
@@ -91,7 +101,7 @@ func (c *GitHubClient) attachGitHubBlockersToIssues(ctx context.Context, issues 
 			Body:       meta.Body,
 		})
 	}
-	blockers, err := c.blockersForGitHubSources(ctx, sources, githubConfiguredStates(c.Config))
+	blockers, err := c.blockersForGitHubSources(ctx, sources, githubConfiguredStates(c.Config), githubBodyBlockerBestEffort)
 	if err != nil {
 		return err
 	}
@@ -107,7 +117,7 @@ func (c *GitHubClient) attachGitHubBlockersToIssues(ctx context.Context, issues 
 	return nil
 }
 
-func (c *GitHubClient) blockersForGitHubSources(ctx context.Context, sources []githubBlockerSource, configuredStates []string) (map[string][]BlockerRef, error) {
+func (c *GitHubClient) blockersForGitHubSources(ctx context.Context, sources []githubBlockerSource, configuredStates []string, bodyLookupPolicy githubBodyBlockerLookupPolicy) (map[string][]BlockerRef, error) {
 	out := make(map[string][]BlockerRef, len(sources))
 	hydrationSources := githubBlockerHydrationSources(sources)
 	native, nativeErr := c.nativeGitHubBlockers(ctx, hydrationSources, configuredStates)
@@ -118,7 +128,7 @@ func (c *GitHubClient) blockersForGitHubSources(ctx context.Context, sources []g
 		return nil, nativeErr
 	}
 	for _, source := range sources {
-		blockedBy, err := c.blockersForGitHubSource(ctx, source, native, configuredStates)
+		blockedBy, err := c.blockersForGitHubSource(ctx, source, native, configuredStates, bodyLookupPolicy)
 		if err != nil {
 			return nil, err
 		}
@@ -127,7 +137,7 @@ func (c *GitHubClient) blockersForGitHubSources(ctx context.Context, sources []g
 	return out, nil
 }
 
-func (c *GitHubClient) blockersForGitHubSource(ctx context.Context, source githubBlockerSource, native map[string]githubNativeBlockers, configuredStates []string) ([]BlockerRef, error) {
+func (c *GitHubClient) blockersForGitHubSource(ctx context.Context, source githubBlockerSource, native map[string]githubNativeBlockers, configuredStates []string, bodyLookupPolicy githubBodyBlockerLookupPolicy) ([]BlockerRef, error) {
 	if !githubBlockerSourceNeedsHydration(source) {
 		return []BlockerRef{}, nil
 	}
@@ -135,7 +145,11 @@ func (c *GitHubClient) blockersForGitHubSource(ctx context.Context, source githu
 	if err != nil {
 		return nil, err
 	}
-	for _, blocker := range c.bodyGitHubBlockers(ctx, source.Body, configuredStates, githubBlockerNumbers(blockedBy)) {
+	bodyBlockers, err := c.bodyGitHubBlockers(ctx, source.Body, configuredStates, githubBlockerNumbers(blockedBy), bodyLookupPolicy)
+	if err != nil {
+		return nil, err
+	}
+	for _, blocker := range bodyBlockers {
 		blockedBy = appendGitHubBlocker(blockedBy, blocker)
 	}
 	if blockedBy == nil {
@@ -183,31 +197,69 @@ func (c *GitHubClient) nativeGitHubBlockers(ctx context.Context, sources []githu
 	if len(nodeIDs) == 0 {
 		return map[string]githubNativeBlockers{}, nil
 	}
+	sourceNumbers, err := githubBlockerSourceNumbers(sources)
+	if err != nil {
+		return nil, err
+	}
 	out := make(map[string]githubNativeBlockers, len(nodeIDs))
 	for start := 0; start < len(nodeIDs); start += githubBlockedBySourceChunkSize {
-		end := start + githubBlockedBySourceChunkSize
-		if end > len(nodeIDs) {
-			end = len(nodeIDs)
-		}
-		decoded, err := c.fetchNativeGitHubBlockers(ctx, nodeIDs[start:end])
+		end := min(start+githubBlockedBySourceChunkSize, len(nodeIDs))
+		blockersByID, err := c.nativeGitHubBlockerChunk(ctx, nodeIDs[start:end], sourceNumbers, configuredStates)
 		if err != nil {
 			return nil, err
 		}
-		for id, blockers := range graphQLNativeBlockers(decoded, configuredStates) {
+		for id, blockers := range blockersByID {
 			out[id] = blockers
 		}
 	}
 	return out, nil
 }
 
+func (c *GitHubClient) nativeGitHubBlockerChunk(ctx context.Context, nodeIDs []string, sourceNumbers map[string]int, configuredStates []string) (map[string]githubNativeBlockers, error) {
+	decoded, err := c.fetchNativeGitHubBlockers(ctx, nodeIDs)
+	if err != nil {
+		return nil, err
+	}
+	expectedNumbers := make(map[string]int, len(nodeIDs))
+	for _, id := range nodeIDs {
+		expectedNumbers[id] = sourceNumbers[id]
+	}
+	return graphQLNativeBlockers(decoded, expectedNumbers, configuredStates)
+}
+
 func githubBlockerNodeIDs(sources []githubBlockerSource) []string {
 	nodeIDs := make([]string, 0, len(sources))
+	seen := make(map[string]struct{}, len(sources))
 	for _, source := range sources {
-		if nodeID := strings.TrimSpace(source.NodeID); nodeID != "" {
-			nodeIDs = append(nodeIDs, nodeID)
+		nodeID := strings.TrimSpace(source.NodeID)
+		if nodeID == "" {
+			continue
 		}
+		if _, duplicate := seen[nodeID]; duplicate {
+			continue
+		}
+		seen[nodeID] = struct{}{}
+		nodeIDs = append(nodeIDs, nodeID)
 	}
 	return nodeIDs
+}
+
+func githubBlockerSourceNumbers(sources []githubBlockerSource) (map[string]int, error) {
+	out := make(map[string]int, len(sources))
+	for _, source := range sources {
+		nodeID := strings.TrimSpace(source.NodeID)
+		if nodeID == "" {
+			continue
+		}
+		if source.Number <= 0 {
+			return nil, incompleteGitHubBlockerResponse("source issue has invalid number")
+		}
+		if number, exists := out[nodeID]; exists && number != source.Number {
+			return nil, incompleteGitHubBlockerResponse("source node id maps to conflicting numbers")
+		}
+		out[nodeID] = source.Number
+	}
+	return out, nil
 }
 
 func (c *GitHubClient) fetchNativeGitHubBlockers(ctx context.Context, nodeIDs []string) (githubGraphQLBlockersResponse, error) {
@@ -270,42 +322,110 @@ func (c *GitHubClient) fetchNativeGitHubBlockers(ctx context.Context, nodeIDs []
 	return decoded, nil
 }
 
-func graphQLNativeBlockers(decoded githubGraphQLBlockersResponse, configuredStates []string) map[string]githubNativeBlockers {
-	out := make(map[string]githubNativeBlockers, len(decoded.Data.Nodes))
-	for _, node := range decoded.Data.Nodes {
-		blockers := make([]BlockerRef, 0, len(node.BlockedBy.Nodes))
-		for _, blocker := range node.BlockedBy.Nodes {
-			blockers = appendGitHubBlocker(blockers, githubGraphQLBlockerRef(blocker, configuredStates))
-		}
-		out[node.ID] = githubNativeBlockers{
-			Blockers:   blockers,
-			Incomplete: node.BlockedBy.PageInfo.HasNextPage,
-		}
+func graphQLNativeBlockers(decoded githubGraphQLBlockersResponse, expectedNumbers map[string]int, configuredStates []string) (map[string]githubNativeBlockers, error) {
+	if decoded.Data == nil || decoded.Data.Nodes == nil {
+		return nil, incompleteGitHubBlockerResponse("missing data.nodes")
 	}
-	return out
+	out := make(map[string]githubNativeBlockers, len(*decoded.Data.Nodes))
+	for _, node := range *decoded.Data.Nodes {
+		id, blockers, err := githubNativeBlockersFromGraphQLNode(node, expectedNumbers, configuredStates)
+		if err != nil {
+			return nil, err
+		}
+		if _, duplicate := out[id]; duplicate {
+			return nil, incompleteGitHubBlockerResponse("duplicate issue node id")
+		}
+		out[id] = blockers
+	}
+	if len(out) != len(expectedNumbers) {
+		return nil, incompleteGitHubBlockerResponse("response omitted a requested source node")
+	}
+	return out, nil
 }
 
-func (c *GitHubClient) bodyGitHubBlockers(ctx context.Context, body string, configuredStates []string, skip map[int]struct{}) []BlockerRef {
+func githubNativeBlockersFromGraphQLNode(node githubGraphQLIssueNode, expectedNumbers map[string]int, configuredStates []string) (string, githubNativeBlockers, error) {
+	if err := validateGitHubGraphQLIssueNode(node); err != nil {
+		return "", githubNativeBlockers{}, err
+	}
+	id := strings.TrimSpace(*node.ID)
+	expectedNumber, requested := expectedNumbers[id]
+	if !requested {
+		return "", githubNativeBlockers{}, incompleteGitHubBlockerResponse("response contains an unrequested source node id")
+	}
+	if *node.Number != expectedNumber {
+		return "", githubNativeBlockers{}, incompleteGitHubBlockerResponse("source node number does not match requested issue")
+	}
+	blockers := make([]BlockerRef, 0, len(*node.BlockedBy.Nodes))
+	for _, blocker := range *node.BlockedBy.Nodes {
+		blockers = appendGitHubBlocker(blockers, githubGraphQLBlockerRef(blocker, configuredStates))
+	}
+	return id, githubNativeBlockers{
+		Blockers:   blockers,
+		Incomplete: *node.BlockedBy.PageInfo.HasNextPage,
+	}, nil
+}
+
+func validateGitHubGraphQLIssueNode(node githubGraphQLIssueNode) error {
+	if err := validateGitHubGraphQLIssueNodeShape(node); err != nil {
+		return err
+	}
+	for _, blocker := range *node.BlockedBy.Nodes {
+		if err := validateGitHubGraphQLBlockerNode(blocker); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateGitHubGraphQLIssueNodeShape(node githubGraphQLIssueNode) error {
+	if node.ID == nil || strings.TrimSpace(*node.ID) == "" || node.Number == nil || *node.Number <= 0 {
+		return incompleteGitHubBlockerResponse("issue node missing identity or blockedBy fields")
+	}
+	if node.BlockedBy == nil || node.BlockedBy.Nodes == nil || node.BlockedBy.PageInfo == nil || node.BlockedBy.PageInfo.HasNextPage == nil {
+		return incompleteGitHubBlockerResponse("issue node missing identity or blockedBy fields")
+	}
+	return nil
+}
+
+func validateGitHubGraphQLBlockerNode(blocker githubGraphQLBlockerNode) error {
+	if blocker.ID == nil || strings.TrimSpace(*blocker.ID) == "" || blocker.Number == nil || *blocker.Number <= 0 ||
+		blocker.State == nil || strings.TrimSpace(*blocker.State) == "" {
+		return incompleteGitHubBlockerResponse("blocker node missing identity, state, or labels")
+	}
+	if blocker.Labels == nil || blocker.Labels.Nodes == nil {
+		return incompleteGitHubBlockerResponse("blocker node missing identity, state, or labels")
+	}
+	for _, label := range *blocker.Labels.Nodes {
+		if label.Name == nil || strings.TrimSpace(*label.Name) == "" {
+			return incompleteGitHubBlockerResponse("blocker label missing non-empty name")
+		}
+	}
+	return nil
+}
+
+func incompleteGitHubBlockerResponse(detail string) error {
+	return fmt.Errorf("%w: GitHub blockedBy response %s", ErrIssueStateRefreshIncomplete, detail)
+}
+
+func (c *GitHubClient) bodyGitHubBlockers(ctx context.Context, body string, configuredStates []string, skip map[int]struct{}, policy githubBodyBlockerLookupPolicy) ([]BlockerRef, error) {
 	numbers := githubBlockedByIssueNumbers(body)
 	if len(numbers) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]BlockerRef, 0, len(numbers))
-	cache := make(map[int]githubBodyBlockerResolution, len(numbers))
 	for _, number := range numbers {
 		if _, ok := skip[number]; ok {
 			continue
 		}
-		resolved, ok := cache[number]
-		if !ok {
-			resolved = c.resolveBodyGitHubBlocker(ctx, number, configuredStates)
-			cache[number] = resolved
+		resolved, err := c.resolveBodyGitHubBlocker(ctx, number, configuredStates, policy)
+		if err != nil {
+			return nil, err
 		}
 		if resolved.Found {
 			out = appendGitHubBlocker(out, resolved.Ref)
 		}
 	}
-	return out
+	return out, nil
 }
 
 func githubBlockerNumbers(blockers []BlockerRef) map[int]struct{} {
@@ -318,16 +438,19 @@ func githubBlockerNumbers(blockers []BlockerRef) map[int]struct{} {
 	return out
 }
 
-func (c *GitHubClient) resolveBodyGitHubBlocker(ctx context.Context, issueNumber int, configuredStates []string) githubBodyBlockerResolution {
-	issue, found, err := c.getIssueByNumber(ctx, issueNumber)
-	if err != nil {
-		if c.Logf != nil {
-			c.Logf("github body blocker lookup for #%d failed; omitting unverified fallback blocker this tick: %v", issueNumber, err)
-		}
-		return githubBodyBlockerResolution{}
+func (c *GitHubClient) resolveBodyGitHubBlocker(ctx context.Context, issueNumber int, configuredStates []string, policy githubBodyBlockerLookupPolicy) (githubBodyBlockerResolution, error) {
+	issue, found, lookupErr := c.getIssueByNumber(ctx, issueNumber)
+	if lookupErr != nil {
+		return c.bodyGitHubBlockerLookupFailure(ctx, issueNumber, lookupErr, policy)
 	}
 	if !found {
-		return githubBodyBlockerResolution{}
+		return githubBodyBlockerResolution{}, nil
+	}
+	if issue.Number != issueNumber {
+		if c.Logf != nil {
+			c.Logf("github body blocker lookup for #%d returned issue #%d; failing closed with the requested blocker placeholder", issueNumber, issue.Number)
+		}
+		return githubBodyBlockerPlaceholder(issueNumber), nil
 	}
 	id := strconv.FormatInt(issue.ID, 10)
 	c.cacheIssueNumber(id, issue.Number)
@@ -339,24 +462,50 @@ func (c *GitHubClient) resolveBodyGitHubBlocker(ctx context.Context, issueNumber
 			State:      githubResolveState(issue, configuredStates),
 		},
 		Found: true,
+	}, nil
+}
+
+func (c *GitHubClient) bodyGitHubBlockerLookupFailure(ctx context.Context, issueNumber int, lookupErr error, policy githubBodyBlockerLookupPolicy) (githubBodyBlockerResolution, error) {
+	if policy == githubBodyBlockerBestEffort {
+		if c.Logf != nil {
+			c.Logf("github body blocker lookup for #%d failed; omitting unverified fallback blocker this tick: %v", issueNumber, lookupErr)
+		}
+		return githubBodyBlockerResolution{}, nil
+	}
+	if ShouldStopIssueStateRefresh(ctx, lookupErr) {
+		if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(lookupErr, ctxErr) {
+			lookupErr = errors.Join(lookupErr, ctxErr)
+		}
+		return githubBodyBlockerResolution{}, lookupErr
+	}
+	if c.Logf != nil {
+		c.Logf("github body blocker lookup for #%d failed; failing closed with an open placeholder this tick: %v", issueNumber, lookupErr)
+	}
+	return githubBodyBlockerPlaceholder(issueNumber), nil
+}
+
+func githubBodyBlockerPlaceholder(issueNumber int) githubBodyBlockerResolution {
+	return githubBodyBlockerResolution{
+		Ref:   BlockerRef{Identifier: fmt.Sprintf("#%d", issueNumber)},
+		Found: true,
 	}
 }
 
 func githubGraphQLBlockerRef(blocker githubGraphQLBlockerNode, configuredStates []string) BlockerRef {
-	labels := make([]githubLabel, 0, len(blocker.Labels.Nodes))
-	for _, label := range blocker.Labels.Nodes {
-		labels = append(labels, githubLabel(label))
+	labels := make([]githubLabel, 0, len(*blocker.Labels.Nodes))
+	for _, label := range *blocker.Labels.Nodes {
+		labels = append(labels, githubLabel{Name: *label.Name})
 	}
-	id := strings.TrimSpace(blocker.ID)
-	if blocker.DatabaseID > 0 {
-		id = strconv.FormatInt(blocker.DatabaseID, 10)
+	id := strings.TrimSpace(*blocker.ID)
+	if blocker.DatabaseID != nil && *blocker.DatabaseID > 0 {
+		id = strconv.FormatInt(*blocker.DatabaseID, 10)
 	}
 	return BlockerRef{
 		ID:         id,
-		Identifier: fmt.Sprintf("#%d", blocker.Number),
+		Identifier: fmt.Sprintf("#%d", *blocker.Number),
 		State: githubResolveState(githubIssue{
-			Number: blocker.Number,
-			State:  blocker.State,
+			Number: *blocker.Number,
+			State:  *blocker.State,
 			Labels: labels,
 		}, configuredStates),
 	}

--- a/internal/tracker/github_refresh.go
+++ b/internal/tracker/github_refresh.go
@@ -2,6 +2,8 @@ package tracker
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,11 +18,11 @@ import (
 // `GET /repos/{owner}/{repo}/issues/{number}` per ID using the repo issue
 // number cached during prior list calls. Ref-aware callers can also provide
 // the human identifier (`#123`) so a rebuilt tracker client can query by repo
-// issue number before any list call repopulates the cache. Per-ID 404/410
-// responses are treated as "issue removed" and silently skipped so a single
-// deleted issue does not abort reconciliation for the rest of the running set.
-// Other HTTP errors abort the whole call so a transient outage cannot silently
-// degrade per-tick state refresh.
+// issue number before any list call repopulates the cache. A 404/410 confirms
+// absence only when this client previously cached the ID-to-number mapping for
+// the current repository; fallback-only not-found responses remain unknown.
+// Ambiguous references and failed reads remain unknown, while independent
+// current/absent rows survive a partial batch error.
 //
 // State derivation: if any label on the issue matches a state configured in
 // active_states / terminal_states / inactive_states (case-insensitive), the
@@ -54,75 +56,136 @@ type githubFetchedIssueState struct {
 	labels  []string
 }
 
-func (c *GitHubClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef) (map[string]IssueState, error) { //nolint:gocognit // baseline (#521)
+type githubIssueStateLookup struct {
+	outcome IssueStateOutcome
+	fetched githubFetchedIssueState
+}
+
+type githubIssueStateLookupBatch struct {
+	fetched []githubFetchedIssueState
+	absent  []string
+	errs    []error
+	halted  bool
+}
+
+func (c *GitHubClient) FetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef) (map[string]IssueState, error) {
 	return c.fetchIssueStatesByRefs(ctx, issueRefs, true)
 }
 
-func (c *GitHubClient) fetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef, includeBlockers bool) (map[string]IssueState, error) { //nolint:gocognit // baseline (#521)
+func (c *GitHubClient) fetchIssueStatesByRefs(ctx context.Context, issueRefs []IssueRef, includeBlockers bool) (map[string]IssueState, error) {
+	states, refs := UnknownIssueStatesByRefs(issueRefs)
 	if strings.TrimSpace(c.Token) == "" {
-		return nil, fmt.Errorf("GitHub tracker api_key is required")
+		return states, fmt.Errorf("GitHub tracker api_key is required")
 	}
-	if len(issueRefs) == 0 {
-		return map[string]IssueState{}, nil
+	if len(refs) == 0 {
+		return states, nil
 	}
 	if strings.TrimSpace(c.Owner) == "" || strings.TrimSpace(c.Repo) == "" {
-		return nil, fmt.Errorf("repo.owner and repo.name are required for GitHub tracker polling")
+		return states, fmt.Errorf("repo.owner and repo.name are required for GitHub tracker polling")
 	}
 	configuredStates := githubConfiguredStates(c.Config)
-	fetched := make([]githubFetchedIssueState, 0, len(issueRefs))
-	seen := map[string]struct{}{}
-	for _, issueRef := range issueRefs {
-		issueID := strings.TrimSpace(issueRef.ID)
-		if issueID == "" {
-			continue
-		}
-		if _, ok := seen[issueID]; ok {
-			continue
-		}
-		seen[issueID] = struct{}{}
-		issueNumber, ok := c.issueNumberForStateRefresh(issueRef)
-		if !ok {
-			c.logStateRefreshCacheMiss(issueRef)
-			continue
-		}
-		issue, found, err := c.getIssueByNumber(ctx, issueNumber)
+	batch := c.lookupGitHubIssueStates(ctx, refs, configuredStates, includeBlockers)
+	for _, issueID := range batch.absent {
+		states[issueID] = IssueState{Outcome: IssueStateOutcomeAbsent}
+	}
+	var blockersByID map[string][]BlockerRef
+	var blockerErr error
+	if !batch.halted {
+		blockersByID, blockerErr = c.blockerRefsForFetchedGitHubIssueStates(ctx, batch.fetched, configuredStates, includeBlockers)
+	}
+	if blockerErr != nil {
+		batch.errs = append(batch.errs, blockerErr)
+	}
+	applyCurrentGitHubIssueStates(states, batch.fetched, blockersByID, includeBlockers, batch.halted || blockerErr != nil)
+	return states, errors.Join(batch.errs...)
+}
+
+func (c *GitHubClient) lookupGitHubIssueStates(ctx context.Context, refs []IssueRef, configuredStates []string, includeBlockers bool) githubIssueStateLookupBatch {
+	batch := githubIssueStateLookupBatch{fetched: make([]githubFetchedIssueState, 0, len(refs))}
+	for _, issueRef := range refs {
+		lookup, err := c.lookupGitHubIssueState(ctx, issueRef, configuredStates, includeBlockers)
 		if err != nil {
-			return nil, err
-		}
-		if !found {
+			batch.errs = append(batch.errs, err)
+			if ShouldStopIssueStateRefresh(ctx, err) {
+				batch.halted = true
+				break
+			}
 			continue
 		}
-		refreshedID := strconv.FormatInt(issue.ID, 10)
-		if !githubFetchedIssueMatchesRef(issueID, issueRef.Identifier, refreshedID, issue.Number) {
-			c.cacheIssueNumber(refreshedID, issue.Number)
+		switch lookup.outcome {
+		case IssueStateOutcomeAbsent:
+			batch.absent = append(batch.absent, issueRef.ID)
+		case IssueStateOutcomeCurrent:
+			batch.fetched = append(batch.fetched, lookup.fetched)
+		}
+	}
+	return batch
+}
+
+func applyCurrentGitHubIssueStates(states map[string]IssueState, fetched []githubFetchedIssueState, blockersByID map[string][]BlockerRef, includeBlockers, todoBlockersUnavailable bool) {
+	for _, row := range fetched {
+		if includeBlockers && githubTodoWorkflowState(row.state) && todoBlockersUnavailable {
 			continue
 		}
-		c.cacheIssueNumber(refreshedID, issue.Number)
-		if issueNumberID := githubIssueNumberID(issue.Number); issueID == issueNumberID {
-			c.cacheIssueNumber(issueID, issue.Number)
+		// Carry the full label set (SPEC §6.4 required_labels gate) alongside the
+		// resolved state so label removal can stop/release already-claimed work.
+		states[row.issueID] = IssueState{Outcome: IssueStateOutcomeCurrent, State: row.state, Labels: row.labels, BlockedBy: githubIssueStateBlockers(blockersByID, row.issueID, includeBlockers)}
+	}
+}
+
+func (c *GitHubClient) lookupGitHubIssueState(ctx context.Context, issueRef IssueRef, configuredStates []string, includeBlockers bool) (githubIssueStateLookup, error) {
+	issueNumber, ok, cached := c.issueNumberForStateRefresh(issueRef)
+	if !ok {
+		c.logStateRefreshCacheMiss(issueRef)
+		return githubIssueStateLookup{}, nil
+	}
+	if !githubIssueRefMatchesNumber(issueRef, issueNumber) {
+		return githubIssueStateLookup{}, nil
+	}
+	issue, found, bodyPresent, err := c.getIssueByNumberWithBodyPresence(ctx, issueNumber)
+	if err != nil {
+		return githubIssueStateLookup{}, err
+	}
+	if !found {
+		if cached {
+			return githubIssueStateLookup{outcome: IssueStateOutcomeAbsent}, nil
 		}
-		state := githubResolveState(issue, configuredStates)
-		if state == "" {
-			continue
-		}
-		fetched = append(fetched, githubFetchedIssueState{
-			issueID: issueID,
+		return githubIssueStateLookup{}, nil
+	}
+	return c.classifyFetchedGitHubIssueState(issueRef, issueNumber, issue, bodyPresent, configuredStates, includeBlockers)
+}
+
+func (c *GitHubClient) classifyFetchedGitHubIssueState(issueRef IssueRef, issueNumber int, issue githubIssue, bodyPresent bool, configuredStates []string, includeBlockers bool) (githubIssueStateLookup, error) {
+	if issue.Number != issueNumber {
+		return githubIssueStateLookup{}, nil
+	}
+	refreshedID := strconv.FormatInt(issue.ID, 10)
+	if !githubFetchedIssueMatchesRef(issueRef.ID, issueRef.Identifier, refreshedID, issue.Number) {
+		return githubIssueStateLookup{}, nil
+	}
+	c.cacheIssueNumber(refreshedID, issue.Number)
+	if issueNumberID := githubIssueNumberID(issue.Number); issueRef.ID == issueNumberID {
+		c.cacheIssueNumber(issueRef.ID, issue.Number)
+	}
+	state := githubResolveState(issue, configuredStates)
+	if state == "" {
+		return githubIssueStateLookup{}, nil
+	}
+	if includeBlockers && githubTodoWorkflowState(state) && !bodyPresent {
+		return githubIssueStateLookup{}, fmt.Errorf("%w: GitHub Todo issue response missing body", ErrIssueStateRefreshIncomplete)
+	}
+	if includeBlockers && githubTodoWorkflowState(state) && strings.TrimSpace(issue.NodeID) == "" {
+		return githubIssueStateLookup{}, fmt.Errorf("%w: GitHub Todo issue response missing node_id", ErrIssueStateRefreshIncomplete)
+	}
+	return githubIssueStateLookup{
+		outcome: IssueStateOutcomeCurrent,
+		fetched: githubFetchedIssueState{
+			issueID: issueRef.ID,
 			issue:   issue,
 			state:   state,
 			labels:  githubIssueLabels(issue),
-		})
-	}
-	states := make(map[string]IssueState, len(fetched))
-	blockersByID, err := c.blockerRefsForFetchedGitHubIssueStates(ctx, fetched, configuredStates, includeBlockers)
-	if err != nil {
-		return nil, err
-	}
-	for _, row := range fetched {
-		// Carry the full label set (SPEC §6.4 required_labels gate) alongside the
-		// resolved state so label removal can stop/release already-claimed work.
-		states[row.issueID] = IssueState{State: row.state, Labels: row.labels, BlockedBy: githubIssueStateBlockers(blockersByID, row.issueID, includeBlockers)}
-	}
-	return states, nil
+		},
+	}, nil
 }
 
 func (c *GitHubClient) blockerRefsForFetchedGitHubIssueStates(ctx context.Context, fetched []githubFetchedIssueState, configuredStates []string, includeBlockers bool) (map[string][]BlockerRef, error) {
@@ -154,21 +217,37 @@ func (c *GitHubClient) blockersForRefreshedGitHubIssues(ctx context.Context, row
 			Body:       row.issue.Body,
 		})
 	}
-	return c.blockersForGitHubSources(ctx, sources, configuredStates)
+	return c.blockersForGitHubSources(ctx, sources, configuredStates, githubBodyBlockerRefresh)
 }
 
 func githubFetchedIssueMatchesRef(issueID, identifier, refreshedID string, issueNumber int) bool {
 	issueID = strings.TrimSpace(issueID)
-	if issueID == refreshedID {
-		return true
-	}
 	if !githubIdentifierMatchesIssueNumber(identifier, issueNumber) {
 		return false
+	}
+	if issueID == refreshedID {
+		return true
 	}
 	if strings.HasPrefix(issueID, "#") {
 		return issueID == fmt.Sprintf("#%d", issueNumber)
 	}
 	return issueID == githubIssueNumberID(issueNumber)
+}
+
+func githubIssueRefMatchesNumber(ref IssueRef, issueNumber int) bool {
+	identifier := strings.TrimSpace(ref.Identifier)
+	if identifier != "" {
+		got, ok := githubIssueNumberFromIdentifier(identifier)
+		if !ok || got != issueNumber {
+			return false
+		}
+	}
+	id := strings.TrimSpace(ref.ID)
+	if !strings.HasPrefix(id, "#") {
+		return true
+	}
+	got, ok := githubIssueNumberFromIdentifier(id)
+	return ok && got == issueNumber
 }
 
 func githubIdentifierMatchesIssueNumber(identifier string, issueNumber int) bool {
@@ -185,17 +264,18 @@ func githubIssueNumberID(issueNumber int) string {
 	return strconv.Itoa(issueNumber)
 }
 
-func (c *GitHubClient) issueNumberForStateRefresh(ref IssueRef) (int, bool) {
+func (c *GitHubClient) issueNumberForStateRefresh(ref IssueRef) (int, bool, bool) {
 	if issueNumber, ok := c.cachedIssueNumber(ref.ID); ok {
-		return issueNumber, true
+		return issueNumber, true, true
 	}
 	if issueNumber, ok := githubIssueNumberFromIdentifier(ref.Identifier); ok {
-		return issueNumber, true
+		return issueNumber, true, false
 	}
 	if strings.HasPrefix(strings.TrimSpace(ref.ID), "#") {
-		return githubIssueNumberFromIdentifier(ref.ID)
+		issueNumber, ok := githubIssueNumberFromIdentifier(ref.ID)
+		return issueNumber, ok, false
 	}
-	return 0, false
+	return 0, false, false
 }
 
 func (c *GitHubClient) logStateRefreshCacheMiss(ref IssueRef) {
@@ -218,12 +298,17 @@ func githubIssueNumberFromIdentifier(identifier string) (int, bool) {
 }
 
 func (c *GitHubClient) getIssueByNumber(ctx context.Context, issueNumber int) (githubIssue, bool, error) {
+	issue, found, _, err := c.getIssueByNumberWithBodyPresence(ctx, issueNumber)
+	return issue, found, err
+}
+
+func (c *GitHubClient) getIssueByNumberWithBodyPresence(ctx context.Context, issueNumber int) (githubIssue, bool, bool, error) {
 	endpoint := fmt.Sprintf("%s/repos/%s/%s/issues/%d", c.BaseURL, url.PathEscape(c.Owner), url.PathEscape(c.Repo), issueNumber)
 	reqCtx, cancel := context.WithTimeout(ctx, c.requestTimeout())
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return githubIssue{}, false, err
+		return githubIssue{}, false, false, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
@@ -234,23 +319,56 @@ func (c *GitHubClient) getIssueByNumber(ctx context.Context, issueNumber int) (g
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return githubIssue{}, false, err
+		return githubIssue{}, false, false, err
 	}
 	defer DrainAndClose(resp)
 	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
-		return githubIssue{}, false, nil
+		return githubIssue{}, false, false, nil
 	}
 	if githubRateLimited(resp) {
-		return githubIssue{}, false, NewRateLimitedError(fmt.Sprintf("get GitHub issue #%d", issueNumber), resp.StatusCode, resp.Header)
+		return githubIssue{}, false, false, NewRateLimitedError(fmt.Sprintf("get GitHub issue #%d", issueNumber), resp.StatusCode, resp.Header)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return githubIssue{}, false, fmt.Errorf("get GitHub issue #%d failed: status %d", issueNumber, resp.StatusCode)
+		return githubIssue{}, false, false, fmt.Errorf("get GitHub issue #%d failed: status %d", issueNumber, resp.StatusCode)
 	}
-	var issue githubIssue
-	if err := DecodeJSONResponse(resp, &issue); err != nil {
+	issue, bodyPresent, err := decodeGitHubIssueStateResponse(resp)
+	if err != nil {
+		return githubIssue{}, false, false, err
+	}
+	return issue, true, bodyPresent, nil
+}
+
+func decodeGitHubIssueStateResponse(resp *http.Response) (githubIssue, bool, error) {
+	var raw json.RawMessage
+	if err := DecodeJSONResponse(resp, &raw); err != nil {
 		return githubIssue{}, false, fmt.Errorf("decode GitHub issue response: %w", err)
 	}
-	return issue, true, nil
+	var presence struct {
+		ID     *int64          `json:"id"`
+		Number *int            `json:"number"`
+		State  *string         `json:"state"`
+		Body   json.RawMessage `json:"body"`
+		Labels *[]struct {
+			Name *string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal(raw, &presence); err != nil {
+		return githubIssue{}, false, fmt.Errorf("decode GitHub issue response: %w", err)
+	}
+	if presence.ID == nil || *presence.ID <= 0 || presence.Number == nil || *presence.Number <= 0 ||
+		presence.State == nil || strings.TrimSpace(*presence.State) == "" || presence.Labels == nil {
+		return githubIssue{}, false, fmt.Errorf("%w: GitHub issue response has incomplete id, number, state, or labels", ErrIssueStateRefreshIncomplete)
+	}
+	for _, label := range *presence.Labels {
+		if label.Name == nil || strings.TrimSpace(*label.Name) == "" {
+			return githubIssue{}, false, fmt.Errorf("%w: GitHub issue label missing non-empty name", ErrIssueStateRefreshIncomplete)
+		}
+	}
+	var issue githubIssue
+	if err := json.Unmarshal(raw, &issue); err != nil {
+		return githubIssue{}, false, fmt.Errorf("decode GitHub issue response: %w", err)
+	}
+	return issue, len(presence.Body) > 0, nil
 }
 
 func (c *GitHubClient) cacheIssueNumber(issueID string, issueNumber int) {

--- a/internal/tracker/github_test.go
+++ b/internal/tracker/github_test.go
@@ -396,6 +396,68 @@ func TestGitHubClientListIssuesByStatesReturnsErrorWhenNativeBlockerLookupIsRate
 	}
 }
 
+func TestGitHubClientListIssuesByStatesOmitsBodyFallbackOnLookupFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "ordinary failure", statusCode: http.StatusInternalServerError},
+		{name: "rate limit", statusCode: http.StatusTooManyRequests},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var logs []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/acme/api/pulls":
+					_ = json.NewEncoder(w).Encode([]map[string]any{})
+				case "/repos/acme/api/issues":
+					_ = json.NewEncoder(w).Encode([]githubIssue{{
+						ID: 100, NodeID: "I_100", Number: 10, Title: "best effort body dependency",
+						Body: "Blocked by #13", State: "open", Labels: []githubLabel{{Name: "aiops:todo"}},
+					}})
+				case "/graphql":
+					_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+						map[string]any{
+							"id": "I_100", "number": float64(10),
+							"blockedBy": map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false}},
+						},
+					}}})
+				case "/repos/acme/api/issues/13":
+					w.WriteHeader(tc.statusCode)
+				default:
+					t.Fatalf("request path = %q; want known listing or blocker endpoint", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			client := NewGitHubClient(workflow.TrackerConfig{
+				APIKey:       "test-token",
+				ActiveStates: []string{"aiops:todo"},
+			}, srv.URL, "acme", "api")
+			client.HTTP = srv.Client()
+			client.Logf = func(format string, args ...any) {
+				logs = append(logs, fmt.Sprintf(format, args...))
+			}
+
+			issues, err := client.ListActiveIssues(context.Background())
+			if err != nil {
+				t.Fatalf("ListActiveIssues(status=%d) error = %v; want nil", tc.statusCode, err)
+			}
+			if len(issues) != 1 {
+				t.Fatalf("ListActiveIssues(status=%d) issues = %#v; want one listed issue", tc.statusCode, issues)
+			}
+			if got := issues[0].BlockedBy; got == nil || len(got) != 0 {
+				t.Fatalf("ListActiveIssues(status=%d) BlockedBy = %#v; want non-nil empty blockers", tc.statusCode, got)
+			}
+			if len(logs) != 1 || !strings.Contains(logs[0], "omitting unverified fallback blocker this tick") {
+				t.Fatalf("ListActiveIssues(status=%d) logs = %#v; want one omitted-fallback diagnostic", tc.statusCode, logs)
+			}
+		})
+	}
+}
+
 func TestGitHubClientListIssuesByStatesOmitsBodyFallbackWhenLookupTransportFails(t *testing.T) {
 	var fallbackRequested bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -497,9 +559,13 @@ func TestGitHubClientListIssuesByStatesChunksNativeBlockerLookups(t *testing.T) 
 			graphqlBatchSizes = append(graphqlBatchSizes, len(req.Variables.IDs))
 			nodes := make([]any, 0, len(req.Variables.IDs))
 			for _, id := range req.Variables.IDs {
+				var number int
+				if _, err := fmt.Sscanf(id, "I_%d", &number); err != nil {
+					t.Fatalf("parse node id %q error = %v; want nil", id, err)
+				}
 				nodes = append(nodes, map[string]any{
 					"id":     id,
-					"number": float64(1),
+					"number": float64(number),
 					"blockedBy": map[string]any{
 						"nodes":    []any{},
 						"pageInfo": map[string]any{"hasNextPage": false},
@@ -916,8 +982,8 @@ func TestGitHubClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIDs: %v", err)
 	}
-	if got, want := states, map[string]string{"101": "done"}; len(got) != len(want) || got["101"].State != want["101"] {
-		t.Fatalf("states = %#v, want %#v", got, want)
+	if len(states) != 4 || states["101"].Outcome != IssueStateOutcomeCurrent || states["101"].State != "done" || states["202"].Outcome != IssueStateOutcomeAbsent || states["303"].Outcome != IssueStateOutcomeAbsent || states["999"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want current 101, absent 202/303, unknown 999", states)
 	}
 	if got, want := states["101"].Labels, []string{"done", "aiops-ready"}; !slices.Equal(got, want) {
 		t.Fatalf("FetchIssueStatesByIDs(101).Labels = %v; want %v", got, want)
@@ -926,6 +992,372 @@ func TestGitHubClientFetchIssueStatesByIDsUsesCachedIssueNumbers(t *testing.T) {
 	gotJoined := strings.Join(requestedPaths[2:], ",")
 	if gotJoined != wantPathPrefix {
 		t.Fatalf("requested paths after listing = %s, want %s", gotJoined, wantPathPrefix)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByRefsOutcomeMatrixAndPartialError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/1":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 101, Number: 1, State: "closed", Labels: []githubLabel{{Name: "Done"}}})
+		case "/repos/acme/api/issues/2":
+			http.NotFound(w, r)
+		case "/repos/acme/api/issues/3":
+			w.WriteHeader(http.StatusGone)
+		case "/repos/acme/api/issues/4":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 999, Number: 4, State: "open"})
+		case "/repos/acme/api/issues/5":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 505, Number: 5})
+		case "/repos/acme/api/issues/6":
+			http.Error(w, "boom", http.StatusInternalServerError)
+		case "/repos/acme/api/issues/7":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 707, Number: 7, State: "closed", Labels: []githubLabel{{Name: "Done"}}})
+		case "/repos/acme/api/issues/8":
+			http.NotFound(w, r)
+		default:
+			t.Fatalf("request path = %q; want one of issue endpoints #1 through #8", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", TerminalStates: []string{"done"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+	client.cacheIssueNumber("202", 2)
+	client.cacheIssueNumber("303", 3)
+	refs := []IssueRef{
+		{ID: "101", Identifier: "#1"},
+		{ID: "202", Identifier: "#2"},
+		{ID: "303", Identifier: "#3"},
+		{ID: "opaque"},
+		{ID: "#bad"},
+		{ID: "404", Identifier: "#4"},
+		{ID: "505", Identifier: "#5"},
+		{ID: "606", Identifier: "#6"},
+		{ID: "707", Identifier: "#7"},
+		{ID: "808", Identifier: "#8"},
+		{ID: "101", Identifier: "#1"},
+		{},
+	}
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), refs)
+	if err == nil {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want HTTP 500", err)
+	}
+	want := map[string]IssueStateOutcome{
+		"101":    IssueStateOutcomeCurrent,
+		"202":    IssueStateOutcomeAbsent,
+		"303":    IssueStateOutcomeAbsent,
+		"opaque": IssueStateOutcomeUnknown,
+		"#bad":   IssueStateOutcomeUnknown,
+		"404":    IssueStateOutcomeUnknown,
+		"505":    IssueStateOutcomeUnknown,
+		"606":    IssueStateOutcomeUnknown,
+		"707":    IssueStateOutcomeCurrent,
+		"808":    IssueStateOutcomeUnknown,
+	}
+	if len(states) != len(want) {
+		t.Fatalf("states len = %d; want %d: %#v", len(states), len(want), states)
+	}
+	for id, outcome := range want {
+		if got := states[id].Outcome; got != outcome {
+			t.Fatalf("states[%q].Outcome = %v; want %v (row=%#v)", id, got, outcome, states[id])
+		}
+	}
+}
+
+func TestGitHubClientFetchIssueStatesPayloadNumberMismatchStaysUnknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(githubIssue{ID: 101, Number: 2, State: "open", Labels: []githubLabel{}})
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+	client.cacheIssueNumber("101", 1)
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "101", Identifier: "#1"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil", err)
+	}
+	if got := states["101"].Outcome; got != IssueStateOutcomeUnknown {
+		t.Fatalf("outcome = %v; want unknown for payload number mismatch", got)
+	}
+	if number, ok := client.cachedIssueNumber("101"); !ok || number != 1 {
+		t.Fatalf("cached issue number = %d, %v; want original 1 preserved", number, ok)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesPartialPayloadAndEmptyLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     string
+		wantOutcome IssueStateOutcome
+		wantErr     bool
+	}{
+		{name: "missing id", payload: `{"node_id":"I_101","number":1,"state":"open","labels":[]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "zero id", payload: `{"id":0,"node_id":"I_101","number":1,"state":"open","labels":[]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "missing number", payload: `{"id":101,"node_id":"I_101","state":"open","labels":[]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "zero number", payload: `{"id":101,"node_id":"I_101","number":0,"state":"open","labels":[]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "missing state", payload: `{"id":101,"node_id":"I_101","number":1,"labels":[]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "empty state", payload: `{"id":101,"node_id":"I_101","number":1,"state":"  ","labels":[]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "missing labels", payload: `{"id":101,"node_id":"I_101","number":1,"state":"open"}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "null labels", payload: `{"id":101,"node_id":"I_101","number":1,"state":"open","labels":null}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "label missing name", payload: `{"id":101,"node_id":"I_101","number":1,"state":"open","labels":[{}]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "label null name", payload: `{"id":101,"node_id":"I_101","number":1,"state":"open","labels":[{"name":null}]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "label empty name", payload: `{"id":101,"node_id":"I_101","number":1,"state":"open","labels":[{"name":"  "}]}`, wantOutcome: IssueStateOutcomeUnknown, wantErr: true},
+		{name: "empty labels", payload: `{"id":101,"node_id":"I_101","number":1,"state":"open","labels":[]}`, wantOutcome: IssueStateOutcomeCurrent},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.payload)
+			}))
+			defer srv.Close()
+			client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, srv.URL, "acme", "api")
+			client.HTTP = srv.Client()
+			client.cacheIssueNumber("101", 1)
+
+			states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"101"})
+			if tc.wantErr && !errors.Is(err, ErrIssueStateRefreshIncomplete) {
+				t.Fatalf("FetchIssueStatesByIDs error = %v; want typed incomplete response", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("FetchIssueStatesByIDs() error = %v; want nil", err)
+			}
+			if got := states["101"].Outcome; got != tc.wantOutcome {
+				t.Fatalf("outcome = %v; want %v", got, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+func TestGitHubClientFetchIssueStatesTodoRequiresNodeIDOnlyWithBlockers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":101,"number":1,"state":"open","labels":[{"name":"todo"}]}`)
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", ActiveStates: []string{"todo"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+	ref := IssueRef{ID: "101", Identifier: "#1"}
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{ref})
+	if !errors.Is(err, ErrIssueStateRefreshIncomplete) || states["101"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("with-blockers = (%#v, %v); want unknown and typed incomplete node_id", states, err)
+	}
+	states, err = client.FetchIssueStatesWithoutBlockersByRefs(context.Background(), []IssueRef{ref})
+	if err != nil || states["101"].Outcome != IssueStateOutcomeCurrent {
+		t.Fatalf("without-blockers = (%#v, %v); want current without node_id requirement", states, err)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesTodoRequiresBodyOnlyWithBlockers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/api/issues/1":
+			_, _ = io.WriteString(w, `{"id":101,"node_id":"I_101","number":1,"state":"open","labels":[{"name":"todo"}]}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			_, _ = io.WriteString(w, `{"data":{"nodes":[{"id":"I_101","number":1,"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}}]}}`)
+		default:
+			t.Fatalf("request = %s %s; want GET issue #1 or POST /graphql", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", ActiveStates: []string{"todo"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+	ref := IssueRef{ID: "101", Identifier: "#1"}
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{ref})
+	if !errors.Is(err, ErrIssueStateRefreshIncomplete) || states["101"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("with-blockers = (%#v, %v); want unknown and typed incomplete body", states, err)
+	}
+	states, err = client.FetchIssueStatesWithoutBlockersByRefs(context.Background(), []IssueRef{ref})
+	if err != nil || states["101"].Outcome != IssueStateOutcomeCurrent {
+		t.Fatalf("without-blockers = (%#v, %v); want current without body requirement", states, err)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesTodoAcceptsExplicitEmptyBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "null", body: "null"},
+		{name: "empty string", body: `""`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/api/issues/1":
+					_, _ = fmt.Fprintf(w, `{"id":101,"node_id":"I_101","number":1,"body":%s,"state":"open","labels":[{"name":"todo"}]}`, tc.body)
+				case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+					_, _ = io.WriteString(w, `{"data":{"nodes":[{"id":"I_101","number":1,"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}}]}}`)
+				default:
+					t.Fatalf("request = %s %s; want GET issue #1 or POST /graphql", r.Method, r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+			client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", ActiveStates: []string{"todo"}}, srv.URL, "acme", "api")
+			client.HTTP = srv.Client()
+			ref := IssueRef{ID: "101", Identifier: "#1"}
+
+			states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{ref})
+			if err != nil || states["101"].Outcome != IssueStateOutcomeCurrent || states["101"].BlockedBy == nil || len(states["101"].BlockedBy) != 0 {
+				t.Fatalf("FetchIssueStatesByRefs = (%#v, %v); want current with non-nil empty blockers", states, err)
+			}
+		})
+	}
+}
+
+func TestGitHubClientFetchIssueStatesIncompletePayloadPreservesLaterCurrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/1":
+			_, _ = io.WriteString(w, `{"id":101,"number":1,"state":"open"}`)
+		case "/repos/acme/api/issues/2":
+			_, _ = io.WriteString(w, `{"id":202,"number":2,"state":"closed","labels":[]}`)
+		default:
+			t.Fatalf("request path = %q; want issue endpoint #1 or #2", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "101", Identifier: "#1"}, {ID: "202", Identifier: "#2"}})
+	if !errors.Is(err, ErrIssueStateRefreshIncomplete) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want typed incomplete response", err)
+	}
+	if states["101"].Outcome != IssueStateOutcomeUnknown || states["202"].Outcome != IssueStateOutcomeCurrent {
+		t.Fatalf("states = %#v; want incomplete row unknown and later clean row current", states)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesRateLimitStopsLaterRefs(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "101", Identifier: "#1"}, {ID: "202", Identifier: "#2"}})
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want typed rate limit", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d; want stop after first rate limit", requests)
+	}
+	if states["101"].Outcome != IssueStateOutcomeUnknown || states["202"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want both refs unknown", states)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesRequestDeadlineStopsLaterRefs(t *testing.T) {
+	serverRequests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		serverRequests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":202,"number":2,"state":"open","labels":[]}`)
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, srv.URL, "acme", "api")
+	client.HTTP = &http.Client{Transport: githubPathErrorTransport{
+		base: srv.Client().Transport,
+		path: "/repos/acme/api/issues/1",
+		err:  context.DeadlineExceeded,
+	}}
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "101", Identifier: "#1"}, {ID: "202", Identifier: "#2"}})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want request deadline", err)
+	}
+	if serverRequests != 0 {
+		t.Fatalf("server requests = %d; want no second lookup after request deadline", serverRequests)
+	}
+	if states["101"].Outcome != IssueStateOutcomeUnknown || states["202"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want both refs unknown", states)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesUnknownForInconsistentCachedRefOutcome(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token"}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+	tests := []struct {
+		name string
+		ref  IssueRef
+	}{
+		{name: "conflicting identifier", ref: IssueRef{ID: "101", Identifier: "#2"}},
+		{name: "malformed identifier", ref: IssueRef{ID: "101", Identifier: "not-a-number"}},
+		{name: "number id conflicts with identifier", ref: IssueRef{ID: "#1", Identifier: "#2"}},
+		{name: "number id conflicts with cache", ref: IssueRef{ID: "#2"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client.cacheIssueNumber(tc.ref.ID, 1)
+			states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{tc.ref})
+			if err != nil {
+				t.Fatalf("FetchIssueStatesByRefs(%+v) error = %v; want nil", tc.ref, err)
+			}
+			if got := states[tc.ref.ID].Outcome; got != IssueStateOutcomeUnknown {
+				t.Fatalf("outcome = %v; want unknown for inconsistent cached ref", got)
+			}
+		})
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d; want inconsistent refs rejected before network lookup", requests)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesOutcomeBlockerFailureOnlyInvalidatesTodo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/api/issues/1":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 101, NodeID: "todo-node", Number: 1, State: "open", Labels: []githubLabel{{Name: "Todo"}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/api/issues/2":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 202, NodeID: "done-node", Number: 2, State: "closed", Labels: []githubLabel{{Name: "Done"}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			http.Error(w, "boom", http.StatusInternalServerError)
+		default:
+			t.Fatalf("request = %s %s; want GET issue #1/#2 or POST /graphql", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "token", ActiveStates: []string{"todo"}, TerminalStates: []string{"done"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+	refs := []IssueRef{{ID: "101", Identifier: "#1"}, {ID: "202", Identifier: "#2"}}
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), refs)
+	if err == nil {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want blocker hydration error", err)
+	}
+	if got := states["101"].Outcome; got != IssueStateOutcomeUnknown {
+		t.Fatalf("Todo outcome = %v; want unknown after blocker hydration failure", got)
+	}
+	if got := states["202"].Outcome; got != IssueStateOutcomeCurrent {
+		t.Fatalf("Done outcome = %v; want current despite unrelated blocker failure", got)
+	}
+
+	states, err = client.FetchIssueStatesWithoutBlockersByRefs(context.Background(), refs)
+	if err != nil {
+		t.Fatalf("FetchIssueStatesWithoutBlockersByRefs() error = %v; want nil", err)
+	}
+	if states["101"].Outcome != IssueStateOutcomeCurrent || states["202"].Outcome != IssueStateOutcomeCurrent {
+		t.Fatalf("without-blockers outcomes = %#v; want both current", states)
 	}
 }
 
@@ -983,8 +1415,8 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs wrong ID: %v", err)
 	}
-	if len(states) != 0 {
-		t.Fatalf("states for mismatched issue id = %#v, want empty", states)
+	if len(states) != 1 || states["other-global-id"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states for mismatched issue id = %#v; want explicit unknown", states)
 	}
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "#7"}})
 	if err != nil {
@@ -997,8 +1429,8 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs mismatched #number ID: %v", err)
 	}
-	if len(states) != 0 {
-		t.Fatalf("states for mismatched #number ID = %#v, want empty", states)
+	if len(states) != 1 || states["#8"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states for mismatched #number ID = %#v; want explicit unknown", states)
 	}
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "7", Identifier: "#7"}})
 	if err != nil {
@@ -1011,24 +1443,24 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs mismatched numeric fallback ID: %v", err)
 	}
-	if len(states) != 0 {
-		t.Fatalf("states for mismatched numeric fallback ID = %#v, want empty", states)
+	if len(states) != 1 || states["5"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states for mismatched numeric fallback ID = %#v; want explicit unknown", states)
 	}
 	client.cacheIssueNumber("5", 5)
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "5", Identifier: "#7"}})
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs cached mismatched numeric fallback ID: %v", err)
 	}
-	if len(states) != 0 {
-		t.Fatalf("states for cached mismatched numeric fallback ID = %#v, want empty", states)
+	if len(states) != 1 || states["5"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states for cached mismatched numeric fallback ID = %#v; want explicit unknown", states)
 	}
 	client.cacheIssueNumber("555", 5)
 	states, err = client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "555", Identifier: "#7"}})
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByRefs cached global ID with stale identifier: %v", err)
 	}
-	if got := states["555"].State; got != "done" {
-		t.Fatalf("cached global ID state = %q, want done", got)
+	if got := states["555"].Outcome; got != IssueStateOutcomeUnknown {
+		t.Fatalf("cached global ID outcome = %v; want unknown for stale identifier", got)
 	}
 	states, err = client.FetchIssueStatesByIDs(context.Background(), []string{"987654"})
 	if err != nil {
@@ -1041,8 +1473,12 @@ func TestGitHubClientFetchIssueStatesByRefsUsesIdentifierFallbackWithoutCache(t 
 
 func TestGitHubClientFetchIssueStatesByIDsRequiresToken(t *testing.T) {
 	client := NewGitHubClient(workflow.TrackerConfig{}, "https://api.github.test", "acme", "api")
-	if _, err := client.FetchIssueStatesByIDs(context.Background(), []string{"1"}); err == nil || !strings.Contains(err.Error(), "GitHub tracker api_key") {
-		t.Fatalf("missing token error = %v", err)
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"1", "2", "1", ""})
+	if err == nil {
+		t.Fatal("missing token error = nil; want configuration error")
+	}
+	if len(states) != 2 || states["1"].Outcome != IssueStateOutcomeUnknown || states["2"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want explicit unknown rows for configuration failure", states)
 	}
 }
 
@@ -1155,6 +1591,283 @@ func TestGitHubClientFetchIssueStatesByRefsPopulatesBlockedByAndDropsDeletedFall
 	}
 	if got := states["230"].BlockedBy; got == nil || len(got) != 0 {
 		t.Fatalf("FetchIssueStatesByRefs(#23).BlockedBy = %#v, want non-nil empty slice for confirmed no blockers", got)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByRefsRejectsMissingBlockedByPayload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/20":
+			_ = json.NewEncoder(w).Encode(githubIssue{
+				ID:     200,
+				NodeID: "I_200",
+				Number: 20,
+				State:  "open",
+				Labels: []githubLabel{{Name: "aiops:todo"}},
+			})
+		case "/graphql":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+				map[string]any{"id": "I_200", "number": float64(20)},
+			}}})
+		default:
+			t.Fatalf("request path = %q; want issue #20 or /graphql", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token", ActiveStates: []string{"aiops:todo"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}})
+	if !errors.Is(err, ErrIssueStateRefreshIncomplete) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want typed incomplete blockedBy payload", err)
+	}
+	if got := states["200"].Outcome; got != IssueStateOutcomeUnknown {
+		t.Fatalf("outcome = %v; want Todo refresh unknown when native blockers are incomplete", got)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByRefsRejectsDuplicateBlockerSourceNode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/20":
+			_ = json.NewEncoder(w).Encode(githubIssue{
+				ID:     200,
+				NodeID: "I_200",
+				Number: 20,
+				State:  "open",
+				Labels: []githubLabel{{Name: "aiops:todo"}},
+			})
+		case "/graphql":
+			blockedBy := func(nodes []any) map[string]any {
+				return map[string]any{"nodes": nodes, "pageInfo": map[string]any{"hasNextPage": false}}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+				map[string]any{
+					"id": "I_200", "number": float64(20),
+					"blockedBy": blockedBy([]any{map[string]any{
+						"id": "I_210", "databaseId": float64(210), "number": float64(21),
+						"state": "OPEN", "labels": map[string]any{"nodes": []any{}},
+					}}),
+				},
+				map[string]any{"id": "I_200", "number": float64(20), "blockedBy": blockedBy([]any{})},
+			}}})
+		default:
+			t.Fatalf("request path = %q; want issue #20 or /graphql", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token", ActiveStates: []string{"aiops:todo"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}})
+	if !errors.Is(err, ErrIssueStateRefreshIncomplete) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want typed duplicate source-node error", err)
+	}
+	if got := states["200"].Outcome; got != IssueStateOutcomeUnknown {
+		t.Fatalf("outcome = %v; want Todo refresh unknown for duplicate native source node", got)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByRefsRejectsNativeSourceNumberMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/20":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 200, NodeID: "I_200", Number: 20, State: "open", Labels: []githubLabel{{Name: "aiops:todo"}}})
+		case "/graphql":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+				map[string]any{"id": "I_200", "number": float64(99), "blockedBy": map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false}}},
+			}}})
+		default:
+			t.Fatalf("request path = %q; want issue #20 or /graphql", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token", ActiveStates: []string{"aiops:todo"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}})
+	if !errors.Is(err, ErrIssueStateRefreshIncomplete) {
+		t.Fatalf("FetchIssueStatesByRefs error = %v; want typed native source-number mismatch", err)
+	}
+	if got := states["200"].Outcome; got != IssueStateOutcomeUnknown {
+		t.Fatalf("outcome = %v; want Todo refresh unknown for mismatched native source number", got)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesByRefsRejectsUnexpectedOrMissingNativeSourceNodes(t *testing.T) {
+	tests := []struct {
+		name  string
+		nodes []any
+	}{
+		{
+			name: "unexpected source id",
+			nodes: []any{
+				map[string]any{"id": "I_999", "number": float64(20), "blockedBy": map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false}}},
+			},
+		},
+		{name: "missing requested source", nodes: []any{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/acme/api/issues/20":
+					_ = json.NewEncoder(w).Encode(githubIssue{ID: 200, NodeID: "I_200", Number: 20, State: "open", Labels: []githubLabel{{Name: "aiops:todo"}}})
+				case "/graphql":
+					_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": tc.nodes}})
+				default:
+					t.Fatalf("request path = %q; want issue #20 or /graphql", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+			client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token", ActiveStates: []string{"aiops:todo"}}, srv.URL, "acme", "api")
+			client.HTTP = srv.Client()
+
+			states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}})
+			if !errors.Is(err, ErrIssueStateRefreshIncomplete) {
+				t.Fatalf("FetchIssueStatesByRefs error = %v; want typed native source authority error", err)
+			}
+			if got := states["200"].Outcome; got != IssueStateOutcomeUnknown {
+				t.Fatalf("outcome = %v; want Todo refresh unknown for non-authoritative native source set", got)
+			}
+		})
+	}
+}
+
+func TestGitHubClientFetchIssueStatesBodyFallbackHaltStopsLaterBlockerLookups(t *testing.T) {
+	tests := []struct {
+		name      string
+		blocker21 func(http.ResponseWriter)
+		transport error
+		wantErr   error
+	}{
+		{
+			name: "rate limit",
+			blocker21: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusTooManyRequests)
+			},
+			wantErr: ErrRateLimited,
+		},
+		{
+			name:      "request deadline",
+			transport: context.DeadlineExceeded,
+			wantErr:   context.DeadlineExceeded,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestedPaths []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestedPaths = append(requestedPaths, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/acme/api/issues/20":
+					_ = json.NewEncoder(w).Encode(githubIssue{ID: 200, NodeID: "I_200", Number: 20, Body: "Depends on #21\nDepends on #22", State: "open", Labels: []githubLabel{{Name: "aiops:todo"}}})
+				case "/repos/acme/api/issues/23":
+					_ = json.NewEncoder(w).Encode(githubIssue{ID: 230, NodeID: "I_230", Number: 23, Body: "Depends on #24", State: "open", Labels: []githubLabel{{Name: "aiops:todo"}}})
+				case "/graphql":
+					_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+						map[string]any{"id": "I_200", "number": float64(20), "blockedBy": map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false}}},
+						map[string]any{"id": "I_230", "number": float64(23), "blockedBy": map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false}}},
+					}}})
+				case "/repos/acme/api/issues/21":
+					if tc.blocker21 == nil {
+						t.Fatal("blocker #21 handler reached = true; want false with injected transport error")
+					}
+					tc.blocker21(w)
+				case "/repos/acme/api/issues/22", "/repos/acme/api/issues/24":
+					_ = json.NewEncoder(w).Encode(githubIssue{ID: 999, Number: 99, State: "closed", Labels: []githubLabel{{Name: "done"}}})
+				default:
+					t.Fatalf("request path = %q; want source #20/#23, /graphql, or blocker #21/#22/#24", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+			client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token", ActiveStates: []string{"aiops:todo"}}, srv.URL, "acme", "api")
+			client.HTTP = srv.Client()
+			if tc.transport != nil {
+				client.HTTP = &http.Client{Transport: githubPathErrorTransport{base: srv.Client().Transport, path: "/repos/acme/api/issues/21", err: tc.transport}}
+			}
+
+			states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}, {ID: "230", Identifier: "#23"}})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("FetchIssueStatesByRefs error = %v; want %v", err, tc.wantErr)
+			}
+			for _, path := range []string{"/repos/acme/api/issues/22", "/repos/acme/api/issues/24"} {
+				if slices.Contains(requestedPaths, path) {
+					t.Fatalf("requested paths = %v; want later blocker %s skipped after halt", requestedPaths, path)
+				}
+			}
+			if states["200"].Outcome != IssueStateOutcomeUnknown || states["230"].Outcome != IssueStateOutcomeUnknown {
+				t.Fatalf("states = %#v; want Todo refs unknown after body fallback halt", states)
+			}
+		})
+	}
+}
+
+func TestGitHubClientFetchIssueStatesBodyFallbackFailureUsesPlaceholder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/20":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 200, NodeID: "I_200", Number: 20, Body: "Depends on #21", State: "open", Labels: []githubLabel{{Name: "aiops:todo"}}})
+		case "/graphql":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+				map[string]any{"id": "I_200", "number": float64(20), "blockedBy": map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false}}},
+			}}})
+		case "/repos/acme/api/issues/21":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("request path = %q; want source #20, /graphql, or blocker #21", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token", ActiveStates: []string{"aiops:todo"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil", err)
+	}
+	got := states["200"]
+	if got.Outcome != IssueStateOutcomeCurrent || len(got.BlockedBy) != 1 || got.BlockedBy[0].Identifier != "#21" || got.BlockedBy[0].State != "" {
+		t.Fatalf("states[200] = %#v; want current Todo with fail-closed #21 placeholder", got)
+	}
+}
+
+func TestGitHubClientFetchIssueStatesBodyFallbackNumberMismatchFailsClosedWithoutCaching(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/acme/api/issues/20":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 200, NodeID: "I_200", Number: 20, Body: "Depends on #21", State: "open", Labels: []githubLabel{{Name: "aiops:todo"}}})
+		case "/graphql":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"nodes": []any{
+				map[string]any{"id": "I_200", "number": float64(20), "blockedBy": map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false}}},
+			}}})
+		case "/repos/acme/api/issues/21":
+			_ = json.NewEncoder(w).Encode(githubIssue{ID: 990, Number: 99, State: "closed", Labels: []githubLabel{{Name: "done"}}})
+		default:
+			t.Fatalf("request path = %q; want source #20, /graphql, or blocker #21", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	client := NewGitHubClient(workflow.TrackerConfig{APIKey: "test-token", ActiveStates: []string{"aiops:todo"}, TerminalStates: []string{"done"}}, srv.URL, "acme", "api")
+	client.HTTP = srv.Client()
+
+	states, err := client.FetchIssueStatesByRefs(context.Background(), []IssueRef{{ID: "200", Identifier: "#20"}})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByRefs() error = %v; want nil", err)
+	}
+	got := states["200"]
+	if got.Outcome != IssueStateOutcomeCurrent || len(got.BlockedBy) != 1 || got.BlockedBy[0].Identifier != "#21" || got.BlockedBy[0].State != "" {
+		t.Fatalf("states[200] = %#v; want current Todo with fail-closed requested #21 placeholder", got)
+	}
+	if number, ok := client.cachedIssueNumber("990"); ok {
+		t.Fatalf("cached mismatched blocker id 990 as issue #%d; want no cache pollution", number)
 	}
 }
 

--- a/internal/tracker/linear.go
+++ b/internal/tracker/linear.go
@@ -369,144 +369,12 @@ func parseLinearIssueTime(field, value string) (time.Time, error) {
 	return parsed, nil
 }
 
-// labels(first:250) mirrors listLinearIssuesQuery: the SPEC §6.4 required_labels
-// gate consults the refresh's label set to stop/release already-claimed work on
-// label removal, so the projection must be wide enough that a required label
-// cannot sort past the cap and look removed (#705).
-const issueStatesByIDsQuery = `query IssueStatesByIDs($ids: [ID!]!, $first: Int!) {
-  issues(filter: { id: { in: $ids } }, first: $first) {
-    nodes {
-      id
-      state { name }
-      labels(first: 250) { nodes { name } }
-    }
-  }
-}`
-
-func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]IssueState, error) { //nolint:gocognit // baseline (#521)
-	if c.APIKey == "" {
-		return nil, NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
-	}
-	if len(issueIDs) == 0 {
-		return map[string]IssueState{}, nil
-	}
-	states := make(map[string]IssueState, len(issueIDs))
-	for start := 0; start < len(issueIDs); start += linearIssuePageSize {
-		end := start + linearIssuePageSize
-		if end > len(issueIDs) {
-			end = len(issueIDs)
-		}
-		chunk := issueIDs[start:end]
-		var out struct {
-			Data struct {
-				Issues struct {
-					Nodes []struct {
-						ID    string `json:"id"`
-						State struct {
-							Name string `json:"name"`
-						} `json:"state"`
-						Labels struct {
-							Nodes []struct {
-								Name string `json:"name"`
-							} `json:"nodes"`
-						} `json:"labels"`
-					} `json:"nodes"`
-				} `json:"issues"`
-			} `json:"data"`
-			Errors []map[string]any `json:"errors"`
-		}
-		if err := c.graphql(ctx, issueStatesByIDsQuery, map[string]any{"ids": chunk, "first": len(chunk)}, &out); err != nil {
-			return nil, err
-		}
-		if len(out.Errors) > 0 {
-			return nil, linearGraphQLErrors(out.Errors)
-		}
-		for _, n := range out.Data.Issues.Nodes {
-			labels := make([]string, 0, len(n.Labels.Nodes))
-			for _, label := range n.Labels.Nodes {
-				if name := strings.ToLower(strings.TrimSpace(label.Name)); name != "" {
-					labels = append(labels, name)
-				}
-			}
-			states[n.ID] = IssueState{State: n.State.Name, Labels: labels}
-		}
-	}
-	if err := c.attachRefreshedTodoBlockers(ctx, states); err != nil {
-		// Blocker data is consumed only by dispatch-time revalidation; the
-		// reconcile and §16.5 per-turn refreshers share this method and must
-		// not fail on it — their state/label result is already complete, and
-		// an error here would short-circuit a healthy run's turn loop on a
-		// transient inverse-relations failure (PR #752 review). Instead,
-		// every refreshed Todo entry fails closed with an empty-state
-		// placeholder blocker — the same shape the Gitea adapter uses for an
-		// unresolvable reference — so the revalidation gate skips the
-		// candidate for this tick and the next tick retries, rather than
-		// dispatching past a blocker the failed query could not see (a
-		// listing-time "unblocked" verdict may predate a newly added
-		// relation). State-only consumers ignore BlockedBy and are
-		// unaffected.
-		log.Printf("event=linear_blocker_refresh_failed error=%q detail=\"refreshed Todo issues fail closed with a placeholder blocker this batch\"", err.Error())
-		failClosedTodoBlockers(states)
-	}
-	return states, nil
-}
-
-// failClosedTodoBlockers marks every Todo-state entry with one empty-state
-// placeholder blocker, which tracker.BlockedByNonTerminal treats as open.
-func failClosedTodoBlockers(states map[string]IssueState) {
-	for id, state := range states {
-		if !isTodoState(state.State) {
-			continue
-		}
-		state.BlockedBy = []BlockerRef{{}}
-		states[id] = state
-	}
-}
-
 func failClosedTodoIssueBlockers(issues []Issue) {
 	for i := range issues {
 		if isTodoState(issues[i].State) {
 			issues[i].BlockedBy = []BlockerRef{{}}
 		}
 	}
-}
-
-// attachRefreshedTodoBlockers resolves blocker data for the refreshed issues
-// whose state is Todo — the only state the SPEC §8.2 blocker gate applies to,
-// mirroring the listing path's Todo-only resolution (#672) — so dispatch-time
-// revalidation can re-apply the gate on refreshed data like upstream
-// retry_candidate_issue? (orchestrator.ex:1602-1604) does (#750). Non-Todo
-// entries keep a nil BlockedBy ("no blocker knowledge supplied"); Todo
-// entries get the non-nil (possibly empty) result linearBlockersForIssues
-// guarantees for every requested id.
-//
-// Dispatch revalidation is the only consumer of the blocker data; the
-// reconcile and §16.5 per-turn refreshers share FetchIssueStatesByIDs and
-// inherit the extra Todo-only batched query as a side effect but ignore
-// BlockedBy (reconcile cancellation and the per-turn continue gate are
-// state/label-only by design). Upstream's fetch_issue_states_by_ids returns
-// fully normalized issues including blocked_by on every caller too, so the
-// cost profile matches the reference.
-func (c *LinearClient) attachRefreshedTodoBlockers(ctx context.Context, states map[string]IssueState) error {
-	ids := make([]string, 0, len(states))
-	for id, state := range states {
-		if isTodoState(state.State) {
-			ids = append(ids, id)
-		}
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-	blockers, err := c.linearBlockersForIssues(ctx, ids)
-	if err != nil {
-		return err
-	}
-	for _, id := range ids {
-		state := states[id]
-		state.BlockedBy = blockers[id]
-		states[id] = state
-	}
-	return nil
 }
 
 type linearRelationNode struct {
@@ -518,6 +386,14 @@ type linearRelationNode struct {
 			Name string `json:"name"`
 		} `json:"state"`
 	} `json:"issue"`
+}
+
+type linearInverseRelationsPage struct {
+	Nodes    *[]linearRelationNode `json:"nodes"`
+	PageInfo *struct {
+		HasNextPage *bool   `json:"hasNextPage"`
+		EndCursor   *string `json:"endCursor"`
+	} `json:"pageInfo"`
 }
 
 func isTodoState(state string) bool {
@@ -569,17 +445,11 @@ const listLinearIssuesInverseRelationsQuery = `query ListIssuesInverseRelations(
 // linearBatchInverseRelationsResponse is the batched first-page inverse-relations
 // payload returned by listLinearIssuesInverseRelationsQuery for a chunk of ids.
 type linearBatchInverseRelationsResponse struct {
-	Data struct {
-		Issues struct {
-			Nodes []struct {
-				ID               string `json:"id"`
-				InverseRelations struct {
-					Nodes    []linearRelationNode `json:"nodes"`
-					PageInfo struct {
-						HasNextPage bool   `json:"hasNextPage"`
-						EndCursor   string `json:"endCursor"`
-					} `json:"pageInfo"`
-				} `json:"inverseRelations"`
+	Data *struct {
+		Issues *struct {
+			Nodes *[]struct {
+				ID               *string                     `json:"id"`
+				InverseRelations *linearInverseRelationsPage `json:"inverseRelations"`
 			} `json:"nodes"`
 		} `json:"issues"`
 	} `json:"data"`
@@ -619,17 +489,93 @@ func (c *LinearClient) fetchLinearBlockerChunk(ctx context.Context, chunk []stri
 	if len(out.Errors) > 0 {
 		return linearGraphQLErrors(out.Errors)
 	}
-	for _, n := range out.Data.Issues.Nodes {
-		blockers, err := c.linearBlockersFromInverseRelations(ctx, n.ID, n.InverseRelations.Nodes, n.InverseRelations.PageInfo.HasNextPage, n.InverseRelations.PageInfo.EndCursor)
+	if out.Data == nil || out.Data.Issues == nil || out.Data.Issues.Nodes == nil {
+		return incompleteLinearBlockerResponse("missing data.issues.nodes")
+	}
+	requested := make(map[string]struct{}, len(chunk))
+	for _, id := range chunk {
+		requested[id] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(chunk))
+	for _, n := range *out.Data.Issues.Nodes {
+		id, blockers, err := c.linearBlockersForBatchNode(ctx, n.ID, n.InverseRelations, requested, seen)
 		if err != nil {
 			return err
 		}
-		result[n.ID] = blockers
+		result[id] = blockers
+		seen[id] = struct{}{}
+	}
+	if len(seen) != len(requested) {
+		return incompleteLinearBlockerResponse("response omitted a requested issue node")
 	}
 	return nil
 }
 
+func (c *LinearClient) linearBlockersForBatchNode(
+	ctx context.Context,
+	rawID *string,
+	page *linearInverseRelationsPage,
+	requested, seen map[string]struct{},
+) (string, []BlockerRef, error) {
+	if rawID == nil || strings.TrimSpace(*rawID) == "" {
+		return "", nil, incompleteLinearBlockerResponse("issue node missing id")
+	}
+	id := strings.TrimSpace(*rawID)
+	if _, ok := requested[id]; !ok {
+		return "", nil, incompleteLinearBlockerResponse("issue node id was not requested")
+	}
+	if _, duplicate := seen[id]; duplicate {
+		return "", nil, incompleteLinearBlockerResponse("duplicate issue node id")
+	}
+	nodes, hasNextPage, endCursor, err := linearInverseRelationsValues(page)
+	if err != nil {
+		return "", nil, err
+	}
+	blockers, err := c.linearBlockersFromInverseRelations(ctx, id, nodes, hasNextPage, endCursor)
+	if err != nil {
+		return "", nil, err
+	}
+	return id, blockers, nil
+}
+
+func linearInverseRelationsValues(page *linearInverseRelationsPage) ([]linearRelationNode, bool, string, error) {
+	if page == nil || page.Nodes == nil || page.PageInfo == nil || page.PageInfo.HasNextPage == nil {
+		return nil, false, "", incompleteLinearBlockerResponse("missing inverseRelations nodes or pageInfo")
+	}
+	if err := validateLinearRelationNodes(*page.Nodes); err != nil {
+		return nil, false, "", err
+	}
+	endCursor := ""
+	if page.PageInfo.EndCursor != nil {
+		endCursor = strings.TrimSpace(*page.PageInfo.EndCursor)
+	}
+	if *page.PageInfo.HasNextPage && endCursor == "" {
+		return nil, false, "", incompleteLinearBlockerResponse("paginated inverseRelations missing endCursor")
+	}
+	return *page.Nodes, *page.PageInfo.HasNextPage, endCursor, nil
+}
+
+func validateLinearRelationNodes(nodes []linearRelationNode) error {
+	for _, relation := range nodes {
+		if strings.TrimSpace(relation.Type) == "" {
+			return incompleteLinearBlockerResponse("inverse relation missing type")
+		}
+		if relation.Type == "blocks" && (strings.TrimSpace(relation.Issue.ID) == "" ||
+			strings.TrimSpace(relation.Issue.Identifier) == "" || strings.TrimSpace(relation.Issue.State.Name) == "") {
+			return incompleteLinearBlockerResponse("blocking relation missing issue identity or state")
+		}
+	}
+	return nil
+}
+
+func incompleteLinearBlockerResponse(detail string) error {
+	return NewError(CategoryLinearUnknownPayload, "incomplete Linear blocker response", fmt.Errorf("%w: %s", ErrIssueStateRefreshIncomplete, detail))
+}
+
 func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, issueID string, nodes []linearRelationNode, hasNextPage bool, endCursor string) ([]BlockerRef, error) { //nolint:gocognit // baseline (#521)
+	if err := validateLinearRelationNodes(nodes); err != nil {
+		return nil, err
+	}
 	blockers := make([]BlockerRef, 0, len(nodes))
 	appendBlockers := func(nodes []linearRelationNode) {
 		for _, r := range nodes {
@@ -649,15 +595,9 @@ func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, i
 			return nil, NewError(CategoryLinearMissingEndCursor, fmt.Sprintf("linear inverse relation pagination missing endCursor for issue %s", issueID), nil)
 		}
 		var out struct {
-			Data struct {
-				Issue struct {
-					InverseRelations struct {
-						Nodes    []linearRelationNode `json:"nodes"`
-						PageInfo struct {
-							HasNextPage bool   `json:"hasNextPage"`
-							EndCursor   string `json:"endCursor"`
-						} `json:"pageInfo"`
-					} `json:"inverseRelations"`
+			Data *struct {
+				Issue *struct {
+					InverseRelations *linearInverseRelationsPage `json:"inverseRelations"`
 				} `json:"issue"`
 			} `json:"data"`
 			Errors []map[string]any `json:"errors"`
@@ -673,9 +613,16 @@ func (c *LinearClient) linearBlockersFromInverseRelations(ctx context.Context, i
 		if len(out.Errors) > 0 {
 			return nil, linearGraphQLErrors(out.Errors)
 		}
-		appendBlockers(out.Data.Issue.InverseRelations.Nodes)
-		hasNextPage = out.Data.Issue.InverseRelations.PageInfo.HasNextPage
-		endCursor = out.Data.Issue.InverseRelations.PageInfo.EndCursor
+		if out.Data == nil || out.Data.Issue == nil {
+			return nil, incompleteLinearBlockerResponse("missing data.issue")
+		}
+		nextNodes, nextPage, nextCursor, err := linearInverseRelationsValues(out.Data.Issue.InverseRelations)
+		if err != nil {
+			return nil, err
+		}
+		appendBlockers(nextNodes)
+		hasNextPage = nextPage
+		endCursor = nextCursor
 	}
 	return blockers, nil
 }
@@ -711,11 +658,8 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 		return NewError(CategoryLinearAPIRequest, "send Linear GraphQL request", err)
 	}
 	defer DrainAndClose(resp)
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return NewRateLimitedError("linear request", resp.StatusCode, resp.Header)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return NewError(CategoryLinearAPIStatus, fmt.Sprintf("linear request failed: status %d", resp.StatusCode), nil)
+	if err := linearGraphQLResponseError(resp); err != nil {
+		return err
 	}
 	if out == nil {
 		return nil
@@ -724,6 +668,44 @@ func (c *LinearClient) graphql(ctx context.Context, query string, variables map[
 		return NewError(CategoryLinearUnknownPayload, "decode Linear GraphQL response", err)
 	}
 	return nil
+}
+
+func linearGraphQLResponseError(resp *http.Response) error {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return NewRateLimitedError("linear request", resp.StatusCode, resp.Header)
+	}
+	if resp.StatusCode == http.StatusBadRequest {
+		rateLimited, probeErr := linearGraphQLRateLimited(resp)
+		if probeErr != nil {
+			return NewError(CategoryLinearUnknownPayload, "decode Linear GraphQL error response", probeErr)
+		}
+		if rateLimited {
+			return NewRateLimitedError("linear request", resp.StatusCode, resp.Header)
+		}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return NewError(CategoryLinearAPIStatus, fmt.Sprintf("linear request failed: status %d", resp.StatusCode), nil)
+	}
+	return nil
+}
+
+func linearGraphQLRateLimited(resp *http.Response) (bool, error) {
+	var payload struct {
+		Errors []struct {
+			Extensions struct {
+				Code string `json:"code"`
+			} `json:"extensions"`
+		} `json:"errors"`
+	}
+	if err := DecodeJSONResponse(resp, &payload); err != nil {
+		return false, err
+	}
+	for _, graphqlErr := range payload.Errors {
+		if strings.EqualFold(strings.TrimSpace(graphqlErr.Extensions.Code), "RATELIMITED") {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func linearGraphQLErrors(errs []map[string]any) error {

--- a/internal/tracker/linear_refresh.go
+++ b/internal/tracker/linear_refresh.go
@@ -1,0 +1,202 @@
+package tracker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+)
+
+// labels(first:250) mirrors listLinearIssuesQuery: the SPEC §6.4 required_labels
+// gate consults the refresh's label set to stop/release already-claimed work on
+// label removal, so the projection must be wide enough that a required label
+// cannot sort past the cap and look removed (#705).
+const issueStatesByIDsQuery = `query IssueStatesByIDs($ids: [ID!]!, $first: Int!) {
+  issues(filter: { id: { in: $ids } }, first: $first) {
+    nodes {
+      id
+      state { name }
+      labels(first: 250) { nodes { name } }
+    }
+  }
+}`
+
+type linearIssueStateNode struct {
+	ID    *string `json:"id"`
+	State *struct {
+		Name *string `json:"name"`
+	} `json:"state"`
+	Labels *struct {
+		Nodes *[]struct {
+			Name *string `json:"name"`
+		} `json:"nodes"`
+	} `json:"labels"`
+}
+
+type linearIssueStatesResponse struct {
+	Data *struct {
+		Issues *struct {
+			Nodes *[]linearIssueStateNode `json:"nodes"`
+		} `json:"issues"`
+	} `json:"data"`
+	Errors []map[string]any `json:"errors"`
+}
+
+func (c *LinearClient) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]IssueState, error) { //nolint:gocognit // baseline (#521)
+	states, ids := unknownIssueStatesByIDs(issueIDs)
+	if c.APIKey == "" {
+		return states, NewError(CategoryMissingTrackerAPIKey, "Linear API key is required", nil)
+	}
+	if len(ids) == 0 {
+		return states, nil
+	}
+	var refreshErrs []error
+	halted := false
+	for start := 0; start < len(ids); start += linearIssuePageSize {
+		end := start + linearIssuePageSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+		var out linearIssueStatesResponse
+		if err := c.graphql(ctx, issueStatesByIDsQuery, map[string]any{"ids": chunk, "first": len(chunk)}, &out); err != nil {
+			refreshErrs = append(refreshErrs, err)
+			if ShouldStopIssueStateRefresh(ctx, err) {
+				halted = true
+				break
+			}
+			continue
+		}
+		if len(out.Errors) > 0 {
+			refreshErrs = append(refreshErrs, linearGraphQLErrors(out.Errors))
+			continue
+		}
+		chunkStates, err := classifyLinearIssueStateChunk(chunk, out)
+		if err != nil {
+			refreshErrs = append(refreshErrs, err)
+			continue
+		}
+		for id, state := range chunkStates {
+			states[id] = state
+		}
+	}
+	if halted {
+		failClosedTodoBlockers(states)
+	} else if err := c.attachRefreshedTodoBlockers(ctx, states); err != nil {
+		// Blocker data is consumed only by dispatch-time revalidation; the
+		// reconcile and §16.5 per-turn refreshers share this method and must
+		// not fail on it — their state/label result is already complete, and
+		// an error here would short-circuit a healthy run's turn loop on a
+		// transient inverse-relations failure (PR #752 review). Instead,
+		// every refreshed Todo entry fails closed with an empty-state
+		// placeholder blocker — the same shape the Gitea adapter uses for an
+		// unresolvable reference — so the revalidation gate skips the
+		// candidate for this tick and the next tick retries, rather than
+		// dispatching past a blocker the failed query could not see (a
+		// listing-time "unblocked" verdict may predate a newly added
+		// relation). State-only consumers ignore BlockedBy and are
+		// unaffected.
+		log.Printf("event=linear_blocker_refresh_failed error=%q detail=\"refreshed Todo issues fail closed with a placeholder blocker this batch\"", err.Error())
+		failClosedTodoBlockers(states)
+	}
+	return states, errors.Join(refreshErrs...)
+}
+
+func classifyLinearIssueStateChunk(chunk []string, out linearIssueStatesResponse) (map[string]IssueState, error) {
+	if out.Data == nil || out.Data.Issues == nil || out.Data.Issues.Nodes == nil {
+		return nil, incompleteLinearIssueStateResponse("missing data.issues.nodes")
+	}
+	classified := make(map[string]IssueState, len(chunk))
+	for _, id := range chunk {
+		classified[id] = IssueState{Outcome: IssueStateOutcomeAbsent}
+	}
+	seen := make(map[string]struct{}, len(*out.Data.Issues.Nodes))
+	for _, node := range *out.Data.Issues.Nodes {
+		if err := classifyLinearIssueStateNode(node, classified, seen); err != nil {
+			return nil, err
+		}
+	}
+	return classified, nil
+}
+
+func classifyLinearIssueStateNode(node linearIssueStateNode, classified map[string]IssueState, seen map[string]struct{}) error {
+	if node.ID == nil || node.State == nil || node.State.Name == nil || node.Labels == nil || node.Labels.Nodes == nil {
+		return incompleteLinearIssueStateResponse("issue node missing id, state, or labels")
+	}
+	id := strings.TrimSpace(*node.ID)
+	state := strings.TrimSpace(*node.State.Name)
+	if id == "" || state == "" {
+		return incompleteLinearIssueStateResponse("issue node has empty id or state")
+	}
+	if _, requested := classified[id]; !requested {
+		return incompleteLinearIssueStateResponse("issue node id was not requested")
+	}
+	if _, duplicate := seen[id]; duplicate {
+		return incompleteLinearIssueStateResponse("duplicate issue node id")
+	}
+	labels := make([]string, 0, len(*node.Labels.Nodes))
+	for _, label := range *node.Labels.Nodes {
+		if label.Name == nil || strings.TrimSpace(*label.Name) == "" {
+			return incompleteLinearIssueStateResponse("issue label missing non-empty name")
+		}
+		labels = append(labels, strings.ToLower(strings.TrimSpace(*label.Name)))
+	}
+	classified[id] = IssueState{Outcome: IssueStateOutcomeCurrent, State: *node.State.Name, Labels: labels}
+	seen[id] = struct{}{}
+	return nil
+}
+
+func incompleteLinearIssueStateResponse(detail string) error {
+	return NewError(CategoryLinearUnknownPayload, "incomplete Linear issue state response", fmt.Errorf("%w: %s", ErrIssueStateRefreshIncomplete, detail))
+}
+
+// failClosedTodoBlockers marks every Todo-state entry with one empty-state
+// placeholder blocker, which tracker.BlockedByNonTerminal treats as open.
+func failClosedTodoBlockers(states map[string]IssueState) {
+	for id, state := range states {
+		if !isTodoState(state.State) {
+			continue
+		}
+		state.BlockedBy = []BlockerRef{{}}
+		states[id] = state
+	}
+}
+
+// attachRefreshedTodoBlockers resolves blocker data for the refreshed issues
+// whose state is Todo — the only state the SPEC §8.2 blocker gate applies to,
+// mirroring the listing path's Todo-only resolution (#672) — so dispatch-time
+// revalidation can re-apply the gate on refreshed data like upstream
+// retry_candidate_issue? (orchestrator.ex:1602-1604) does (#750). Non-Todo
+// entries keep a nil BlockedBy ("no blocker knowledge supplied"); Todo
+// entries get the non-nil (possibly empty) result linearBlockersForIssues
+// guarantees for every requested id.
+//
+// Dispatch revalidation is the only consumer of the blocker data; the
+// reconcile and §16.5 per-turn refreshers share FetchIssueStatesByIDs and
+// inherit the extra Todo-only batched query as a side effect but ignore
+// BlockedBy (reconcile cancellation and the per-turn continue gate are
+// state/label-only by design). Upstream's fetch_issue_states_by_ids returns
+// fully normalized issues including blocked_by on every caller too, so the
+// cost profile matches the reference.
+func (c *LinearClient) attachRefreshedTodoBlockers(ctx context.Context, states map[string]IssueState) error {
+	ids := make([]string, 0, len(states))
+	for id, state := range states {
+		if isTodoState(state.State) {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	blockers, err := c.linearBlockersForIssues(ctx, ids)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		state := states[id]
+		state.BlockedBy = blockers[id]
+		states[id] = state
+	}
+	return nil
+}

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -60,6 +60,28 @@ func TestLinearClient_SatisfiesIssueStateRefresher(t *testing.T) {
 	var _ IssueStateRefresher = (*LinearClient)(nil)
 }
 
+func TestIssueStateOutcomeZeroSafe(t *testing.T) {
+	var zero IssueState
+	if zero.Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("zero IssueState outcome = %v; want unknown", zero.Outcome)
+	}
+
+	current := IssueState{
+		Outcome:   IssueStateOutcomeCurrent,
+		State:     "Todo",
+		Labels:    []string{"ready"},
+		BlockedBy: []BlockerRef{{ID: "blocker-1", State: "In Progress"}},
+	}
+	if current.Outcome != IssueStateOutcomeCurrent || current.State != "Todo" || len(current.Labels) != 1 || len(current.BlockedBy) != 1 {
+		t.Fatalf("current IssueState = %#v; want outcome and refreshed facts preserved", current)
+	}
+
+	absent := IssueState{Outcome: IssueStateOutcomeAbsent}
+	if absent.Outcome != IssueStateOutcomeAbsent || absent.State != "" || absent.Labels != nil || absent.BlockedBy != nil {
+		t.Fatalf("absent IssueState = %#v; want outcome without fabricated facts", absent)
+	}
+}
+
 func TestListIssuesByStatesRequiresProjectSlugAndUsesProjectFilter(t *testing.T) {
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -251,7 +273,7 @@ func TestFetchIssueStatesByIDsUsesIDListQuery(t *testing.T) {
 		mu.Lock()
 		recorded = fakeLinearRequest{OpName: opNameFromQuery(payload.Query), Query: payload.Query, Variables: payload.Variables}
 		mu.Unlock()
-		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Todo"},"labels":{"nodes":[{"name":"Aiops-Ready"}]}},{"id":"issue-2","state":{"name":"Done"}}]}}}`)
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Todo"},"labels":{"nodes":[{"name":"Aiops-Ready"}]}},{"id":"issue-2","state":{"name":"Done"},"labels":{"nodes":[]}}]}}}`)
 	}))
 	defer httpSrv.Close()
 	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
@@ -287,6 +309,269 @@ func TestFetchIssueStatesByIDsUsesIDListQuery(t *testing.T) {
 	}
 	if states["issue-2"].BlockedBy != nil {
 		t.Fatalf("FetchIssueStatesByIDs(issue-2).BlockedBy = %#v; want nil for non-Todo state", states["issue-2"].BlockedBy)
+	}
+}
+
+func TestFetchIssueStatesByIDsOutcomeCleanMissingIsAbsent(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Done"},"labels":{"nodes":[]}}]}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"issue-1", "issue-2", "issue-1", " "})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs() error = %v; want nil", err)
+	}
+	if got := states["issue-1"]; got.Outcome != IssueStateOutcomeCurrent || got.State != "Done" {
+		t.Fatalf("issue-1 = %#v; want current Done", got)
+	}
+	if got := states["issue-2"]; got.Outcome != IssueStateOutcomeAbsent || got.State != "" {
+		t.Fatalf("issue-2 = %#v; want confirmed absent without state", got)
+	}
+	if len(states) != 2 {
+		t.Fatalf("states = %#v; want one row per unique non-empty id", states)
+	}
+}
+
+func TestFetchIssueStatesByIDsPartialGraphQLErrorLeavesChunkUnknown(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Done"}}]}},"errors":[{"message":"partial"}]}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"issue-1", "issue-2"})
+	if !errors.Is(err, ErrLinearGraphQLErrors) {
+		t.Fatalf("FetchIssueStatesByIDs error = %v; want GraphQL error", err)
+	}
+	for _, id := range []string{"issue-1", "issue-2"} {
+		if got := states[id]; got.Outcome != IssueStateOutcomeUnknown {
+			t.Fatalf("%s = %#v; want unknown for the failed GraphQL chunk", id, got)
+		}
+	}
+}
+
+func TestFetchIssueStatesByIDsPartialPayloadLeavesChunkUnknown(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{name: "missing data", payload: `{}`},
+		{name: "missing issues", payload: `{"data":{}}`},
+		{name: "missing nodes", payload: `{"data":{"issues":{}}}`},
+		{name: "node missing id", payload: `{"data":{"issues":{"nodes":[{"state":{"name":"Done"},"labels":{"nodes":[]}}]}}}`},
+		{name: "node missing state", payload: `{"data":{"issues":{"nodes":[{"id":"issue-1","labels":{"nodes":[]}}]}}}`},
+		{name: "node missing labels", payload: `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Done"}}]}}}`},
+		{name: "label missing name", payload: `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Done"},"labels":{"nodes":[{}]}}]}}}`},
+		{name: "label null name", payload: `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Done"},"labels":{"nodes":[{"name":null}]}}]}}}`},
+		{name: "label empty name", payload: `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Done"},"labels":{"nodes":[{"name":"  "}]}}]}}}`},
+		{name: "duplicate returned id", payload: `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Done"},"labels":{"nodes":[]}},{"id":"issue-1","state":{"name":"Done"},"labels":{"nodes":[]}}]}}}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.payload)
+			}))
+			defer httpSrv.Close()
+			client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+			states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"issue-1", "issue-2"})
+			if !errors.Is(err, ErrLinearUnknownPayload) || !errors.Is(err, ErrIssueStateRefreshIncomplete) {
+				t.Fatalf("FetchIssueStatesByIDs error = %v; want typed incomplete Linear payload", err)
+			}
+			if states["issue-1"].Outcome != IssueStateOutcomeUnknown || states["issue-2"].Outcome != IssueStateOutcomeUnknown {
+				t.Fatalf("states = %#v; want whole incomplete chunk unknown", states)
+			}
+		})
+	}
+}
+
+func TestFetchIssueStatesByIDsExplicitEmptyNodesMeansAbsent(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[]}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"issue-1"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs() error = %v; want nil", err)
+	}
+	if got := states["issue-1"].Outcome; got != IssueStateOutcomeAbsent {
+		t.Fatalf("outcome = %v; want absent for explicit empty nodes", got)
+	}
+}
+
+func TestFetchIssueStatesByIDsIncompleteChunkPreservesLaterCurrent(t *testing.T) {
+	requests := 0
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		if requests == 1 {
+			_, _ = io.WriteString(w, `{"data":{"issues":{}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-51","state":{"name":"Done"},"labels":{"nodes":[]}}]}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+	ids := make([]string, linearIssuePageSize+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("issue-%d", i+1)
+	}
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), ids)
+	if !errors.Is(err, ErrIssueStateRefreshIncomplete) {
+		t.Fatalf("FetchIssueStatesByIDs error = %v; want typed incomplete response", err)
+	}
+	if states["issue-1"].Outcome != IssueStateOutcomeUnknown || states["issue-51"].Outcome != IssueStateOutcomeCurrent {
+		t.Fatalf("states = %#v; want incomplete first chunk unknown and later clean row current", states)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d; want later independent chunk fetched", requests)
+	}
+}
+
+func TestFetchIssueStatesByIDsRateLimitStopsLaterChunks(t *testing.T) {
+	requests := 0
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+	ids := make([]string, linearIssuePageSize+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("issue-%d", i+1)
+	}
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), ids)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("FetchIssueStatesByIDs error = %v; want typed rate limit", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d; want stop after first rate limit", requests)
+	}
+	if got := states["issue-51"].Outcome; got != IssueStateOutcomeUnknown {
+		t.Fatalf("trailing outcome = %v; want unknown without second request", got)
+	}
+}
+
+func TestFetchIssueStatesByIDsGraphQLRateLimitStopsLaterChunks(t *testing.T) {
+	requests := 0
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"errors":[{"message":"rate limit exceeded","extensions":{"code":"RATELIMITED"}}]}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+	ids := make([]string, linearIssuePageSize+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("issue-%d", i+1)
+	}
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), ids)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("FetchIssueStatesByIDs error = %v; want typed GraphQL rate limit", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d; want stop after first GraphQL rate limit", requests)
+	}
+	if states["issue-1"].Outcome != IssueStateOutcomeUnknown || states["issue-51"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want all rows unknown", states)
+	}
+}
+
+func TestFetchIssueStatesByIDsBadRequestProbeFailureStopsLaterChunks(t *testing.T) {
+	requests := 0
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", maxJSONResponseBytes+1))
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+	ids := make([]string, linearIssuePageSize+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("issue-%d", i+1)
+	}
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), ids)
+	if !errors.Is(err, ErrJSONResponseTooLarge) {
+		t.Fatalf("FetchIssueStatesByIDs error = %v; want oversized 400 probe error", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d; want stop after failed 400 response probe", requests)
+	}
+	if states["issue-1"].Outcome != IssueStateOutcomeUnknown || states["issue-51"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want all rows unknown", states)
+	}
+}
+
+func TestFetchIssueStatesByIDsNonRateLimitBadRequestRemainsAPIStatus(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"errors":[{"message":"bad request","extensions":{"code":"BAD_USER_INPUT"}}]}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	_, err := client.FetchIssueStatesByIDs(context.Background(), []string{"issue-1"})
+	if !errors.Is(err, ErrLinearAPIStatus) || errors.Is(err, ErrRateLimited) {
+		t.Fatalf("FetchIssueStatesByIDs error = %v; want generic API status, not rate limit", err)
+	}
+}
+
+func TestFetchIssueStatesByIDsPartialFailedChunkPreservesEarlierOutcomes(t *testing.T) {
+	requests := 0
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		if requests == 1 {
+			_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Done"},"labels":{"nodes":[]}}]}}}`)
+			return
+		}
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+	ids := make([]string, linearIssuePageSize+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("issue-%d", i+1)
+	}
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), ids)
+	if !errors.Is(err, ErrLinearAPIStatus) {
+		t.Fatalf("FetchIssueStatesByIDs error = %v; want API status error", err)
+	}
+	if got := states["issue-1"].Outcome; got != IssueStateOutcomeCurrent {
+		t.Fatalf("issue-1 outcome = %v; want current from clean earlier chunk", got)
+	}
+	if got := states["issue-2"].Outcome; got != IssueStateOutcomeAbsent {
+		t.Fatalf("issue-2 outcome = %v; want absent from clean earlier chunk", got)
+	}
+	if got := states["issue-51"].Outcome; got != IssueStateOutcomeUnknown {
+		t.Fatalf("issue-51 outcome = %v; want unknown from failed chunk", got)
+	}
+}
+
+func TestFetchIssueStatesByIDsUnknownOnConfigurationFailure(t *testing.T) {
+	client := &LinearClient{}
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"issue-1", "issue-2", "issue-1", ""})
+	if !errors.Is(err, ErrMissingTrackerAPIKey) {
+		t.Fatalf("FetchIssueStatesByIDs error = %v; want missing API key", err)
+	}
+	if len(states) != 2 || states["issue-1"].Outcome != IssueStateOutcomeUnknown || states["issue-2"].Outcome != IssueStateOutcomeUnknown {
+		t.Fatalf("states = %#v; want explicit unknown rows for configuration failure", states)
 	}
 }
 
@@ -372,7 +657,7 @@ func linearIssueStatesJSON(ids []any) string {
 		}
 		b.WriteString(`{"id":"`)
 		b.WriteString(id.(string))
-		b.WriteString(`","state":{"name":"Todo"}}`)
+		b.WriteString(`","state":{"name":"Todo"},"labels":{"nodes":[]}}`)
 	}
 	b.WriteString(`]}}}`)
 	return b.String()
@@ -1149,5 +1434,32 @@ func TestFetchIssueStatesByIDsSurvivesBlockerResolutionFailure(t *testing.T) {
 	}
 	if len(got.BlockedBy) != 1 || got.BlockedBy[0].State != "" {
 		t.Fatalf("states[issue-1].BlockedBy = %#v; want one empty-state placeholder (fail closed) after blocker resolution failure", got.BlockedBy)
+	}
+}
+
+func TestFetchIssueStatesByIDsFailsClosedOnIncompleteBlockerPayload(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		w.Header().Set("Content-Type", "application/json")
+		if opNameFromQuery(payload.Query) == "ListIssuesInverseRelations" {
+			_, _ = io.WriteString(w, `{"data":{"issues":{}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{"issues":{"nodes":[{"id":"issue-1","state":{"name":"Todo"},"labels":{"nodes":[]}}]}}}`)
+	}))
+	defer httpSrv.Close()
+	client := newTestClient(t, httpSrv, workflow.TrackerConfig{ProjectSlug: "aiops"})
+
+	states, err := client.FetchIssueStatesByIDs(context.Background(), []string{"issue-1"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs = error %v; want state refresh to survive incomplete blocker payload", err)
+	}
+	got := states["issue-1"]
+	if got.Outcome != IssueStateOutcomeCurrent || len(got.BlockedBy) != 1 || got.BlockedBy[0].State != "" {
+		t.Fatalf("states[issue-1] = %#v; want current state with fail-closed blocker placeholder", got)
 	}
 }

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 )
@@ -21,14 +22,33 @@ type Issue struct {
 	BlockedBy   []BlockerRef
 }
 
-// IssueState is the narrow SPEC §11.2 state-refresh fact: an issue's current
-// workflow state plus its normalized labels. Labels are carried so the SPEC §6.4
-// required_labels "continue" gate can observe label removal on already-claimed
-// issues that may sit beyond the active-listing page (#682). Producing clients
-// lowercase/trim each label so matching is case-insensitive.
+// IssueStateOutcome classifies one requested narrow-refresh reference. Unknown
+// is the zero value so a missing map key or an unclassified response can never
+// be mistaken for an authoritative tracker fact.
+type IssueStateOutcome uint8
+
+// ErrIssueStateRefreshIncomplete marks a syntactically decodable issue-state
+// or blocker response that omits fields required for authoritative
+// classification. Transport failures, malformed JSON, and oversized bodies
+// retain their own error identity instead of being mislabeled as structurally
+// incomplete.
+var ErrIssueStateRefreshIncomplete = errors.New("issue state refresh response incomplete")
+
+const (
+	IssueStateOutcomeUnknown IssueStateOutcome = iota
+	IssueStateOutcomeCurrent
+	IssueStateOutcomeAbsent
+)
+
+// IssueState is the narrow SPEC §11.2 state-refresh fact for one requested
+// reference. Current rows carry workflow state plus normalized labels; absent
+// rows carry no fabricated issue facts. Labels let the SPEC §6.4 required_labels
+// "continue" gate observe label removal on already-claimed issues beyond the
+// active-listing page (#682). Producing clients lowercase/trim each label.
 type IssueState struct {
-	State  string
-	Labels []string
+	Outcome IssueStateOutcome
+	State   string
+	Labels  []string
 	// BlockedBy carries the refreshed blocker dependencies so dispatch-time
 	// revalidation can re-apply the SPEC §8.2 Todo blocker gate, matching
 	// upstream retry_candidate_issue? (orchestrator.ex:1602-1604), which
@@ -57,6 +77,44 @@ type IssueState struct {
 type IssueRef struct {
 	ID         string
 	Identifier string
+}
+
+// UnknownIssueStatesByRefs totalizes refs into one zero-safe Unknown row per
+// unique non-empty ID while preserving the first ref for adapter lookup.
+func UnknownIssueStatesByRefs(issueRefs []IssueRef) (map[string]IssueState, []IssueRef) {
+	states := make(map[string]IssueState, len(issueRefs))
+	refs := make([]IssueRef, 0, len(issueRefs))
+	for _, ref := range issueRefs {
+		ref.ID = strings.TrimSpace(ref.ID)
+		if ref.ID == "" {
+			continue
+		}
+		if _, exists := states[ref.ID]; exists {
+			continue
+		}
+		states[ref.ID] = IssueState{Outcome: IssueStateOutcomeUnknown}
+		refs = append(refs, ref)
+	}
+	return states, refs
+}
+
+func unknownIssueStatesByIDs(issueIDs []string) (map[string]IssueState, []string) {
+	states, refs := UnknownIssueStatesByRefs(IssueRefsFromIDs(issueIDs))
+	ids := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		ids = append(ids, ref.ID)
+	}
+	return states, ids
+}
+
+// ShouldStopIssueStateRefresh reports whether an adapter must leave all later
+// refs Unknown because the shared request budget or caller context is spent.
+// Nested tracker reads used to hydrate a listing or refresh obey the same stop
+// rule so a rate limit or spent context cannot trigger more downstream I/O.
+func ShouldStopIssueStateRefresh(ctx context.Context, err error) bool {
+	return errors.Is(err, ErrRateLimited) || errors.Is(err, ErrJSONResponseTooLarge) ||
+		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)
 }
 
 func IssueRefsFromIDs(issueIDs []string) []IssueRef {
@@ -107,8 +165,11 @@ func TimeString(t time.Time) string {
 }
 
 // IssueStateRefresher fetches the current tracker state for explicit issue IDs.
-// Poll-tick reconciliation uses this to refresh already-running issues without
-// relying on candidate pagination side effects.
+// The returned map has one row per unique non-empty requested ID. Missing rows
+// and the zero value mean Unknown; Absent is reserved for authoritative tracker
+// evidence. A non-nil error may accompany usable Current or Absent rows, while
+// failed or unattempted refs remain Unknown. Poll-tick reconciliation uses this
+// without relying on candidate pagination side effects.
 type IssueStateRefresher interface {
 	FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]IssueState, error)
 }


### PR DESCRIPTION
Closes #1113

## Summary
- Adds a zero-safe `Current` / `Absent` / `Unknown` outcome for every narrow issue-state refresh reference across Linear, GitHub, and Gitea.
- Applies destructive reconciliation only to authoritative facts: confirmed absence cancels running work without terminal cleanup and releases blocked/continuation claims, while failure and quota/capacity retries remain timer-owned.
- Preserves usable rows from partial batches, rejects malformed or mismatched authority as unknown, and keeps the pre-existing active-list blocker behavior separate from the stricter refresh policy.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This keeps SPEC section 8.5 reconciliation separate from section 8.4 retry-timer ownership, matching `elixir/lib/symphony_elixir/orchestrator.ex:1142` and `elixir/lib/symphony_elixir/orchestrator.ex:1602` without adding a new phase.

## PR diff size budget (AGENTS.md)
- [ ] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [x] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

Production diff: 14 files, +1251/-517 lines (1768 changed LOC). The adapter contract and every destructive consumer must land atomically: splitting them would create an intermediate revision where an omitted or malformed row can still be interpreted as disappearance. Tests and generated files are excluded from this count.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional local validation:
- `go build ./cmd/worker ./cmd/tui`
- `go test -tags e2e -race -timeout 15m -count=1 ./test/e2e/...` (Docker)
- strict golangci-lint with `--issues-exit-code=1`: `0 issues`
- eleven mutation checks across adapter authority, partial responses, stale-list precedence, retry/timer ownership, cleanup safety, listing-vs-refresh policy seams, response-field presence, and non-Todo blocker isolation
- final Standards and Spec reviews bound to the exact committed head

## Notes
- CI quota exhaustion may prevent hosted checks from running; the complete repository gate and Docker E2E suite passed locally.
- Human size-gate sign-off remains required before merge.
