### PR TITLE
docs(spec): resync Symphony 0.0.2 contract

### DIFF
--- a/.claude/skills/handle-issue/SKILL.md
+++ b/.claude/skills/handle-issue/SKILL.md
@@ -72,7 +72,7 @@ go build ./cmd/worker ./cmd/tui
 ### 5. 提交 → 双审 → 开 PR
 1. 按协议 §2–§3 commit-first + pre-push 双 reviewer；先执行协议里的 **subagent-first reviewer routing**，具体 reviewer-routing 细节以 [`docs/runbooks/pr-review-merge-protocol.md`](../../../docs/runbooks/pr-review-merge-protocol.md) 为唯一来源。主交互会话里的 reviewer subagent 路径在工具契约允许默认派生时**默认开启、不问授权**（#900）；运行时契约挡住时按协议记录 fallback，操作者可在当前请求写 `CLI review only` 等短语 opt-out。review finding 先按当前 head、issue 计划、SPEC/Elixir 参考和相邻路径验证技术正确性，再修复 / 反证 / 延后。§4 每 push 跑 `@codex review` 收敛，§5 处理 review threads。
 2. push 后开 **一个** PR 对应该 issue，body 引用 issue（`Closes #N`），列验收项、验证命令、变异验证、风险/deferral；PR body 是活账本（协议 §7）。
-3. **每条 finding 归入 ≥1 类**：算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试；然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；伞 issue #67）。
+3. **每条 finding 归入 ≥1 类**：算法偏差 / 跨模块一致性 / Go runtime hardening / 安慰剂测试；然后修掉或**开 follow-up issue 延后**（标 `area:spec-alignment`，body 含 upstream 行号引用 + acceptance criteria；挂到 `DEVIATIONS.md` 指向的当前 alignment ledger，不要默认使用历史 D1–D24 的 #67）。
 4. **Deferred 偏差必须开 issue**（AGENTS.md rule 2）：决定延后就**当场**告知用户并立即开 issue，别攒到收尾汇报。
 5. **Scope 分离**：治理/文档类改动从 main 开新分支**单独 PR**，不要塞进 fix PR。
 6. 收敛后交给 `gh-pr-follow-through`（私有 `xrf9268-hue/yy-skills`；云端容器通常没装）盯 CI + 线程到 merge-ready。**该 skill 不可用时就地内联**：`gh pr checks <pr> --watch --fail-fast` 等 CI → GraphQL `reviewThreads` 解决所有未决 actionable thread → 最后一次 PR body 更新后等新的 `PR Metadata` 终态并做 warning audit → merge-ready。期间推了修复就对新 head 重跑协议 §3–§5。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,16 +68,17 @@ jointly authoritative**:
 
 1. The protocol contract: [Symphony SPEC.md](docs/research/SPEC.md) — mirrored
    verbatim from
