### PR TITLE
docs: point Symphony guidance at current authorities

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -7,6 +7,14 @@
 > **See also:** [`AGENTS.md`](AGENTS.md), [`DEVIATIONS.md`](DEVIATIONS.md), [`docs/audits/2026-05-15-spec-vs-go-gap-audit.md`](docs/audits/2026-05-15-spec-vs-go-gap-audit.md)
 > **Earlier version:** preserved in git history at commit `4f9e98d` ("docs: record decision to stop Go port and adopt a Symphony fork"). Read in conjunction with this document for the full reasoning chain.
 
+> [!NOTE]
+> **Current-status scope.** The active decision is to continue the Go port in
+> this repository with the Symphony SPEC as its contract. The D1–D24 counts,
+> sequencing discussion, and next steps below are the dated 2026-05-15 decision
+> record, not a current backlog. Use [`DEVIATIONS.md`](DEVIATIONS.md) for current
+> deviation status and [`docs/architecture.md`](docs/architecture.md) for the
+> current runtime design.
+
 ## TL;DR
 
 `aiops-platform` was started as a Go implementation of OpenAI Symphony. The

--- a/docs/adr/0001-symphony-style-personal-orchestrator.md
+++ b/docs/adr/0001-symphony-style-personal-orchestrator.md
@@ -8,6 +8,11 @@ Accepted
 
 2026-04-28
 
+> [!NOTE]
+> This ADR records the architectural decision and its rationale. See
+> the [architecture overview](../architecture.md) for the current runtime and
+> the [deviation ledger](../../DEVIATIONS.md) for current alignment status.
+
 ## Context
 
 The project started as a Gitea-first automation pipeline:
@@ -56,8 +61,7 @@ Linear or Gitea task
   -> deterministic workspace
   -> WORKFLOW.md
   -> agent runner
-  -> verification
-  -> agent-side pull request handoff
+  -> agent-owned verification + pull request handoff
 ```
 
 ## Consequences
@@ -77,31 +81,6 @@ Linear or Gitea task
 - There is some conceptual overlap with OpenAI Symphony.
 - Linear and Gitea paths may diverge unless adapter boundaries stay clean.
 - More safety and reconciliation work is needed before running against important company code.
-
-## Scope
-
-In scope now:
-
-- Gitea, GitHub, and Linear tracker polling
-- in-memory orchestrator runtime state
-- repo-owned `WORKFLOW.md`
-- deterministic workspace creation
-- mock runner
-- Codex runner shell integration
-- Claude runner shell integration
-- prompt-scoped path guidance with repository-side review and protection
-- verification commands
-- draft pull request handoff
-
-Out of scope for now:
-
-- enterprise RBAC
-- multi-tenant UI
-- Kubernetes deployment
-- automatic merge
-- complex distributed scheduling
-- full dashboard
-- advanced sandbox isolation
 
 ## Safety posture
 
@@ -128,13 +107,3 @@ Rejected as the only path because it delays real productivity. Linear plus Symph
 ### Build a full enterprise platform first
 
 Rejected for now. The current target is personal productivity, not a multi-team internal developer platform.
-
-## Next steps
-
-1. Validate the mock loop end to end.
-2. Validate Codex runner on a personal demo repository.
-3. Add Linear status updates after successful handoff.
-4. Add PR labels and reviewers.
-5. ~~Add better diff statistics and path policy checks.~~ — implemented as the worker `policy` path/diffstat gate, then removed under #561: SPEC §3.2 homes scope/path rules in the `WORKFLOW.md` prompt and the gate ran post-push (could only flag, never prevent). Do not re-add.
-6. ~~Add `RUN_SUMMARY.md` enforcement.~~ — implemented, then removed under #561: the worker gate ran after the agent had already pushed (SPEC §1), the agent's PR body is the change record, and nothing read the artifact. Do not re-add.
-7. Add a Claude analysis-only workflow mode.

--- a/docs/symphony-integration.md
+++ b/docs/symphony-integration.md
@@ -1,93 +1,42 @@
 # Symphony integration
 
 `aiops-platform` is a Go implementation of the OpenAI Symphony SPEC for a
-personal productivity loop.
+personal-productivity coding loop.
 
-## Goal
+## Stable ownership boundary
 
-Keep the Go implementation aligned with `SPEC.md` while supporting local
-Gitea, Linear, and custom workflow needs. `DEVIATIONS.md` tracks the D1–D24
-closure backlog.
-
-## Architecture
+The worker is a scheduler/runner and tracker reader. It polls and reconciles
+tracker state, dispatches eligible issues, prepares deterministic workspaces,
+resolves the repository's `WORKFLOW.md`, and invokes the configured runner.
 
 ```text
