### PR TITLE
fix(runner): restore schema-aligned continuation

### DIFF
--- a/internal/orchestrator/runtime_poller_test.go
+++ b/internal/orchestrator/runtime_poller_test.go
@@ -336,8 +336,8 @@ func TestRuntimeDispatcherIssueStateRefresherPassesIssueIdentifierFallback(t *te
 
 // TestRuntimeDispatcherConfigForSnapshotReturnsNilWithoutRefresher pins the
 // fallback: without SetIssueStateRefresher the dispatcher leaves
-// IssueStateRefresher unset so RunTask keeps the legacy continueRun-only
-// path (e.g. tests, mock runners).
+// IssueStateRefresher unset so RunTask uses the runner's single-turn fallback
+// (e.g. tests, mock runners).
 func TestRuntimeDispatcherConfigForSnapshotReturnsNilWithoutRefresher(t *testing.T) {
 	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
 	snap := WorkflowSnapshot{Workflow: &workflow.Workflow{Config: workflow.Config{
@@ -470,7 +470,7 @@ func TestRuntimePollerWiresRefresherOntoProvidedDispatcher(t *testing.T) {
 // TestRuntimeDispatcherConfigForSnapshotEmptyActiveStatesDisablesFactory
 // guards a foot-gun: if active_states is empty the refresher would mark
 // every state as inactive and kill workers after the first turn. The
-// factory must return nil so the runner falls back to continueRun.
+// factory must return nil so the runner uses its single-turn fallback.
 func TestRuntimeDispatcherConfigForSnapshotEmptyActiveStatesDisablesFactory(t *testing.T) {
 	d := &RuntimeDispatcher{baseConfig: worker.Config{}}
 	d.SetIssueStateRefresher(&stubRefresher{states: map[string]string{"issue-1": "In Progress"}})

--- a/internal/runner/codex_app_server.go
+++ b/internal/runner/codex_app_server.go
@@ -300,24 +300,15 @@ type appServerClient struct {
 	runtimeEvents       []task.RuntimeEvent
 	runtimeEventSink    func(task.RuntimeEvent)
 	phaseTransitionSink func(from, to task.RunAttemptPhase)
-	// continueRun is the agent-emitted "should we keep going?" signal
-	// from turn/completed notifications (`params.continue`). It only
-	// gates the legacy path: when refreshIssueState is wired, SPEC §16.5
-	// per-turn tracker refresh is the authoritative continuation gate
-	// and continueRun is consulted only as the agent's secondary opinion.
-	// Keeping both lets cooperative agents end early (continueRun=false)
-	// while still letting the operator cancel an otherwise-productive
-	// worker by moving the issue out of the active states.
-	continueRun       bool
-	refreshIssueState IssueStateRefresher
-	tools             DynamicToolSet
-	turnTimeoutMs     int
-	readTimeoutMs     int
-	stallTimeoutMs    int
-	approvalPolicy    any
-	lastTerminal      time.Time
-	lastRuntimeEvent  string
-	issueExitState    *IssueStateSnapshot
+	refreshIssueState   IssueStateRefresher
+	tools               DynamicToolSet
+	turnTimeoutMs       int
+	readTimeoutMs       int
+	stallTimeoutMs      int
+	approvalPolicy      any
+	lastTerminal        time.Time
+	lastRuntimeEvent    string
+	issueExitState      *IssueStateSnapshot
 }
 type codexAppServerTextInput struct {
 	Type         string `json:"type"`
@@ -342,7 +333,7 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 	if err != nil {
 		return err
 	}
-	turnLimit, cleanBudgetStop := effectiveTurnLimit(in)
+	turnLimit := effectiveTurnLimit(in)
 	for turn := 1; turn <= turnLimit; turn++ {
 		keepGoing, err := c.runSingleTurn(ctx, in, threadID, prompt, turn)
 		if err != nil {
@@ -352,21 +343,18 @@ func (c *appServerClient) run(ctx context.Context, in RunInput, prompt string) e
 			return nil
 		}
 	}
-	if cleanBudgetStop {
-		return nil
-	}
-	return fmt.Errorf("codex app-server exceeded agent.max_turns=%d", turnLimit)
+	return nil
 }
 
-func effectiveTurnLimit(in RunInput) (limit int, cleanBudgetStop bool) {
+func effectiveTurnLimit(in RunInput) int {
 	maxTurns := in.Workflow.Config.Agent.MaxTurns
 	if maxTurns <= 0 {
 		maxTurns = 20
 	}
 	if in.CleanTurnBudget > 0 && in.CleanTurnBudget <= maxTurns {
-		return in.CleanTurnBudget, true
+		return in.CleanTurnBudget
 	}
-	return maxTurns, false
+	return maxTurns
 }
 
 // initSession records the run's sinks and caches the per-run codex config off
@@ -375,7 +363,6 @@ func (c *appServerClient) initSession(in RunInput) {
 	c.runtimeEventSink = in.RuntimeEventSink
 	c.phaseTransitionSink = in.PhaseTransitionSink
 	c.nextID = 1
-	c.continueRun = false
 	c.refreshIssueState = in.RefreshIssueState
 	c.tools = DynamicToolsForWorkflow(
 		workflow.Workflow{Config: in.Workflow.Config},
@@ -425,9 +412,8 @@ func (c *appServerClient) startThread(ctx context.Context, in RunInput) (string,
 }
 
 // runSingleTurn starts one turn, awaits its completion, and reports whether the
-// loop should continue. Mirrors upstream run_turn: keepGoing=false stops the run
-// (a clean turn with continue=false, or a SPEC §16.5 self-stop), a non-nil error
-// aborts it.
+// loop should continue. Tracker state is the sole continuation authority;
+// keepGoing=false is a clean stop, while a non-nil error aborts the run.
 func (c *appServerClient) runSingleTurn(ctx context.Context, in RunInput, threadID, prompt string, turn int) (bool, error) {
 	turnID, err := c.startTurn(ctx, in, threadID, prompt, turn)
 	if err != nil {
@@ -438,7 +424,6 @@ func (c *appServerClient) runSingleTurn(ctx context.Context, in RunInput, thread
 		c.recordFirstTurnStarted(threadID, turnID)
 	}
 	c.recordTurnStarted(threadID, turnID, turn)
-	c.continueRun = false
 	turnCtx := ctx
 	var cancel context.CancelFunc
 	if c.turnTimeoutMs > 0 {
@@ -455,20 +440,20 @@ func (c *appServerClient) runSingleTurn(ctx context.Context, in RunInput, thread
 	// SPEC §16.5: refresh tracker state between turns so an operator who
 	// cancelled the issue mid-run sees the worker exit after the current turn
 	// rather than at the next orchestrator poll tick. Errors here are surfaced
-	// verbatim per SPEC ("if refreshed_issue failed: fail"); a nil refresher
-	// keeps the legacy continueRun-only path for callers (mock runner, tests)
-	// with no tracker hook.
-	if c.refreshIssueState != nil {
-		snapshot, err := c.refreshIssueState(ctx)
-		if err != nil {
-			return false, fmt.Errorf("codex app-server refresh issue state: %w", err)
-		}
-		if !snapshot.Active {
-			c.issueExitState = &snapshot
-			return false, nil
-		}
+	// verbatim per SPEC ("if refreshed_issue failed: fail"). Callers without a
+	// tracker hook get a single-turn clean fallback rather than invented state.
+	if c.refreshIssueState == nil {
+		return false, nil
 	}
-	return c.continueRun, nil
+	snapshot, err := c.refreshIssueState(ctx)
+	if err != nil {
+		return false, fmt.Errorf("codex app-server refresh issue state: %w", err)
+	}
+	if !snapshot.Active {
+		c.issueExitState = &snapshot
+		return false, nil
+	}
+	return true, nil
 }
 
 // startTurn issues turn/start and resolves the turn id. A failure on the first

--- a/internal/runner/codex_app_server_test.go
+++ b/internal/runner/codex_app_server_test.go
@@ -787,7 +787,7 @@ while IFS= read -r line; do
             ;;
         *'"method":"turn/start"'*)
             printf '{"jsonrpc":"2.0","id":3,"result":{"turn":{"id":"turn-1"}}}\n'
-            printf '{"method":"turn/completed","params":{"turn":{"status":"completed"},"continue":false}}\n'
+            printf '{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"completed"}}}\n'
             exit 0
             ;;
     esac
@@ -1016,15 +1016,16 @@ for line in sys.stdin:
     elif method == 'turn/start':
         turns += 1
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
-        if turns == 1:
-            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'continue', 'continue': True}}), flush=True)
-        else:
-            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'done'}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-%d' % turns, 'items': [], 'status': 'completed'}}}), flush=True)
+        if turns == 2:
             break
 `)
 	wd := codexWorkdir(t, "session once")
 	in := appServerInput(wd)
 	in.Workflow.Config.Agent.MaxTurns = 2
+	in.RefreshIssueState = func(context.Context) (IssueStateSnapshot, error) {
+		return IssueStateSnapshot{Found: true, State: "In Progress", Active: true}, nil
+	}
 
 	res, err := (CodexAppServerRunner{}).Run(context.Background(), in)
 	if err != nil {
@@ -1250,7 +1251,7 @@ for line in sys.stdin:
 	}
 }
 
-func TestCodexAppServerRunnerHonorsMaxTurnsForContinuationRequests(t *testing.T) {
+func TestCodexAppServerRunnerStopsAfterOneTurnWithoutIssueRefresher(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json
 turns=0
@@ -1265,11 +1266,7 @@ for line in sys.stdin:
     elif msg.get('method') == 'turn/start':
         turns += 1
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
-        if turns < 3:
-            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'needs another turn', 'continue': True}}), flush=True)
-        else:
-            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'done after turn 3'}}), flush=True)
-            break
+        print(json.dumps({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-%d' % turns, 'items': [], 'status': 'completed'}}}), flush=True)
     elif msg.get('method') == 'initialized':
         pass
 `)
@@ -1277,12 +1274,16 @@ for line in sys.stdin:
 	in := appServerInput(wd)
 	in.Workflow.Config.Agent.MaxTurns = 3
 
-	res, err := runCodexAppServerForTest(t, in)
+	_, err := runCodexAppServerForTest(t, in)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if res.Summary != "done after turn 3" {
-		t.Fatalf("Summary = %q, want final third-turn summary", res.Summary)
+	stdinLog, err := os.ReadFile(os.Getenv("CODEX_STDIN_LOG"))
+	if err != nil {
+		t.Fatalf("read CODEX_STDIN_LOG: %v", err)
+	}
+	if got := strings.Count(string(stdinLog), `"method":"turn/start"`); got != 1 {
+		t.Fatalf("turn/start requests sent = %d, want single-turn fallback without refresher; stdin=\n%s", got, stdinLog)
 	}
 }
 
@@ -1301,7 +1302,7 @@ for line in sys.stdin:
     elif msg.get('method') == 'turn/start':
         turns += 1
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
-        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'turn %d done' % turns, 'continue': True}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-%d' % turns, 'items': [], 'status': 'completed'}}}), flush=True)
     elif msg.get('method') == 'initialized':
         pass
 `)
@@ -1309,13 +1310,18 @@ for line in sys.stdin:
 	in := appServerInput(wd)
 	in.Workflow.Config.Agent.MaxTurns = 8
 	in.CleanTurnBudget = 2
+	var refreshCalls int
+	in.RefreshIssueState = func(context.Context) (IssueStateSnapshot, error) {
+		refreshCalls++
+		return IssueStateSnapshot{Found: true, State: "In Progress", Active: true}, nil
+	}
 
-	res, err := runCodexAppServerForTest(t, in)
+	_, err := runCodexAppServerForTest(t, in)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if res.Summary != "turn 2 done" {
-		t.Fatalf("Summary = %q; want last budgeted clean turn", res.Summary)
+	if refreshCalls != 2 {
+		t.Fatalf("RefreshIssueState calls = %d, want 2 (one after each budgeted turn)", refreshCalls)
 	}
 	stdinLog, err := os.ReadFile(os.Getenv("CODEX_STDIN_LOG"))
 	if err != nil {
@@ -1326,7 +1332,7 @@ for line in sys.stdin:
 	}
 }
 
-func TestCodexAppServerRunnerErrorsAtMaxTurnsWithoutCleanTurnBudget(t *testing.T) {
+func TestCodexAppServerRunnerStopsCleanlyAtMaxTurns(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json
 turns=0
@@ -1341,17 +1347,32 @@ for line in sys.stdin:
     elif msg.get('method') == 'turn/start':
         turns += 1
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
-        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'turn %d done' % turns, 'continue': True}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-%d' % turns, 'items': [], 'status': 'completed'}}}), flush=True)
     elif msg.get('method') == 'initialized':
         pass
 `)
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Agent.MaxTurns = 2
+	var refreshCalls int
+	in.RefreshIssueState = func(context.Context) (IssueStateSnapshot, error) {
+		refreshCalls++
+		return IssueStateSnapshot{Found: true, State: "In Progress", Active: true}, nil
+	}
 
 	_, err := runCodexAppServerForTest(t, in)
-	if err == nil || !strings.Contains(err.Error(), "codex app-server exceeded agent.max_turns=2") {
-		t.Fatalf("Run error = %v; want native agent.max_turns=2 exhaustion", err)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if refreshCalls != 2 {
+		t.Fatalf("RefreshIssueState calls = %d, want 2 (one after each completed turn)", refreshCalls)
+	}
+	stdinLog, err := os.ReadFile(os.Getenv("CODEX_STDIN_LOG"))
+	if err != nil {
+		t.Fatalf("read CODEX_STDIN_LOG: %v", err)
+	}
+	if got := strings.Count(string(stdinLog), `"method":"turn/start"`); got != 2 {
+		t.Fatalf("turn/start requests sent = %d, want 2 from agent.max_turns; stdin=\n%s", got, stdinLog)
 	}
 }
 
@@ -1370,7 +1391,7 @@ for line in sys.stdin:
     elif msg.get('method') == 'turn/start':
         turns += 1
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
-        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'turn %d done' % turns, 'continue': True}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-%d' % turns, 'items': [], 'status': 'completed'}}}), flush=True)
     elif msg.get('method') == 'initialized':
         pass
 `)
@@ -1378,10 +1399,18 @@ for line in sys.stdin:
 	in := appServerInput(wd)
 	in.Workflow.Config.Agent.MaxTurns = 2
 	in.CleanTurnBudget = 5
+	var refreshCalls int
+	in.RefreshIssueState = func(context.Context) (IssueStateSnapshot, error) {
+		refreshCalls++
+		return IssueStateSnapshot{Found: true, State: "In Progress", Active: true}, nil
+	}
 
 	_, err := runCodexAppServerForTest(t, in)
-	if err == nil || !strings.Contains(err.Error(), "codex app-server exceeded agent.max_turns=2") {
-		t.Fatalf("Run error = %v; want native agent.max_turns=2 exhaustion despite larger clean budget", err)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if refreshCalls != 2 {
+		t.Fatalf("RefreshIssueState calls = %d, want 2 (CleanTurnBudget must not expand agent.max_turns)", refreshCalls)
 	}
 	stdinLog, err := os.ReadFile(os.Getenv("CODEX_STDIN_LOG"))
 	if err != nil {
@@ -1393,11 +1422,9 @@ for line in sys.stdin:
 }
 
 // TestCodexAppServerRunnerExitsWhenIssueLeavesActiveStateBetweenTurns pins
-// SPEC §16.5: after each turn the runner consults the tracker and exits
-// cleanly when the linked issue is no longer active, even when the agent
-// is requesting another turn via params.continue=true. Without this gate
-// the worker would burn the full agent.max_turns budget before the
-// orchestrator's next per-tick reconcile noticed the operator cancel.
+// SPEC §16.5: after each turn the runner consults the tracker, continues on
+// the same live thread while the issue stays active, and exits cleanly once
+// the issue is no longer active.
 func TestCodexAppServerRunnerExitsWhenIssueLeavesActiveStateBetweenTurns(t *testing.T) {
 	codexAppServerStubScript(t, `
 import json
@@ -1413,7 +1440,7 @@ for line in sys.stdin:
     elif msg.get('method') == 'turn/start':
         turns += 1
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
-        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'turn %d done' % turns, 'continue': True}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-%d' % turns, 'items': [], 'status': 'completed'}}}), flush=True)
     elif msg.get('method') == 'initialized':
         pass
 `)
@@ -1424,11 +1451,9 @@ for line in sys.stdin:
 	var refreshCalls int
 	in.RefreshIssueState = func(ctx context.Context) (IssueStateSnapshot, error) {
 		refreshCalls++
-		// First turn: issue is still active, runner should request
-		// another turn. Second turn: operator cancelled (issue moved to
-		// "Done"); refresher reports inactive and the runner must exit
-		// before sending the third turn/start even though the agent's
-		// continue=true would otherwise keep the loop running.
+		// First turn: issue is still active, so the runner should request
+		// another turn. Second turn: the operator moved the issue to Done,
+		// so the runner must exit before sending a third turn/start.
 		if refreshCalls < 2 {
 			return IssueStateSnapshot{Found: true, State: "In Progress", Active: true}, nil
 		}
@@ -1446,9 +1471,6 @@ for line in sys.stdin:
 	if len(completed) != 2 {
 		t.Fatalf("turn_completed events = %d, want exactly 2 (refresher cut off the agent's third turn); events=%#v", len(completed), res.RuntimeEvents)
 	}
-	if res.Summary != "turn 2 done" {
-		t.Fatalf("Summary = %q, want last completed turn's message", res.Summary)
-	}
 	if res.IssueExitState == nil || res.IssueExitState.State != "Done" || !res.IssueExitState.Terminal {
 		t.Fatalf("IssueExitState = %+v, want terminal Done snapshot when SPEC §16.5 refresher stops the run", res.IssueExitState)
 	}
@@ -1462,6 +1484,12 @@ for line in sys.stdin:
 	}
 	if got := strings.Count(string(stdinLog), `"method":"turn/start"`); got != 2 {
 		t.Fatalf("turn/start requests sent = %d, want 2 (runner should not send a third turn after refresher returns inactive); stdin=\n%s", got, stdinLog)
+	}
+	if got := strings.Count(string(stdinLog), `"method":"thread/start"`); got != 1 {
+		t.Fatalf("thread/start requests sent = %d, want 1 for the whole multi-turn session; stdin=\n%s", got, stdinLog)
+	}
+	if got := strings.Count(string(stdinLog), `"threadId":"thread-1"`); got != 2 {
+		t.Fatalf("turn/start requests using thread-1 = %d, want 2; stdin=\n%s", got, stdinLog)
 	}
 }
 
@@ -1481,7 +1509,7 @@ for line in sys.stdin:
         print(json.dumps({'id': msg['id'], 'result': {'thread': {'id': 'thread-1'}}}), flush=True)
     elif msg.get('method') == 'turn/start':
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-1'}}}), flush=True)
-        print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'mid-run', 'continue': True}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-1', 'items': [], 'status': 'completed'}}}), flush=True)
     elif msg.get('method') == 'initialized':
         pass
 `)
@@ -1998,7 +2026,7 @@ for line in sys.stdin:
 	}
 }
 