-   [upstream](https://github.com/openai/symphony/blob/main/SPEC.md) so the
-   contract this port targets cannot drift (upstream is an unmaintained demo
-   repo); re-sync by bumping the commit hash in the mirror's header (#799).
-2. The reference implementation: [`openai/symphony` Elixir tree](https://github.com/openai/symphony/tree/main/elixir).
+   [upstream](https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/SPEC.md) at an
+   audited commit so the contract this port targets cannot move underneath a
+   review; re-sync by replacing the verbatim body and bumping the commit,
+   date, and SHA-256 in the mirror's header (#799, #1138).
+2. The reference implementation: [`openai/symphony` Elixir tree](https://github.com/openai/symphony/tree/653f8b3cc476db03420479ba6f95b2ed7281c401/elixir).
    When SPEC text is ambiguous, the reference's behavior is the tiebreaker.
    Pay particular attention to:
-   - [`elixir/lib/symphony_elixir/orchestrator.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/orchestrator.ex) — in-process GenServer state; no DB; reconcile-on-startup via tracker fetch.
-   - [`elixir/lib/symphony_elixir/codex/app_server.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/codex/app_server.ex) — long-running JSON-RPC 2.0 over stdio; not one-shot exec.
-   - [`elixir/lib/symphony_elixir/tracker.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/tracker.ex) and adapters — polling model with `:poll_interval_ms`; no webhook ingress.
-   - [`elixir/lib/symphony_elixir/config/schema.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/config/schema.ex) — canonical config keys, defaults, and types.
+   - [`elixir/lib/symphony_elixir/orchestrator.ex`](https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/elixir/lib/symphony_elixir/orchestrator.ex) — in-process GenServer state; no DB; reconcile-on-startup via tracker fetch.
+   - [`elixir/lib/symphony_elixir/codex/app_server.ex`](https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/elixir/lib/symphony_elixir/codex/app_server.ex) — long-running JSON-RPC 2.0 over stdio; not one-shot exec.
+   - [`elixir/lib/symphony_elixir/tracker.ex`](https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/elixir/lib/symphony_elixir/tracker.ex) and adapters — polling model with `:poll_interval_ms`; no webhook ingress.
+   - [`elixir/lib/symphony_elixir/config/schema.ex`](https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/elixir/lib/symphony_elixir/config/schema.ex) — canonical config keys, defaults, and types.
 3. The authors' announcement post, mirrored locally as
    [`docs/research/2026-04-27-openai-symphony-blog.md`](docs/research/2026-04-27-openai-symphony-blog.md).
    Provides the design rationale and the SPEC §1 problem statement. Direct
@@ -302,8 +303,10 @@ Rules for agents working on this repo:
    find behavior that violates SPEC or contradicts the reference and is not
    already listed there, **do not add a new "deliberate extension" to make the
    discrepancy disappear**. File an issue with the `area:spec-alignment` label
-   so the deviation is visible and tracked. The umbrella tracker is
-   [#67](https://github.com/xrf9268-hue/aiops-platform/issues/67).
+   so the deviation is visible and tracked, then link it from the active
+   alignment ledger named in `DEVIATIONS.md`. Issue
+   [#67](https://github.com/xrf9268-hue/aiops-platform/issues/67) is the
+   historical D1–D24 ledger, not the default destination for new findings.
 3. **"Has better value than SPEC" is a high bar.** Cosmetic convenience (e.g.
    "let users park a config file in a hidden directory") does not clear it.
    Things that initially look like better value but match neither SPEC nor the

--- a/DECISION.md
+++ b/DECISION.md
@@ -14,6 +14,12 @@
 > record, not a current backlog. Use [`DEVIATIONS.md`](DEVIATIONS.md) for current
 > deviation status and [`docs/architecture.md`](docs/architecture.md) for the
 > current runtime design.
+>
+> **Upstream-status update (2026-07-24).** Upstream resumed development after
+> this decision and is currently audited here at
+> [`653f8b3`](https://github.com/openai/symphony/tree/653f8b3cc476db03420479ba6f95b2ed7281c401).
+> The maintenance assumptions below describe the evidence available on
+> 2026-05-15; they are not the current upstream status.
 
 ## TL;DR
 
@@ -72,12 +78,12 @@ This work happens through AI agents under the operator-as-navigator model
 
 ### 1. "Forking gives day-1 SPEC fidelity" — false framing
 
-`SPEC.md` is the contract, not the `openai/symphony` repo. OpenAI has stated
-the Elixir repo is a reference implementation and will not be maintained as
-a product. Forking it gets us code that one author once interpreted as
-SPEC-aligned — it does not get us SPEC fidelity by construction. Any forked
-code still needs to be audited against `SPEC.md`. The "fork starts at zero
-deviations" claim conflates repo with spec.
+`SPEC.md` is the contract, not the `openai/symphony` repo. At the time, OpenAI
+had stated the Elixir repo was a reference implementation and would not be
+maintained as a product. Forking it gets us code that one author once
+interpreted as SPEC-aligned — it does not get us SPEC fidelity by
+construction. Any forked code still needs to be audited against `SPEC.md`.
+The "fork starts at zero deviations" claim conflates repo with spec.
 
 ### 2. "Verification surface doubles for the human" — invalid under the workflow model
 
@@ -94,10 +100,12 @@ gradient of AI cost, not a hard cap on what is feasible.
 
 ### 3. "Maintenance gradient — upstream changes cost less in a fork" — moot
 
-OpenAI has stated the Elixir repo will not be maintained as a product.
-There are no future upstream changes to inherit by merge. Both paths (Go
-port and Elixir fork) become "we own this code" from day one. The
-gradient flattens to zero.
+At the time of this decision, OpenAI had stated that the Elixir repo would not
+be maintained as a product. The decision therefore assumed future upstream
+changes would not arrive by merge and that both paths (Go port and Elixir
+fork) would become "we own this code" from day one. Upstream later resumed
+development, so this maintenance-gradient premise is historical rather than a
+current project constraint.
 
 ### What is left
 
@@ -119,7 +127,7 @@ gradient flattens to zero.
 
 - Closing D1–D24 against `SPEC.md`, in some order (see Open question).
 - Treating `SPEC.md` as the review target. Where `SPEC.md` is ambiguous,
-  the Elixir [`orchestrator.ex`](https://github.com/openai/symphony/blob/main/elixir/lib/symphony_elixir/orchestrator.ex)
+  the Elixir [`orchestrator.ex`](https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/elixir/lib/symphony_elixir/orchestrator.ex)
   and related modules are the tie-breaking oracle.
 - Refreshing `DEVIATIONS.md` to include D10–D24 alongside D1–D9.
 - Keeping the harness-engineering posture in `AGENTS.md` and applying its

--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -5,9 +5,9 @@ upstream Symphony project. Three sources are jointly authoritative:
 
 - [Symphony SPEC.md](docs/research/SPEC.md) — the protocol contract, mirrored
   verbatim from
-  [upstream](https://github.com/openai/symphony/blob/main/SPEC.md) so it cannot
+  [upstream](https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/SPEC.md) so it cannot
   drift.
-- [`openai/symphony` Elixir reference implementation](https://github.com/openai/symphony/tree/main/elixir/lib/symphony_elixir) —
+- [`openai/symphony` Elixir reference implementation](https://github.com/openai/symphony/tree/653f8b3cc476db03420479ba6f95b2ed7281c401/elixir/lib/symphony_elixir) —
   the working reference. When SPEC text is ambiguous, the Elixir module's
   behavior is the tiebreaker. **Not** a porting target — see
   [`DECISION.md`](DECISION.md).
@@ -38,9 +38,13 @@ operational expectations and harness-engineering posture):
 is a hard requirement and the project is pre-release, so the cost of closing
 deviations is at its minimum right now.
 
-The umbrella tracking issue is [#67](https://github.com/xrf9268-hue/aiops-platform/issues/67).
+The historical D1–D24 umbrella is
+[#67](https://github.com/xrf9268-hue/aiops-platform/issues/67). The current
+Symphony 0.0.2 alignment ledger is
+[#1137](https://github.com/xrf9268-hue/aiops-platform/issues/1137), pinned to
+upstream `504101ec^..653f8b3`.
 
-The 2026-05-15 gap audit (PR [#82](https://github.com/xrf9268-hue/aiops-platform/pull/82), report at [`docs/audits/2026-05-15-spec-vs-go-gap-audit.md`](docs/audits/2026-05-15-spec-vs-go-gap-audit.md)) is the most recent full sweep against SPEC. It confirmed D1–D9, surfaced D10–D24, and documents 12 silent-area categories. When a row below says "see audit", treat the audit doc as the source of file:line evidence and severity reasoning.
+The 2026-05-15 gap audit (PR [#82](https://github.com/xrf9268-hue/aiops-platform/pull/82), report at [`docs/audits/2026-05-15-spec-vs-go-gap-audit.md`](docs/audits/2026-05-15-spec-vs-go-gap-audit.md)) is the historical D1–D24 sweep. The 2026-07-24 incremental source audit recorded in #1137 revalidated the current Go implementation against Symphony 0.0.2 and opened D38–D49 below. The upstream Jira/Asana/GitLab adapters, SSH workspaces, Burrito packaging, and website changes are optional additions rather than missing core behavior in this port.
 
 ## Deviations
 
@@ -83,6 +87,18 @@ The 2026-05-15 gap audit (PR [#82](https://github.com/xrf9268-hue/aiops-platform
 | D35 | Operator Terminal Stop. SPEC §8.5 / §16.5 and upstream `orchestrator.ex` stop active runs when tracker state leaves the active set, but they do not prevent the still-running agent from issuing an agent-owned `issueUpdate` back into an active state before the process observes cancellation; PR #625's upstream comparison reproduced this race for #622. The port now accepts a process-local safety deviation: once this worker observes the current issue in a configured terminal state during reconcile, retry cleanup, or §16.5 finalize-time self-stop without a structured agent-owned current-issue non-active handoff fact, it records an in-memory `OperatorTerminalStop` latch. Agent-owned terminal handoffs still clean the workspace and do not queue continuation, but they do not latch/suppress later intentional rework. Later dispatches and retry-fire dispatches of the same latched issue ID are suppressed even if the tracker currently reads active, cleanup-time active rechecks may skip deletion but cannot resume continuation, and the agent-visible Linear tool rejects current-issue `issueUpdate` into any configured `active_states` before HTTP dispatch. For the current issue, unsupported or ambiguous `issueUpdate` shapes are also rejected fail-closed instead of guessed; non-current issue updates keep the ordinary mutation gate behavior. The guard uses structured tracker snapshots and parsed `issueUpdate(id,input.stateId)` input only; it never parses Codex natural-language output, task-event text, or ad hoc GraphQL substrings. Agent comments/workpad writes after the stop remain possible for audit but use a separate `tool_call_mutation_post_operator_terminal_stop` event so they do not count as agent handoff activity. Like D34 blocked claims, this latch is in-process runtime state: a worker restart clears it, and recovery still comes from tracker polling plus filesystem reconciliation. The latch set is also bounded per process by `MaxRecentOperatorTerminalStops` (default 1000, #667): the oldest latch is evicted once the bound is exceeded, with `CumulativeOperatorTerminalStopsTotal` preserved for observability. Eviction is safe because an evicted issue is re-dispatched only if it currently reads active in the tracker (the poll filters terminal issues out regardless of the latch), and by the time an issue is the oldest of N distinct stops any still-running agent that could have produced the D35 re-activation race has long exited — so an active reading then is intentional rework, where dispatch is the desired outcome; recovery still comes from polling plus reconciliation. | §1 boundary, §8.5, §10.5, §13.7, §16.5 | High | Closed (accepted deviation) | [#622](https://github.com/xrf9268-hue/aiops-platform/issues/622) |
 | D36 | Clone-URL credential masking (`workflow.MaskCloneURL`). An aiops-platform logging-safety utility with no direct upstream Symphony equivalent: it strips embedded basic-auth (`scheme://user:token@host`) from a clone URL before the value reaches any log, error string, or `--print-config` output (the `mirror.go` clone-failure error, `doctor_tracker.go`, `print_config.go`). It implements the SPEC §1 token-isolation posture for orchestrator-side logs — the agent never sees the token, and neither do the operator's logs. #676 added the first direct unit coverage, which exposed a fail-open gap: the helper returned the raw string whenever `url.Parse` rejected the input (a malformed port, a space in the userinfo), leaking the token into the clone-failure log. It now fails closed via a conservative `scheme://userinfo@` string strip on the `url.Parse` error path (mirroring url.Parse's last-`@`-in-authority rule, leaving an `@` in the path/query untouched). The free-text analogue `workspace.redactCredentials`/`credentialURLRe` agrees on the splitting rule. Same masking-must-not-leak class as #469/#483. | §1 boundary | Low | Closed (accepted extension) | [#676](https://github.com/xrf9268-hue/aiops-platform/issues/676) |
 | D37 | Per-claim token/runtime budget guardrails (`agent.max_tokens_per_claim`, `agent.max_runtime_seconds_per_claim`). SPEC and upstream `orchestrator.ex` expose runner/runtime events but do not cap a live claim by observed token or wall-clock usage. The unattended GitHub workflow failures in #1027 showed that process-lifetime totals were too coarse for operators and that an unclear or usage-limit run could keep burning quota without an operator-visible local stop. The port accepts a narrow process-local safety deviation: configured zero values disable the guardrail; a nonzero token value is checked only against worker-observed, runner-reported Codex telemetry for the current claim, while the runtime value uses worker-measured claim time. External GitHub `@codex review` usage, other reviewers outside the worker session, and otherwise unreported nested or subagent usage are unmeasured, not zero, and do not consume `max_tokens_per_claim`. On exceedance the worker cancels the runner context, records `budget_exceeded`, parks the issue in local `Blocked` with `method=budget_exceeded`, and surfaces current-claim / ended-session / process totals in the §13.7 state API and dashboard. It does not inspect natural-language agent output, estimate unreported usage, run PR review/merge/issue-close logic, or write tracker state; recovery still comes from tracker polling plus explicit operator action or process restart. | §1 boundary, §10.4, §13.7, §15.5, §16.5 | High | Closed (accepted deviation) | [#1027](https://github.com/xrf9268-hue/aiops-platform/issues/1027) |
+| D38 | Recorded workspace paths are validated only after `before_remove`, so a symlink escape can run the hook outside the configured root even though deletion is later refused. | §9.5, §15.2; upstream `7cf29df6` | High | Open | [#1139](https://github.com/xrf9268-hue/aiops-platform/issues/1139) |
+| D39 | Sanitized issue identifiers do not receive a stable hash suffix, so distinct identifiers can collide on one workspace path. | §4.2, §9.1 | High | Open | [#1140](https://github.com/xrf9268-hue/aiops-platform/issues/1140) |
+| D40 | `codex.turn_timeout_ms` is enforced as whole-turn wall time instead of a silence interval reset by every app-server output. | §5.3.6, §10.2, §16.5 | High | Open | [#1141](https://github.com/xrf9268-hue/aiops-platform/issues/1141) |
+| D41 | Generic `item/tool/requestUserInput` requests receive a fabricated noninteractive answer, while recognized MCP approval questions are not handled through the reference's narrow ID/policy gate. | §10.5; upstream `app_server.ex` | Medium | Open | [#1142](https://github.com/xrf9268-hue/aiops-platform/issues/1142) |
+| D42 | Candidate sorting treats negative and greater-than-four priority integers as meaningful instead of ranking only 1–4 before unknown values. | §8.2, §11.3 | Medium | Open | [#1143](https://github.com/xrf9268-hue/aiops-platform/issues/1143) |
+| D43 | Tracker endpoint/scope/auth settings live in one flat cross-provider schema instead of an unknown-key-preserving, adapter-owned `tracker.provider` object. | §5.3.1, §6.4, §11.2 | High | Open | [#1144](https://github.com/xrf9268-hue/aiops-platform/issues/1144) |
+| D44 | Semantic-invalid workflow reloads can replace the last-good snapshot because selected-adapter secret admission and explicit blank-command validation are incomplete. | §6.2, §6.3 | High | Open | [#1145](https://github.com/xrf9268-hue/aiops-platform/issues/1145) |
+| D45 | The normalized Issue model/listing path lacks opaque `native_ref`, nullable assignment/priority/timestamps, and explicit adapter-derived `dispatchable` fields required by the provider-neutral contract. | §4.1.1, §11.2, §11.3, §12.2 | High | Open | [#1146](https://github.com/xrf9268-hue/aiops-platform/issues/1146) |
+| D46 | Explicit-ID refresh returns narrow `IssueState` projections and outcome shims instead of complete normalized Issue snapshots with atomic malformed/missing/error semantics. | §11.1, §16.4–§16.6 | High | Open | [#1147](https://github.com/xrf9268-hue/aiops-platform/issues/1147) |
+| D47 | The generic scheduler reconstructs Linear-style Todo blocker eligibility instead of consuming explicit adapter-derived `dispatchable` plus required labels. | §4.1.1, §8.2, §11.2 | High | Open | [#1148](https://github.com/xrf9268-hue/aiops-platform/issues/1148) |
+| D48 | Retry dispatch performs one candidate lookup but lacks the second full by-ID freshness read immediately before spawn. | §8.4, §16.6; upstream `0517275c` | High | Open | [#1149](https://github.com/xrf9268-hue/aiops-platform/issues/1149) |
+| D49 | Provider-native tool selection/configuration remains runner-owned and cannot bind normalized Issue/native-ref plus adapter-declared secret env names through one selected-adapter session snapshot. | §10.5, §11.2, §15.3 | High | Open | [#1150](https://github.com/xrf9268-hue/aiops-platform/issues/1150) |
 
 Severity reflects the risk and the gap to SPEC, not the implementation effort.
 
@@ -95,10 +111,11 @@ Status vocabulary:
   linked issue remains open because the full acceptance criteria are not met.
 - **Reverting**: the current behavior is still present and is intentionally
   scheduled for removal/replacement.
-- **Closed**: the linked implementation issue is closed; leave the row visible
-  until umbrella #67 closes so future audits can see which D1–D24 items were
-  resolved. A `Closed (accepted deviation)` qualifier means the linked issue
-  closed by explicitly accepting a live divergence; keep that rationale visible.
+- **Closed**: the linked implementation issue is closed; leave historical rows
+  visible after their versioned umbrella closes so future audits can see what
+  was resolved. A `Closed (accepted deviation)` qualifier means the linked
+  issue closed by explicitly accepting a live divergence; keep that rationale
+  visible.
 
 ## Deliberate extensions
 
@@ -148,6 +165,7 @@ linked issue for the latest status. A row stays here until either:
    the row here as `Closed (accepted deviation)` with the accepting PR/issue
    link.
 
-Closing all of D1–D24 (or moving each to accepted-deviation status) is what
-would let the project legitimately describe itself as a Symphony Go port
-rather than "inspired by Symphony".
+Closing historical D1–D24 is no longer sufficient for a current alignment
+claim. Every row opened by the pinned 0.0.2 sweep (currently D38–D49) must also
+be fully closed or explicitly accepted under the same high bar before the
+project describes current `main` as aligned with that contract.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Linear, Gitea, or GitHub issue
 It is a Go implementation of [OpenAI Symphony](https://github.com/openai/symphony).
 The [`SPEC.md`](docs/research/SPEC.md) contract — mirrored verbatim into this
 repo from
-[upstream](https://github.com/openai/symphony/blob/main/SPEC.md) so it cannot
-drift (upstream is an unmaintained demo repo) — is authoritative; the Elixir
-reference implementation is the tie-breaker when the SPEC text is ambiguous. Why
-we continue the Go port here rather than forking is recorded in
+[upstream](https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/SPEC.md) at an audited
+commit so a moving upstream branch cannot change the contract mid-review — is
+authoritative; the Elixir reference implementation at that upstream revision
+is the tie-breaker when the SPEC text is ambiguous. Why we continue the Go port
+here rather than forking is recorded in
 [`DECISION.md`](DECISION.md); the current SPEC deviation ledger lives in
 [`DEVIATIONS.md`](DEVIATIONS.md).
 

--- a/README.md
+++ b/README.md
@@ -368,11 +368,14 @@ Legacy fallback files such as `.aiops/WORKFLOW.md` and `.github/WORKFLOW.md` are
 not searched and are not reported as shadowed workflow sources.
 
 If the canonical file does not exist, the worker proceeds with built-in
-defaults. The table below mirrors SPEC §6.4's cheat-sheet so a SPEC reader's
-mental model lines up with `worker --print-config` output; defaults that diverge
-from SPEC are called out and tracked in [`DEVIATIONS.md`](DEVIATIONS.md). It is
-deliberately partial — the exhaustive key-by-key reference (every front-matter
-key with type, default, behavior, and validation rule) is
+defaults. The table below maps the current implementation to SPEC §6.4's
+cheat-sheet so a SPEC reader can compare it with `worker --print-config`
+output. SPEC 0.0.2 moves endpoint/scope/auth settings into the adapter-owned
+`tracker.provider` object and makes state defaults adapter-defined; the
+current flat fields and cross-provider state defaults remain open deviation
+D43 / #1144 rather than SPEC conformance. The table is deliberately partial —
+the exhaustive key-by-key reference (every front-matter key with type, default,
+behavior, and validation rule) is
 [`docs/runbooks/workflow-frontmatter-reference.md`](docs/runbooks/workflow-frontmatter-reference.md):
 
 | Setting | Default | Source |
@@ -389,10 +392,10 @@ key with type, default, behavior, and validation rule) is
 | `server.port` | `4000` (`-1` disables the HTTP state server + dashboard) | implementation |
 | `policy.mode` | `draft_pr` (or `analysis_only`) | implementation |
 | `tracker.kind` | none — REQUIRED per SPEC §6.4; the loader rejects an empty value with an error that names the field and the allowed set (`gitea`, `github`, `linear`) | SPEC §6.4 |
-| `tracker.endpoint` | Linear defaults to `https://api.linear.app/graphql`; Gitea/GitHub use this as the REST API base URL, with env fallbacks only when omitted | SPEC §6.4 / implementation |
-| `tracker.project_slug` | required for `tracker.kind: linear` | SPEC §6.4 |
-| `tracker.active_states` | `[Todo, In Progress]` | SPEC §6.4 |
-| `tracker.terminal_states` | `[Closed, Cancelled, Canceled, Duplicate, Done]` | SPEC §6.4 |
+| `tracker.endpoint` | Linear defaults to `https://api.linear.app/graphql`; Gitea/GitHub use this as the REST API base URL, with env fallbacks only when omitted | implementation (open D43 / #1144; SPEC replacement: `tracker.provider`) |
+| `tracker.project_slug` | required for `tracker.kind: linear` | implementation (open D43 / #1144; SPEC replacement: `tracker.provider`) |
+| `tracker.active_states` | `[Todo, In Progress]` | implementation default (open D43 / #1144; SPEC §6.4 makes the default adapter-defined) |
+| `tracker.terminal_states` | `[Closed, Cancelled, Canceled, Duplicate, Done]` | implementation default (open D43 / #1144; SPEC §6.4 makes the default adapter-defined) |
 | `tracker.required_labels` | `[]` (gate off) — opt-in dispatch filter: an issue must carry every listed label (matched case-insensitively after trimming) to dispatch or keep running. Removing a required label makes a running agent self-stop after its current turn (per-turn refresh) and releases retry/blocked work on the next poll. A blank entry matches no issue. Labels are projected up to the Linear API's 250-per-issue page maximum; a required label beyond that window is outside the gate's evidence (an issue carrying 250+ labels is pathological — keep the marker set small). | SPEC §4.1.1 / §6.4 |
 | `tracker.pagination_max_pages` | adapter default (`github`: 10 pages; `gitea`: 20 pages; `linear`: 200 pages) | implementation |
 | `workspace.root` | `<system-temp>/symphony_workspaces` (resolved via `os.TempDir()` at startup, typically `/tmp/symphony_workspaces` on Linux; per-boot — set explicitly to a long-lived path for persistence) | SPEC §6.4 |

--- a/docs/engineering-rules-rationale.md
+++ b/docs/engineering-rules-rationale.md
@@ -309,9 +309,13 @@ shipped.
   `DEVIATIONS.md` row (principle 6/7). Fill the `SPEC alignment` checklist in the
   PR template. This makes a documented deviation cost something *before* merge
   instead of being unwound later (the #73/#74/#76/#557/#561/D25 recurrence). The
-  required-check wiring lives in `.github/governance/main-ruleset.json`. **Earned
-  by:** #588 — those removals all shipped despite the rules existing, because the
-  checks were judgment at audit time rather than mechanical at author time.
+  required-check wiring lives in `.github/governance/main-ruleset.json`.
+  Route new findings through the active ledger named in `DEVIATIONS.md`; a
+  hard-coded historical umbrella silently misfiles later alignment work.
+  **Earned by:** #588 — those removals all shipped despite the rules existing,
+  because the checks were judgment at audit time rather than mechanical at
+  author time; #1138 — #67 covered the historical D1–D24 sweep after the active
+  ledger had moved on.
 - **PR titles are Conventional Commits.** Squash-merge makes the PR title the
   commit subject release-please parses; titles using freeform `area:` prefixes
   (`maintainability:`, `cmd:`, `stateapi:`, `dashboard:`, …) are dropped silently

--- a/docs/research/SPEC.md
+++ b/docs/research/SPEC.md
@@ -1,19 +1,27 @@
 <!--
-Source: https://github.com/openai/symphony/blob/main/SPEC.md
-Upstream commit: b4ccf7b55327821ca6d9b1b8b9e4ab5ac7f30e15 (2026-06-05)
-Archived: 2026-06-13
-License: Apache License 2.0 — https://github.com/openai/symphony/blob/main/LICENSE
+Source: https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/SPEC.md
+Upstream commit: 653f8b3cc476db03420479ba6f95b2ed7281c401 (2026-07-24)
+Body SHA-256: 29d6b45a85453e045883c064c0e08595f9d4a33f9a2527f649bc1363b74e0176
+Mirrored: 2026-07-24
+License: Apache License 2.0 — https://github.com/openai/symphony/blob/653f8b3cc476db03420479ba6f95b2ed7281c401/LICENSE
 
-Mirrored verbatim so the protocol contract this project ports cannot drift:
-upstream openai/symphony is an unmaintained demo repo (see DECISION.md), yet
-every authoritative doc here (AGENTS.md, DEVIATIONS.md, README, runbooks)
-references "SPEC §N" against it. This is the same treatment the announcement
-blog post already gets in this directory (#799).
+Mirrored verbatim so this repository reviews and implements one pinned protocol
+contract even while upstream continues to evolve. The Elixir reference at the
+same commit resolves behavior that the language-neutral SPEC leaves ambiguous.
 
-Do NOT hand-edit the body below — it is an unmodified copy. To update, re-fetch
-SPEC.md from upstream and bump the commit hash above:
+Do NOT hand-edit the body below. To update it, set `symphony_sha` to the
+intended upstream commit, fetch it, replace the body with
+`/tmp/symphony-SPEC.md`, then update the commit, date, and SHA-256 above, the
+matching constants in `scripts/spec_mirror_docs_test.go`, and the pinned
+authority links covered by that test:
 
-  curl -sS https://raw.githubusercontent.com/openai/symphony/<sha>/SPEC.md
+  symphony_sha=653f8b3cc476db03420479ba6f95b2ed7281c401
+  if ! git -C /tmp/symphony-upstream rev-parse --git-dir >/dev/null 2>&1; then
+    git clone https://github.com/openai/symphony.git /tmp/symphony-upstream
+  fi
+  git -C /tmp/symphony-upstream fetch origin "${symphony_sha}"
+  git -C /tmp/symphony-upstream show "${symphony_sha}:SPEC.md" > /tmp/symphony-SPEC.md
+  shasum -a 256 /tmp/symphony-SPEC.md
 -->
 
 # Symphony Service Specification
@@ -33,9 +41,9 @@ behavior.
 
 ## 1. Problem Statement
 
-Symphony is a long-running automation service that continuously reads work from an issue tracker
-(Linear in this specification version), creates an isolated workspace for each issue, and runs a
-coding agent session for that issue inside the workspace.
+Symphony is a long-running automation service that continuously reads work from a configured issue
+tracker, creates an isolated workspace for each issue, and runs a coding agent session for that
+issue inside the workspace.
 
 The service solves four operational problems:
 
@@ -55,7 +63,9 @@ Important boundary:
 
 - Symphony is a scheduler/runner and tracker reader.
 - Ticket writes (state transitions, comments, PR links) are typically performed by the coding agent
-  using tools available in the workflow/runtime environment.
+  through provider-native tools executed by Symphony with the configured tracker credential.
+- When tracker credentials are supplied through host-side secret references, the coding-agent child
+  process does not need a duplicate tracker login or direct access to raw tracker credentials.
 - A successful run can end at a workflow-defined handoff state (for example `Human Review`), not
   necessarily `Done`.
 
@@ -98,11 +108,13 @@ Important boundary:
    - Applies defaults and environment variable indirection.
    - Performs validation used by the orchestrator before dispatch.
 
-3. `Issue Tracker Client`
+3. `Issue Tracker Adapter`
    - Fetches candidate issues in active states.
    - Fetches current states for specific issue IDs (reconciliation).
    - Fetches terminal-state issues during startup cleanup.
    - Normalizes tracker payloads into a stable issue model.
+   - MAY expose provider-native agent tools without adding provider-specific write APIs to the
+     orchestrator.
 
 4. `Orchestrator`
    - Owns the poll tick.
@@ -147,19 +159,21 @@ Symphony is easiest to port when kept in these layers:
 4. `Execution Layer` (workspace + agent subprocess)
    - Filesystem lifecycle, workspace preparation, coding-agent protocol.
 
-5. `Integration Layer` (Linear adapter)
+5. `Integration Layer` (selected tracker adapter)
    - API calls and normalization for tracker data.
+   - Provider-native agent tools and centralized tracker authentication.
 
 6. `Observability Layer` (logs + OPTIONAL status surface)
    - Operator visibility into orchestrator and agent behavior.
 
 ### 3.3 External Dependencies
 
-- Issue tracker API (Linear for `tracker.kind: linear` in this specification version).
+- One configured issue tracker API.
 - Local filesystem for workspaces and logs.
 - OPTIONAL workspace population tooling (for example Git CLI, if used).
 - Coding-agent executable that supports the targeted Codex app-server mode.
-- Host environment authentication for the issue tracker and coding agent.
+- Host environment authentication for the issue tracker and coding agent. Host-side tracker secret
+  environment variables SHOULD NOT be inherited by the coding-agent child process.
 
 ## 4. Core Domain Model
 
@@ -167,30 +181,44 @@ Symphony is easiest to port when kept in these layers:
 
 #### 4.1.1 Issue
 
-Normalized issue record used by orchestration, prompt rendering, and observability output.
+Normalized schedulable work item used by orchestration, prompt rendering, and observability output.
+The name `Issue` is generic in this specification; an adapter MAY map it from a ticket, card,
+project item, or another provider-native work object.
 
 Fields:
 
 - `id` (string)
-  - Stable tracker-internal ID.
+  - REQUIRED stable dispatch identity within the configured tracker scope.
+  - Opaque to the orchestrator. It MAY be a project-item or board-entry ID instead of the
+    provider's underlying ticket ID.
+- `native_ref` (object or null)
+  - OPTIONAL non-secret provider identifiers needed by provider-native tools.
+  - Opaque to the orchestrator and preserved for prompt/tool context.
 - `identifier` (string)
-  - Human-readable ticket key (example: `ABC-123`).
+  - REQUIRED human-readable ticket key (example: `ABC-123`).
+  - MUST be unique within the configured tracker scope because it names workspaces and
+    operator-facing routes. An adapter spanning multiple namespaces MUST disambiguate it.
 - `title` (string)
 - `description` (string or null)
 - `priority` (integer or null)
   - Lower numbers are higher priority in dispatch sorting.
 - `state` (string)
-  - Current tracker state name.
+  - REQUIRED current provider-native state name.
 - `branch_name` (string or null)
   - Tracker-provided branch metadata if available.
 - `url` (string or null)
+- `assignee_id` (string or null)
 - `labels` (list of strings)
   - Normalized to lowercase.
 - `blocked_by` (list of blocker refs)
-  - Each blocker ref contains:
+  - Best-effort provider metadata. Each blocker ref contains:
     - `id` (string or null)
     - `identifier` (string or null)
     - `state` (string or null)
+- `dispatchable` (boolean)
+  - REQUIRED adapter-derived eligibility for provider-specific rules that the generic scheduler
+    cannot infer safely, such as assignment, board membership, or blocker semantics.
+  - The orchestrator still applies configured state, label, claim, retry, and concurrency rules.
 - `created_at` (timestamp or null)
 - `updated_at` (timestamp or null)
 
@@ -223,7 +251,7 @@ Filesystem workspace assigned to one issue identifier.
 Fields (logical):
 
 - `path` (absolute workspace path)
-- `workspace_key` (sanitized issue identifier)
+- `workspace_key` (collision-resistant sanitized issue identifier)
 - `created_now` (boolean, used to gate `after_create` hook)
 
 #### 4.1.5 Run Attempt
@@ -293,14 +321,23 @@ Fields:
 ### 4.2 Stable Identifiers and Normalization Rules
 
 - `Issue ID`
-  - Use for tracker lookups and internal map keys.
+  - Use for tracker refresh calls and internal map keys.
+  - Treat it as an opaque dispatch identity; do not assume it is the provider's underlying ticket
+    ID.
+- `Native Ref`
+  - Preserve as opaque non-secret data for provider-native agent tools and prompt rendering.
+  - Never use it as an orchestrator map key or interpret provider-specific fields in core logic.
 - `Issue Identifier`
   - Use for human-readable logs and workspace naming.
+  - Require uniqueness within the configured tracker scope.
 - `Workspace Key`
   - Derive from `issue.identifier` by replacing any character not in `[A-Za-z0-9._-]` with `_`.
-  - Use the sanitized value for the workspace directory name.
+  - If sanitization changes the identifier, append a stable hash suffix of the original identifier
+    with at least 64 bits of entropy using only allowed workspace-key characters, making keys for
+    distinct identifiers that sanitize to the same text collision-resistant.
+  - Use the resulting value for the workspace directory name.
 - `Normalized Issue State`
-  - Compare states after `lowercase`.
+  - Compare states after trimming surrounding whitespace and applying `lowercase`.
 - `Session ID`
   - Compose from coding-agent `thread_id` and `turn_id` as `<thread_id>-<turn_id>`.
 
@@ -367,24 +404,26 @@ Fields:
 
 - `kind` (string)
   - REQUIRED for dispatch.
-  - Current supported value: `linear`
-- `endpoint` (string)
-  - Default for `tracker.kind == "linear"`: `https://api.linear.app/graphql`
-- `api_key` (string)
-  - MAY be a literal token or `$VAR_NAME`.
-  - Canonical environment variable for `tracker.kind == "linear"`: `LINEAR_API_KEY`.
-  - If `$VAR_NAME` resolves to an empty string, treat the key as missing.
-- `project_slug` (string)
-  - REQUIRED for dispatch when `tracker.kind == "linear"`.
+  - Selects one implementation-supported tracker adapter.
+- `provider` (object)
+  - Default: `{}`.
+  - Adapter-owned configuration such as endpoint, scope/project selector, and credentials.
+  - Core Symphony MUST preserve unknown keys and MUST NOT prescribe one cross-provider credential
+    or scope schema.
+  - Each adapter MUST document its required keys, defaults, secret keys, `$VAR_NAME` support, and
+    validation errors.
+  - If a documented secret `$VAR_NAME` resolves to an empty string, treat that secret as missing.
 - `required_labels` (list of strings)
   - Default: `[]`.
   - An issue MUST contain every configured label to dispatch or continue.
   - Matching ignores case and surrounding whitespace.
   - A blank configured label matches no issue.
 - `active_states` (list of strings)
-  - Default: `Todo`, `In Progress`
+  - REQUIRED unless the selected adapter profile documents a default.
+  - Values are provider-native state names compared case-insensitively by the scheduler.
 - `terminal_states` (list of strings)
-  - Default: `Closed`, `Cancelled`, `Canceled`, `Duplicate`, `Done`
+  - REQUIRED unless the selected adapter profile documents a default.
+  - Values are provider-native state names compared case-insensitively by the scheduler.
 
 #### 5.3.2 `polling` (object)
 
@@ -444,7 +483,7 @@ Fields:
   - Changes SHOULD be re-applied at runtime and affect future retry scheduling.
 - `max_concurrent_agents_by_state` (map `state_name -> positive integer`)
   - Default: empty map.
-  - State keys are normalized (`lowercase`) for lookup.
+  - State keys are normalized (`trim + lowercase`) for lookup.
   - Invalid entries (non-positive or non-numeric) are ignored.
 
 #### 5.3.6 `codex` (object)
@@ -498,7 +537,7 @@ Template input variables:
 Fallback prompt behavior:
 
 - If the workflow prompt body is empty, the runtime MAY use a minimal default prompt
-  (`You are working on an issue from Linear.`).
+  (`You are working on an issue from the configured tracker.`).
 - Workflow file read/parse failures are configuration/validation errors and SHOULD NOT silently fall
   back to a prompt.
 
@@ -526,11 +565,13 @@ Configuration is resolved in this order:
 1. Select the workflow file path (explicit runtime setting, otherwise cwd default).
 2. Parse YAML front matter into a raw config map.
 3. Apply built-in defaults for missing OPTIONAL fields.
-4. Resolve `$VAR_NAME` indirection only for config values that explicitly contain `$VAR_NAME`.
+4. Resolve `$VAR_NAME` indirection for config values that explicitly contain `$VAR_NAME`, plus any
+   adapter-owned fallback environment names documented for omitted provider fields.
 5. Coerce and validate typed values.
 
 Environment variables do not globally override YAML values. They are used only when a config value
-explicitly references them.
+explicitly references them, or when an adapter profile documents a host-side fallback for an
+omitted provider field. Such a fallback is adapter-local, not a cross-provider convention.
 
 Value coercion semantics:
 
@@ -583,8 +624,8 @@ Validation checks:
 
 - Workflow file can be loaded and parsed.
 - `tracker.kind` is present and supported.
-- `tracker.api_key` is present after `$` resolution.
-- `tracker.project_slug` is present when REQUIRED by the selected tracker kind.
+- The selected adapter accepts `tracker.provider` after documented defaults and `$VAR`
+  resolution.
 - `codex.command` is present and non-empty.
 
 ### 6.4 Core Config Fields Summary (Cheat Sheet)
@@ -593,13 +634,11 @@ This section is intentionally redundant so a coding agent can implement the conf
 Extension fields are documented in the extension section that defines them. Core conformance does
 not require recognizing or validating extension fields unless that extension is implemented.
 
-- `tracker.kind`: string, REQUIRED, currently `linear`
-- `tracker.endpoint`: string, default `https://api.linear.app/graphql` when `tracker.kind=linear`
-- `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
-- `tracker.project_slug`: string, REQUIRED when `tracker.kind=linear`
+- `tracker.kind`: string, REQUIRED, selects one supported adapter
+- `tracker.provider`: object, default `{}`, adapter-owned endpoint/scope/auth settings
 - `tracker.required_labels`: list of strings, default `[]`
-- `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
-- `tracker.terminal_states`: list of strings, default `["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]`
+- `tracker.active_states`: list of provider-native state names, adapter-defined default
+- `tracker.terminal_states`: list of provider-native state names, adapter-defined default
 - `polling.interval_ms`: integer, default `30000`
 - `workspace.root`: path resolved to absolute, default `<system-temp>/symphony_workspaces`
 - `hooks.after_create`: shell script or null
@@ -744,19 +783,21 @@ An issue is dispatch-eligible only if all are true:
 
 - It has `id`, `identifier`, `title`, and `state`.
 - Its state is in `active_states` and not in `terminal_states`.
-- It is routed to this worker by the configured assignee and contains every
-  label in `tracker.required_labels`.
+- Its adapter-provided `dispatchable` value is `true`.
+- It contains every label in `tracker.required_labels`.
 - It is not already in `running`.
 - It is not already in `claimed`.
 - Global concurrency slots are available.
 - Per-state concurrency slots are available.
-- Blocker rule for `Todo` state passes:
-  - If the issue state is `Todo`, do not dispatch when any blocker is non-terminal.
+
+For refresh and continuation checks, `issue_routable(issue)` means only that adapter-provided
+`dispatchable` is true and all `tracker.required_labels` match. State, claims, and concurrency are
+checked separately by the surrounding algorithm.
 
 Sorting order (stable intent):
 
-1. `priority` ascending (1..4 are preferred; null/unknown sorts last)
-2. `created_at` oldest first
+1. `priority` ascending for values `1..4`; all other integers and null sort after that bucket
+2. `created_at` oldest first; null sorts last
 3. `identifier` lexicographic tie-breaker
 
 ### 8.3 Concurrency Control
@@ -787,20 +828,19 @@ Backoff formula:
 
 Retry handling behavior:
 
-1. Fetch active candidate issues (not all issues).
-2. Find the specific issue by `issue_id`.
-3. If not found, release claim.
-4. If found and still candidate-eligible:
+1. Refresh the specific issue with `fetch_issues_by_ids([issue_id])`.
+2. If not found, release claim.
+3. If found in a terminal state, clean its workspace and release claim.
+4. If found and still active and routable:
    - Dispatch if slots are available.
    - Otherwise requeue with error `no available orchestrator slots`.
-5. If found but no longer active, release claim.
+5. If found but no longer active or routable, release claim without dispatch.
 
 Note:
 
-- Terminal-state workspace cleanup is handled by startup cleanup and active-run reconciliation
-  (including terminal transitions for currently running issues).
-- Retry handling mainly operates on active candidates and releases claims when the issue is absent,
-  rather than performing terminal cleanup itself.
+- Terminal-state workspace cleanup is handled by startup cleanup, active-run reconciliation, and
+  retry refreshes that observe a terminal transition.
+- ID refresh avoids treating a terminal, non-active, or newly unroutable issue as merely absent.
 
 ### 8.5 Active Run Reconciliation
 
@@ -819,7 +859,8 @@ Part B: Tracker state refresh
 - Fetch current issue states for all running issue IDs.
 - For each running issue:
   - If tracker state is terminal: terminate worker and clean workspace.
-  - If tracker state is still active: update the in-memory issue snapshot.
+  - If tracker state is still active and routable: update the in-memory issue snapshot.
+  - If tracker state is active but no longer routable: terminate worker without workspace cleanup.
   - If tracker state is neither active nor terminal: terminate worker without workspace cleanup.
 - If state refresh fails, keep workers running and try again on the next tick.
 
@@ -843,7 +884,7 @@ Workspace root:
 
 Per-issue workspace path:
 
-- `<workspace.root>/<sanitized_issue_identifier>`
+- `<workspace.root>/<workspace_key>`
 
 Workspace persistence:
 
@@ -856,7 +897,8 @@ Input: `issue.identifier`
 
 Algorithm summary:
 
-1. Sanitize identifier to `workspace_key`.
+1. Derive `workspace_key` using Section 4.2, including the stable original-identifier hash when
+   sanitization changes the identifier.
 2. Compute workspace path under workspace root.
 3. Ensure the workspace path exists as a directory.
 4. Mark `created_now=true` only if the directory was created during this call; otherwise
@@ -928,6 +970,8 @@ Invariant 3: Workspace key is sanitized.
 
 - Only `[A-Za-z0-9._-]` allowed in workspace directory names.
 - Replace all other characters with `_`.
+- If replacement changes the identifier, append a stable original-identifier hash suffix with at
+  least 64 bits of entropy so keys remain collision-resistant after sanitization.
 
 ## 10. Agent Runner Protocol (Coding Agent Integration)
 
@@ -1002,7 +1046,7 @@ Completion conditions:
 - Targeted-protocol turn completion signal -> success
 - Targeted-protocol turn failure signal -> failure
 - Targeted-protocol turn cancellation signal -> failure
-- turn timeout (`turn_timeout_ms`) -> failure
+- turn stream silence timeout (`turn_timeout_ms`) -> failure
 - subprocess exit -> failure
 
 Continuation processing:
@@ -1070,47 +1114,47 @@ Unsupported dynamic tool calls:
   using the targeted protocol and continue the session.
 - This prevents the session from stalling on unsupported tool execution paths.
 
-Optional client-side tool extension:
+Optional provider-native agent tool extension:
 
-- An implementation MAY expose a limited set of client-side tools to the app-server session.
-- Current standardized optional tool: `linear_graphql`.
-- If implemented, supported tools SHOULD be advertised to the app-server session during startup
-  using the protocol mechanism supported by the targeted Codex app-server version.
-- Unsupported tool names SHOULD still return a failure result using the targeted protocol and
+- An adapter MAY expose provider-native tools to the app-server session.
+- The selected adapter's tool specs SHOULD be advertised during session startup using the protocol
+  mechanism supported by the targeted Codex app-server version.
+- Tool specs, adapter selection, and effective tracker settings MUST be bound to one session
+  snapshot. A workflow reload applies to future sessions; it MUST NOT make an in-flight session
+  advertise one provider and execute another.
+- Tool names, schemas, and result payloads are adapter-owned. Symphony does not standardize a
+  lowest-common-denominator CRUD API.
+- The runtime MUST execute advertised tool calls host-side with the active adapter configuration and
+  MUST NOT require the coding-agent child process to read raw tracker tokens from disk or
+  environment.
+- The runtime SHOULD pass the current normalized issue to the adapter as internal execution context.
+  The adapter MAY use `issue.id` and `issue.native_ref` to preserve provider-specific richness
+  without teaching the orchestrator provider semantics.
+- Tracker credentials SHOULD NOT be inherited by the coding-agent child process. An adapter that
+  resolves credentials from environment variables MUST declare which secret environment names the
+  launcher removes from local and remote child environments. Literal credentials in a repo-owned
+  `WORKFLOW.md` remain readable to a child with workspace access and SHOULD NOT be used when this
+  isolation matters.
+- Unsupported tool names MUST return a structured failure result using the targeted protocol and
   continue the session.
+- Each adapter that ships tools MUST document:
+  - tool names and input schemas;
+  - whether a tool can mutate tracker state;
+  - scope/authorization behavior;
+  - result and error semantics;
+  - any provider-side idempotency or rate-limit expectations.
 
-`linear_graphql` extension contract:
+Minimal language-neutral adapter hooks for this OPTIONAL extension:
 
-- Purpose: execute a raw GraphQL query or mutation against Linear using Symphony's configured
-  tracker auth for the current session.
-- Availability: only meaningful when `tracker.kind == "linear"` and valid Linear auth is configured.
-- Preferred input shape:
+```text
+agent_tool_specs() -> list<ToolSpec>
+secret_environment_names() -> list<string>
+execute_agent_tool(name, arguments, context={issue}) -> ToolResult
+```
 
-  ```json
-  {
-    "query": "single GraphQL query or mutation document",
-    "variables": {
-      "optional": "graphql variables object"
-    }
-  }
-  ```
-
-- `query` MUST be a non-empty string.
-- `query` MUST contain exactly one GraphQL operation.
-- `variables` is OPTIONAL and, when present, MUST be a JSON object.
-- Implementations MAY additionally accept a raw GraphQL query string as shorthand input.
-- Execute one GraphQL operation per tool call.
-- If the provided document contains multiple operations, reject the tool call as invalid input.
-- `operationName` selection is intentionally out of scope for this extension.
-- Reuse the configured Linear endpoint and auth from the active Symphony workflow/runtime config; do
-  not require the coding agent to read raw tokens from disk.
-- Tool result semantics:
-  - transport success + no top-level GraphQL `errors` -> `success=true`
-  - top-level GraphQL `errors` present -> `success=false`, but preserve the GraphQL response body
-    for debugging
-  - invalid input, missing auth, or transport failure -> `success=false` with an error payload
-- Return the GraphQL response or error payload as structured tool output that the model can inspect
-  in-session.
+`ToolResult` MUST distinguish success from failure and carry JSON-safe structured output that can
+be translated to the targeted app-server protocol. The context contains the normalized issue, never
+the credential.
 
 User-input-required policy:
 
@@ -1125,7 +1169,8 @@ User-input-required policy:
 Timeouts:
 
 - `codex.read_timeout_ms`: request/response timeout during startup and sync requests
-- `codex.turn_timeout_ms`: total turn stream timeout
+- `codex.turn_timeout_ms`: maximum silence interval while a turn stream is active; each
+  app-server output resets it, so it is not a total turn runtime cap
 - `codex.stall_timeout_ms`: enforced by orchestrator based on event inactivity
 
 Error mapping (RECOMMENDED normalized categories):
@@ -1156,71 +1201,130 @@ Note:
 
 - Workspaces are intentionally preserved after successful runs.
 
-## 11. Issue Tracker Integration Contract (Linear-Compatible)
+## 11. Issue Tracker Integration Contract
 
-### 11.1 REQUIRED Operations
+The issue tracker boundary is deliberately small: a portable read kernel for scheduling plus
+OPTIONAL provider-native agent tools. Do not add generic comment/state/attachment CRUD merely to
+make providers look alike; those operations lose useful provider semantics and are not needed by
+the orchestrator.
 
-An implementation MUST support these tracker adapter operations:
+### 11.1 REQUIRED Adapter Operations
 
-1. `fetch_candidate_issues()`
-   - Return issues in configured active states for a configured project.
+An implementation MUST support these adapter operations:
 
-2. `fetch_issues_by_states(state_names)`
-   - Used for startup terminal cleanup.
+1. `fetch_issues_by_states(state_names)`
+   - Return normalized issues visible in the configured tracker scope and requested state names.
+   - The adapter MUST apply provider-side scope selection and pagination.
+   - Used with configured active states for candidate polling and terminal states for startup
+     cleanup.
+   - When used for candidate polling, include active scoped issues even when
+     `dispatchable=false`; the scheduler owns that final filter.
+   - The orchestrator applies `required_labels`, `dispatchable`, claims, retries, and concurrency
+     after normalization.
+   - An empty `state_names` list MUST return an empty result without a provider request.
 
-3. `fetch_issue_states_by_ids(issue_ids)`
-   - Used for active-run reconciliation.
+2. `fetch_issues_by_ids(issue_ids)`
+   - Return current normalized issue snapshots for the supplied opaque dispatch IDs.
+   - Used for active-run reconciliation and stale-dispatch revalidation.
+   - An empty `issue_ids` list MUST return an empty result without a provider request.
+   - IDs no longer visible in the configured scope are omitted; the orchestrator treats omission as
+     "no longer visible" rather than inventing a synthetic state.
 
-### 11.2 Query Semantics (Linear)
+Both operations return either `ok(list<Issue>)` or an adapter error. For portability, an adapter
+error SHOULD expose a stable category and human-readable message. An implementation MAY use a
+language-native tagged error, exception, tuple, or enum instead of a literal error object when its
+adapter profile documents how those public error forms map to category and message. The
+orchestrator relies only on success versus failure.
 
-Linear-specific requirements for `tracker.kind == "linear"`:
+The operations are atomic from the scheduler's perspective after a paging or transport failure. For
+these rules, a record is malformed only when the adapter cannot produce the required normalized
+fields (`id`, `identifier`, `title`, `state`, and explicit `dispatchable`) or cannot produce a
+valid `Issue` after applying the optional-field fallback rules in Section 11.3. Unusable nullable
+or best-effort provider metadata MAY normalize to `null`, an empty list, or omitted best-effort
+entries; that fallback alone does not make a record malformed.
 
-- `tracker.kind == "linear"`
-- GraphQL endpoint (default `https://api.linear.app/graphql`)
-- Auth token sent in `Authorization` header
-- `tracker.project_slug` maps to Linear project `slugId`
-- Candidate issue query filters project using `project: { slugId: { eq: $projectSlug } }`
-- Candidate and issue-state refresh queries include issue labels. Required
-  label filtering happens after normalization so refresh can observe label
-  removal and stop or release existing work.
-- Issue-state refresh query uses GraphQL issue IDs with variable type `[ID!]`
-- Pagination REQUIRED for candidate issues
-- Page size default: `50`
-- Network timeout: `30000 ms`
+A state-list call MAY omit an individually malformed provider record because it was never safe to
+dispatch, and SHOULD log that omission. An ID-refresh call MUST fail instead of silently omitting a
+malformed requested record, because omission is meaningful. A successful
+`fetch_issues_by_ids` result is complete for that call. Output order is not significant, input IDs
+are treated as a set, and each dispatch ID appears at most once.
 
-Important:
+The refresh operation returns full normalized snapshots, not only state strings, because label,
+assignment, routing, and provider-specific dispatchability can change while a run is active.
 
-- Linear GraphQL schema details can drift. Keep query construction isolated and test the exact query
-  fields/types REQUIRED by this specification.
+### 11.2 Adapter Responsibilities
 
-A non-Linear implementation MAY change transport details, but the normalized outputs MUST match the
-domain model in Section 4.
+Each adapter owns:
+
+- construction from the current effective tracker configuration, including active/terminal states;
+- endpoint, authentication, transport, timeouts, pagination, and rate-limit handling;
+- provider-specific scope selection (project, board, team, repository, query, or equivalent);
+- mapping provider payloads into the normalized Issue fields in Section 4.1.1;
+- choosing a stable dispatch identity and preserving any distinct underlying IDs in `native_ref`;
+- deriving `dispatchable` from provider-specific routing rules;
+- preserving provider-native state names while allowing case-insensitive scheduler comparison;
+- OPTIONAL provider-native agent tools and their authorization boundary.
+
+The orchestrator MUST NOT inspect provider payloads, assume that `issue.id` is an underlying
+ticket ID, or branch on provider-specific blocker, board, transition, or comment semantics.
+
+Each adapter MUST publish a compact profile in implementation documentation, not only code,
+containing:
+
+- exact supported `tracker.kind` value;
+- exact `tracker.provider` keys, defaults, secret keys/environment names, and validation errors;
+- scope selection, pagination behavior, and provider request limits;
+- `id` and `native_ref` mapping;
+- state, label, priority, timestamp, `dispatchable`, malformed-record, and optional-field
+  normalization;
+- provider-native tool names/schemas, mutation capability, scope, and result/error behavior if any;
+- mapping from public language-native error forms to portable transport/auth/rate-limit error
+  categories and human-readable messages.
 
 ### 11.3 Normalization Rules
 
-Candidate issue normalization SHOULD produce fields listed in Section 4.1.1.
+Adapter output MUST satisfy Section 4.1.1. In addition:
 
-Additional normalization details:
-
-- Label names are trimmed and lowercased.
-
-- `labels` -> lowercase strings
-- `blocked_by` -> derived from inverse relations where relation type is `blocks`
-- `priority` -> integer only (non-integers become null)
-- `created_at` and `updated_at` -> parse ISO-8601 timestamps
+- Every listed field MUST be present in the normalized record. Nullable fields use `null`;
+  collection fields use an empty list when absent.
+- `id`, `identifier`, `title`, and `state` MUST be non-empty strings.
+- `labels` MUST be trimmed, lowercased strings; blank labels MUST be dropped and duplicate labels
+  SHOULD be removed.
+- `priority` MUST be an integer or null.
+- The scheduler ranks priorities `1..4` before null/unknown values; other integers sort with
+  null/unknown unless an implementation documents a different mapping.
+- `created_at` and `updated_at` MUST represent parsed RFC 3339 instants or null; the in-memory
+  timestamp type is implementation-defined.
+- Unusable provider values for nullable fields MAY normalize to `null`. Unusable best-effort
+  collection entries MAY be dropped; if no usable entries remain, use an empty list. These
+  fallbacks MUST NOT be used for `id`, `identifier`, `title`, `state`, or explicit
+  `dispatchable`.
+- Preserve provider spelling in `state`, but trim and lowercase only for scheduler comparisons.
+- `blocked_by` is best-effort metadata; adapters MUST NOT invent blocker semantics they cannot
+  represent reliably.
+- `dispatchable` MUST be explicit. It is `true` only when provider-specific eligibility checks
+  pass; the generic scheduler never tries to reconstruct those checks from `native_ref`.
+- `native_ref` MUST be null or a JSON-safe object containing only non-secret values safe to expose
+  in prompt/tool context. If provider metadata cannot be represented safely, normalize
+  `native_ref` to null; otherwise preserve the retained object verbatim.
 
 ### 11.4 Error Handling Contract
 
-RECOMMENDED error categories:
+RECOMMENDED adapter error categories:
 
 - `unsupported_tracker_kind`
-- `missing_tracker_api_key`
-- `missing_tracker_project_slug`
-- `linear_api_request` (transport failures)
-- `linear_api_status` (non-200 HTTP)
-- `linear_graphql_errors`
-- `linear_unknown_payload`
-- `linear_missing_end_cursor` (pagination integrity error)
+- `invalid_tracker_config`
+- `missing_tracker_secret`
+- `tracker_request` (transport failure)
+- `tracker_status` (non-success response)
+- `tracker_response` (malformed or semantically invalid payload)
+- `tracker_pagination` (pagination integrity failure)
+- `tracker_rate_limited`
+
+For portability, every adapter profile MUST document how each public language-native error form
+maps to a stable `category` and human-readable `message`. A literal `{category, message}`
+object is not required. Adapters MAY add `retryable`, `retry_after_ms`, provider status, and
+provider-specific detail, but the orchestrator only relies on success vs. failure.
 
 Orchestrator behavior on tracker errors:
 
@@ -1228,17 +1332,19 @@ Orchestrator behavior on tracker errors:
 - Running-state refresh failure: log and keep active workers running.
 - Startup terminal cleanup failure: log warning and continue startup.
 
-### 11.5 Tracker Writes (Important Boundary)
+### 11.5 Tracker Writes and Agent Tools (Important Boundary)
 
 Symphony does not require first-class tracker write APIs in the orchestrator.
 
-- Ticket mutations (state transitions, comments, PR metadata) are typically handled by the coding
-  agent using tools defined by the workflow prompt.
+- Ticket mutations (state transitions, comments, attachments, PR metadata) are typically handled by
+  the coding agent through the selected adapter's provider-native tools.
+- Tools execute in Symphony with the configured adapter credential; the child receives tool results,
+  not a raw token.
+- The current normalized issue is available to tool execution as context, including opaque
+  `native_ref`, so adapters can retain provider richness without adding it to the core scheduler.
 - The service remains a scheduler/runner and tracker reader.
 - Workflow-specific success often means "reached the next handoff state" (for example
   `Human Review`) rather than tracker terminal state `Done`.
-- If the `linear_graphql` client-side tool extension is implemented, it is still part of the agent
-  toolchain rather than orchestrator business logic.
 
 ## 12. Prompt Construction and Context Assembly
 
@@ -1259,12 +1365,14 @@ Inputs to prompt rendering:
 
 ### 12.3 Retry/Continuation Semantics
 
-`attempt` SHOULD be passed to the template because the workflow prompt can provide different
-instructions for:
+`attempt` SHOULD be passed to the template as a 1-based retry/continuation count:
 
-- first run (`attempt` null or absent)
-- continuation run after a successful prior session
-- retry after error/timeout/stall
+- first run: `attempt` is null or absent;
+- any later run: `attempt` is an integer.
+
+The core `attempt` value does not distinguish a normal continuation from an error/timeout/stall
+retry. An implementation MAY expose an additional `retry_kind` template field if workflows need
+that distinction, but it is not part of core conformance.
 
 ### 12.4 Failure Semantics
 
@@ -1555,7 +1663,7 @@ API design notes:
 1. `Workflow/Config Failures`
    - Missing `WORKFLOW.md`
    - Invalid YAML front matter
-   - Unsupported tracker kind or missing tracker credentials/project slug
+   - Unsupported tracker kind or invalid adapter-owned tracker configuration
    - Missing coding-agent executable
 
 2. `Workspace Failures`
@@ -1573,10 +1681,10 @@ API design notes:
    - Stalled session (no activity)
 
 4. `Tracker Failures`
-   - API transport errors
-   - Non-200 status
-   - GraphQL errors
-   - malformed payloads
+   - Provider transport errors
+   - Non-success provider responses
+   - Provider-reported application errors
+   - Malformed payloads
 
 5. `Observability Failures`
    - Snapshot timeout
@@ -1667,6 +1775,12 @@ RECOMMENDED additional hardening for ports:
 - Support `$VAR` indirection in workflow config.
 - Do not log API tokens or secret env values.
 - Validate presence of secrets without printing them.
+- Execute provider-native tracker tools in the Symphony host process with the configured adapter
+  credential.
+- Do not pass tracker credentials through the coding-agent child environment. Adapters MUST declare
+  secret environment names so local and remote launchers can remove them from child environments.
+- Do not place literal tracker credentials in a repo-owned `WORKFLOW.md` when the child can read
+  that workspace; use host-side secret references instead.
 
 ### 15.4 Hook Script Safety
 
@@ -1697,10 +1811,10 @@ Possible hardening measures include:
   of running with a maximally permissive configuration.
 - Adding external isolation layers such as OS/container/VM sandboxing, network restrictions, or
   separate credentials beyond the built-in Codex policy controls.
-- Filtering which Linear issues, projects, teams, labels, or other tracker sources are eligible for
-  dispatch so untrusted or out-of-scope tasks do not automatically reach the agent.
-- Narrowing the `linear_graphql` tool so it can only read or mutate data inside the
-  intended project scope, rather than exposing general workspace-wide tracker access.
+- Filtering which issues, projects, boards, teams, labels, or other tracker sources are eligible
+  for dispatch so untrusted or out-of-scope tasks do not automatically reach the agent.
+- Narrowing provider-native tools so they can only read or mutate data inside the intended tracker
+  scope, rather than exposing general workspace-wide tracker access.
 - Reducing the set of client-side tools, credentials, filesystem paths, and network destinations
   available to the agent to the minimum needed for the workflow.
 
@@ -1752,7 +1866,7 @@ on_tick(state):
     schedule_tick(state.poll_interval_ms)
     return state
 
-  issues = tracker.fetch_candidate_issues()
+  issues = tracker.fetch_issues_by_states(active_states)
   if issues failed:
     log_tracker_error()
     notify_observers()
@@ -1781,7 +1895,7 @@ function reconcile_running_issues(state):
   if running_ids is empty:
     return state
 
-  refreshed = tracker.fetch_issue_states_by_ids(running_ids)
+  refreshed = tracker.fetch_issues_by_ids(running_ids)
   if refreshed failed:
     log_debug("keep workers running")
     return state
@@ -1789,10 +1903,14 @@ function reconcile_running_issues(state):
   for issue in refreshed:
     if issue.state in terminal_states:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=true)
-    else if issue.state in active_states:
+    else if issue.state in active_states and issue_routable(issue):
       state.running[issue.id].issue = issue
     else:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=false)
+
+  returned_ids = set(issue.id for issue in refreshed)
+  for missing_id in running_ids - returned_ids:
+    state = terminate_running_issue(state, missing_id, cleanup_workspace=false)
 
   return state
 ```
@@ -1874,15 +1992,18 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
       run_hook_best_effort("after_run", workspace.path)
       fail_worker("agent turn error")
 
-    refreshed_issue = tracker.fetch_issue_states_by_ids([issue.id])
+    refreshed_issue = tracker.fetch_issues_by_ids([issue.id])
     if refreshed_issue failed:
       app_server.stop_session(session)
       run_hook_best_effort("after_run", workspace.path)
       fail_worker("issue state refresh error")
 
-    issue = refreshed_issue[0] or issue
+    if refreshed_issue is empty:
+      break
 
-    if issue.state is not active:
+    issue = refreshed_issue[0]
+
+    if issue.state is not active or not issue_routable(issue):
       break
 
     if turn_number >= max_turns:
@@ -1925,19 +2046,23 @@ on_retry_timer(issue_id, state):
   if missing:
     return state
 
-  candidates = tracker.fetch_candidate_issues()
+  refreshed = tracker.fetch_issues_by_ids([issue_id])
   if fetch failed:
     return schedule_retry(state, issue_id, retry_entry.attempt + 1, {
       identifier: retry_entry.identifier,
-      error: "retry poll failed"
+      error: "retry refresh failed"
     })
 
-  issue = find_by_id(candidates, issue_id)
+  issue = find_by_id(refreshed, issue_id)
   if issue is null:
     state.claimed.remove(issue_id)
     return state
 
-  if available_slots(state) == 0:
+  if not retry_dispatch_allowed(issue, state, ignore_existing_claim=issue_id):
+    state.claimed.remove(issue_id)
+    return state
+
+  if no_available_slots(state):
     return schedule_retry(state, issue_id, retry_entry.attempt + 1, {
       identifier: issue.identifier,
       error: "no available orchestrator slots"
@@ -1974,9 +2099,9 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Invalid YAML front matter returns typed error
 - Front matter non-map returns typed error
 - Config defaults apply when OPTIONAL values are missing
-- `tracker.kind` validation enforces currently supported kind (`linear`)
-- `tracker.api_key` works (including `$VAR` indirection)
-- `$VAR` resolution works for tracker API key and path values
+- `tracker.kind` validation enforces an implementation-supported adapter
+- `tracker.provider` preserves adapter-owned keys and validates them through the selected adapter
+- `$VAR` resolution works for documented adapter secret keys and path values
 - `~` path expansion works
 - `codex.command` is preserved as a shell command string
 - Per-state concurrency override map normalizes state names and ignores invalid values
@@ -1995,26 +2120,35 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - `before_run` hook runs before each attempt and failure/timeouts abort the current attempt
 - `after_run` hook runs after each attempt and failure/timeouts are logged and ignored
 - `before_remove` hook runs on cleanup and failures/timeouts are ignored
-- Workspace path sanitization and root containment invariants are enforced before agent launch
+- Workspace path sanitization, stable original-identifier-hash collision resistance, and root
+  containment invariants are enforced before agent launch
+- Identifiers unchanged by sanitization keep their deterministic workspace key; conformance tests
+  include distinct identifiers that sanitize to the same text and verify distinct keys
 - Agent launch uses the per-issue workspace path as cwd and rejects out-of-root paths
 
-### 17.3 Issue Tracker Client
+### 17.3 Issue Tracker Adapter
 
-- Candidate issue fetch uses active states and project slug
-- Linear query uses the specified project filter field (`slugId`)
-- Empty `fetch_issues_by_states([])` returns empty without API call
+- Candidate issue fetch applies configured active states and adapter-owned scope selection
+- Empty `fetch_issues_by_states([])` returns empty without a provider call
+- Empty `fetch_issues_by_ids([])` returns empty without a provider call
 - Pagination preserves order across multiple pages
-- Blockers are normalized from inverse relations of type `blocks`
 - Labels are normalized to lowercase
-- Issue state refresh by ID returns minimal normalized issues
-- Issue state refresh query uses GraphQL ID typing (`[ID!]`) as specified in Section 11.2
-- Error mapping for request errors, non-200, GraphQL errors, malformed payloads
+- Unusable optional provider metadata normalizes to null/empty without hiding valid required fields
+- State-list reads log omitted malformed required records; ID refresh fails malformed requested
+  records instead of treating them as invisible
+- Refresh by opaque dispatch ID returns full normalized issue snapshots
+- A distinct provider ticket ID or project-item ID is preserved in `native_ref` when needed
+- Provider-specific routing/blocker/assignment rules become explicit `dispatchable`
+- The adapter publishes the required compact profile for config, scope, normalization, tools, and
+  portable error mapping
+- Error mapping covers config, request, non-success response, malformed payload, pagination, and
+  rate limiting, including documented category/message mappings for language-native errors
 
 ### 17.4 Orchestrator Dispatch, Reconciliation, and Retry
 
 - Dispatch sort order is priority then oldest creation time
-- `Todo` issue with non-terminal blockers is not eligible
-- `Todo` issue with terminal blockers is eligible
+- `dispatchable=false` issues are not eligible
+- Required-label filtering is case-insensitive and applies after adapter normalization
 - Active-state issue refresh updates running entry state
 - Non-active state stops running agent without workspace cleanup
 - Terminal state stops running agent and cleans workspace
@@ -2051,10 +2185,11 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
   targeted protocol
 - If client-side tools are implemented, session startup advertises the supported tool specs
   using the targeted app-server protocol
-- If the `linear_graphql` client-side tool extension is implemented:
-  - the tool is advertised to the session
-  - valid `query` / `variables` inputs execute against configured Linear auth
-  - top-level GraphQL `errors` produce `success=false` while preserving the GraphQL body
+- If provider-native agent tools are implemented:
+  - only the selected adapter's tools are advertised to the session
+  - valid inputs execute host-side with configured adapter auth
+  - the current normalized issue and `native_ref` are available as internal tool context
+  - tracker secrets are not inherited by the coding-agent child process
   - invalid arguments, missing auth, and transport failures return structured failure payloads
   - unsupported tool names still fail without stalling the session
 
@@ -2083,8 +2218,8 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 These checks are RECOMMENDED for production readiness and MAY be skipped in CI when credentials,
 network access, or external service permissions are unavailable.
 
-- A real tracker smoke test can be run with valid credentials supplied by `LINEAR_API_KEY` or a
-  documented local bootstrap mechanism (for example `~/.linear_api_key`).
+- A real tracker smoke test can be run with valid credentials supplied through the selected
+  adapter's documented secret mechanism.
 - Real integration tests SHOULD use isolated test identifiers/workspaces and clean up tracker
   artifacts when practical.
 - A skipped real-integration test SHOULD be reported as skipped, not silently treated as passed.
@@ -2106,11 +2241,11 @@ Use the same validation profiles as Section 17:
 - Typed config layer with defaults and `$` resolution
 - Dynamic `WORKFLOW.md` watch/reload/re-apply for config and prompt
 - Polling orchestrator with single-authority mutable state
-- Issue tracker client with candidate fetch + state refresh + terminal fetch
-- Workspace manager with sanitized per-issue workspaces
+- Issue tracker adapter with state-list + ID-refresh reads
+- Workspace manager with sanitized, collision-resistant per-issue workspaces
 - Workspace lifecycle hooks (`after_create`, `before_run`, `after_run`, `before_remove`)
 - Hook timeout config (`hooks.timeout_ms`, default `60000`)
-- Coding-agent app-server subprocess client with JSON line protocol
+- Coding-agent app-server subprocess client with the targeted transport/framing protocol
 - Codex launch command config (`codex.command`, default `codex app-server`)
 - Strict prompt rendering with `issue` and `attempt` variables
 - Exponential retry queue with continuation retries after normal exit
@@ -2124,14 +2259,13 @@ Use the same validation profiles as Section 17:
 
 - HTTP server extension honors CLI `--port` over `server.port`, uses a safe default bind host, and
   exposes the baseline endpoints/error semantics in Section 13.7 if shipped.
-- `linear_graphql` client-side tool extension exposes raw Linear GraphQL access through the
-  app-server session using configured Symphony auth.
+- Provider-native agent tools, when shipped, execute through the app-server session using
+  host-side configured adapter auth without passing tracker secrets to the child.
 - TODO: Persist retry queue and session metadata across process restarts.
 - TODO: Make observability settings configurable in workflow front matter without prescribing UI
   implementation details.
-- TODO: Add first-class tracker write APIs (comments/state transitions) in the orchestrator instead
-  of only via agent tools.
-- TODO: Add pluggable issue tracker adapters beyond Linear.
+- TODO: Extract common semantic helper tools only after multiple adapters demonstrate real
+  duplication; do not preemptively replace provider-native tools with generic CRUD.
 
 ### 18.3 Operational Validation Before Production (RECOMMENDED)
 

--- a/docs/runbooks/workflow-frontmatter-reference.md
+++ b/docs/runbooks/workflow-frontmatter-reference.md
@@ -3,10 +3,13 @@
 The exhaustive operator-facing reference for every key the worker reads from
 `WORKFLOW.md` YAML front matter (schema: `internal/workflow/config.go`). The
 README's [defaults table](../../README.md#workflowmd-configuration) is the
-SPEC §6.4 cheat-sheet view — it deliberately mirrors SPEC's own table; this
-page is the complete view, including the keys SPEC's cheat-sheet does not
-list. Keep the two consistent: the cheat-sheet stays the SPEC-mapping summary,
-this page the single exhaustive source (clean-code rule 3).
+current-to-SPEC §6.4 mapping view; this page is the complete implementation
+view, including keys that SPEC's cheat-sheet does not list. The current flat
+tracker endpoint/scope/auth fields predate SPEC 0.0.2's adapter-owned
+`tracker.provider` object and remain open deviation D43 / #1144, so their
+presence below documents current behavior rather than conformance. Keep the
+two views consistent and this page the single exhaustive source (clean-code
+rule 3).
 
 For any one workdir, `worker --print-config /path/to/clone` prints the
 effective resolved config (with `tracker.api_key` masked) and is the ground
@@ -52,18 +55,23 @@ truth this page approximates.
 
 ## `tracker`
 
+The flat endpoint/scope/auth fields and cross-provider state defaults below
+describe the current pre-release implementation. SPEC §6.4 assigns those
+settings/defaults to the selected adapter; D43 / #1144 owns their atomic
+replacement with `tracker.provider`.
+
 | Key | Type | Default | Behavior | Validation |
 |-----|------|---------|----------|------------|
 | `tracker.kind` | string | — | Selects the tracker adapter | **required**; `gitea`, `github`, or `linear` |
-| `tracker.api_key` | string | — | Tracker API token, referenced as `$VAR` (e.g. `$LINEAR_API_KEY`, `$GITEA_TOKEN`, `$GITHUB_TOKEN`). Worker-held: both the variable name and its value are denied from every agent `env_passthrough`/`env_allowlist`, and `--print-config` masks it | `$VAR` resolved at load |
-| `tracker.endpoint` | string | — | Tracker API base URL (SPEC §5.3.1). Linear defaults to `https://api.linear.app/graphql`. When omitted, GitHub falls back to the `GITHUB_API_BASE_URL` env var, then `https://api.github.com`; Gitea falls back to the `GITEA_BASE_URL` env var, then the local-dev default `http://localhost:3000` | `$VAR` |
-| `tracker.team_key` | string | — | Linear team key. Scopes the `linear_graphql` current-issue mutation guard's workflow-state lookup to one team, so state names that repeat across teams resolve unambiguously (`internal/runner/linear_graphql_current_issue_guard.go`) | — |
-| `tracker.project_slug` | string | — | Linear project to poll (SPEC §11.2) | required when `kind: linear` |
-| `tracker.active_states` | string list | `[Todo, In Progress]` | Issue states polled as dispatch candidates | — |
-| `tracker.terminal_states` | string list | `[Closed, Cancelled, Canceled, Duplicate, Done]` | States that end work on an issue (also used by the retry/backoff loop to stop redispatch) | — |
+| `tracker.api_key` | string | — | Current flat token field (open D43 / #1144), referenced as `$VAR` (e.g. `$LINEAR_API_KEY`, `$GITEA_TOKEN`, `$GITHUB_TOKEN`). Worker-held: both the variable name and its value are denied from every agent `env_passthrough`/`env_allowlist`, and `--print-config` masks it | `$VAR` resolved at load |
+| `tracker.endpoint` | string | — | Current flat API-base field (open D43 / #1144). Linear defaults to `https://api.linear.app/graphql`. When omitted, GitHub falls back to the `GITHUB_API_BASE_URL` env var, then `https://api.github.com`; Gitea falls back to the `GITEA_BASE_URL` env var, then the local-dev default `http://localhost:3000` | `$VAR` |
+| `tracker.team_key` | string | — | Current flat Linear scope field (open D43 / #1144). Scopes the `linear_graphql` current-issue mutation guard's workflow-state lookup to one team, so state names that repeat across teams resolve unambiguously (`internal/runner/linear_graphql_current_issue_guard.go`) | — |
+| `tracker.project_slug` | string | — | Current flat Linear project scope (open D43 / #1144) | required when `kind: linear` |
+| `tracker.active_states` | string list | `[Todo, In Progress]` | Current cross-provider implementation default; SPEC §6.4 makes the default adapter-defined (open D43 / #1144) | — |
+| `tracker.terminal_states` | string list | `[Closed, Cancelled, Canceled, Duplicate, Done]` | Current cross-provider implementation default; SPEC §6.4 makes the default adapter-defined (open D43 / #1144); terminal states also stop retry/backoff redispatch | — |
 | `tracker.inactive_states` | string list | `[]` | Non-terminal states that make an already-running issue ineligible: poll-tick reconciliation stops in-flight runs when an issue moves here (operator-pause states such as `Backlog`) | — |
 | `tracker.required_labels` | string list | `[]` (gate off) | Opt-in dispatch gate (SPEC §4.1.1): an issue must carry every listed label to dispatch or keep running. Entries are trimmed, lowercased, de-duped; a blank entry matches no issue. See the README table row for the Linear 250-label projection ceiling | — |
-| `tracker.pagination_max_pages` | int | `0` = adapter default (`github` 10, `gitea` 20, `linear` 200) | Caps one tracker pagination scan. Linear applies the same cap to issue listing and inverse-relation pagination | ≥ 0 |
+| `tracker.pagination_max_pages` | int | `0` = adapter default (`github` 10, `gitea` 20, `linear` 200) | Current flat adapter-tuning field (open D43 / #1144). Caps one tracker pagination scan; Linear applies the same cap to issue listing and inverse-relation pagination | ≥ 0 |
 
 ## `polling`
 

--- a/internal/orchestrator/poller_test.go
+++ b/internal/orchestrator/poller_test.go
@@ -1126,9 +1126,9 @@ func TestPollOnceFiltersTodoIssuesBlockedByNonTerminalBlockers(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	// Construct through the production reconciliation path with the SPEC §5.3.1
-	// default terminal_states (workflow.DefaultConfig), so a Done blocker is
-	// still treated as terminal and only the unblocked Todo issue dispatches.
+	// Construct through the production reconciliation path with the current
+	// cross-provider terminal-state default. D43 / #1144 tracks the move to
+	// adapter-defined defaults; until then a Done blocker remains terminal.
 	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
 		ActiveStates:   []string{"Todo"},
 		TerminalStates: workflow.DefaultConfig().Tracker.TerminalStates,
@@ -1263,7 +1263,7 @@ func TestPollOnceIgnoresBlockersForNonTodoStates(t *testing.T) {
 	close(dispatcher.releaseCh)
 }
 
-func TestPollOnceTreatsDefaultSpecTerminalBlockersAsUnblocked(t *testing.T) {
+func TestPollOnceTreatsCurrentDefaultTerminalBlockersAsUnblocked(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1281,11 +1281,11 @@ func TestPollOnceTreatsDefaultSpecTerminalBlockersAsUnblocked(t *testing.T) {
 		t.Fatalf("wait for orchestrator: %v", err)
 	}
 
-	// Use workflow.DefaultConfig().Tracker.TerminalStates so the test actually
-	// exercises the SPEC §5.3.1 5-state default ("Done", "Canceled",
-	// "Cancelled", "Closed", "Duplicate"). Previously this was hard-coded to
-	// ["Done", "Canceled"] and relied on filterEligibleCandidates's now-removed
-	// hardcoded overlay (#232) to backfill the remaining three terminal states.
+	// Use workflow.DefaultConfig().Tracker.TerminalStates so the test exercises
+	// the current D43 / #1144 5-state implementation default. Previously this
+	// was hard-coded to ["Done", "Canceled"] and relied on
+	// filterEligibleCandidates's now-removed overlay (#232) to backfill the
+	// remaining three terminal states.
 	poller := NewPollerWithReconciliation(trackerClient, orch, ReconciliationConfig{
 		ActiveStates:   []string{"Todo"},
 		TerminalStates: workflow.DefaultConfig().Tracker.TerminalStates,
@@ -1344,8 +1344,8 @@ func TestPollOnceTodoBlockerHonorsOperatorConfiguredTerminalStates(t *testing.T)
 // TestFilterEligibleCandidatesExplicitEmptyTerminalStatesBlocksAll confirms
 // that an explicitly empty terminal_states slice from
 // NewPollerWithReconciliation reaches filterEligibleCandidates verbatim — it
-// is NOT silently replaced by the DefaultConfig 5-state set. SPEC §5.3.1
-// default semantics: defaults apply on omission, not on explicit override.
+// is NOT silently replaced by the current D43 / #1144 DefaultConfig 5-state
+// set. Defaults apply on omission, not on an explicit override.
 func TestFilterEligibleCandidatesExplicitEmptyTerminalStatesBlocksAll(t *testing.T) {
 	issues := []tracker.Issue{
 		{ID: "todo-done", Identifier: "LIN-1", Title: "Done blocker", State: "Todo", BlockedBy: []tracker.BlockerRef{{ID: "blk", Identifier: "LIN-0", State: "Done"}}},

--- a/internal/tracker/linear_test.go
+++ b/internal/tracker/linear_test.go
@@ -1210,18 +1210,18 @@ func TestNewLinearClient_DefaultsRequestTimeoutTo30s(t *testing.T) {
 	}
 }
 
-// TestNewLinearClientHonorsEndpointOverride pins SPEC §5.3.1 (#242): an
-// explicit `tracker.endpoint` configures the Linear client's BaseURL.
-// Workflows pointing at a httptest mock, a regional Linear endpoint, or a
-// proxy can express the override in WORKFLOW.md without code changes.
-func TestNewLinearClientHonorsEndpointOverride(t *testing.T) {
+// TestNewLinearClientHonorsCurrentEndpointOverride pins the current flat
+// `tracker.endpoint` wiring. D43 / #1144 owns its atomic replacement with
+// adapter-owned `tracker.provider`; the existing behavior remains required
+// until that cutover.
+func TestNewLinearClientHonorsCurrentEndpointOverride(t *testing.T) {
 	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k", Endpoint: "https://linear.example/graphql"})
 	if client.BaseURL != "https://linear.example/graphql" {
 		t.Fatalf("BaseURL = %q, want override from tracker.endpoint", client.BaseURL)
 	}
 }
 
-func TestNewLinearClientDefaultsToSpecEndpoint(t *testing.T) {
+func TestNewLinearClientDefaultsToLinearEndpoint(t *testing.T) {
 	client := NewLinearClient(workflow.TrackerConfig{APIKey: "k"})
 	if client.BaseURL != DefaultLinearEndpoint {
 		t.Fatalf("BaseURL = %q, want DefaultLinearEndpoint when override absent", client.BaseURL)

--- a/internal/workflow/config_test.go
+++ b/internal/workflow/config_test.go
@@ -2276,13 +2276,11 @@ prompt
 	}
 }
 
-// TestDefaultConfig_AlignsToSPEC_6_4 pins every SPEC §6.4 default
-// `DefaultConfig()` is responsible for. Each field gets its own
-// assertion so a regression on any one of them surfaces in CI rather
-// than being papered over by a sibling field's check. Mirrors the
-// Elixir reference (`elixir/lib/symphony_elixir/config/schema.ex`
-// lines 53, 54, 93, 131, 160).
-func TestDefaultConfig_AlignsToSPEC_6_4(t *testing.T) {
+// TestDefaultConfig_PinsSPECAndTrackedDefaults separates implemented SPEC §6.4
+// defaults from current cross-provider state defaults. SPEC 0.0.2 makes state
+// defaults adapter-defined; D43 / #1144 owns that cutover. Each field keeps an
+// independent assertion so one regression cannot hide behind a sibling.
+func TestDefaultConfig_PinsSPECAndTrackedDefaults(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig()
 
@@ -2309,11 +2307,11 @@ func TestDefaultConfig_AlignsToSPEC_6_4(t *testing.T) {
 
 	wantActive := []string{"Todo", "In Progress"}
 	if !reflect.DeepEqual(cfg.Tracker.ActiveStates, wantActive) {
-		t.Errorf("Tracker.ActiveStates = %#v, want SPEC §6.4 default %#v", cfg.Tracker.ActiveStates, wantActive)
+		t.Errorf("Tracker.ActiveStates = %#v, want current D43 / #1144 implementation default %#v", cfg.Tracker.ActiveStates, wantActive)
 	}
 	wantTerminal := []string{"Closed", "Cancelled", "Canceled", "Duplicate", "Done"}
 	if !reflect.DeepEqual(cfg.Tracker.TerminalStates, wantTerminal) {
-		t.Errorf("Tracker.TerminalStates = %#v, want SPEC §6.4 default %#v (order matters; mirrors Elixir schema.ex:54)", cfg.Tracker.TerminalStates, wantTerminal)
+		t.Errorf("Tracker.TerminalStates = %#v, want current D43 / #1144 implementation default %#v (order matters)", cfg.Tracker.TerminalStates, wantTerminal)
 	}
 
 	// SPEC §6.4 marks tracker.kind REQUIRED, so DefaultConfig must

--- a/scripts/spec_mirror_docs_test.go
+++ b/scripts/spec_mirror_docs_test.go
@@ -1,0 +1,177 @@
+package scripts
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+const (
+	symphonySpecCommit       = "653f8b3cc476db03420479ba6f95b2ed7281c401"
+	symphonySpecCommitDate   = "2026-07-24"
+	symphonySpecMirroredDate = "2026-07-24"
+	symphonySpecSHA256       = "29d6b45a85453e045883c064c0e08595f9d4a33f9a2527f649bc1363b74e0176"
+)
+
+func TestSymphonySpecMirrorMatchesPinnedUpstream(t *testing.T) {
+	root := gitRepoRoot(t)
+	mirror := readRepoFile(t, root, "docs/research/SPEC.md")
+	header, body, ok := bytes.Cut(mirror, []byte("-->\n\n"))
+	if !ok {
+		t.Fatal("docs/research/SPEC.md is missing its provenance header terminator")
+	}
+	if got, want := headerValue(header, "Upstream commit: "), symphonySpecCommit+" ("+symphonySpecCommitDate+")"; got != want {
+		t.Errorf("SPEC mirror upstream commit = %q; want %q", got, want)
+	}
+	if got, want := headerValue(header, "Body SHA-256: "), symphonySpecSHA256; got != want {
+		t.Errorf("SPEC mirror body SHA-256 header = %q; want %q", got, want)
+	}
+	for prefix, want := range map[string]string{
+		"Source: ":   "https://github.com/openai/symphony/blob/" + symphonySpecCommit + "/SPEC.md",
+		"Mirrored: ": symphonySpecMirroredDate,
+		"License: ":  "Apache License 2.0 — https://github.com/openai/symphony/blob/" + symphonySpecCommit + "/LICENSE",
+	} {
+		if got := headerValue(header, prefix); got != want {
+			t.Errorf("SPEC mirror %s header = %q; want %q", prefix, got, want)
+		}
+	}
+	guardedClone := "  if ! git -C /tmp/symphony-upstream rev-parse --git-dir >/dev/null 2>&1; then\n" +
+		"    git clone https://github.com/openai/symphony.git /tmp/symphony-upstream\n" +
+		"  fi"
+	if !bytes.Contains(header, []byte(guardedClone)) {
+		t.Errorf("SPEC mirror header is missing guarded clone block %q", guardedClone)
+	}
+	for _, command := range []string{
+		"  symphony_sha=" + symphonySpecCommit,
+		`  git -C /tmp/symphony-upstream fetch origin "${symphony_sha}"`,
+		`  git -C /tmp/symphony-upstream show "${symphony_sha}:SPEC.md" > /tmp/symphony-SPEC.md`,
+		"  shasum -a 256 /tmp/symphony-SPEC.md",
+	} {
+		if !bytes.Contains(header, []byte(command)) {
+			t.Errorf("SPEC mirror header is missing reproducible command %q", command)
+		}
+	}
+	normalizedHeader := bytes.Join(bytes.Fields(header), []byte(" "))
+	for _, updateTarget := range []string{"scripts/spec_mirror_docs_test.go", "pinned authority links"} {
+		if !bytes.Contains(normalizedHeader, []byte(updateTarget)) {
+			t.Errorf("SPEC mirror header does not name refresh update target %q", updateTarget)
+		}
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(body)); got != symphonySpecSHA256 {
+		t.Errorf("SPEC mirror body SHA-256 = %s; want %s", got, symphonySpecSHA256)
+	}
+}
+
+func TestCurrentAuthorityDocsDoNotCallSymphonyUnmaintained(t *testing.T) {
+	root := gitRepoRoot(t)
+	for _, path := range []string{"AGENTS.md", "DECISION.md", "DEVIATIONS.md", "README.md", "docs/research/SPEC.md"} {
+		body := repoAuthoredAuthorityText(t, root, path)
+		normalized := bytes.ToLower(bytes.Join(bytes.Fields(body), []byte(" ")))
+		if bytes.Contains(normalized, []byte("unmaintained demo")) {
+			t.Errorf("%s still calls current upstream an unmaintained demo", path)
+		}
+	}
+	decision := bytes.Join(bytes.Fields(readRepoFile(t, root, "DECISION.md")), []byte(" "))
+	if current := "Upstream resumed development"; !bytes.Contains(decision, []byte(current)) {
+		t.Errorf("DECISION.md is missing current upstream-status correction %q", current)
+	}
+	for _, stale := range []string{
+		"OpenAI has stated the Elixir repo is a reference implementation and will not be maintained as a product.",
+		"There are no future upstream changes to inherit by merge.",
+		"Both paths (Go port and Elixir fork) become \"we own this code\" from day one.",
+	} {
+		if bytes.Contains(decision, []byte(stale)) {
+			t.Errorf("DECISION.md still presents historical upstream premise as current fact %q", stale)
+		}
+	}
+}
+
+func TestCurrentSymphonyAuthorityLinksStayPinned(t *testing.T) {
+	root := gitRepoRoot(t)
+	for _, path := range []string{"AGENTS.md", "DECISION.md", "DEVIATIONS.md", "README.md", "docs/research/SPEC.md"} {
+		body := repoAuthoredAuthorityText(t, root, path)
+		assertAllSymphonyAuthorityLinksPinned(t, path, body)
+	}
+}
+
+func TestCurrentDeviationDocsDoNotRouteNewFindingsToHistoricalLedger(t *testing.T) {
+	root := gitRepoRoot(t)
+	for path, contract := range map[string]struct {
+		current string
+		stale   string
+	}{
+		"DEVIATIONS.md": {
+			current: "The current Symphony 0.0.2 alignment ledger is [#1137]",
+		},
+		"AGENTS.md": {
+			current: "active alignment ledger named in `DEVIATIONS.md`",
+			stale:   "The umbrella tracker is [#67]",
+		},
+		".claude/skills/handle-issue/SKILL.md": {
+			current: "挂到 `DEVIATIONS.md` 指向的当前 alignment ledger",
+			stale:   "伞 issue #67",
+		},
+		"docs/engineering-rules-rationale.md": {
+			current: "Route new findings through the active ledger named in `DEVIATIONS.md`",
+		},
+	} {
+		body := readRepoFile(t, root, path)
+		normalized := bytes.Join(bytes.Fields(body), []byte(" "))
+		if !bytes.Contains(normalized, []byte(contract.current)) {
+			t.Errorf("%s is missing current deviation-ledger contract %q", path, contract.current)
+		}
+		if contract.stale != "" && bytes.Contains(normalized, []byte(contract.stale)) {
+			t.Errorf("%s still routes new deviations to historical ledger #67 via %q", path, contract.stale)
+		}
+	}
+}
+
+func repoAuthoredAuthorityText(t *testing.T, root, path string) []byte {
+	t.Helper()
+	body := readRepoFile(t, root, path)
+	if path != "docs/research/SPEC.md" {
+		return body
+	}
+	header, _, ok := bytes.Cut(body, []byte("-->\n\n"))
+	if !ok {
+		t.Fatal("docs/research/SPEC.md is missing its provenance header terminator")
+	}
+	return header
+}
+
+func assertAllSymphonyAuthorityLinksPinned(t *testing.T, path string, body []byte) {
+	t.Helper()
+	githubLinks := regexp.MustCompile(
+		`https://github\.com/openai/symphony/(blob|tree)/([^/)[:space:]]+)`,
+	).FindAllSubmatch(body, -1)
+	rawLinks := regexp.MustCompile(
+		`https://raw\.githubusercontent\.com/openai/symphony/([^/)[:space:]]+)`,
+	).FindAllSubmatch(body, -1)
+	if len(githubLinks)+len(rawLinks) == 0 {
+		t.Errorf("%s does not contain a pinned Symphony authority link", path)
+	}
+	for _, match := range githubLinks {
+		assertSymphonyAuthorityRef(t, path, string(match[0]), string(match[2]))
+	}
+	for _, match := range rawLinks {
+		assertSymphonyAuthorityRef(t, path, string(match[0]), string(match[1]))
+	}
+}
+
+func assertSymphonyAuthorityRef(t *testing.T, path, link, got string) {
+	t.Helper()
+	if got != symphonySpecCommit {
+		t.Errorf("%s Symphony authority link %q uses ref %q; want %q", path, link, got, symphonySpecCommit)
+	}
+}
+
+func headerValue(header []byte, prefix string) string {
+	for _, line := range bytes.Split(header, []byte("\n")) {
+		if value, ok := bytes.CutPrefix(line, []byte(prefix)); ok {
+			return string(value)
+		}
+	}
+	return ""
+}

--- a/scripts/spec_mirror_docs_test.go
+++ b/scripts/spec_mirror_docs_test.go
@@ -128,6 +128,128 @@ func TestCurrentDeviationDocsDoNotRouteNewFindingsToHistoricalLedger(t *testing.
 	}
 }
 
+func TestCurrentDocsDoNotCertifyOpenD43AsSPECConformance(t *testing.T) {
+	root := gitRepoRoot(t)
+	assertFilesContainD43Contracts(t, root)
+	assertD43TableRows(t, root)
+	assertStaleD43AttributionsAbsent(t, root)
+}
+
+func assertFilesContainD43Contracts(t *testing.T, root string) {
+	t.Helper()
+	for path, required := range map[string][]string{
+		"README.md": {
+			"`tracker.provider`",
+			"D43",
+			"#1144",
+		},
+		"docs/runbooks/workflow-frontmatter-reference.md": {
+			"`tracker.provider`",
+			"D43",
+			"#1144",
+		},
+		"internal/workflow/config_test.go": {
+			"TestDefaultConfig_PinsSPECAndTrackedDefaults",
+			"D43",
+			"#1144",
+		},
+		"internal/orchestrator/poller_test.go": {
+			"TestPollOnceTreatsCurrentDefaultTerminalBlockersAsUnblocked",
+			"D43",
+			"#1144",
+		},
+		"internal/tracker/linear_test.go": {
+			"TestNewLinearClientHonorsCurrentEndpointOverride",
+			"TestNewLinearClientDefaultsToLinearEndpoint",
+			"D43",
+			"#1144",
+		},
+	} {
+		body := readRepoFile(t, root, path)
+		for _, contract := range required {
+			if !bytes.Contains(body, []byte(contract)) {
+				t.Errorf("%s is missing D43 attribution contract %q", path, contract)
+			}
+		}
+	}
+}
+
+func assertD43TableRows(t *testing.T, root string) {
+	t.Helper()
+	for _, row := range []struct {
+		path     string
+		prefix   string
+		required []string
+	}{
+		{"README.md", "| `tracker.endpoint` |", []string{"D43", "#1144", "`tracker.provider`"}},
+		{"README.md", "| `tracker.project_slug` |", []string{"D43", "#1144", "`tracker.provider`"}},
+		{"README.md", "| `tracker.active_states` |", []string{"D43", "#1144", "adapter-defined"}},
+		{"README.md", "| `tracker.terminal_states` |", []string{"D43", "#1144", "adapter-defined"}},
+		{"docs/runbooks/workflow-frontmatter-reference.md", "| `tracker.api_key` |", []string{"D43", "#1144"}},
+		{"docs/runbooks/workflow-frontmatter-reference.md", "| `tracker.endpoint` |", []string{"D43", "#1144"}},
+		{"docs/runbooks/workflow-frontmatter-reference.md", "| `tracker.team_key` |", []string{"D43", "#1144"}},
+		{"docs/runbooks/workflow-frontmatter-reference.md", "| `tracker.project_slug` |", []string{"D43", "#1144"}},
+		{"docs/runbooks/workflow-frontmatter-reference.md", "| `tracker.active_states` |", []string{"D43", "#1144", "adapter-defined"}},
+		{"docs/runbooks/workflow-frontmatter-reference.md", "| `tracker.terminal_states` |", []string{"D43", "#1144", "adapter-defined"}},
+		{"docs/runbooks/workflow-frontmatter-reference.md", "| `tracker.pagination_max_pages` |", []string{"D43", "#1144"}},
+	} {
+		body := readRepoFile(t, root, row.path)
+		assertLineContainsAll(t, row.path, body, row.prefix, row.required)
+	}
+}
+
+func assertStaleD43AttributionsAbsent(t *testing.T, root string) {
+	t.Helper()
+	for path, stale := range map[string][]string{
+		"README.md": {
+			"table below mirrors SPEC §6.4's cheat-sheet",
+		},
+		"docs/runbooks/workflow-frontmatter-reference.md": {
+			"it deliberately mirrors SPEC's own table",
+			"Tracker API base URL (SPEC §5.3.1)",
+		},
+		"internal/workflow/config_test.go": {
+			"TestDefaultConfig_AlignsToSPEC_6_4",
+			"Tracker.ActiveStates = %#v, want SPEC §6.4 default",
+			"Tracker.TerminalStates = %#v, want SPEC §6.4 default",
+		},
+		"internal/orchestrator/poller_test.go": {
+			"SPEC §5.3.1",
+			"TestPollOnceTreatsDefaultSpecTerminalBlockersAsUnblocked",
+		},
+		"internal/tracker/linear_test.go": {
+			"TestNewLinearClientHonorsEndpointOverride pins SPEC",
+			"TestNewLinearClientDefaultsToSpecEndpoint",
+		},
+	} {
+		body := readRepoFile(t, root, path)
+		for _, attribution := range stale {
+			if bytes.Contains(body, []byte(attribution)) {
+				t.Errorf("%s still contains stale D43 attribution %q", path, attribution)
+			}
+		}
+	}
+}
+
+func assertLineContainsAll(t *testing.T, path string, body []byte, prefix string, required []string) {
+	t.Helper()
+	matches := 0
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		if !bytes.HasPrefix(bytes.TrimSpace(line), []byte(prefix)) {
+			continue
+		}
+		matches++
+		for _, contract := range required {
+			if !bytes.Contains(line, []byte(contract)) {
+				t.Errorf("%s line %q is missing contract %q", path, line, contract)
+			}
+		}
+	}
+	if matches != 1 {
+		t.Errorf("%s has %d lines with prefix %q; want exactly 1", path, matches, prefix)
+	}
+}
+
 func repoAuthoredAuthorityText(t *testing.T, root, path string) []byte {
 	t.Helper()
 	body := readRepoFile(t, root, path)


### PR DESCRIPTION
Closes #1138

## Summary
- resync the local verbatim Symphony SPEC mirror to `openai/symphony@653f8b3cc476db03420479ba6f95b2ed7281c401`
- pin every current authority link and provenance field to the audited head, and document a reproducible exact-SHA refresh procedure
- rebaseline the active deviation ledger as #1137 with open D38-D49 rows for #1139-#1150 while preserving #67 as historical
- correct stale upstream-maintenance assumptions, including explicitly time-qualifying the 2026-05 decision record
- relabel stale current §6.4 consumers so open D43/#1144 is not certified as SPEC conformance
- add regression checks for mirror bytes/hash, provenance, per-link refs, active-ledger routing, stale upstream wording, and D43 attribution

## SPEC alignment (AGENTS.md principle 6/7)
- [x] No new top-level `WORKFLOW.md`/`Config` key and no new worker/orchestrator phase/gate/artifact.
- [ ] Adds one, justified by an upstream **Elixir reference** — cite the matching file and line from the openai/symphony Elixir tree in the body below (a bare module name does not count; the gate looks for a concrete source path).
- [ ] Adds one, tracked as a **DEVIATIONS.md row** + an `area:spec-alignment` issue, updated in this PR.

This is a documentation/governance resync only. It introduces no runtime behavior or new extension.

## PR diff size budget (AGENTS.md)
- [x] `within budget` — ≤12 production files / ≤300 production LOC (test files and generated code excluded).
- [ ] `size-gated: justified overage` — production diff over budget for correctness / regression / race-safety coverage that cannot be split without losing atomicity. **Needs human size-gate sign-off.**
- [ ] `size-gated: split recommended` — over budget for scope creep / separable concerns. Split instead.

No production Go files changed.

## Testing
- [x] `go test -run '^TestProductionGoFilesStayWithinSizeBudget$' -count=1 ./scripts`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic ./...`
- [x] `gofmt -l` clean + blocking golangci gate (`staticcheck,unparam,unused,…`)
- [x] additional validation noted below when needed

Additional validation:
- `npm test` — 28/28 dashboard tests passed
- `npm run build` — dashboard production bundle built successfully
- `go build ./cmd/worker ./cmd/tui`
- exact byte comparison against `git -C /tmp/symphony-upstream show 653f8b3:SPEC.md`
- mirror body SHA-256: `29d6b45a85453e045883c064c0e08595f9d4a33f9a2527f649bc1363b74e0176`
- exact-SHA fetch dry-run and authority-link target checks
- committed-artifact mutations confirmed failures for body/hash, guarded clone, refresh sync targets, stale wording, active-ledger deletion, a single stale authority URL, independent commit/mirror dates, individual D43 table rows, and stale conformance test names; every mutation was restored and the targeted tests passed again
- exact-head CI run `30129715692`: all six checks passed, including E2E and Docker; emitted warning annotations/output: 0

## Review ledger
- Base: `04e25100caf47ca5d7bf6da4d016b689910a0c29`
- Head: `0d81a640da32578be01b052d83fdf19b1d1f5ae8`
- Standards axis: `APPROVE`, no HIGH/MEDIUM/LOW findings on the exact head
- Spec axis: `APPROVE`, no HIGH/MEDIUM/LOW findings on the exact head
- Independent Claude Sonnet exact-head delta review: `MERGE-READY`, no findings
- GitHub Codex found one P2 on predecessor `6e851d87`; fixed class-wide in `0d81a640`, replied, and resolved
- Fresh `@codex review` was requested for `0d81a640`; the connector returned its code-review usage-limit error instead of a review. This is recorded explicitly and is not treated as an approval. Exact-head independent Standards, Spec, and Claude adversarial reviews are the fallback evidence.
- Unresolved non-outdated review threads: 0
- No findings deferred

## Scope exclusions
- no Jira/Asana/GitLab adapter implementation
- no SSH workspace, Burrito packaging, or website work
- no production code, generated dashboard assets, or historical audit rewrite