-Linear or Gitea tracker poll
-  -> in-memory scheduler/runtime
-  -> deterministic workspace
-  -> WORKFLOW.md
+tracker issue
+  -> worker poll + reconcile + dispatch
+  -> deterministic workspace + WORKFLOW.md
   -> runner
-  -> verification
-  -> agent-side branch push + pull request handoff
+  -> coding agent
+  -> agent-owned verify + branch push + PR + tracker write-back
 ```
 
-## Mapping
+The coding agent owns source changes and the irreversible handoff steps. The
+worker may expose authenticated runtime tools without exposing their tokens, but
+it does not decide or perform agent-side tracker mutations, pushes, or pull
+requests. Verification instructions belong in the workflow prompt and are run
+by the agent before handoff; there is no worker-owned post-turn verification
+phase.
 
-| Symphony concept | aiops-platform module |
-|---|---|
-| Issue tracker | `internal/tracker` |
-| Workflow contract | `internal/workflow` and `WORKFLOW.md` |
-| Workspace manager | `internal/workspace` |
-| Agent runner | `internal/runner` |
-| Runtime state | in-process orchestrator state with tracker/filesystem restart recovery |
-| Git handoff | agent via dynamic tool / CLI (`internal/gitea` backs the tool implementation) |
+## Current authorities
 
-## Usage model
+This page intentionally does not copy feature inventories or deviation status.
+Use the maintained sources instead:
 
-Start with the mock runner:
-
-```yaml
-agent:
-  default: mock
-```
-
-After the queue, workspace, and agent-side branch/PR handoff loop works, switch personal projects to:
-
-```yaml
-agent:
-  default: codex-app-server
-```
-
-For company repositories, keep human review in the loop and prefer draft pull requests.
-
-## Current scope
-
-Implemented:
-
-- Gitea label polling trigger
-- Linear polling trigger
-- GitHub issue polling trigger (`tracker.kind: github`, wired through
-  `cmd/worker` and `internal/tracker/github.go`)
-- repo-owned `WORKFLOW.md` in the service/repository root (single canonical path; see `DEVIATIONS.md` D4 closure)
-- mock, codex-app-server, and claude runner abstraction
-- deterministic local workspace keyed by sanitized source issue identifier (`source_type` + `source_event_id`), so reruns for the same issue reuse the same path while receiving a fresh checkout
-- prompt-scoped path guidance (advisory; repository controls enforce what lands)
-- verification commands
-- `linear_graphql` dynamic tool advertisement and invocation for Codex app-server sessions, proxying Linear GraphQL through orchestrator-held auth without exposing the Linear token to the agent process
-
-Not yet implemented:
-
-- remaining app-server protocol gaps not covered by `linear_graphql`, as tracked in `DEVIATIONS.md`
-- pull request labels and reviewers
-- per-tick reconciliation (#78); startup reconciliation is already closed in #68
-- dashboard
-- robust event streaming
-- sandbox backend coverage beyond the current optional runner enforcement
-
-## Deviations from SPEC
-
-Tracked centrally in [`DEVIATIONS.md`](../DEVIATIONS.md). Deliberate extensions
-beyond the SPEC are scoped narrowly and listed there per deviation. Closed
-historical deviations — for example multi-path `WORKFLOW.md` discovery (D4,
-#72), Gitea webhook ingress (D7, #74), and orchestrator-side PR / push /
-Linear writes (D8, #76) — are no longer in the codebase; legacy alternate
-workflow paths are not searched or reported as shadow sources.
-
-## Pointers
-
-- Symphony's Codex integration uses the long-running `codex app-server`
-  JSON-RPC protocol (`elixir/lib/symphony_elixir/codex/app_server.ex`) and
-  exposes per-turn sandbox overrides via `Codex.changeset`
-  (`elixir/lib/symphony_elixir/config/schema.ex`). This platform now has a
-  Codex app-server runner path; remaining protocol/runtime gaps stay tracked in
-  `DEVIATIONS.md` until their rows close.
+- [README](../README.md) — current product surface, usage, and configuration.
+- [Symphony SPEC mirror](research/SPEC.md) — authoritative protocol contract;
+  the upstream Elixir implementation resolves ambiguity.
+- [Architecture overview](architecture.md) — current runtime flow and package
+  boundaries.
+- [ADR 0001](adr/0001-symphony-style-personal-orchestrator.md) and the
+  [engineering-rules rationale](engineering-rules-rationale.md) — design and
+  harness decisions with provenance.
+- [Deviation ledger](../DEVIATIONS.md) — current SPEC differences and their
+  tracked status.

--- a/docs/validation/2026-07-03-codex-multi-agent-mode-audit.md
+++ b/docs/validation/2026-07-03-codex-multi-agent-mode-audit.md
@@ -3,6 +3,20 @@
 **Date:** 2026-07-03
 **Issue:** #1056
 
+> [!WARNING]
+> **Superseded protocol conclusion.** This dated audit is retained as evidence
+> for [#1056](https://github.com/xrf9268-hue/aiops-platform/issues/1056) and the
+> Codex 0.142.x contract, but its recommendation to send
+> `thread/start.multiAgentMode` is no longer current. [#1101](https://github.com/xrf9268-hue/aiops-platform/issues/1101)
+> aligned the runner with Codex 0.144.4, where that field is deprecated and
+> ignored, so the current payload intentionally omits it. Use the
+> [protocol/version pin](../../internal/runner/codex_version.go) and
+> [schema contract tests](../../internal/runner/codex_app_server_schema_test.go)
+> as the current protocol sources of truth; the
+> [payload builder](../../internal/runner/codex_app_server.go) shows the current
+> request shape. The material below is historical evidence, not current payload
+> guidance.
+
 ## Verdict
 
 Keep `thread/start.multiAgentMode: "none"` in the Codex app-server runner.


### PR DESCRIPTION
Closes #1118

## Summary
- Shrink the Symphony integration guide to the stable scheduler/runner versus agent ownership boundary and authoritative links.
- Delete stale scope, next-step, implemented, and not-implemented inventories instead of refreshing duplicated status.
- Mark the dated multiAgentMode audit as superseded while retaining its historical evidence and pointing to the current 0.144.4 protocol sources.
- Net documentation change: 4 files, 60 insertions, 120 deletions.

## SPEC alignment (AGENTS.md principle 6/7)

- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below.
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This is a documentation-only deletion-first correction to the SPEC §1 ownership boundary. It adds no runtime behavior or new current-state inventory.

## PR diff size budget (AGENTS.md)

- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity.
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional local validation:
- `go mod tidy` left `go.mod` and `go.sum` clean.
- `go build ./cmd/worker ./cmd/tui`
- `go test -tags e2e -race -timeout 15m ./test/e2e/...` with Docker running.
- Focused stale-claim search and local Markdown link resolution.
- Fixed-base Standards review: CLEAN.
- Fixed-base Spec review: CLEAN.
- Independent `codex review` on exact commit `a32c749b527d5f74b5bd546340ef9a304f4be9c2`: no actionable defect confirmed.

## Notes
- No runtime, workflow, dashboard, or protocol behavior changed.
- Historical benchmark material was not rewritten.