### PR TITLE
fix(worker): remove only confirmed terminal workspaces

### DIFF
--- a/docs/runbooks/personal-daily-workflow.md
+++ b/docs/runbooks/personal-daily-workflow.md
@@ -175,7 +175,7 @@ change is larger.
 
 ## Handling failed tasks
 
-The SPEC-aligned worker does not persist scheduler attempts in Postgres. It polls the tracker, records in-flight/completed/retry state in the in-memory orchestrator runtime, and starts with fresh scheduler state after restart. Startup reconciliation compares tracker state with deterministic workspaces before the first poll so terminal/unknown workspace directories are cleaned without reading queue rows.
+The SPEC-aligned worker does not persist scheduler attempts in Postgres. It polls the tracker, records in-flight/completed/retry state in the in-memory orchestrator runtime, and starts with fresh scheduler state after restart. Before the first poll, startup reconciliation removes only deterministic workspaces whose issue identifiers the tracker confirms are terminal; unmatched workspaces remain untouched.
 
 ### Triage with the runtime status API
 

--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -221,7 +221,8 @@ only when a tracker actually emits an `issue.ID` containing uppercase or
 `[^a-zA-Z0-9._-]` characters.)
 
 Plain (non-rework) per-issue dirs created under the old sanitizer are
-not back-compat-matched and will be reconciled away.
+not back-compat-matched. They remain on disk unless the tracker explicitly
+confirms the corresponding issue is terminal or an operator removes them.
 
 ## Cleanup policy
 