-func TestCodexAppServerRunnerSendsContinuationInputAfterContinueRequest(t *testing.T) {
+func TestCodexAppServerRunnerSendsContinuationInputAfterActiveRefresh(t *testing.T) {
 	binDir := codexAppServerStubScript(t, `
 import json
 turns=0
@@ -2013,10 +2041,8 @@ for line in sys.stdin:
     elif msg.get('method') == 'turn/start':
         turns += 1
         print(json.dumps({'id': msg['id'], 'result': {'turn': {'id': 'turn-%d' % turns}}}), flush=True)
-        if turns == 1:
-            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'needs follow-up', 'continue': True}}), flush=True)
-        else:
-            print(json.dumps({'method': 'turn/completed', 'params': {'lastAssistantMessage': 'done'}}), flush=True)
+        print(json.dumps({'method': 'turn/completed', 'params': {'threadId': 'thread-1', 'turn': {'id': 'turn-%d' % turns, 'items': [], 'status': 'completed'}}}), flush=True)
+        if turns == 2:
             break
     elif msg.get('method') == 'initialized':
         pass
@@ -2024,6 +2050,9 @@ for line in sys.stdin:
 	wd := codexWorkdir(t, "x")
 	in := appServerInput(wd)
 	in.Workflow.Config.Agent.MaxTurns = 2
+	in.RefreshIssueState = func(context.Context) (IssueStateSnapshot, error) {
+		return IssueStateSnapshot{Found: true, State: "In Progress", Active: true}, nil
+	}
 
 	_, err := (CodexAppServerRunner{}).Run(context.Background(), in)
 	if err != nil {

--- a/internal/runner/codex_app_server_turn.go
+++ b/internal/runner/codex_app_server_turn.go
@@ -211,9 +211,6 @@ func (c *appServerClient) handleNotification(msg map[string]any) {
 		return
 	}
 	params, _ := msg["params"].(map[string]any)
-	if v, ok := params["continue"].(bool); ok {
-		c.continueRun = v
-	}
 	for _, key := range []string{"lastAssistantMessage", "last_message", "message", "summary"} {
 		if v, _ := params[key].(string); strings.TrimSpace(v) != "" {
 			c.lastMessage = strings.TrimSpace(v)

--- a/internal/runner/codex_app_server_turn_test.go
+++ b/internal/runner/codex_app_server_turn_test.go
@@ -3,8 +3,8 @@ package runner
 // codex_app_server_turn_test.go holds characterization tests that drive
 // (*appServerClient).awaitTurnCompletion directly over an in-memory JSON-RPC
 // stream, without spawning a real `codex app-server` subprocess. They pin the
-// turn loop's input→(returned error, recorded runtime events, continuation
-// signal) behavior at the exact function boundary before #499 decomposes the
+// turn loop's input→(returned error, recorded runtime events) behavior at the
+// exact function boundary before #499 decomposes the
 // 78-cognitive-complexity loop into per-concern handlers; the assertions must
 // hold identically before and after that refactor.
 //
@@ -66,31 +66,13 @@ func runtimeEventNames(c *appServerClient) []string {
 
 func TestAwaitTurnCompletion_TurnCompletedSuccess(t *testing.T) {
 	c, _ := newTurnLoopClient(t, []string{
-		`{"method":"turn/completed","params":{"lastAssistantMessage":"all done","continue":false}}`,
+		`{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"completed"}}}`,
 	})
 	if err := c.awaitTurnCompletion(context.Background()); err != nil {
 		t.Fatalf("awaitTurnCompletion() = %v; want nil on turn/completed success", err)
 	}
-	if got, want := c.summary(), "all done"; got != want {
-		t.Errorf("summary() = %q; want %q", got, want)
-	}
-	if c.continueRun {
-		t.Errorf("continueRun = true; want false (params.continue=false)")
-	}
 	if got, want := runtimeEventNames(c), []string{task.EventTurnCompleted}; !slices.Equal(got, want) {
 		t.Errorf("runtime events = %v; want %v", got, want)
-	}
-}
-
-func TestAwaitTurnCompletion_TurnCompletedSetsContinueRun(t *testing.T) {
-	c, _ := newTurnLoopClient(t, []string{
-		`{"method":"turn/completed","params":{"continue":true,"lastAssistantMessage":"keep going"}}`,
-	})
-	if err := c.awaitTurnCompletion(context.Background()); err != nil {
-		t.Fatalf("awaitTurnCompletion() = %v; want nil", err)
-	}
-	if !c.continueRun {
-		t.Errorf("continueRun = false; want true (params.continue=true)")
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,10 +32,8 @@ type RunInput struct {
 	// RefreshIssueState, when non-nil, implements SPEC §16.5's per-turn
 	// tracker refresh: the runner calls it after each agent turn finishes
 	// and exits cleanly when the issue is no longer in the workflow's
-	// active states. Without it the runner falls back to the agent-driven
-	// `continue` notification flag and operator-cancel only becomes
-	// visible at the next orchestrator poll tick. Nil keeps the legacy
-	// behavior for callers (tests, mock runners) that have no tracker.
+	// active states. Nil gives callers without a tracker hook a single-turn
+	// clean fallback; the runner does not invent continuation state.
 	RefreshIssueState IssueStateRefresher
 	// LookupOperatorTerminalStop reads the process-local Operator Terminal Stop
 	// latch for this run's issue. It is intentionally narrower than

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	// the runner-level SPEC §16.5 per-turn refresh hook
 	// (runner.RunInput.RefreshIssueState). Returning nil for a task opts
 	// that run out of the refresh (e.g. mock tasks with no tracker row);
-	// the runner then falls back to the agent-driven continue flag.
+	// the runner then uses its single-turn clean fallback.
 	IssueStateRefresher IssueStateRefresherFactory
 	// OperatorTerminalStopLookup, when non-nil, builds a process-local latch
 	// reader for post-stop mutation auditing. Unlike IssueStateRefresher, this
@@ -42,7 +42,7 @@ type Config struct {
 // runner invokes between turns. The factory receives the task and the
 // workflow config that resolved for it (so the closure can read the
 // active_states vocabulary) and returns either a callable or nil when the
-// task should keep the legacy continue-driven loop.
+// task should use the runner's single-turn fallback.
 type IssueStateRefresherFactory func(t task.Task, cfg workflow.Config) runner.IssueStateRefresher
 
 // OperatorTerminalStopLookupFactory builds a per-task lookup for the


### PR DESCRIPTION
Closes #1129

## Summary
- Make refreshed tracker state the sole in-session continuation authority: active continues on the existing app-server thread; inactive stops cleanly and preserves the exit snapshot.
- Remove the schema-invalid `turn/completed.params.continue` shim and replace related fixtures with the Codex 0.144.4 `threadId` + `turn` notification shape.
- Treat `agent.max_turns` and the smaller `CleanTurnBudget` as clean handback limits; callers without a refresher keep a single-turn fallback.

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This restores the loop in SPEC §7.1/§16.5 and matches `openai/symphony/elixir/lib/symphony_elixir/agent_runner.ex`, where tracker refresh drives continuation and max-turn exhaustion returns `:ok`.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

## Testing
- [x] `go test -run ^TestProductionGoFilesStayWithinSizeBudget -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `go test -race ./internal/runner -count=1`
- `go test -tags e2e -race -timeout 15m ./test/e2e/...`
- committed-artifact mutation: active refresh changed to stop → high-seam test failed at one refresh; restored commit → test passed
- fixed-base Standards review: CLEAN; fixed-base Spec review: CLEAN
- `codex review --commit a66320f77d964d5850a14903033a7060852d3c6e`: no actionable defects

## Notes
- Production behavior changes remain in `internal/runner`; worker/orchestrator hunks only correct stale comments about the removed fallback.
- No new state, retry policy, adapter, queue, phase, or outer-loop change.