--- a/docs/runbooks/workspace-cache.md
+++ b/docs/runbooks/workspace-cache.md
@@ -182,10 +182,10 @@ Because the project is pre-release ([`AGENTS.md`
 §SPEC-alignment-is-a-hard-requirement](../../AGENTS.md#spec-alignment-is-a-hard-requirement),
 [`DEVIATIONS.md`](../../DEVIATIONS.md)) the cutover is hard, not
 gradual: dirs created under the pre-#229 sanitizer are orphaned on
-disk and will be removed by the next startup reconciliation pass as
-"unknown" workspaces. Operators should clean up the orphans before
-rolling out the change to avoid a one-time burst of reconcile-remove
-events on the next worker boot:
+disk and remain unmatched by current workspace keys. Startup
+reconciliation deliberately keeps those dirs because their absence from a
+tracker result is not proof of terminal state. Operators who no longer need
+the orphans should audit and remove them explicitly:
 
 ```sh
 # Audit (no removals): list workspace components that contain old-style

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -142,12 +142,13 @@ func fetchReconcileIssues(ctx context.Context, cfg ReconcileConfig, taskID strin
 }
 
 // reconcileIndex is the per-workspace lookup state derived from the fetched
-// issues: active/terminal key maps and the issues used to match active rework
-// workspaces.
+// issues: active/terminal key maps and the issues used to match historical
+// rework workspace keys.
 type reconcileIndex struct {
-	activeKeys   map[string]tracker.Issue
-	terminalKeys map[string]tracker.Issue
-	activeIssues []tracker.Issue
+	activeKeys     map[string]tracker.Issue
+	terminalKeys   map[string]tracker.Issue
+	activeIssues   []tracker.Issue
+	terminalIssues []tracker.Issue
 }
 
 func newReconcileIndex(fetch reconcileFetch) reconcileIndex {
@@ -164,9 +165,10 @@ func newReconcileIndex(fetch reconcileFetch) reconcileIndex {
 		}
 	}
 	return reconcileIndex{
-		activeKeys:   activeKeys,
-		terminalKeys: terminalKeys,
-		activeIssues: fetch.activeIssues,
+		activeKeys:     activeKeys,
+		terminalKeys:   terminalKeys,
+		activeIssues:   fetch.activeIssues,
+		terminalIssues: fetch.terminalIssues,
 	}
 }
 
@@ -218,6 +220,10 @@ func reconcileWorkspace(ctx context.Context, cfg ReconcileConfig, taskID string,
 		return false, true, nil
 	}
 	if issue, ok := idx.terminalKeys[workspace.Key]; ok {
+		removedOne, err = removeWorkspace(ctx, cfg, taskID, workspace.Path, issue, "terminal")
+		return removedOne, false, err
+	}
+	if issue, ok := terminalReworkIssueForWorkspace(workspace.Key, idx.terminalIssues); ok {
 		removedOne, err = removeWorkspace(ctx, cfg, taskID, workspace.Path, issue, "terminal")
 		return removedOne, false, err
 	}
@@ -436,13 +442,32 @@ func activeReworkIssueForWorkspace(workspaceKey string, issues []tracker.Issue) 
 		if !strings.EqualFold(issue.State, "Rework") || strings.TrimSpace(issue.ID) == "" {
 			continue
 		}
-		for _, prefix := range reworkWorkspaceKeyPrefixes(issue) {
-			if strings.HasPrefix(workspaceKey, prefix) {
-				return issue, true
-			}
+		if reworkWorkspaceMatchesIssue(workspaceKey, issue) {
+			return issue, true
 		}
 	}
 	return tracker.Issue{}, false
+}
+
+func terminalReworkIssueForWorkspace(workspaceKey string, issues []tracker.Issue) (tracker.Issue, bool) {
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.ID) == "" {
+			continue
+		}
+		if reworkWorkspaceMatchesIssue(workspaceKey, issue) {
+			return issue, true
+		}
+	}
+	return tracker.Issue{}, false
+}
+
+func reworkWorkspaceMatchesIssue(workspaceKey string, issue tracker.Issue) bool {
+	for _, prefix := range reworkWorkspaceKeyPrefixes(issue) {
+		if strings.HasPrefix(workspaceKey, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func reworkWorkspaceKeyPrefixes(issue tracker.Issue) []string { //nolint:gocognit // baseline (#521)

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -439,7 +439,7 @@ func RemoveIssueWorkspace(ctx context.Context, ev EventEmitter, req RemoveWorksp
 
 func activeReworkIssueForWorkspace(workspaceKey string, issues []tracker.Issue) (tracker.Issue, bool) {
 	for _, issue := range issues {
-		if !strings.EqualFold(issue.State, "Rework") || strings.TrimSpace(issue.ID) == "" {
+		if !strings.EqualFold(issue.State, "Rework") {
 			continue
 		}
 		if reworkWorkspaceMatchesIssue(workspaceKey, issue) {
@@ -451,9 +451,6 @@ func activeReworkIssueForWorkspace(workspaceKey string, issues []tracker.Issue) 
 
 func terminalReworkIssueForWorkspace(workspaceKey string, issues []tracker.Issue) (tracker.Issue, bool) {
 	for _, issue := range issues {
-		if strings.TrimSpace(issue.ID) == "" {
-			continue
-		}
 		if reworkWorkspaceMatchesIssue(workspaceKey, issue) {
 			return issue, true
 		}
@@ -471,6 +468,9 @@ func reworkWorkspaceMatchesIssue(workspaceKey string, issue tracker.Issue) bool 
 }
 
 func reworkWorkspaceKeyPrefixes(issue tracker.Issue) []string { //nolint:gocognit // baseline (#521)
+	if strings.TrimSpace(issue.ID) == "" {
+		return nil
+	}
 	seen := map[string]struct{}{}
 	var prefixes []string
 	baseKeys := []string{workspace.SanitizeComponent(issue.ID), sanitizeLegacyWorkspaceKey(issue.ID)}
@@ -545,6 +545,9 @@ func workspaceKeysForRawIssueKeys(issue tracker.Issue, rawKeys []string) []strin
 		}
 	}
 	for _, raw := range rawKeys {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
 		for _, key := range []string{workspace.SanitizeComponent(raw), sanitizeLegacyWorkspaceKey(raw)} {
 			if key == "" {
 				continue

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -26,8 +26,8 @@ type ReconcileTracker interface {
 }
 
 // ReconcileConfig contains the dependencies for the SPEC startup reconciliation
-// pass. The pass is idempotent: active issue workspaces are preserved, while
-// terminal and unknown/deleted issue workspaces are removed before dispatch.
+// pass. The pass is idempotent: active and unmatched issue workspaces are
+// preserved, while tracker-confirmed terminal issue workspaces are removed.
 type ReconcileConfig struct {
 	WorkspaceRoot      string
 	ActiveStates       []string
@@ -43,10 +43,10 @@ type ReconcileConfig struct {
 }
 
 // ReconcileStartup reconciles existing per-issue workspaces with tracker state.
-// It removes terminal and unknown/deleted workspaces and leaves active issue
-// workspaces intact. It emits reconcile_start, reconcile_workspace, and
-// reconcile_end task events so startup recovery is visible in the same event
-// stream as normal task lifecycle activity.
+// It removes only tracker-confirmed terminal workspaces and leaves active or
+// unmatched workspaces intact. It emits reconcile_start, reconcile_workspace,
+// and reconcile_end task events so startup recovery is visible in the same
+// event stream as normal task lifecycle activity.
 func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	if err := validateReconcileConfig(cfg); err != nil {
 		return err
@@ -70,9 +70,6 @@ func ReconcileStartup(ctx context.Context, cfg ReconcileConfig) error {
 	workspaces, err := listIssueWorkspaces(cfg.WorkspaceRoot, cfg.TrackerKind)
 	if err != nil {
 		return err
-	}
-	if fetch.terminalFetchOK && len(workspaces) > 0 && len(fetch.activeIssues)+len(fetch.terminalIssues) == 0 {
-		return fmt.Errorf("tracker returned no active or terminal issues; refusing to remove %d existing workspaces", len(workspaces))
 	}
 
 	removed, kept, err := reconcileWorkspaces(ctx, cfg, taskID, workspaces, idx)
@@ -119,8 +116,8 @@ type reconcileFetch struct {
 // worst case — without the active list we cannot confirm any workspace is safe
 // to delete — so it emits reconcile_end with `status: skipped` and returns
 // skip=true, leaving every workspace intact. A terminal-fetch failure is
-// non-fatal: active workspaces are still kept and terminal/unknown removal is
-// skipped because canRemoveUnknown stays false when terminalIssues is empty.
+// non-fatal: active and unmatched workspaces are still kept, while terminal
+// cleanup is skipped because no terminal issue identifiers were returned.
 func fetchReconcileIssues(ctx context.Context, cfg ReconcileConfig, taskID string, activeStates, terminalStates []string) (reconcileFetch, bool) {
 	activeIssues, err := cfg.Tracker.ListIssuesByStates(ctx, activeStates)
 	if err != nil {
@@ -145,13 +142,12 @@ func fetchReconcileIssues(ctx context.Context, cfg ReconcileConfig, taskID strin
 }
 
 // reconcileIndex is the per-workspace lookup state derived from the fetched
-// issues: active/terminal key maps, whether unknown workspaces may be removed,
-// and the key function used to match active workspaces.
+// issues: active/terminal key maps and the issues used to match active rework
+// workspaces.
 type reconcileIndex struct {
-	activeKeys       map[string]tracker.Issue
-	terminalKeys     map[string]tracker.Issue
-	canRemoveUnknown bool
-	activeIssues     []tracker.Issue
+	activeKeys   map[string]tracker.Issue
+	terminalKeys map[string]tracker.Issue
+	activeIssues []tracker.Issue
 }
 
 func newReconcileIndex(fetch reconcileFetch) reconcileIndex {
@@ -168,10 +164,9 @@ func newReconcileIndex(fetch reconcileFetch) reconcileIndex {
 		}
 	}
 	return reconcileIndex{
-		activeKeys:       activeKeys,
-		terminalKeys:     terminalKeys,
-		canRemoveUnknown: len(fetch.terminalIssues) > 0,
-		activeIssues:     fetch.activeIssues,
+		activeKeys:   activeKeys,
+		terminalKeys: terminalKeys,
+		activeIssues: fetch.activeIssues,
 	}
 }
 
@@ -199,8 +194,8 @@ func reconcileWorkspaces(ctx context.Context, cfg ReconcileConfig, taskID string
 
 // reconcileWorkspace classifies a single workspace and keeps or removes it,
 // returning whether it was removed and/or kept (both false when removal was
-// declined). Mirrors SPEC §8.6: keep active (exact key or rework), remove
-// terminal, and keep-or-remove unknown depending on canRemoveUnknown.
+// declined). Mirrors SPEC §8.6: keep active (exact key or rework), remove a
+// tracker-confirmed terminal workspace, and keep unmatched workspaces.
 func reconcileWorkspace(ctx context.Context, cfg ReconcileConfig, taskID string, workspace issueWorkspace, idx reconcileIndex) (removedOne, keptOne bool, err error) {
 	if _, ok := idx.activeKeys[workspace.Key]; ok {
 		Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept active workspace", map[string]any{
@@ -226,17 +221,13 @@ func reconcileWorkspace(ctx context.Context, cfg ReconcileConfig, taskID string,
 		removedOne, err = removeWorkspace(ctx, cfg, taskID, workspace.Path, issue, "terminal")
 		return removedOne, false, err
 	}
-	if !idx.canRemoveUnknown {
-		Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept unknown workspace", map[string]any{
-			"path":   workspace.Path,
-			"key":    workspace.Key,
-			"action": "keep",
-			"reason": "unknown_terminal_state_unconfirmed",
-		})
-		return false, true, nil
-	}
-	removedOne, err = removeWorkspace(ctx, cfg, taskID, workspace.Path, tracker.Issue{}, "unknown")
-	return removedOne, false, err
+	Emit(ctx, cfg.Emitter, taskID, "", task.EventReconcileWorkspace, "kept unknown workspace", map[string]any{
+		"path":   workspace.Path,
+		"key":    workspace.Key,
+		"action": "keep",
+		"reason": "unknown_terminal_state_unconfirmed",
+	})
+	return false, true, nil
 }
 
 // reconcileEndPayload assembles the reconcile_end event payload, recording a

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -268,9 +268,9 @@ func TestReconcileStartupTolerantOfActiveFetchFailure(t *testing.T) {
 
 // TestReconcileStartupSafeWhenActiveListingCapped pins #401/#402: a partial
 // active list (signaled by tracker.ErrIssueListingCapped) MUST be treated as a
-// fetch failure so reconcile skips cleanup. Otherwise an active workspace that
-// fell past the page cap would be deleted as "unknown" on restart whenever
-// terminal issues are present.
+// fetch failure so reconcile skips cleanup. This preserves the established
+// fail-safe: no terminal workspace is removed from a startup snapshot whose
+// active half is incomplete.
 func TestReconcileStartupSafeWhenActiveListingCapped(t *testing.T) {
 	root := t.TempDir()
 	activePath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1")
@@ -318,8 +318,8 @@ func TestReconcileStartupSafeWhenActiveListingCapped(t *testing.T) {
 	if reason, _ := payload["reason"].(string); reason != "active_fetch_failed" {
 		t.Fatalf("reconcile_end reason = %q, want \"active_fetch_failed\"", reason)
 	}
-	if errMsg, _ := payload["error"].(string); !strings.Contains(errMsg, "issue_listing_capped") {
-		t.Fatalf("reconcile_end error = %q, want issue_listing_capped category surfaced", errMsg)
+	if errMsg, _ := payload["error"].(string); errMsg != tracker.ErrIssueListingCapped.Error() {
+		t.Fatalf("reconcile_end error = %q, want %q", errMsg, tracker.ErrIssueListingCapped.Error())
 	}
 }
 
@@ -413,8 +413,8 @@ func TestReconcileStartupSafeWhenTerminalListingCapped(t *testing.T) {
 	if reason, _ := payload["reason"].(string); reason != "terminal_fetch_failed" {
 		t.Fatalf("reconcile_end reason = %q, want \"terminal_fetch_failed\"", reason)
 	}
-	if errMsg, _ := payload["error"].(string); !strings.Contains(errMsg, "issue_listing_capped") {
-		t.Fatalf("reconcile_end error = %q, want issue_listing_capped category surfaced", errMsg)
+	if errMsg, _ := payload["error"].(string); errMsg != tracker.ErrIssueListingCapped.Error() {
+		t.Fatalf("reconcile_end error = %q, want %q", errMsg, tracker.ErrIssueListingCapped.Error())
 	}
 	wantPayloadCount(t, payload, "kept", 2)
 	wantPayloadCount(t, payload, "removed", 0)

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -192,18 +192,30 @@ func TestReconcileStartupRemovesOnlyTrackerConfirmedTerminalWorkspace(t *testing
 
 func TestReconcileStartupRemovesTrackerConfirmedTerminalReworkWorkspaces(t *testing.T) {
 	tests := []struct {
-		name string
-		key  string
+		name         string
+		key          string
+		unmatchedKey string
 	}{
-		{name: "current sanitizer", key: "issue-2_rework_2026-05-16T10_00_00Z"},
-		{name: "legacy sanitizer", key: "issue-2-rework-2026-05-16t10-00-00z"},
+		{
+			name:         "current sanitizer",
+			key:          "issue-2_rework_2026-05-16T10_00_00Z",
+			unmatchedKey: "issue-404_rework_2026-05-16T10_00_00Z",
+		},
+		{
+			name:         "legacy sanitizer",
+			key:          "issue-2-rework-2026-05-16t10-00-00z",
+			unmatchedKey: "issue-404-rework-2026-05-16t10-00-00z",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			root := t.TempDir()
 			terminalPath := filepath.Join(root, "acme", "repo", "linear_issue", tt.key)
-			if err := os.MkdirAll(terminalPath, 0o755); err != nil {
-				t.Fatalf("mkdir %s: %v", terminalPath, err)
+			unmatchedPath := filepath.Join(root, "acme", "repo", "linear_issue", tt.unmatchedKey)
+			for _, path := range []string{terminalPath, unmatchedPath} {
+				if err := os.MkdirAll(path, 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", path, err)
+				}
 			}
 
 			emitter := &fakeEmitter{}
@@ -224,7 +236,63 @@ func TestReconcileStartupRemovesTrackerConfirmedTerminalReworkWorkspaces(t *test
 			if _, err := os.Stat(terminalPath); !os.IsNotExist(err) {
 				t.Fatalf("tracker-confirmed terminal Rework workspace should be removed, stat err=%v", err)
 			}
-			wantSingleReconcileWorkspaceReason(t, emitter, "terminal")
+			if _, err := os.Stat(unmatchedPath); err != nil {
+				t.Fatalf("unmatched Rework workspace should remain: %v", err)
+			}
+			wantReconcileWorkspaceReasonForPath(t, emitter, terminalPath, "terminal")
+			wantReconcileWorkspaceReasonForPath(t, emitter, unmatchedPath, "unknown_terminal_state_unconfirmed")
+		})
+	}
+}
+
+func TestReconcileStartupDoesNotIndexBlankTerminalIssueKeys(t *testing.T) {
+	tests := []struct {
+		name            string
+		issueID         string
+		currentFallback string
+	}{
+		{name: "empty", issueID: "", currentFallback: "unknown"},
+		{name: "whitespace", issueID: "   ", currentFallback: "___"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			confirmedPath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-2")
+			currentFallbackPath := filepath.Join(root, "acme", "repo", "linear_issue", tt.currentFallback)
+			legacyFallbackPath := filepath.Join(root, "acme", "repo", "linear_issue", "workspace")
+			currentReworkFallbackPath := filepath.Join(root, "acme", "repo", "linear_issue", tt.currentFallback+"_rework_2026-05-16T10_00_00Z")
+			legacyReworkFallbackPath := filepath.Join(root, "acme", "repo", "linear_issue", "workspace-rework-2026-05-16t10-00-00z")
+			fallbackPaths := []string{currentFallbackPath, legacyFallbackPath, currentReworkFallbackPath, legacyReworkFallbackPath}
+			for _, path := range append([]string{confirmedPath}, fallbackPaths...) {
+				if err := os.MkdirAll(path, 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", path, err)
+				}
+			}
+
+			emitter := &fakeEmitter{}
+			err := ReconcileStartup(context.Background(), ReconcileConfig{
+				WorkspaceRoot:  root,
+				ActiveStates:   []string{"Todo"},
+				TerminalStates: []string{"Done"},
+				Tracker: &fakeReconcileTrackerByCall{issuesByCall: [][]tracker.Issue{
+					nil,
+					{{ID: tt.issueID, Identifier: "LIN-2", State: "Done"}},
+				}},
+				Emitter:         emitter,
+				ReconcileTaskID: "reconcile-startup",
+			})
+			if err != nil {
+				t.Fatalf("ReconcileStartup: %v", err)
+			}
+			if _, err := os.Stat(confirmedPath); !os.IsNotExist(err) {
+				t.Fatalf("identifier-confirmed terminal workspace should be removed, stat err=%v", err)
+			}
+			for _, path := range fallbackPaths {
+				if _, err := os.Stat(path); err != nil {
+					t.Fatalf("blank-key fallback workspace %s should remain: %v", path, err)
+				}
+				wantReconcileWorkspaceReasonForPath(t, emitter, path, "unknown_terminal_state_unconfirmed")
+			}
 		})
 	}
 }
@@ -946,6 +1014,35 @@ func TestReconcileStartupKeepsWorkspaceWhenActiveAndTerminalKeysConflict(t *test
 	wantSingleReconcileWorkspaceReason(t, emitter, "active")
 }
 
+func TestReconcileStartupKeepsActiveReworkWhenTerminalSnapshotConflicts(t *testing.T) {
+	root := t.TempDir()
+	workspacePath := filepath.Join(root, "acme", "repo", "linear-issue", "issue-3_rework_2026-05-16T10_00_00Z")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	fake := &fakeReconcileTrackerByCall{issuesByCall: [][]tracker.Issue{
+		{{ID: "issue-3", Identifier: "LIN-3", State: "Rework", UpdatedAt: mustTime("2026-05-16T11:30:00Z")}},
+		{{ID: "issue-3", Identifier: "LIN-3", State: "Done"}},
+	}}
+	emitter := &fakeEmitter{}
+	err := ReconcileStartup(context.Background(), ReconcileConfig{
+		WorkspaceRoot:   root,
+		ActiveStates:    []string{"Rework"},
+		TerminalStates:  []string{"Done"},
+		Tracker:         fake,
+		Emitter:         emitter,
+		ReconcileTaskID: "reconcile-startup",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStartup: %v", err)
+	}
+	if _, err := os.Stat(workspacePath); err != nil {
+		t.Fatalf("conflicting active Rework workspace should remain: %v", err)
+	}
+	wantSingleReconcileWorkspaceReason(t, emitter, "active_rework")
+}
+
 func TestReconcileStartupKeepsUnknownWorkspaceWhenTrackerHasActiveIssuesOnly(t *testing.T) {
 	root := t.TempDir()
 	unknownPath := filepath.Join(root, "acme", "repo", "linear-issue", "lin-unknown")
@@ -1022,6 +1119,21 @@ func wantSingleReconcileWorkspaceReason(t *testing.T, emitter *fakeEmitter, want
 	if got, _ := payload["reason"].(string); got != want {
 		t.Fatalf("reconcile_workspace reason = %q, want %q", got, want)
 	}
+}
+
+func wantReconcileWorkspaceReasonForPath(t *testing.T, emitter *fakeEmitter, path, want string) {
+	t.Helper()
+	for _, event := range emitter.byKind(task.EventReconcileWorkspace) {
+		payload, ok := event.Payload.(map[string]any)
+		if !ok || payload["path"] != path {
+			continue
+		}
+		if got, _ := payload["reason"].(string); got != want {
+			t.Fatalf("reconcile_workspace reason for %s = %q, want %q", path, got, want)
+		}
+		return
+	}
+	t.Fatalf("reconcile_workspace event for %s not found", path)
 }
 
 func TestReconcileStartupEndPayloadReportsKeptRemovedCounts(t *testing.T) {

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -190,6 +190,45 @@ func TestReconcileStartupRemovesOnlyTrackerConfirmedTerminalWorkspace(t *testing
 	}
 }
 
+func TestReconcileStartupRemovesTrackerConfirmedTerminalReworkWorkspaces(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "current sanitizer", key: "issue-2_rework_2026-05-16T10_00_00Z"},
+		{name: "legacy sanitizer", key: "issue-2-rework-2026-05-16t10-00-00z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			terminalPath := filepath.Join(root, "acme", "repo", "linear_issue", tt.key)
+			if err := os.MkdirAll(terminalPath, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", terminalPath, err)
+			}
+
+			emitter := &fakeEmitter{}
+			err := ReconcileStartup(context.Background(), ReconcileConfig{
+				WorkspaceRoot:  root,
+				ActiveStates:   []string{"Rework"},
+				TerminalStates: []string{"Done"},
+				Tracker: &fakeReconcileTrackerByCall{issuesByCall: [][]tracker.Issue{
+					nil,
+					{{ID: "issue-2", Identifier: "LIN-2", State: "Done"}},
+				}},
+				Emitter:         emitter,
+				ReconcileTaskID: "reconcile-startup",
+			})
+			if err != nil {
+				t.Fatalf("ReconcileStartup: %v", err)
+			}
+			if _, err := os.Stat(terminalPath); !os.IsNotExist(err) {
+				t.Fatalf("tracker-confirmed terminal Rework workspace should be removed, stat err=%v", err)
+			}
+			wantSingleReconcileWorkspaceReason(t, emitter, "terminal")
+		})
+	}
+}
+
 func TestReconcileStartupKeepsWorkspacesWhenTrackerReturnsNoIssues(t *testing.T) {
 	root := t.TempDir()
 	unknownPath := filepath.Join(root, "acme", "repo", "linear-issue", "lin-404")

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/xrf9268-hue/aiops-platform/internal/task"
 	"github.com/xrf9268-hue/aiops-platform/internal/tracker"
 	"github.com/xrf9268-hue/aiops-platform/internal/workflow"
+	"github.com/xrf9268-hue/aiops-platform/internal/workspace"
 )
 
 type fakeReconcileTracker struct {
@@ -156,15 +157,18 @@ func TestReconcileStartupIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestReconcileStartupRemovesUnknownWorkspacesWhenTerminalIssuesObserved(t *testing.T) {
+func TestReconcileStartupRemovesOnlyTrackerConfirmedTerminalWorkspace(t *testing.T) {
 	root := t.TempDir()
+	terminalPath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-2")
 	unknownPath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-404")
-	if err := os.MkdirAll(unknownPath, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
+	for _, path := range []string{terminalPath, unknownPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
 	}
 
 	fake := &fakeReconcileTrackerByCall{issuesByCall: [][]tracker.Issue{
-		{{ID: "issue-1", Identifier: "LIN-1", State: "Todo"}},
+		nil,
 		{{ID: "issue-2", Identifier: "LIN-2", State: "Done"}},
 	}}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
@@ -178,32 +182,39 @@ func TestReconcileStartupRemovesUnknownWorkspacesWhenTerminalIssuesObserved(t *t
 	if err != nil {
 		t.Fatalf("ReconcileStartup: %v", err)
 	}
-	if _, err := os.Stat(unknownPath); !os.IsNotExist(err) {
-		t.Fatalf("unknown workspace should be removed after terminal state is observed, stat err=%v", err)
+	if _, err := os.Stat(terminalPath); !os.IsNotExist(err) {
+		t.Fatalf("tracker-confirmed terminal workspace should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(unknownPath); err != nil {
+		t.Fatalf("unmatched workspace should remain without terminal-state confirmation: %v", err)
 	}
 }
 
-func TestReconcileStartupRefusesToRemoveWhenTrackerReturnsNoIssues(t *testing.T) {
+func TestReconcileStartupKeepsWorkspacesWhenTrackerReturnsNoIssues(t *testing.T) {
 	root := t.TempDir()
 	unknownPath := filepath.Join(root, "acme", "repo", "linear-issue", "lin-404")
 	if err := os.MkdirAll(unknownPath, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 
+	emitter := &fakeEmitter{}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:   root,
 		ActiveStates:    []string{"Todo"},
 		TerminalStates:  []string{"Done"},
 		Tracker:         fakeReconcileTracker{},
-		Emitter:         &fakeEmitter{},
+		Emitter:         emitter,
 		ReconcileTaskID: "reconcile-startup",
 	})
-	if err == nil || !strings.Contains(err.Error(), "tracker returned no active or terminal issues") {
-		t.Fatalf("ReconcileStartup error = %v, want empty tracker safety error", err)
+	if err != nil {
+		t.Fatalf("ReconcileStartup must continue when tracker returns no issues: %v", err)
 	}
 	if _, err := os.Stat(unknownPath); err != nil {
 		t.Fatalf("workspace should remain when tracker returns no issues: %v", err)
 	}
+	payload := reconcileEndPayloadFor(t, emitter)
+	wantPayloadCount(t, payload, "kept", 1)
+	wantPayloadCount(t, payload, "removed", 0)
 }
 
 // TestReconcileStartupTolerantOfActiveFetchFailure pins SPEC §8.6 / §11.4:
@@ -276,8 +287,8 @@ func TestReconcileStartupSafeWhenActiveListingCapped(t *testing.T) {
 		ActiveStates:   []string{"Todo"},
 		TerminalStates: []string{"Done"},
 		Tracker: &fakeReconcileTrackerByCall{
-			// Active fetch returns capped error; terminal fetch would have
-			// terminal issues, which is what would normally arm canRemoveUnknown.
+			// Active fetch returns capped error; terminal fetch would otherwise
+			// provide positive evidence for removing LIN-2.
 			errByCall:    []error{tracker.ErrIssueListingCapped, nil},
 			issuesByCall: [][]tracker.Issue{nil, {{ID: "issue-2", Identifier: "LIN-2", State: "Done"}}},
 		},
@@ -313,8 +324,8 @@ func TestReconcileStartupSafeWhenActiveListingCapped(t *testing.T) {
 }
 
 // TestReconcileStartupTolerantOfTerminalFetchFailure: terminal-fetch failure
-// is non-fatal. Active workspaces are still kept; terminal/unknown removal is
-// skipped because terminalKeys is empty and canRemoveUnknown stays false.
+// is non-fatal. Active workspaces are still kept and no terminal workspace is
+// removed because the tracker returned no positive terminal-state evidence.
 func TestReconcileStartupTolerantOfTerminalFetchFailure(t *testing.T) {
 	root := t.TempDir()
 	activePath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1")
@@ -357,6 +368,56 @@ func TestReconcileStartupTolerantOfTerminalFetchFailure(t *testing.T) {
 	if reason, _ := payload["reason"].(string); reason != "terminal_fetch_failed" {
 		t.Fatalf("reconcile_end reason = %q, want \"terminal_fetch_failed\"", reason)
 	}
+}
+
+func TestReconcileStartupSafeWhenTerminalListingCapped(t *testing.T) {
+	root := t.TempDir()
+	activePath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-1")
+	unmatchedPath := filepath.Join(root, "acme", "repo", "linear_issue", "LIN-9")
+	for _, path := range []string{activePath, unmatchedPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+
+	emitter := &fakeEmitter{}
+	var reconcileErr error
+	logs := captureLog(t, func() {
+		reconcileErr = ReconcileStartup(context.Background(), ReconcileConfig{
+			WorkspaceRoot:  root,
+			ActiveStates:   []string{"In Progress"},
+			TerminalStates: []string{"Done"},
+			Tracker: &fakeReconcileTrackerByCall{
+				issuesByCall: [][]tracker.Issue{{{ID: "issue-1", Identifier: "LIN-1", State: "In Progress"}}, nil},
+				errByCall:    []error{nil, tracker.ErrIssueListingCapped},
+			},
+			Emitter:         emitter,
+			ReconcileTaskID: "reconcile-startup",
+		})
+	})
+	if reconcileErr != nil {
+		t.Fatalf("ReconcileStartup must not fail when terminal listing is capped: %v", reconcileErr)
+	}
+	if !strings.Contains(logs, "event=startup_reconcile_terminal_fetch_failed") || !strings.Contains(logs, "issue_listing_capped") {
+		t.Fatalf("terminal listing warning log = %q, want event and issue_listing_capped category", logs)
+	}
+	for _, path := range []string{activePath, unmatchedPath} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("workspace %s must remain when terminal listing is capped: %v", path, err)
+		}
+	}
+	payload := reconcileEndPayloadFor(t, emitter)
+	if status, _ := payload["status"].(string); status != "partial" {
+		t.Fatalf("reconcile_end status = %q, want \"partial\"", status)
+	}
+	if reason, _ := payload["reason"].(string); reason != "terminal_fetch_failed" {
+		t.Fatalf("reconcile_end reason = %q, want \"terminal_fetch_failed\"", reason)
+	}
+	if errMsg, _ := payload["error"].(string); !strings.Contains(errMsg, "issue_listing_capped") {
+		t.Fatalf("reconcile_end error = %q, want issue_listing_capped category surfaced", errMsg)
+	}
+	wantPayloadCount(t, payload, "kept", 2)
+	wantPayloadCount(t, payload, "removed", 0)
 }
 
 // TestReconcileStartupTolerantOfBothFetchFailures: both fail. Treated as the
@@ -493,7 +554,7 @@ func TestReconcileStartupMatchesGitHubWorkspaceLayout(t *testing.T) {
 
 func TestReconcileStartupSkipsOtherTrackerWorkspaceLayouts(t *testing.T) {
 	root := t.TempDir()
-	linearTerminalPath := filepath.Join(root, "acme", "repo", "linear-issue", "lin-2-done")
+	linearTerminalPath := filepath.Join(root, "acme", "repo", "linear-issue", "issue-2")
 	giteaOtherTrackerPath := filepath.Join(root, "acme", "repo", "gitea_issue", "issue-owned-by-gitea-worker")
 	for _, path := range []string{linearTerminalPath, giteaOtherTrackerPath} {
 		if err := os.MkdirAll(path, 0o755); err != nil {
@@ -592,8 +653,8 @@ func TestReworkWorkspaceKeyPrefixesMatchCanonicalAndLegacyOffsetSuffixes(t *test
 // created by the pre-#229 sanitizer (lowercased input, `-` separators
 // throughout, lowercased timestamp) must still be classified as
 // `active_rework` on the first reconcile after the upgrade, instead of
-// being removed as `unknown` once a terminal fetch unlocks the
-// unknown-removal path. The shipped trackers' Rework key is the
+// being misclassified when the terminal fetch also returns issues. The shipped
+// trackers' Rework key is the
 // all-lowercase `issue.ID`, so the case-preserving form 2 (`<id>-rework-`)
 // matches the on-disk directory — this is exactly why #679 could drop the
 // speculative lowercased-base third form without regressing the promise.
@@ -611,6 +672,7 @@ func TestReconcileStartupKeepsPreSpecLowercasedReworkWorkspace(t *testing.T) {
 	if err := os.MkdirAll(preSpecPath, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	emitter := &fakeEmitter{}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:  root,
 		ActiveStates:   []string{"Rework"},
@@ -619,7 +681,7 @@ func TestReconcileStartupKeepsPreSpecLowercasedReworkWorkspace(t *testing.T) {
 			{ID: "issue-3", Identifier: "LIN-123", State: "Rework", UpdatedAt: mustTime("2026-05-16T11:30:00Z")},
 			{ID: "issue-2", Identifier: "LIN-2", State: "Done"},
 		}},
-		Emitter:         &fakeEmitter{},
+		Emitter:         emitter,
 		ReconcileTaskID: "reconcile-startup",
 	})
 	if err != nil {
@@ -628,6 +690,7 @@ func TestReconcileStartupKeepsPreSpecLowercasedReworkWorkspace(t *testing.T) {
 	if _, err := os.Stat(preSpecPath); err != nil {
 		t.Fatalf("pre-#229 Rework workspace should remain after the SPEC §4.2 cutover: %v", err)
 	}
+	wantSingleReconcileWorkspaceReason(t, emitter, "active_rework")
 }
 
 // TestReworkWorkspaceKeyPrefixesOmitsPreSpecLowercaseForm pins #679: the
@@ -826,12 +889,13 @@ func TestReconcileStartupKeepsWorkspaceWhenActiveAndTerminalKeysConflict(t *test
 		{{ID: "active", Identifier: "same key", State: "In Progress"}},
 		{{ID: "terminal", Identifier: "same key", State: "Done"}},
 	}}
+	emitter := &fakeEmitter{}
 	err := ReconcileStartup(context.Background(), ReconcileConfig{
 		WorkspaceRoot:   root,
 		ActiveStates:    []string{"In Progress"},
 		TerminalStates:  []string{"Done"},
 		Tracker:         fake,
-		Emitter:         &fakeEmitter{},
+		Emitter:         emitter,
 		ReconcileTaskID: "reconcile-startup",
 	})
 	if err != nil {
@@ -840,6 +904,7 @@ func TestReconcileStartupKeepsWorkspaceWhenActiveAndTerminalKeysConflict(t *test
 	if _, err := os.Stat(workspacePath); err != nil {
 		t.Fatalf("conflicting active workspace should be preserved: %v", err)
 	}
+	wantSingleReconcileWorkspaceReason(t, emitter, "active")
 }
 
 func TestReconcileStartupKeepsUnknownWorkspaceWhenTrackerHasActiveIssuesOnly(t *testing.T) {
@@ -905,6 +970,21 @@ func wantPayloadCount(t *testing.T, payload map[string]any, key string, want int
 	}
 }
 
+func wantSingleReconcileWorkspaceReason(t *testing.T, emitter *fakeEmitter, want string) {
+	t.Helper()
+	events := emitter.byKind(task.EventReconcileWorkspace)
+	if len(events) != 1 {
+		t.Fatalf("reconcile_workspace events = %d, want 1", len(events))
+	}
+	payload, ok := events[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("reconcile_workspace payload = %T, want map", events[0].Payload)
+	}
+	if got, _ := payload["reason"].(string); got != want {
+		t.Fatalf("reconcile_workspace reason = %q, want %q", got, want)
+	}
+}
+
 func TestReconcileStartupEndPayloadReportsKeptRemovedCounts(t *testing.T) {
 	root := t.TempDir()
 	for _, key := range []string{"LIN-1", "LIN-2", "LIN-3"} {
@@ -931,8 +1011,8 @@ func TestReconcileStartupEndPayloadReportsKeptRemovedCounts(t *testing.T) {
 	if status, _ := payload["status"].(string); status != "ok" {
 		t.Errorf("reconcile_end status = %q, want \"ok\"", status)
 	}
-	wantPayloadCount(t, payload, "kept", 1)    // LIN-1 active
-	wantPayloadCount(t, payload, "removed", 2) // LIN-2 terminal + LIN-3 unknown
+	wantPayloadCount(t, payload, "kept", 2)    // LIN-1 active + LIN-3 unmatched
+	wantPayloadCount(t, payload, "removed", 1) // LIN-2 terminal
 	wantPayloadCount(t, payload, "active_issues", 1)
 	wantPayloadCount(t, payload, "terminal_issues", 1)
 }
@@ -970,8 +1050,7 @@ func TestReconcileStartupEndPayloadCountsOnTerminalFetchFailure(t *testing.T) {
 // TestReconcileStartupEndPayloadCountsReworkKeep pins the active_rework branch's
 // kept count. The on-disk workspace timestamp differs from the issue's current
 // updatedAt, so it matches via reworkWorkspaceKeyPrefixes (not an exact active
-// key); a terminal issue arms canRemoveUnknown, so a rework branch that failed
-// to count/keep would remove the workspace instead.
+// key). The terminal result keeps the test representative of a mixed board.
 func TestReconcileStartupEndPayloadCountsReworkKeep(t *testing.T) {
 	root := t.TempDir()
 	reworkPath := filepath.Join(root, "acme", "repo", "linear-issue", "issue-3-rework-2026-05-16t10-00-00z")
@@ -999,6 +1078,31 @@ func TestReconcileStartupEndPayloadCountsReworkKeep(t *testing.T) {
 	payload := reconcileEndPayloadFor(t, emitter)
 	wantPayloadCount(t, payload, "kept", 1) // matched via active_rework prefix branch
 	wantPayloadCount(t, payload, "removed", 0)
+	wantSingleReconcileWorkspaceReason(t, emitter, "active_rework")
+}
+
+func TestRemoveIssueWorkspaceRejectsUnsafePathWithoutRemoveEvent(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	emitter := &fakeEmitter{}
+	removed, err := RemoveIssueWorkspace(context.Background(), emitter, RemoveWorkspaceRequest{
+		WorkspaceRoot: root,
+		TaskID:        "reconcile-startup",
+		Path:          outside,
+		Reason:        "terminal",
+	})
+	if !errors.Is(err, workspace.ErrSafeRemoveEscapesRoot) {
+		t.Fatalf("RemoveIssueWorkspace error = %v, want ErrSafeRemoveEscapesRoot", err)
+	}
+	if removed {
+		t.Fatal("RemoveIssueWorkspace removed = true, want false")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("unsafe outside path must remain: %v", err)
+	}
+	if got := len(emitter.byKind(task.EventReconcileWorkspace)); got != 0 {
+		t.Fatalf("reconcile_workspace events = %d, want 0 after failed removal", got)
+	}
 }
 
 // listIssueWorkspaceKeys returns just the sanitized keys discovered by


### PR DESCRIPTION
Closes #1114

## Summary
- remove only workspaces whose keys match issues returned by the successful terminal-state query
- keep unmatched workspaces and allow startup to continue when the active and terminal board is empty
- remove current and legacy Rework workspaces only when their issue ID is confirmed terminal, while active Rework still wins conflicting snapshots
- ignore empty and whitespace issue keys before plain or Rework key construction so sanitizer fallback names never become deletion evidence
- preserve fetch-failure safeguards, hook behavior, safe removal, and idempotence
- correct both operator runbooks so unmatched legacy workspaces require explicit cleanup

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level WORKFLOW.md/Config key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream Elixir reference — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a DEVIATIONS.md row + an area:spec-alignment issue, updated in this PR.

This narrows existing startup cleanup to SPEC section 8.6. The upstream implementation at elixir/lib/symphony_elixir/orchestrator.ex:1141-1156 iterates only the terminal issues returned by the tracker and removes their identifier-specific workspaces.

## PR diff size budget (AGENTS.md)
- [x] within budget — 3 production files and fewer than 300 changed production LOC; tests and generated code excluded.
- [ ] size-gated: justified overage — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. Needs human size-gate sign-off.
- [ ] size-gated: split recommended — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] go test -run TestProductionGoFilesStayWithinSizeBudget -count=1 ./scripts
- [x] go vet ./...
- [x] go test -race -covermode=atomic ./...
- [x] gofmt -l clean + blocking golangci gate with 0 issues
- [x] additional validation noted below when needed

Additional validation:
- go mod tidy left go.mod and go.sum unchanged
- go build ./cmd/worker ./cmd/tui
- go test -tags e2e -race -timeout 15m ./test/e2e/ with Docker 28.3.2
- RED to GREEN coverage for matched and unmatched current/legacy Rework, active-terminal Rework conflicts, and empty/whitespace plain plus Rework fallback keys
- compiling mutations for broad Rework matching, terminal-before-active ordering, removed blank guards, and weakened TrimSpace guards all failed the corresponding regression tests before restoration
- Standards, Spec, and focused edge reviews passed against base 16d91050 and final head 775910f9

## Notes
- CI quota exhaustion is non-blocking per operator instruction; all required local gates passed on the exact pushed head.